### PR TITLE
feat: browser notifications on @mentions (Phase 1+2)

### DIFF
--- a/chat/public/sw.js
+++ b/chat/public/sw.js
@@ -1,0 +1,30 @@
+/** Service worker for Waddle push notifications. */
+
+self.addEventListener("push", (event) => {
+  const data = event.data?.json() ?? {};
+  event.waitUntil(
+    self.registration.showNotification(data.title ?? "Waddle", {
+      body: data.body ?? "",
+      tag: data.roomJid,
+      icon: "/favicon.svg",
+      data: { url: data.url ?? "/" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? "/";
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((windowClients) => {
+      for (const client of windowClients) {
+        if (client.url.includes(self.location.origin) && "focus" in client) {
+          client.focus();
+          client.navigate(url);
+          return;
+        }
+      }
+      return clients.openWindow(url);
+    }),
+  );
+});

--- a/chat/public/sw.js
+++ b/chat/public/sw.js
@@ -1,7 +1,13 @@
 /** Service worker for Waddle push notifications. */
 
 self.addEventListener("push", (event) => {
-  const data = event.data?.json() ?? {};
+  let data = {};
+  try {
+    data = event.data?.json() ?? {};
+  } catch {
+    const text = event.data?.text() ?? "";
+    data = { title: "Waddle", body: text };
+  }
   event.waitUntil(
     self.registration.showNotification(data.title ?? "Waddle", {
       body: data.body ?? "",

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -109,6 +109,25 @@ const publicBrowseQuery = ref("");
 const isApplyingRoute = ref(false);
 let routeRequestId = 0;
 
+async function setupPushSubscription() {
+  if (!xmppClient.value || !auth.session.value) return;
+  await notifications.syncPushSubscription(xmppClient.value, auth.session.value.jid);
+}
+
+async function handleRequestNotifications() {
+  const state = await notifications.requestPermission();
+  if (state === "granted") {
+    await setupPushSubscription();
+  }
+}
+
+function handleToggleNotifications() {
+  notifications.notificationsEnabled.value = !notifications.notificationsEnabled.value;
+  if (notifications.notificationsEnabled.value) {
+    void setupPushSubscription();
+  }
+}
+
 async function sendGif(url: string) {
   await messaging.sendMessage(url);
 }
@@ -196,8 +215,11 @@ async function bootstrap() {
       }
     }
 
-    // Register service worker for push notifications (best-effort, non-blocking)
-    void notifications.registerServiceWorker();
+    // Register service worker and sync push subscription (best-effort, non-blocking)
+    void (async () => {
+      await notifications.registerServiceWorker();
+      await setupPushSubscription();
+    })();
   }
 }
 
@@ -428,8 +450,8 @@ onUnmounted(() => {
           :notification-permission="notifications.permissionState.value"
           :notifications-enabled="notifications.notificationsEnabled.value"
           @logout="handleLogout"
-          @request-notifications="notifications.requestPermission()"
-          @toggle-notifications="notifications.notificationsEnabled.value = !notifications.notificationsEnabled.value"
+          @request-notifications="handleRequestNotifications"
+          @toggle-notifications="handleToggleNotifications"
         />
       </div>
     </AppDrawer>

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -5,6 +5,7 @@ import { useWaddles } from "@/composables/useWaddles";
 import { useMembers } from "@/composables/useMembers";
 import { useMessaging } from "@/composables/useMessaging";
 import { useUiState } from "@/composables/useUiState";
+import { useNotifications } from "@/composables/useNotifications";
 import { parseRoute, pushRoute, resolveWaddle, resolveChannel } from "@/composables/useRouting";
 import { BrowserXmppClient } from "@/lib/xmpp-client";
 import LandingState from "@/components/chat/LandingState.vue";
@@ -62,6 +63,47 @@ const messaging = useMessaging(
   ui.actionError,
   ui.clearActionError,
 );
+
+const notifications = useNotifications();
+
+function resolveChannelNameFromJid(roomJid: string): string | null {
+  const localpart = roomJid.split("@")[0] ?? "";
+  const waddleId = waddles.activeWaddleId.value;
+  const channelId = waddleId && localpart.startsWith(`${waddleId}_`)
+    ? localpart.slice(waddleId.length + 1)
+    : localpart;
+  return waddles.channels.value.find((c) => c.id === channelId)?.name ?? null;
+}
+
+watch(() => messaging.lastMentionActivity.value, (event) => {
+  if (!event) return;
+
+  const channelName = resolveChannelNameFromJid(event.roomJid) ?? "unknown";
+  const isBroadcast = !!event.broadcastMention;
+  const isPersonalMention = event.mentions?.some(
+    (m) => m === auth.session.value?.username || m.split("@")[0] === auth.session.value?.username,
+  );
+
+  if (isBroadcast || isPersonalMention) {
+    notifications.showMentionNotification({
+      senderNick: event.nick,
+      channelName,
+      body: event.body,
+      roomJid: event.roomJid,
+      isBroadcast,
+      onNavigate: (roomJid) => {
+        const localpart = roomJid.split("@")[0] ?? "";
+        const waddleId = waddles.activeWaddleId.value;
+        const channelId = waddleId && localpart.startsWith(`${waddleId}_`)
+          ? localpart.slice(waddleId.length + 1)
+          : localpart;
+        void selectChannel(channelId);
+      },
+    });
+  }
+
+  messaging.lastMentionActivity.value = null;
+});
 
 const publicBrowseQuery = ref("");
 const isApplyingRoute = ref(false);
@@ -153,6 +195,9 @@ async function bootstrap() {
         updateUrl();
       }
     }
+
+    // Register service worker for push notifications (best-effort, non-blocking)
+    void notifications.registerServiceWorker();
   }
 }
 
@@ -380,7 +425,11 @@ onUnmounted(() => {
         <ProfilePanel
           v-if="auth.session.value"
           :session="auth.session.value"
+          :notification-permission="notifications.permissionState.value"
+          :notifications-enabled="notifications.notificationsEnabled.value"
           @logout="handleLogout"
+          @request-notifications="notifications.requestPermission()"
+          @toggle-notifications="notifications.notificationsEnabled.value = !notifications.notificationsEnabled.value"
         />
       </div>
     </AppDrawer>

--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -43,6 +43,7 @@ function handleBellClick() {
         ? 'opacity-30 cursor-not-allowed'
         : 'hover:bg-foreground/10'"
       :title="bellTitle"
+      :aria-label="bellTitle"
       :disabled="notificationPermission === 'denied'"
       @click="handleBellClick"
     >

--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -1,21 +1,54 @@
 <script setup lang="ts">
-import { LogOut } from "lucide-vue-next";
+import { computed } from "vue";
+import { Bell, BellOff, LogOut } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import type { WaddleSession } from "@/lib/server-auth";
 
-defineProps<{
+const props = defineProps<{
   session: WaddleSession;
+  notificationPermission?: NotificationPermission;
+  notificationsEnabled?: boolean;
 }>();
 
 const emit = defineEmits<{
   logout: [];
+  "request-notifications": [];
+  "toggle-notifications": [];
 }>();
+
+const bellTitle = computed(() => {
+  if (props.notificationPermission === "denied") return "Notifications blocked — update browser settings";
+  if (props.notificationPermission === "granted" && props.notificationsEnabled) return "Notifications enabled";
+  if (props.notificationPermission === "granted") return "Notifications disabled";
+  return "Enable notifications";
+});
+
+function handleBellClick() {
+  if (props.notificationPermission === "denied") return;
+  if (props.notificationPermission === "granted") {
+    emit("toggle-notifications");
+  } else {
+    emit("request-notifications");
+  }
+}
 </script>
 
 <template>
   <div class="h-16 border-t border-foreground px-6 flex items-center gap-3 flex-shrink-0">
     <AppAvatar :name="session.username" size="sm" />
     <span class="flex-1 min-w-0 text-sm font-mono font-bold truncate">{{ session.username }}</span>
+    <button
+      class="h-7 w-7 flex items-center justify-center transition-colors flex-shrink-0"
+      :class="notificationPermission === 'denied'
+        ? 'opacity-30 cursor-not-allowed'
+        : 'hover:bg-foreground/10'"
+      :title="bellTitle"
+      :disabled="notificationPermission === 'denied'"
+      @click="handleBellClick"
+    >
+      <BellOff v-if="notificationPermission === 'denied' || (notificationPermission === 'granted' && !notificationsEnabled)" class="w-3.5 h-3.5" />
+      <Bell v-else class="w-3.5 h-3.5" />
+    </button>
     <button
       class="h-7 w-7 flex items-center justify-center hover:bg-destructive hover:text-destructive-foreground transition-colors flex-shrink-0"
       title="Log out"

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -5,6 +5,7 @@ import {
   BrowserXmppClient,
   roomBareJidFor,
   type LiveRoomMessage,
+  type RoomActivityEvent,
   type XmppStatusSnapshot,
   type ChatStateType,
   type RoomHats,
@@ -70,6 +71,7 @@ export function useMessaging(
   const roomHats = ref<RoomHats>({});
   const slowModeCooldown = ref(0);
   const activeChannels = ref<Set<string>>(new Set());
+  const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
   const searchQuery = ref("");
   const searchResults = ref<{ id: string; nick: string; body: string; createdAt: string }[]>([]);
@@ -112,6 +114,28 @@ export function useMessaging(
         }
 
         mergeLiveMessage(fromLiveMessage(session.value!, msg));
+
+        // Trigger notification for mentions when tab is unfocused
+        if (
+          msg.nick !== session.value?.username &&
+          (!document.hasFocus() || document.visibilityState === "hidden")
+        ) {
+          const isMentioned =
+            !!msg.broadcastMention ||
+            msg.mentions?.some(
+              (m) => m === session.value?.username || m.split("@")[0] === session.value?.username,
+            );
+          if (isMentioned) {
+            const activity: RoomActivityEvent = {
+              roomJid: msg.roomJid,
+              nick: msg.nick,
+              body: msg.body,
+            };
+            if (msg.mentions) activity.mentions = msg.mentions;
+            if (msg.broadcastMention) activity.broadcastMention = msg.broadcastMention;
+            lastMentionActivity.value = activity;
+          }
+        }
       });
       client.setStatusHandler((status) => {
         xmppStatus.value = status;
@@ -135,8 +159,11 @@ export function useMessaging(
       client.setHatsHandler((hats) => {
         roomHats.value = hats;
       });
-      client.setActivityHandler((roomJid) => {
-        activeChannels.value = new Set([...activeChannels.value, roomJid]);
+      client.setActivityHandler((event) => {
+        activeChannels.value = new Set([...activeChannels.value, event.roomJid]);
+        if (event.mentions?.length || event.broadcastMention) {
+          lastMentionActivity.value = event;
+        }
       });
       // XEP-0486: Track room avatar hashes from presence
       client.setRoomAvatarHandler((roomJid, hash) => {
@@ -619,5 +646,6 @@ export function useMessaging(
     clearSearch,
     clearChannelActivity,
     scrollToBottom,
+    lastMentionActivity,
   };
 }

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -116,10 +116,9 @@ export function useMessaging(
         mergeLiveMessage(fromLiveMessage(session.value!, msg));
 
         // Trigger notification for mentions when tab is unfocused
-        if (
-          msg.nick !== session.value?.username &&
-          (!document.hasFocus() || document.visibilityState === "hidden")
-        ) {
+        const isTabHidden = typeof document !== "undefined"
+          && (!document.hasFocus() || document.visibilityState === "hidden");
+        if (msg.nick !== session.value?.username && isTabHidden) {
           const isMentioned =
             !!msg.broadcastMention ||
             msg.mentions?.some(

--- a/chat/src/composables/useNotifications.ts
+++ b/chat/src/composables/useNotifications.ts
@@ -1,6 +1,9 @@
 import { ref, watch } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
 
 const STORAGE_KEY = "waddle.chat.notifications-enabled";
+const VAPID_PUBLIC_KEY = (import.meta.env.PUBLIC_WADDLE_WEB_PUSH_VAPID_PUBLIC_KEY ?? "").trim();
+const PUSH_SERVICE_JID = (import.meta.env.PUBLIC_WADDLE_XMPP_PUSH_SERVICE_JID ?? "").trim();
 
 const hasNotificationApi =
   typeof window !== "undefined" && "Notification" in window;
@@ -92,6 +95,32 @@ export function useNotifications() {
     }
   }
 
+  async function syncPushSubscription(xmppClient: BrowserXmppClient, userJid: string): Promise<boolean> {
+    if (!notificationsEnabled.value || permissionState.value !== "granted") return false;
+    if (!VAPID_PUBLIC_KEY) return false;
+
+    const sub = await subscribeToPush(VAPID_PUBLIC_KEY);
+    if (!sub) return false;
+
+    const subJson = sub.toJSON();
+    const endpoint = subJson.endpoint ?? sub.endpoint;
+    const p256dh = subJson.keys?.p256dh;
+    const auth = subJson.keys?.auth;
+    if (!endpoint || !p256dh || !auth) return false;
+
+    const domain = userJid.includes("@") ? userJid.split("@")[1] ?? "" : "";
+    const serviceJid = PUSH_SERVICE_JID || (domain ? `push.${domain}` : "");
+    if (!serviceJid) return false;
+
+    return xmppClient.enablePushNotifications({
+      serviceJid,
+      node: "web-push",
+      endpoint,
+      p256dh,
+      auth,
+    });
+  }
+
   return {
     permissionState,
     notificationsEnabled,
@@ -99,6 +128,7 @@ export function useNotifications() {
     showMentionNotification,
     registerServiceWorker,
     subscribeToPush,
+    syncPushSubscription,
   };
 }
 

--- a/chat/src/composables/useNotifications.ts
+++ b/chat/src/composables/useNotifications.ts
@@ -1,0 +1,124 @@
+import { ref, watch } from "vue";
+
+const STORAGE_KEY = "waddle.chat.notifications-enabled";
+
+const hasNotificationApi =
+  typeof window !== "undefined" && "Notification" in window;
+
+export interface MentionNotificationOptions {
+  senderNick: string;
+  channelName: string;
+  body: string;
+  roomJid: string;
+  isBroadcast: boolean;
+  onNavigate?: (roomJid: string) => void;
+}
+
+export function useNotifications() {
+  const permissionState = ref<NotificationPermission>(
+    hasNotificationApi ? Notification.permission : "denied",
+  );
+  const notificationsEnabled = ref(loadEnabled());
+
+  watch(notificationsEnabled, (v) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(v));
+    }
+  });
+
+  async function requestPermission(): Promise<NotificationPermission> {
+    if (!hasNotificationApi) return "denied";
+    const result = await Notification.requestPermission();
+    permissionState.value = result;
+    if (result === "granted") {
+      notificationsEnabled.value = true;
+    }
+    return result;
+  }
+
+  function showMentionNotification(opts: MentionNotificationOptions) {
+    if (!hasNotificationApi) return;
+    if (permissionState.value !== "granted" || !notificationsEnabled.value) return;
+
+    const title = opts.isBroadcast
+      ? `@everyone in #${opts.channelName}`
+      : `@${opts.senderNick} in #${opts.channelName}`;
+    const body =
+      opts.body.length > 100 ? `${opts.body.slice(0, 100)}…` : opts.body;
+
+    const notification = new Notification(title, {
+      body,
+      tag: opts.roomJid,
+      icon: "/favicon.svg",
+    });
+
+    notification.onclick = () => {
+      window.focus();
+      opts.onNavigate?.(opts.roomJid);
+      notification.close();
+    };
+
+    setTimeout(() => notification.close(), 5000);
+  }
+
+  // -- Service worker + Web Push --
+
+  let swRegistration: ServiceWorkerRegistration | null = null;
+
+  async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return null;
+    try {
+      swRegistration = await navigator.serviceWorker.register("/sw.js");
+      return swRegistration;
+    } catch {
+      return null;
+    }
+  }
+
+  async function subscribeToPush(
+    vapidPublicKey: string,
+  ): Promise<PushSubscription | null> {
+    const reg = swRegistration ?? (await registerServiceWorker());
+    if (!reg) return null;
+    try {
+      const keyBytes = urlBase64ToUint8Array(vapidPublicKey);
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: keyBytes.buffer as ArrayBuffer,
+      });
+      return sub;
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    permissionState,
+    notificationsEnabled,
+    requestPermission,
+    showMentionNotification,
+    registerServiceWorker,
+    subscribeToPush,
+  };
+}
+
+function loadEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) === true : false;
+  } catch {
+    return false;
+  }
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(base64);
+  const arr = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    arr[i] = raw.charCodeAt(i);
+  }
+  return arr;
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -294,6 +294,33 @@ export class BrowserXmppClient {
     return this.xmpp ? messaging.sendCallInvite(this.xmpp, roomBareJidFor(this.session, w, c), meetingUrl, video) : null;
   }
 
+  async enablePushNotifications(opts: {
+    serviceJid: string;
+    node?: string;
+    endpoint: string;
+    p256dh: string;
+    auth: string;
+  }): Promise<boolean> {
+    await this.connect();
+    if (!this.xmpp) return false;
+    try {
+      await this.xmpp.sendIQ({
+        type: "set",
+        pushEnable: {
+          jid: opts.serviceJid,
+          node: opts.node ?? "web-push",
+          endpoint: opts.endpoint,
+          p256dh: opts.p256dh,
+          auth: opts.auth,
+        },
+      } as Parameters<Agent["sendIQ"]>[0]);
+      return true;
+    } catch (err) {
+      console.warn("Failed to enable XMPP push notifications", err);
+      return false;
+    }
+  }
+
   // -- Query delegators --
 
   async queryMam(w: string, c: string, max = 50): Promise<LiveRoomMessage[]> {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -6,7 +6,7 @@ import type { WaddleSession } from "../server-auth";
 import type { WaddleHat } from "./extensions/hats";
 import type {
   ChatStateEvent, ChatStateType, DiscoveredChannel, DiscoveredWaddle,
-  DisplayedEvent, LiveRoomMessage, ReactionEvent, RoomHats, XmppStatusSnapshot,
+  DisplayedEvent, LiveRoomMessage, ReactionEvent, RoomActivityEvent, RoomHats, XmppStatusSnapshot,
 } from "./types";
 import { roomBareJidFor } from "./jid";
 import { registerWaddleExtensions } from "./extensions";
@@ -73,7 +73,7 @@ export class BrowserXmppClient {
   private chatStateHandler: ((event: ChatStateEvent) => void) | null = null;
   private hatsHandler: ((hats: RoomHats) => void) | null = null;
   private slowModeHandler: ((seconds: number) => void) | null = null;
-  private activityHandler: ((roomJid: string) => void) | null = null;
+  private activityHandler: ((event: RoomActivityEvent) => void) | null = null;
   private roomAvatarHandler: ((roomJid: string, hash: string) => void) | null = null;
   private roomDisconnectHandler: (() => void) | null = null;
   private xmpp: Agent | null = null;
@@ -94,7 +94,7 @@ export class BrowserXmppClient {
   setDisplayedHandler(h: (event: DisplayedEvent) => void) { this.displayedHandler = h; }
   setHatsHandler(h: (hats: RoomHats) => void) { this.hatsHandler = h; }
   setSlowModeHandler(h: (seconds: number) => void) { this.slowModeHandler = h; }
-  setActivityHandler(h: (roomJid: string) => void) { this.activityHandler = h; }
+  setActivityHandler(h: (event: RoomActivityEvent) => void) { this.activityHandler = h; }
   setRoomAvatarHandler(h: (roomJid: string, hash: string) => void) { this.roomAvatarHandler = h; }
   setRoomDisconnectHandler(h: () => void) { this.roomDisconnectHandler = h; }
 

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -8,6 +8,7 @@ import fileSharing from "./file-sharing";
 import stickers from "./stickers";
 import calls from "./calls";
 import mentions from "./mentions";
+import push from "./push";
 
 const allDefinitions = [
   ...hats,
@@ -18,6 +19,7 @@ const allDefinitions = [
   ...stickers,
   ...calls,
   ...mentions,
+  ...push,
 ];
 
 export function registerWaddleExtensions(client: Agent): void {

--- a/chat/src/lib/xmpp/extensions/push.ts
+++ b/chat/src/lib/xmpp/extensions/push.ts
@@ -1,0 +1,44 @@
+/** XEP-0357: Push Notifications (client IQ enable/disable). */
+import type { DefinitionOptions } from "stanza/jxt";
+import { attribute } from "stanza/jxt";
+
+const NS_PUSH_0 = "urn:xmpp:push:0";
+
+export interface WaddlePushEnable {
+  jid: string;
+  node?: string;
+  endpoint?: string;
+  p256dh?: string;
+  auth?: string;
+}
+
+export interface WaddlePushDisable {
+  jid: string;
+  node?: string;
+}
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "iq.pushEnable", multiple: false }],
+    element: "enable",
+    fields: {
+      jid: attribute("jid"),
+      node: attribute("node"),
+      endpoint: attribute("endpoint"),
+      p256dh: attribute("p256dh"),
+      auth: attribute("auth"),
+    },
+    namespace: NS_PUSH_0,
+  },
+  {
+    aliases: [{ path: "iq.pushDisable", multiple: false }],
+    element: "disable",
+    fields: {
+      jid: attribute("jid"),
+      node: attribute("node"),
+    },
+    namespace: NS_PUSH_0,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -10,6 +10,7 @@ export type {
   LiveRoomMessage,
   OccupantHat,
   ReactionEvent,
+  RoomActivityEvent,
   RoomHats,
   SharedFileInfo,
   XmppStatusSnapshot,

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -2,7 +2,7 @@
 import type { ReceivedMessage } from "stanza/protocol";
 import type {
   CallInviteInfo, ChatStateEvent, ChatStateType, DisplayedEvent,
-  LiveRoomMessage, ReactionEvent, SharedFileInfo,
+  LiveRoomMessage, ReactionEvent, RoomActivityEvent, SharedFileInfo,
 } from "./types";
 
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
@@ -79,7 +79,7 @@ export interface GroupchatHandlers {
   onChatState: ((event: ChatStateEvent) => void) | null;
   onDisplayed: ((event: DisplayedEvent) => void) | null;
   onReaction: ((event: ReactionEvent) => void) | null;
-  onActivity: ((roomJid: string) => void) | null;
+  onActivity: ((event: RoomActivityEvent) => void) | null;
 }
 
 /** Route an inbound groupchat message to the appropriate handler. */
@@ -89,7 +89,15 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
   if (!roomJid) return;
 
   if (roomJid !== h.currentRoom) {
-    if (msg.body) h.onActivity?.(roomJid);
+    if (msg.body) {
+      const partial: LiveRoomMessage = { id: "", roomJid, nick, body: msg.body, createdAt: "", type: "message" };
+      extractReferences(msg, partial);
+      extractExplicitMentions(msg, partial);
+      const activity: RoomActivityEvent = { roomJid, nick, body: msg.body };
+      if (partial.mentions) activity.mentions = partial.mentions;
+      if (partial.broadcastMention) activity.broadcastMention = partial.broadcastMention;
+      h.onActivity?.(activity);
+    }
     return;
   }
 

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -85,3 +85,14 @@ export interface DiscoveredChannel {
   id: string;
   name: string;
 }
+
+/** Cross-room activity event with optional mention data for notifications. */
+export interface RoomActivityEvent {
+  roomJid: string;
+  nick: string;
+  body: string;
+  /** XEP-0372 */
+  mentions?: string[];
+  /** XEP-0513 */
+  broadcastMention?: "everyone" | "here";
+}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5620,6 +5620,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.9.2",
  "rcgen",
+ "reqwest",
  "rustls 0.23.37",
  "rustls-pemfile",
  "rxml 0.12.0",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5637,6 +5637,7 @@ dependencies = [
  "tokio-xmpp",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
  "waddle-xmpp-xep-github",
  "xmpp-parsers",

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -47,6 +47,7 @@ opentelemetry = { workspace = true }
 # Utilities
 uuid = { workspace = true }
 chrono = { workspace = true }
+url = { workspace = true }
 base64 = { workspace = true }
 
 # HTML rendering

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -34,6 +34,7 @@ rustls-pemfile = "2.2"
 
 # Serialization
 serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Error Handling
 thiserror = { workspace = true }

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -61,6 +61,9 @@ hmac = { workspace = true }
 rand = { workspace = true }
 pbkdf2 = { version = "0.12", features = ["hmac"] }
 
+# HTTP client (for Web Push notifications)
+reqwest = { workspace = true }
+
 # GitHub link enrichment
 waddle-xmpp-xep-github = { path = "../waddle-xmpp-xep-github" }
 

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -11,6 +11,7 @@ use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, info, instrument, warn};
+use url::{Host, Url};
 use xmpp_parsers::iq::IqType;
 use xmpp_parsers::message::MessageType;
 use xmpp_parsers::presence::Type as PresenceType;
@@ -84,11 +85,11 @@ use crate::xep::xep0191::{
     build_unblock_push, is_blocking_query, parse_blocking_request, BlockingRequest,
 };
 use crate::xep::xep0199::{build_ping_result, is_ping};
+use crate::xep::xep0249::{parse_direct_invite_from_message, DirectInvite};
 use crate::xep::xep0357::{
     build_push_disable_result, build_push_enable_result, is_push_disable, is_push_enable,
     parse_push_disable, parse_push_enable,
 };
-use crate::xep::xep0249::{parse_direct_invite_from_message, DirectInvite};
 use crate::xep::xep0363::{
     build_upload_error, build_upload_slot_response, is_upload_request, parse_upload_request,
     UploadError, UploadSlot,
@@ -7115,28 +7116,15 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         };
 
         let bare_jid = sender_jid.to_bare().to_string();
-        let endpoint = enable.options.iter().find(|(k, _)| k == "endpoint").map(|(_, v)| v.clone());
+        let endpoint = enable
+            .options
+            .iter()
+            .find(|(k, _)| k == "endpoint")
+            .map(|(_, v)| v.clone());
 
-        // SSRF protection: only allow https endpoints, reject private/local URLs
+        // SSRF protection: only allow https endpoints and reject local/private targets.
         if let Some(ref ep) = endpoint {
-            if !ep.starts_with("https://") {
-                return Err(XmppError::bad_request(Some(
-                    "Push endpoint must use https".into(),
-                )));
-            }
-            let host = ep.trim_start_matches("https://").split('/').next().unwrap_or("");
-            let host_no_port = host.split(':').next().unwrap_or("");
-            if host_no_port == "localhost"
-                || host_no_port == "127.0.0.1"
-                || host_no_port == "::1"
-                || host_no_port.starts_with("10.")
-                || host_no_port.starts_with("192.168.")
-                || host_no_port.starts_with("169.254.")
-            {
-                return Err(XmppError::bad_request(Some(
-                    "Push endpoint must not target private networks".into(),
-                )));
-            }
+            validate_push_endpoint(ep)?;
         }
 
         let sub = crate::push::PushSubscription {
@@ -7144,8 +7132,16 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             service_jid: enable.jid.clone(),
             node: enable.node.clone(),
             endpoint,
-            p256dh: enable.options.iter().find(|(k, _)| k == "p256dh").map(|(_, v)| v.clone()),
-            auth_key: enable.options.iter().find(|(k, _)| k == "auth").map(|(_, v)| v.clone()),
+            p256dh: enable
+                .options
+                .iter()
+                .find(|(k, _)| k == "p256dh")
+                .map(|(_, v)| v.clone()),
+            auth_key: enable
+                .options
+                .iter()
+                .find(|(k, _)| k == "auth")
+                .map(|(_, v)| v.clone()),
         };
 
         if let Err(e) = self.push_store.register(sub).await {
@@ -7237,6 +7233,77 @@ fn isr_token_in_sasl_success_enabled() -> bool {
     )
 }
 
+fn validate_push_endpoint(endpoint: &str) -> Result<(), XmppError> {
+    let url = Url::parse(endpoint)
+        .map_err(|_| XmppError::bad_request(Some("Invalid push endpoint URL".into())))?;
+
+    if url.scheme() != "https" {
+        return Err(XmppError::bad_request(Some(
+            "Push endpoint must use https".into(),
+        )));
+    }
+
+    match url.host() {
+        Some(Host::Domain(host)) => {
+            let host = host.to_ascii_lowercase();
+            if host == "localhost" || host.ends_with(".localhost") || host.ends_with(".local") {
+                return Err(XmppError::bad_request(Some(
+                    "Push endpoint must not target private networks".into(),
+                )));
+            }
+        }
+        Some(Host::Ipv4(ipv4)) => {
+            if is_disallowed_push_ipv4(ipv4) {
+                return Err(XmppError::bad_request(Some(
+                    "Push endpoint must not target private networks".into(),
+                )));
+            }
+        }
+        Some(Host::Ipv6(ipv6)) => {
+            if is_disallowed_push_ipv6(ipv6) {
+                return Err(XmppError::bad_request(Some(
+                    "Push endpoint must not target private networks".into(),
+                )));
+            }
+        }
+        None => {
+            return Err(XmppError::bad_request(Some(
+                "Invalid push endpoint URL".into(),
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_disallowed_push_ipv4(ip: std::net::Ipv4Addr) -> bool {
+    let octets = ip.octets();
+
+    // RFC 6598: 100.64.0.0/10 (Carrier-grade NAT)
+    let is_cgnat = octets[0] == 100 && (octets[1] & 0b1100_0000) == 0b0100_0000;
+    // RFC 2544: 198.18.0.0/15 (Benchmarking)
+    let is_benchmark = octets[0] == 198 && (octets[1] == 18 || octets[1] == 19);
+
+    ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_unspecified()
+        || is_cgnat
+        || is_benchmark
+}
+
+fn is_disallowed_push_ipv6(ip: std::net::Ipv6Addr) -> bool {
+    if let Some(mapped) = ip.to_ipv4_mapped() {
+        return is_disallowed_push_ipv4(mapped);
+    }
+
+    ip.is_loopback()
+        || ip.is_unspecified()
+        || ip.is_unique_local()
+        || ip.is_unicast_link_local()
+        || ip.is_multicast()
+}
+
 /// Parsed stanza types.
 #[derive(Debug, Clone)]
 pub enum Stanza {
@@ -7262,5 +7329,35 @@ impl Stanza {
             Stanza::Presence(p) => p.clone().into(),
             Stanza::Iq(i) => i.clone().into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_push_endpoint;
+
+    #[test]
+    fn accepts_public_https_endpoint() {
+        assert!(validate_push_endpoint("https://push.example.com/notify").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_https_endpoint() {
+        assert!(validate_push_endpoint("http://push.example.com/notify").is_err());
+    }
+
+    #[test]
+    fn rejects_localhost_endpoint() {
+        assert!(validate_push_endpoint("https://localhost/notify").is_err());
+    }
+
+    #[test]
+    fn rejects_private_ipv4_endpoint() {
+        assert!(validate_push_endpoint("https://10.0.0.12/notify").is_err());
+    }
+
+    #[test]
+    fn rejects_link_local_ipv6_endpoint() {
+        assert!(validate_push_endpoint("https://[fe80::1]/notify").is_err());
     }
 }

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -1592,6 +1592,14 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         let remote_domain_count = federated_messages.remote_domain_count();
         let remote_count = federated_messages.remote_count();
 
+        // XEP-0357: Collect occupant bare JIDs for broadcast mention push (before dropping room lock)
+        let occupant_bare_jids: Vec<String> = room
+            .occupants
+            .values()
+            .filter(|o| o.real_jid != sender_jid)
+            .map(|o| o.real_jid.to_bare().to_string())
+            .collect();
+
         drop(room); // Release the read lock before archival and sending
 
         // Archive the message to MAM storage (only if it has a body)
@@ -1698,11 +1706,20 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
         // XEP-0357: Trigger push notifications for mentioned users
         if muc_msg.has_body() {
-            let mentioned_jids = crate::xep::xep0372::extract_mentioned_jids(&muc_msg.message);
+            let mut push_jids = crate::xep::xep0372::extract_mentioned_jids(&muc_msg.message);
             let explicit = crate::xep::xep0513::extract_explicit_mentions(&muc_msg.message);
             let is_broadcast = explicit.as_ref().is_some_and(|m| m.has_broadcast());
 
-            if !mentioned_jids.is_empty() || is_broadcast {
+            // For broadcast mentions (@everyone/@here), expand to all room occupants
+            if is_broadcast {
+                for jid in &occupant_bare_jids {
+                    if !push_jids.contains(jid) {
+                        push_jids.push(jid.clone());
+                    }
+                }
+            }
+
+            if !push_jids.is_empty() {
                 let body = muc_msg
                     .message
                     .bodies
@@ -1716,12 +1733,11 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                 let room_jid_str = room_jid.to_string();
                 let nick = sender_nick.clone();
 
-                // Send push notifications in a background task to avoid blocking message delivery
                 tokio::spawn(async move {
                     crate::push::notify_mentioned_users(
                         push_store.as_ref(),
                         push_sender.as_ref(),
-                        &mentioned_jids,
+                        &push_jids,
                         &nick,
                         &body,
                         &room_jid_str,
@@ -7099,11 +7115,35 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         };
 
         let bare_jid = sender_jid.to_bare().to_string();
+        let endpoint = enable.options.iter().find(|(k, _)| k == "endpoint").map(|(_, v)| v.clone());
+
+        // SSRF protection: only allow https endpoints, reject private/local URLs
+        if let Some(ref ep) = endpoint {
+            if !ep.starts_with("https://") {
+                return Err(XmppError::bad_request(Some(
+                    "Push endpoint must use https".into(),
+                )));
+            }
+            let host = ep.trim_start_matches("https://").split('/').next().unwrap_or("");
+            let host_no_port = host.split(':').next().unwrap_or("");
+            if host_no_port == "localhost"
+                || host_no_port == "127.0.0.1"
+                || host_no_port == "::1"
+                || host_no_port.starts_with("10.")
+                || host_no_port.starts_with("192.168.")
+                || host_no_port.starts_with("169.254.")
+            {
+                return Err(XmppError::bad_request(Some(
+                    "Push endpoint must not target private networks".into(),
+                )));
+            }
+        }
+
         let sub = crate::push::PushSubscription {
             user_jid: bare_jid.clone(),
             service_jid: enable.jid.clone(),
             node: enable.node.clone(),
-            endpoint: enable.options.iter().find(|(k, _)| k == "endpoint").map(|(_, v)| v.clone()),
+            endpoint,
             p256dh: enable.options.iter().find(|(k, _)| k == "p256dh").map(|(_, v)| v.clone()),
             auth_key: enable.options.iter().find(|(k, _)| k == "auth").map(|(_, v)| v.clone()),
         };

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -84,6 +84,10 @@ use crate::xep::xep0191::{
     build_unblock_push, is_blocking_query, parse_blocking_request, BlockingRequest,
 };
 use crate::xep::xep0199::{build_ping_result, is_ping};
+use crate::xep::xep0357::{
+    build_push_disable_result, build_push_enable_result, is_push_disable, is_push_enable,
+    parse_push_disable, parse_push_enable,
+};
 use crate::xep::xep0249::{parse_direct_invite_from_message, DirectInvite};
 use crate::xep::xep0363::{
     build_upload_error, build_upload_slot_response, is_upload_request, parse_upload_request,
@@ -166,13 +170,17 @@ pub struct ConnectionActor<S: AppState, M: MamStorage> {
     /// Whether the server operates in single-tenant mode (XEP-0503).
     /// When true, all spaces are publicly discoverable regardless of membership.
     single_tenant: bool,
+    /// XEP-0357 Push notification subscription store
+    push_store: Arc<dyn crate::push::PushSubscriptionStore + Send + Sync>,
+    /// XEP-0357 Push notification sender
+    push_sender: Arc<dyn crate::push::WebPushSender + Send + Sync>,
 }
 
 impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
     /// Handle a new incoming connection.
     #[instrument(
         name = "xmpp.connection.handle",
-        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, github_enricher),
+        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, github_enricher, push_store, push_sender),
         fields(peer = %peer_addr)
     )]
     #[allow(clippy::too_many_arguments)]
@@ -191,6 +199,8 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         pubsub_storage: Arc<dyn PubSubStorage + Send + Sync>,
         github_enricher: Option<Arc<MessageEnricher>>,
         single_tenant: bool,
+        push_store: Arc<dyn crate::push::PushSubscriptionStore + Send + Sync>,
+        push_sender: Arc<dyn crate::push::WebPushSender + Send + Sync>,
     ) -> Result<(), XmppError> {
         info!("New connection from {}", peer_addr);
 
@@ -220,6 +230,8 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             converting_avatar: false, // XEP-0398: guard against infinite conversion loops
             github_enricher,          // GitHub link enrichment (optional)
             single_tenant,            // XEP-0503: single-tenant mode for spaces
+            push_store,               // XEP-0357: push subscription store
+            push_sender,              // XEP-0357: push notification sender
         };
 
         actor.run(tls_acceptor, registration_enabled).await
@@ -1681,6 +1693,41 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                         );
                     }
                 }
+            }
+        }
+
+        // XEP-0357: Trigger push notifications for mentioned users
+        if muc_msg.has_body() {
+            let mentioned_jids = crate::xep::xep0372::extract_mentioned_jids(&muc_msg.message);
+            let explicit = crate::xep::xep0513::extract_explicit_mentions(&muc_msg.message);
+            let is_broadcast = explicit.as_ref().is_some_and(|m| m.has_broadcast());
+
+            if !mentioned_jids.is_empty() || is_broadcast {
+                let body = muc_msg
+                    .message
+                    .bodies
+                    .get("")
+                    .or_else(|| muc_msg.message.bodies.values().next())
+                    .map(|b| b.0.clone())
+                    .unwrap_or_default();
+
+                let push_store = Arc::clone(&self.push_store);
+                let push_sender = Arc::clone(&self.push_sender);
+                let room_jid_str = room_jid.to_string();
+                let nick = sender_nick.clone();
+
+                // Send push notifications in a background task to avoid blocking message delivery
+                tokio::spawn(async move {
+                    crate::push::notify_mentioned_users(
+                        push_store.as_ref(),
+                        push_sender.as_ref(),
+                        &mentioned_jids,
+                        &nick,
+                        &body,
+                        &room_jid_str,
+                    )
+                    .await;
+                });
             }
         }
 
@@ -3728,6 +3775,16 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         // Check if this is a PubSub/PEP IQ (XEP-0060/XEP-0163)
         if is_pubsub_iq(&iq) {
             return self.handle_pubsub_iq(iq).await;
+        }
+
+        // Check if this is a push notification enable request (XEP-0357)
+        if is_push_enable(&iq) {
+            return self.handle_push_enable(iq).await;
+        }
+
+        // Check if this is a push notification disable request (XEP-0357)
+        if is_push_disable(&iq) {
+            return self.handle_push_disable(iq).await;
         }
 
         // Unhandled IQ get/set - RFC 6120 §8.2.3 requires an error response
@@ -7017,6 +7074,95 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                 }
             }
         }
+    }
+
+    // =========================================================================
+    // XEP-0357 Push Notification Handlers
+    // =========================================================================
+
+    async fn handle_push_enable(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
+        let sender_jid = match &self.jid {
+            Some(jid) => jid.clone(),
+            None => {
+                warn!("Push enable received before JID bound");
+                return Err(XmppError::not_authorized(Some("Not authenticated".into())));
+            }
+        };
+
+        let enable = match parse_push_enable(&iq) {
+            Some(e) => e,
+            None => {
+                return Err(XmppError::bad_request(Some(
+                    "Invalid push enable request".into(),
+                )));
+            }
+        };
+
+        let bare_jid = sender_jid.to_bare().to_string();
+        let sub = crate::push::PushSubscription {
+            user_jid: bare_jid.clone(),
+            service_jid: enable.jid.clone(),
+            node: enable.node.clone(),
+            endpoint: enable.options.iter().find(|(k, _)| k == "endpoint").map(|(_, v)| v.clone()),
+            p256dh: enable.options.iter().find(|(k, _)| k == "p256dh").map(|(_, v)| v.clone()),
+            auth_key: enable.options.iter().find(|(k, _)| k == "auth").map(|(_, v)| v.clone()),
+        };
+
+        if let Err(e) = self.push_store.register(sub).await {
+            warn!(user = %bare_jid, error = %e, "Failed to register push subscription");
+            return Err(XmppError::internal_server_error(Some(
+                "Failed to store push subscription".into(),
+            )));
+        }
+
+        debug!(
+            user = %bare_jid,
+            service = %enable.jid,
+            node = ?enable.node,
+            "Push notification subscription registered"
+        );
+
+        let response = build_push_enable_result(&iq);
+        self.stream.write_stanza(&Stanza::Iq(response)).await
+    }
+
+    async fn handle_push_disable(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
+        let sender_jid = match &self.jid {
+            Some(jid) => jid.clone(),
+            None => {
+                warn!("Push disable received before JID bound");
+                return Err(XmppError::not_authorized(Some("Not authenticated".into())));
+            }
+        };
+
+        let disable = match parse_push_disable(&iq) {
+            Some(d) => d,
+            None => {
+                return Err(XmppError::bad_request(Some(
+                    "Invalid push disable request".into(),
+                )));
+            }
+        };
+
+        let bare_jid = sender_jid.to_bare().to_string();
+
+        if let Err(e) = self
+            .push_store
+            .remove(&bare_jid, &disable.jid, disable.node.as_deref())
+            .await
+        {
+            warn!(user = %bare_jid, error = %e, "Failed to remove push subscription");
+        }
+
+        debug!(
+            user = %bare_jid,
+            service = %disable.jid,
+            node = ?disable.node,
+            "Push notification subscription removed"
+        );
+
+        let response = build_push_disable_result(&iq);
+        self.stream.write_stanza(&Stanza::Iq(response)).await
     }
 }
 

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -35,6 +35,7 @@ pub mod parser;
 pub mod presence;
 pub mod prometheus;
 pub mod pubsub;
+pub mod push;
 pub mod registry;
 pub mod roster;
 pub mod routing;

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -1,0 +1,84 @@
+//! Push Notification Subscription Storage and Web Push Sender
+//!
+//! Provides a trait-based abstraction for managing push notification subscriptions
+//! and sending Web Push notifications. Subscriptions are registered via XEP-0357
+//! enable/disable IQ stanzas and stored for later notification delivery.
+
+mod sender;
+mod store;
+
+pub use sender::{notify_mentioned_users, HttpWebPushSender, WebPushSender};
+pub use store::{InMemoryPushStore, PushSubscriptionStore};
+
+use thiserror::Error;
+
+/// Errors that can occur during push operations.
+#[derive(Debug, Error)]
+pub enum PushError {
+    /// The subscription was not found.
+    #[error("push subscription not found")]
+    NotFound,
+    /// Failed to send a push notification.
+    #[error("failed to send push notification: {0}")]
+    SendFailed(String),
+    /// The subscription endpoint is missing.
+    #[error("push subscription endpoint is missing")]
+    MissingEndpoint,
+    /// An internal storage error occurred.
+    #[error("push storage error: {0}")]
+    StorageError(String),
+    /// An HTTP request error occurred.
+    #[error("HTTP request error: {0}")]
+    HttpError(String),
+}
+
+/// A push notification subscription registered via XEP-0357.
+#[derive(Debug, Clone)]
+pub struct PushSubscription {
+    /// The bare JID of the user who registered the subscription.
+    pub user_jid: String,
+    /// The JID of the push service.
+    pub service_jid: String,
+    /// The PubSub node on the push service.
+    pub node: Option<String>,
+    /// The Web Push endpoint URL (from data form options).
+    pub endpoint: Option<String>,
+    /// The client's P-256 ECDH public key (base64, from data form options).
+    pub p256dh: Option<String>,
+    /// The client's authentication secret (base64, from data form options).
+    pub auth_key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_push_error_display() {
+        assert_eq!(PushError::NotFound.to_string(), "push subscription not found");
+        assert_eq!(
+            PushError::SendFailed("timeout".into()).to_string(),
+            "failed to send push notification: timeout"
+        );
+        assert_eq!(
+            PushError::MissingEndpoint.to_string(),
+            "push subscription endpoint is missing"
+        );
+    }
+
+    #[test]
+    fn test_push_subscription_clone_debug() {
+        let sub = PushSubscription {
+            user_jid: "alice@example.com".into(),
+            service_jid: "push.example.com".into(),
+            node: Some("web-push".into()),
+            endpoint: Some("https://push.example.com/abc".into()),
+            p256dh: Some("key".into()),
+            auth_key: Some("auth".into()),
+        };
+        let cloned = sub.clone();
+        assert_eq!(cloned.user_jid, "alice@example.com");
+        let debug = format!("{:?}", sub);
+        assert!(debug.contains("alice@example.com"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/mod.rs
+++ b/server/crates/waddle-xmpp/src/push/mod.rs
@@ -55,7 +55,10 @@ mod tests {
 
     #[test]
     fn test_push_error_display() {
-        assert_eq!(PushError::NotFound.to_string(), "push subscription not found");
+        assert_eq!(
+            PushError::NotFound.to_string(),
+            "push subscription not found"
+        );
         assert_eq!(
             PushError::SendFailed("timeout".into()).to_string(),
             "failed to send push notification: timeout"

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -1,12 +1,12 @@
 //! Web Push notification sender.
 
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
 
 use tracing::{debug, warn};
 
-use super::{PushError, PushSubscription};
 use super::store::PushSubscriptionStore;
+use super::{PushError, PushSubscription};
 
 /// Trait for sending Web Push notifications.
 pub trait WebPushSender: Send + Sync + 'static {
@@ -109,7 +109,10 @@ pub async fn notify_mentioned_users<S, W>(
             body.to_string()
         };
         for sub in &subs {
-            if let Err(e) = sender.send_notification(sub, &title, &preview, room_jid).await {
+            if let Err(e) = sender
+                .send_notification(sub, &title, &preview, room_jid)
+                .await
+            {
                 debug!(user_jid = %jid, error = %e, "Push notification failed");
             }
         }
@@ -118,17 +121,27 @@ pub async fn notify_mentioned_users<S, W>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::store::InMemoryPushStore;
+    use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     struct MockSender(AtomicUsize);
     impl MockSender {
-        fn new() -> Self { Self(AtomicUsize::new(0)) }
-        fn count(&self) -> usize { self.0.load(Ordering::SeqCst) }
+        fn new() -> Self {
+            Self(AtomicUsize::new(0))
+        }
+        fn count(&self) -> usize {
+            self.0.load(Ordering::SeqCst)
+        }
     }
     impl WebPushSender for MockSender {
-        fn send_notification(&self, _: &PushSubscription, _: &str, _: &str, _: &str) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+        fn send_notification(
+            &self,
+            _: &PushSubscription,
+            _: &str,
+            _: &str,
+            _: &str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
             self.0.fetch_add(1, Ordering::SeqCst);
             Box::pin(async { Ok(()) })
         }
@@ -137,14 +150,28 @@ mod tests {
     #[tokio::test]
     async fn test_notify_sends_to_subscribed() {
         let store = InMemoryPushStore::new();
-        store.register(PushSubscription {
-            user_jid: "alice@ex".into(), service_jid: "push.ex".into(),
-            node: Some("n1".into()), endpoint: Some("https://ep".into()),
-            p256dh: None, auth_key: None,
-        }).await.expect("ok");
+        store
+            .register(PushSubscription {
+                user_jid: "alice@ex".into(),
+                service_jid: "push.ex".into(),
+                node: Some("n1".into()),
+                endpoint: Some("https://ep".into()),
+                p256dh: None,
+                auth_key: None,
+            })
+            .await
+            .expect("ok");
 
         let sender = MockSender::new();
-        notify_mentioned_users(&store, &sender, &["alice@ex".into(), "bob@ex".into()], "charlie", "Hey!", "room@muc").await;
+        notify_mentioned_users(
+            &store,
+            &sender,
+            &["alice@ex".into(), "bob@ex".into()],
+            "charlie",
+            "Hey!",
+            "room@muc",
+        )
+        .await;
         assert_eq!(sender.count(), 1); // only alice has a sub
     }
 
@@ -152,7 +179,15 @@ mod tests {
     async fn test_notify_no_subs() {
         let store = InMemoryPushStore::new();
         let sender = MockSender::new();
-        notify_mentioned_users(&store, &sender, &["alice@ex".into()], "bob", "Hi", "room@muc").await;
+        notify_mentioned_users(
+            &store,
+            &sender,
+            &["alice@ex".into()],
+            "bob",
+            "Hi",
+            "room@muc",
+        )
+        .await;
         assert_eq!(sender.count(), 0);
     }
 }

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -27,11 +27,13 @@ pub struct HttpWebPushSender {
 }
 
 impl HttpWebPushSender {
-    /// Create a new HTTP Web Push sender.
+    /// Create a new HTTP Web Push sender with a 10-second request timeout.
     pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-        }
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
+        Self { client }
     }
 }
 
@@ -50,15 +52,14 @@ impl WebPushSender for HttpWebPushSender {
         room_jid: &str,
     ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
         let endpoint = subscription.endpoint.clone();
-        let json_body = format!(
-            r#"{{"title":"{}","body":"{}","roomJid":"{}"}}"#,
-            title.replace('\\', "\\\\").replace('"', "\\\""),
-            body.replace('\\', "\\\\").replace('"', "\\\""),
-            room_jid.replace('\\', "\\\\").replace('"', "\\\""),
-        );
+        let payload = serde_json::json!({
+            "title": title,
+            "body": body,
+            "roomJid": room_jid,
+        });
         Box::pin(async move {
             let ep = endpoint.as_deref().ok_or(PushError::MissingEndpoint)?;
-            match self.client.post(ep).body(json_body).header("Content-Type", "application/json").send().await {
+            match self.client.post(ep).json(&payload).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     debug!(endpoint = %ep, "Push notification delivered");
                     Ok(())

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -1,0 +1,157 @@
+//! Web Push notification sender.
+
+use std::pin::Pin;
+use std::future::Future;
+
+use tracing::{debug, warn};
+
+use super::{PushError, PushSubscription};
+use super::store::PushSubscriptionStore;
+
+/// Trait for sending Web Push notifications.
+pub trait WebPushSender: Send + Sync + 'static {
+    /// Send a push notification to the given subscription.
+    fn send_notification(
+        &self,
+        subscription: &PushSubscription,
+        title: &str,
+        body: &str,
+        room_jid: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+}
+
+/// HTTP-based Web Push sender that POSTs JSON to a push relay/gateway.
+#[derive(Debug, Clone)]
+pub struct HttpWebPushSender {
+    client: reqwest::Client,
+}
+
+impl HttpWebPushSender {
+    /// Create a new HTTP Web Push sender.
+    pub fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+impl Default for HttpWebPushSender {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WebPushSender for HttpWebPushSender {
+    fn send_notification(
+        &self,
+        subscription: &PushSubscription,
+        title: &str,
+        body: &str,
+        room_jid: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+        let endpoint = subscription.endpoint.clone();
+        let json_body = format!(
+            r#"{{"title":"{}","body":"{}","roomJid":"{}"}}"#,
+            title.replace('\\', "\\\\").replace('"', "\\\""),
+            body.replace('\\', "\\\\").replace('"', "\\\""),
+            room_jid.replace('\\', "\\\\").replace('"', "\\\""),
+        );
+        Box::pin(async move {
+            let ep = endpoint.as_deref().ok_or(PushError::MissingEndpoint)?;
+            match self.client.post(ep).body(json_body).header("Content-Type", "application/json").send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(endpoint = %ep, "Push notification delivered");
+                    Ok(())
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    warn!(endpoint = %ep, status = %status, "Push rejected");
+                    Err(PushError::SendFailed(format!("HTTP {}", status)))
+                }
+                Err(e) => {
+                    warn!(endpoint = %ep, error = %e, "Push delivery failed");
+                    Err(PushError::HttpError(e.to_string()))
+                }
+            }
+        })
+    }
+}
+
+/// Send push notifications for mentioned users.
+pub async fn notify_mentioned_users<S, W>(
+    store: &S,
+    sender: &W,
+    mentioned_jids: &[String],
+    sender_nick: &str,
+    body: &str,
+    room_jid: &str,
+) where
+    S: PushSubscriptionStore + ?Sized,
+    W: WebPushSender + ?Sized,
+{
+    for jid in mentioned_jids {
+        let subs = match store.get_for_user(jid).await {
+            Ok(s) => s,
+            Err(e) => {
+                debug!(user_jid = %jid, error = %e, "Failed to get push subs");
+                continue;
+            }
+        };
+        if subs.is_empty() {
+            continue;
+        }
+        let title = format!("@{} mentioned you", sender_nick);
+        let preview = if body.len() > 100 {
+            let end = body.char_indices().nth(100).map_or(body.len(), |(i, _)| i);
+            format!("{}...", &body[..end])
+        } else {
+            body.to_string()
+        };
+        for sub in &subs {
+            if let Err(e) = sender.send_notification(sub, &title, &preview, room_jid).await {
+                debug!(user_jid = %jid, error = %e, "Push notification failed");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::store::InMemoryPushStore;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct MockSender(AtomicUsize);
+    impl MockSender {
+        fn new() -> Self { Self(AtomicUsize::new(0)) }
+        fn count(&self) -> usize { self.0.load(Ordering::SeqCst) }
+    }
+    impl WebPushSender for MockSender {
+        fn send_notification(&self, _: &PushSubscription, _: &str, _: &str, _: &str) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_notify_sends_to_subscribed() {
+        let store = InMemoryPushStore::new();
+        store.register(PushSubscription {
+            user_jid: "alice@ex".into(), service_jid: "push.ex".into(),
+            node: Some("n1".into()), endpoint: Some("https://ep".into()),
+            p256dh: None, auth_key: None,
+        }).await.expect("ok");
+
+        let sender = MockSender::new();
+        notify_mentioned_users(&store, &sender, &["alice@ex".into(), "bob@ex".into()], "charlie", "Hey!", "room@muc").await;
+        assert_eq!(sender.count(), 1); // only alice has a sub
+    }
+
+    #[tokio::test]
+    async fn test_notify_no_subs() {
+        let store = InMemoryPushStore::new();
+        let sender = MockSender::new();
+        notify_mentioned_users(&store, &sender, &["alice@ex".into()], "bob", "Hi", "room@muc").await;
+        assert_eq!(sender.count(), 0);
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/store.rs
+++ b/server/crates/waddle-xmpp/src/push/store.rs
@@ -1,7 +1,7 @@
 //! In-memory push subscription storage.
 
-use std::pin::Pin;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -11,11 +11,22 @@ use super::{PushError, PushSubscription};
 /// Trait for storing and retrieving push notification subscriptions.
 pub trait PushSubscriptionStore: Send + Sync + 'static {
     /// Register a new push subscription.
-    fn register(&self, sub: PushSubscription) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+    fn register(
+        &self,
+        sub: PushSubscription,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
     /// Remove a push subscription.
-    fn remove(&self, user_jid: &str, service_jid: &str, node: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+    fn remove(
+        &self,
+        user_jid: &str,
+        service_jid: &str,
+        node: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
     /// Get all subscriptions for a user.
-    fn get_for_user(&self, user_jid: &str) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>>;
+    fn get_for_user(
+        &self,
+        user_jid: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>>;
 }
 
 /// In-memory push subscription store backed by [`DashMap`].
@@ -40,7 +51,10 @@ impl InMemoryPushStore {
 }
 
 impl PushSubscriptionStore for InMemoryPushStore {
-    fn register(&self, sub: PushSubscription) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+    fn register(
+        &self,
+        sub: PushSubscription,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
         let service_jid = sub.service_jid.clone();
         let node = sub.node.clone();
         let user_jid = sub.user_jid.clone();
@@ -54,7 +68,12 @@ impl PushSubscriptionStore for InMemoryPushStore {
         Box::pin(std::future::ready(Ok(())))
     }
 
-    fn remove(&self, user_jid: &str, service_jid: &str, node: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+    fn remove(
+        &self,
+        user_jid: &str,
+        service_jid: &str,
+        node: Option<&str>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
         let user_jid = user_jid.to_owned();
         let service_jid = service_jid.to_owned();
         let node = node.map(|s| s.to_owned());
@@ -66,10 +85,17 @@ impl PushSubscriptionStore for InMemoryPushStore {
         })
     }
 
-    fn get_for_user(&self, user_jid: &str) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>> {
+    fn get_for_user(
+        &self,
+        user_jid: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>> {
         let user_jid = user_jid.to_owned();
         Box::pin(async move {
-            Ok(self.subs.get(&user_jid).map(|e| e.clone()).unwrap_or_default())
+            Ok(self
+                .subs
+                .get(&user_jid)
+                .map(|e| e.clone())
+                .unwrap_or_default())
         })
     }
 }
@@ -92,7 +118,10 @@ mod tests {
     #[tokio::test]
     async fn test_register_and_get() {
         let store = InMemoryPushStore::new();
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
         let subs = store.get_for_user("alice@ex").await.expect("ok");
         assert_eq!(subs.len(), 1);
     }
@@ -100,24 +129,42 @@ mod tests {
     #[tokio::test]
     async fn test_register_replaces_same_key() {
         let store = InMemoryPushStore::new();
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
         assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 1);
     }
 
     #[tokio::test]
     async fn test_different_nodes_coexist() {
         let store = InMemoryPushStore::new();
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
-        store.register(make_sub("alice@ex", "push.ex", Some("n2"))).await.expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n2")))
+            .await
+            .expect("ok");
         assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 2);
     }
 
     #[tokio::test]
     async fn test_remove() {
         let store = InMemoryPushStore::new();
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
-        store.remove("alice@ex", "push.ex", Some("n1")).await.expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
+        store
+            .remove("alice@ex", "push.ex", Some("n1"))
+            .await
+            .expect("ok");
         assert!(store.get_for_user("alice@ex").await.expect("ok").is_empty());
     }
 
@@ -130,14 +177,24 @@ mod tests {
     #[tokio::test]
     async fn test_get_empty() {
         let store = InMemoryPushStore::new();
-        assert!(store.get_for_user("nobody@ex").await.expect("ok").is_empty());
+        assert!(store
+            .get_for_user("nobody@ex")
+            .await
+            .expect("ok")
+            .is_empty());
     }
 
     #[tokio::test]
     async fn test_user_isolation() {
         let store = InMemoryPushStore::new();
-        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
-        store.register(make_sub("bob@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store
+            .register(make_sub("alice@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
+        store
+            .register(make_sub("bob@ex", "push.ex", Some("n1")))
+            .await
+            .expect("ok");
         assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 1);
         assert_eq!(store.get_for_user("bob@ex").await.expect("ok").len(), 1);
     }

--- a/server/crates/waddle-xmpp/src/push/store.rs
+++ b/server/crates/waddle-xmpp/src/push/store.rs
@@ -1,0 +1,141 @@
+//! In-memory push subscription storage.
+
+use std::pin::Pin;
+use std::future::Future;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use super::{PushError, PushSubscription};
+
+/// Trait for storing and retrieving push notification subscriptions.
+pub trait PushSubscriptionStore: Send + Sync + 'static {
+    /// Register a new push subscription.
+    fn register(&self, sub: PushSubscription) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+    /// Remove a push subscription.
+    fn remove(&self, user_jid: &str, service_jid: &str, node: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
+    /// Get all subscriptions for a user.
+    fn get_for_user(&self, user_jid: &str) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>>;
+}
+
+/// In-memory push subscription store backed by [`DashMap`].
+#[derive(Debug, Clone)]
+pub struct InMemoryPushStore {
+    subs: Arc<DashMap<String, Vec<PushSubscription>>>,
+}
+
+impl Default for InMemoryPushStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryPushStore {
+    /// Create a new empty in-memory push store.
+    pub fn new() -> Self {
+        Self {
+            subs: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+impl PushSubscriptionStore for InMemoryPushStore {
+    fn register(&self, sub: PushSubscription) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+        Box::pin(async move {
+            let service_jid = sub.service_jid.clone();
+            let node = sub.node.clone();
+            let mut entry = self.subs.entry(sub.user_jid.clone()).or_default();
+            entry.retain(|s| !(s.service_jid == service_jid && s.node == node));
+            entry.push(sub);
+            Ok(())
+        })
+    }
+
+    fn remove(&self, user_jid: &str, service_jid: &str, node: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
+        let user_jid = user_jid.to_owned();
+        let service_jid = service_jid.to_owned();
+        let node = node.map(|s| s.to_owned());
+        Box::pin(async move {
+            if let Some(mut entry) = self.subs.get_mut(&user_jid) {
+                entry.retain(|s| !(s.service_jid == service_jid && s.node == node));
+            }
+            Ok(())
+        })
+    }
+
+    fn get_for_user(&self, user_jid: &str) -> Pin<Box<dyn Future<Output = Result<Vec<PushSubscription>, PushError>> + Send + '_>> {
+        let user_jid = user_jid.to_owned();
+        Box::pin(async move {
+            Ok(self.subs.get(&user_jid).map(|e| e.clone()).unwrap_or_default())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_sub(user: &str, service: &str, node: Option<&str>) -> PushSubscription {
+        PushSubscription {
+            user_jid: user.into(),
+            service_jid: service.into(),
+            node: node.map(|s| s.into()),
+            endpoint: Some("https://push.example.com/ep".into()),
+            p256dh: None,
+            auth_key: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_register_and_get() {
+        let store = InMemoryPushStore::new();
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        let subs = store.get_for_user("alice@ex").await.expect("ok");
+        assert_eq!(subs.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_register_replaces_same_key() {
+        let store = InMemoryPushStore::new();
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_different_nodes_coexist() {
+        let store = InMemoryPushStore::new();
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store.register(make_sub("alice@ex", "push.ex", Some("n2"))).await.expect("ok");
+        assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_remove() {
+        let store = InMemoryPushStore::new();
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store.remove("alice@ex", "push.ex", Some("n1")).await.expect("ok");
+        assert!(store.get_for_user("alice@ex").await.expect("ok").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_remove_nonexistent_ok() {
+        let store = InMemoryPushStore::new();
+        assert!(store.remove("nobody@ex", "push.ex", None).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_empty() {
+        let store = InMemoryPushStore::new();
+        assert!(store.get_for_user("nobody@ex").await.expect("ok").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_user_isolation() {
+        let store = InMemoryPushStore::new();
+        store.register(make_sub("alice@ex", "push.ex", Some("n1"))).await.expect("ok");
+        store.register(make_sub("bob@ex", "push.ex", Some("n1"))).await.expect("ok");
+        assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 1);
+        assert_eq!(store.get_for_user("bob@ex").await.expect("ok").len(), 1);
+    }
+}

--- a/server/crates/waddle-xmpp/src/push/store.rs
+++ b/server/crates/waddle-xmpp/src/push/store.rs
@@ -41,14 +41,17 @@ impl InMemoryPushStore {
 
 impl PushSubscriptionStore for InMemoryPushStore {
     fn register(&self, sub: PushSubscription) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
-        Box::pin(async move {
-            let service_jid = sub.service_jid.clone();
-            let node = sub.node.clone();
-            let mut entry = self.subs.entry(sub.user_jid.clone()).or_default();
+        let service_jid = sub.service_jid.clone();
+        let node = sub.node.clone();
+        let user_jid = sub.user_jid.clone();
+
+        {
+            let mut entry = self.subs.entry(user_jid).or_default();
             entry.retain(|s| !(s.service_jid == service_jid && s.node == node));
             entry.push(sub);
-            Ok(())
-        })
+        }
+
+        Box::pin(std::future::ready(Ok(())))
     }
 
     fn remove(&self, user_jid: &str, service_jid: &str, node: Option<&str>) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
@@ -137,5 +140,29 @@ mod tests {
         store.register(make_sub("bob@ex", "push.ex", Some("n1"))).await.expect("ok");
         assert_eq!(store.get_for_user("alice@ex").await.expect("ok").len(), 1);
         assert_eq!(store.get_for_user("bob@ex").await.expect("ok").len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_register_same_key_concurrent_dedup() {
+        let store = InMemoryPushStore::new();
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let store = store.clone();
+            tasks.push(tokio::spawn(async move {
+                store
+                    .register(make_sub("alice@ex", "push.ex", Some("same-node")))
+                    .await
+                    .expect("ok");
+            }));
+        }
+
+        for task in tasks {
+            task.await.expect("task joined");
+        }
+
+        let subs = store.get_for_user("alice@ex").await.expect("ok");
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].service_jid, "push.ex");
+        assert_eq!(subs[0].node.as_deref(), Some("same-node"));
     }
 }

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -145,8 +145,7 @@ impl<S: AppState> XmppServer<S> {
         // Create the push subscription store and sender (XEP-0357)
         let push_store: Arc<dyn PushSubscriptionStore + Send + Sync> =
             Arc::new(InMemoryPushStore::new());
-        let push_sender: Arc<dyn WebPushSender + Send + Sync> =
-            Arc::new(HttpWebPushSender::new());
+        let push_sender: Arc<dyn WebPushSender + Send + Sync> = Arc::new(HttpWebPushSender::new());
         info!("Push notification store initialized");
 
         // Create the GitHub link enricher from environment

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -17,6 +17,7 @@ use crate::isr::{create_shared_store, SharedIsrTokenStore};
 use crate::mam::LibSqlMamStorage;
 use crate::muc::MucRoomRegistry;
 use crate::pubsub::{InMemoryPubSubStorage, PubSubStorage};
+use crate::push::{HttpWebPushSender, InMemoryPushStore, PushSubscriptionStore, WebPushSender};
 use crate::registry::ConnectionRegistry;
 use crate::routing::{RouterConfig, StanzaRouter};
 use crate::s2s::{S2sListener, S2sListenerConfig};
@@ -90,6 +91,10 @@ pub struct XmppServer<S: AppState> {
     pubsub_storage: Arc<dyn PubSubStorage + Send + Sync>,
     /// GitHub link enricher shared across all connections
     github_enricher: Option<Arc<waddle_xmpp_xep_github::MessageEnricher>>,
+    /// XEP-0357 Push subscription store
+    push_store: Arc<dyn PushSubscriptionStore + Send + Sync>,
+    /// XEP-0357 Push notification sender
+    push_sender: Arc<dyn WebPushSender + Send + Sync>,
     /// C2S listener — passed in by the caller (Ecdysis or fresh-bound).
     c2s_listener: TcpListener,
     /// S2S listener — passed in if S2S federation is enabled.
@@ -137,6 +142,13 @@ impl<S: AppState> XmppServer<S> {
             Arc::new(InMemoryPubSubStorage::new());
         info!("PubSub storage initialized");
 
+        // Create the push subscription store and sender (XEP-0357)
+        let push_store: Arc<dyn PushSubscriptionStore + Send + Sync> =
+            Arc::new(InMemoryPushStore::new());
+        let push_sender: Arc<dyn WebPushSender + Send + Sync> =
+            Arc::new(HttpWebPushSender::new());
+        info!("Push notification store initialized");
+
         // Create the GitHub link enricher from environment
         let github_enricher = {
             let enricher = waddle_xmpp_xep_github::MessageEnricher::from_env();
@@ -160,6 +172,8 @@ impl<S: AppState> XmppServer<S> {
             sm_session_registry,
             pubsub_storage,
             github_enricher,
+            push_store,
+            push_sender,
             c2s_listener,
             s2s_listener,
             shutdown_token,
@@ -312,6 +326,8 @@ impl<S: AppState> XmppServer<S> {
             let isr_token_store = self.isr_token_store;
             let sm_session_registry = self.sm_session_registry;
             let pubsub_storage = self.pubsub_storage;
+            let push_store = self.push_store;
+            let push_sender = self.push_sender;
             let registration_enabled = self.config.registration_enabled;
             let single_tenant = self.config.single_tenant;
             let github_enricher = self.github_enricher;
@@ -343,6 +359,8 @@ impl<S: AppState> XmppServer<S> {
                     let isr_token_store = Arc::clone(&isr_token_store);
                     let sm_session_registry = Arc::clone(&sm_session_registry);
                     let pubsub_storage = Arc::clone(&pubsub_storage);
+                    let push_store = Arc::clone(&push_store);
+                    let push_sender = Arc::clone(&push_sender);
                     let github_enricher = github_enricher.clone();
 
                     tokio::spawn(
@@ -362,6 +380,8 @@ impl<S: AppState> XmppServer<S> {
                                 pubsub_storage,
                                 github_enricher,
                                 single_tenant,
+                                push_store,
+                                push_sender,
                             )
                             .await
                             {

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -160,6 +160,7 @@ pub mod xep0319;
 pub mod xep0333;
 pub mod xep0334;
 pub mod xep0352;
+pub mod xep0357;
 pub mod xep0359;
 pub mod xep0363;
 pub mod xep0372;
@@ -377,6 +378,11 @@ pub use xep0352::{
     build_csi_feature, classify_message_urgency, classify_presence_urgency,
     data_contains_csi_active, data_contains_csi_inactive, is_csi_active, is_csi_inactive,
     is_muc_mention, ClientState, StanzaUrgency, MAX_CSI_BUFFER_SIZE, NS_CSI,
+};
+
+pub use xep0357::{
+    build_push_disable_result, build_push_enable_result, is_push_disable, is_push_enable,
+    parse_push_disable, parse_push_enable, PushDisable, PushEnable, NS_PUSH,
 };
 
 pub use xep0410::{

--- a/server/crates/waddle-xmpp/src/xep/xep0357.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357.rs
@@ -415,9 +415,7 @@ mod tests {
 
     #[test]
     fn test_parse_push_enable_empty_jid() {
-        let elem = Element::builder("enable", NS_PUSH)
-            .attr("jid", "")
-            .build();
+        let elem = Element::builder("enable", NS_PUSH).attr("jid", "").build();
         let iq = Iq {
             from: None,
             to: None,

--- a/server/crates/waddle-xmpp/src/xep/xep0357.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357.rs
@@ -1,0 +1,569 @@
+//! XEP-0357: Push Notifications
+//!
+//! Enables and disables push notification subscriptions via IQ stanzas.
+//! A client sends `<enable/>` with a push service JID and optional node/options
+//! to register for push, or `<disable/>` to unregister.
+//!
+//! ## XML Format
+//!
+//! Enable push with options (data form fields):
+//! ```xml
+//! <iq type='set' id='push1'>
+//!   <enable xmlns='urn:xmpp:push:0' jid='push-service.example.com' node='web-push'>
+//!     <x xmlns='jabber:x:data' type='submit'>
+//!       <field var='endpoint'><value>https://push.example.com/...</value></field>
+//!       <field var='p256dh'><value>BASE64KEY</value></field>
+//!       <field var='auth'><value>BASE64AUTH</value></field>
+//!     </x>
+//!   </enable>
+//! </iq>
+//! ```
+//!
+//! Disable push:
+//! ```xml
+//! <iq type='set' id='push2'>
+//!   <disable xmlns='urn:xmpp:push:0' jid='push-service.example.com' node='web-push'/>
+//! </iq>
+//! ```
+//!
+//! ## Server Behavior
+//!
+//! 1. On `<enable/>`, store the push subscription for the user
+//! 2. On `<disable/>`, remove the matching subscription
+//! 3. When a notification-worthy event occurs, send a push notification
+//!    to the registered push service
+
+use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
+
+/// Namespace for XEP-0357 Push Notifications.
+pub const NS_PUSH: &str = "urn:xmpp:push:0";
+
+/// Namespace for XEP-0004 Data Forms (used in enable options).
+const NS_DATA_FORMS: &str = "jabber:x:data";
+
+/// A parsed push enable request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushEnable {
+    /// The JID of the push service.
+    pub jid: String,
+    /// The PubSub node on the push service.
+    pub node: Option<String>,
+    /// Key-value pairs from the data form options.
+    pub options: Vec<(String, String)>,
+}
+
+/// A parsed push disable request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushDisable {
+    /// The JID of the push service to disable.
+    pub jid: String,
+    /// The PubSub node on the push service to disable.
+    pub node: Option<String>,
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an IQ stanza is a push enable request.
+pub fn is_push_enable(iq: &Iq) -> bool {
+    match &iq.payload {
+        IqType::Set(elem) => elem.name() == "enable" && elem.ns() == NS_PUSH,
+        _ => false,
+    }
+}
+
+/// Check if an IQ stanza is a push disable request.
+pub fn is_push_disable(iq: &Iq) -> bool {
+    match &iq.payload {
+        IqType::Set(elem) => elem.name() == "disable" && elem.ns() == NS_PUSH,
+        _ => false,
+    }
+}
+
+// ── Parsing ─────────────────────────────────────────────────────────
+
+/// Parse a push enable request from an IQ stanza.
+///
+/// Returns `None` if the IQ is not a valid push enable request.
+pub fn parse_push_enable(iq: &Iq) -> Option<PushEnable> {
+    let elem = match &iq.payload {
+        IqType::Set(elem) if elem.name() == "enable" && elem.ns() == NS_PUSH => elem,
+        _ => return None,
+    };
+
+    let jid = elem.attr("jid").filter(|s| !s.is_empty())?.to_owned();
+    let node = elem
+        .attr("node")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_owned());
+
+    let options = parse_data_form_options(elem);
+
+    Some(PushEnable { jid, node, options })
+}
+
+/// Parse a push disable request from an IQ stanza.
+///
+/// Returns `None` if the IQ is not a valid push disable request.
+pub fn parse_push_disable(iq: &Iq) -> Option<PushDisable> {
+    let elem = match &iq.payload {
+        IqType::Set(elem) if elem.name() == "disable" && elem.ns() == NS_PUSH => elem,
+        _ => return None,
+    };
+
+    let jid = elem.attr("jid").filter(|s| !s.is_empty())?.to_owned();
+    let node = elem
+        .attr("node")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_owned());
+
+    Some(PushDisable { jid, node })
+}
+
+/// Extract key-value pairs from a `<x xmlns='jabber:x:data'>` child element.
+fn parse_data_form_options(parent: &Element) -> Vec<(String, String)> {
+    let Some(form) = parent.get_child("x", NS_DATA_FORMS) else {
+        return Vec::new();
+    };
+
+    form.children()
+        .filter(|c| c.name() == "field" && c.ns() == NS_DATA_FORMS)
+        .filter_map(|field| {
+            let var = field.attr("var").filter(|s| !s.is_empty())?;
+            let value = field
+                .get_child("value", NS_DATA_FORMS)
+                .map(|v| v.text())
+                .filter(|s| !s.is_empty())?;
+            Some((var.to_owned(), value))
+        })
+        .collect()
+}
+
+// ── Building ────────────────────────────────────────────────────────
+
+/// Build an IQ result for a push enable request.
+pub fn build_push_enable_result(iq: &Iq) -> Iq {
+    Iq {
+        from: iq.to.clone(),
+        to: iq.from.clone(),
+        id: iq.id.clone(),
+        payload: IqType::Result(None),
+    }
+}
+
+/// Build an IQ result for a push disable request.
+pub fn build_push_disable_result(iq: &Iq) -> Iq {
+    Iq {
+        from: iq.to.clone(),
+        to: iq.from.clone(),
+        id: iq.id.clone(),
+        payload: IqType::Result(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_enable_iq(jid_attr: &str, node_attr: Option<&str>, with_form: bool) -> Iq {
+        let mut enable = Element::builder("enable", NS_PUSH).attr("jid", jid_attr);
+
+        if let Some(node) = node_attr {
+            enable = enable.attr("node", node);
+        }
+
+        let mut enable_elem = enable.build();
+
+        if with_form {
+            let endpoint_value = Element::builder("value", NS_DATA_FORMS)
+                .append("https://push.example.com/abc")
+                .build();
+            let endpoint_field = Element::builder("field", NS_DATA_FORMS)
+                .attr("var", "endpoint")
+                .append(endpoint_value)
+                .build();
+
+            let p256dh_value = Element::builder("value", NS_DATA_FORMS)
+                .append("BASE64KEY")
+                .build();
+            let p256dh_field = Element::builder("field", NS_DATA_FORMS)
+                .attr("var", "p256dh")
+                .append(p256dh_value)
+                .build();
+
+            let auth_value = Element::builder("value", NS_DATA_FORMS)
+                .append("BASE64AUTH")
+                .build();
+            let auth_field = Element::builder("field", NS_DATA_FORMS)
+                .attr("var", "auth")
+                .append(auth_value)
+                .build();
+
+            let form = Element::builder("x", NS_DATA_FORMS)
+                .attr("type", "submit")
+                .append(endpoint_field)
+                .append(p256dh_field)
+                .append(auth_field)
+                .build();
+
+            enable_elem.append_child(form);
+        }
+
+        Iq {
+            from: Some("alice@example.com".parse().expect("valid jid")),
+            to: Some("example.com".parse().expect("valid jid")),
+            id: "push1".to_string(),
+            payload: IqType::Set(enable_elem),
+        }
+    }
+
+    fn make_disable_iq(jid_attr: &str, node_attr: Option<&str>) -> Iq {
+        let mut disable = Element::builder("disable", NS_PUSH).attr("jid", jid_attr);
+
+        if let Some(node) = node_attr {
+            disable = disable.attr("node", node);
+        }
+
+        Iq {
+            from: Some("alice@example.com".parse().expect("valid jid")),
+            to: Some("example.com".parse().expect("valid jid")),
+            id: "push2".to_string(),
+            payload: IqType::Set(disable.build()),
+        }
+    }
+
+    #[test]
+    fn test_ns_push_constant() {
+        assert_eq!(NS_PUSH, "urn:xmpp:push:0");
+    }
+
+    #[test]
+    fn test_is_push_enable() {
+        let iq = make_enable_iq("push-service.example.com", Some("web-push"), true);
+        assert!(is_push_enable(&iq));
+        assert!(!is_push_disable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_enable_false_for_get() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Get(elem),
+        };
+        assert!(!is_push_enable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_enable_false_for_wrong_ns() {
+        let elem = Element::builder("enable", "wrong:ns")
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Set(elem),
+        };
+        assert!(!is_push_enable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_enable_false_for_result() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Result(None),
+        };
+        assert!(!is_push_enable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_disable() {
+        let iq = make_disable_iq("push-service.example.com", Some("web-push"));
+        assert!(is_push_disable(&iq));
+        assert!(!is_push_enable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_disable_false_for_get() {
+        let elem = Element::builder("disable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Get(elem),
+        };
+        assert!(!is_push_disable(&iq));
+    }
+
+    #[test]
+    fn test_is_push_disable_false_for_wrong_element() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Set(elem),
+        };
+        assert!(!is_push_disable(&iq));
+    }
+
+    #[test]
+    fn test_parse_push_enable_with_options() {
+        let iq = make_enable_iq("push-service.example.com", Some("web-push"), true);
+        let enable = parse_push_enable(&iq).expect("should parse");
+
+        assert_eq!(enable.jid, "push-service.example.com");
+        assert_eq!(enable.node.as_deref(), Some("web-push"));
+        assert_eq!(enable.options.len(), 3);
+
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "endpoint" && v == "https://push.example.com/abc"));
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "p256dh" && v == "BASE64KEY"));
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "auth" && v == "BASE64AUTH"));
+    }
+
+    #[test]
+    fn test_parse_push_enable_without_options() {
+        let iq = make_enable_iq("push-service.example.com", Some("web-push"), false);
+        let enable = parse_push_enable(&iq).expect("should parse");
+
+        assert_eq!(enable.jid, "push-service.example.com");
+        assert_eq!(enable.node.as_deref(), Some("web-push"));
+        assert!(enable.options.is_empty());
+    }
+
+    #[test]
+    fn test_parse_push_enable_without_node() {
+        let iq = make_enable_iq("push-service.example.com", None, false);
+        let enable = parse_push_enable(&iq).expect("should parse");
+
+        assert_eq!(enable.jid, "push-service.example.com");
+        assert!(enable.node.is_none());
+    }
+
+    #[test]
+    fn test_parse_push_enable_missing_jid() {
+        let elem = Element::builder("enable", NS_PUSH).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Set(elem),
+        };
+        assert!(parse_push_enable(&iq).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_enable_empty_jid() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Set(elem),
+        };
+        assert!(parse_push_enable(&iq).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_enable_wrong_payload_type() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Get(elem),
+        };
+        assert!(parse_push_enable(&iq).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_disable() {
+        let iq = make_disable_iq("push-service.example.com", Some("web-push"));
+        let disable = parse_push_disable(&iq).expect("should parse");
+
+        assert_eq!(disable.jid, "push-service.example.com");
+        assert_eq!(disable.node.as_deref(), Some("web-push"));
+    }
+
+    #[test]
+    fn test_parse_push_disable_without_node() {
+        let iq = make_disable_iq("push-service.example.com", None);
+        let disable = parse_push_disable(&iq).expect("should parse");
+
+        assert_eq!(disable.jid, "push-service.example.com");
+        assert!(disable.node.is_none());
+    }
+
+    #[test]
+    fn test_parse_push_disable_missing_jid() {
+        let elem = Element::builder("disable", NS_PUSH).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Set(elem),
+        };
+        assert!(parse_push_disable(&iq).is_none());
+    }
+
+    #[test]
+    fn test_parse_push_disable_wrong_payload_type() {
+        let elem = Element::builder("disable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test".to_string(),
+            payload: IqType::Get(elem),
+        };
+        assert!(parse_push_disable(&iq).is_none());
+    }
+
+    #[test]
+    fn test_build_push_enable_result() {
+        let iq = make_enable_iq("push-service.example.com", Some("web-push"), true);
+        let result = build_push_enable_result(&iq);
+
+        assert_eq!(result.id, "push1");
+        assert_eq!(result.from, iq.to);
+        assert_eq!(result.to, iq.from);
+        assert!(matches!(result.payload, IqType::Result(None)));
+    }
+
+    #[test]
+    fn test_build_push_disable_result() {
+        let iq = make_disable_iq("push-service.example.com", Some("web-push"));
+        let result = build_push_disable_result(&iq);
+
+        assert_eq!(result.id, "push2");
+        assert_eq!(result.from, iq.to);
+        assert_eq!(result.to, iq.from);
+        assert!(matches!(result.payload, IqType::Result(None)));
+    }
+
+    #[test]
+    fn test_build_result_with_none_addresses() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "test-none".to_string(),
+            payload: IqType::Set(elem),
+        };
+        let result = build_push_enable_result(&iq);
+        assert!(result.from.is_none());
+        assert!(result.to.is_none());
+        assert_eq!(result.id, "test-none");
+    }
+
+    #[test]
+    fn test_parse_data_form_with_empty_value() {
+        let empty_value = Element::builder("value", NS_DATA_FORMS).build();
+        let field = Element::builder("field", NS_DATA_FORMS)
+            .attr("var", "endpoint")
+            .append(empty_value)
+            .build();
+        let form = Element::builder("x", NS_DATA_FORMS)
+            .attr("type", "submit")
+            .append(field)
+            .build();
+        let mut enable_elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        enable_elem.append_child(form);
+
+        let options = parse_data_form_options(&enable_elem);
+        assert!(options.is_empty());
+    }
+
+    #[test]
+    fn test_parse_data_form_with_missing_var() {
+        let value = Element::builder("value", NS_DATA_FORMS)
+            .append("some-value")
+            .build();
+        let field = Element::builder("field", NS_DATA_FORMS)
+            .append(value)
+            .build();
+        let form = Element::builder("x", NS_DATA_FORMS)
+            .attr("type", "submit")
+            .append(field)
+            .build();
+        let mut enable_elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push.example.com")
+            .build();
+        enable_elem.append_child(form);
+
+        let options = parse_data_form_options(&enable_elem);
+        assert!(options.is_empty());
+    }
+
+    #[test]
+    fn test_push_enable_struct_debug() {
+        let enable = PushEnable {
+            jid: "push.example.com".to_string(),
+            node: Some("web-push".to_string()),
+            options: vec![("key".to_string(), "val".to_string())],
+        };
+        let debug = format!("{:?}", enable);
+        assert!(debug.contains("push.example.com"));
+        assert!(debug.contains("web-push"));
+    }
+
+    #[test]
+    fn test_push_disable_struct_debug() {
+        let disable = PushDisable {
+            jid: "push.example.com".to_string(),
+            node: None,
+        };
+        let debug = format!("{:?}", disable);
+        assert!(debug.contains("push.example.com"));
+    }
+
+    #[test]
+    fn test_push_enable_clone_eq() {
+        let enable = PushEnable {
+            jid: "push.example.com".to_string(),
+            node: Some("node1".to_string()),
+            options: vec![("k".to_string(), "v".to_string())],
+        };
+        let cloned = enable.clone();
+        assert_eq!(enable, cloned);
+    }
+
+    #[test]
+    fn test_push_disable_clone_eq() {
+        let disable = PushDisable {
+            jid: "push.example.com".to_string(),
+            node: Some("node1".to_string()),
+        };
+        let cloned = disable.clone();
+        assert_eq!(disable, cloned);
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0357.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357.rs
@@ -97,7 +97,14 @@ pub fn parse_push_enable(iq: &Iq) -> Option<PushEnable> {
         .filter(|s| !s.is_empty())
         .map(|s| s.to_owned());
 
-    let options = parse_data_form_options(elem);
+    let mut options = parse_data_form_options(elem);
+    for attr_key in ["endpoint", "p256dh", "auth"] {
+        if let Some(value) = elem.attr(attr_key).filter(|s| !s.is_empty()) {
+            if !options.iter().any(|(k, _)| k == attr_key) {
+                options.push((attr_key.to_owned(), value.to_owned()));
+            }
+        }
+    }
 
     Some(PushEnable { jid, node, options })
 }
@@ -349,6 +356,40 @@ mod tests {
         assert_eq!(enable.jid, "push-service.example.com");
         assert_eq!(enable.node.as_deref(), Some("web-push"));
         assert!(enable.options.is_empty());
+    }
+
+    #[test]
+    fn test_parse_push_enable_with_attribute_options() {
+        let elem = Element::builder("enable", NS_PUSH)
+            .attr("jid", "push-service.example.com")
+            .attr("node", "web-push")
+            .attr("endpoint", "https://push.example.com/abc")
+            .attr("p256dh", "BASE64KEY")
+            .attr("auth", "BASE64AUTH")
+            .build();
+        let iq = Iq {
+            from: Some("alice@example.com".parse().expect("valid jid")),
+            to: Some("example.com".parse().expect("valid jid")),
+            id: "push1".to_string(),
+            payload: IqType::Set(elem),
+        };
+        let enable = parse_push_enable(&iq).expect("should parse");
+
+        assert_eq!(enable.jid, "push-service.example.com");
+        assert_eq!(enable.node.as_deref(), Some("web-push"));
+        assert_eq!(enable.options.len(), 3);
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "endpoint" && v == "https://push.example.com/abc"));
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "p256dh" && v == "BASE64KEY"));
+        assert!(enable
+            .options
+            .iter()
+            .any(|(k, v)| k == "auth" && v == "BASE64AUTH"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -619,9 +619,8 @@ async fn run_test_server<S: AppState>(
     // Create a shared PubSub storage for PEP
     let pubsub_storage: std::sync::Arc<dyn waddle_xmpp::pubsub::PubSubStorage + Send + Sync> =
         std::sync::Arc::new(waddle_xmpp::pubsub::InMemoryPubSubStorage::new());
-    let push_store: std::sync::Arc<
-        dyn waddle_xmpp::push::PushSubscriptionStore + Send + Sync,
-    > = std::sync::Arc::new(waddle_xmpp::push::InMemoryPushStore::new());
+    let push_store: std::sync::Arc<dyn waddle_xmpp::push::PushSubscriptionStore + Send + Sync> =
+        std::sync::Arc::new(waddle_xmpp::push::InMemoryPushStore::new());
     let push_sender: std::sync::Arc<dyn waddle_xmpp::push::WebPushSender + Send + Sync> =
         std::sync::Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
 

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -619,6 +619,11 @@ async fn run_test_server<S: AppState>(
     // Create a shared PubSub storage for PEP
     let pubsub_storage: std::sync::Arc<dyn waddle_xmpp::pubsub::PubSubStorage + Send + Sync> =
         std::sync::Arc::new(waddle_xmpp::pubsub::InMemoryPubSubStorage::new());
+    let push_store: std::sync::Arc<
+        dyn waddle_xmpp::push::PushSubscriptionStore + Send + Sync,
+    > = std::sync::Arc::new(waddle_xmpp::push::InMemoryPushStore::new());
+    let push_sender: std::sync::Arc<dyn waddle_xmpp::push::WebPushSender + Send + Sync> =
+        std::sync::Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
 
     loop {
         tokio::select! {
@@ -635,12 +640,14 @@ async fn run_test_server<S: AppState>(
                         let isr = Arc::clone(&isr_token_store);
                         let sm_reg = Arc::clone(&sm_session_registry);
                         let pubsub = Arc::clone(&pubsub_storage);
+                        let push_store = Arc::clone(&push_store);
+                        let push_sender = Arc::clone(&push_sender);
                         // Enable registration for tests
                         let registration_enabled = true;
                         let st = single_tenant;
                         tokio::spawn(async move {
                             let _ = waddle_xmpp::connection::ConnectionActor::handle_connection(
-                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, None, st
+                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, None, st, push_store, push_sender
                             ).await;
                         });
                     }


### PR DESCRIPTION
Add foreground browser notifications when the user is @mentioned or
@everyone/@here is used in a channel they're not currently viewing, or when
the tab is unfocused. Also adds a service worker for future background push
notification support.

- Expand cross-room activity handler to carry mention data (RoomActivityEvent)
- Create useNotifications composable (permission management, Notification API)
- Wire mention detection in useMessaging for both cross-room and current-room
- Add notification bell toggle to ProfilePanel
- Register service worker on bootstrap for push readiness

https://claude.ai/code/session_01EiZngCSieuZZMRHPxN3noj