### PR TITLE
fix(chat): preserve custom homeserver login sessions

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -252,7 +252,9 @@ onUnmounted(() => {
   <LoginScreen
     v-else-if="auth.appState.value === 'signed-out'"
     :default-server-url="props.serverBaseUrl"
+    :active-server-url="auth.activeServerUrl.value"
     :providers="auth.providers.value"
+    :error-message="auth.appError.value"
     @login="(url, pid) => auth.login(url, pid)"
     @fetch-providers="auth.fetchProviders"
   />

--- a/chat/src/components/chat/LoginScreen.vue
+++ b/chat/src/components/chat/LoginScreen.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import { ChevronDown, ChevronUp, Loader2 } from "lucide-vue-next";
+import { ChevronDown, ChevronUp } from "lucide-vue-next";
 import type { AuthProvider } from "@/lib/server-auth";
 
 const props = defineProps<{
   defaultServerUrl: string;
+  activeServerUrl: string;
   providers: AuthProvider[];
+  errorMessage: string;
 }>();
 
 const emit = defineEmits<{
@@ -16,7 +18,10 @@ const emit = defineEmits<{
 const showCustomServer = ref(false);
 const useCustom = ref(false);
 const customUrl = ref("");
-const isFetchingProviders = ref(false);
+
+function normalizeServerUrl(value: string) {
+  return value.trim().replace(/\/$/, "");
+}
 
 const displayDefault = computed(() => {
   try {
@@ -25,6 +30,17 @@ const displayDefault = computed(() => {
     return props.defaultServerUrl;
   }
 });
+
+watch(
+  () => props.activeServerUrl,
+  (serverUrl) => {
+    const normalizedActive = normalizeServerUrl(serverUrl);
+    const normalizedDefault = normalizeServerUrl(props.defaultServerUrl);
+    useCustom.value = normalizedActive !== normalizedDefault;
+    customUrl.value = useCustom.value ? normalizedActive : "";
+  },
+  { immediate: true },
+);
 
 const activeServerUrl = computed(() =>
   useCustom.value && customUrl.value.trim()
@@ -43,8 +59,13 @@ const activeServerDisplay = computed(() => {
   return displayDefault.value;
 });
 
+const singleProviderLabel = computed(
+  () => props.providers[0]?.display_name || props.providers[0]?.id || activeServerDisplay.value,
+);
+
 function selectDefault() {
   useCustom.value = false;
+  customUrl.value = "";
   emit("fetchProviders", props.defaultServerUrl);
 }
 
@@ -135,7 +156,7 @@ function handleLogin(providerId?: string) {
               v-if="useCustom"
               v-model="customUrl"
               type="url"
-              placeholder="https://api.example.com"
+              placeholder="https://server.example.com"
               class="w-full font-mono text-sm px-3 py-2 border border-current bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-background"
               @focus="selectCustom"
             />
@@ -145,6 +166,13 @@ function handleLogin(providerId?: string) {
 
       <!-- Providers / Login -->
       <div class="p-6 space-y-3">
+        <p
+          v-if="errorMessage"
+          class="border border-destructive px-3 py-2 text-sm font-mono text-destructive"
+        >
+          {{ errorMessage }}
+        </p>
+
         <template v-if="providers.length > 1">
           <label class="text-xs font-mono uppercase tracking-widest text-muted-foreground">
             Sign in with
@@ -162,9 +190,11 @@ function handleLogin(providerId?: string) {
         <button
           v-else
           class="w-full py-2 px-4 font-mono text-sm uppercase tracking-wider border border-foreground bg-foreground text-background hover:bg-foreground/90 transition-colors"
+          :disabled="providers.length === 0"
+          :class="providers.length === 0 ? 'opacity-50 cursor-not-allowed' : ''"
           @click="handleLogin(providers[0]?.id)"
         >
-          Sign in via {{ activeServerDisplay }}
+          {{ providers.length === 0 ? "No sign-in methods found" : `Sign in with ${singleProviderLabel}` }}
         </button>
       </div>
     </div>

--- a/chat/src/composables/useAuth.ts
+++ b/chat/src/composables/useAuth.ts
@@ -3,8 +3,153 @@ import { createServerAuth, type WaddleSession, type AuthProvider } from "@/lib/s
 import { WaddleApi } from "@/lib/waddle-api";
 import type { AppState } from "@/lib/chat-ui";
 
+const ACTIVE_SERVER_STORAGE_KEY = "waddle.chat.active-server";
+const SESSION_STORAGE_KEY = "waddle.chat.sessions";
+
+type SessionMap = Record<string, string>;
+
+function trimTrailingSlash(value: string) {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function normalizeServerUrl(value: string) {
+  return trimTrailingSlash(value.trim());
+}
+
+function readSessionMap(): SessionMap {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+
+    const parsed = JSON.parse(raw) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as SessionMap) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeSessionMap(sessions: SessionMap) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(sessions));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function getStoredSessionId(serverUrl: string) {
+  return readSessionMap()[normalizeServerUrl(serverUrl)] ?? null;
+}
+
+function storeSessionId(serverUrl: string, sessionId: string) {
+  const sessions = readSessionMap();
+  sessions[normalizeServerUrl(serverUrl)] = sessionId;
+  writeSessionMap(sessions);
+}
+
+function clearStoredSessionId(serverUrl: string) {
+  const sessions = readSessionMap();
+  delete sessions[normalizeServerUrl(serverUrl)];
+  writeSessionMap(sessions);
+}
+
+function loadActiveServer(defaultServerUrl: string) {
+  if (typeof window === "undefined") {
+    return defaultServerUrl;
+  }
+
+  try {
+    return normalizeServerUrl(
+      window.localStorage.getItem(ACTIVE_SERVER_STORAGE_KEY) || defaultServerUrl,
+    );
+  } catch {
+    return defaultServerUrl;
+  }
+}
+
+function saveActiveServer(serverUrl: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(ACTIVE_SERVER_STORAGE_KEY, normalizeServerUrl(serverUrl));
+  } catch {
+    // ignore storage failures
+  }
+}
+
+function buildReturnUrl(currentUrl: string, serverUrl: string, defaultServerUrl: string) {
+  const url = new URL(currentUrl);
+  const active = normalizeServerUrl(serverUrl);
+  const defaultServer = normalizeServerUrl(defaultServerUrl);
+
+  if (active !== defaultServer) {
+    url.searchParams.set("waddle_server", active);
+  } else {
+    url.searchParams.delete("waddle_server");
+  }
+
+  const hashParams = new URLSearchParams(url.hash.replace(/^#/, ""));
+  hashParams.delete("waddle_session_id");
+  const hash = hashParams.toString();
+  url.hash = hash ? `#${hash}` : "";
+
+  return url.toString();
+}
+
+function consumeRedirectState(defaultServerUrl: string) {
+  const fallbackServerUrl = loadActiveServer(defaultServerUrl);
+
+  if (typeof window === "undefined") {
+    return {
+      serverUrl: fallbackServerUrl,
+      sessionId: getStoredSessionId(fallbackServerUrl),
+    };
+  }
+
+  const url = new URL(window.location.href);
+  const hashParams = new URLSearchParams(url.hash.replace(/^#/, ""));
+  const requestedServer = url.searchParams.get("waddle_server");
+  const serverUrl = normalizeServerUrl(requestedServer || fallbackServerUrl);
+  const sessionId = hashParams.get("waddle_session_id");
+
+  if (requestedServer) {
+    url.searchParams.delete("waddle_server");
+    saveActiveServer(serverUrl);
+  }
+
+  if (sessionId) {
+    storeSessionId(serverUrl, sessionId);
+    hashParams.delete("waddle_session_id");
+  }
+
+  const nextSearch = url.searchParams.toString();
+  const nextHash = hashParams.toString();
+  const cleanedUrl = `${url.pathname}${nextSearch ? `?${nextSearch}` : ""}${nextHash ? `#${nextHash}` : ""}`;
+  const currentUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (cleanedUrl !== currentUrl) {
+    window.history.replaceState(null, "", cleanedUrl);
+  }
+
+  return {
+    serverUrl,
+    sessionId: sessionId ?? getStoredSessionId(serverUrl),
+  };
+}
+
 export function useAuth(defaultServerUrl: string) {
-  const activeServerUrl = ref(defaultServerUrl);
+  const normalizedDefaultServerUrl = normalizeServerUrl(defaultServerUrl);
+  const activeServerUrl = ref(loadActiveServer(normalizedDefaultServerUrl));
   const providers = ref<AuthProvider[]>([]);
 
   let auth = createServerAuth(activeServerUrl.value);
@@ -15,23 +160,42 @@ export function useAuth(defaultServerUrl: string) {
   const appError = ref("");
   const isBootstrapping = ref(false);
 
+  async function loadProviders() {
+    try {
+      providers.value = await auth.getProviders();
+      appError.value = providers.value.length === 0 ? "No auth providers available on this server." : "";
+    } catch (e) {
+      providers.value = [];
+      appError.value = e instanceof Error ? e.message : "Failed to load auth providers.";
+    }
+  }
+
   async function bootstrap() {
     isBootstrapping.value = true;
     appState.value = "loading";
     appError.value = "";
 
     try {
-      const loaded = await auth.getSession();
+      const redirectState = consumeRedirectState(normalizedDefaultServerUrl);
+      if (redirectState.serverUrl !== activeServerUrl.value) {
+        activeServerUrl.value = redirectState.serverUrl;
+        auth = createServerAuth(activeServerUrl.value);
+      }
+
+      const loaded = await auth.getSession(redirectState.sessionId ?? undefined);
 
       if (!loaded || loaded.is_expired) {
+        clearStoredSessionId(activeServerUrl.value);
         session.value = null;
         api.value = null;
         // Fetch available providers for the login screen
-        providers.value = await auth.getProviders();
+        await loadProviders();
         appState.value = "signed-out";
         return;
       }
 
+      saveActiveServer(activeServerUrl.value);
+      storeSessionId(activeServerUrl.value, loaded.session_id);
       session.value = loaded;
       api.value = new WaddleApi(activeServerUrl.value, loaded.session_id);
       appState.value = "ready";
@@ -44,34 +208,53 @@ export function useAuth(defaultServerUrl: string) {
   }
 
   async function login(serverUrl?: string, providerId?: string) {
-    if (serverUrl && serverUrl !== activeServerUrl.value) {
-      activeServerUrl.value = serverUrl;
-      auth = createServerAuth(serverUrl);
-      providers.value = await auth.getProviders();
+    const nextServerUrl = normalizeServerUrl(serverUrl || activeServerUrl.value);
+    if (nextServerUrl !== activeServerUrl.value) {
+      activeServerUrl.value = nextServerUrl;
+      auth = createServerAuth(nextServerUrl);
+      await loadProviders();
     }
 
+    saveActiveServer(activeServerUrl.value);
     const pid = providerId ?? providers.value[0]?.id;
     if (!pid) {
       appError.value = "No auth providers available on this server.";
       return;
     }
-    window.location.href = auth.loginUrl(window.location.href, pid);
+
+    const nextUrl = buildReturnUrl(
+      window.location.href,
+      activeServerUrl.value,
+      normalizedDefaultServerUrl,
+    );
+    const sessionTransport =
+      activeServerUrl.value === normalizedDefaultServerUrl ? "cookie" : "fragment";
+
+    window.location.href = auth.loginUrl(nextUrl, pid, {
+      sessionTransport,
+    });
   }
 
   async function fetchProviders(serverUrl: string) {
-    if (serverUrl !== activeServerUrl.value) {
-      activeServerUrl.value = serverUrl;
-      auth = createServerAuth(serverUrl);
+    const nextServerUrl = normalizeServerUrl(serverUrl);
+    if (nextServerUrl !== activeServerUrl.value) {
+      activeServerUrl.value = nextServerUrl;
+      auth = createServerAuth(nextServerUrl);
     }
-    providers.value = await auth.getProviders();
+    saveActiveServer(activeServerUrl.value);
+    await loadProviders();
   }
 
   async function logout() {
     try {
-      await auth.logout();
+      const sessionId =
+        session.value?.session_id ?? getStoredSessionId(activeServerUrl.value) ?? undefined;
+      await auth.logout(sessionId);
     } catch {
       // ignore logout errors
     }
+    clearStoredSessionId(activeServerUrl.value);
+    await loadProviders();
     session.value = null;
     api.value = null;
     appState.value = "signed-out";

--- a/chat/src/lib/server-auth.ts
+++ b/chat/src/lib/server-auth.ts
@@ -19,6 +19,10 @@ export interface AuthProvider {
   display_name?: string;
 }
 
+export interface LoginUrlOptions {
+  sessionTransport?: "cookie" | "fragment";
+}
+
 export function createServerAuth(serverBaseUrl: string) {
   const baseUrl = trimTrailingSlash(serverBaseUrl);
 
@@ -36,15 +40,23 @@ export function createServerAuth(serverBaseUrl: string) {
       return Array.isArray(data) ? (data as AuthProvider[]) : [];
     },
 
-    loginUrl(nextUrl: string, providerId: string) {
+    loginUrl(nextUrl: string, providerId: string, options?: LoginUrlOptions) {
       const url = new URL("/api/auth/start", `${baseUrl}/`);
       url.searchParams.set("provider", providerId);
       url.searchParams.set("flow", "browser");
       url.searchParams.set("next", nextUrl);
+      if (options?.sessionTransport) {
+        url.searchParams.set("session_transport", options.sessionTransport);
+      }
       return url.toString();
     },
-    async getSession() {
-      const response = await fetch(`${baseUrl}/api/auth/session`, {
+    async getSession(sessionId?: string) {
+      const url = new URL("/api/auth/session", `${baseUrl}/`);
+      if (sessionId) {
+        url.searchParams.set("session_id", sessionId);
+      }
+
+      const response = await fetch(url.toString(), {
         credentials: "include",
       });
 
@@ -58,11 +70,19 @@ export function createServerAuth(serverBaseUrl: string) {
 
       return (await response.json()) as WaddleSession;
     },
-    async logout() {
-      const response = await fetch(`${baseUrl}/api/auth/logout`, {
+    async logout(sessionId?: string) {
+      const init: RequestInit = {
         method: "POST",
         credentials: "include",
-      });
+        headers: {
+          "Content-Type": "application/json",
+        },
+      };
+      if (sessionId) {
+        init.body = JSON.stringify({ session_id: sessionId });
+      }
+
+      const response = await fetch(`${baseUrl}/api/auth/logout`, init);
 
       if (!response.ok && response.status !== 204) {
         throw new Error(`Failed to log out (${response.status})`);

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -229,6 +229,7 @@ impl PendingAuthorization {
 pub enum PendingFlow {
     Browser {
         next: Option<String>,
+        session_transport: BrowserSessionTransport,
     },
     Device {
         device_code: String,
@@ -238,6 +239,24 @@ pub enum PendingFlow {
         client_state: Option<String>,
         client_code_challenge: Option<String>,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserSessionTransport {
+    Cookie,
+    Fragment,
+}
+
+impl BrowserSessionTransport {
+    fn from_query(value: &str) -> Result<Self, AuthError> {
+        match value {
+            "cookie" => Ok(Self::Cookie),
+            "fragment" => Ok(Self::Fragment),
+            _ => Err(AuthError::InvalidRequest(
+                "session_transport must be cookie|fragment".to_string(),
+            )),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -294,6 +313,8 @@ pub struct StartQuery {
     pub flow: String,
     #[serde(default)]
     pub next: Option<String>,
+    #[serde(default = "default_session_transport")]
+    pub session_transport: String,
 
     // XMPP fields
     #[serde(default)]
@@ -310,6 +331,10 @@ pub struct StartQuery {
 
 fn default_flow() -> String {
     "browser".to_string()
+}
+
+fn default_session_transport() -> String {
+    "cookie".to_string()
 }
 
 #[derive(Debug, Deserialize)]
@@ -407,7 +432,17 @@ pub async fn start_handler(
     };
 
     let flow = match query.flow.as_str() {
-        "browser" => PendingFlow::Browser { next: query.next },
+        "browser" => {
+            let session_transport =
+                match BrowserSessionTransport::from_query(&query.session_transport) {
+                    Ok(value) => value,
+                    Err(err) => return auth_error_to_response(err).into_response(),
+                };
+            PendingFlow::Browser {
+                next: query.next,
+                session_transport,
+            }
+        }
         "device" => {
             let Some(device_code) = query.device_code else {
                 return auth_error_to_response(AuthError::InvalidRequest(
@@ -595,8 +630,46 @@ pub async fn callback_handler(
     }
 
     match pending.flow {
-        PendingFlow::Browser { next } => {
-            let redirect_to = next.unwrap_or_else(|| "/".to_string());
+        PendingFlow::Browser {
+            next,
+            session_transport,
+        } => {
+            let redirect_to = match session_transport {
+                BrowserSessionTransport::Cookie => next.unwrap_or_else(|| "/".to_string()),
+                BrowserSessionTransport::Fragment => {
+                    let target = next.unwrap_or_else(|| "/".to_string());
+                    let mut url = match url::Url::parse(&target) {
+                        Ok(parsed) => parsed,
+                        Err(_) => match url::Url::parse(&state.base_url)
+                            .and_then(|base| base.join(&target))
+                        {
+                            Ok(parsed) => parsed,
+                            Err(err) => {
+                                return auth_error_to_response(AuthError::InvalidRequest(format!(
+                                    "invalid browser redirect target: {}",
+                                    err
+                                )))
+                                .into_response();
+                            }
+                        },
+                    };
+
+                    let mut fragment = url::form_urlencoded::Serializer::new(String::new());
+                    if let Some(existing) = url.fragment() {
+                        for (key, value) in
+                            url::form_urlencoded::parse(existing.as_bytes()).into_owned()
+                        {
+                            if key != "waddle_session_id" {
+                                fragment.append_pair(&key, &value);
+                            }
+                        }
+                    }
+                    fragment.append_pair("waddle_session_id", &session.id);
+                    url.set_fragment(Some(&fragment.finish()));
+                    url.to_string()
+                }
+            };
+
             let mut response = Redirect::temporary(&redirect_to).into_response();
             response.headers_mut().append(
                 header::SET_COOKIE,


### PR DESCRIPTION
- return custom homeserver sessions in the redirect fragment so chat.waddle.social can resume broker logins without third-party cookies
- persist the selected homeserver and session id in the client so bootstrap and logout stay bound to the right server
- surface active homeserver state and provider errors on the login screen for custom auth flows