### PR TITLE
refactor(db): actor model migration Phases 0-4 (#42)

### DIFF
--- a/.github/workflows/gitops-push.yml
+++ b/.github/workflows/gitops-push.yml
@@ -32,6 +32,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Pin image tag to commit SHA
+        working-directory: infrastructure/waddle.cloud
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          sed -i "s/tag: main/tag: sha-${SHORT_SHA}/" ./gitops/waddle-server/helmrelease.yaml
+
       - name: Push gitops artifact
         working-directory: infrastructure/waddle.cloud
         run: |

--- a/server/crates/waddle-server/src/auth/identity.rs
+++ b/server/crates/waddle-server/src/auth/identity.rs
@@ -114,16 +114,19 @@ impl IdentityService {
             LIMIT 1
         "#;
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         let mut rows = conn
             .query(query, libsql::params![issuer, subject])
             .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to query identity: {}", e))
-            })?;
-        let row = rows.next().await.map_err(|e| {
-            AuthError::DatabaseError(format!("Failed to read identity row: {}", e))
-        })?;
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to query identity: {}", e)))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to read identity row: {}", e)))?;
 
         match row {
             Some(row) => Ok(Some(UserRecord {
@@ -210,7 +213,11 @@ impl IdentityService {
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#;
 
-            let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+            let conn = self
+                .db
+                .guard()
+                .await
+                .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
             let result = conn
                 .execute(
                     insert,
@@ -268,7 +275,11 @@ impl IdentityService {
         let raw = serde_json::to_string(&claims.raw_claims)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to serialize claims: {}", e)))?;
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(
             r#"
                 INSERT INTO auth_identities (
@@ -303,7 +314,11 @@ impl IdentityService {
     ) -> Result<(), AuthError> {
         let now = Utc::now().to_rfc3339();
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(
             "UPDATE auth_identities SET last_login_at = ?, provider_id = ? WHERE issuer = ? AND subject = ?",
             libsql::params![now.as_str(), provider.id.as_str(), issuer, subject],

--- a/server/crates/waddle-server/src/auth/identity.rs
+++ b/server/crates/waddle-server/src/auth/identity.rs
@@ -114,31 +114,16 @@ impl IdentityService {
             LIMIT 1
         "#;
 
-        let row = if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn
-                .query(query, libsql::params![issuer, subject])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to query identity: {}", e))
-                })?;
-            rows.next().await.map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to read identity row: {}", e))
-            })?
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let mut rows = conn
+            .query(query, libsql::params![issuer, subject])
+            .await
+            .map_err(|e| {
+                AuthError::DatabaseError(format!("Failed to query identity: {}", e))
             })?;
-            let mut rows = conn
-                .query(query, libsql::params![issuer, subject])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to query identity: {}", e))
-                })?;
-            rows.next().await.map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to read identity row: {}", e))
-            })?
-        };
+        let row = rows.next().await.map_err(|e| {
+            AuthError::DatabaseError(format!("Failed to read identity row: {}", e))
+        })?;
 
         match row {
             Some(row) => Ok(Some(UserRecord {
@@ -225,9 +210,9 @@ impl IdentityService {
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             "#;
 
-            let result = if let Some(persistent) = self.db.persistent_connection() {
-                let conn = persistent.lock().await;
-                conn.execute(
+            let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+            let result = conn
+                .execute(
                     insert,
                     libsql::params![
                         user_id.clone(),
@@ -240,26 +225,7 @@ impl IdentityService {
                         now.clone()
                     ],
                 )
-                .await
-            } else {
-                let conn = self.db.connect().map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-                })?;
-                conn.execute(
-                    insert,
-                    libsql::params![
-                        user_id.clone(),
-                        username.clone(),
-                        xmpp_localpart.clone(),
-                        claims.name.clone(),
-                        claims.avatar_url.clone(),
-                        claims.email.clone(),
-                        now.clone(),
-                        now.clone()
-                    ],
-                )
-                .await
-            };
+                .await;
 
             match result {
                 Ok(_) => {
@@ -302,57 +268,29 @@ impl IdentityService {
         let raw = serde_json::to_string(&claims.raw_claims)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to serialize claims: {}", e)))?;
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                r#"
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(
+            r#"
                 INSERT INTO auth_identities (
                     id, user_id, provider_id, issuer, subject, email, email_verified,
                     raw_claims_json, created_at, last_login_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
-                libsql::params![
-                    identity_id.as_str(),
-                    user_id,
-                    provider.id.as_str(),
-                    issuer,
-                    claims.subject.as_str(),
-                    claims.email.clone(),
-                    claims.email_verified.map(|v| if v { 1 } else { 0 }),
-                    raw.as_str(),
-                    now.as_str(),
-                    now.as_str()
-                ],
-            )
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to insert identity: {}", e)))?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-            })?;
-            conn.execute(
-                r#"
-                INSERT INTO auth_identities (
-                    id, user_id, provider_id, issuer, subject, email, email_verified,
-                    raw_claims_json, created_at, last_login_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                "#,
-                libsql::params![
-                    identity_id.as_str(),
-                    user_id,
-                    provider.id.as_str(),
-                    issuer,
-                    claims.subject.as_str(),
-                    claims.email.clone(),
-                    claims.email_verified.map(|v| if v { 1 } else { 0 }),
-                    raw.as_str(),
-                    now.as_str(),
-                    now.as_str()
-                ],
-            )
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to insert identity: {}", e)))?;
-        }
+            libsql::params![
+                identity_id.as_str(),
+                user_id,
+                provider.id.as_str(),
+                issuer,
+                claims.subject.as_str(),
+                claims.email.clone(),
+                claims.email_verified.map(|v| if v { 1 } else { 0 }),
+                raw.as_str(),
+                now.as_str(),
+                now.as_str()
+            ],
+        )
+        .await
+        .map_err(|e| AuthError::DatabaseError(format!("Failed to insert identity: {}", e)))?;
 
         Ok(())
     }
@@ -365,29 +303,15 @@ impl IdentityService {
     ) -> Result<(), AuthError> {
         let now = Utc::now().to_rfc3339();
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                "UPDATE auth_identities SET last_login_at = ?, provider_id = ? WHERE issuer = ? AND subject = ?",
-                libsql::params![now.as_str(), provider.id.as_str(), issuer, subject],
-            )
-            .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to update identity login timestamp: {}", e))
-            })?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-            })?;
-            conn.execute(
-                "UPDATE auth_identities SET last_login_at = ?, provider_id = ? WHERE issuer = ? AND subject = ?",
-                libsql::params![now.as_str(), provider.id.as_str(), issuer, subject],
-            )
-            .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to update identity login timestamp: {}", e))
-            })?;
-        }
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(
+            "UPDATE auth_identities SET last_login_at = ?, provider_id = ? WHERE issuer = ? AND subject = ?",
+            libsql::params![now.as_str(), provider.id.as_str(), issuer, subject],
+        )
+        .await
+        .map_err(|e| {
+            AuthError::DatabaseError(format!("Failed to update identity login timestamp: {}", e))
+        })?;
 
         Ok(())
     }

--- a/server/crates/waddle-server/src/auth/native.rs
+++ b/server/crates/waddle-server/src/auth/native.rs
@@ -60,17 +60,8 @@ impl NativeUserStore {
     /// For in-memory databases, this returns a guard to the persistent connection
     /// to ensure data consistency (libSQL creates isolated databases for each `:memory:` connection).
     /// For file-based databases, we create new connections.
-    async fn get_connection(&self) -> Result<ConnectionGuard<'_>, AuthError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let guard = persistent.lock().await;
-            Ok(ConnectionGuard::Persistent(guard))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-            Ok(ConnectionGuard::Owned(conn))
-        }
+    async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, AuthError> {
+        self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))
     }
 
     /// Register a new native user.
@@ -111,8 +102,7 @@ impl NativeUserStore {
         let conn = self.get_connection().await?;
 
         let email_str = request.email.as_deref();
-        conn.as_ref()
-            .execute(
+        conn.execute(
                 r#"
                 INSERT INTO native_users (username, domain, password_hash, salt, iterations, stored_key, server_key, email)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -131,7 +121,7 @@ impl NativeUserStore {
             .await
             .map_err(db_err)?;
 
-        let user_id = conn.as_ref().last_insert_rowid();
+        let user_id = conn.last_insert_rowid();
 
         debug!(
             username = %request.username,
@@ -147,9 +137,7 @@ impl NativeUserStore {
     pub async fn user_exists(&self, username: &str, domain: &str) -> Result<bool, AuthError> {
         let conn = self.get_connection().await?;
 
-        let mut rows = conn
-            .as_ref()
-            .query(
+        let mut rows = conn.query(
                 "SELECT 1 FROM native_users WHERE username = ? AND domain = ?",
                 (username, domain),
             )
@@ -167,9 +155,7 @@ impl NativeUserStore {
     ) -> Result<Option<ScramCredentials>, AuthError> {
         let conn = self.get_connection().await?;
 
-        let mut rows = conn
-            .as_ref()
-            .query(
+        let mut rows = conn.query(
                 r#"
                 SELECT salt, iterations, stored_key, server_key
                 FROM native_users
@@ -206,9 +192,7 @@ impl NativeUserStore {
 
         let conn = self.get_connection().await?;
 
-        let mut rows = conn
-            .as_ref()
-            .query(
+        let mut rows = conn.query(
                 "SELECT password_hash FROM native_users WHERE username = ? AND domain = ?",
                 (username, domain),
             )
@@ -257,8 +241,7 @@ impl NativeUserStore {
 
         let conn = self.get_connection().await?;
 
-        let affected = conn.as_ref()
-            .execute(
+        let affected = conn.execute(
                 r#"
                 UPDATE native_users
                 SET password_hash = ?, salt = ?, stored_key = ?, server_key = ?, updated_at = datetime('now')
@@ -290,7 +273,6 @@ impl NativeUserStore {
         let conn = self.get_connection().await?;
 
         let affected = conn
-            .as_ref()
             .execute(
                 "DELETE FROM native_users WHERE username = ? AND domain = ?",
                 (username, domain),
@@ -303,28 +285,6 @@ impl NativeUserStore {
             Ok(true)
         } else {
             Ok(false)
-        }
-    }
-}
-
-/// A guard that wraps either a persistent connection (for in-memory databases)
-/// or an owned connection (for file-based databases).
-///
-/// This ensures that in-memory databases always use the persistent connection
-/// to maintain data across operations.
-enum ConnectionGuard<'a> {
-    /// Persistent connection guard for in-memory databases
-    Persistent(tokio::sync::MutexGuard<'a, libsql::Connection>),
-    /// Owned connection for file-based databases
-    Owned(libsql::Connection),
-}
-
-impl<'a> ConnectionGuard<'a> {
-    /// Get a reference to the underlying connection
-    fn as_ref(&self) -> &libsql::Connection {
-        match self {
-            ConnectionGuard::Persistent(guard) => guard,
-            ConnectionGuard::Owned(conn) => conn,
         }
     }
 }

--- a/server/crates/waddle-server/src/auth/native.rs
+++ b/server/crates/waddle-server/src/auth/native.rs
@@ -61,7 +61,10 @@ impl NativeUserStore {
     /// to ensure data consistency (libSQL creates isolated databases for each `:memory:` connection).
     /// For file-based databases, we create new connections.
     async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, AuthError> {
-        self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))
+        self.db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))
     }
 
     /// Register a new native user.
@@ -137,7 +140,8 @@ impl NativeUserStore {
     pub async fn user_exists(&self, username: &str, domain: &str) -> Result<bool, AuthError> {
         let conn = self.get_connection().await?;
 
-        let mut rows = conn.query(
+        let mut rows = conn
+            .query(
                 "SELECT 1 FROM native_users WHERE username = ? AND domain = ?",
                 (username, domain),
             )
@@ -155,7 +159,8 @@ impl NativeUserStore {
     ) -> Result<Option<ScramCredentials>, AuthError> {
         let conn = self.get_connection().await?;
 
-        let mut rows = conn.query(
+        let mut rows = conn
+            .query(
                 r#"
                 SELECT salt, iterations, stored_key, server_key
                 FROM native_users
@@ -192,7 +197,8 @@ impl NativeUserStore {
 
         let conn = self.get_connection().await?;
 
-        let mut rows = conn.query(
+        let mut rows = conn
+            .query(
                 "SELECT password_hash FROM native_users WHERE username = ? AND domain = ?",
                 (username, domain),
             )

--- a/server/crates/waddle-server/src/auth/session.rs
+++ b/server/crates/waddle-server/src/auth/session.rs
@@ -1,15 +1,19 @@
 //! Local session management for provider-authenticated users.
+//!
+//! All database access is routed through a `DbActor` to serialise operations
+//! and avoid SQLite write-lock contention.
 
 use super::AuthError;
 use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use hmac::{Hmac, Mac};
+use kameo::actor::ActorRef;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::sync::Arc;
 use tracing::{debug, instrument, warn};
 use uuid::Uuid;
 
-use crate::db::Database;
+use crate::db::actor::{DbActor, DbExecute, DbQueryOne, RowValues};
+use crate::db::{row_value, ValueExt};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -49,14 +53,14 @@ impl Session {
 }
 
 pub struct SessionManager {
-    db: Arc<Database>,
+    actor: ActorRef<DbActor>,
     hash_key: Option<Vec<u8>>,
 }
 
 impl SessionManager {
-    pub fn new(db: Arc<Database>, hash_key: Option<&[u8]>) -> Self {
+    pub fn new(actor: ActorRef<DbActor>, hash_key: Option<&[u8]>) -> Self {
         Self {
-            db,
+            actor,
             hash_key: hash_key.map(|k| k.to_vec()),
         }
     }
@@ -76,29 +80,31 @@ impl SessionManager {
         }
     }
 
+    /// Convert an actor ask error into an AuthError.
+    fn ask_err(e: impl std::fmt::Display) -> AuthError {
+        AuthError::DatabaseError(e.to_string())
+    }
+
     async fn ensure_user_exists(&self, session: &Session) -> Result<(), AuthError> {
-        let query = r#"
+        let sql = r#"
             INSERT OR IGNORE INTO users (id, username, xmpp_localpart, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?)
-        "#;
+        "#
+        .to_string();
 
-        let conn = self
-            .db
-            .guard()
+        self.actor
+            .ask(DbExecute {
+                sql,
+                params: vec![
+                    libsql::Value::from(session.user_id.as_str()),
+                    libsql::Value::from(session.username.as_str()),
+                    libsql::Value::from(session.xmpp_localpart.as_str()),
+                    libsql::Value::from(session.created_at.to_rfc3339()),
+                    libsql::Value::from(session.created_at.to_rfc3339()),
+                ],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        conn.execute(
-            query,
-            libsql::params![
-                session.user_id.as_str(),
-                session.username.as_str(),
-                session.xmpp_localpart.as_str(),
-                session.created_at.to_rfc3339(),
-                session.created_at.to_rfc3339()
-            ],
-        )
-        .await
-        .map_err(|e| AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e)))?;
+            .map_err(Self::ask_err)?;
         Ok(())
     }
 
@@ -109,29 +115,29 @@ impl SessionManager {
         let token_hash = self.token_hash(&session.id);
         let expires_at = session.expires_at.map(|v| v.to_rfc3339());
 
-        let query = r#"
+        let sql = r#"
             INSERT INTO sessions (id, user_id, token_hash, expires_at, created_at, last_used_at)
             VALUES (?, ?, ?, ?, ?, ?)
-        "#;
+        "#
+        .to_string();
 
-        let conn = self
-            .db
-            .guard()
+        self.actor
+            .ask(DbExecute {
+                sql,
+                params: vec![
+                    libsql::Value::from(session.id.as_str()),
+                    libsql::Value::from(session.user_id.as_str()),
+                    libsql::Value::from(token_hash),
+                    match expires_at {
+                        Some(v) => libsql::Value::from(v),
+                        None => libsql::Value::Null,
+                    },
+                    libsql::Value::from(session.created_at.to_rfc3339()),
+                    libsql::Value::from(session.last_used_at.to_rfc3339()),
+                ],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        conn.execute(
-            query,
-            libsql::params![
-                session.id.as_str(),
-                session.user_id.as_str(),
-                token_hash,
-                expires_at,
-                session.created_at.to_rfc3339(),
-                session.last_used_at.to_rfc3339()
-            ],
-        )
-        .await
-        .map_err(|e| AuthError::DatabaseError(format!("Failed to insert session: {}", e)))?;
+            .map_err(Self::ask_err)?;
 
         debug!(session_id = %session.id, user_id = %session.user_id, "Session created");
         Ok(())
@@ -152,41 +158,49 @@ impl SessionManager {
         )))
     }
 
-    fn row_to_session(&self, row: &libsql::Row) -> Result<Session, AuthError> {
-        let id: String = row
-            .get(0)
+    fn values_to_session(&self, row: &[libsql::Value]) -> Result<Session, AuthError> {
+        let id = row_value(row, 0)
+            .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get session id: {}", e)))?;
-        let user_id: String = row
-            .get(1)
+        let user_id = row_value(row, 1)
+            .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get user id: {}", e)))?;
-        let token_hash: String = row
-            .get(2)
+        let token_hash = row_value(row, 2)
+            .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get token hash: {}", e)))?;
 
         if token_hash != self.token_hash(&id) {
             return Err(AuthError::SessionNotFound(id));
         }
 
-        let expires_at = row
-            .get::<Option<String>>(3)
-            .ok()
-            .flatten()
+        let expires_at = row_value(row, 3)
+            .and_then(ValueExt::as_optional_string)
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to get expires_at: {}", e)))?
             .map(|v| Self::parse_ts(&v))
             .transpose()?;
-        let created_at =
-            Self::parse_ts(&row.get::<String>(4).map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to get created_at: {}", e))
-            })?)?;
-        let last_used_at = Self::parse_ts(&row.get::<String>(5).map_err(|e| {
-            AuthError::DatabaseError(format!("Failed to get last_used_at: {}", e))
-        })?)?;
+        let created_at = Self::parse_ts(
+            &row_value(row, 4)
+                .and_then(ValueExt::as_string)
+                .map_err(|e| {
+                    AuthError::DatabaseError(format!("Failed to get created_at: {}", e))
+                })?,
+        )?;
+        let last_used_at = Self::parse_ts(
+            &row_value(row, 5)
+                .and_then(ValueExt::as_string)
+                .map_err(|e| {
+                    AuthError::DatabaseError(format!("Failed to get last_used_at: {}", e))
+                })?,
+        )?;
 
-        let username: String = row
-            .get(6)
+        let username = row_value(row, 6)
+            .and_then(ValueExt::as_string)
             .map_err(|e| AuthError::DatabaseError(format!("Failed to get username: {}", e)))?;
-        let xmpp_localpart: String = row.get(7).map_err(|e| {
-            AuthError::DatabaseError(format!("Failed to get xmpp_localpart: {}", e))
-        })?;
+        let xmpp_localpart = row_value(row, 7)
+            .and_then(ValueExt::as_string)
+            .map_err(|e| {
+                AuthError::DatabaseError(format!("Failed to get xmpp_localpart: {}", e))
+            })?;
 
         Ok(Session {
             id,
@@ -201,31 +215,27 @@ impl SessionManager {
 
     #[instrument(skip(self))]
     pub async fn get_session(&self, session_id: &str) -> Result<Option<Session>, AuthError> {
-        let query = r#"
+        let sql = r#"
             SELECT s.id, s.user_id, s.token_hash, s.expires_at, s.created_at, s.last_used_at,
                    u.username, u.xmpp_localpart
             FROM sessions s
             JOIN users u ON u.id = s.user_id
             WHERE s.id = ?
             LIMIT 1
-        "#;
+        "#
+        .to_string();
 
-        let conn = self
-            .db
-            .guard()
+        let row: Option<RowValues> = self
+            .actor
+            .ask(DbQueryOne {
+                sql,
+                params: vec![libsql::Value::from(session_id)],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        let mut rows = conn
-            .query(query, libsql::params![session_id])
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to query session: {}", e)))?;
-        let row = rows
-            .next()
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to read session row: {}", e)))?;
+            .map_err(Self::ask_err)?;
 
         match row {
-            Some(row) => Ok(Some(self.row_to_session(&row)?)),
+            Some(values) => Ok(Some(self.values_to_session(&values)?)),
             None => Ok(None),
         }
     }
@@ -233,30 +243,26 @@ impl SessionManager {
     #[instrument(skip(self))]
     pub async fn touch_session(&self, session_id: &str) -> Result<(), AuthError> {
         let now = Utc::now().to_rfc3339();
-        let query = "UPDATE sessions SET last_used_at = ? WHERE id = ?";
 
-        let conn = self
-            .db
-            .guard()
+        self.actor
+            .ask(DbExecute {
+                sql: "UPDATE sessions SET last_used_at = ? WHERE id = ?".to_string(),
+                params: vec![libsql::Value::from(now), libsql::Value::from(session_id)],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        conn.execute(query, libsql::params![now, session_id])
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to update session: {}", e)))?;
+            .map_err(Self::ask_err)?;
         Ok(())
     }
 
     #[instrument(skip(self))]
     pub async fn delete_session(&self, session_id: &str) -> Result<(), AuthError> {
-        let query = "DELETE FROM sessions WHERE id = ?";
-        let conn = self
-            .db
-            .guard()
+        self.actor
+            .ask(DbExecute {
+                sql: "DELETE FROM sessions WHERE id = ?".to_string(),
+                params: vec![libsql::Value::from(session_id)],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        conn.execute(query, libsql::params![session_id])
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to delete session: {}", e)))?;
+            .map_err(Self::ask_err)?;
         Ok(())
     }
 
@@ -279,18 +285,15 @@ impl SessionManager {
     #[allow(dead_code)]
     pub async fn cleanup_expired_sessions(&self) -> Result<usize, AuthError> {
         let now = Utc::now().to_rfc3339();
-        let query = "DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < ?";
-        let conn = self
-            .db
-            .guard()
+        let deleted = self
+            .actor
+            .ask(DbExecute {
+                sql: "DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < ?"
+                    .to_string(),
+                params: vec![libsql::Value::from(now)],
+            })
             .await
-            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
-        let deleted = conn
-            .execute(query, libsql::params![now])
-            .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed cleanup expired sessions: {}", e))
-            })?;
+            .map_err(Self::ask_err)?;
         Ok(deleted as usize)
     }
 }

--- a/server/crates/waddle-server/src/auth/session.rs
+++ b/server/crates/waddle-server/src/auth/session.rs
@@ -82,43 +82,22 @@ impl SessionManager {
             VALUES (?, ?, ?, ?, ?)
         "#;
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                query,
-                libsql::params![
-                    session.user_id.as_str(),
-                    session.username.as_str(),
-                    session.xmpp_localpart.as_str(),
-                    session.created_at.to_rfc3339(),
-                    session.created_at.to_rfc3339()
-                ],
-            )
-            .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e))
-            })?;
-            Ok(())
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-            })?;
-            conn.execute(
-                query,
-                libsql::params![
-                    session.user_id.as_str(),
-                    session.username.as_str(),
-                    session.xmpp_localpart.as_str(),
-                    session.created_at.to_rfc3339(),
-                    session.created_at.to_rfc3339()
-                ],
-            )
-            .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e))
-            })?;
-            Ok(())
-        }
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(
+            query,
+            libsql::params![
+                session.user_id.as_str(),
+                session.username.as_str(),
+                session.xmpp_localpart.as_str(),
+                session.created_at.to_rfc3339(),
+                session.created_at.to_rfc3339()
+            ],
+        )
+        .await
+        .map_err(|e| {
+            AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e))
+        })?;
+        Ok(())
     }
 
     #[instrument(skip(self, session))]
@@ -133,39 +112,20 @@ impl SessionManager {
             VALUES (?, ?, ?, ?, ?, ?)
         "#;
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                query,
-                libsql::params![
-                    session.id.as_str(),
-                    session.user_id.as_str(),
-                    token_hash,
-                    expires_at,
-                    session.created_at.to_rfc3339(),
-                    session.last_used_at.to_rfc3339()
-                ],
-            )
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to insert session: {}", e)))?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-            })?;
-            conn.execute(
-                query,
-                libsql::params![
-                    session.id.as_str(),
-                    session.user_id.as_str(),
-                    token_hash,
-                    expires_at,
-                    session.created_at.to_rfc3339(),
-                    session.last_used_at.to_rfc3339()
-                ],
-            )
-            .await
-            .map_err(|e| AuthError::DatabaseError(format!("Failed to insert session: {}", e)))?;
-        }
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(
+            query,
+            libsql::params![
+                session.id.as_str(),
+                session.user_id.as_str(),
+                token_hash,
+                expires_at,
+                session.created_at.to_rfc3339(),
+                session.last_used_at.to_rfc3339()
+            ],
+        )
+        .await
+        .map_err(|e| AuthError::DatabaseError(format!("Failed to insert session: {}", e)))?;
 
         debug!(session_id = %session.id, user_id = %session.user_id, "Session created");
         Ok(())
@@ -244,27 +204,14 @@ impl SessionManager {
             LIMIT 1
         "#;
 
-        let row = if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn
-                .query(query, libsql::params![session_id])
-                .await
-                .map_err(|e| AuthError::DatabaseError(format!("Failed to query session: {}", e)))?;
-            rows.next().await.map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to read session row: {}", e))
-            })?
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
-            })?;
-            let mut rows = conn
-                .query(query, libsql::params![session_id])
-                .await
-                .map_err(|e| AuthError::DatabaseError(format!("Failed to query session: {}", e)))?;
-            rows.next().await.map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to read session row: {}", e))
-            })?
-        };
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let mut rows = conn
+            .query(query, libsql::params![session_id])
+            .await
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to query session: {}", e)))?;
+        let row = rows.next().await.map_err(|e| {
+            AuthError::DatabaseError(format!("Failed to read session row: {}", e))
+        })?;
 
         match row {
             Some(row) => Ok(Some(self.row_to_session(&row)?)),
@@ -277,46 +224,24 @@ impl SessionManager {
         let now = Utc::now().to_rfc3339();
         let query = "UPDATE sessions SET last_used_at = ? WHERE id = ?";
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(query, libsql::params![now, session_id])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to update session: {}", e))
-                })?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(query, libsql::params![now, session_id])
+            .await
+            .map_err(|e| {
+                AuthError::DatabaseError(format!("Failed to update session: {}", e))
             })?;
-            conn.execute(query, libsql::params![now, session_id])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to update session: {}", e))
-                })?;
-        }
         Ok(())
     }
 
     #[instrument(skip(self))]
     pub async fn delete_session(&self, session_id: &str) -> Result<(), AuthError> {
         let query = "DELETE FROM sessions WHERE id = ?";
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(query, libsql::params![session_id])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to delete session: {}", e))
-                })?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        conn.execute(query, libsql::params![session_id])
+            .await
+            .map_err(|e| {
+                AuthError::DatabaseError(format!("Failed to delete session: {}", e))
             })?;
-            conn.execute(query, libsql::params![session_id])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed to delete session: {}", e))
-                })?;
-        }
         Ok(())
     }
 
@@ -340,23 +265,13 @@ impl SessionManager {
     pub async fn cleanup_expired_sessions(&self) -> Result<usize, AuthError> {
         let now = Utc::now().to_rfc3339();
         let query = "DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < ?";
-        let deleted = if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(query, libsql::params![now])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed cleanup expired sessions: {}", e))
-                })?
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to connect database: {}", e))
+        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let deleted = conn
+            .execute(query, libsql::params![now])
+            .await
+            .map_err(|e| {
+                AuthError::DatabaseError(format!("Failed cleanup expired sessions: {}", e))
             })?;
-            conn.execute(query, libsql::params![now])
-                .await
-                .map_err(|e| {
-                    AuthError::DatabaseError(format!("Failed cleanup expired sessions: {}", e))
-                })?
-        };
         Ok(deleted as usize)
     }
 }

--- a/server/crates/waddle-server/src/auth/session.rs
+++ b/server/crates/waddle-server/src/auth/session.rs
@@ -82,7 +82,11 @@ impl SessionManager {
             VALUES (?, ?, ?, ?, ?)
         "#;
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(
             query,
             libsql::params![
@@ -94,9 +98,7 @@ impl SessionManager {
             ],
         )
         .await
-        .map_err(|e| {
-            AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e))
-        })?;
+        .map_err(|e| AuthError::DatabaseError(format!("Failed to ensure user exists: {}", e)))?;
         Ok(())
     }
 
@@ -112,7 +114,11 @@ impl SessionManager {
             VALUES (?, ?, ?, ?, ?, ?)
         "#;
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(
             query,
             libsql::params![
@@ -204,14 +210,19 @@ impl SessionManager {
             LIMIT 1
         "#;
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         let mut rows = conn
             .query(query, libsql::params![session_id])
             .await
             .map_err(|e| AuthError::DatabaseError(format!("Failed to query session: {}", e)))?;
-        let row = rows.next().await.map_err(|e| {
-            AuthError::DatabaseError(format!("Failed to read session row: {}", e))
-        })?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to read session row: {}", e)))?;
 
         match row {
             Some(row) => Ok(Some(self.row_to_session(&row)?)),
@@ -224,24 +235,28 @@ impl SessionManager {
         let now = Utc::now().to_rfc3339();
         let query = "UPDATE sessions SET last_used_at = ? WHERE id = ?";
 
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(query, libsql::params![now, session_id])
             .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to update session: {}", e))
-            })?;
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to update session: {}", e)))?;
         Ok(())
     }
 
     #[instrument(skip(self))]
     pub async fn delete_session(&self, session_id: &str) -> Result<(), AuthError> {
         let query = "DELETE FROM sessions WHERE id = ?";
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         conn.execute(query, libsql::params![session_id])
             .await
-            .map_err(|e| {
-                AuthError::DatabaseError(format!("Failed to delete session: {}", e))
-            })?;
+            .map_err(|e| AuthError::DatabaseError(format!("Failed to delete session: {}", e)))?;
         Ok(())
     }
 
@@ -265,7 +280,11 @@ impl SessionManager {
     pub async fn cleanup_expired_sessions(&self) -> Result<usize, AuthError> {
         let now = Utc::now().to_rfc3339();
         let query = "DELETE FROM sessions WHERE expires_at IS NOT NULL AND expires_at < ?";
-        let conn = self.db.guard().await.map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
         let deleted = conn
             .execute(query, libsql::params![now])
             .await

--- a/server/crates/waddle-server/src/db/actor.rs
+++ b/server/crates/waddle-server/src/db/actor.rs
@@ -89,11 +89,7 @@ pub type RowValues = Vec<libsql::Value>;
 impl kameo::message::Message<DbQuery> for DbActor {
     type Reply = Result<Vec<RowValues>, DatabaseError>;
 
-    async fn handle(
-        &mut self,
-        msg: DbQuery,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+    async fn handle(&mut self, msg: DbQuery, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.touch();
         let conn = self.db.guard().await?;
         let mut rows = conn.query(&msg.sql, msg.params).await?;

--- a/server/crates/waddle-server/src/db/actor.rs
+++ b/server/crates/waddle-server/src/db/actor.rs
@@ -1,0 +1,259 @@
+//! Kameo actor wrapping a Database connection.
+//!
+//! The `DbActor` owns a `Database` and processes all operations sequentially,
+//! eliminating the need for external Mutex locking. This is the foundation
+//! of the actor-model migration described in issue #42 Phase 1.
+
+use std::time::Instant;
+
+use kameo::message::Context;
+use kameo::Actor;
+
+use super::{Database, DatabaseError};
+
+/// Actor that owns a `Database` and handles queries sequentially.
+///
+/// Because Kameo processes messages one at a time, the actor holds a single
+/// `Database` with no external synchronisation required.
+#[derive(Actor)]
+pub struct DbActor {
+    db: Database,
+    last_accessed: Instant,
+}
+
+impl DbActor {
+    /// Create a new `DbActor` wrapping the given database.
+    pub fn new(db: Database) -> Self {
+        Self {
+            db,
+            last_accessed: Instant::now(),
+        }
+    }
+
+    fn touch(&mut self) {
+        self.last_accessed = Instant::now();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Request the inner `Database` handle (backward-compat for callers that still
+/// use `guard()`).
+pub struct GetDatabase;
+
+impl kameo::message::Message<GetDatabase> for DbActor {
+    type Reply = Database;
+
+    async fn handle(
+        &mut self,
+        _msg: GetDatabase,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.touch();
+        self.db.clone()
+    }
+}
+
+/// Execute a SQL statement and return the number of affected rows.
+pub struct DbExecute {
+    pub sql: String,
+    pub params: Vec<libsql::Value>,
+}
+
+impl kameo::message::Message<DbExecute> for DbActor {
+    type Reply = Result<u64, DatabaseError>;
+
+    async fn handle(
+        &mut self,
+        msg: DbExecute,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.touch();
+        let conn = self.db.guard().await?;
+        let rows = conn.execute(&msg.sql, msg.params).await?;
+        Ok(rows)
+    }
+}
+
+/// Execute a SQL query and return all result rows.
+pub struct DbQuery {
+    pub sql: String,
+    pub params: Vec<libsql::Value>,
+}
+
+/// A single row of query results, represented as a vector of `libsql::Value`.
+pub type RowValues = Vec<libsql::Value>;
+
+impl kameo::message::Message<DbQuery> for DbActor {
+    type Reply = Result<Vec<RowValues>, DatabaseError>;
+
+    async fn handle(
+        &mut self,
+        msg: DbQuery,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.touch();
+        let conn = self.db.guard().await?;
+        let mut rows = conn.query(&msg.sql, msg.params).await?;
+        let col_count = rows.column_count();
+
+        let mut result = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let mut values = Vec::with_capacity(col_count as usize);
+            for i in 0..col_count {
+                values.push(row.get_value(i)?);
+            }
+            result.push(values);
+        }
+        Ok(result)
+    }
+}
+
+/// Execute a SQL query and return at most one row.
+pub struct DbQueryOne {
+    pub sql: String,
+    pub params: Vec<libsql::Value>,
+}
+
+impl kameo::message::Message<DbQueryOne> for DbActor {
+    type Reply = Result<Option<RowValues>, DatabaseError>;
+
+    async fn handle(
+        &mut self,
+        msg: DbQueryOne,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.touch();
+        let conn = self.db.guard().await?;
+        let mut rows = conn.query(&msg.sql, msg.params).await?;
+        let col_count = rows.column_count();
+
+        match rows.next().await? {
+            Some(row) => {
+                let mut values = Vec::with_capacity(col_count as usize);
+                for i in 0..col_count {
+                    values.push(row.get_value(i)?);
+                }
+                Ok(Some(values))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+/// Check if the database is healthy.
+pub struct DbHealthCheck;
+
+impl kameo::message::Message<DbHealthCheck> for DbActor {
+    type Reply = Result<bool, DatabaseError>;
+
+    async fn handle(
+        &mut self,
+        _msg: DbHealthCheck,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.touch();
+        self.db.health_check().await
+    }
+}
+
+/// Return milliseconds since the actor last handled a message.
+pub struct GetIdleMs;
+
+impl kameo::message::Message<GetIdleMs> for DbActor {
+    type Reply = u64;
+
+    async fn handle(
+        &mut self,
+        _msg: GetIdleMs,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.last_accessed.elapsed().as_millis() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::ActorRef;
+
+    async fn spawn_test_actor() -> ActorRef<DbActor> {
+        let db = Database::in_memory("test-db-actor").await.expect("db");
+        // Run migrations so tables exist
+        let runner = super::super::MigrationRunner::global();
+        runner.run(&db).await.expect("migrations");
+        kameo::spawn(DbActor::new(db))
+    }
+
+    #[tokio::test]
+    async fn test_get_database() {
+        let actor = spawn_test_actor().await;
+        let db: Database = actor.ask(GetDatabase).await.expect("ask");
+        assert_eq!(db.name(), "test-db-actor");
+    }
+
+    #[tokio::test]
+    async fn test_execute_and_query() {
+        let actor = spawn_test_actor().await;
+
+        // Create a table
+        actor
+            .ask(DbExecute {
+                sql: "CREATE TABLE actor_test (id INTEGER PRIMARY KEY, val TEXT)".to_string(),
+                params: vec![],
+            })
+            .await
+            .expect("create table");
+
+        // Insert a row
+        let affected = actor
+            .ask(DbExecute {
+                sql: "INSERT INTO actor_test (val) VALUES (?)".to_string(),
+                params: vec![libsql::Value::from("hello")],
+            })
+            .await
+            .expect("insert");
+        assert_eq!(affected, 1);
+
+        // Query
+        let rows = actor
+            .ask(DbQuery {
+                sql: "SELECT val FROM actor_test".to_string(),
+                params: vec![],
+            })
+            .await
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_query_one() {
+        let actor = spawn_test_actor().await;
+
+        let row = actor
+            .ask(DbQueryOne {
+                sql: "SELECT 42".to_string(),
+                params: vec![],
+            })
+            .await
+            .expect("query one");
+        assert!(row.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let actor = spawn_test_actor().await;
+        let healthy = actor.ask(DbHealthCheck).await.expect("health check");
+        assert!(healthy);
+    }
+
+    #[tokio::test]
+    async fn test_idle_ms() {
+        let actor = spawn_test_actor().await;
+        let idle = actor.ask(GetIdleMs).await.expect("ask");
+        // Should be very small since we just created it
+        assert!(idle < 1000);
+    }
+}

--- a/server/crates/waddle-server/src/db/blocking.rs
+++ b/server/crates/waddle-server/src/db/blocking.rs
@@ -150,49 +150,24 @@ impl DatabaseBlockingStorage {
         Ok(result as usize)
     }
 
-    /// Execute a query using the persistent connection for in-memory databases.
-    /// This ensures data written by migrations is visible to queries.
+    /// Execute a query using a connection guard.
     async fn query_with_persistent(
         &self,
         sql: &str,
         params: impl IntoParams,
     ) -> Result<libsql::Rows, BlockingStorageError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.query(sql, params)
-                .await
-                .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
-            conn.query(sql, params)
-                .await
-                .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
-        }
+        let conn = self.db.guard().await.map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
+        conn.query(sql, params).await.map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
     }
 
-    /// Execute a statement using the persistent connection for in-memory databases.
+    /// Execute a statement using a connection guard.
     async fn execute_with_persistent(
         &self,
         sql: &str,
         params: impl IntoParams,
     ) -> Result<u64, BlockingStorageError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(sql, params)
-                .await
-                .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
-            conn.execute(sql, params)
-                .await
-                .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
-        }
+        let conn = self.db.guard().await.map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
+        conn.execute(sql, params).await.map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
     }
 }
 

--- a/server/crates/waddle-server/src/db/blocking.rs
+++ b/server/crates/waddle-server/src/db/blocking.rs
@@ -156,8 +156,14 @@ impl DatabaseBlockingStorage {
         sql: &str,
         params: impl IntoParams,
     ) -> Result<libsql::Rows, BlockingStorageError> {
-        let conn = self.db.guard().await.map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
-        conn.query(sql, params).await.map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
     }
 
     /// Execute a statement using a connection guard.
@@ -166,8 +172,14 @@ impl DatabaseBlockingStorage {
         sql: &str,
         params: impl IntoParams,
     ) -> Result<u64, BlockingStorageError> {
-        let conn = self.db.guard().await.map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
-        conn.execute(sql, params).await.map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| BlockingStorageError::ConnectionFailed(e.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|e| BlockingStorageError::QueryFailed(e.to_string()))
     }
 }
 

--- a/server/crates/waddle-server/src/db/migrations.rs
+++ b/server/crates/waddle-server/src/db/migrations.rs
@@ -357,17 +357,8 @@ impl MigrationRunner {
     /// Run all pending migrations on the database
     #[instrument(skip_all, fields(db_name = %db.name()))]
     pub async fn run(&self, db: &Database) -> Result<Vec<i64>, DatabaseError> {
-        // Use persistent connection for in-memory databases to ensure data persists
-        // We need to handle both cases: in-memory (with persistent conn) and file-based
-        if let Some(persistent) = db.persistent_connection() {
-            // For in-memory databases, use the persistent connection
-            let conn = persistent.lock().await;
-            self.run_with_connection(&conn).await
-        } else {
-            // For file-based databases, create a new connection
-            let conn = db.connect()?;
-            self.run_with_connection(&conn).await
-        }
+        let conn = db.guard().await?;
+        self.run_with_connection(&conn).await
     }
 
     /// Internal method to run migrations with a given connection
@@ -515,14 +506,8 @@ impl MigrationRunner {
     #[allow(dead_code)]
     #[instrument(skip_all, fields(db_name = %db.name()))]
     pub async fn current_version(&self, db: &Database) -> Result<Option<i64>, DatabaseError> {
-        // Use persistent connection for in-memory databases to ensure we see the same data
-        if let Some(persistent) = db.persistent_connection() {
-            let conn = persistent.lock().await;
-            self.current_version_with_connection(&conn).await
-        } else {
-            let conn = db.connect()?;
-            self.current_version_with_connection(&conn).await
-        }
+        let conn = db.guard().await?;
+        self.current_version_with_connection(&conn).await
     }
 
     /// Internal method to get current version with a given connection
@@ -612,9 +597,8 @@ mod tests {
         let applied = runner.run(&db).await.unwrap();
         assert!(!applied.is_empty());
 
-        // Verify tables exist - use persistent connection for in-memory database
-        let conn = db.persistent_connection().unwrap();
-        let conn = conn.lock().await;
+        // Verify tables exist
+        let conn = db.guard().await.unwrap();
         let mut rows = conn
             .query(
                 "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name",
@@ -655,8 +639,7 @@ mod tests {
         let db = Database::in_memory("test-incompatible-history")
             .await
             .unwrap();
-        let conn = db.persistent_connection().unwrap();
-        let conn = conn.lock().await;
+        let conn = db.guard().await.unwrap();
 
         conn.execute(
             r#"

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -56,9 +56,67 @@ impl Deref for ConnectionGuard<'_> {
     }
 }
 
+pub use actor::{DbActor, DbExecute, DbQuery, DbQueryOne, RowValues};
 pub use migrations::MigrationRunner;
 pub use pool::{DatabasePool, PoolConfig, PoolHealth};
 // ConnectionGuard is public via the enum definition above
+
+/// Extension trait for extracting typed values from `libsql::Value`.
+///
+/// Used when parsing `RowValues` returned by `DbActor` messages, which return
+/// `Vec<libsql::Value>` rather than borrowed `libsql::Row` references.
+pub trait ValueExt {
+    fn as_string(&self) -> Result<String, DatabaseError>;
+    fn as_optional_string(&self) -> Result<Option<String>, DatabaseError>;
+    fn as_i64(&self) -> Result<i64, DatabaseError>;
+}
+
+impl ValueExt for libsql::Value {
+    fn as_string(&self) -> Result<String, DatabaseError> {
+        match self {
+            libsql::Value::Text(s) => Ok(s.clone()),
+            libsql::Value::Null => {
+                Err(DatabaseError::QueryFailed("expected text, got null".into()))
+            }
+            other => Err(DatabaseError::QueryFailed(format!(
+                "expected text, got {:?}",
+                other
+            ))),
+        }
+    }
+
+    fn as_optional_string(&self) -> Result<Option<String>, DatabaseError> {
+        match self {
+            libsql::Value::Null => Ok(None),
+            libsql::Value::Text(s) => Ok(Some(s.clone())),
+            other => Err(DatabaseError::QueryFailed(format!(
+                "expected text or null, got {:?}",
+                other
+            ))),
+        }
+    }
+
+    fn as_i64(&self) -> Result<i64, DatabaseError> {
+        match self {
+            libsql::Value::Integer(i) => Ok(*i),
+            other => Err(DatabaseError::QueryFailed(format!(
+                "expected integer, got {:?}",
+                other
+            ))),
+        }
+    }
+}
+
+/// Get a value from a row by index with bounds checking.
+pub fn row_value(row: &[libsql::Value], idx: usize) -> Result<&libsql::Value, DatabaseError> {
+    row.get(idx).ok_or_else(|| {
+        DatabaseError::QueryFailed(format!(
+            "column index {} out of bounds (row has {} columns)",
+            idx,
+            row.len()
+        ))
+    })
+}
 
 /// Database-specific errors
 #[derive(Error, Debug)]

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -16,20 +16,49 @@
 //! - Independent scaling per waddle
 //! - Easy data export/backup per community
 
+pub mod actor;
 pub mod blocking;
 mod migrations;
 mod pool;
 pub mod roster;
 
 use libsql::{Connection, Database as LibSqlDatabase};
+use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{debug, info, instrument};
 
+/// A guard that wraps either a persistent connection (for in-memory databases)
+/// or an owned connection (for file-based databases).
+///
+/// For in-memory databases, libSQL creates a new isolated database for each
+/// `connect()` call, so we must reuse a single persistent connection behind
+/// a Mutex. For file-based databases, we create fresh connections.
+///
+/// Use `Database::guard()` to obtain one. The guard auto-derefs to `Connection`.
+pub enum ConnectionGuard<'a> {
+    /// Persistent connection guard for in-memory databases.
+    Persistent(tokio::sync::MutexGuard<'a, Connection>),
+    /// Owned connection for file-based databases.
+    Owned(Connection),
+}
+
+impl Deref for ConnectionGuard<'_> {
+    type Target = Connection;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            ConnectionGuard::Persistent(guard) => guard,
+            ConnectionGuard::Owned(conn) => conn,
+        }
+    }
+}
+
 pub use migrations::MigrationRunner;
 pub use pool::{DatabasePool, PoolConfig, PoolHealth};
+// ConnectionGuard is public via the enum definition above
 
 /// Database-specific errors
 #[derive(Error, Debug)]
@@ -97,7 +126,7 @@ impl DatabaseConfig {
 /// persists across multiple `connect()` calls. libSQL's `:memory:` creates
 /// a new isolated database for each connection, so we need to reuse the same
 /// connection to maintain data.
-#[derive(Clone)]
+#[derive(Clone, kameo::Reply)]
 pub struct Database {
     db: Arc<LibSqlDatabase>,
     name: String,
@@ -234,29 +263,21 @@ impl Database {
         Ok(conn)
     }
 
-    /// Execute a callback with a connection, using the persistent connection for in-memory databases.
+    /// Obtain a connection guard for database operations.
     ///
-    /// This method ensures that for in-memory databases, all operations use the same
-    /// connection to maintain data consistency.
-    #[allow(dead_code)] // API method for future use
-    pub async fn with_connection<F, Fut, T>(&self, f: F) -> Result<T, DatabaseError>
-    where
-        F: FnOnce(&Connection) -> Fut,
-        Fut: std::future::Future<Output = T>,
-    {
+    /// For in-memory databases, returns a guard to the shared persistent
+    /// connection (locked via Mutex). For file-based databases, creates a
+    /// fresh connection with busy_timeout already set.
+    ///
+    /// The returned guard auto-derefs to `Connection`.
+    pub async fn guard(&self) -> Result<ConnectionGuard<'_>, DatabaseError> {
         if let Some(ref persistent) = self.persistent_conn {
-            let conn = persistent.lock().await;
-            Ok(f(&conn).await)
+            let guard = persistent.lock().await;
+            Ok(ConnectionGuard::Persistent(guard))
         } else {
-            let conn = self.db.connect()?;
-            Ok(f(&conn).await)
+            let conn = self.connect()?;
+            Ok(ConnectionGuard::Owned(conn))
         }
-    }
-
-    /// Get a reference to the persistent connection if this is an in-memory database.
-    /// This is useful for operations that need to maintain connection state.
-    pub fn persistent_connection(&self) -> Option<&Arc<Mutex<Connection>>> {
-        self.persistent_conn.as_ref()
     }
 
     /// Get the database name
@@ -276,24 +297,12 @@ impl Database {
     /// Check if the database is healthy by executing a simple query
     #[instrument(skip_all, fields(name = %self.name))]
     pub async fn health_check(&self) -> Result<bool, DatabaseError> {
-        // Use persistent connection for in-memory databases
-        if let Some(ref persistent) = self.persistent_conn {
-            let conn = persistent.lock().await;
-            match conn.query("SELECT 1", ()).await {
-                Ok(_) => Ok(true),
-                Err(e) => {
-                    tracing::warn!("Database health check failed: {}", e);
-                    Ok(false)
-                }
-            }
-        } else {
-            let conn = self.connect()?;
-            match conn.query("SELECT 1", ()).await {
-                Ok(_) => Ok(true),
-                Err(e) => {
-                    tracing::warn!("Database health check failed: {}", e);
-                    Ok(false)
-                }
+        let conn = self.guard().await?;
+        match conn.query("SELECT 1", ()).await {
+            Ok(_) => Ok(true),
+            Err(e) => {
+                tracing::warn!("Database health check failed: {}", e);
+                Ok(false)
             }
         }
     }
@@ -302,16 +311,9 @@ impl Database {
     #[allow(dead_code)]
     #[instrument(skip_all, fields(name = %self.name))]
     pub async fn execute(&self, sql: &str) -> Result<u64, DatabaseError> {
-        // Use persistent connection for in-memory databases
-        if let Some(ref persistent) = self.persistent_conn {
-            let conn = persistent.lock().await;
-            let rows = conn.execute(sql, ()).await?;
-            Ok(rows)
-        } else {
-            let conn = self.connect()?;
-            let rows = conn.execute(sql, ()).await?;
-            Ok(rows)
-        }
+        let conn = self.guard().await?;
+        let rows = conn.execute(sql, ()).await?;
+        Ok(rows)
     }
 }
 
@@ -346,9 +348,8 @@ mod tests {
             .await
             .unwrap();
 
-        // Query should succeed - use persistent connection for in-memory database
-        let conn = db.persistent_connection().unwrap();
-        let conn = conn.lock().await;
+        // Query should succeed
+        let conn = db.guard().await.unwrap();
         let mut rows = conn.query("SELECT * FROM test", ()).await.unwrap();
         let row = rows.next().await.unwrap().unwrap();
         let name: String = row.get(1).unwrap();

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -215,17 +215,22 @@ impl DatabasePool {
 
     /// Evict the most idle waddle actor (by idle time), skipping the given id.
     async fn evict_most_idle(&self, skip_id: &str) {
+        // Snapshot actor refs to avoid holding DashMap shard locks across .await
+        let actors: Vec<(String, ActorRef<DbActor>)> = self
+            .waddle_actors
+            .iter()
+            .filter(|e| e.key() != skip_id)
+            .map(|e| (e.key().clone(), e.value().clone()))
+            .collect();
+
         let mut most_idle_key: Option<String> = None;
         let mut most_idle_ms: u64 = 0;
 
-        for entry in self.waddle_actors.iter() {
-            if entry.key() == skip_id {
-                continue;
-            }
-            if let Ok(idle) = entry.value().ask(GetIdleMs).await {
+        for (key, actor) in actors {
+            if let Ok(idle) = actor.ask(GetIdleMs).await {
                 if idle > most_idle_ms {
                     most_idle_ms = idle;
-                    most_idle_key = Some(entry.key().clone());
+                    most_idle_key = Some(key);
                 }
             }
         }
@@ -267,23 +272,35 @@ impl DatabasePool {
     /// Perform a health check on the pool
     #[instrument(skip_all)]
     pub async fn health_check(&self) -> Result<PoolHealth, DatabaseError> {
-        let global_healthy = self
-            .global_actor
-            .ask(DbHealthCheck)
-            .await
-            .unwrap_or(false);
+        let global_healthy = match self.global_actor.ask(DbHealthCheck).await {
+            Ok(healthy) => healthy,
+            Err(e) => {
+                tracing::warn!("Global DB health check failed: {}", e);
+                false
+            }
+        };
 
-        // Check a sample of loaded waddle actors
+        // Snapshot actor refs to avoid holding DashMap shard locks across .await
+        let sample: Vec<ActorRef<DbActor>> = self
+            .waddle_actors
+            .iter()
+            .take(5)
+            .map(|e| e.value().clone())
+            .collect();
+
         let mut waddle_healthy = true;
-        for entry in self.waddle_actors.iter().take(5) {
-            if let Ok(healthy) = entry.value().ask(DbHealthCheck).await {
-                if !healthy {
+        for actor in sample {
+            match actor.ask(DbHealthCheck).await {
+                Ok(healthy) if !healthy => {
                     waddle_healthy = false;
                     break;
                 }
-            } else {
-                waddle_healthy = false;
-                break;
+                Err(e) => {
+                    tracing::warn!("Waddle DB health check failed: {}", e);
+                    waddle_healthy = false;
+                    break;
+                }
+                _ => {}
             }
         }
 
@@ -300,8 +317,14 @@ impl DatabasePool {
     pub async fn sync_all(&self) -> Result<(), DatabaseError> {
         if self.config.turso_url.is_some() {
             self.global_db.sync().await?;
-            for entry in self.waddle_actors.iter() {
-                if let Ok(db) = entry.value().ask(GetDatabase).await {
+            // Snapshot actor refs to avoid holding DashMap shard locks across .await
+            let actors: Vec<ActorRef<DbActor>> = self
+                .waddle_actors
+                .iter()
+                .map(|e| e.value().clone())
+                .collect();
+            for actor in actors {
+                if let Ok(db) = actor.ask(GetDatabase).await {
                     db.sync().await?;
                 }
             }

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -237,7 +237,10 @@ impl DatabasePool {
 
         if let Some(key) = most_idle_key {
             self.waddle_actors.remove(&key);
-            debug!("Evicted most idle waddle actor from cache: {} (idle {}ms)", key, most_idle_ms);
+            debug!(
+                "Evicted most idle waddle actor from cache: {} (idle {}ms)",
+                key, most_idle_ms
+            );
         }
     }
 

--- a/server/crates/waddle-server/src/db/pool.rs
+++ b/server/crates/waddle-server/src/db/pool.rs
@@ -1,9 +1,13 @@
 //! Database connection pool for Waddle Server
 //!
 //! Manages both the global database and per-Waddle databases.
+//! Internally uses Kameo actors: each database is owned by a `DbActor`,
+//! ensuring sequential access without external Mutex locking.
 
+use super::actor::{DbActor, DbHealthCheck, GetDatabase, GetIdleMs};
 use super::{Database, DatabaseConfig, DatabaseError};
 use dashmap::DashMap;
+use kameo::actor::ActorRef;
 use std::path::PathBuf;
 use tracing::{debug, info, instrument};
 
@@ -32,11 +36,17 @@ impl Default for PoolConfig {
 /// - A single global database for users, sessions, waddle registry
 /// - Per-Waddle databases for channels and messages
 /// - Lazy loading of per-Waddle databases
+///
+/// Internally each database is owned by a `DbActor`. The `global()` and
+/// `get_waddle_db()` methods return `Database` clones for backward
+/// compatibility; callers may also obtain the `ActorRef<DbActor>` directly.
 pub struct DatabasePool {
-    /// Global database (always loaded)
-    global: Database,
-    /// Per-Waddle databases (loaded on demand)
-    waddle_dbs: DashMap<String, Database>,
+    /// Global database actor (always running)
+    global_actor: ActorRef<DbActor>,
+    /// Cached clone of the global database for cheap access
+    global_db: Database,
+    /// Per-Waddle database actors (spawned on demand)
+    waddle_actors: DashMap<String, ActorRef<DbActor>>,
     /// Database configuration
     config: DatabaseConfig,
     /// Pool configuration
@@ -53,7 +63,7 @@ impl DatabasePool {
         info!("Initializing database pool");
 
         // Create the global database
-        let global = match (
+        let global_db = match (
             &config.global_db_path,
             &config.turso_url,
             &config.turso_auth_token,
@@ -70,6 +80,9 @@ impl DatabasePool {
 
         info!("Global database initialized");
 
+        // Spawn the global actor
+        let global_actor = kameo::spawn(DbActor::new(global_db.clone()));
+
         // Ensure waddle database directory exists if configured
         if let Some(base_path) = &config.waddle_db_base_path {
             std::fs::create_dir_all(base_path).map_err(|e| {
@@ -81,8 +94,9 @@ impl DatabasePool {
         }
 
         Ok(Self {
-            global,
-            waddle_dbs: DashMap::new(),
+            global_actor,
+            global_db,
+            waddle_actors: DashMap::new(),
             config,
             pool_config,
         })
@@ -90,7 +104,12 @@ impl DatabasePool {
 
     /// Get a reference to the global database
     pub fn global(&self) -> &Database {
-        &self.global
+        &self.global_db
+    }
+
+    /// Get the actor ref for the global database
+    pub fn global_actor(&self) -> &ActorRef<DbActor> {
+        &self.global_actor
     }
 
     /// Get or create a per-Waddle database
@@ -98,32 +117,19 @@ impl DatabasePool {
     /// This lazily loads the database if not already in memory.
     #[instrument(skip_all, fields(waddle_id = %waddle_id))]
     pub async fn get_waddle_db(&self, waddle_id: &str) -> Result<Database, DatabaseError> {
-        // Check if already loaded
-        if let Some(db) = self.waddle_dbs.get(waddle_id) {
-            debug!("Returning cached waddle database: {}", waddle_id);
-            return Ok(db.clone());
-        }
+        let actor = self.get_or_spawn_waddle_actor(waddle_id).await?;
+        actor
+            .ask(GetDatabase)
+            .await
+            .map_err(|e| DatabaseError::Internal(libsql::Error::ConnectionFailed(e.to_string())))
+    }
 
-        // Load or create the database
-        debug!("Loading waddle database: {}", waddle_id);
-        let db = self.open_waddle_db(waddle_id).await?;
-
-        // Cache it
-        self.waddle_dbs.insert(waddle_id.to_string(), db.clone());
-
-        // Evict old entries if we're over the limit
-        // (Simple LRU would be better, but this is good enough for now)
-        if self.waddle_dbs.len() > self.pool_config.max_waddle_dbs {
-            // Remove a random entry that isn't the one we just added
-            if let Some(entry) = self.waddle_dbs.iter().find(|e| e.key() != waddle_id) {
-                let key = entry.key().clone();
-                drop(entry);
-                self.waddle_dbs.remove(&key);
-                debug!("Evicted waddle database from cache: {}", key);
-            }
-        }
-
-        Ok(db)
+    /// Get or spawn the actor for a per-Waddle database.
+    pub async fn get_waddle_actor(
+        &self,
+        waddle_id: &str,
+    ) -> Result<ActorRef<DbActor>, DatabaseError> {
+        self.get_or_spawn_waddle_actor(waddle_id).await
     }
 
     /// Create a new per-Waddle database
@@ -132,7 +138,7 @@ impl DatabasePool {
     #[instrument(skip_all, fields(waddle_id = %waddle_id))]
     pub async fn create_waddle_db(&self, waddle_id: &str) -> Result<Database, DatabaseError> {
         // Check if it already exists
-        if self.waddle_dbs.contains_key(waddle_id) {
+        if self.waddle_actors.contains_key(waddle_id) {
             return Err(DatabaseError::AlreadyExists(waddle_id.to_string()));
         }
 
@@ -146,11 +152,41 @@ impl DatabasePool {
 
         info!("Creating new waddle database: {}", waddle_id);
         let db = self.open_waddle_db(waddle_id).await?;
+        let db_clone = db.clone();
+
+        // Spawn actor and cache it
+        let actor = kameo::spawn(DbActor::new(db));
+        self.waddle_actors.insert(waddle_id.to_string(), actor);
+
+        Ok(db_clone)
+    }
+
+    /// Internal: get an existing actor or spawn a new one for this waddle.
+    async fn get_or_spawn_waddle_actor(
+        &self,
+        waddle_id: &str,
+    ) -> Result<ActorRef<DbActor>, DatabaseError> {
+        // Check if already loaded
+        if let Some(actor) = self.waddle_actors.get(waddle_id) {
+            debug!("Returning cached waddle actor: {}", waddle_id);
+            return Ok(actor.clone());
+        }
+
+        // Load or create the database, spawn an actor
+        debug!("Spawning waddle actor: {}", waddle_id);
+        let db = self.open_waddle_db(waddle_id).await?;
+        let actor = kameo::spawn(DbActor::new(db));
 
         // Cache it
-        self.waddle_dbs.insert(waddle_id.to_string(), db.clone());
+        self.waddle_actors
+            .insert(waddle_id.to_string(), actor.clone());
 
-        Ok(db)
+        // Evict the most idle actor if we're over the limit
+        if self.waddle_actors.len() > self.pool_config.max_waddle_dbs {
+            self.evict_most_idle(waddle_id).await;
+        }
+
+        Ok(actor)
     }
 
     /// Open a waddle database (create if needed)
@@ -165,8 +201,6 @@ impl DatabasePool {
             // Turso sync enabled (url and token will be used in future when implementing Turso sync)
             (Some(base_path), Some(_url), Some(_token)) => {
                 let db_path = PathBuf::from(base_path).join(format!("{}.db", waddle_id));
-                // For per-waddle databases, we'd use a different Turso database
-                // For now, use local-only
                 Database::open_local(&name, db_path).await
             }
             // Local file-based
@@ -179,10 +213,33 @@ impl DatabasePool {
         }
     }
 
+    /// Evict the most idle waddle actor (by idle time), skipping the given id.
+    async fn evict_most_idle(&self, skip_id: &str) {
+        let mut most_idle_key: Option<String> = None;
+        let mut most_idle_ms: u64 = 0;
+
+        for entry in self.waddle_actors.iter() {
+            if entry.key() == skip_id {
+                continue;
+            }
+            if let Ok(idle) = entry.value().ask(GetIdleMs).await {
+                if idle > most_idle_ms {
+                    most_idle_ms = idle;
+                    most_idle_key = Some(entry.key().clone());
+                }
+            }
+        }
+
+        if let Some(key) = most_idle_key {
+            self.waddle_actors.remove(&key);
+            debug!("Evicted most idle waddle actor from cache: {} (idle {}ms)", key, most_idle_ms);
+        }
+    }
+
     /// Check if a waddle database exists
     #[allow(dead_code)]
     pub fn waddle_db_exists(&self, waddle_id: &str) -> bool {
-        if self.waddle_dbs.contains_key(waddle_id) {
+        if self.waddle_actors.contains_key(waddle_id) {
             return true;
         }
 
@@ -197,25 +254,34 @@ impl DatabasePool {
 
     /// Remove a waddle database from the pool (does not delete the file)
     pub fn unload_waddle_db(&self, waddle_id: &str) {
-        self.waddle_dbs.remove(waddle_id);
+        self.waddle_actors.remove(waddle_id);
         debug!("Unloaded waddle database: {}", waddle_id);
     }
 
     /// Get the number of currently loaded waddle databases
     #[allow(dead_code)]
     pub fn loaded_waddle_count(&self) -> usize {
-        self.waddle_dbs.len()
+        self.waddle_actors.len()
     }
 
     /// Perform a health check on the pool
     #[instrument(skip_all)]
     pub async fn health_check(&self) -> Result<PoolHealth, DatabaseError> {
-        let global_healthy = self.global.health_check().await?;
+        let global_healthy = self
+            .global_actor
+            .ask(DbHealthCheck)
+            .await
+            .unwrap_or(false);
 
-        // Check a sample of loaded waddle databases
+        // Check a sample of loaded waddle actors
         let mut waddle_healthy = true;
-        for entry in self.waddle_dbs.iter().take(5) {
-            if !entry.value().health_check().await? {
+        for entry in self.waddle_actors.iter().take(5) {
+            if let Ok(healthy) = entry.value().ask(DbHealthCheck).await {
+                if !healthy {
+                    waddle_healthy = false;
+                    break;
+                }
+            } else {
                 waddle_healthy = false;
                 break;
             }
@@ -224,7 +290,7 @@ impl DatabasePool {
         Ok(PoolHealth {
             global_healthy,
             waddle_dbs_healthy: waddle_healthy,
-            loaded_waddle_count: self.waddle_dbs.len(),
+            loaded_waddle_count: self.waddle_actors.len(),
         })
     }
 
@@ -233,9 +299,11 @@ impl DatabasePool {
     #[instrument(skip_all)]
     pub async fn sync_all(&self) -> Result<(), DatabaseError> {
         if self.config.turso_url.is_some() {
-            self.global.sync().await?;
-            for entry in self.waddle_dbs.iter() {
-                entry.value().sync().await?;
+            self.global_db.sync().await?;
+            for entry in self.waddle_actors.iter() {
+                if let Ok(db) = entry.value().ask(GetDatabase).await {
+                    db.sync().await?;
+                }
             }
         }
         Ok(())

--- a/server/crates/waddle-server/src/db/roster.rs
+++ b/server/crates/waddle-server/src/db/roster.rs
@@ -357,49 +357,36 @@ impl DatabaseRosterStorage {
         Ok(jids)
     }
 
-    /// Execute a query using the persistent connection for in-memory databases.
-    /// This ensures data written by migrations is visible to queries.
+    /// Execute a query using a connection guard from the database.
     async fn query_with_persistent(
         &self,
         sql: &str,
         params: impl IntoParams,
     ) -> Result<libsql::Rows, RosterStorageError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.query(sql, params)
-                .await
-                .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| RosterStorageError::ConnectionFailed(e.to_string()))?;
-            conn.query(sql, params)
-                .await
-                .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
-        }
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| RosterStorageError::ConnectionFailed(e.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
     }
 
-    /// Execute a statement using the persistent connection for in-memory databases.
+    /// Execute a statement using a connection guard from the database.
     async fn execute_with_persistent(
         &self,
         sql: &str,
         params: impl IntoParams,
     ) -> Result<u64, RosterStorageError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(sql, params)
-                .await
-                .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| RosterStorageError::ConnectionFailed(e.to_string()))?;
-            conn.execute(sql, params)
-                .await
-                .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
-        }
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| RosterStorageError::ConnectionFailed(e.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|e| RosterStorageError::QueryFailed(e.to_string()))
     }
 
     /// Execute a statement with retries for transient sqlite lock contention.

--- a/server/crates/waddle-server/src/main.rs
+++ b/server/crates/waddle-server/src/main.rs
@@ -11,6 +11,7 @@ mod permissions;
 mod server;
 mod telemetry;
 mod vcard;
+mod waddle;
 
 pub use config::{ServerConfig, ServerMode};
 

--- a/server/crates/waddle-server/src/messages/mod.rs
+++ b/server/crates/waddle-server/src/messages/mod.rs
@@ -77,8 +77,7 @@ mod tests {
 
     /// Helper function to create a test channel in the database
     async fn create_test_channel(db: &Arc<Database>, channel_id: &str) {
-        let conn = db.persistent_connection().unwrap();
-        let conn = conn.lock().await;
+        let conn = db.guard().await.unwrap();
         conn.execute(
             "INSERT INTO channels (id, name, channel_type, position, is_default) VALUES (?, ?, 'text', 0, 0)",
             libsql::params![channel_id, format!("Test Channel {}", channel_id)],

--- a/server/crates/waddle-server/src/messages/repository.rs
+++ b/server/crates/waddle-server/src/messages/repository.rs
@@ -41,55 +41,30 @@ impl MessageRepository {
         let expires_at_str = create.expires_at.map(|dt| dt.to_rfc3339());
         let created_at_str = created_at.to_rfc3339();
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                r#"
+        let conn = self.db.guard().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+        })?;
+        conn.execute(
+            r#"
                 INSERT INTO messages (
                     id, channel_id, author_user_id, content, reply_to_id, thread_id,
                     flags, edited_at, created_at, expires_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
                 "#,
-                libsql::params![
-                    id.clone(),
-                    create.channel_id.clone(),
-                    create.author_user_id.clone(),
-                    content.clone(),
-                    create.reply_to_id.clone(),
-                    create.thread_id.clone(),
-                    flags_bits,
-                    created_at_str.clone(),
-                    expires_at_str.clone()
-                ],
-            )
-            .await
-            .map_err(|e| MessageError::DatabaseError(format!("Failed to insert message: {}", e)))?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
-            })?;
-            conn.execute(
-                r#"
-                INSERT INTO messages (
-                    id, channel_id, author_user_id, content, reply_to_id, thread_id,
-                    flags, edited_at, created_at, expires_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
-                "#,
-                libsql::params![
-                    id.clone(),
-                    create.channel_id.clone(),
-                    create.author_user_id.clone(),
-                    content.clone(),
-                    create.reply_to_id.clone(),
-                    create.thread_id.clone(),
-                    flags_bits,
-                    created_at_str,
-                    expires_at_str
-                ],
-            )
-            .await
-            .map_err(|e| MessageError::DatabaseError(format!("Failed to insert message: {}", e)))?;
-        }
+            libsql::params![
+                id.clone(),
+                create.channel_id.clone(),
+                create.author_user_id.clone(),
+                content.clone(),
+                create.reply_to_id.clone(),
+                create.thread_id.clone(),
+                flags_bits,
+                created_at_str,
+                expires_at_str
+            ],
+        )
+        .await
+        .map_err(|e| MessageError::DatabaseError(format!("Failed to insert message: {}", e)))?;
 
         debug!("Created message: {}", id);
 
@@ -117,27 +92,16 @@ impl MessageRepository {
             WHERE id = ?
         "#;
 
-        let row = if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn.query(query, libsql::params![id]).await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to query message: {}", e))
-            })?;
+        let conn = self.db.guard().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+        })?;
+        let mut rows = conn.query(query, libsql::params![id]).await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to query message: {}", e))
+        })?;
 
-            rows.next().await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to read message row: {}", e))
-            })?
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
-            })?;
-            let mut rows = conn.query(query, libsql::params![id]).await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to query message: {}", e))
-            })?;
-
-            rows.next().await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to read message row: {}", e))
-            })?
-        };
+        let row = rows.next().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to read message row: {}", e))
+        })?;
 
         match row {
             Some(row) => {
@@ -175,37 +139,12 @@ impl MessageRepository {
             Some(cursor) => {
                 // Get the created_at of the cursor message for proper pagination
                 let cursor_query = "SELECT created_at FROM messages WHERE id = ?";
-                let cursor_created_at = if let Some(persistent) = self.db.persistent_connection() {
-                    let conn = persistent.lock().await;
-                    let mut rows = conn
-                        .query(cursor_query, libsql::params![cursor])
-                        .await
-                        .map_err(|e| {
-                            MessageError::DatabaseError(format!("Failed to query cursor: {}", e))
-                        })?;
-
-                    match rows.next().await.map_err(|e| {
-                        MessageError::DatabaseError(format!("Failed to read cursor row: {}", e))
-                    })? {
-                        Some(row) => {
-                            let created_at: String = row.get(0).map_err(|e| {
-                                MessageError::DatabaseError(format!(
-                                    "Failed to get cursor created_at: {}",
-                                    e
-                                ))
-                            })?;
-                            created_at
-                        }
-                        None => {
-                            return Err(MessageError::InvalidId(format!(
-                                "Cursor message not found: {}",
-                                cursor
-                            )))
-                        }
-                    }
-                } else {
-                    let conn = self.db.connect().map_err(|e| {
-                        MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+                let cursor_created_at = {
+                    let conn = self.db.guard().await.map_err(|e| {
+                        MessageError::DatabaseError(format!(
+                            "Failed to connect to database: {}",
+                            e
+                        ))
                     })?;
                     let mut rows = conn
                         .query(cursor_query, libsql::params![cursor])
@@ -266,30 +205,17 @@ impl MessageRepository {
 
         let mut messages = Vec::new();
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn.query(query, params).await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to query messages: {}", e))
-            })?;
+        let conn = self.db.guard().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+        })?;
+        let mut rows = conn.query(query, params).await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to query messages: {}", e))
+        })?;
 
-            while let Some(row) = rows.next().await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to read message row: {}", e))
-            })? {
-                messages.push(self.row_to_message(&row)?);
-            }
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
-            })?;
-            let mut rows = conn.query(query, params).await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to query messages: {}", e))
-            })?;
-
-            while let Some(row) = rows.next().await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to read message row: {}", e))
-            })? {
-                messages.push(self.row_to_message(&row)?);
-            }
+        while let Some(row) = rows.next().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to read message row: {}", e))
+        })? {
+            messages.push(self.row_to_message(&row)?);
         }
 
         // Check if there are more messages
@@ -350,13 +276,8 @@ impl MessageRepository {
             set_clauses.join(", ")
         );
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(&query, params).await.map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to update message: {}", e))
-            })?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
+        {
+            let conn = self.db.guard().await.map_err(|e| {
                 MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
             })?;
             conn.execute(&query, params).await.map_err(|e| {
@@ -375,32 +296,18 @@ impl MessageRepository {
     /// Delete a message
     #[instrument(skip(self))]
     pub async fn delete(&self, id: &str) -> Result<(), MessageError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let rows_affected = conn
-                .execute("DELETE FROM messages WHERE id = ?", libsql::params![id])
-                .await
-                .map_err(|e| {
-                    MessageError::DatabaseError(format!("Failed to delete message: {}", e))
-                })?;
-
-            if rows_affected == 0 {
-                return Err(MessageError::NotFound(id.to_string()));
-            }
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+        let conn = self.db.guard().await.map_err(|e| {
+            MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
+        })?;
+        let rows_affected = conn
+            .execute("DELETE FROM messages WHERE id = ?", libsql::params![id])
+            .await
+            .map_err(|e| {
+                MessageError::DatabaseError(format!("Failed to delete message: {}", e))
             })?;
-            let rows_affected = conn
-                .execute("DELETE FROM messages WHERE id = ?", libsql::params![id])
-                .await
-                .map_err(|e| {
-                    MessageError::DatabaseError(format!("Failed to delete message: {}", e))
-                })?;
 
-            if rows_affected == 0 {
-                return Err(MessageError::NotFound(id.to_string()));
-            }
+        if rows_affected == 0 {
+            return Err(MessageError::NotFound(id.to_string()));
         }
 
         debug!("Deleted message: {}", id);

--- a/server/crates/waddle-server/src/messages/repository.rs
+++ b/server/crates/waddle-server/src/messages/repository.rs
@@ -95,9 +95,10 @@ impl MessageRepository {
         let conn = self.db.guard().await.map_err(|e| {
             MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
         })?;
-        let mut rows = conn.query(query, libsql::params![id]).await.map_err(|e| {
-            MessageError::DatabaseError(format!("Failed to query message: {}", e))
-        })?;
+        let mut rows = conn
+            .query(query, libsql::params![id])
+            .await
+            .map_err(|e| MessageError::DatabaseError(format!("Failed to query message: {}", e)))?;
 
         let row = rows.next().await.map_err(|e| {
             MessageError::DatabaseError(format!("Failed to read message row: {}", e))
@@ -141,10 +142,7 @@ impl MessageRepository {
                 let cursor_query = "SELECT created_at FROM messages WHERE id = ?";
                 let cursor_created_at = {
                     let conn = self.db.guard().await.map_err(|e| {
-                        MessageError::DatabaseError(format!(
-                            "Failed to connect to database: {}",
-                            e
-                        ))
+                        MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
                     })?;
                     let mut rows = conn
                         .query(cursor_query, libsql::params![cursor])
@@ -208,9 +206,10 @@ impl MessageRepository {
         let conn = self.db.guard().await.map_err(|e| {
             MessageError::DatabaseError(format!("Failed to connect to database: {}", e))
         })?;
-        let mut rows = conn.query(query, params).await.map_err(|e| {
-            MessageError::DatabaseError(format!("Failed to query messages: {}", e))
-        })?;
+        let mut rows = conn
+            .query(query, params)
+            .await
+            .map_err(|e| MessageError::DatabaseError(format!("Failed to query messages: {}", e)))?;
 
         while let Some(row) = rows.next().await.map_err(|e| {
             MessageError::DatabaseError(format!("Failed to read message row: {}", e))
@@ -302,9 +301,7 @@ impl MessageRepository {
         let rows_affected = conn
             .execute("DELETE FROM messages WHERE id = ?", libsql::params![id])
             .await
-            .map_err(|e| {
-                MessageError::DatabaseError(format!("Failed to delete message: {}", e))
-            })?;
+            .map_err(|e| MessageError::DatabaseError(format!("Failed to delete message: {}", e)))?;
 
         if rows_affected == 0 {
             return Err(MessageError::NotFound(id.to_string()));

--- a/server/crates/waddle-server/src/permissions/actor.rs
+++ b/server/crates/waddle-server/src/permissions/actor.rs
@@ -1,0 +1,389 @@
+//! Kameo actor wrapping the permission service.
+//!
+//! The `PermissionActor` owns a `PermissionService` and processes all
+//! permission operations as actor messages. This centralises permission
+//! checking into a single actor with the LRU cache owned internally.
+//! This is Phase 4 of the actor-model migration described in issue #42.
+
+use kameo::message::Context;
+use kameo::Actor;
+
+use super::tuple::{Object, Subject, Tuple};
+use super::PermissionService;
+
+/// Actor that owns a [`PermissionService`] and handles permission operations
+/// sequentially via message passing.
+#[derive(Actor)]
+pub struct PermissionActor {
+    service: PermissionService,
+}
+
+impl PermissionActor {
+    /// Create a new `PermissionActor` wrapping the given service.
+    pub fn new(service: PermissionService) -> Self {
+        Self { service }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Check whether a subject has a permission on an object.
+///
+/// The subject, permission, and object are provided as strings and parsed
+/// internally (Zanzibar tuple format: `type:id` for subject/object).
+pub struct CheckPermission {
+    pub subject: String,
+    pub permission: String,
+    pub object: String,
+}
+
+impl kameo::message::Message<CheckPermission> for PermissionActor {
+    type Reply = Result<bool, String>;
+
+    async fn handle(
+        &mut self,
+        msg: CheckPermission,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let subject = Subject::parse(&msg.subject).map_err(|e| e.to_string())?;
+        let object = Object::parse(&msg.object).map_err(|e| e.to_string())?;
+
+        let response = self
+            .service
+            .check(&subject, &msg.permission, &object)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(response.allowed)
+    }
+}
+
+/// Write a new permission tuple.
+///
+/// The tuple is provided in Zanzibar string format:
+/// `object#relation@subject` (e.g. `waddle:test#owner@user:alice`).
+pub struct WriteTuple {
+    pub tuple_str: String,
+}
+
+impl kameo::message::Message<WriteTuple> for PermissionActor {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        msg: WriteTuple,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let tuple = Tuple::parse(&msg.tuple_str).map_err(|e| e.to_string())?;
+        self.service
+            .write_tuple(tuple)
+            .await
+            .map_err(|e| e.to_string())?;
+        // Invalidate the permission cache after a write to ensure
+        // subsequent checks reflect the new state.
+        self.service.checker.clear_cache().await;
+        Ok(())
+    }
+}
+
+/// Delete an existing permission tuple.
+///
+/// The tuple is provided in Zanzibar string format:
+/// `object#relation@subject`.
+pub struct DeleteTuple {
+    pub tuple_str: String,
+}
+
+impl kameo::message::Message<DeleteTuple> for PermissionActor {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        msg: DeleteTuple,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let tuple = Tuple::parse(&msg.tuple_str).map_err(|e| e.to_string())?;
+        self.service
+            .delete_tuple(&tuple)
+            .await
+            .map_err(|e| e.to_string())?;
+        // Invalidate the permission cache after a delete to ensure
+        // subsequent checks reflect the removal.
+        self.service.checker.clear_cache().await;
+        Ok(())
+    }
+}
+
+/// List all relations a subject has on an object.
+///
+/// Both subject and object are in `type:id` format.
+pub struct ListRelations {
+    pub subject: String,
+    pub object: String,
+}
+
+impl kameo::message::Message<ListRelations> for PermissionActor {
+    type Reply = Result<Vec<String>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: ListRelations,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let subject = Subject::parse(&msg.subject).map_err(|e| e.to_string())?;
+        let object = Object::parse(&msg.object).map_err(|e| e.to_string())?;
+
+        self.service
+            .list_relations(&subject, &object)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// List all subjects that hold a specific relation on an object.
+///
+/// The object is in `type:id` format and the relation is a plain string.
+/// Returns subject strings in their display format (e.g. `user:alice`).
+pub struct ListSubjects {
+    pub object: String,
+    pub relation: String,
+}
+
+impl kameo::message::Message<ListSubjects> for PermissionActor {
+    type Reply = Result<Vec<String>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: ListSubjects,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let object = Object::parse(&msg.object).map_err(|e| e.to_string())?;
+
+        let subjects = self
+            .service
+            .list_subjects(&object, &msg.relation)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(subjects.into_iter().map(|s| s.to_string()).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use kameo::actor::ActorRef;
+
+    use super::*;
+    use crate::db::{Database, MigrationRunner};
+
+    async fn spawn_test_actor() -> ActorRef<PermissionActor> {
+        let db = Database::in_memory("test-permission-actor")
+            .await
+            .expect("db");
+        let db = Arc::new(db);
+
+        let runner = MigrationRunner::global();
+        runner.run(&db).await.expect("migrations");
+
+        let service = PermissionService::new(db);
+        kameo::spawn(PermissionActor::new(service))
+    }
+
+    #[tokio::test]
+    async fn test_write_and_check_permission() {
+        let actor = spawn_test_actor().await;
+
+        // Write a tuple: alice is owner of waddle:test
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#owner@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write should succeed");
+
+        // Check: alice has owner permission
+        let allowed: bool = actor
+            .ask(CheckPermission {
+                subject: "user:user-alice".to_string(),
+                permission: "owner".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("check");
+        assert!(allowed);
+
+        // Check: bob does NOT have owner permission
+        let allowed: bool = actor
+            .ask(CheckPermission {
+                subject: "user:user-bob".to_string(),
+                permission: "owner".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("check");
+        assert!(!allowed);
+    }
+
+    #[tokio::test]
+    async fn test_write_and_delete_tuple() {
+        let actor = spawn_test_actor().await;
+
+        // Write
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#member@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write");
+
+        // Verify it exists
+        let allowed: bool = actor
+            .ask(CheckPermission {
+                subject: "user:user-alice".to_string(),
+                permission: "member".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("check");
+        assert!(allowed);
+
+        // Delete
+        actor
+            .ask(DeleteTuple {
+                tuple_str: "waddle:test#member@user:user-alice".to_string(),
+            })
+            .await
+            .expect("delete");
+
+        // Verify it no longer exists
+        let allowed: bool = actor
+            .ask(CheckPermission {
+                subject: "user:user-alice".to_string(),
+                permission: "member".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("check");
+        assert!(!allowed);
+    }
+
+    #[tokio::test]
+    async fn test_list_relations() {
+        let actor = spawn_test_actor().await;
+
+        // Write two relations for the same subject/object
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#owner@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write owner");
+
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#admin@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write admin");
+
+        let relations: Vec<String> = actor
+            .ask(ListRelations {
+                subject: "user:user-alice".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("list_relations");
+
+        assert_eq!(relations.len(), 2);
+        assert!(relations.contains(&"owner".to_string()));
+        assert!(relations.contains(&"admin".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_list_subjects() {
+        let actor = spawn_test_actor().await;
+
+        // Write two members
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#member@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write alice");
+
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#member@user:user-bob".to_string(),
+            })
+            .await
+            .expect("write bob");
+
+        let subjects: Vec<String> = actor
+            .ask(ListSubjects {
+                object: "waddle:test".to_string(),
+                relation: "member".to_string(),
+            })
+            .await
+            .expect("list_subjects");
+
+        assert_eq!(subjects.len(), 2);
+        assert!(subjects.contains(&"user:user-alice".to_string()));
+        assert!(subjects.contains(&"user:user-bob".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_computed_permission_via_actor() {
+        let actor = spawn_test_actor().await;
+
+        // alice is owner of waddle:test
+        actor
+            .ask(WriteTuple {
+                tuple_str: "waddle:test#owner@user:user-alice".to_string(),
+            })
+            .await
+            .expect("write");
+
+        // owner should have delete permission (computed via schema)
+        let allowed: bool = actor
+            .ask(CheckPermission {
+                subject: "user:user-alice".to_string(),
+                permission: "delete".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await
+            .expect("check");
+        assert!(allowed, "owner should have computed delete permission");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_tuple_format() {
+        let actor = spawn_test_actor().await;
+
+        let result = actor
+            .ask(WriteTuple {
+                tuple_str: "not-a-valid-tuple".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err(), "invalid tuple should return error");
+    }
+
+    #[tokio::test]
+    async fn test_invalid_subject_in_check() {
+        let actor = spawn_test_actor().await;
+
+        let result = actor
+            .ask(CheckPermission {
+                subject: "bad-subject".to_string(),
+                permission: "owner".to_string(),
+                object: "waddle:test".to_string(),
+            })
+            .await;
+
+        assert!(result.is_err(), "invalid subject should return error");
+    }
+}

--- a/server/crates/waddle-server/src/permissions/mod.rs
+++ b/server/crates/waddle-server/src/permissions/mod.rs
@@ -21,6 +21,7 @@
 //! channel:general#viewer@waddle:penguin-club#member
 //! ```
 
+pub mod actor;
 mod check;
 mod schema;
 mod tuple;

--- a/server/crates/waddle-server/src/permissions/tuple.rs
+++ b/server/crates/waddle-server/src/permissions/tuple.rs
@@ -703,7 +703,10 @@ impl TupleStore {
 
     /// Get database connection, using persistent connection for in-memory databases
     async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, PermissionError> {
-        self.db.guard().await.map_err(|e| PermissionError::DatabaseError(e.to_string()))
+        self.db
+            .guard()
+            .await
+            .map_err(|e| PermissionError::DatabaseError(e.to_string()))
     }
 }
 

--- a/server/crates/waddle-server/src/permissions/tuple.rs
+++ b/server/crates/waddle-server/src/permissions/tuple.rs
@@ -381,8 +381,7 @@ impl TupleStore {
 
         let subject_relation = tuple.subject.relation.as_deref();
 
-        conn.as_ref()
-            .execute(
+        conn.execute(
             r#"
             INSERT INTO permission_tuples (id, object_type, object_id, relation, subject_type, subject_id, subject_relation)
             VALUES (?, ?, ?, ?, ?, ?, ?)
@@ -419,7 +418,6 @@ impl TupleStore {
         let subject_relation = tuple.subject.relation.as_deref();
 
         let rows = conn
-            .as_ref()
             .execute(
                 r#"
                 DELETE FROM permission_tuples
@@ -460,7 +458,6 @@ impl TupleStore {
         let subject_relation = subject.relation.as_deref();
 
         let mut rows = conn
-            .as_ref()
             .query(
                 r#"
                 SELECT 1 FROM permission_tuples
@@ -501,7 +498,6 @@ impl TupleStore {
         let subject_relation = subject.relation.as_deref();
 
         let mut rows = conn
-            .as_ref()
             .query(
                 r#"
                 SELECT DISTINCT relation FROM permission_tuples
@@ -546,7 +542,6 @@ impl TupleStore {
         let conn = self.get_connection().await?;
 
         let mut rows = conn
-            .as_ref()
             .query(
                 r#"
                 SELECT subject_type, subject_id, subject_relation FROM permission_tuples
@@ -597,7 +592,6 @@ impl TupleStore {
         let conn = self.get_connection().await?;
 
         let mut rows = conn
-            .as_ref()
             .query(
                 r#"
                 SELECT id, object_type, object_id, relation, subject_type, subject_id, subject_relation, created_at
@@ -628,8 +622,7 @@ impl TupleStore {
         let conn = self.get_connection().await?;
 
         let mut rows = if let Some(rel) = relation {
-            conn.as_ref()
-                .query(
+            conn.query(
                 r#"
                 SELECT id, object_type, object_id, relation, subject_type, subject_id, subject_relation, created_at
                 FROM permission_tuples
@@ -640,8 +633,7 @@ impl TupleStore {
             .await
             .map_err(|e| PermissionError::DatabaseError(e.to_string()))?
         } else {
-            conn.as_ref()
-                .query(
+            conn.query(
                 r#"
                 SELECT id, object_type, object_id, relation, subject_type, subject_id, subject_relation, created_at
                 FROM permission_tuples
@@ -710,36 +702,8 @@ impl TupleStore {
     }
 
     /// Get database connection, using persistent connection for in-memory databases
-    async fn get_connection(&self) -> Result<ConnectionGuard<'_>, PermissionError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let guard = persistent.lock().await;
-            Ok(ConnectionGuard::Persistent(guard))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| PermissionError::DatabaseError(e.to_string()))?;
-            Ok(ConnectionGuard::Owned(conn))
-        }
-    }
-}
-
-/// A guard that wraps either a persistent connection (for in-memory databases)
-/// or an owned connection (for file-based databases).
-enum ConnectionGuard<'a> {
-    /// Persistent connection guard for in-memory databases
-    Persistent(tokio::sync::MutexGuard<'a, libsql::Connection>),
-    /// Owned connection for file-based databases
-    Owned(libsql::Connection),
-}
-
-impl<'a> ConnectionGuard<'a> {
-    /// Get a reference to the underlying connection.
-    fn as_ref(&self) -> &libsql::Connection {
-        match self {
-            ConnectionGuard::Persistent(guard) => guard,
-            ConnectionGuard::Owned(conn) => conn,
-        }
+    async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, PermissionError> {
+        self.db.guard().await.map_err(|e| PermissionError::DatabaseError(e.to_string()))
     }
 }
 

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1198,8 +1198,7 @@ mod tests {
         runner.run(&waddle_db).await.unwrap();
 
         // Verify tables exist - use persistent connection for in-memory database
-        let conn = waddle_db.persistent_connection().unwrap();
-        let conn = conn.lock().await;
+        let conn = waddle_db.guard().await.unwrap();
         let mut rows = conn
             .query(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='channels'",

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -396,6 +396,7 @@ pub async fn start_with_config(
             XmppAppState::new(
                 xmpp_config.domain.clone(),
                 Arc::new(db_pool.global().clone()),
+                db_pool.global_actor().clone(),
                 encryption_key.as_ref().map(|s| s.as_bytes()),
             )
             .with_db_pool(Arc::clone(&db_pool)),

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -53,7 +53,8 @@ impl AuthState {
         encryption_key: Option<&[u8]>,
     ) -> Self {
         let db = Arc::new(app_state.db_pool.global().clone());
-        let session_manager = SessionManager::new(Arc::clone(&db), encryption_key);
+        let session_manager =
+            SessionManager::new(app_state.db_pool.global_actor().clone(), encryption_key);
         let identity_service = IdentityService::new(Arc::clone(&db));
         let providers = ProviderRegistry::new(server_config.auth.providers.clone())
             .unwrap_or_else(|e| panic!("invalid provider config at startup: {}", e));

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -40,7 +40,8 @@ impl ChannelState {
     pub fn new(app_state: Arc<AppState>, encryption_key: Option<&[u8]>) -> Self {
         let db = Arc::new(app_state.db_pool.global().clone());
         let permission_service = PermissionService::new(Arc::clone(&db));
-        let session_manager = SessionManager::new(Arc::clone(&db), encryption_key);
+        let session_manager =
+            SessionManager::new(app_state.db_pool.global_actor().clone(), encryption_key);
         Self {
             app_state,
             permission_service,

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -573,44 +573,22 @@ async fn insert_channel(
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(
-            query,
-            libsql::params![
-                id,
-                name,
-                description,
-                channel_type,
-                position,
-                is_default as i32,
-                now,
-                now
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to insert channel: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(
-            query,
-            libsql::params![
-                id,
-                name,
-                description,
-                channel_type,
-                position,
-                is_default as i32,
-                now,
-                now
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to insert channel: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(
+        query,
+        libsql::params![
+            id,
+            name,
+            description,
+            channel_type,
+            position,
+            is_default as i32,
+            now,
+            now
+        ],
+    )
+    .await
+    .map_err(|e| format!("Failed to insert channel: {}", e))?;
 
     Ok(())
 }
@@ -627,30 +605,16 @@ pub(crate) async fn get_channel_from_db(
         WHERE id = ?
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![channel_id])
-            .await
-            .map_err(|e| format!("Failed to query channel: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![channel_id])
+        .await
+        .map_err(|e| format!("Failed to query channel: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read channel row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![channel_id])
-            .await
-            .map_err(|e| format!("Failed to query channel: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read channel row: {}", e))?
-    };
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read channel row: {}", e))?;
 
     match row {
         Some(row) => {
@@ -705,39 +669,19 @@ pub(crate) async fn list_channels_from_db(
 
     let mut channels = Vec::new();
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query channels: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![limit as i64, offset as i64])
+        .await
+        .map_err(|e| format!("Failed to query channels: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read channel row: {}", e))?
-        {
-            let channel = parse_channel_row(&row, waddle_id)?;
-            channels.push(channel);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query channels: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read channel row: {}", e))?
-        {
-            let channel = parse_channel_row(&row, waddle_id)?;
-            channels.push(channel);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read channel row: {}", e))?
+    {
+        let channel = parse_channel_row(&row, waddle_id)?;
+        channels.push(channel);
     }
 
     Ok(channels)
@@ -807,20 +751,10 @@ async fn update_channel_in_db(
 
     let query = format!("UPDATE channels SET {} WHERE id = ?", updates.join(", "));
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(&query, params)
-            .await
-            .map_err(|e| format!("Failed to update channel: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(&query, params)
-            .await
-            .map_err(|e| format!("Failed to update channel: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(&query, params)
+        .await
+        .map_err(|e| format!("Failed to update channel: {}", e))?;
 
     Ok(())
 }
@@ -830,20 +764,10 @@ async fn delete_channel_from_db(db: &Database, channel_id: &str) -> Result<(), S
     // Messages will be cascade deleted due to foreign key constraint
     let query = "DELETE FROM channels WHERE id = ?";
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![channel_id])
-            .await
-            .map_err(|e| format!("Failed to delete channel: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(query, libsql::params![channel_id])
-            .await
-            .map_err(|e| format!("Failed to delete channel: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![channel_id])
+        .await
+        .map_err(|e| format!("Failed to delete channel: {}", e))?;
 
     Ok(())
 }

--- a/server/crates/waddle-server/src/server/routes/uploads.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads.rs
@@ -178,30 +178,16 @@ async fn get_upload_slot(db: &Database, slot_id: &str) -> Result<Option<UploadSl
         WHERE id = ?
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![slot_id])
-            .await
-            .map_err(|e| format!("Failed to query upload slot: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![slot_id])
+        .await
+        .map_err(|e| format!("Failed to query upload slot: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read slot row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![slot_id])
-            .await
-            .map_err(|e| format!("Failed to query upload slot: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read slot row: {}", e))?
-    };
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read slot row: {}", e))?;
 
     match row {
         Some(row) => {
@@ -244,20 +230,10 @@ async fn mark_slot_uploaded(db: &Database, slot_id: &str, storage_key: &str) -> 
         WHERE id = ?
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![storage_key, now, slot_id])
-            .await
-            .map_err(|e| format!("Failed to update slot status: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(query, libsql::params![storage_key, now, slot_id])
-            .await
-            .map_err(|e| format!("Failed to update slot status: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![storage_key, now, slot_id])
+        .await
+        .map_err(|e| format!("Failed to update slot status: {}", e))?;
 
     Ok(())
 }
@@ -633,15 +609,13 @@ mod tests {
             VALUES (?, 'test@example.com', ?, ?, ?, 'pending', ?)
         "#;
 
-        if let Some(persistent) = db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                query,
-                libsql::params![slot_id, filename, size, content_type, expires_at],
-            )
-            .await
-            .unwrap();
-        }
+        let conn = db.guard().await.unwrap();
+        conn.execute(
+            query,
+            libsql::params![slot_id, filename, size, content_type, expires_at],
+        )
+        .await
+        .unwrap();
     }
 
     async fn create_expired_slot(state: &UploadState, slot_id: &str) {
@@ -654,12 +628,10 @@ mod tests {
             VALUES (?, 'test@example.com', 'expired.txt', 100, 'text/plain', 'pending', ?)
         "#;
 
-        if let Some(persistent) = db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(query, libsql::params![slot_id, expires_at])
-                .await
-                .unwrap();
-        }
+        let conn = db.guard().await.unwrap();
+        conn.execute(query, libsql::params![slot_id, expires_at])
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/users.rs
+++ b/server/crates/waddle-server/src/server/routes/users.rs
@@ -155,37 +155,23 @@ async fn search_users(
         LIMIT ?2
     "#;
 
+    let conn = db
+        .guard()
+        .await
+        .map_err(|e| e.to_string())?;
+
     let mut users = Vec::new();
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(sql, libsql::params![query, limit])
-            .await
-            .map_err(|e| format!("Failed to query users: {}", e))?;
+    let mut rows = conn
+        .query(sql, libsql::params![query, limit])
+        .await
+        .map_err(|e| format!("Failed to query users: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read user row: {}", e))?
-        {
-            users.push(parse_user_row(&row, xmpp_domain)?);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-        let mut rows = conn
-            .query(sql, libsql::params![query, limit])
-            .await
-            .map_err(|e| format!("Failed to query users: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read user row: {}", e))?
-        {
-            users.push(parse_user_row(&row, xmpp_domain)?);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read user row: {}", e))?
+    {
+        users.push(parse_user_row(&row, xmpp_domain)?);
     }
 
     Ok(users)

--- a/server/crates/waddle-server/src/server/routes/users.rs
+++ b/server/crates/waddle-server/src/server/routes/users.rs
@@ -155,10 +155,7 @@ async fn search_users(
         LIMIT ?2
     "#;
 
-    let conn = db
-        .guard()
-        .await
-        .map_err(|e| e.to_string())?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
 
     let mut users = Vec::new();
     let mut rows = conn

--- a/server/crates/waddle-server/src/server/routes/waddles.rs
+++ b/server/crates/waddle-server/src/server/routes/waddles.rs
@@ -1370,44 +1370,22 @@ async fn insert_waddle(
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(
-            query,
-            libsql::params![
-                id,
-                name,
-                description,
-                owner_id,
-                icon_url,
-                is_public as i32,
-                now,
-                now
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to insert waddle: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(
-            query,
-            libsql::params![
-                id,
-                name,
-                description,
-                owner_id,
-                icon_url,
-                is_public as i32,
-                now,
-                now
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to insert waddle: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(
+        query,
+        libsql::params![
+            id,
+            name,
+            description,
+            owner_id,
+            icon_url,
+            is_public as i32,
+            now,
+            now
+        ],
+    )
+    .await
+    .map_err(|e| format!("Failed to insert waddle: {}", e))?;
 
     Ok(())
 }
@@ -1424,20 +1402,10 @@ async fn add_waddle_member(
         VALUES (?, ?, ?)
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![waddle_id, user_id, role])
-            .await
-            .map_err(|e| format!("Failed to add waddle member: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(query, libsql::params![waddle_id, user_id, role])
-            .await
-            .map_err(|e| format!("Failed to add waddle member: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![waddle_id, user_id, role])
+        .await
+        .map_err(|e| format!("Failed to add waddle member: {}", e))?;
 
     Ok(())
 }
@@ -1454,30 +1422,16 @@ async fn get_waddle_from_db(
         WHERE w.id = ?
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to query waddle: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![waddle_id])
+        .await
+        .map_err(|e| format!("Failed to query waddle: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to query waddle: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-    };
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read waddle row: {}", e))?;
 
     match row {
         Some(row) => {
@@ -1526,32 +1480,17 @@ async fn get_user_role(
         WHERE wm.waddle_id = ? AND wm.user_id = ?
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query role: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![waddle_id, user_id])
+        .await
+        .map_err(|e| format!("Failed to query role: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read role row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query role: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read role row: {}", e))?
-    };
-
-    match row {
+    match rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read role row: {}", e))?
+    {
         Some(row) => {
             let role: String = row
                 .get(0)
@@ -1597,20 +1536,10 @@ async fn update_waddle_in_db(
 
     let query = format!("UPDATE waddles SET {} WHERE id = ?", updates.join(", "));
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(&query, params)
-            .await
-            .map_err(|e| format!("Failed to update waddle: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(&query, params)
-            .await
-            .map_err(|e| format!("Failed to update waddle: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(&query, params)
+        .await
+        .map_err(|e| format!("Failed to update waddle: {}", e))?;
 
     Ok(())
 }
@@ -1621,26 +1550,13 @@ async fn delete_waddle_from_db(db: &Database, waddle_id: &str) -> Result<(), Str
     let delete_members_query = "DELETE FROM waddle_members WHERE waddle_id = ?";
     let delete_waddle_query = "DELETE FROM waddles WHERE id = ?";
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(delete_members_query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to delete waddle members: {}", e))?;
-        conn.execute(delete_waddle_query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to delete waddle: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(delete_members_query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to delete waddle members: {}", e))?;
-        conn.execute(delete_waddle_query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to delete waddle: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(delete_members_query, libsql::params![waddle_id])
+        .await
+        .map_err(|e| format!("Failed to delete waddle members: {}", e))?;
+    conn.execute(delete_waddle_query, libsql::params![waddle_id])
+        .await
+        .map_err(|e| format!("Failed to delete waddle: {}", e))?;
 
     Ok(())
 }
@@ -1664,39 +1580,19 @@ pub(crate) async fn list_user_waddles(
 
     let mut waddles = Vec::new();
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![user_id, limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query waddles: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![user_id, limit as i64, offset as i64])
+        .await
+        .map_err(|e| format!("Failed to query waddles: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row(&row)?;
-            waddles.push(waddle);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![user_id, limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query waddles: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row(&row)?;
-            waddles.push(waddle);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read waddle row: {}", e))?
+    {
+        let waddle = parse_waddle_row(&row)?;
+        waddles.push(waddle);
     }
 
     Ok(waddles)
@@ -1757,41 +1653,20 @@ pub(crate) async fn get_waddle_by_id(
         WHERE w.id = ?
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to query waddle: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![waddle_id])
+        .await
+        .map_err(|e| format!("Failed to query waddle: {}", e))?;
 
-        if let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            Ok(Some(parse_waddle_row_base(&row)?))
-        } else {
-            Ok(None)
-        }
+    if let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read waddle row: {}", e))?
+    {
+        Ok(Some(parse_waddle_row_base(&row)?))
     } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id])
-            .await
-            .map_err(|e| format!("Failed to query waddle: {}", e))?;
-
-        if let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            Ok(Some(parse_waddle_row_base(&row)?))
-        } else {
-            Ok(None)
-        }
+        Ok(None)
     }
 }
 
@@ -1813,39 +1688,19 @@ pub(crate) async fn list_all_waddles_from_db(
 
     let mut waddles = Vec::new();
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query waddles: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![limit as i64, offset as i64])
+        .await
+        .map_err(|e| format!("Failed to query waddles: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row_base(&row)?;
-            waddles.push(waddle);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![limit as i64, offset as i64])
-            .await
-            .map_err(|e| format!("Failed to query waddles: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row_base(&row)?;
-            waddles.push(waddle);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read waddle row: {}", e))?
+    {
+        let waddle = parse_waddle_row_base(&row)?;
+        waddles.push(waddle);
     }
 
     Ok(waddles)
@@ -1900,39 +1755,19 @@ pub(crate) async fn list_public_waddles_from_db(
 
     let mut waddles = Vec::new();
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(sql, params.clone())
-            .await
-            .map_err(|e| format!("Failed to query public waddles: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(sql, params)
+        .await
+        .map_err(|e| format!("Failed to query public waddles: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read public waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row_base(&row)?;
-            waddles.push(waddle);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(sql, params)
-            .await
-            .map_err(|e| format!("Failed to query public waddles: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read public waddle row: {}", e))?
-        {
-            let waddle = parse_waddle_row_base(&row)?;
-            waddles.push(waddle);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read public waddle row: {}", e))?
+    {
+        let waddle = parse_waddle_row_base(&row)?;
+        waddles.push(waddle);
     }
 
     Ok(waddles)
@@ -1965,45 +1800,22 @@ async fn list_waddle_members(
 
     let mut members = Vec::new();
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(
-                query,
-                libsql::params![waddle_id, limit as i64, offset as i64],
-            )
-            .await
-            .map_err(|e| format!("Failed to query members: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(
+            query,
+            libsql::params![waddle_id, limit as i64, offset as i64],
+        )
+        .await
+        .map_err(|e| format!("Failed to query members: {}", e))?;
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read member row: {}", e))?
-        {
-            let member = parse_member_row(&row)?;
-            members.push(member);
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(
-                query,
-                libsql::params![waddle_id, limit as i64, offset as i64],
-            )
-            .await
-            .map_err(|e| format!("Failed to query members: {}", e))?;
-
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read member row: {}", e))?
-        {
-            let member = parse_member_row(&row)?;
-            members.push(member);
-        }
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read member row: {}", e))?
+    {
+        let member = parse_member_row(&row)?;
+        members.push(member);
     }
 
     Ok(members)
@@ -2046,29 +1858,16 @@ async fn get_waddle_member(
         LIMIT 1
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query member: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![waddle_id, user_id])
+        .await
+        .map_err(|e| format!("Failed to query member: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read member row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query member: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read member row: {}", e))?
-    };
+    let row = rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read member row: {}", e))?;
 
     row.map(|row| parse_member_row(&row)).transpose()
 }
@@ -2085,32 +1884,17 @@ async fn get_member_role(
         WHERE wm.waddle_id = ? AND wm.user_id = ?
     "#;
 
-    let row = if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query member role: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![waddle_id, user_id])
+        .await
+        .map_err(|e| format!("Failed to query member role: {}", e))?;
 
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read member role row: {}", e))?
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to query member role: {}", e))?;
-
-        rows.next()
-            .await
-            .map_err(|e| format!("Failed to read member role row: {}", e))?
-    };
-
-    match row {
+    match rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read member role row: {}", e))?
+    {
         Some(row) => {
             let role: String = row
                 .get(0)
@@ -2134,19 +1918,10 @@ async fn update_waddle_member_role(
         WHERE waddle_id = ? AND user_id = ?
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![role, waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to update waddle member role: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-        conn.execute(query, libsql::params![role, waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to update waddle member role: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![role, waddle_id, user_id])
+        .await
+        .map_err(|e| format!("Failed to update waddle member role: {}", e))?;
 
     Ok(())
 }
@@ -2164,20 +1939,10 @@ async fn add_waddle_member_with_timestamp(
         VALUES (?, ?, ?, ?)
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![waddle_id, user_id, role, joined_at])
-            .await
-            .map_err(|e| format!("Failed to add waddle member: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(query, libsql::params![waddle_id, user_id, role, joined_at])
-            .await
-            .map_err(|e| format!("Failed to add waddle member: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![waddle_id, user_id, role, joined_at])
+        .await
+        .map_err(|e| format!("Failed to add waddle member: {}", e))?;
 
     Ok(())
 }
@@ -2188,20 +1953,10 @@ async fn remove_waddle_member(db: &Database, waddle_id: &str, user_id: &str) -> 
         DELETE FROM waddle_members WHERE waddle_id = ? AND user_id = ?
     "#;
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to remove waddle member: {}", e))?;
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        conn.execute(query, libsql::params![waddle_id, user_id])
-            .await
-            .map_err(|e| format!("Failed to remove waddle member: {}", e))?;
-    }
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    conn.execute(query, libsql::params![waddle_id, user_id])
+        .await
+        .map_err(|e| format!("Failed to remove waddle member: {}", e))?;
 
     Ok(())
 }
@@ -2210,45 +1965,22 @@ async fn remove_waddle_member(db: &Database, waddle_id: &str, user_id: &str) -> 
 async fn get_username_by_user_id(db: &Database, user_id: &str) -> Result<Option<String>, String> {
     let query = "SELECT username FROM users WHERE id = ?";
 
-    if let Some(persistent) = db.persistent_connection() {
-        let conn = persistent.lock().await;
-        let mut rows = conn
-            .query(query, libsql::params![user_id])
-            .await
-            .map_err(|e| format!("Failed to query username: {}", e))?;
+    let conn = db.guard().await.map_err(|e| e.to_string())?;
+    let mut rows = conn
+        .query(query, libsql::params![user_id])
+        .await
+        .map_err(|e| format!("Failed to query username: {}", e))?;
 
-        match rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read username row: {}", e))?
-        {
-            Some(row) => row
-                .get(0)
-                .map(Some)
-                .map_err(|e| format!("Failed to get username: {}", e)),
-            None => Ok(None),
-        }
-    } else {
-        let conn = db
-            .connect()
-            .map_err(|e| format!("Failed to connect to database: {}", e))?;
-
-        let mut rows = conn
-            .query(query, libsql::params![user_id])
-            .await
-            .map_err(|e| format!("Failed to query username: {}", e))?;
-
-        match rows
-            .next()
-            .await
-            .map_err(|e| format!("Failed to read username row: {}", e))?
-        {
-            Some(row) => row
-                .get(0)
-                .map(Some)
-                .map_err(|e| format!("Failed to get username: {}", e)),
-            None => Ok(None),
-        }
+    match rows
+        .next()
+        .await
+        .map_err(|e| format!("Failed to read username row: {}", e))?
+    {
+        Some(row) => row
+            .get(0)
+            .map(Some)
+            .map_err(|e| format!("Failed to get username: {}", e)),
+        None => Ok(None),
     }
 }
 
@@ -2266,28 +1998,8 @@ async fn create_default_channel(
         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     "#;
 
-    if let Some(persistent) = waddle_db.persistent_connection() {
-        let conn = persistent.lock().await;
-        conn.execute(
-            query,
-            libsql::params![
-                channel_id.as_str(),
-                "general",
-                "General discussion",
-                "text",
-                0,
-                1,
-                now.clone(),
-                now
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to create default channel: {}", e))?;
-    } else {
-        let conn = waddle_db
-            .connect()
-            .map_err(|e| format!("Failed to connect to waddle database: {}", e))?;
-
+    {
+        let conn = waddle_db.guard().await.map_err(|e| e.to_string())?;
         conn.execute(
             query,
             libsql::params![
@@ -2318,13 +2030,7 @@ async fn create_default_channel(
     if let Err(err) = permission_service.write_tuple(parent_tuple).await {
         let delete_query = "DELETE FROM channels WHERE id = ?";
 
-        if let Some(persistent) = waddle_db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let _ = conn.execute(delete_query, [channel_id.as_str()]).await;
-        } else {
-            let conn = waddle_db
-                .connect()
-                .map_err(|e| format!("Failed to connect to waddle database: {}", e))?;
+        if let Ok(conn) = waddle_db.guard().await {
             let _ = conn.execute(delete_query, [channel_id.as_str()]).await;
         }
 
@@ -2386,21 +2092,12 @@ mod tests {
             .await
             .unwrap();
 
-        let row = if let Some(persistent) = waddle_db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn
-                .query("SELECT id FROM channels WHERE is_default = 1 LIMIT 1", ())
-                .await
-                .unwrap();
-            rows.next().await.unwrap().unwrap()
-        } else {
-            let conn = waddle_db.connect().unwrap();
-            let mut rows = conn
-                .query("SELECT id FROM channels WHERE is_default = 1 LIMIT 1", ())
-                .await
-                .unwrap();
-            rows.next().await.unwrap().unwrap()
-        };
+        let conn = waddle_db.guard().await.unwrap();
+        let mut rows = conn
+            .query("SELECT id FROM channels WHERE is_default = 1 LIMIT 1", ())
+            .await
+            .unwrap();
+        let row = rows.next().await.unwrap().unwrap();
 
         row.get(0).unwrap()
     }

--- a/server/crates/waddle-server/src/server/routes/waddles.rs
+++ b/server/crates/waddle-server/src/server/routes/waddles.rs
@@ -52,7 +52,8 @@ impl WaddleState {
     ) -> Self {
         let db = Arc::new(app_state.db_pool.global().clone());
         let permission_service = PermissionService::new(Arc::clone(&db));
-        let session_manager = SessionManager::new(Arc::clone(&db), encryption_key);
+        let session_manager =
+            SessionManager::new(app_state.db_pool.global_actor().clone(), encryption_key);
         Self {
             app_state,
             permission_service,

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -1713,9 +1713,9 @@ mod tests {
             .app_state
             .db_pool
             .global()
-            .persistent_connection()
+            .guard()
+            .await
             .expect("persistent connection");
-        let conn = conn.lock().await;
         conn.execute(
             "INSERT INTO waddles (id, name, description, owner_id, icon_url, is_public, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             libsql::params![
@@ -1744,9 +1744,9 @@ mod tests {
             .app_state
             .db_pool
             .global()
-            .persistent_connection()
+            .guard()
+            .await
             .expect("persistent connection");
-        let conn = conn.lock().await;
         conn.execute(
             "INSERT INTO waddle_members (waddle_id, user_id, role, joined_at) VALUES (?, ?, 'member', ?)",
             libsql::params![waddle_id, user_id, chrono::Utc::now().to_rfc3339()],
@@ -1861,9 +1861,9 @@ mod tests {
             .await
             .expect("waddle migrations");
         let conn = waddle_db
-            .persistent_connection()
+            .guard()
+            .await
             .expect("persistent connection");
-        let conn = conn.lock().await;
         conn.execute(
             "INSERT INTO channels (id, name, channel_type, position, is_default) VALUES (?, ?, 'text', 0, 0)",
             libsql::params!["general", "General"],

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -1860,10 +1860,7 @@ mod tests {
             .run(&waddle_db)
             .await
             .expect("waddle migrations");
-        let conn = waddle_db
-            .guard()
-            .await
-            .expect("persistent connection");
+        let conn = waddle_db.guard().await.expect("persistent connection");
         conn.execute(
             "INSERT INTO channels (id, name, channel_type, position, is_default) VALUES (?, ?, 'text', 0, 0)",
             libsql::params!["general", "General"],

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -11,11 +11,13 @@ use waddle_xmpp::{Session as XmppSession, XmppError};
 use crate::auth::{
     jid_to_localpart, localpart_to_jid, NativeUserStore, RegisterRequest, SessionManager,
 };
+use crate::db::actor::DbActor;
 use crate::db::{Database, DatabasePool, MigrationRunner};
 use crate::permissions::{Object, PermissionService, Subject};
 use crate::server::routes::channels::list_channels_from_db as list_channels_for_waddle_from_db;
 use crate::server::routes::waddles::list_user_waddles as list_user_waddles_from_db;
 use crate::vcard::VCardStore;
+use kameo::actor::ActorRef;
 
 /// XMPP application state that bridges to waddle-server services.
 ///
@@ -50,8 +52,13 @@ impl XmppAppState {
     /// * `domain` - The XMPP server domain (e.g., "waddle.social")
     /// * `db` - The global database for session and permission storage
     /// * `encryption_key` - Optional encryption key for session token encryption
-    pub fn new(domain: String, db: Arc<Database>, encryption_key: Option<&[u8]>) -> Self {
-        let session_manager = SessionManager::new(Arc::clone(&db), encryption_key);
+    pub fn new(
+        domain: String,
+        db: Arc<Database>,
+        db_actor: ActorRef<DbActor>,
+        encryption_key: Option<&[u8]>,
+    ) -> Self {
+        let session_manager = SessionManager::new(db_actor, encryption_key);
         let permission_service = PermissionService::new(Arc::clone(&db));
         let native_user_store = NativeUserStore::new(Arc::clone(&db));
         let vcard_store = VCardStore::new(Arc::clone(&db));
@@ -1212,7 +1219,7 @@ mod tests {
     use crate::permissions::ObjectType;
     use waddle_xmpp::AppState;
 
-    async fn create_test_db() -> Arc<Database> {
+    async fn create_test_db() -> (Arc<Database>, ActorRef<DbActor>) {
         let db = Database::in_memory("test-xmpp-state")
             .await
             .expect("Failed to create test database");
@@ -1222,13 +1229,14 @@ mod tests {
         let runner = MigrationRunner::global();
         runner.run(&db).await.expect("Failed to run migrations");
 
-        db
+        let actor = kameo::spawn(DbActor::new((*db).clone()));
+        (db, actor)
     }
 
     #[tokio::test]
     async fn test_xmpp_state_creation() {
-        let db = create_test_db().await;
-        let state = XmppAppState::new("waddle.social".to_string(), db, None);
+        let (db, actor) = create_test_db().await;
+        let state = XmppAppState::new("waddle.social".to_string(), db, actor, None);
 
         assert_eq!(state.domain(), "waddle.social");
     }

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -533,43 +533,24 @@ impl waddle_xmpp::AppState for XmppAppState {
         let get_url = format!("{}/api/files/{}/{}", base_url, slot_id, safe_filename);
 
         // Store the slot in the database
-        // Use persistent connection for in-memory databases
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(
-                "INSERT INTO upload_slots (id, requester_jid, filename, size_bytes, content_type, status, expires_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
-                libsql::params![
-                    slot_id.clone(),
-                    requester_jid.to_string(),
-                    safe_filename.clone(),
-                    size as i64,
-                    effective_type.clone(),
-                    expires_at.to_rfc3339(),
-                ],
-            ).await.map_err(|e| {
-                warn!(error = %e, "Failed to create upload slot in database");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-        } else {
-            let conn = self.db.connect().map_err(|e| {
-                warn!(error = %e, "Failed to connect to database for upload slot");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-            conn.execute(
-                "INSERT INTO upload_slots (id, requester_jid, filename, size_bytes, content_type, status, expires_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
-                libsql::params![
-                    slot_id.clone(),
-                    requester_jid.to_string(),
-                    safe_filename.clone(),
-                    size as i64,
-                    effective_type.clone(),
-                    expires_at.to_rfc3339(),
-                ],
-            ).await.map_err(|e| {
-                warn!(error = %e, "Failed to create upload slot in database");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-        }
+        let conn = self.db.guard().await.map_err(|e| {
+            warn!(error = %e, "Failed to connect to database for upload slot");
+            XmppError::internal(format!("Database error: {}", e))
+        })?;
+        conn.execute(
+            "INSERT INTO upload_slots (id, requester_jid, filename, size_bytes, content_type, status, expires_at) VALUES (?, ?, ?, ?, ?, 'pending', ?)",
+            libsql::params![
+                slot_id.clone(),
+                requester_jid.to_string(),
+                safe_filename.clone(),
+                size as i64,
+                effective_type.clone(),
+                expires_at.to_rfc3339(),
+            ],
+        ).await.map_err(|e| {
+            warn!(error = %e, "Failed to create upload slot in database");
+            XmppError::internal(format!("Database error: {}", e))
+        })?;
 
         debug!(
             slot_id = %slot_id,
@@ -924,47 +905,27 @@ impl waddle_xmpp::AppState for XmppAppState {
         let query = "SELECT xml_content FROM private_xml_storage WHERE jid = ? AND namespace = ?";
         let params = libsql::params![jid.to_string(), namespace.to_string()];
 
-        let result = if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            let mut rows = conn.query(query, params).await.map_err(|e| {
-                warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to get private XML");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-            match rows
-                .next()
-                .await
-                .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?
-            {
-                Some(row) => {
-                    let xml: String = row
-                        .get(0)
-                        .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
-                    Some(xml)
-                }
-                None => None,
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
+        let mut rows = conn.query(query, params).await.map_err(|e| {
+            warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to get private XML");
+            XmppError::internal(format!("Database error: {}", e))
+        })?;
+        let result = match rows
+            .next()
+            .await
+            .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?
+        {
+            Some(row) => {
+                let xml: String = row
+                    .get(0)
+                    .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
+                Some(xml)
             }
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
-            let mut rows = conn.query(query, params).await.map_err(|e| {
-                warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to get private XML");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-            match rows
-                .next()
-                .await
-                .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?
-            {
-                Some(row) => {
-                    let xml: String = row
-                        .get(0)
-                        .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
-                    Some(xml)
-                }
-                None => None,
-            }
+            None => None,
         };
 
         Ok(result)
@@ -986,22 +947,15 @@ impl waddle_xmpp::AppState for XmppAppState {
             xml_content.to_string()
         ];
 
-        if let Some(persistent) = self.db.persistent_connection() {
-            let conn = persistent.lock().await;
-            conn.execute(query, params).await.map_err(|e| {
-                warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to set private XML");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
-            conn.execute(query, params).await.map_err(|e| {
-                warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to set private XML");
-                XmppError::internal(format!("Database error: {}", e))
-            })?;
-        }
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| XmppError::internal(format!("Database error: {}", e)))?;
+        conn.execute(query, params).await.map_err(|e| {
+            warn!(jid = %jid, namespace = %namespace, error = %e, "Failed to set private XML");
+            XmppError::internal(format!("Database error: {}", e))
+        })?;
 
         Ok(())
     }

--- a/server/crates/waddle-server/src/vcard.rs
+++ b/server/crates/waddle-server/src/vcard.rs
@@ -41,7 +41,10 @@ impl VCardStore {
     /// to ensure data consistency (libSQL creates isolated databases for each `:memory:` connection).
     /// For file-based databases, we create new connections.
     async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, VCardError> {
-        self.db.guard().await.map_err(|e| VCardError::DatabaseError(e.to_string()))
+        self.db
+            .guard()
+            .await
+            .map_err(|e| VCardError::DatabaseError(e.to_string()))
     }
 
     /// Get the vCard for a user.
@@ -84,17 +87,17 @@ impl VCardStore {
         let conn = self.get_connection().await?;
 
         conn.execute(
-                r#"
+            r#"
                 INSERT INTO vcard_storage (jid, vcard_xml, created_at, updated_at)
                 VALUES (?, ?, datetime('now'), datetime('now'))
                 ON CONFLICT(jid) DO UPDATE SET
                     vcard_xml = excluded.vcard_xml,
                     updated_at = datetime('now')
                 "#,
-                (jid_str.as_str(), vcard_xml),
-            )
-            .await
-            .map_err(db_err)?;
+            (jid_str.as_str(), vcard_xml),
+        )
+        .await
+        .map_err(db_err)?;
 
         debug!(jid = %jid_str, "vCard stored successfully");
         Ok(())

--- a/server/crates/waddle-server/src/vcard.rs
+++ b/server/crates/waddle-server/src/vcard.rs
@@ -40,17 +40,8 @@ impl VCardStore {
     /// For in-memory databases, this returns a guard to the persistent connection
     /// to ensure data consistency (libSQL creates isolated databases for each `:memory:` connection).
     /// For file-based databases, we create new connections.
-    async fn get_connection(&self) -> Result<ConnectionGuard<'_>, VCardError> {
-        if let Some(persistent) = self.db.persistent_connection() {
-            let guard = persistent.lock().await;
-            Ok(ConnectionGuard::Persistent(guard))
-        } else {
-            let conn = self
-                .db
-                .connect()
-                .map_err(|e| VCardError::DatabaseError(e.to_string()))?;
-            Ok(ConnectionGuard::Owned(conn))
-        }
+    async fn get_connection(&self) -> Result<crate::db::ConnectionGuard<'_>, VCardError> {
+        self.db.guard().await.map_err(|e| VCardError::DatabaseError(e.to_string()))
     }
 
     /// Get the vCard for a user.
@@ -63,7 +54,6 @@ impl VCardStore {
         let conn = self.get_connection().await?;
 
         let mut rows = conn
-            .as_ref()
             .query(
                 "SELECT vcard_xml FROM vcard_storage WHERE jid = ?",
                 [jid_str.as_str()],
@@ -93,8 +83,7 @@ impl VCardStore {
 
         let conn = self.get_connection().await?;
 
-        conn.as_ref()
-            .execute(
+        conn.execute(
                 r#"
                 INSERT INTO vcard_storage (jid, vcard_xml, created_at, updated_at)
                 VALUES (?, ?, datetime('now'), datetime('now'))
@@ -122,7 +111,6 @@ impl VCardStore {
         let conn = self.get_connection().await?;
 
         let affected = conn
-            .as_ref()
             .execute(
                 "DELETE FROM vcard_storage WHERE jid = ?",
                 [jid_str.as_str()],
@@ -136,28 +124,6 @@ impl VCardStore {
         } else {
             debug!(jid = %jid_str, "No vCard to delete");
             Ok(false)
-        }
-    }
-}
-
-/// A guard that wraps either a persistent connection (for in-memory databases)
-/// or an owned connection (for file-based databases).
-///
-/// This ensures that in-memory databases always use the persistent connection
-/// to maintain data across operations.
-enum ConnectionGuard<'a> {
-    /// Persistent connection guard for in-memory databases
-    Persistent(tokio::sync::MutexGuard<'a, libsql::Connection>),
-    /// Owned connection for file-based databases
-    Owned(libsql::Connection),
-}
-
-impl<'a> ConnectionGuard<'a> {
-    /// Get a reference to the underlying connection
-    fn as_ref(&self) -> &libsql::Connection {
-        match self {
-            ConnectionGuard::Persistent(guard) => guard,
-            ConnectionGuard::Owned(conn) => conn,
         }
     }
 }

--- a/server/crates/waddle-server/src/waddle/actor.rs
+++ b/server/crates/waddle-server/src/waddle/actor.rs
@@ -1,0 +1,347 @@
+//! Kameo actor representing a single Waddle community.
+//!
+//! The `WaddleActor` supervises one waddle (community). It tracks the set of
+//! channels (rooms) that belong to this waddle and holds a reference to the
+//! waddle's `DbActor` for database operations.
+//!
+//! This is Phase 3 of the actor-model migration: one `WaddleActor` per
+//! community, sitting between the global registry and the per-room actors
+//! that live in waddle-xmpp's `RoomRegistryActor`.
+
+use std::collections::HashSet;
+
+use kameo::actor::ActorRef;
+use kameo::message::Context;
+use kameo::Actor;
+
+use crate::db::actor::DbActor;
+
+// ---------------------------------------------------------------------------
+// Reply wrappers
+// ---------------------------------------------------------------------------
+
+/// Newtype wrapper around `ActorRef<DbActor>` that implements `kameo::Reply`.
+#[derive(Clone, kameo::Reply)]
+pub struct DbActorRef(pub ActorRef<DbActor>);
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for a Waddle community.
+#[derive(Debug, Clone, Default, kameo::Reply)]
+pub struct WaddleConfig {
+    /// Human-readable name of the waddle.
+    pub name: String,
+    /// Optional description.
+    pub description: Option<String>,
+    /// Whether this waddle is publicly discoverable.
+    pub is_public: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+/// Actor representing a single Waddle community.
+///
+/// Each waddle has its own `DbActor` for database isolation. The set of
+/// channel IDs is maintained here; the actual room actors are managed by
+/// waddle-xmpp's `RoomRegistryActor` (cross-crate boundary).
+#[derive(Actor)]
+pub struct WaddleActor {
+    /// Unique identifier for this waddle community.
+    waddle_id: String,
+    /// Database actor scoped to this waddle.
+    db_actor: ActorRef<DbActor>,
+    /// Channel IDs belonging to this waddle.
+    channels: HashSet<String>,
+    /// Waddle configuration (name, description, visibility).
+    config: WaddleConfig,
+}
+
+impl WaddleActor {
+    /// Create a new `WaddleActor`.
+    pub fn new(
+        waddle_id: String,
+        db_actor: ActorRef<DbActor>,
+        config: WaddleConfig,
+    ) -> Self {
+        Self {
+            waddle_id,
+            db_actor,
+            channels: HashSet::new(),
+            config,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Retrieve the current waddle configuration.
+pub struct GetConfig;
+
+impl kameo::message::Message<GetConfig> for WaddleActor {
+    type Reply = WaddleConfig;
+
+    async fn handle(
+        &mut self,
+        _msg: GetConfig,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.config.clone()
+    }
+}
+
+/// Replace the waddle configuration.
+pub struct UpdateConfig {
+    pub config: WaddleConfig,
+}
+
+impl kameo::message::Message<UpdateConfig> for WaddleActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: UpdateConfig,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.config = msg.config;
+    }
+}
+
+/// Register a channel (room) as belonging to this waddle.
+pub struct RegisterChannel {
+    pub channel_id: String,
+}
+
+impl kameo::message::Message<RegisterChannel> for WaddleActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RegisterChannel,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.channels.insert(msg.channel_id);
+    }
+}
+
+/// Remove a channel from this waddle.
+pub struct UnregisterChannel {
+    pub channel_id: String,
+}
+
+impl kameo::message::Message<UnregisterChannel> for WaddleActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: UnregisterChannel,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.channels.remove(&msg.channel_id);
+    }
+}
+
+/// List all channel IDs registered to this waddle.
+pub struct ListChannels;
+
+impl kameo::message::Message<ListChannels> for WaddleActor {
+    type Reply = Vec<String>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListChannels,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.channels.iter().cloned().collect()
+    }
+}
+
+/// Retrieve the waddle's unique ID.
+pub struct GetWaddleId;
+
+impl kameo::message::Message<GetWaddleId> for WaddleActor {
+    type Reply = String;
+
+    async fn handle(
+        &mut self,
+        _msg: GetWaddleId,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.waddle_id.clone()
+    }
+}
+
+/// Retrieve a reference to the waddle's database actor.
+pub struct GetDbActor;
+
+impl kameo::message::Message<GetDbActor> for WaddleActor {
+    type Reply = DbActorRef;
+
+    async fn handle(
+        &mut self,
+        _msg: GetDbActor,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        DbActorRef(self.db_actor.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{Database, MigrationRunner};
+
+    async fn spawn_test_waddle() -> ActorRef<WaddleActor> {
+        let db = Database::in_memory("test-waddle-actor")
+            .await
+            .expect("db");
+        let runner = MigrationRunner::global();
+        runner.run(&db).await.expect("migrations");
+
+        let db_actor = kameo::spawn(DbActor::new(db));
+
+        let config = WaddleConfig {
+            name: "Test Waddle".to_string(),
+            description: Some("A test community".to_string()),
+            is_public: true,
+        };
+
+        kameo::spawn(WaddleActor::new(
+            "waddle-123".to_string(),
+            db_actor,
+            config,
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_get_waddle_id() {
+        let actor = spawn_test_waddle().await;
+        let id: String = actor.ask(GetWaddleId).await.expect("ask");
+        assert_eq!(id, "waddle-123");
+    }
+
+    #[tokio::test]
+    async fn test_get_config() {
+        let actor = spawn_test_waddle().await;
+        let config: WaddleConfig = actor.ask(GetConfig).await.expect("ask");
+        assert_eq!(config.name, "Test Waddle");
+        assert_eq!(config.description.as_deref(), Some("A test community"));
+        assert!(config.is_public);
+    }
+
+    #[tokio::test]
+    async fn test_update_config() {
+        let actor = spawn_test_waddle().await;
+
+        let new_config = WaddleConfig {
+            name: "Renamed Waddle".to_string(),
+            description: None,
+            is_public: false,
+        };
+        actor
+            .ask(UpdateConfig {
+                config: new_config,
+            })
+            .await
+            .expect("ask");
+
+        let config: WaddleConfig = actor.ask(GetConfig).await.expect("ask");
+        assert_eq!(config.name, "Renamed Waddle");
+        assert!(config.description.is_none());
+        assert!(!config.is_public);
+    }
+
+    #[tokio::test]
+    async fn test_register_and_list_channels() {
+        let actor = spawn_test_waddle().await;
+
+        // Initially empty
+        let channels: Vec<String> = actor.ask(ListChannels).await.expect("ask");
+        assert!(channels.is_empty());
+
+        // Register two channels
+        actor
+            .ask(RegisterChannel {
+                channel_id: "general".to_string(),
+            })
+            .await
+            .expect("ask");
+        actor
+            .ask(RegisterChannel {
+                channel_id: "random".to_string(),
+            })
+            .await
+            .expect("ask");
+
+        let mut channels: Vec<String> = actor.ask(ListChannels).await.expect("ask");
+        channels.sort();
+        assert_eq!(channels, vec!["general", "random"]);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_channel() {
+        let actor = spawn_test_waddle().await;
+
+        actor
+            .ask(RegisterChannel {
+                channel_id: "general".to_string(),
+            })
+            .await
+            .expect("ask");
+        actor
+            .ask(RegisterChannel {
+                channel_id: "random".to_string(),
+            })
+            .await
+            .expect("ask");
+
+        actor
+            .ask(UnregisterChannel {
+                channel_id: "general".to_string(),
+            })
+            .await
+            .expect("ask");
+
+        let channels: Vec<String> = actor.ask(ListChannels).await.expect("ask");
+        assert_eq!(channels, vec!["random"]);
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_channel_registration() {
+        let actor = spawn_test_waddle().await;
+
+        actor
+            .ask(RegisterChannel {
+                channel_id: "general".to_string(),
+            })
+            .await
+            .expect("ask");
+        actor
+            .ask(RegisterChannel {
+                channel_id: "general".to_string(),
+            })
+            .await
+            .expect("ask");
+
+        let channels: Vec<String> = actor.ask(ListChannels).await.expect("ask");
+        assert_eq!(channels.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_get_db_actor() {
+        let actor = spawn_test_waddle().await;
+        let db_ref: DbActorRef = actor.ask(GetDbActor).await.expect("ask");
+        // Verify the db actor is alive by sending a health check
+        let healthy: Result<bool, _> = db_ref.0.ask(crate::db::actor::DbHealthCheck).await;
+        assert!(healthy.expect("health check"));
+    }
+}

--- a/server/crates/waddle-server/src/waddle/actor.rs
+++ b/server/crates/waddle-server/src/waddle/actor.rs
@@ -62,11 +62,7 @@ pub struct WaddleActor {
 
 impl WaddleActor {
     /// Create a new `WaddleActor`.
-    pub fn new(
-        waddle_id: String,
-        db_actor: ActorRef<DbActor>,
-        config: WaddleConfig,
-    ) -> Self {
+    pub fn new(waddle_id: String, db_actor: ActorRef<DbActor>, config: WaddleConfig) -> Self {
         Self {
             waddle_id,
             db_actor,
@@ -201,9 +197,7 @@ mod tests {
     use crate::db::{Database, MigrationRunner};
 
     async fn spawn_test_waddle() -> ActorRef<WaddleActor> {
-        let db = Database::in_memory("test-waddle-actor")
-            .await
-            .expect("db");
+        let db = Database::in_memory("test-waddle-actor").await.expect("db");
         let runner = MigrationRunner::global();
         runner.run(&db).await.expect("migrations");
 
@@ -215,11 +209,7 @@ mod tests {
             is_public: true,
         };
 
-        kameo::spawn(WaddleActor::new(
-            "waddle-123".to_string(),
-            db_actor,
-            config,
-        ))
+        kameo::spawn(WaddleActor::new("waddle-123".to_string(), db_actor, config))
     }
 
     #[tokio::test]
@@ -248,9 +238,7 @@ mod tests {
             is_public: false,
         };
         actor
-            .ask(UpdateConfig {
-                config: new_config,
-            })
+            .ask(UpdateConfig { config: new_config })
             .await
             .expect("ask");
 

--- a/server/crates/waddle-server/src/waddle/mod.rs
+++ b/server/crates/waddle-server/src/waddle/mod.rs
@@ -1,0 +1,8 @@
+//! Waddle community module.
+//!
+//! Each waddle is a community with its own set of channels, configuration,
+//! and database. The `WaddleActor` supervises a single community.
+
+pub mod actor;
+
+pub use actor::{WaddleActor, WaddleConfig};

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -15,7 +15,9 @@ pub mod federation;
 pub mod messages;
 pub mod owner;
 pub mod presence;
+pub mod room_actor;
 pub mod room_registry;
+pub mod room_registry_actor;
 
 pub use admin::{
     build_admin_result, build_admin_set_result, build_role_result, is_affiliation_change_query,

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -8,8 +8,8 @@ use jid::{BareJid, FullJid};
 use kameo::message::Context;
 use kameo::Actor;
 
-use super::{MucRoom, RoomConfig};
 use super::room_registry::RoomInfo;
+use super::{MucRoom, RoomConfig};
 use crate::types::{Affiliation, Role};
 
 // ---------------------------------------------------------------------------
@@ -71,11 +71,7 @@ pub struct Join {
 impl kameo::message::Message<Join> for RoomActor {
     type Reply = Result<(), String>;
 
-    async fn handle(
-        &mut self,
-        msg: Join,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+    async fn handle(&mut self, msg: Join, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         if self.room.is_full() {
             return Err("Room is full".to_string());
         }
@@ -102,11 +98,7 @@ pub struct Leave {
 impl kameo::message::Message<Leave> for RoomActor {
     type Reply = Result<(), String>;
 
-    async fn handle(
-        &mut self,
-        msg: Leave,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+    async fn handle(&mut self, msg: Leave, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         self.room
             .remove_occupant(&msg.nick)
             .map(|_| ())
@@ -458,10 +450,7 @@ mod tests {
             .await
             .expect("join");
 
-        let info = actor
-            .ask(GetOccupantByJid { jid })
-            .await
-            .expect("ask");
+        let info = actor.ask(GetOccupantByJid { jid }).await.expect("ask");
         assert!(info.is_some());
     }
 
@@ -487,9 +476,7 @@ mod tests {
         let mut new_config = config;
         new_config.members_only = false;
         actor
-            .ask(UpdateConfig {
-                config: new_config,
-            })
+            .ask(UpdateConfig { config: new_config })
             .await
             .expect("ask");
 
@@ -516,10 +503,7 @@ mod tests {
             .await
             .expect("ask");
 
-        let aff = actor
-            .ask(GetAffiliation { jid })
-            .await
-            .expect("ask");
+        let aff = actor.ask(GetAffiliation { jid }).await.expect("ask");
         assert_eq!(aff, Affiliation::Admin);
     }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -1,0 +1,584 @@
+//! Kameo actor wrapping a single MUC room.
+//!
+//! Each `RoomActor` owns a [`MucRoom`] and processes all operations
+//! sequentially, removing the need for external `RwLock` synchronisation.
+//! This is part of the Phase 3 actor-model migration.
+
+use jid::{BareJid, FullJid};
+use kameo::message::Context;
+use kameo::Actor;
+
+use super::{MucRoom, RoomConfig};
+use super::room_registry::RoomInfo;
+use crate::types::{Affiliation, Role};
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/// Snapshot of occupant data, safe to send across actor boundaries.
+#[derive(Debug, Clone)]
+pub struct OccupantInfo {
+    pub nick: String,
+    pub real_jid: FullJid,
+    pub role: Role,
+    pub affiliation: Affiliation,
+}
+
+impl OccupantInfo {
+    fn from_occupant(o: &super::Occupant) -> Self {
+        Self {
+            nick: o.nick.clone(),
+            real_jid: o.real_jid.clone(),
+            role: o.role,
+            affiliation: o.affiliation,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+/// Actor that owns a single [`MucRoom`] and handles all room operations.
+///
+/// Because Kameo processes messages one at a time, the actor holds a
+/// `MucRoom` directly with no external synchronisation required.
+#[derive(Actor)]
+pub struct RoomActor {
+    room: MucRoom,
+}
+
+impl RoomActor {
+    /// Create a new `RoomActor` wrapping the given room.
+    pub fn new(room: MucRoom) -> Self {
+        Self { room }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Add an occupant to the room.
+pub struct Join {
+    pub nick: String,
+    pub real_jid: FullJid,
+    pub role: Role,
+    pub affiliation: Affiliation,
+}
+
+impl kameo::message::Message<Join> for RoomActor {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        msg: Join,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.room.is_full() {
+            return Err("Room is full".to_string());
+        }
+        if self.room.get_occupant(&msg.nick).is_some() {
+            return Err(format!("Nick '{}' already in use", msg.nick));
+        }
+        self.room.add_occupant(super::Occupant {
+            real_jid: msg.real_jid,
+            nick: msg.nick,
+            role: msg.role,
+            affiliation: msg.affiliation,
+            is_remote: false,
+            home_server: None,
+        });
+        Ok(())
+    }
+}
+
+/// Remove an occupant from the room.
+pub struct Leave {
+    pub nick: String,
+}
+
+impl kameo::message::Message<Leave> for RoomActor {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        msg: Leave,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room
+            .remove_occupant(&msg.nick)
+            .map(|_| ())
+            .ok_or_else(|| format!("No occupant with nick '{}'", msg.nick))
+    }
+}
+
+/// Look up an occupant by their real JID.
+pub struct GetOccupantByJid {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<GetOccupantByJid> for RoomActor {
+    type Reply = Option<OccupantInfo>;
+
+    async fn handle(
+        &mut self,
+        msg: GetOccupantByJid,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room
+            .find_occupant_by_real_jid(&msg.jid)
+            .map(OccupantInfo::from_occupant)
+    }
+}
+
+/// Look up an occupant by their nickname.
+pub struct GetOccupantByNick {
+    pub nick: String,
+}
+
+impl kameo::message::Message<GetOccupantByNick> for RoomActor {
+    type Reply = Option<OccupantInfo>;
+
+    async fn handle(
+        &mut self,
+        msg: GetOccupantByNick,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room
+            .get_occupant(&msg.nick)
+            .map(OccupantInfo::from_occupant)
+    }
+}
+
+/// Get basic room information.
+pub struct GetInfo;
+
+impl kameo::message::Message<GetInfo> for RoomActor {
+    type Reply = Result<RoomInfo, String>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetInfo,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(RoomInfo {
+            room_jid: self.room.room_jid.clone(),
+            occupant_count: self.room.occupant_count(),
+            name: self.room.config.name.clone(),
+        })
+    }
+}
+
+/// Get the current room configuration.
+pub struct GetConfig;
+
+impl kameo::message::Message<GetConfig> for RoomActor {
+    type Reply = Result<RoomConfig, String>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetConfig,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.room.config.clone())
+    }
+}
+
+/// Replace the room configuration.
+pub struct UpdateConfig {
+    pub config: RoomConfig,
+}
+
+impl kameo::message::Message<UpdateConfig> for RoomActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: UpdateConfig,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room.config = msg.config;
+    }
+}
+
+/// Change the persistent affiliation for a JID.
+pub struct ChangeAffiliation {
+    pub jid: BareJid,
+    pub affiliation: Affiliation,
+}
+
+impl kameo::message::Message<ChangeAffiliation> for RoomActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: ChangeAffiliation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room.set_affiliation(msg.jid, msg.affiliation);
+    }
+}
+
+/// Query the persistent affiliation for a JID.
+pub struct GetAffiliation {
+    pub jid: BareJid,
+}
+
+impl kameo::message::Message<GetAffiliation> for RoomActor {
+    type Reply = Result<Affiliation, String>;
+
+    async fn handle(
+        &mut self,
+        msg: GetAffiliation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.room.get_affiliation(&msg.jid))
+    }
+}
+
+/// List all current occupants.
+pub struct ListOccupants;
+
+impl kameo::message::Message<ListOccupants> for RoomActor {
+    type Reply = Vec<OccupantInfo>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListOccupants,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room
+            .occupants
+            .values()
+            .map(OccupantInfo::from_occupant)
+            .collect()
+    }
+}
+
+/// Get the number of occupants currently in the room.
+pub struct OccupantCount;
+
+impl kameo::message::Message<OccupantCount> for RoomActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: OccupantCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room.occupant_count()
+    }
+}
+
+/// Destroy the room (clears all occupants).
+pub struct Destroy;
+
+impl kameo::message::Message<Destroy> for RoomActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: Destroy,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room.occupants.clear();
+    }
+}
+
+/// Get the room's bare JID.
+pub struct GetRoomJid;
+
+impl kameo::message::Message<GetRoomJid> for RoomActor {
+    type Reply = Result<BareJid, String>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetRoomJid,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.room.room_jid.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::ActorRef;
+
+    fn test_room() -> MucRoom {
+        let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
+        MucRoom::new(
+            room_jid,
+            "waddle-1".to_string(),
+            "channel-1".to_string(),
+            RoomConfig::default(),
+        )
+    }
+
+    fn test_full_jid(user: &str) -> FullJid {
+        format!("{}@example.com/res", user)
+            .parse()
+            .expect("valid jid")
+    }
+
+    async fn spawn_room_actor() -> ActorRef<RoomActor> {
+        kameo::spawn(RoomActor::new(test_room()))
+    }
+
+    #[tokio::test]
+    async fn test_join_and_occupant_count() {
+        let actor = spawn_room_actor().await;
+
+        let count = actor.ask(OccupantCount).await.expect("ask");
+        assert_eq!(count, 0);
+
+        // Reply = Result<(), String> -- ask flattens to Result<(), SendError<..., String>>
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join should succeed");
+
+        let count = actor.ask(OccupantCount).await.expect("ask");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_join_duplicate_nick_rejected() {
+        let actor = spawn_room_actor().await;
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("first join");
+
+        // The handler returns Err(String) which kameo surfaces as
+        // SendError::HandlerError, so .await produces Err(_).
+        let result = actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("bob"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_leave() {
+        let actor = spawn_room_actor().await;
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+
+        actor
+            .ask(Leave {
+                nick: "alice".to_string(),
+            })
+            .await
+            .expect("leave should succeed");
+
+        let count = actor.ask(OccupantCount).await.expect("ask");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_leave_unknown_nick() {
+        let actor = spawn_room_actor().await;
+
+        let result = actor
+            .ask(Leave {
+                nick: "ghost".to_string(),
+            })
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_occupant_by_nick() {
+        let actor = spawn_room_actor().await;
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+
+        let info = actor
+            .ask(GetOccupantByNick {
+                nick: "alice".to_string(),
+            })
+            .await
+            .expect("ask");
+        assert!(info.is_some());
+        let info = info.expect("occupant present");
+        assert_eq!(info.nick, "alice");
+        assert_eq!(info.role, Role::Participant);
+    }
+
+    #[tokio::test]
+    async fn test_get_occupant_by_jid() {
+        let actor = spawn_room_actor().await;
+        let jid = test_full_jid("alice");
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: jid.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+
+        let info = actor
+            .ask(GetOccupantByJid { jid })
+            .await
+            .expect("ask");
+        assert!(info.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_info() {
+        let actor = spawn_room_actor().await;
+
+        let info = actor.ask(GetInfo).await.expect("ask");
+        assert_eq!(info.occupant_count, 0);
+        assert_eq!(
+            info.room_jid,
+            "testroom@muc.example.com".parse::<BareJid>().expect("jid")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_and_update_config() {
+        let actor = spawn_room_actor().await;
+
+        let config = actor.ask(GetConfig).await.expect("ask");
+        assert!(config.members_only); // default
+
+        let mut new_config = config;
+        new_config.members_only = false;
+        actor
+            .ask(UpdateConfig {
+                config: new_config,
+            })
+            .await
+            .expect("ask");
+
+        let config = actor.ask(GetConfig).await.expect("ask");
+        assert!(!config.members_only);
+    }
+
+    #[tokio::test]
+    async fn test_change_and_get_affiliation() {
+        let actor = spawn_room_actor().await;
+        let jid: BareJid = "alice@example.com".parse().expect("jid");
+
+        let aff = actor
+            .ask(GetAffiliation { jid: jid.clone() })
+            .await
+            .expect("ask");
+        assert_eq!(aff, Affiliation::None);
+
+        actor
+            .ask(ChangeAffiliation {
+                jid: jid.clone(),
+                affiliation: Affiliation::Admin,
+            })
+            .await
+            .expect("ask");
+
+        let aff = actor
+            .ask(GetAffiliation { jid })
+            .await
+            .expect("ask");
+        assert_eq!(aff, Affiliation::Admin);
+    }
+
+    #[tokio::test]
+    async fn test_list_occupants() {
+        let actor = spawn_room_actor().await;
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join alice");
+
+        actor
+            .ask(Join {
+                nick: "bob".to_string(),
+                real_jid: test_full_jid("bob"),
+                role: Role::Moderator,
+                affiliation: Affiliation::Admin,
+            })
+            .await
+            .expect("join bob");
+
+        let list = actor.ask(ListOccupants).await.expect("ask");
+        assert_eq!(list.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_destroy() {
+        let actor = spawn_room_actor().await;
+
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+
+        actor.ask(Destroy).await.expect("ask");
+
+        let count = actor.ask(OccupantCount).await.expect("ask");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_get_room_jid() {
+        let actor = spawn_room_actor().await;
+
+        let jid = actor.ask(GetRoomJid).await.expect("ask");
+        assert_eq!(
+            jid,
+            "testroom@muc.example.com".parse::<BareJid>().expect("jid")
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -1,0 +1,457 @@
+//! MUC Room Registry Actor
+//!
+//! Kameo actor that manages all MUC room actors. Replaces the DashMap-based
+//! `MucRoomRegistry` with a single-writer actor that owns the room map and
+//! spawns per-room `RoomActor` instances on demand.
+
+use std::collections::HashMap;
+
+use jid::BareJid;
+use kameo::actor::ActorRef;
+use kameo::message::Context;
+use kameo::Actor;
+use tracing::{debug, info, warn};
+
+use super::room_actor::RoomActor;
+use super::{MucRoom, RoomConfig};
+
+/// Actor that owns the mapping from room JIDs to per-room actors.
+///
+/// All room creation, lookup, and destruction flows through this actor,
+/// so no external synchronisation is needed.
+#[derive(Actor)]
+pub struct RoomRegistryActor {
+    rooms: HashMap<BareJid, ActorRef<RoomActor>>,
+    muc_domain: String,
+}
+
+impl RoomRegistryActor {
+    /// Create a new registry for the given MUC service domain.
+    pub fn new(muc_domain: String) -> Self {
+        info!(domain = %muc_domain, "Creating RoomRegistryActor");
+        Self {
+            rooms: HashMap::new(),
+            muc_domain,
+        }
+    }
+
+    /// Spawn a `RoomActor` for the given room and insert it into the map.
+    ///
+    /// Returns a reference to the spawned actor.
+    fn spawn_room(
+        &mut self,
+        room_jid: BareJid,
+        waddle_id: String,
+        channel_id: String,
+        config: RoomConfig,
+    ) -> ActorRef<RoomActor> {
+        let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
+        let actor_ref = kameo::spawn(RoomActor::new(room));
+        self.rooms.insert(room_jid, actor_ref.clone());
+        actor_ref
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Look up a room actor by JID.
+pub struct GetRoom {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<GetRoom> for RoomRegistryActor {
+    type Reply = Result<Option<ActorRef<RoomActor>>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: GetRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.rooms.get(&msg.room_jid).cloned())
+    }
+}
+
+/// Get an existing room or create one if it does not exist.
+pub struct GetOrCreateRoom {
+    pub room_jid: BareJid,
+    pub waddle_id: String,
+    pub channel_id: String,
+    pub config: RoomConfig,
+}
+
+impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
+    type Reply = Result<ActorRef<RoomActor>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: GetOrCreateRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if let Some(actor_ref) = self.rooms.get(&msg.room_jid) {
+            debug!(room = %msg.room_jid, "Room already exists");
+            return Ok(actor_ref.clone());
+        }
+
+        info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
+        let actor_ref = self.spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config);
+        Ok(actor_ref)
+    }
+}
+
+/// Create a room. Fails if a room with the same JID already exists.
+pub struct CreateRoom {
+    pub room_jid: BareJid,
+    pub waddle_id: String,
+    pub channel_id: String,
+    pub config: RoomConfig,
+}
+
+impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
+    type Reply = Result<ActorRef<RoomActor>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: CreateRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.rooms.contains_key(&msg.room_jid) {
+            return Err(format!("Room {} already exists", msg.room_jid));
+        }
+
+        info!(room = %msg.room_jid, "Creating new room");
+        let actor_ref = self.spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config);
+        Ok(actor_ref)
+    }
+}
+
+/// Destroy a room, removing it from the registry.
+///
+/// Returns `true` if the room existed and was removed.
+pub struct DestroyRoom {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DestroyRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match self.rooms.remove(&msg.room_jid) {
+            Some(_actor_ref) => {
+                info!(room = %msg.room_jid, "Destroyed room");
+                true
+            }
+            None => {
+                warn!(room = %msg.room_jid, "Attempted to destroy non-existent room");
+                false
+            }
+        }
+    }
+}
+
+/// Check whether a room exists.
+pub struct RoomExists {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<RoomExists> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: RoomExists,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.rooms.contains_key(&msg.room_jid)
+    }
+}
+
+/// Check whether a bare JID belongs to this MUC service domain.
+pub struct IsMucJid {
+    pub jid: BareJid,
+}
+
+impl kameo::message::Message<IsMucJid> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsMucJid,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        msg.jid.domain().as_str() == self.muc_domain
+    }
+}
+
+/// List all room JIDs.
+pub struct ListRooms;
+
+impl kameo::message::Message<ListRooms> for RoomRegistryActor {
+    type Reply = Result<Vec<BareJid>, String>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListRooms,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.rooms.keys().cloned().collect())
+    }
+}
+
+/// Return the number of active rooms.
+pub struct RoomCount;
+
+impl kameo::message::Message<RoomCount> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: RoomCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.rooms.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_room_jid(name: &str) -> BareJid {
+        format!("{}@muc.example.com", name)
+            .parse()
+            .expect("valid test JID")
+    }
+
+    async fn spawn_registry() -> ActorRef<RoomRegistryActor> {
+        kameo::spawn(RoomRegistryActor::new("muc.example.com".to_string()))
+    }
+
+    #[tokio::test]
+    async fn test_room_count_starts_at_zero() {
+        let registry = spawn_registry().await;
+        let count: usize = registry.ask(RoomCount).await.expect("ask");
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_create_room() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("general");
+
+        // Kameo flattens Result replies: ask() returns T directly
+        let _actor_ref: ActorRef<RoomActor> = registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room");
+
+        let exists: bool = registry
+            .ask(RoomExists { room_jid: jid })
+            .await
+            .expect("exists");
+        assert!(exists);
+
+        let count: usize = registry.ask(RoomCount).await.expect("count");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_room_fails() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("dup");
+
+        registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("first create");
+
+        let result = registry
+            .ask(CreateRoom {
+                room_jid: jid,
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await;
+
+        // Should fail with HandlerError (duplicate)
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_room() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("lookup");
+
+        // Non-existent room returns None
+        let got: Option<ActorRef<RoomActor>> = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get room");
+        assert!(got.is_none());
+
+        // Create it
+        registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create");
+
+        // Now it should be found
+        let got: Option<ActorRef<RoomActor>> = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get room");
+        assert!(got.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_create_room_idempotent() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("idempotent");
+
+        let first: ActorRef<RoomActor> = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("first get_or_create");
+
+        let second: ActorRef<RoomActor> = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid,
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("second get_or_create");
+
+        assert_eq!(first.id(), second.id());
+
+        let count: usize = registry.ask(RoomCount).await.expect("count");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_destroy_room() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("doomed");
+
+        registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create");
+
+        let removed: bool = registry
+            .ask(DestroyRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("destroy");
+        assert!(removed);
+
+        let exists: bool = registry
+            .ask(RoomExists { room_jid: jid })
+            .await
+            .expect("exists");
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn test_destroy_non_existent_room_returns_false() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("ghost");
+
+        let removed: bool = registry
+            .ask(DestroyRoom { room_jid: jid })
+            .await
+            .expect("destroy");
+        assert!(!removed);
+    }
+
+    #[tokio::test]
+    async fn test_is_muc_jid() {
+        let registry = spawn_registry().await;
+
+        let muc_jid: BareJid = "room@muc.example.com".parse().expect("valid JID");
+        let other_jid: BareJid = "user@example.com".parse().expect("valid JID");
+
+        let is_muc: bool = registry
+            .ask(IsMucJid { jid: muc_jid })
+            .await
+            .expect("is_muc");
+        assert!(is_muc);
+
+        let is_muc: bool = registry
+            .ask(IsMucJid { jid: other_jid })
+            .await
+            .expect("is_muc");
+        assert!(!is_muc);
+    }
+
+    #[tokio::test]
+    async fn test_list_rooms() {
+        let registry = spawn_registry().await;
+
+        registry
+            .ask(CreateRoom {
+                room_jid: test_room_jid("alpha"),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create alpha");
+
+        registry
+            .ask(CreateRoom {
+                room_jid: test_room_jid("beta"),
+                waddle_id: "w-2".to_string(),
+                channel_id: "c-2".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create beta");
+
+        let mut rooms: Vec<BareJid> = registry.ask(ListRooms).await.expect("list");
+        rooms.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+
+        assert_eq!(rooms.len(), 2);
+        assert_eq!(rooms[0].to_string(), "alpha@muc.example.com");
+        assert_eq!(rooms[1].to_string(), "beta@muc.example.com");
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -64,11 +64,7 @@ pub struct GetRoom {
 impl kameo::message::Message<GetRoom> for RoomRegistryActor {
     type Reply = Result<Option<ActorRef<RoomActor>>, String>;
 
-    async fn handle(
-        &mut self,
-        msg: GetRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+    async fn handle(&mut self, msg: GetRoom, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         Ok(self.rooms.get(&msg.room_jid).cloned())
     }
 }

--- a/server/crates/waddle-xmpp/src/registry/mod.rs
+++ b/server/crates/waddle-xmpp/src/registry/mod.rs
@@ -17,5 +17,10 @@
 //! ```
 
 mod connection_registry;
+pub mod user_actor;
+pub mod user_registry;
 
 pub use connection_registry::{ConnectionRegistry, OutboundStanza, SendResult};
+pub use user_registry::{
+    GetOrCreateUser, GetUser, ListUsers, RemoveUser, UserCount, UserRegistryActor,
+};

--- a/server/crates/waddle-xmpp/src/registry/user_actor.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor.rs
@@ -612,8 +612,7 @@ mod tests {
             .await
             .expect("clear");
 
-        let state: Option<PresenceState> =
-            actor.ask(GetPresenceState { jid }).await.expect("get");
+        let state: Option<PresenceState> = actor.ask(GetPresenceState { jid }).await.expect("get");
         assert!(state.is_none());
     }
 
@@ -630,17 +629,11 @@ mod tests {
             .await
             .expect("queue");
 
-        let drained: Vec<Stanza> = actor
-            .ask(DrainPendingSubscriptions)
-            .await
-            .expect("drain");
+        let drained: Vec<Stanza> = actor.ask(DrainPendingSubscriptions).await.expect("drain");
         assert_eq!(drained.len(), 1);
 
         // Second drain should be empty
-        let drained: Vec<Stanza> = actor
-            .ask(DrainPendingSubscriptions)
-            .await
-            .expect("drain");
+        let drained: Vec<Stanza> = actor.ask(DrainPendingSubscriptions).await.expect("drain");
         assert!(drained.is_empty());
     }
 
@@ -674,10 +667,7 @@ mod tests {
             .await
             .expect("set");
 
-        let enabled: bool = actor
-            .ask(IsCarbonsEnabled { jid })
-            .await
-            .expect("check");
+        let enabled: bool = actor.ask(IsCarbonsEnabled { jid }).await.expect("check");
         assert!(enabled);
     }
 

--- a/server/crates/waddle-xmpp/src/registry/user_actor.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor.rs
@@ -1,0 +1,756 @@
+//! Per-user actor managing connection state and presence.
+//!
+//! One `UserActor` exists per bare JID. It owns all mutable per-user state
+//! (connected resources, presence, pending subscriptions, carbons) and
+//! processes messages sequentially, removing the need for external locking.
+
+use std::collections::HashMap;
+
+use jid::{BareJid, FullJid};
+use kameo::message::Context;
+use kameo::Actor;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+use crate::connection::Stanza;
+use crate::registry::connection_registry::{OutboundStanza, PresenceState};
+
+/// Actor that manages per-user connection state.
+///
+/// Each connected bare JID gets exactly one `UserActor`. The actor tracks all
+/// connected resources, their presence, carbons state, and any pending
+/// subscription stanzas that arrived while the user was offline.
+#[derive(Actor)]
+pub struct UserActor {
+    bare_jid: BareJid,
+    resources: HashMap<FullJid, mpsc::Sender<OutboundStanza>>,
+    presence_available: HashMap<FullJid, bool>,
+    presence_priority: HashMap<FullJid, i8>,
+    presence_states: HashMap<FullJid, PresenceState>,
+    pending_subscriptions: Vec<Stanza>,
+    carbons_enabled: HashMap<FullJid, bool>,
+}
+
+impl UserActor {
+    /// Create a new `UserActor` for the given bare JID.
+    pub fn new(bare_jid: BareJid) -> Self {
+        Self {
+            bare_jid,
+            resources: HashMap::new(),
+            presence_available: HashMap::new(),
+            presence_priority: HashMap::new(),
+            presence_states: HashMap::new(),
+            pending_subscriptions: Vec::new(),
+            carbons_enabled: HashMap::new(),
+        }
+    }
+
+    /// The bare JID this actor manages.
+    pub fn bare_jid(&self) -> &BareJid {
+        &self.bare_jid
+    }
+
+    /// Remove all state associated with a resource.
+    fn remove_resource(&mut self, jid: &FullJid) {
+        self.resources.remove(jid);
+        self.presence_available.remove(jid);
+        self.presence_priority.remove(jid);
+        self.presence_states.remove(jid);
+        self.carbons_enabled.remove(jid);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Register a new connection (resource) for this user.
+pub struct RegisterConnection {
+    pub jid: FullJid,
+    pub sender: mpsc::Sender<OutboundStanza>,
+}
+
+impl kameo::message::Message<RegisterConnection> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RegisterConnection,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        debug!(jid = %msg.jid, bare = %self.bare_jid, "Registering connection");
+        self.resources.insert(msg.jid.clone(), msg.sender);
+        self.presence_available.insert(msg.jid.clone(), false);
+        self.presence_priority.insert(msg.jid.clone(), 0);
+        self.carbons_enabled.insert(msg.jid, false);
+    }
+}
+
+/// Unregister a connection (resource) for this user.
+pub struct UnregisterConnection {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<UnregisterConnection> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: UnregisterConnection,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        debug!(jid = %msg.jid, bare = %self.bare_jid, "Unregistering connection");
+        self.remove_resource(&msg.jid);
+    }
+}
+
+/// Route a stanza to a specific resource.
+pub struct RouteStanza {
+    pub target: FullJid,
+    pub stanza: Stanza,
+}
+
+impl kameo::message::Message<RouteStanza> for UserActor {
+    type Reply = Result<(), String>;
+
+    async fn handle(
+        &mut self,
+        msg: RouteStanza,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let sender = match self.resources.get(&msg.target) {
+            Some(s) => s,
+            None => return Err(format!("Resource {} not connected", msg.target)),
+        };
+        let outbound = OutboundStanza::new(msg.stanza);
+        match sender.try_send(outbound) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                warn!(target = %msg.target, "Outbound channel full");
+                Err("channel full".to_string())
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!(target = %msg.target, "Outbound channel closed, removing stale resource");
+                self.remove_resource(&msg.target);
+                Err("channel closed".to_string())
+            }
+        }
+    }
+}
+
+/// Get all connected resource JIDs.
+pub struct GetResources;
+
+impl kameo::message::Message<GetResources> for UserActor {
+    type Reply = Vec<FullJid>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetResources,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resources.keys().cloned().collect()
+    }
+}
+
+/// Get available resources with their priorities.
+pub struct GetAvailableResources;
+
+impl kameo::message::Message<GetAvailableResources> for UserActor {
+    type Reply = Vec<(FullJid, i8)>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetAvailableResources,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resources
+            .keys()
+            .filter(|jid| self.presence_available.get(*jid).copied().unwrap_or(false))
+            .map(|jid| {
+                let priority = self.presence_priority.get(jid).copied().unwrap_or(0);
+                (jid.clone(), priority)
+            })
+            .collect()
+    }
+}
+
+/// Get all connected resources except a specific one.
+pub struct GetOtherResources {
+    pub exclude: FullJid,
+}
+
+impl kameo::message::Message<GetOtherResources> for UserActor {
+    type Reply = Vec<FullJid>;
+
+    async fn handle(
+        &mut self,
+        msg: GetOtherResources,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resources
+            .keys()
+            .filter(|jid| **jid != msg.exclude)
+            .cloned()
+            .collect()
+    }
+}
+
+/// Update presence availability and priority for a resource.
+pub struct UpdatePresence {
+    pub jid: FullJid,
+    pub available: bool,
+    pub priority: i8,
+}
+
+impl kameo::message::Message<UpdatePresence> for UserActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: UpdatePresence,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.resources.contains_key(&msg.jid) {
+            self.presence_available
+                .insert(msg.jid.clone(), msg.available);
+            self.presence_priority.insert(msg.jid, msg.priority);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Update full presence state (show/status/priority) for a resource.
+pub struct UpdatePresenceState {
+    pub jid: FullJid,
+    pub show: Option<String>,
+    pub status: Option<String>,
+    pub priority: i8,
+}
+
+impl kameo::message::Message<UpdatePresenceState> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: UpdatePresenceState,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.presence_states.insert(
+            msg.jid,
+            PresenceState {
+                show: msg.show,
+                status: msg.status,
+                priority: msg.priority,
+            },
+        );
+    }
+}
+
+/// Get the stored presence state for a resource.
+pub struct GetPresenceState {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<GetPresenceState> for UserActor {
+    type Reply = Option<PresenceState>;
+
+    async fn handle(
+        &mut self,
+        msg: GetPresenceState,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.presence_states.get(&msg.jid).cloned()
+    }
+}
+
+/// Clear stored presence state for a resource.
+pub struct ClearPresenceState {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<ClearPresenceState> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: ClearPresenceState,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.presence_states.remove(&msg.jid);
+    }
+}
+
+/// Queue a subscription stanza for later delivery.
+pub struct QueuePendingSubscription {
+    pub stanza: Stanza,
+}
+
+impl kameo::message::Message<QueuePendingSubscription> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: QueuePendingSubscription,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.pending_subscriptions.push(msg.stanza);
+    }
+}
+
+/// Drain and return all pending subscription stanzas.
+pub struct DrainPendingSubscriptions;
+
+impl kameo::message::Message<DrainPendingSubscriptions> for UserActor {
+    type Reply = Vec<Stanza>;
+
+    async fn handle(
+        &mut self,
+        _msg: DrainPendingSubscriptions,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        std::mem::take(&mut self.pending_subscriptions)
+    }
+}
+
+/// Check if a specific resource is connected.
+pub struct IsConnected {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<IsConnected> for UserActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsConnected,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resources.contains_key(&msg.jid)
+    }
+}
+
+/// Set carbons enabled/disabled for a resource.
+pub struct SetCarbonsEnabled {
+    pub jid: FullJid,
+    pub enabled: bool,
+}
+
+impl kameo::message::Message<SetCarbonsEnabled> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: SetCarbonsEnabled,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.carbons_enabled.insert(msg.jid, msg.enabled);
+    }
+}
+
+/// Check if carbons is enabled for a resource.
+pub struct IsCarbonsEnabled {
+    pub jid: FullJid,
+}
+
+impl kameo::message::Message<IsCarbonsEnabled> for UserActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsCarbonsEnabled,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.carbons_enabled.get(&msg.jid).copied().unwrap_or(false)
+    }
+}
+
+/// Get the number of connected resources.
+pub struct ResourceCount;
+
+impl kameo::message::Message<ResourceCount> for UserActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: ResourceCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.resources.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::ActorRef;
+
+    fn bare(user: &str) -> BareJid {
+        format!("{user}@example.com").parse().expect("bare jid")
+    }
+
+    fn full(user: &str, resource: &str) -> FullJid {
+        format!("{user}@example.com/{resource}")
+            .parse()
+            .expect("full jid")
+    }
+
+    async fn spawn_actor(user: &str) -> ActorRef<UserActor> {
+        kameo::spawn(UserActor::new(bare(user)))
+    }
+
+    #[tokio::test]
+    async fn test_register_and_resource_count() {
+        let actor = spawn_actor("alice").await;
+        let (tx, _rx) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: full("alice", "phone"),
+                sender: tx,
+            })
+            .await
+            .expect("register");
+
+        let count: usize = actor.ask(ResourceCount).await.expect("count");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_cleans_up() {
+        let actor = spawn_actor("alice").await;
+        let (tx, _rx) = mpsc::channel(16);
+        let jid = full("alice", "phone");
+
+        actor
+            .ask(RegisterConnection {
+                jid: jid.clone(),
+                sender: tx,
+            })
+            .await
+            .expect("register");
+
+        actor
+            .ask(UnregisterConnection { jid: jid.clone() })
+            .await
+            .expect("unregister");
+
+        let count: usize = actor.ask(ResourceCount).await.expect("count");
+        assert_eq!(count, 0);
+
+        let connected: bool = actor.ask(IsConnected { jid }).await.expect("connected");
+        assert!(!connected);
+    }
+
+    #[tokio::test]
+    async fn test_get_resources() {
+        let actor = spawn_actor("alice").await;
+        let (tx1, _rx1) = mpsc::channel(16);
+        let (tx2, _rx2) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: full("alice", "phone"),
+                sender: tx1,
+            })
+            .await
+            .expect("register");
+
+        actor
+            .ask(RegisterConnection {
+                jid: full("alice", "laptop"),
+                sender: tx2,
+            })
+            .await
+            .expect("register");
+
+        let resources: Vec<FullJid> = actor.ask(GetResources).await.expect("resources");
+        assert_eq!(resources.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_other_resources() {
+        let actor = spawn_actor("alice").await;
+        let phone = full("alice", "phone");
+        let laptop = full("alice", "laptop");
+
+        let (tx1, _rx1) = mpsc::channel(16);
+        let (tx2, _rx2) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: phone.clone(),
+                sender: tx1,
+            })
+            .await
+            .expect("register");
+
+        actor
+            .ask(RegisterConnection {
+                jid: laptop.clone(),
+                sender: tx2,
+            })
+            .await
+            .expect("register");
+
+        let others: Vec<FullJid> = actor
+            .ask(GetOtherResources {
+                exclude: phone.clone(),
+            })
+            .await
+            .expect("others");
+
+        assert_eq!(others.len(), 1);
+        assert_eq!(others[0], laptop);
+    }
+
+    #[tokio::test]
+    async fn test_presence_update_and_available_resources() {
+        let actor = spawn_actor("alice").await;
+        let phone = full("alice", "phone");
+        let laptop = full("alice", "laptop");
+
+        let (tx1, _rx1) = mpsc::channel(16);
+        let (tx2, _rx2) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: phone.clone(),
+                sender: tx1,
+            })
+            .await
+            .expect("register");
+
+        actor
+            .ask(RegisterConnection {
+                jid: laptop.clone(),
+                sender: tx2,
+            })
+            .await
+            .expect("register");
+
+        // Initially no resources are available
+        let available: Vec<(FullJid, i8)> =
+            actor.ask(GetAvailableResources).await.expect("available");
+        assert!(available.is_empty());
+
+        // Make phone available with priority 5
+        let updated: bool = actor
+            .ask(UpdatePresence {
+                jid: phone.clone(),
+                available: true,
+                priority: 5,
+            })
+            .await
+            .expect("update");
+        assert!(updated);
+
+        let available: Vec<(FullJid, i8)> =
+            actor.ask(GetAvailableResources).await.expect("available");
+        assert_eq!(available.len(), 1);
+        assert_eq!(available[0].0, phone);
+        assert_eq!(available[0].1, 5);
+    }
+
+    #[tokio::test]
+    async fn test_update_presence_missing_resource() {
+        let actor = spawn_actor("alice").await;
+        let missing = full("alice", "missing");
+
+        let updated: bool = actor
+            .ask(UpdatePresence {
+                jid: missing,
+                available: true,
+                priority: 0,
+            })
+            .await
+            .expect("update");
+        assert!(!updated);
+    }
+
+    #[tokio::test]
+    async fn test_presence_state() {
+        let actor = spawn_actor("alice").await;
+        let jid = full("alice", "phone");
+
+        // No state before setting
+        let state: Option<PresenceState> = actor
+            .ask(GetPresenceState { jid: jid.clone() })
+            .await
+            .expect("get");
+        assert!(state.is_none());
+
+        // Set state
+        actor
+            .ask(UpdatePresenceState {
+                jid: jid.clone(),
+                show: Some("away".to_string()),
+                status: Some("Gone fishing".to_string()),
+                priority: 3,
+            })
+            .await
+            .expect("update");
+
+        let state: Option<PresenceState> = actor
+            .ask(GetPresenceState { jid: jid.clone() })
+            .await
+            .expect("get");
+        let state = state.expect("should have state");
+        assert_eq!(state.show.as_deref(), Some("away"));
+        assert_eq!(state.status.as_deref(), Some("Gone fishing"));
+        assert_eq!(state.priority, 3);
+
+        // Clear state
+        actor
+            .ask(ClearPresenceState { jid: jid.clone() })
+            .await
+            .expect("clear");
+
+        let state: Option<PresenceState> =
+            actor.ask(GetPresenceState { jid }).await.expect("get");
+        assert!(state.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_pending_subscriptions() {
+        let actor = spawn_actor("alice").await;
+
+        let subscribe =
+            xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::Subscribe);
+        actor
+            .ask(QueuePendingSubscription {
+                stanza: Stanza::Presence(subscribe),
+            })
+            .await
+            .expect("queue");
+
+        let drained: Vec<Stanza> = actor
+            .ask(DrainPendingSubscriptions)
+            .await
+            .expect("drain");
+        assert_eq!(drained.len(), 1);
+
+        // Second drain should be empty
+        let drained: Vec<Stanza> = actor
+            .ask(DrainPendingSubscriptions)
+            .await
+            .expect("drain");
+        assert!(drained.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_carbons() {
+        let actor = spawn_actor("alice").await;
+        let jid = full("alice", "phone");
+        let (tx, _rx) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: jid.clone(),
+                sender: tx,
+            })
+            .await
+            .expect("register");
+
+        // Default is disabled
+        let enabled: bool = actor
+            .ask(IsCarbonsEnabled { jid: jid.clone() })
+            .await
+            .expect("check");
+        assert!(!enabled);
+
+        // Enable
+        actor
+            .ask(SetCarbonsEnabled {
+                jid: jid.clone(),
+                enabled: true,
+            })
+            .await
+            .expect("set");
+
+        let enabled: bool = actor
+            .ask(IsCarbonsEnabled { jid })
+            .await
+            .expect("check");
+        assert!(enabled);
+    }
+
+    #[tokio::test]
+    async fn test_route_stanza() {
+        let actor = spawn_actor("alice").await;
+        let jid = full("alice", "phone");
+        let (tx, mut rx) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: jid.clone(),
+                sender: tx,
+            })
+            .await
+            .expect("register");
+
+        let msg = xmpp_parsers::message::Message::new(Some(jid::Jid::from(bare("alice"))));
+        actor
+            .ask(RouteStanza {
+                target: jid,
+                stanza: Stanza::Message(msg),
+            })
+            .await
+            .expect("route should succeed");
+
+        let received = rx.try_recv();
+        assert!(received.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_route_stanza_not_connected() {
+        let actor = spawn_actor("alice").await;
+        let jid = full("alice", "phone");
+
+        let msg = xmpp_parsers::message::Message::new(Some(jid::Jid::from(bare("alice"))));
+        let result = actor
+            .ask(RouteStanza {
+                target: jid,
+                stanza: Stanza::Message(msg),
+            })
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_route_stanza_closed_channel_removes_resource() {
+        let actor = spawn_actor("alice").await;
+        let jid = full("alice", "phone");
+        let (tx, rx) = mpsc::channel(16);
+
+        actor
+            .ask(RegisterConnection {
+                jid: jid.clone(),
+                sender: tx,
+            })
+            .await
+            .expect("register");
+
+        // Drop receiver to close channel
+        drop(rx);
+
+        let msg = xmpp_parsers::message::Message::new(Some(jid::Jid::from(bare("alice"))));
+        let result = actor
+            .ask(RouteStanza {
+                target: jid.clone(),
+                stanza: Stanza::Message(msg),
+            })
+            .await;
+        assert!(result.is_err());
+
+        // Resource should have been cleaned up
+        let count: usize = actor.ask(ResourceCount).await.expect("count");
+        assert_eq!(count, 0);
+    }
+}

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -1,0 +1,316 @@
+//! User Registry Actor.
+//!
+//! A Kameo actor that maps bare JIDs to per-user `UserActor` instances.
+//! One `UserRegistryActor` exists for the entire server, replacing the
+//! DashMap-based lookup portion of `ConnectionRegistry` for user-level
+//! concerns (Phase 2 of the actor-model migration).
+
+use std::collections::HashMap;
+
+use jid::BareJid;
+use kameo::actor::ActorRef;
+use kameo::message::Context;
+use kameo::Actor;
+use tracing::{debug, info};
+
+use super::user_actor::UserActor;
+
+/// Server-wide registry that maps bare JIDs to their `UserActor`.
+///
+/// All mutations are serialised through the actor mailbox, so no
+/// external synchronisation is required.
+#[derive(Actor)]
+pub struct UserRegistryActor {
+    users: HashMap<BareJid, ActorRef<UserActor>>,
+}
+
+impl UserRegistryActor {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        info!("Creating user registry actor");
+        Self {
+            users: HashMap::new(),
+        }
+    }
+}
+
+impl Default for UserRegistryActor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+/// Return the `UserActor` for the given bare JID, spawning one if it does not
+/// already exist.
+pub struct GetOrCreateUser {
+    pub bare_jid: BareJid,
+}
+
+impl kameo::message::Message<GetOrCreateUser> for UserRegistryActor {
+    type Reply = Result<ActorRef<UserActor>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: GetOrCreateUser,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if let Some(actor_ref) = self.users.get(&msg.bare_jid) {
+            debug!(jid = %msg.bare_jid, "Returning existing UserActor");
+            return Ok(actor_ref.clone());
+        }
+
+        debug!(jid = %msg.bare_jid, "Spawning new UserActor");
+        let actor = UserActor::new(msg.bare_jid.clone());
+        let actor_ref = kameo::spawn(actor);
+        self.users.insert(msg.bare_jid, actor_ref.clone());
+        Ok(actor_ref)
+    }
+}
+
+/// Look up an existing `UserActor` without creating one.
+pub struct GetUser {
+    pub bare_jid: BareJid,
+}
+
+impl kameo::message::Message<GetUser> for UserRegistryActor {
+    type Reply = Result<Option<ActorRef<UserActor>>, String>;
+
+    async fn handle(
+        &mut self,
+        msg: GetUser,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        Ok(self.users.get(&msg.bare_jid).cloned())
+    }
+}
+
+/// Remove a user from the registry.
+///
+/// Returns `true` if the user was present and removed.
+pub struct RemoveUser {
+    pub bare_jid: BareJid,
+}
+
+impl kameo::message::Message<RemoveUser> for UserRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: RemoveUser,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let removed = self.users.remove(&msg.bare_jid).is_some();
+        if removed {
+            debug!(jid = %msg.bare_jid, "Removed user from registry");
+        }
+        removed
+    }
+}
+
+/// List all bare JIDs that currently have a `UserActor`.
+pub struct ListUsers;
+
+impl kameo::message::Message<ListUsers> for UserRegistryActor {
+    type Reply = Vec<BareJid>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListUsers,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.users.keys().cloned().collect()
+    }
+}
+
+/// Return the number of tracked users.
+pub struct UserCount;
+
+impl kameo::message::Message<UserCount> for UserRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: UserCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.users.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bare(user: &str) -> BareJid {
+        format!("{user}@example.com").parse().expect("valid JID")
+    }
+
+    async fn spawn_registry() -> ActorRef<UserRegistryActor> {
+        kameo::spawn(UserRegistryActor::new())
+    }
+
+    #[tokio::test]
+    async fn test_get_or_create_spawns_new_user() {
+        let registry = spawn_registry().await;
+
+        let actor_ref = registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("alice"),
+            })
+            .await
+            .expect("ask failed");
+
+        // Asking again should return the same actor (by id).
+        let actor_ref2 = registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("alice"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert_eq!(actor_ref.id(), actor_ref2.id());
+    }
+
+    #[tokio::test]
+    async fn test_get_user_returns_none_when_absent() {
+        let registry = spawn_registry().await;
+
+        let result = registry
+            .ask(GetUser {
+                bare_jid: bare("ghost"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_user_returns_some_after_create() {
+        let registry = spawn_registry().await;
+
+        registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("bob"),
+            })
+            .await
+            .expect("ask failed");
+
+        let result = registry
+            .ask(GetUser {
+                bare_jid: bare("bob"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_remove_user() {
+        let registry = spawn_registry().await;
+
+        registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("carol"),
+            })
+            .await
+            .expect("ask failed");
+
+        let removed = registry
+            .ask(RemoveUser {
+                bare_jid: bare("carol"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert!(removed);
+
+        // Removing again should return false.
+        let removed_again = registry
+            .ask(RemoveUser {
+                bare_jid: bare("carol"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert!(!removed_again);
+    }
+
+    #[tokio::test]
+    async fn test_list_users() {
+        let registry = spawn_registry().await;
+
+        registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("alice"),
+            })
+            .await
+            .expect("ask failed");
+
+        registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("bob"),
+            })
+            .await
+            .expect("ask failed");
+
+        let mut users = registry
+            .ask(ListUsers)
+            .await
+            .expect("ask failed");
+
+        users.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+
+        assert_eq!(users.len(), 2);
+        assert_eq!(users[0], bare("alice"));
+        assert_eq!(users[1], bare("bob"));
+    }
+
+    #[tokio::test]
+    async fn test_user_count() {
+        let registry = spawn_registry().await;
+
+        let count = registry.ask(UserCount).await.expect("ask failed");
+        assert_eq!(count, 0);
+
+        registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("alice"),
+            })
+            .await
+            .expect("ask failed");
+
+        let count = registry.ask(UserCount).await.expect("ask failed");
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_different_users_get_different_actors() {
+        let registry = spawn_registry().await;
+
+        let alice = registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("alice"),
+            })
+            .await
+            .expect("ask failed");
+
+        let bob = registry
+            .ask(GetOrCreateUser {
+                bare_jid: bare("bob"),
+            })
+            .await
+            .expect("ask failed");
+
+        assert_ne!(alice.id(), bob.id());
+    }
+}

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -79,11 +79,7 @@ pub struct GetUser {
 impl kameo::message::Message<GetUser> for UserRegistryActor {
     type Reply = Result<Option<ActorRef<UserActor>>, String>;
 
-    async fn handle(
-        &mut self,
-        msg: GetUser,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+    async fn handle(&mut self, msg: GetUser, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         Ok(self.users.get(&msg.bare_jid).cloned())
     }
 }
@@ -263,10 +259,7 @@ mod tests {
             .await
             .expect("ask failed");
 
-        let mut users = registry
-            .ask(ListUsers)
-            .await
-            .expect("ask failed");
+        let mut users = registry.ask(ListUsers).await.expect("ask failed");
 
         users.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
 


### PR DESCRIPTION
## Summary

Complete actor model migration (Phases 0-4) as described in #42. Introduces Kameo virtual actors throughout the server — one actor per user, per room, per waddle, each with its own inbox for sequential message processing.

### Phase 0 — ConnectionGuard extraction
- Unified the duplicated `persistent_connection()` if/else pattern (20+ sites across 18 files) into a shared `ConnectionGuard` enum with `Database::guard()` method
- Removed three local `ConnectionGuard` copies and the now-unused `persistent_connection()` method
- Net **-560 lines**

### Phase 1 — Database Actors
- `DbActor`: Kameo actor that owns a `Database`, handles `DbExecute`, `DbQuery`, `DbQueryOne`, `DbHealthCheck`, `GetIdleMs` messages
- `DatabasePool` refactored to `DashMap<String, ActorRef<DbActor>>` with idle-time-based eviction
- External API (`global()`, `get_waddle_db()`) unchanged

### Phase 2 — User Actors (one per bare JID)
- `UserActor`: manages per-user resources, presence state, carbons, pending subscriptions — each user has their own inbox
- `UserRegistryActor`: maps `BareJid → ActorRef<UserActor>`, spawns actors on demand
- 16 message types covering registration, routing, presence, carbons

### Phase 3 — Room and Waddle Actors (one per entity)
- `RoomActor`: owns a `MucRoom` directly (no `RwLock`), handles join/leave/broadcast/affiliation via messages — one inbox per room
- `RoomRegistryActor`: maps room JIDs to `RoomActor` refs, spawns on demand
- `WaddleActor`: one per waddle community, tracks channels, holds ref to its `DbActor`

### Phase 4 — PermissionActor
- Wraps existing `PermissionService` (Zanzibar-style ReBAC with LRU cache) as a Kameo actor
- Messages: `CheckPermission`, `WriteTuple`, `DeleteTuple`, `ListRelations`, `ListSubjects`

### Supervision Tree

```
[DatabasePool]
  +-- [DbActor: global]
  +-- [DbActor: waddle-1]
  +-- [DbActor: waddle-2]

[UserRegistryActor]
  +-- [UserActor: alice@waddle.social]
  +-- [UserActor: bob@waddle.social]

[RoomRegistryActor]
  +-- [RoomActor: general@muc.waddle.social]
  +-- [RoomActor: random@muc.waddle.social]

[WaddleActor: waddle-1]
[WaddleActor: waddle-2]

[PermissionActor]
```

Closes #42 (Phases 0-4; Phase 5 distributed actors is explicitly future work)

## Test plan

- [x] All 1987 tests pass across the full workspace (0 failures)
- [x] 174 waddle-server tests (14 new actor tests)
- [x] 1389 waddle-xmpp tests (40 new actor tests)
- [x] Verified no deadlocks in guard scoping
- [x] `persistent_connection()` only in `db/mod.rs` guard impl (grep verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)