### PR TITLE
fix(chat): use SASL OAUTHBEARER for session token auth

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -50,10 +50,18 @@ export class BrowserXmppClient {
   async connect() {
     if (this.xmpp) return;
     const xmpp = createClient({
-      jid: this.session.jid, password: this.session.session_id, resource: "web",
+      jid: this.session.jid,
+      // The session_id is a bearer token — use OAUTHBEARER (RFC 7628)
+      credentials: { token: this.session.session_id },
+      resource: "web",
       transports: { websocket: this.session.xmpp_websocket_url, bosh: false },
+      useStreamManagement: false,
       sendReceipts: false, chatMarkers: false,
     });
+    // Only keep OAUTHBEARER; session tokens aren't SCRAM/PLAIN passwords
+    for (const mech of ["EXTERNAL", "SCRAM-SHA-256-PLUS", "SCRAM-SHA-256", "SCRAM-SHA-1-PLUS", "SCRAM-SHA-1", "DIGEST-MD5", "X-OAUTH2", "PLAIN", "ANONYMOUS"]) {
+      xmpp.sasl.disable(mech);
+    }
     registerWaddleExtensions(xmpp);
     this.wireEvents(xmpp);
     this.xmpp = xmpp;


### PR DESCRIPTION
## Summary

- Switch from SASL PLAIN to **OAUTHBEARER (RFC 7628)** for XMPP authentication — the `session_id` is a bearer token, not a password
- Disable all other SASL mechanisms (SCRAM-SHA-256, PLAIN, etc.) to prevent stanza from selecting SCRAM, which requires real password credentials
- Disable stream management (`useStreamManagement: false`) which the old `@xmpp/client` never used

### Why this broke

After #46 replaced `@xmpp/client` with `stanza`, the SASL mechanism selection changed. Stanza prefers SCRAM-SHA-256 (priority 300) over PLAIN (priority 1). Since the web client authenticates with a session_id token — not the user's SCRAM password — the auth handshake fails, producing a bind error and `policy-violation` disconnect.

OAUTHBEARER is the semantically correct mechanism: the server's handler (`connection.rs:392`) validates purely by token via `validate_session_token()` and derives the JID from the session.

## Test plan

- [ ] Login via OAuth, verify XMPP connects successfully
- [ ] Verify channels load and messages can be sent/received
- [ ] Verify no `bind error` or `policy-violation` in browser console

https://claude.ai/code/session_01CJV7do89hqGYn5P9zDmFjC