### PR TITLE
fix(chat): fix blank page after stanza XMPP migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # XMPP XEPs
 xeps
 
+# Astro
+.astro/
+
 # Bun
 node_modules
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -137,10 +137,12 @@ export class BrowserXmppClient {
     return this.xmpp ? history.searchMessages(this.xmpp, roomBareJidFor(this.session, w, c), query, max) : [];
   }
   async discoverWaddles(): Promise<DiscoveredWaddle[]> {
-    return discovery.discoverWaddles(this.xmpp!, this.session.jid);
+    await this.connect();
+    return this.xmpp ? discovery.discoverWaddles(this.xmpp, this.session.jid) : [];
   }
   async discoverChannels(waddleId: string): Promise<DiscoveredChannel[]> {
-    return discovery.discoverChannels(this.xmpp!, this.session.jid, waddleId);
+    await this.connect();
+    return this.xmpp ? discovery.discoverChannels(this.xmpp, this.session.jid, waddleId) : [];
   }
 
   // -- Private --


### PR DESCRIPTION
## Summary

- **Add `events` polyfill** to fix `Class extends value undefined is not a constructor or null` — Vite was externalizing Node.js `events` module, making `EventEmitter` undefined and preventing the stanza `Client` class from loading
- **Ensure XMPP connection before discovery calls** — `discoverWaddles()` and `discoverChannels()` were the only query methods missing `await this.connect()`, causing a null dereference on app startup
- **Replace CJS `require()` with ES import** in `file-sharing.ts` — two `require("stanza/jxt/Element")` calls would fail at runtime in the browser

Fixes blank white page introduced by #46.

## Test plan

- [x] `bun run build` succeeds with zero `externalized for browser compatibility` warnings
- [ ] Verify chat.waddle.social loads without blank page
- [ ] Verify waddle/channel discovery works on startup
- [ ] Verify file sharing still works (the refactored exporter path)

https://claude.ai/code/session_01CJV7do89hqGYn5P9zDmFjC