### PR TITLE
fix(chart): use data with b64enc instead of stringData in secret

### DIFF
--- a/server/charts/waddle-server/templates/secret.yaml
+++ b/server/charts/waddle-server/templates/secret.yaml
@@ -21,12 +21,12 @@ metadata:
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
 type: Opaque
-stringData:
-  WADDLE_SESSION_KEY: {{ $sessionKey | quote }}
+data:
+  WADDLE_SESSION_KEY: {{ $sessionKey | b64enc }}
   {{- if $authProvidersJson }}
-  WADDLE_AUTH_PROVIDERS_JSON: {{ $authProvidersJson | quote }}
+  WADDLE_AUTH_PROVIDERS_JSON: {{ $authProvidersJson | b64enc }}
   {{- end }}
   {{- if .Values.secret.githubToken }}
-  GITHUB_TOKEN: {{ .Values.secret.githubToken | quote }}
+  GITHUB_TOKEN: {{ .Values.secret.githubToken | b64enc }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Flux drift detection compares the Helm-rendered manifest (`stringData` with plaintext) against the live Kubernetes state (`data` with base64), causing `illegal base64 data at input byte 0` on correction patches. This created a drift correction loop that blocked HelmRelease reconciliation and prevented new deployments from rolling out.

Switches to explicit `data` + `b64enc` so the rendered manifest matches what Kubernetes stores, eliminating the mismatch.