### PR TITLE
fix(server): use XMPP domain for websocket/disco routing

### DIFF
--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -671,12 +671,9 @@ fn create_router(
     // Create connection registry for WebSocket message routing
     let connection_registry = Arc::new(ConnectionRegistry::new());
 
-    // Create MUC room registry with the MUC domain
-    let domain = url::Url::parse(&base_url)
-        .ok()
-        .and_then(|u| u.host_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| "localhost".to_string());
-    let muc_domain = format!("muc.{}", domain);
+    // Create MUC room registry with the XMPP domain (not the HTTP base_url host)
+    let xmpp_domain = auth_state.xmpp_domain.clone();
+    let muc_domain = format!("muc.{}", xmpp_domain);
     let muc_registry = Arc::new(MucRoomRegistry::new(muc_domain));
 
     // GitHub link enricher for message embeds (fail-open, reads GITHUB_TOKEN from env)

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -90,7 +90,7 @@ const OUTBOUND_CHANNEL_SIZE: usize = 256;
 
 /// Handle an XMPP WebSocket connection
 async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
-    let domain = extract_domain(&state.auth_state.base_url);
+    let domain = state.auth_state.xmpp_domain.clone();
     info!(domain = %domain, "XMPP WebSocket connection established");
 
     let (mut ws_sender, mut ws_receiver) = socket.split();
@@ -1738,14 +1738,6 @@ fn parse_room_jid_context(room_jid: &jid::BareJid) -> (String, String) {
         }
     }
     ("default".to_string(), "default".to_string())
-}
-
-/// Extract domain from base URL
-fn extract_domain(base_url: &str) -> String {
-    url::Url::parse(base_url)
-        .ok()
-        .and_then(|u| u.host_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| "localhost".to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary: use WADDLE_XMPP_DOMAIN for websocket-side XMPP routing and build MUC registry domain from XMPP domain instead of HTTP base URL host. Why: API/WebSocket host is xmpp.waddle.chat while JIDs remain @waddle.social, and base_url-derived domain caused disco mismatches. Validation: cd server && cargo test -p waddle-server.