### PR TITLE
feat(auth): add native XMPP OAuth login flow

### DIFF
--- a/app/gui/src/App.vue
+++ b/app/gui/src/App.vue
@@ -16,7 +16,7 @@ const runtimeStore = useRuntimeStore();
 const authStore = useAuthStore();
 const { setActiveConversation, startListening, stopListening } = useConversations();
 
-const isLoginRoute = computed(() => route.name === 'login');
+const hideSidebar = computed(() => Boolean(route.meta.public));
 
 // Only bootstrap runtime & conversations when authenticated
 watch(
@@ -49,8 +49,8 @@ watch(
 
 <template>
   <div class="flex h-screen overflow-hidden bg-background">
-    <!-- Left sidebar (hidden on login) -->
-    <SidebarNav v-if="!isLoginRoute" />
+    <!-- Left sidebar (hidden on public/auth routes) -->
+    <SidebarNav v-if="!hideSidebar" />
 
     <!-- Main content area -->
     <main class="flex min-w-0 flex-1 flex-col bg-chat-bg">

--- a/app/gui/src/router/index.ts
+++ b/app/gui/src/router/index.ts
@@ -8,12 +8,19 @@ import RoomsView from '../views/RoomsView.vue';
 import RosterView from '../views/RosterView.vue';
 import ProfileView from '../views/ProfileView.vue';
 import SettingsView from '../views/SettingsView.vue';
+import XmppOAuthCallbackView from '../views/XmppOAuthCallbackView.vue';
 
 const routes: RouteRecordRaw[] = [
   {
     path: '/login',
     name: 'login',
     component: LoginView,
+    meta: { public: true },
+  },
+  {
+    path: '/oauth/xmpp/callback',
+    name: 'oauth-xmpp-callback',
+    component: XmppOAuthCallbackView,
     meta: { public: true },
   },
   {

--- a/app/gui/src/utils/xmppOAuth.test.ts
+++ b/app/gui/src/utils/xmppOAuth.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  XMPP_OAUTH_PENDING_FLOW_KEY,
+  beginXmppOAuthFlow,
+  completeXmppOAuthFlow,
+  consumePendingXmppOAuthFlow,
+  createPkceCodeChallenge,
+  createPkceVerifier,
+  discoverXmppOAuthMetadata,
+  extractXmppDomain,
+  type PendingXmppOAuthFlow,
+  type XmppOAuthMetadata,
+} from './xmppOAuth';
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('extractXmppDomain', () => {
+  test('parses domain from a bare domain', () => {
+    expect(extractXmppDomain('example.com')).toBe('example.com');
+  });
+
+  test('parses domain from full JID', () => {
+    expect(extractXmppDomain('alice@example.com/mobile')).toBe('example.com');
+  });
+});
+
+describe('PKCE helpers', () => {
+  test('creates URL-safe verifier and challenge', async () => {
+    const verifier = createPkceVerifier();
+    const challenge = await createPkceCodeChallenge(verifier);
+
+    expect(verifier.length).toBeGreaterThan(30);
+    expect(challenge.length).toBeGreaterThan(30);
+    expect(verifier).not.toContain('=');
+    expect(challenge).not.toContain('=');
+  });
+});
+
+describe('beginXmppOAuthFlow', () => {
+  test('builds authorize URL and persists pending flow', async () => {
+    const storage = new MemoryStorage();
+    const metadata: XmppOAuthMetadata = {
+      issuer: 'https://auth.example.com',
+      authorization_endpoint: 'https://auth.example.com/api/auth/xmpp/authorize',
+      token_endpoint: 'https://auth.example.com/api/auth/xmpp/token',
+    };
+
+    const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      if (url.pathname === '/.well-known/oauth-authorization-server') {
+        return jsonResponse(metadata);
+      }
+      throw new Error(`Unexpected request: ${url.toString()}`);
+    };
+
+    const result = await beginXmppOAuthFlow({
+      jidOrDomain: 'alice@example.com',
+      providerId: 'github',
+      endpoint: 'wss://xmpp.example.com/xmpp-websocket',
+      redirectUri: 'https://app.example.com/oauth/xmpp/callback',
+      callbackBaseUrl: 'https://app.example.com',
+      fetchImpl,
+      storage,
+    });
+
+    const authorizeUrl = new URL(result.authorizeUrl);
+    expect(authorizeUrl.origin).toBe('https://auth.example.com');
+    expect(authorizeUrl.pathname).toBe('/api/auth/xmpp/authorize');
+    expect(authorizeUrl.searchParams.get('provider')).toBe('github');
+    expect(authorizeUrl.searchParams.get('response_type')).toBe('code');
+    expect(authorizeUrl.searchParams.get('scope')).toBe('xmpp:client:normal');
+
+    const persisted = storage.getItem(XMPP_OAUTH_PENDING_FLOW_KEY);
+    expect(persisted).not.toBeNull();
+    const parsed = JSON.parse(persisted ?? '{}') as PendingXmppOAuthFlow;
+    expect(parsed.domain).toBe('example.com');
+    expect(parsed.endpoint).toBe('wss://xmpp.example.com/xmpp-websocket');
+    expect(parsed.tokenEndpoint).toBe('https://auth.example.com/api/auth/xmpp/token');
+  });
+});
+
+describe('discoverXmppOAuthMetadata', () => {
+  test('uses explicit server URL when provided', async () => {
+    const metadata: XmppOAuthMetadata = {
+      issuer: 'http://localhost:3000',
+      authorization_endpoint: 'http://localhost:3000/api/auth/xmpp/authorize',
+      token_endpoint: 'http://localhost:3000/api/auth/xmpp/token',
+    };
+
+    const fetchImpl = async (input: RequestInfo | URL): Promise<Response> => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      expect(url.origin).toBe('http://localhost:3000');
+      expect(url.pathname).toBe('/.well-known/oauth-authorization-server');
+      return jsonResponse(metadata);
+    };
+
+    const discovered = await discoverXmppOAuthMetadata('http://localhost:3000', fetchImpl);
+    expect(discovered.domain).toBe('localhost');
+    expect(discovered.metadata.issuer).toBe('http://localhost:3000');
+  });
+});
+
+describe('completeXmppOAuthFlow', () => {
+  test('exchanges code, resolves session, and builds final JID', async () => {
+    const storage = new MemoryStorage();
+    const flow: PendingXmppOAuthFlow = {
+      state: 'state-123',
+      codeVerifier: 'verifier-123',
+      redirectUri: 'https://app.example.com/oauth/xmpp/callback',
+      domain: 'example.com',
+      endpoint: 'wss://example.com/xmpp-websocket',
+      providerId: 'github',
+      sessionEndpoint: 'https://auth.example.com/api/auth/session',
+      tokenEndpoint: 'https://auth.example.com/api/auth/xmpp/token',
+      createdAt: Date.now(),
+    };
+    storage.setItem(XMPP_OAUTH_PENDING_FLOW_KEY, JSON.stringify(flow));
+
+    const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = input instanceof URL ? input : new URL(String(input));
+      if (url.pathname === '/api/auth/xmpp/token') {
+        expect(init?.method).toBe('POST');
+        const body = init?.body;
+        expect(body instanceof URLSearchParams).toBe(true);
+        if (body instanceof URLSearchParams) {
+          expect(body.get('code')).toBe('auth-code-1');
+          expect(body.get('code_verifier')).toBe('verifier-123');
+        }
+        return jsonResponse({
+          access_token: 'session-abc',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          scope: 'xmpp:client:normal',
+        });
+      }
+
+      if (url.pathname === '/api/auth/session') {
+        expect(url.searchParams.get('session_id')).toBe('session-abc');
+        return jsonResponse({
+          session_id: 'session-abc',
+          user_id: 'user-1',
+          username: 'alice',
+          xmpp_localpart: 'alice',
+          is_expired: false,
+          expires_at: null,
+        });
+      }
+
+      throw new Error(`Unexpected request: ${url.toString()}`);
+    };
+
+    const result = await completeXmppOAuthFlow({
+      code: 'auth-code-1',
+      state: 'state-123',
+      fetchImpl,
+      storage,
+    });
+
+    expect(result.token.access_token).toBe('session-abc');
+    expect(result.session.username).toBe('alice');
+    expect(result.jid).toBe('alice@example.com');
+    expect(storage.getItem(XMPP_OAUTH_PENDING_FLOW_KEY)).toBeNull();
+  });
+
+  test('rejects callback if the state is invalid', () => {
+    const storage = new MemoryStorage();
+    const flow: PendingXmppOAuthFlow = {
+      state: 'expected-state',
+      codeVerifier: 'verifier-123',
+      redirectUri: 'https://app.example.com/oauth/xmpp/callback',
+      domain: 'example.com',
+      endpoint: 'wss://example.com/xmpp-websocket',
+      providerId: null,
+      sessionEndpoint: 'https://auth.example.com/api/auth/session',
+      tokenEndpoint: 'https://auth.example.com/api/auth/xmpp/token',
+      createdAt: Date.now(),
+    };
+    storage.setItem(XMPP_OAUTH_PENDING_FLOW_KEY, JSON.stringify(flow));
+
+    expect(() => consumePendingXmppOAuthFlow('wrong-state', storage)).toThrow(
+      'OAuth state mismatch. Please retry sign-in.',
+    );
+  });
+});

--- a/app/gui/src/utils/xmppOAuth.ts
+++ b/app/gui/src/utils/xmppOAuth.ts
@@ -1,0 +1,502 @@
+import { discoverWebSocketEndpoint } from './discover';
+
+export const XMPP_OAUTH_PENDING_FLOW_KEY = 'waddle:auth:xmpp-oauth:pending';
+
+const FLOW_MAX_AGE_MS = 10 * 60 * 1000;
+const DEFAULT_CALLBACK_PATH = '/oauth/xmpp/callback';
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export interface XmppOAuthProvider {
+  id: string;
+  display_name: string;
+  kind: string;
+}
+
+export interface XmppOAuthMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+}
+
+export interface XmppOAuthTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope: string;
+}
+
+export interface XmppOAuthSessionResponse {
+  session_id: string;
+  user_id: string;
+  username: string;
+  xmpp_localpart: string;
+  is_expired: boolean;
+  expires_at: string | null;
+}
+
+export interface PendingXmppOAuthFlow {
+  state: string;
+  codeVerifier: string;
+  redirectUri: string;
+  domain: string;
+  endpoint: string;
+  providerId: string | null;
+  sessionEndpoint: string;
+  tokenEndpoint: string;
+  createdAt: number;
+}
+
+export interface BeginXmppOAuthFlowInput {
+  jidOrDomain: string;
+  providerId?: string;
+  endpoint?: string;
+  redirectUri?: string;
+  callbackBaseUrl?: string;
+  fetchImpl?: FetchLike;
+  storage?: StorageLike;
+}
+
+export interface CompleteXmppOAuthFlowInput {
+  code: string;
+  state: string;
+  fetchImpl?: FetchLike;
+  storage?: StorageLike;
+}
+
+interface OAuthErrorResponse {
+  error?: string;
+  message?: string;
+}
+
+function getFetch(fetchImpl?: FetchLike): FetchLike {
+  if (fetchImpl) return fetchImpl;
+  if (typeof fetch === 'function') return fetch.bind(globalThis);
+  throw new Error('Fetch API is not available in this runtime');
+}
+
+function getStorage(storage?: StorageLike): StorageLike {
+  if (storage) return storage;
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+  throw new Error('Local storage is not available in this runtime');
+}
+
+function getBaseUrl(baseUrl?: string): string {
+  if (baseUrl) return baseUrl;
+  if (typeof window !== 'undefined' && window.location.origin) {
+    return window.location.origin;
+  }
+  throw new Error('Unable to resolve base URL');
+}
+
+function resolveOAuthServerBase(input: string): { baseUrl: string; domain: string } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Server URL or domain is required');
+  }
+
+  if (trimmed.includes('://')) {
+    let parsed: URL;
+    try {
+      parsed = new URL(trimmed);
+    } catch {
+      throw new Error('Invalid server URL');
+    }
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      throw new Error('Server URL must start with http:// or https://');
+    }
+
+    return {
+      baseUrl: parsed.origin,
+      domain: parsed.hostname,
+    };
+  }
+
+  const domain = extractXmppDomain(trimmed);
+  return {
+    baseUrl: `https://${domain}`,
+    domain,
+  };
+}
+
+async function parseJsonOrThrow<T>(response: Response, fallback: string): Promise<T> {
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new Error(fallback);
+  }
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  if (typeof btoa !== 'function') {
+    throw new Error('btoa is not available in this runtime');
+  }
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+function randomBytes(length: number): Uint8Array {
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error('Secure random generator is not available');
+  }
+  const bytes = new Uint8Array(length);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+async function parseErrorResponse(response: Response, fallback: string): Promise<Error> {
+  let message = `${fallback} (${response.status})`;
+  try {
+    const payload = (await response.json()) as OAuthErrorResponse;
+    if (typeof payload.message === 'string' && payload.message.trim().length > 0) {
+      message = payload.message;
+    } else if (typeof payload.error === 'string' && payload.error.trim().length > 0) {
+      message = payload.error;
+    }
+  } catch {
+    // no-op: use fallback message
+  }
+  return new Error(message);
+}
+
+export function extractXmppDomain(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('JID or domain is required');
+  }
+
+  const bare = trimmed.split('/')[0] || trimmed;
+
+  if (bare.includes('://')) {
+    try {
+      const parsed = new URL(bare);
+      if (parsed.hostname) return parsed.hostname;
+    } catch {
+      // Continue to JID/domain parsing below
+    }
+  }
+
+  if (bare.includes('@')) {
+    const [, domain] = bare.split('@', 2);
+    if (!domain || domain.trim().length === 0) {
+      throw new Error('Invalid JID — expected user@domain');
+    }
+    return domain.trim().toLowerCase();
+  }
+
+  return bare.toLowerCase();
+}
+
+export function buildXmppJid(localpart: string, domain: string): string {
+  const cleanLocalpart = localpart.trim();
+  const cleanDomain = domain.trim();
+  if (!cleanLocalpart || !cleanDomain) {
+    throw new Error('Unable to build JID from OAuth session');
+  }
+  return `${cleanLocalpart}@${cleanDomain}`;
+}
+
+export function createPkceVerifier(): string {
+  return toBase64Url(randomBytes(32));
+}
+
+export async function createPkceCodeChallenge(verifier: string): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error('WebCrypto subtle API is not available');
+  }
+  const encoded = new TextEncoder().encode(verifier);
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', encoded);
+  return toBase64Url(new Uint8Array(digest));
+}
+
+export function createOAuthState(): string {
+  return toBase64Url(randomBytes(24));
+}
+
+export async function discoverXmppOAuthMetadata(
+  serverUrlOrDomain: string,
+  fetchImpl?: FetchLike,
+): Promise<{ domain: string; metadata: XmppOAuthMetadata }> {
+  const { baseUrl, domain } = resolveOAuthServerBase(serverUrlOrDomain);
+  const requestUrl = new URL('/.well-known/oauth-authorization-server', baseUrl);
+  const doFetch = getFetch(fetchImpl);
+
+  const response = await doFetch(requestUrl, {
+    method: 'GET',
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response, 'Failed to discover OAuth metadata');
+  }
+
+  const payload = await parseJsonOrThrow<Partial<XmppOAuthMetadata>>(
+    response,
+    `OAuth metadata for ${domain} is not valid JSON`,
+  );
+  if (
+    typeof payload.issuer !== 'string'
+    || typeof payload.authorization_endpoint !== 'string'
+    || typeof payload.token_endpoint !== 'string'
+  ) {
+    throw new Error('OAuth metadata response is invalid');
+  }
+
+  return { domain, metadata: payload as XmppOAuthMetadata };
+}
+
+export async function fetchXmppOAuthProviders(
+  serverUrlOrDomain: string,
+  fetchImpl?: FetchLike,
+): Promise<XmppOAuthProvider[]> {
+  const { metadata } = await discoverXmppOAuthMetadata(serverUrlOrDomain, fetchImpl);
+  const requestUrl = new URL('/api/auth/providers', metadata.issuer);
+  const doFetch = getFetch(fetchImpl);
+
+  const response = await doFetch(requestUrl, {
+    method: 'GET',
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response, 'Failed to load OAuth providers');
+  }
+
+  const payload = await parseJsonOrThrow<unknown>(
+    response,
+    'OAuth providers response is not valid JSON',
+  );
+  if (!Array.isArray(payload)) {
+    throw new Error('OAuth providers response is invalid');
+  }
+
+  return payload
+    .filter((provider): provider is XmppOAuthProvider => {
+      if (!provider || typeof provider !== 'object') return false;
+      const candidate = provider as Partial<XmppOAuthProvider>;
+      return (
+        typeof candidate.id === 'string'
+        && typeof candidate.display_name === 'string'
+        && typeof candidate.kind === 'string'
+      );
+    });
+}
+
+export function buildXmppOAuthAuthorizeUrl(input: {
+  authorizationEndpoint: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+  providerId?: string;
+}): string {
+  const authorizeUrl = new URL(input.authorizationEndpoint);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('redirect_uri', input.redirectUri);
+  authorizeUrl.searchParams.set('scope', 'xmpp:client:normal');
+  authorizeUrl.searchParams.set('state', input.state);
+  authorizeUrl.searchParams.set('code_challenge', input.codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  if (input.providerId && input.providerId.trim().length > 0) {
+    authorizeUrl.searchParams.set('provider', input.providerId);
+  }
+  return authorizeUrl.toString();
+}
+
+export function storePendingXmppOAuthFlow(
+  flow: PendingXmppOAuthFlow,
+  storage?: StorageLike,
+): void {
+  getStorage(storage).setItem(XMPP_OAUTH_PENDING_FLOW_KEY, JSON.stringify(flow));
+}
+
+export function consumePendingXmppOAuthFlow(
+  expectedState: string,
+  storage?: StorageLike,
+): PendingXmppOAuthFlow {
+  const store = getStorage(storage);
+  const raw = store.getItem(XMPP_OAUTH_PENDING_FLOW_KEY);
+  store.removeItem(XMPP_OAUTH_PENDING_FLOW_KEY);
+
+  if (!raw) {
+    throw new Error('Missing OAuth flow state. Please retry sign-in.');
+  }
+
+  let parsed: PendingXmppOAuthFlow;
+  try {
+    parsed = JSON.parse(raw) as PendingXmppOAuthFlow;
+  } catch {
+    throw new Error('Stored OAuth flow is invalid. Please retry sign-in.');
+  }
+
+  if (parsed.state !== expectedState) {
+    throw new Error('OAuth state mismatch. Please retry sign-in.');
+  }
+
+  if (
+    typeof parsed.createdAt !== 'number'
+    || parsed.createdAt + FLOW_MAX_AGE_MS < Date.now()
+  ) {
+    throw new Error('OAuth flow has expired. Please retry sign-in.');
+  }
+
+  return parsed;
+}
+
+export async function exchangeXmppOAuthCode(input: {
+  tokenEndpoint: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+  fetchImpl?: FetchLike;
+}): Promise<XmppOAuthTokenResponse> {
+  const doFetch = getFetch(input.fetchImpl);
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    code_verifier: input.codeVerifier,
+  });
+
+  const response = await doFetch(input.tokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response, 'OAuth token exchange failed');
+  }
+
+  const payload = (await response.json()) as Partial<XmppOAuthTokenResponse>;
+  if (
+    typeof payload.access_token !== 'string'
+    || typeof payload.token_type !== 'string'
+    || typeof payload.scope !== 'string'
+    || typeof payload.expires_in !== 'number'
+  ) {
+    throw new Error('OAuth token response is invalid');
+  }
+
+  return payload as XmppOAuthTokenResponse;
+}
+
+export async function fetchXmppOAuthSession(input: {
+  sessionEndpoint: string;
+  sessionId: string;
+  fetchImpl?: FetchLike;
+}): Promise<XmppOAuthSessionResponse> {
+  const doFetch = getFetch(input.fetchImpl);
+  const endpoint = new URL(input.sessionEndpoint);
+  endpoint.searchParams.set('session_id', input.sessionId);
+
+  const response = await doFetch(endpoint, {
+    method: 'GET',
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    throw await parseErrorResponse(response, 'Failed to resolve OAuth session');
+  }
+
+  const payload = (await response.json()) as Partial<XmppOAuthSessionResponse>;
+  if (
+    typeof payload.session_id !== 'string'
+    || typeof payload.user_id !== 'string'
+    || typeof payload.username !== 'string'
+    || typeof payload.xmpp_localpart !== 'string'
+    || typeof payload.is_expired !== 'boolean'
+  ) {
+    throw new Error('OAuth session response is invalid');
+  }
+
+  return {
+    session_id: payload.session_id,
+    user_id: payload.user_id,
+    username: payload.username,
+    xmpp_localpart: payload.xmpp_localpart,
+    is_expired: payload.is_expired,
+    expires_at: payload.expires_at ?? null,
+  };
+}
+
+export async function beginXmppOAuthFlow(
+  input: BeginXmppOAuthFlowInput,
+): Promise<{ authorizeUrl: string; flow: PendingXmppOAuthFlow }> {
+  const { domain, metadata } = await discoverXmppOAuthMetadata(input.jidOrDomain, input.fetchImpl);
+  const resolvedEndpoint = input.endpoint?.trim() || await discoverWebSocketEndpoint(domain);
+  const resolvedBaseUrl = getBaseUrl(input.callbackBaseUrl);
+  const resolvedRedirectUri = input.redirectUri
+    ?? new URL(DEFAULT_CALLBACK_PATH, resolvedBaseUrl).toString();
+  const codeVerifier = createPkceVerifier();
+  const state = createOAuthState();
+  const codeChallenge = await createPkceCodeChallenge(codeVerifier);
+
+  const flow: PendingXmppOAuthFlow = {
+    state,
+    codeVerifier,
+    redirectUri: resolvedRedirectUri,
+    domain,
+    endpoint: resolvedEndpoint,
+    providerId: input.providerId ?? null,
+    sessionEndpoint: new URL('/api/auth/session', metadata.issuer).toString(),
+    tokenEndpoint: metadata.token_endpoint,
+    createdAt: Date.now(),
+  };
+
+  storePendingXmppOAuthFlow(flow, input.storage);
+
+  const authorizeUrl = buildXmppOAuthAuthorizeUrl({
+    authorizationEndpoint: metadata.authorization_endpoint,
+    redirectUri: resolvedRedirectUri,
+    state,
+    codeChallenge,
+    providerId: input.providerId,
+  });
+
+  return { authorizeUrl, flow };
+}
+
+export async function completeXmppOAuthFlow(input: CompleteXmppOAuthFlowInput): Promise<{
+  flow: PendingXmppOAuthFlow;
+  token: XmppOAuthTokenResponse;
+  session: XmppOAuthSessionResponse;
+  jid: string;
+}> {
+  const flow = consumePendingXmppOAuthFlow(input.state, input.storage);
+  const token = await exchangeXmppOAuthCode({
+    tokenEndpoint: flow.tokenEndpoint,
+    code: input.code,
+    redirectUri: flow.redirectUri,
+    codeVerifier: flow.codeVerifier,
+    fetchImpl: input.fetchImpl,
+  });
+
+  const session = await fetchXmppOAuthSession({
+    sessionEndpoint: flow.sessionEndpoint,
+    sessionId: token.access_token,
+    fetchImpl: input.fetchImpl,
+  });
+
+  if (session.is_expired) {
+    throw new Error('OAuth session has already expired. Please retry sign-in.');
+  }
+
+  return {
+    flow,
+    token,
+    session,
+    jid: buildXmppJid(session.xmpp_localpart, flow.domain),
+  };
+}

--- a/app/gui/src/views/XmppOAuthCallbackView.vue
+++ b/app/gui/src/views/XmppOAuthCallbackView.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useAuthStore } from '../stores/auth';
+
+const route = useRoute();
+const router = useRouter();
+const authStore = useAuthStore();
+
+const status = ref<'processing' | 'error'>('processing');
+const message = ref('Completing OAuth sign-in…');
+
+onMounted(async () => {
+  try {
+    const callbackError = route.query.error;
+    const callbackDescription = route.query.error_description;
+
+    if (typeof callbackError === 'string') {
+      const details = typeof callbackDescription === 'string'
+        ? callbackDescription
+        : callbackError;
+      throw new Error(details);
+    }
+
+    const code = route.query.code;
+    const state = route.query.state;
+    if (typeof code !== 'string' || typeof state !== 'string') {
+      throw new Error('Missing OAuth callback parameters');
+    }
+
+    await authStore.completeOAuthLogin(code, state);
+    await router.replace('/');
+  } catch (err) {
+    status.value = 'error';
+    message.value = err instanceof Error ? err.message : String(err);
+  }
+});
+
+async function backToLogin(): Promise<void> {
+  await router.replace({ name: 'login' });
+}
+</script>
+
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-background px-4">
+    <div class="w-full max-w-sm rounded-lg bg-surface p-6 text-center">
+      <h1 class="mb-2 text-xl font-bold text-foreground">
+        {{ status === 'processing' ? 'Signing in…' : 'OAuth sign-in failed' }}
+      </h1>
+
+      <p
+        class="text-sm"
+        :class="status === 'processing' ? 'text-muted' : 'text-danger'"
+      >
+        {{ message }}
+      </p>
+
+      <button
+        v-if="status === 'error'"
+        type="button"
+        class="mt-4 w-full rounded-lg bg-accent py-2 text-sm font-semibold text-white transition-colors hover:bg-accent/80"
+        @click="backToLogin"
+      >
+        Back to login
+      </button>
+    </div>
+  </div>
+</template>

--- a/chat/.dev.vars.example
+++ b/chat/.dev.vars.example
@@ -1,2 +1,2 @@
-# Local Cloudflare-compatible vars used by Astro dev.
-SERVER_BASE_URL=http://localhost:3000
+# Not needed — SERVER_BASE_URL is set via env.cue and passed to wrangler with --var.
+# Only create .dev.vars if you need to override something wrangler-specific locally.

--- a/chat/README.md
+++ b/chat/README.md
@@ -4,7 +4,7 @@ Minimal Astro + Svelte client for `waddle-server`, wired for Cloudflare Workers,
 
 ## Commands
 
-Run these from [`chat/`](/Users/icepuma/development/waddle/chat):
+Run these from `chat/`:
 
 ```sh
 cuenv task install
@@ -20,17 +20,27 @@ If you need Cloudflare runtime types without a full build:
 cuenv task generateTypes
 ```
 
+## Configuration
+
+All environment variables live in `env.cue` — not in `wrangler.jsonc` or `.dev.vars`.
+
+| Variable | Default (local) | Production |
+|---|---|---|
+| `SERVER_BASE_URL` | `http://localhost:3000` | `https://api.waddle.social` |
+
+`cuenv task dev` passes vars to wrangler via `--var`, so no `.dev.vars` file is needed.
+
 ## Local Setup
 
-1. Copy `.dev.vars.example` to `.dev.vars`.
-2. Set `SERVER_BASE_URL` in `.dev.vars` to `http://localhost:3000`.
-3. Generate Cloudflare runtime types if needed:
-   - `bun run generate-types`
+1. Start the server: `cd ../server && cuenv task dev`
+2. Start the chat: `cd ../chat && cuenv task dev`
+
+The server's `local/waddle.env.example` already includes `WADDLE_CORS_ORIGINS=http://localhost:4321,http://localhost:3000`.
 
 ## Notes
 
 - `astro.config.mjs` is the source of truth for Astro configuration.
 - `chat` does not authenticate against Colony directly. It sends the browser to `waddle-server`, which owns the Waddle session and delegates to Colony.
-- `wrangler.jsonc` is aligned with the Cloudflare adapter setup used in `colony/`.
+- `wrangler.jsonc` holds only infra config (routes, assets, compat flags). No `vars` block.
 - `cuenv task dev` runs the Wrangler local runtime for the built worker.
 - The `cuenv` tasks use Bun only. Do not introduce `npm`, `pnpm`, or `yarn`.

--- a/chat/env.cue
+++ b/chat/env.cue
@@ -9,102 +9,110 @@ name: "waddle-chat"
 let _t = tasks
 
 env: {
-  environment: production: {
-    CLOUDFLARE_ACCOUNT_ID: schema.#OnePasswordRef & {
-      ref: "op://waddle-production/Cloudflare/username"
-    }
-    CLOUDFLARE_API_TOKEN: schema.#OnePasswordRef & {
-      ref: "op://waddle-production/Cloudflare/password"
-    }
-  }
+	vars: {
+		SERVER_BASE_URL: "http://localhost:3000"
+	}
+
+	environment: production: {
+		vars: {
+			SERVER_BASE_URL: "https://api.waddle.social"
+		}
+
+		CLOUDFLARE_ACCOUNT_ID: schema.#OnePasswordRef & {
+			ref: "op://waddle-production/Cloudflare/username"
+		}
+		CLOUDFLARE_API_TOKEN: schema.#OnePasswordRef & {
+			ref: "op://waddle-production/Cloudflare/password"
+		}
+	}
 }
 
 ci: pipelines: {
-  default: {
-    environment: "production"
-    when: {
-      branch:        ["main"]
-      defaultBranch: true
-      manual:        true
-    }
-    tasks: [_t.deployMain]
-  }
-  pullRequest: {
-    environment: "production"
-    when: {
-      pullRequest: true
-    }
-    tasks: [_t.deployPreview]
-  }
+	default: {
+		environment: "production"
+		when: {
+			branch:        ["main"]
+			defaultBranch: true
+			manual:        true
+		}
+		tasks: [_t.deployMain]
+	}
+	pullRequest: {
+		environment: "production"
+		when: {
+			pullRequest: true
+		}
+		tasks: [_t.deployPreview]
+	}
 }
 
 tasks: {
-  install: {
-    command: "bun"
-    args: ["install", "--frozen-lockfile"]
-    inputs: [
-      "package.json",
-      "bun.lock",
-    ]
-  }
-  generateTypes: {
-    command: "bun"
-    args: ["run", "generate-types"]
-    dependsOn: [_t.install]
-    inputs: [
-      "package.json",
-      "bun.lock",
-      "wrangler.jsonc",
-    ]
-    outputs: [
-      "worker-configuration.d.ts",
-    ]
-  }
-  dev: {
-    command: "bun"
-    args: ["x", "wrangler", "dev", "--local", "--port", "4321"]
-    dependsOn: [_t.build]
-  }
-  build: {
-    command: "bun"
-    args: ["run", "build"]
-    dependsOn: [_t.generateTypes]
-    inputs: [
-      "package.json",
-      "bun.lock",
-      "astro.config.mjs",
-      "svelte.config.js",
-      "tsconfig.json",
-      "wrangler.jsonc",
-      "src/**",
-      "public/**",
-    ]
-    outputs: [
-      "dist/**",
-    ]
-  }
-  deployPreview: {
-    command: "bun"
-    args: ["x", "wrangler", "versions", "upload"]
-    dependsOn: [_t.build]
-    outputs: [
-      ".wrangler/**",
-    ]
-  }
-  deployProduction: {
-    command: "bun"
-    args: ["x", "wrangler", "deploy"]
-    dependsOn: [_t.build]
-    inputs: [
-      "wrangler.jsonc",
-      "dist/**",
-    ]
-    outputs: [
-      ".wrangler/**",
-    ]
-  }
-  deployMain: schema.#Task & {
-    command: "true"
-    dependsOn: [_t.deployProduction]
-  }
+	install: {
+		command: "bun"
+		args: ["install", "--frozen-lockfile"]
+		inputs: [
+			"package.json",
+			"bun.lock",
+		]
+	}
+	generateTypes: {
+		command: "bun"
+		args: ["run", "generate-types"]
+		dependsOn: [_t.install]
+		inputs: [
+			"package.json",
+			"bun.lock",
+			"wrangler.jsonc",
+		]
+		outputs: [
+			"worker-configuration.d.ts",
+		]
+	}
+	dev: {
+		command: "bun"
+		args: ["x", "wrangler", "dev", "--local", "--port", "4321", "--var", "SERVER_BASE_URL:${SERVER_BASE_URL}"]
+		dependsOn: [_t.build]
+	}
+	build: {
+		command: "bun"
+		args: ["run", "build"]
+		dependsOn: [_t.generateTypes]
+		inputs: [
+			"package.json",
+			"bun.lock",
+			"astro.config.mjs",
+			"svelte.config.js",
+			"tsconfig.json",
+			"wrangler.jsonc",
+			"src/**",
+			"public/**",
+		]
+		outputs: [
+			"dist/**",
+		]
+	}
+	deployPreview: {
+		command: "bun"
+		args: ["x", "wrangler", "versions", "upload", "--var", "SERVER_BASE_URL:${SERVER_BASE_URL}"]
+		dependsOn: [_t.build]
+		outputs: [
+			".wrangler/**",
+		]
+	}
+	deployProduction: {
+		command: "bun"
+		args: ["x", "wrangler", "deploy", "--var", "SERVER_BASE_URL:${SERVER_BASE_URL}"]
+		dependsOn: [_t.build]
+		inputs: [
+			"wrangler.jsonc",
+			"dist/**",
+		]
+		outputs: [
+			".wrangler/**",
+		]
+	}
+	deployMain: schema.#Task & {
+		command: "true"
+		dependsOn: [_t.deployProduction]
+	}
 }

--- a/chat/wrangler.jsonc
+++ b/chat/wrangler.jsonc
@@ -22,8 +22,5 @@
   ],
   "observability": {
     "enabled": true
-  },
-  "vars": {
-    "SERVER_BASE_URL": "https://server.waddle.social"
   }
 }

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -33,6 +33,15 @@ use std::sync::Arc;
 use tracing::{error, instrument, warn};
 use uuid::Uuid;
 
+/// A dynamically registered OAuth client (RFC 7591).
+#[derive(Debug, Clone)]
+pub struct DynamicClient {
+    pub client_id: String,
+    pub redirect_uris: Vec<String>,
+    pub client_name: Option<String>,
+    pub registered_at: DateTime<Utc>,
+}
+
 /// Shared auth state.
 pub struct AuthState {
     pub session_manager: SessionManager,
@@ -44,6 +53,8 @@ pub struct AuthState {
     pub pending_auth: Arc<DashMap<String, PendingAuthorization>>,
     pub device_auth: Arc<DashMap<String, DeviceAuthorization>>,
     pub xmpp_auth_codes: Arc<DashMap<String, XmppAuthCode>>,
+    /// RFC 7591 dynamic client registrations (XEP-0493 §2.3.2).
+    pub dynamic_clients: Arc<DashMap<String, DynamicClient>>,
 }
 
 impl AuthState {
@@ -69,7 +80,26 @@ impl AuthState {
             pending_auth: Arc::new(DashMap::new()),
             device_auth: Arc::new(DashMap::new()),
             xmpp_auth_codes: Arc::new(DashMap::new()),
+            dynamic_clients: Arc::new(DashMap::new()),
         }
+    }
+
+    /// Register a dynamically discovered OAuth client (RFC 7591).
+    pub fn register_dynamic_client(
+        &self,
+        client_id: &str,
+        redirect_uris: &[String],
+        client_name: Option<&str>,
+    ) {
+        self.dynamic_clients.insert(
+            client_id.to_string(),
+            DynamicClient {
+                client_id: client_id.to_string(),
+                redirect_uris: redirect_uris.to_vec(),
+                client_name: client_name.map(String::from),
+                registered_at: Utc::now(),
+            },
+        );
     }
 
     fn callback_url(&self) -> String {
@@ -237,6 +267,8 @@ pub enum PendingFlow {
         client_redirect_uri: String,
         client_state: Option<String>,
         client_code_challenge: Option<String>,
+        /// XEP-0493 §3 validated scope (e.g. "xmpp:client:normal").
+        granted_scope: String,
     },
 }
 
@@ -268,6 +300,8 @@ pub struct XmppAuthCode {
     pub session_id: String,
     pub redirect_uri: String,
     pub code_challenge: Option<String>,
+    /// XEP-0493 scope granted during authorization.
+    pub granted_scope: String,
     pub created_at: DateTime<Utc>,
 }
 
@@ -428,6 +462,7 @@ pub async fn start_handler(
                 client_redirect_uri,
                 client_state: query.client_state,
                 client_code_challenge: query.code_challenge,
+                granted_scope: super::xmpp_oauth::SCOPE_CLIENT_NORMAL.to_string(),
             }
         }
         _ => {
@@ -623,6 +658,7 @@ pub async fn callback_handler(
             client_redirect_uri,
             client_state,
             client_code_challenge,
+            granted_scope,
         } => {
             let auth_code = Uuid::new_v4().to_string();
             state.xmpp_auth_codes.insert(
@@ -631,6 +667,7 @@ pub async fn callback_handler(
                     session_id: session.id,
                     redirect_uri: client_redirect_uri.clone(),
                     code_challenge: client_code_challenge,
+                    granted_scope,
                     created_at: Utc::now(),
                 },
             );

--- a/server/crates/waddle-server/src/server/routes/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/mod.rs
@@ -10,6 +10,6 @@ pub mod users; // Authenticated user search
 pub mod waddles; // Waddle (community) CRUD operations
 pub mod websocket; // XMPP over WebSocket (RFC 7395)
 pub mod well_known; // /.well-known/ endpoints (host-meta, etc.)
-pub mod xmpp_oauth; // XMPP OAuth (XEP-0493) for standard XMPP clients
+pub mod xmpp_oauth; // XEP-0493 OAuth Client Login (RFC 7628 + RFC 8414 + RFC 7591)
 
 // Future route modules will be defined here:

--- a/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
+++ b/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
@@ -1,4 +1,10 @@
-//! XMPP OAuth routes (XEP-0493) backed by the auth broker.
+//! XEP-0493: OAuth Client Login routes backed by the auth broker.
+//!
+//! Implements the HTTP-side of XEP-0493 (OAuth Client Login):
+//! - RFC 8414 authorization server metadata (`/.well-known/oauth-authorization-server`)
+//! - Authorization endpoint with PKCE (RFC 7636)
+//! - Token endpoint (Authorization Code grant)
+//! - RFC 7591 Dynamic Client Registration (DCR)
 
 use super::auth::{AuthState, ErrorResponse, PendingFlow};
 use axum::{
@@ -22,6 +28,7 @@ pub fn router(auth_state: Arc<AuthState>) -> Router {
         )
         .route("/api/auth/xmpp/authorize", get(xmpp_authorize_handler))
         .route("/api/auth/xmpp/token", post(xmpp_token_handler))
+        .route("/api/auth/xmpp/register", post(xmpp_register_handler))
         .with_state(auth_state)
 }
 
@@ -30,6 +37,7 @@ struct OAuthServerMetadata {
     issuer: String,
     authorization_endpoint: String,
     token_endpoint: String,
+    registration_endpoint: String,
     response_types_supported: Vec<String>,
     grant_types_supported: Vec<String>,
     code_challenge_methods_supported: Vec<String>,
@@ -37,16 +45,26 @@ struct OAuthServerMetadata {
     token_endpoint_auth_methods_supported: Vec<String>,
 }
 
+/// XEP-0493 scopes per §3.
+pub const SCOPE_CLIENT_NORMAL: &str = "xmpp:client:normal";
+pub const SCOPE_ACCOUNT_READ: &str = "xmpp:account:read";
+pub const SCOPE_ACCOUNT_WRITE: &str = "xmpp:account:write";
+
 #[instrument(skip(state))]
 pub async fn oauth_discovery_handler(State(state): State<Arc<AuthState>>) -> impl IntoResponse {
     let metadata = OAuthServerMetadata {
         issuer: state.base_url.clone(),
         authorization_endpoint: format!("{}/api/auth/xmpp/authorize", state.base_url),
         token_endpoint: format!("{}/api/auth/xmpp/token", state.base_url),
+        registration_endpoint: format!("{}/api/auth/xmpp/register", state.base_url),
         response_types_supported: vec!["code".to_string()],
         grant_types_supported: vec!["authorization_code".to_string()],
         code_challenge_methods_supported: vec!["S256".to_string()],
-        scopes_supported: vec!["xmpp".to_string()],
+        scopes_supported: vec![
+            SCOPE_CLIENT_NORMAL.to_string(),
+            SCOPE_ACCOUNT_READ.to_string(),
+            SCOPE_ACCOUNT_WRITE.to_string(),
+        ],
         token_endpoint_auth_methods_supported: vec!["none".to_string()],
     };
 
@@ -66,10 +84,27 @@ pub struct XmppAuthorizeQuery {
     pub code_challenge_method: Option<String>,
     #[serde(default)]
     pub state: Option<String>,
+    #[serde(default)]
+    pub scope: Option<String>,
 }
 
 fn default_response_type() -> String {
     "code".to_string()
+}
+
+/// Recognised XEP-0493 scopes.
+const VALID_SCOPES: &[&str] = &[SCOPE_CLIENT_NORMAL, SCOPE_ACCOUNT_READ, SCOPE_ACCOUNT_WRITE];
+
+/// Validate a space-separated scope string. Returns the validated scope
+/// or a default of `xmpp:client:normal` when none is provided.
+fn validate_scope(scope: Option<&str>) -> Result<String, String> {
+    let requested = scope.unwrap_or(SCOPE_CLIENT_NORMAL);
+    for s in requested.split_whitespace() {
+        if !VALID_SCOPES.contains(&s) {
+            return Err(format!("Unknown scope: {}", s));
+        }
+    }
+    Ok(requested.to_string())
 }
 
 #[instrument(skip(state))]
@@ -100,6 +135,18 @@ pub async fn xmpp_authorize_handler(
                 .into_response();
         }
     }
+
+    // XEP-0493 §3: validate requested scope
+    let granted_scope = match validate_scope(params.scope.as_deref()) {
+        Ok(s) => s,
+        Err(msg) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new("invalid_scope", &msg)),
+            )
+                .into_response();
+        }
+    };
 
     let provider_id = match params.provider {
         Some(v) => v,
@@ -138,6 +185,7 @@ pub async fn xmpp_authorize_handler(
                 client_redirect_uri: params.redirect_uri,
                 client_state: params.state,
                 client_code_challenge: params.code_challenge,
+                granted_scope,
             },
         )
         .await
@@ -156,6 +204,8 @@ pub struct XmppTokenRequest {
     pub grant_type: String,
     pub code: String,
     pub redirect_uri: String,
+    #[serde(default)]
+    pub client_id: Option<String>,
     #[serde(default)]
     pub code_verifier: Option<String>,
 }
@@ -187,6 +237,18 @@ pub async fn xmpp_token_handler(
             )),
         )
             .into_response();
+    }
+
+    // RFC 6749 §4.1.3: public clients MUST send client_id.
+    // If a DCR-registered client_id is provided, validate it.
+    if let Some(ref cid) = request.client_id {
+        if cid.starts_with("dcr-") && !state.dynamic_clients.contains_key(cid) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new("invalid_client", "Unknown client_id")),
+            )
+                .into_response();
+        }
     }
 
     let code = match state.xmpp_auth_codes.remove(&request.code) {
@@ -268,6 +330,7 @@ pub async fn xmpp_token_handler(
     debug!(
         user_id = %session.user_id,
         username = %session.username,
+        scope = %code.granted_scope,
         "Issued XMPP OAuth bearer token"
     );
 
@@ -277,8 +340,514 @@ pub async fn xmpp_token_handler(
             access_token: session.id,
             token_type: "Bearer".to_string(),
             expires_in: 3600,
-            scope: "xmpp".to_string(),
+            scope: code.granted_scope,
         }),
     )
         .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// RFC 7591: OAuth 2.0 Dynamic Client Registration
+// Required by XEP-0493 §2.3.2 so third-party clients can auto-register.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct DcrRequest {
+    /// Human-readable client name.
+    #[serde(default)]
+    pub client_name: Option<String>,
+    /// Redirect URIs the client will use.
+    #[serde(default)]
+    pub redirect_uris: Vec<String>,
+    /// URI for the client's homepage/logo.
+    #[serde(default)]
+    pub client_uri: Option<String>,
+    /// Grant types the client intends to use.
+    #[serde(default)]
+    pub grant_types: Vec<String>,
+    /// Token endpoint auth method. Public XMPP clients use "none".
+    #[serde(default)]
+    pub token_endpoint_auth_method: Option<String>,
+    /// Response types (should contain "code").
+    #[serde(default)]
+    pub response_types: Vec<String>,
+    /// Software identifier.
+    #[serde(default)]
+    pub software_id: Option<String>,
+    /// Software version.
+    #[serde(default)]
+    pub software_version: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DcrResponse {
+    pub client_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    pub client_id_issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_name: Option<String>,
+    pub redirect_uris: Vec<String>,
+    pub grant_types: Vec<String>,
+    pub token_endpoint_auth_method: String,
+    pub response_types: Vec<String>,
+}
+
+/// RFC 7591 Dynamic Client Registration endpoint.
+///
+/// XEP-0493 §2.3.2 requires this so third-party XMPP clients can register
+/// themselves before initiating the authorization flow.
+///
+/// For now this is a permissive implementation that accepts any registration
+/// and issues a client_id. A production deployment should add rate-limiting
+/// and may persist registrations for audit/revocation.
+#[instrument(skip(state))]
+pub async fn xmpp_register_handler(
+    State(state): State<Arc<AuthState>>,
+    Json(request): Json<DcrRequest>,
+) -> impl IntoResponse {
+    // Validate redirect_uris — at least one is required
+    if request.redirect_uris.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "invalid_client_metadata",
+                "At least one redirect_uri is required",
+            )),
+        )
+            .into_response();
+    }
+
+    // Validate redirect URIs use https (or localhost for dev)
+    for uri in &request.redirect_uris {
+        match url::Url::parse(uri) {
+            Ok(parsed) => {
+                let is_localhost = parsed.host_str().map_or(false, |h| {
+                    h == "localhost" || h == "127.0.0.1" || h == "[::1]"
+                });
+                if parsed.scheme() != "https" && !is_localhost {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorResponse::new(
+                            "invalid_redirect_uri",
+                            "redirect_uris must use https (except localhost)",
+                        )),
+                    )
+                        .into_response();
+                }
+            }
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse::new(
+                        "invalid_redirect_uri",
+                        "Invalid redirect_uri format",
+                    )),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    // Generate a unique client_id
+    let client_id = format!("dcr-{}", uuid::Uuid::new_v4());
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let auth_method = request
+        .token_endpoint_auth_method
+        .unwrap_or_else(|| "none".to_string());
+
+    let grant_types = if request.grant_types.is_empty() {
+        vec!["authorization_code".to_string()]
+    } else {
+        request.grant_types
+    };
+
+    let response_types = if request.response_types.is_empty() {
+        vec!["code".to_string()]
+    } else {
+        request.response_types
+    };
+
+    // Store the registration for later validation
+    state.register_dynamic_client(
+        &client_id,
+        &request.redirect_uris,
+        request.client_name.as_deref(),
+    );
+
+    debug!(
+        client_id = %client_id,
+        client_name = ?request.client_name,
+        redirect_uris = ?request.redirect_uris,
+        "Registered dynamic OAuth client"
+    );
+
+    (
+        StatusCode::CREATED,
+        Json(DcrResponse {
+            client_id,
+            client_secret: None, // Public clients don't get secrets
+            client_id_issued_at: now,
+            client_name: request.client_name,
+            redirect_uris: request.redirect_uris,
+            grant_types,
+            token_endpoint_auth_method: auth_method,
+            response_types,
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{
+        AuthProviderConfig, AuthProviderKind, AuthProviderTokenEndpointAuthMethod, Session,
+    };
+    use crate::config::{AuthConfig, ServerConfig, ServerMode};
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use crate::server::routes::auth::XmppAuthCode;
+    use crate::server::AppState;
+    use axum::{body::Body, http::Request};
+    use chrono::{Duration, Utc};
+    use http_body_util::BodyExt;
+    use serde_json::Value;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn test_provider() -> AuthProviderConfig {
+        AuthProviderConfig {
+            id: "github".to_string(),
+            display_name: "GitHub".to_string(),
+            kind: AuthProviderKind::OAuth2,
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::ClientSecretPost,
+            scopes: vec!["read:user".to_string()],
+            issuer: Some("https://github.com".to_string()),
+            authorization_endpoint: Some("https://github.com/login/oauth/authorize".to_string()),
+            token_endpoint: Some("https://github.com/login/oauth/access_token".to_string()),
+            userinfo_endpoint: Some("https://api.github.com/user".to_string()),
+            jwks_uri: None,
+            subject_claim: "id".to_string(),
+            username_claim: Some("login".to_string()),
+            email_claim: Some("email".to_string()),
+        }
+    }
+
+    fn test_server_config() -> ServerConfig {
+        ServerConfig {
+            mode: ServerMode::HomeServer,
+            base_url: "http://localhost:3000".to_string(),
+            session_key: Some("test-key-32-bytes-long-for-aes!".to_string()),
+            auth: AuthConfig {
+                providers: vec![test_provider()],
+            },
+        }
+    }
+
+    async fn create_test_auth_state() -> Arc<AuthState> {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig::default())
+            .await
+            .expect("database pool should initialize");
+
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations should run");
+
+        let server_config = test_server_config();
+        let app_state = Arc::new(AppState::new(Arc::new(db_pool)));
+
+        Arc::new(AuthState::new(
+            app_state,
+            &server_config,
+            server_config.session_key.as_ref().map(|s| s.as_bytes()),
+        ))
+    }
+
+    async fn create_session(state: &Arc<AuthState>) -> Session {
+        let session = Session::new("user-1", "alice", "alice");
+        state
+            .session_manager
+            .create_session(&session)
+            .await
+            .expect("session should be created");
+        session
+    }
+
+    fn insert_auth_code(
+        state: &Arc<AuthState>,
+        code: &str,
+        session_id: &str,
+        redirect_uri: &str,
+        code_challenge: Option<String>,
+        created_at: chrono::DateTime<Utc>,
+    ) {
+        state.xmpp_auth_codes.insert(
+            code.to_string(),
+            XmppAuthCode {
+                session_id: session_id.to_string(),
+                redirect_uri: redirect_uri.to_string(),
+                code_challenge,
+                granted_scope: SCOPE_CLIENT_NORMAL.to_string(),
+                created_at,
+            },
+        );
+    }
+
+    fn encode_form(fields: &[(&str, &str)]) -> String {
+        fields
+            .iter()
+            .map(|(key, value)| {
+                format!(
+                    "{}={}",
+                    urlencoding::encode(key),
+                    urlencoding::encode(value)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("&")
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("body should be readable")
+            .to_bytes();
+        serde_json::from_slice(&bytes).expect("response body should be valid json")
+    }
+
+    #[tokio::test]
+    async fn xmpp_authorize_rejects_unsupported_response_type() {
+        let state = create_test_auth_state().await;
+        let app = router(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/auth/xmpp/authorize?response_type=token&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback")
+                    .body(Body::empty())
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"], "unsupported_response_type");
+    }
+
+    #[tokio::test]
+    async fn xmpp_token_accepts_valid_pkce_verifier() {
+        let state = create_test_auth_state().await;
+        let session = create_session(&state).await;
+
+        let code = "auth-code-valid-pkce";
+        let redirect_uri = "https://client.example/callback";
+        let code_verifier = "valid-verifier-123";
+        let code_challenge = pkce_s256(code_verifier);
+
+        insert_auth_code(
+            &state,
+            code,
+            &session.id,
+            redirect_uri,
+            Some(code_challenge),
+            Utc::now(),
+        );
+
+        let app = router(state.clone());
+        let body = encode_form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("code_verifier", code_verifier),
+        ]);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload = response_json(response).await;
+        assert_eq!(payload["access_token"], session.id);
+        assert_eq!(payload["token_type"], "Bearer");
+        assert!(!state.xmpp_auth_codes.contains_key(code));
+    }
+
+    #[tokio::test]
+    async fn xmpp_token_rejects_invalid_pkce_verifier() {
+        let state = create_test_auth_state().await;
+        let session = create_session(&state).await;
+
+        let code = "auth-code-invalid-pkce";
+        let redirect_uri = "https://client.example/callback";
+
+        insert_auth_code(
+            &state,
+            code,
+            &session.id,
+            redirect_uri,
+            Some(pkce_s256("expected-verifier")),
+            Utc::now(),
+        );
+
+        let app = router(state);
+        let body = encode_form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("code_verifier", "wrong-verifier"),
+        ]);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(body))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response_json(response).await;
+        assert_eq!(payload["error"], "invalid_grant");
+        assert_eq!(payload["message"], "PKCE verification failed");
+    }
+
+    #[tokio::test]
+    async fn xmpp_token_rejects_edge_cases() {
+        let state = create_test_auth_state().await;
+        let session = create_session(&state).await;
+        let app = router(state.clone());
+
+        // unsupported grant type
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(encode_form(&[
+                        ("grant_type", "refresh_token"),
+                        ("code", "any-code"),
+                        ("redirect_uri", "https://client.example/callback"),
+                    ])))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response_json(response).await;
+        assert_eq!(payload["error"], "unsupported_grant_type");
+
+        // redirect_uri mismatch
+        insert_auth_code(
+            &state,
+            "code-redirect-mismatch",
+            &session.id,
+            "https://client.example/callback-a",
+            None,
+            Utc::now(),
+        );
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(encode_form(&[
+                        ("grant_type", "authorization_code"),
+                        ("code", "code-redirect-mismatch"),
+                        ("redirect_uri", "https://client.example/callback-b"),
+                    ])))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response_json(response).await;
+        assert_eq!(payload["error"], "invalid_grant");
+        assert_eq!(payload["message"], "redirect_uri mismatch");
+
+        // expired code
+        insert_auth_code(
+            &state,
+            "code-expired",
+            &session.id,
+            "https://client.example/callback",
+            None,
+            Utc::now() - Duration::minutes(11),
+        );
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(encode_form(&[
+                        ("grant_type", "authorization_code"),
+                        ("code", "code-expired"),
+                        ("redirect_uri", "https://client.example/callback"),
+                    ])))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response_json(response).await;
+        assert_eq!(payload["error"], "invalid_grant");
+        assert_eq!(payload["message"], "Authorization code expired");
+
+        // missing session
+        insert_auth_code(
+            &state,
+            "code-missing-session",
+            "missing-session-id",
+            "https://client.example/callback",
+            None,
+            Utc::now(),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/xmpp/token")
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .body(Body::from(encode_form(&[
+                        ("grant_type", "authorization_code"),
+                        ("code", "code-missing-session"),
+                        ("redirect_uri", "https://client.example/callback"),
+                    ])))
+                    .expect("request should build"),
+            )
+            .await
+            .expect("request should succeed");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let payload = response_json(response).await;
+        assert_eq!(payload["error"], "invalid_grant");
+        assert_eq!(payload["message"], "Session not found");
+    }
 }

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -249,7 +249,7 @@ impl waddle_xmpp::AppState for XmppAppState {
         &self.domain
     }
 
-    /// Get the OAuth discovery URL for XMPP OAUTHBEARER (XEP-0493).
+    /// Get the OAuth discovery URL for XEP-0493 OAuth Client Login.
     ///
     /// Returns the RFC 8414 OAuth authorization server metadata endpoint URL.
     fn oauth_discovery_url(&self) -> String {

--- a/server/crates/waddle-xmpp/src/auth/mod.rs
+++ b/server/crates/waddle-xmpp/src/auth/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements SASL authentication for XMPP connections, including:
 //! - SASL PLAIN (username/password or JID/token)
-//! - SASL OAUTHBEARER (RFC 7628, XEP-0493)
+//! - SASL OAUTHBEARER (RFC 7628) with XEP-0493 OAuth Client Login discovery
 //! - SASL SCRAM-SHA-256 (RFC 5802, RFC 7677)
 
 pub mod scram;
@@ -21,7 +21,7 @@ use crate::XmppError;
 pub enum SaslMechanism {
     /// PLAIN mechanism (RFC 4616)
     Plain,
-    /// OAUTHBEARER mechanism (RFC 7628, XEP-0493)
+    /// OAUTHBEARER mechanism (RFC 7628)
     OAuthBearer,
     /// SCRAM-SHA-256 mechanism (RFC 5802, RFC 7677)
     ScramSha256,
@@ -108,8 +108,9 @@ pub struct OAuthBearerCredentials {
 /// Result of parsing OAUTHBEARER SASL data.
 #[derive(Debug, Clone)]
 pub enum OAuthBearerResult {
-    /// Client sent an empty/discovery request
-    /// Per XEP-0493 §3.2, server should respond with discovery URL
+    /// Client sent an empty/discovery request.
+    /// Per XEP-0493 §2.3.1 + RFC 7628 §3.2.2, server responds with
+    /// a JSON challenge containing the `openid-configuration` discovery URL.
     DiscoveryRequest,
     /// Client sent valid credentials with a token
     Credentials(OAuthBearerCredentials),
@@ -128,8 +129,8 @@ pub enum OAuthBearerResult {
 /// Example with token: `n,,\x01auth=Bearer TOKEN\x01\x01`
 /// Empty request for discovery: `n,,\x01\x01` (or just empty data)
 ///
-/// Per XEP-0493:
-/// - Empty or minimal data triggers OAuth discovery response
+/// Per XEP-0493 §2.3.1 + RFC 7628:
+/// - Empty or minimal data triggers OAuth discovery (JSON challenge)
 /// - Token data is validated against the session store
 pub fn parse_oauthbearer(data: &[u8]) -> Result<OAuthBearerResult, XmppError> {
     // Empty data or just "n,," means discovery request
@@ -140,7 +141,7 @@ pub fn parse_oauthbearer(data: &[u8]) -> Result<OAuthBearerResult, XmppError> {
     let data_str = String::from_utf8_lossy(data);
 
     // Check for minimal/discovery request patterns
-    // XEP-0493 specifies sending empty OAUTHBEARER or just GS2 header for discovery
+    // XEP-0493 §2.3.1: client sends empty OAUTHBEARER to trigger discovery
     // Common patterns: "", "n,,\x01\x01", "n,,"
     if data_str.trim().is_empty()
         || data_str == "n,,"

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -94,10 +94,11 @@ pub trait AppState: Send + Sync + 'static {
     /// Get the domain for this XMPP server.
     fn domain(&self) -> &str;
 
-    /// Get the OAuth discovery URL for XMPP OAUTHBEARER (XEP-0493).
+    /// Get the OAuth discovery URL for XEP-0493 OAuth Client Login.
     ///
-    /// This URL is sent to clients that request OAuth discovery.
-    /// Should point to the RFC 8414 OAuth authorization server metadata endpoint.
+    /// Returned inside the RFC 7628 §3.2.2 JSON challenge as the
+    /// `openid-configuration` field. Should point to the RFC 8414
+    /// authorization server metadata endpoint.
     fn oauth_discovery_url(&self) -> String;
 
     /// List all relations a subject has on an object.

--- a/server/crates/waddle-xmpp/src/stream.rs
+++ b/server/crates/waddle-xmpp/src/stream.rs
@@ -648,36 +648,94 @@ impl XmppStream {
         Ok(())
     }
 
-    /// Send OAUTHBEARER discovery response per XEP-0493 §3.2.
+    /// Send OAUTHBEARER discovery response per XEP-0493 §2.3.1 + RFC 7628 §3.2.2.
     ///
     /// When a client sends an empty OAUTHBEARER request, we respond with
     /// the OAuth authorization server discovery URL so the client can
     /// complete the OAuth flow.
     ///
-    /// Response format per XEP-0493:
-    /// ```xml
-    /// <failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
-    ///   <not-authorized/>
-    ///   <openid-configuration>https://example.com/.well-known/oauth-authorization-server</openid-configuration>
-    /// </failure>
+    /// Per RFC 7628 §3.2.2, the server sends a JSON error object as a SASL
+    /// challenge. The client acknowledges with a dummy `\x01` response, then
+    /// the server sends the final SASL failure.
+    ///
+    /// Wire format:
+    /// ```text
+    /// S: <challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>base64(JSON)</challenge>
+    /// C: <response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>AQ==</response>
+    /// S: <failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><not-authorized/></failure>
+    /// ```
+    ///
+    /// The JSON object contains:
+    /// ```json
+    /// {
+    ///   "status": "invalid_token",
+    ///   "openid-configuration": "https://example.com/.well-known/oauth-authorization-server"
+    /// }
     /// ```
     pub async fn send_oauthbearer_discovery(
         &mut self,
         discovery_url: &str,
     ) -> Result<(), XmppError> {
-        let response = format!(
-            "<failure xmlns='{}'>\
-                <not-authorized/>\
-                <openid-configuration>{}</openid-configuration>\
-            </failure>",
-            ns::SASL,
+        // Step 1: Send RFC 7628 JSON error as a SASL challenge (base64-encoded)
+        let json_payload = format!(
+            r#"{{"status":"invalid_token","openid-configuration":"{}"}}"#,
             discovery_url
         );
-        self.write_all(response.as_bytes()).await?;
+        let encoded = BASE64_STANDARD.encode(json_payload.as_bytes());
+        let challenge = format!("<challenge xmlns='{}'>{}</challenge>", ns::SASL, encoded);
+        self.write_all(challenge.as_bytes()).await?;
         self.flush().await?;
 
-        debug!(discovery_url = %discovery_url, "Sent OAUTHBEARER discovery response");
+        debug!(discovery_url = %discovery_url, "Sent OAUTHBEARER discovery challenge");
+
+        // Step 2: Wait for the client's dummy response (RFC 7628 §3.2.3)
+        // Client MUST send either \x01 or abort
+        self.wait_for_oauthbearer_dummy_response().await?;
+
+        // Step 3: Send the final SASL failure
+        self.send_sasl_failure("not-authorized").await?;
+
+        debug!("Completed OAUTHBEARER discovery sequence");
         Ok(())
+    }
+
+    /// Wait for the client's dummy OAUTHBEARER response per RFC 7628 §3.2.3.
+    ///
+    /// After receiving the JSON discovery challenge, the client MUST send
+    /// a response containing a single `\x01` byte (base64: `AQ==`), or abort.
+    async fn wait_for_oauthbearer_dummy_response(&mut self) -> Result<(), XmppError> {
+        let mut buf = [0u8; 4096];
+
+        loop {
+            let n = self.read(&mut buf).await?;
+            if n == 0 {
+                return Err(XmppError::stream(
+                    "Connection closed during OAUTHBEARER discovery",
+                ));
+            }
+
+            self.parser.feed(&buf[..n]);
+
+            if self.parser.has_complete_stanza() {
+                let stanza = match self.parser.next_stanza()? {
+                    Some(stanza) => stanza,
+                    None => continue,
+                };
+
+                match stanza {
+                    ParsedStanza::SaslResponse { .. } => {
+                        // Got the dummy response — continue to send failure
+                        return Ok(());
+                    }
+                    _ => {
+                        // Unexpected stanza during discovery; treat as abort
+                        return Err(XmppError::auth_failed(
+                            "Unexpected stanza during OAUTHBEARER discovery",
+                        ));
+                    }
+                }
+            }
+        }
     }
 
     /// Parse SASL PLAIN authentication data.

--- a/server/crates/waddle-xmpp/tests/xep0493_oauthbearer.rs
+++ b/server/crates/waddle-xmpp/tests/xep0493_oauthbearer.rs
@@ -1,0 +1,283 @@
+#![recursion_limit = "256"]
+//! XEP-0493: OAuth Client Login compatibility suite.
+//!
+//! Tests the SASL OAUTHBEARER mechanism (RFC 7628) and discovery flow
+//! as specified by XEP-0493 §2.3.1.
+//!
+//! Discovery wire format per RFC 7628 §3.2.2:
+//! ```text
+//! C: <auth mechanism='OAUTHBEARER'>base64(empty-token)</auth>
+//! S: <challenge>base64({"status":"invalid_token","openid-configuration":"..."})</challenge>
+//! C: <response>AQ==</response>
+//! S: <failure><not-authorized/></failure>
+//! ```
+
+mod common;
+
+use base64::prelude::*;
+use common::{init_test_env, MockAppState, RawXmppClient, TestServer, DEFAULT_TIMEOUT};
+use std::sync::Arc;
+
+const SASL_NS: &str = "urn:ietf:params:xml:ns:xmpp-sasl";
+const OAUTH_DISCOVERY_URL: &str = "https://localhost/.well-known/oauth-authorization-server";
+
+async fn connect_and_get_sasl_features(
+    client: &mut RawXmppClient,
+    server: &TestServer,
+) -> std::io::Result<String> {
+    client
+        .send(&format!(
+            "<?xml version='1.0'?>\
+            <stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' \
+            to='{}' version='1.0'>",
+            server.domain
+        ))
+        .await?;
+    client
+        .read_until("</stream:features>", DEFAULT_TIMEOUT)
+        .await?;
+    client.clear();
+
+    client
+        .send("<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>")
+        .await?;
+    client.read_until("<proceed", DEFAULT_TIMEOUT).await?;
+    client.clear();
+
+    client
+        .upgrade_tls(server.tls_connector(), &server.domain)
+        .await?;
+
+    client
+        .send(&format!(
+            "<?xml version='1.0'?>\
+            <stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams' \
+            to='{}' version='1.0'>",
+            server.domain
+        ))
+        .await?;
+    client
+        .read_until("</stream:features>", DEFAULT_TIMEOUT)
+        .await
+}
+
+async fn send_oauthbearer_auth(
+    client: &mut RawXmppClient,
+    raw_payload: &str,
+) -> std::io::Result<()> {
+    let encoded = BASE64_STANDARD.encode(raw_payload.as_bytes());
+    client
+        .send(&format!(
+            "<auth xmlns='{}' mechanism='OAUTHBEARER'>{}</auth>",
+            SASL_NS, encoded
+        ))
+        .await
+}
+
+/// Helper: send empty OAUTHBEARER, receive the RFC 7628 JSON challenge,
+/// send the dummy \x01 response, then receive the SASL failure.
+///
+/// Returns the decoded JSON string from the challenge.
+async fn perform_discovery_exchange(client: &mut RawXmppClient) -> std::io::Result<String> {
+    // Server should send a <challenge> with base64-encoded JSON
+    let challenge_xml = client.read_until("</challenge>", DEFAULT_TIMEOUT).await?;
+
+    // Extract the base64 content from <challenge xmlns='...'>DATA</challenge>
+    let b64_start = challenge_xml.find('>').map(|i| i + 1).unwrap_or(0);
+    let b64_end = challenge_xml
+        .find("</challenge>")
+        .unwrap_or(challenge_xml.len());
+    let b64_data = &challenge_xml[b64_start..b64_end];
+    let json_bytes = BASE64_STANDARD
+        .decode(b64_data.trim().as_bytes())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let json_str = String::from_utf8(json_bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+    client.clear();
+
+    // Send the RFC 7628 §3.2.3 dummy response (\x01)
+    let dummy_response = BASE64_STANDARD.encode(b"\x01");
+    client
+        .send(&format!(
+            "<response xmlns='{}'>{}</response>",
+            SASL_NS, dummy_response
+        ))
+        .await?;
+
+    // Server should then send <failure><not-authorized/></failure>
+    let failure = client.read_until("</failure>", DEFAULT_TIMEOUT).await?;
+    assert!(
+        failure.contains("<not-authorized/>"),
+        "Expected <not-authorized/> in failure, got: {}",
+        failure
+    );
+
+    Ok(json_str)
+}
+
+#[tokio::test]
+async fn xep0493_discovery_returns_rfc7628_json_challenge() {
+    init_test_env();
+
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+
+    let features = connect_and_get_sasl_features(&mut client, &server)
+        .await
+        .expect("sasl features");
+    assert!(
+        features.contains("<mechanism>OAUTHBEARER</mechanism>"),
+        "Expected OAUTHBEARER mechanism advertisement, got: {}",
+        features
+    );
+
+    client.clear();
+
+    // Send empty OAUTHBEARER to trigger discovery
+    send_oauthbearer_auth(&mut client, "n,,\x01\x01")
+        .await
+        .expect("send discovery auth");
+
+    let json_str = perform_discovery_exchange(&mut client)
+        .await
+        .expect("discovery exchange");
+
+    // Validate the JSON structure per RFC 7628 §3.2.2
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_str).expect("challenge should be valid JSON");
+
+    assert_eq!(
+        parsed["status"], "invalid_token",
+        "Expected status=invalid_token, got: {}",
+        json_str
+    );
+    assert!(
+        parsed["openid-configuration"]
+            .as_str()
+            .unwrap_or("")
+            .contains("/.well-known/oauth-authorization-server"),
+        "Expected openid-configuration URL in JSON, got: {}",
+        json_str
+    );
+}
+
+#[tokio::test]
+async fn xep0493_oauthbearer_auth_succeeds_with_valid_token() {
+    init_test_env();
+
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+
+    connect_and_get_sasl_features(&mut client, &server)
+        .await
+        .expect("sasl features");
+    client.clear();
+
+    send_oauthbearer_auth(&mut client, "n,,\x01auth=Bearer valid-token-123\x01\x01")
+        .await
+        .expect("send oauth auth");
+    let response = client
+        .read_until("<success", DEFAULT_TIMEOUT)
+        .await
+        .expect("sasl success");
+
+    assert!(
+        response.contains("<success") && response.contains(SASL_NS),
+        "Expected SASL success response, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0493_oauthbearer_auth_fails_with_invalid_token() {
+    init_test_env();
+
+    let server = TestServer::start_with_state(Arc::new(MockAppState::rejecting("localhost"))).await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+
+    connect_and_get_sasl_features(&mut client, &server)
+        .await
+        .expect("sasl features");
+    client.clear();
+
+    send_oauthbearer_auth(&mut client, "n,,\x01auth=Bearer invalid-token-456\x01\x01")
+        .await
+        .expect("send oauth auth");
+    let response = client
+        .read_until("</failure>", DEFAULT_TIMEOUT)
+        .await
+        .expect("sasl failure");
+
+    assert!(
+        response.contains("<failure") && response.contains("<not-authorized/>"),
+        "Expected not-authorized failure, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0493_feature_advertisement_matches_discovery_contract() {
+    init_test_env();
+
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+
+    let features = connect_and_get_sasl_features(&mut client, &server)
+        .await
+        .expect("sasl features");
+    let advertises_oauthbearer = features.contains("<mechanism>OAUTHBEARER</mechanism>");
+
+    client.clear();
+
+    // Trigger discovery
+    send_oauthbearer_auth(&mut client, "n,,\x01\x01")
+        .await
+        .expect("send discovery auth");
+    let json_str = perform_discovery_exchange(&mut client)
+        .await
+        .expect("discovery exchange");
+    let has_discovery_url = json_str.contains(OAUTH_DISCOVERY_URL);
+
+    assert!(
+        advertises_oauthbearer && has_discovery_url,
+        "Expected OAUTHBEARER feature and matching discovery URL. features: {}, json: {}",
+        features,
+        json_str
+    );
+}
+
+#[tokio::test]
+async fn xep0493_discovery_json_contains_required_fields() {
+    init_test_env();
+
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+
+    connect_and_get_sasl_features(&mut client, &server)
+        .await
+        .expect("sasl features");
+    client.clear();
+
+    send_oauthbearer_auth(&mut client, "n,,\x01\x01")
+        .await
+        .expect("send discovery auth");
+    let json_str = perform_discovery_exchange(&mut client)
+        .await
+        .expect("discovery exchange");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).expect("valid JSON");
+
+    // RFC 7628 §3.2.2: "status" is REQUIRED
+    assert!(
+        parsed.get("status").is_some(),
+        "Missing required 'status' field in discovery JSON"
+    );
+
+    // RFC 7628 §3.2.2: "openid-configuration" is OPTIONAL but XEP-0493 §4.2
+    // says servers MUST provide it
+    assert!(
+        parsed.get("openid-configuration").is_some(),
+        "Missing 'openid-configuration' field required by XEP-0493"
+    );
+}


### PR DESCRIPTION
## Summary
- add end-to-end OAuth login in the GUI (server URL/domain input, provider loading, redirect/callback handling)
- add `xmppOAuth` utility module with PKCE/state handling, metadata discovery, token exchange, and session resolution
- hide sidebar for all public routes and add `/oauth/xmpp/callback` route/view
- implement XMPP OAuth authorization-code + PKCE handling in `xmpp_oauth` server routes
- add dedicated XEP-0493 OAUTHBEARER Rust custom test suite and route-level token exchange tests

## Validation
- ✅ `bun test app/gui/src/utils/xmppOAuth.test.ts`
- ✅ `cargo test -p waddle-server xmpp_token -- --nocapture`
- ✅ `cargo test -p waddle-xmpp --test xep0493_oauthbearer -- --nocapture`
- ⚠️ `bun test` (repo-wide) fails due missing package `xstate` in `server/scripts/ralph-loop/src/state.test.ts` (pre-existing)
- ⚠️ `bun run lint` fails due nested Biome root configuration conflict in `generators/projen-data-service/biome.json` (pre-existing)

## Notes
- callback and token flows now use PKCE verifier/challenge checks consistently
- GUI now supports provider auto-discovery from `/.well-known/oauth-authorization-server` + `/api/auth/providers`