### PR TITLE
fix(infra): provision XMPP TLS cert via cert-manager

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -26,6 +26,8 @@ spec:
     xmpp:
       domain: waddle.social
       mamDbPath: /data/mam.db
+      tls:
+        secretName: waddle-xmpp-tls
     persistence:
       storageClassName: openebs-mayastor
     service:

--- a/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - xmpp-certificate.yaml
   - helmrepository.yaml
   - helmrelease.yaml
   - httproute.yaml

--- a/infrastructure/waddle.cloud/gitops/waddle-server/xmpp-certificate.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/xmpp-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: waddle-xmpp-tls
+  namespace: waddle
+spec:
+  secretName: waddle-xmpp-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - xmpp.waddle.social


### PR DESCRIPTION
## Summary
- configure waddle-server HelmRelease to mount an XMPP TLS secret (xmpp.tls.secretName)
- add a cert-manager Certificate in the waddle namespace that issues waddle-xmpp-tls
- include the certificate manifest in the waddle-server kustomization so Flux applies it

## Why
The server failed startup due to missing local certs/server.crt and server.key. This wires certificate provisioning and mounting through GitOps plus cert-manager so XMPP can boot with managed TLS material.