### PR TITLE
feat: migrate XMPP server from xmpp.waddle.chat to xmpp.waddle.social

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -355,18 +355,13 @@ export class BrowserXmppClient {
   async discoverWaddles(): Promise<DiscoveredWaddle[]> {
     await this.connect();
     return this.xmpp
-      ? discovery.discoverWaddles(this.xmpp, this.session.jid, this.session.xmpp_websocket_url)
+      ? discovery.discoverWaddles(this.xmpp, this.session.jid)
       : [];
   }
   async discoverChannels(waddleId: string): Promise<DiscoveredChannel[]> {
     await this.connect();
     return this.xmpp
-      ? discovery.discoverChannels(
-          this.xmpp,
-          this.session.jid,
-          this.session.xmpp_websocket_url,
-          waddleId,
-        )
+      ? discovery.discoverChannels(this.xmpp, this.session.jid, waddleId)
       : [];
   }
 

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -35,24 +35,15 @@ function parseWaddleName(infoResult: DiscoInfoResult): string | null {
   );
 }
 
-function spacesServiceDomain(jid: string, xmppWebsocketUrl: string): string {
-  try {
-    const host = new URL(xmppWebsocketUrl).hostname;
-    if (host) {
-      return `spaces.${host}`;
-    }
-  } catch {
-    // Fall back to JID-derived domain if websocket URL is malformed.
-  }
+function spacesServiceDomain(jid: string): string {
   return `spaces.${jidDomain(jid)}`;
 }
 
 export async function discoverWaddles(
   xmpp: Agent,
   jid: string,
-  xmppWebsocketUrl: string,
 ): Promise<DiscoveredWaddle[]> {
-  const spacesDomain = spacesServiceDomain(jid, xmppWebsocketUrl);
+  const spacesDomain = spacesServiceDomain(jid);
   const response = await xmpp.getDiscoItems(spacesDomain, "");
 
   const discovered = (response.items ?? [])
@@ -78,10 +69,9 @@ export async function discoverWaddles(
 export async function discoverChannels(
   xmpp: Agent,
   jid: string,
-  xmppWebsocketUrl: string,
   waddleId: string,
 ): Promise<DiscoveredChannel[]> {
-  const spacesDomain = spacesServiceDomain(jid, xmppWebsocketUrl);
+  const spacesDomain = spacesServiceDomain(jid);
   const response = await xmpp.getDiscoItems(spacesDomain, waddleId);
 
   const prefix = `${waddleId}_`;

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -5,14 +5,10 @@ export function jidDomain(jid: string): string {
   return jid.split("@")[1] ?? "localhost";
 }
 
-function websocketHost(websocketUrl: string): string {
-  return new URL(websocketUrl).hostname;
-}
-
 export function roomBareJidFor(
   session: WaddleSession,
   waddleId: string,
   channelId: string,
 ): string {
-  return `${waddleId}_${channelId}@muc.${websocketHost(session.xmpp_websocket_url)}`;
+  return `${waddleId}_${channelId}@muc.${jidDomain(session.jid)}`;
 }

--- a/chat/wrangler.jsonc
+++ b/chat/wrangler.jsonc
@@ -24,6 +24,6 @@
     "enabled": true
   },
   "vars": {
-    "SERVER_BASE_URL": "https://xmpp.waddle.chat"
+    "SERVER_BASE_URL": "https://xmpp.waddle.social"
   }
 }

--- a/colony/worker-configuration.d.ts
+++ b/colony/worker-configuration.d.ts
@@ -10,7 +10,7 @@ declare namespace Cloudflare {
 		ASSETS: Fetcher;
 		BETTER_AUTH_URL: "https://colony.waddle.social";
 		GITHUB_CLIENT_ID: "Ov23liag5CB15O5sIQ60";
-		WADDLE_SERVER_OIDC_REDIRECT_URLS: "https://xmpp.waddle.chat/api/auth/callback";
+		WADDLE_SERVER_OIDC_REDIRECT_URLS: "https://xmpp.waddle.social/api/auth/callback";
 	}
 }
 interface Env extends Cloudflare.Env {}

--- a/colony/wrangler.jsonc
+++ b/colony/wrangler.jsonc
@@ -34,7 +34,7 @@
   "vars": {
     "BETTER_AUTH_URL": "https://colony.waddle.social",
     "GITHUB_CLIENT_ID": "Ov23liag5CB15O5sIQ60",
-    "WADDLE_SERVER_OIDC_REDIRECT_URLS": "https://xmpp.waddle.chat/api/auth/callback"
+    "WADDLE_SERVER_OIDC_REDIRECT_URLS": "https://xmpp.waddle.social/api/auth/callback"
   },
   "secrets_store_secrets": [
     {

--- a/infrastructure/waddle.cloud/gitops/cilium-gateway/api-certificate.yaml
+++ b/infrastructure/waddle.cloud/gitops/cilium-gateway/api-certificate.yaml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: xmpp-waddle-chat-tls
+  name: xmpp-waddle-social-tls
   namespace: default
 spec:
-  secretName: xmpp-waddle-chat-tls
+  secretName: xmpp-waddle-social-tls
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
   dnsNames:
-    - xmpp.waddle.chat
+    - xmpp.waddle.social

--- a/infrastructure/waddle.cloud/gitops/cilium-gateway/gateway.yaml
+++ b/infrastructure/waddle.cloud/gitops/cilium-gateway/gateway.yaml
@@ -27,18 +27,18 @@ spec:
     - name: https-xmpp
       protocol: HTTPS
       port: 443
-      hostname: xmpp.waddle.chat
+      hostname: xmpp.waddle.social
       tls:
         mode: Terminate
         certificateRefs:
-          - name: xmpp-waddle-chat-tls
+          - name: xmpp-waddle-social-tls
       allowedRoutes:
         namespaces:
           from: All
     - name: http-xmpp
       protocol: HTTP
       port: 80
-      hostname: xmpp.waddle.chat
+      hostname: xmpp.waddle.social
       allowedRoutes:
         namespaces:
           from: All

--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
       repository: ghcr.io/waddle-social/waddle
       tag: main
     config:
-      baseUrl: https://xmpp.waddle.chat
-      corsOrigins: https://xmpp.waddle.chat,https://waddle.chat,http://localhost:4321
+      baseUrl: https://xmpp.waddle.social
+      corsOrigins: https://waddle.chat,http://localhost:4321
     xmpp:
       domain: waddle.social
       mamDbPath: /data/mam.db

--- a/infrastructure/waddle.cloud/gitops/waddle-server/httproute-http-redirect.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/httproute-http-redirect.yaml
@@ -9,7 +9,7 @@ spec:
       namespace: default
       sectionName: http-xmpp
   hostnames:
-    - xmpp.waddle.chat
+    - xmpp.waddle.social
   rules:
     - filters:
         - type: RequestRedirect

--- a/infrastructure/waddle.cloud/gitops/waddle-server/httproute.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/httproute.yaml
@@ -9,7 +9,7 @@ spec:
       namespace: default
       sectionName: https-xmpp
   hostnames:
-    - xmpp.waddle.chat
+    - xmpp.waddle.social
   rules:
     - backendRefs:
         - name: waddle-server

--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -117,13 +117,13 @@ helm upgrade --install waddle ./charts/waddle-server \
   --set-json secret.authProvidersJson='[{"id":"rawkode","display_name":"rawkode.academy","kind":"oidc","issuer":"https://id.rawkode.academy/auth","client_id":"...","token_endpoint_auth_method":"none","scopes":["openid","profile","email"],"subject_claim":"sub","username_claim":"preferred_username","email_claim":"email"}]'
 ```
 
-Example provider config (Colony + chat custom domain `waddle.chat` with API at `xmpp.waddle.chat`):
+Example provider config (Colony + chat custom domain `waddle.chat` with API at `xmpp.waddle.social`):
 
 ```bash
 helm upgrade --install waddle ./charts/waddle-server \
   --namespace waddle \
-  --set config.baseUrl=https://xmpp.waddle.chat \
-  --set config.corsOrigins='https://waddle.chat,http://localhost:4321,https://xmpp.waddle.chat' \
+  --set config.baseUrl=https://xmpp.waddle.social \
+  --set config.corsOrigins='https://waddle.chat,http://localhost:4321' \
   --set xmpp.domain=waddle.social \
   --set-json secret.authProvidersJson='[{"id":"colony","display_name":"Colony","kind":"oidc","issuer":"https://colony.waddle.social","client_id":"waddle-server","client_secret":"...","scopes":["openid","profile","email"],"subject_claim":"sub","username_claim":"preferred_username","email_claim":"email"}]'
 ```

--- a/server/docs/specs/api-contracts.md
+++ b/server/docs/specs/api-contracts.md
@@ -7,7 +7,7 @@ This document specifies the HTTP API for Waddle Social, covering endpoints, auth
 ## Base URL
 
 ```
-Production: https://xmpp.waddle.chat/v1
+Production: https://xmpp.waddle.social/v1
 Development: http://localhost:3000/v1
 ```
 
@@ -282,7 +282,7 @@ GET    /waddles/:id/presence      Get Waddle presence
 
 ```http
 POST /v1/waddles HTTP/1.1
-Host: xmpp.waddle.chat
+Host: xmpp.waddle.social
 Authorization: Bearer eyJ...
 Content-Type: application/json
 
@@ -315,7 +315,7 @@ Response:
 
 ```http
 POST /v1/channels/ch_general/messages HTTP/1.1
-Host: xmpp.waddle.chat
+Host: xmpp.waddle.social
 Authorization: Bearer eyJ...
 Content-Type: application/json
 
@@ -329,7 +329,7 @@ Content-Type: application/json
 
 ```http
 GET /v1/channels/ch_general/messages?limit=50&before=msg_xyz HTTP/1.1
-Host: xmpp.waddle.chat
+Host: xmpp.waddle.social
 Authorization: Bearer eyJ...
 ```
 


### PR DESCRIPTION
## Summary

Moves the XMPP server domain from `xmpp.waddle.chat` to `xmpp.waddle.social` to properly separate the web app domain (`waddle.chat`) from XMPP infrastructure (`waddle.social`).

## Domain Architecture (after)

| Domain | Purpose |
|--------|---------|
| `waddle.chat` | Web app (Cloudflare Pages) |
| `waddle.social` | XMPP JID domain (`WADDLE_XMPP_DOMAIN`, unchanged) |
| `xmpp.waddle.social` | XMPP server API + WebSocket (`WADDLE_BASE_URL`) |
| `colony.waddle.social` | Auth provider (unchanged) |

## Changes

### Client fix (server-agnostic discovery)
- `discovery.ts` — derive XMPP subdomains (`muc.*`, `spaces.*`) from JID domain instead of WebSocket URL hostname
- `jid.ts` — derive room JIDs from JID domain instead of WebSocket host
- `client.ts` — remove now-unnecessary `xmpp_websocket_url` params from discovery calls

This makes the chat client work with **any** XMPP server, not just our default.

### Infrastructure
- `helmrelease.yaml` — `baseUrl` + CORS origins
- `httproute.yaml` + `httproute-http-redirect.yaml` — hostnames
- `gateway.yaml` — listener hostnames + TLS cert ref
- `api-certificate.yaml` — cert name, secret, and SAN

### Colony
- `wrangler.jsonc` + `worker-configuration.d.ts` — OIDC redirect callback URL

### Chat
- `wrangler.jsonc` — default `SERVER_BASE_URL`

### Docs
- `api-contracts.md` + Helm `README.md` — updated production URL examples

## Pre-deploy requirement

Create a DNS record for `xmpp.waddle.social` pointing to the cluster before deploying.