### PR TITLE
fix(chat): add events polyfill to fix blank page after stanza migration

### DIFF
--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -25,7 +25,11 @@ export default defineConfig({
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
+        events: "events",
       },
+    },
+    optimizeDeps: {
+      include: ["events", "stanza"],
     },
   },
 

--- a/chat/bun.lock
+++ b/chat/bun.lock
@@ -10,6 +10,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.0.8",
         "emojilib": "^4.0.2",
+        "events": "^3.3.0",
         "lucide-vue-next": "^0.509.0",
         "marked": "^15.0.7",
         "stanza": "^12.22.1",
@@ -599,6 +600,8 @@
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -18,11 +18,12 @@
     "@astrojs/cloudflare": "^13.1.3",
     "@astrojs/vue": "^5.0.7",
     "@tailwindcss/vite": "^4.2.2",
-    "stanza": "^12.22.1",
     "astro": "^6.0.8",
     "emojilib": "^4.0.2",
+    "events": "^3.3.0",
     "lucide-vue-next": "^0.509.0",
     "marked": "^15.0.7",
+    "stanza": "^12.22.1",
     "tailwindcss": "^4.2.2",
     "vue": "^3.5.16",
     "wrangler": "^4.76.0"

--- a/chat/src/lib/xmpp/extensions/file-sharing.ts
+++ b/chat/src/lib/xmpp/extensions/file-sharing.ts
@@ -16,7 +16,7 @@
  */
 import type { DefinitionOptions, FieldDefinition } from "stanza/jxt";
 import { attribute, deepChildText } from "stanza/jxt";
-import type XMLElement from "stanza/jxt/Element";
+import XMLElement from "stanza/jxt/Element";
 
 const NS_SFS_0 = "urn:xmpp:sfs:0";
 const NS_FILE_METADATA_0 = "urn:xmpp:file:metadata:0";
@@ -52,14 +52,12 @@ const urlField: FieldDefinition<string> = {
     if (!value) return;
     let sources = xml.getChild("sources", NS_SFS_0);
     if (!sources) {
-      const { default: XElem } = require("stanza/jxt/Element") as { default: new (name: string, attrs?: Record<string, string>) => XMLElement };
-      sources = new XElem("sources", { xmlns: NS_SFS_0 });
+      sources = new XMLElement("sources", { xmlns: NS_SFS_0 });
       xml.appendChild(sources);
     }
     let urlData = sources.getChild("url-data", NS_URL_DATA);
     if (!urlData) {
-      const { default: XElem } = require("stanza/jxt/Element") as { default: new (name: string, attrs?: Record<string, string>) => XMLElement };
-      urlData = new XElem("url-data", { xmlns: NS_URL_DATA });
+      urlData = new XMLElement("url-data", { xmlns: NS_URL_DATA });
       sources.appendChild(urlData);
     }
     urlData.setAttribute("target", value);


### PR DESCRIPTION
Vite was externalizing the Node.js `events` module for browser
compatibility, making EventEmitter undefined. Since stanza's Client
class extends EventEmitter, this caused "Class extends value undefined
is not a constructor or null" at hydration time — a blank white page.

- Add `events` npm package as a browser-compatible polyfill
- Configure Vite resolve alias and optimizeDeps to bundle it
- Replace CJS require() calls in file-sharing.ts with ES module import

Fixes blank page introduced by #46.

https://claude.ai/code/session_01CJV7do89hqGYn5P9zDmFjC