### PR TITLE
feat: image drag-and-drop & paste upload with R2 blob storage

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -274,6 +274,18 @@ async function sendGif(url: string) {
   await activeTarget.value.sendMessage(url);
 }
 
+const activeUploadProgress = computed(() =>
+  ui.sidebarMode.value === "dms" ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
+);
+
+async function sendActiveFileMessage(file: File | Blob) {
+  if (ui.sidebarMode.value === "dms") {
+    await dmMessaging.sendFileMessage(file);
+    return;
+  }
+  await messaging.sendFileMessage(file);
+}
+
 async function sendActiveMessage(body?: string, markup?: MarkupSpan[]) {
   if (ui.sidebarMode.value === "dms") {
     await dmMessaging.sendMessage();
@@ -834,9 +846,11 @@ onUnmounted(() => {
         :muji-error="muji.error.value"
         :muji-local-stream="muji.localStream.value"
         :muji-remote-participants="muji.remoteParticipants.value"
+        :upload-progress="activeUploadProgress"
         @send="sendActiveMessage"
         @typing="notifyActiveComposing"
         @select-gif="sendGif"
+        @file-upload="sendActiveFileMessage"
         @edit-message="editActiveMessage"
         @retract-message="retractActiveMessage"
         @react-message="reactActiveMessage"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -130,6 +130,7 @@ let dragLeaveTimeout: ReturnType<typeof setTimeout> | null = null;
 
 function onDragEnter(e: DragEvent) {
   e.preventDefault();
+  if (!e.dataTransfer?.types.includes("Files")) return;
   if (dragLeaveTimeout) { clearTimeout(dragLeaveTimeout); dragLeaveTimeout = null; }
   isDragging.value = true;
 }

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { Hash, MessageCircle, Settings, Search, X, Phone, Video, PhoneOff, Mic, MicOff, VideoOff } from "lucide-vue-next";
+import { Hash, MessageCircle, Settings, Search, X, Phone, Video, PhoneOff, Mic, MicOff, VideoOff, Upload } from "lucide-vue-next";
+import { extractImageFromEvent } from "@/lib/xmpp/file-upload";
 import type { ChannelSummary, WaddleSummary } from "@/lib/waddle-api";
 import type { TimelineMessage, MarkupSpan } from "@/lib/chat-ui";
 import type { MujiCallPhase, XmppStatusSnapshot, RoomHats, RoomPresence } from "@/lib/xmpp-client";
@@ -48,12 +49,14 @@ const props = defineProps<{
   mujiError: string;
   mujiLocalStream: MediaStream | null;
   mujiRemoteParticipants: Map<string, { jid: string; stream: MediaStream }>;
+  uploadProgress: { uploading: boolean; progress: number; filename: string };
 }>();
 
 const emit = defineEmits<{
   send: [body: string, markup: MarkupSpan[]];
   typing: [];
   selectGif: [url: string];
+  fileUpload: [file: File | Blob];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[]];
   retractMessage: [messageId: string];
   reactMessage: [messageId: string, emoji: string];
@@ -121,6 +124,31 @@ function openPopoverDm() {
   popoverAuthor.value = null;
 }
 
+// -- Drag-and-drop file upload --
+const isDragging = ref(false);
+let dragLeaveTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function onDragEnter(e: DragEvent) {
+  e.preventDefault();
+  if (dragLeaveTimeout) { clearTimeout(dragLeaveTimeout); dragLeaveTimeout = null; }
+  isDragging.value = true;
+}
+
+function onDragOver(e: DragEvent) {
+  e.preventDefault();
+}
+
+function onDragLeave() {
+  dragLeaveTimeout = setTimeout(() => { isDragging.value = false; }, 50);
+}
+
+function onDrop(e: DragEvent) {
+  e.preventDefault();
+  isDragging.value = false;
+  const file = extractImageFromEvent(e);
+  if (file) emit("fileUpload", file);
+}
+
 // XEP-0333: Send displayed marker for the latest non-self message
 watch(
   () => props.messages,
@@ -135,7 +163,22 @@ watch(
 </script>
 
 <template>
-  <div class="flex-1 flex flex-col min-w-0 min-h-0 bg-background">
+  <div
+    class="flex-1 flex flex-col min-w-0 min-h-0 bg-background relative"
+    @dragenter="onDragEnter"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <!-- Drop zone overlay -->
+    <div
+      v-if="isDragging"
+      class="absolute inset-0 z-50 bg-primary/10 border-2 border-dashed border-primary rounded-xl flex flex-col items-center justify-center pointer-events-none animate-fade-in"
+    >
+      <Upload class="w-8 h-8 text-primary mb-2" />
+      <span class="text-primary font-display font-bold text-lg">Drop image to upload</span>
+    </div>
+
     <!-- Header — sleek, floating feel -->
     <div class="h-14 border-b border-border px-6 flex items-center justify-between flex-shrink-0 glass-surface">
       <div class="flex items-center gap-3">
@@ -390,9 +433,11 @@ watch(
       :tenor-api-key="tenorApiKey"
       :member-names="memberNames"
       :slow-mode-cooldown="slowModeCooldown"
+      :upload-progress="uploadProgress"
       @send="(body, markup) => emit('send', body, markup)"
       @typing="emit('typing')"
       @select-gif="(url) => emit('selectGif', url)"
+      @file-upload="(file) => emit('fileUpload', file)"
     />
     <UserPopover
       :open="!!popoverAuthor"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -5,6 +5,7 @@ import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
+import { extractImageFromEvent } from "@/lib/xmpp/file-upload";
 import type { MarkupSpan } from "@/lib/chat-ui";
 
 const draft = defineModel<string>("draft", { required: true });
@@ -16,12 +17,14 @@ const props = defineProps<{
   tenorApiKey: string;
   memberNames: string[];
   slowModeCooldown: number;
+  uploadProgress: { uploading: boolean; progress: number; filename: string };
 }>();
 
 const emit = defineEmits<{
   send: [body: string, markup: MarkupSpan[]];
   typing: [];
   selectGif: [url: string];
+  fileUpload: [file: File | Blob];
 }>();
 
 const showGifPicker = ref(false);
@@ -210,6 +213,14 @@ function onGifSelected(url: string) {
   emit("selectGif", url);
 }
 
+function onPaste(e: ClipboardEvent) {
+  const file = extractImageFromEvent(e);
+  if (file) {
+    e.preventDefault();
+    emit("fileUpload", file);
+  }
+}
+
 // Clear editor content when draft is reset externally (e.g. after successful send)
 watch(
   () => draft.value,
@@ -222,7 +233,23 @@ watch(
 </script>
 
 <template>
-  <div class="relative px-4 py-3 flex items-center gap-2.5 flex-shrink-0" @keydown="onKeydown">
+  <div class="relative px-4 py-3 flex-shrink-0" @keydown="onKeydown" @paste="onPaste">
+    <!-- Upload progress bar -->
+    <div
+      v-if="uploadProgress.uploading"
+      class="flex items-center gap-2 text-[11px] text-muted-foreground mb-2 animate-fade-in"
+    >
+      <span class="truncate max-w-40">Uploading {{ uploadProgress.filename }}...</span>
+      <div class="flex-1 h-1 bg-muted rounded-full overflow-hidden">
+        <div
+          class="h-full bg-primary rounded-full transition-all duration-300"
+          :style="{ width: `${Math.round(uploadProgress.progress * 100)}%` }"
+        />
+      </div>
+      <span class="tabular-nums font-mono">{{ Math.round(uploadProgress.progress * 100) }}%</span>
+    </div>
+
+    <div class="flex items-center gap-2.5">
     <GifPicker
       v-if="showGifPicker"
       :api-key="tenorApiKey"
@@ -293,5 +320,6 @@ watch(
       <span v-if="slowModeCooldown > 0" class="text-[10px] font-bold font-mono tabular-nums">{{ slowModeCooldown }}</span>
       <Send v-else class="w-4 h-4" />
     </button>
+    </div>
   </div>
 </template>

--- a/chat/src/composables/sendFileMessageHelper.ts
+++ b/chat/src/composables/sendFileMessageHelper.ts
@@ -1,0 +1,59 @@
+import type { Ref } from "vue";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import type { UploadProgress } from "@/lib/xmpp/file-upload";
+import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
+
+export async function executeSendFileMessage(opts: {
+  file: File | Blob;
+  username: string;
+  uploadProgress: Ref<{ uploading: boolean; progress: number; filename: string }>;
+  messages: Ref<TimelineMessage[]>;
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  scrollToBottom: () => Promise<void>;
+  normalizeError: (e: unknown) => string;
+  doUpload: (
+    file: File | Blob,
+    onProgress: (p: UploadProgress) => void,
+  ) => Promise<{ msgId: string; fileUrl: string } | null>;
+}): Promise<void> {
+  const { file, username, uploadProgress, messages, actionError, clearActionError, scrollToBottom, normalizeError, doUpload } = opts;
+
+  if (file.size > MAX_IMAGE_UPLOAD_BYTES) {
+    actionError.value = `File too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Maximum upload size is 10 MB.`;
+    return;
+  }
+
+  const filename = file instanceof File ? file.name : `image-${Date.now()}.png`;
+  uploadProgress.value = { uploading: true, progress: 0, filename };
+  clearActionError();
+
+  try {
+    const result = await doUpload(file, (p) => {
+      uploadProgress.value = {
+        uploading: true,
+        progress: p.total > 0 ? p.loaded / p.total : 0,
+        filename,
+      };
+    });
+
+    if (result) {
+      messages.value = [
+        ...messages.value,
+        {
+          id: result.msgId,
+          author: username,
+          body: result.fileUrl,
+          createdAt: new Date().toISOString(),
+          isSelf: true,
+          deliveryStatus: "sending",
+        },
+      ];
+      void scrollToBottom();
+    }
+  } catch (e) {
+    actionError.value = normalizeError(e);
+  } finally {
+    uploadProgress.value = { uploading: false, progress: 0, filename: "" };
+  }
+}

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
+import { executeSendFileMessage } from "./sendFileMessageHelper";
 
 function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): TimelineMessage {
   const tm: TimelineMessage = {
@@ -269,38 +270,17 @@ export function useDmMessaging(
     const peerJid = activePeerJid.value;
     if (!client || !peerJid || !session.value) return;
 
-    const filename = file instanceof File ? file.name : `image-${Date.now()}.png`;
-    uploadProgress.value = { uploading: true, progress: 0, filename };
-    clearActionError();
-
-    try {
-      const msgId = await client.uploadAndSendDirectFile(peerJid, file, (p) => {
-        uploadProgress.value = {
-          uploading: true,
-          progress: p.total > 0 ? p.loaded / p.total : 0,
-          filename,
-        };
-      });
-
-      if (msgId && session.value) {
-        messages.value = [
-          ...messages.value,
-          {
-            id: msgId,
-            author: session.value.username,
-            body: filename,
-            createdAt: new Date().toISOString(),
-            isSelf: true,
-            deliveryStatus: "sending",
-          },
-        ];
-        void scrollToBottom();
-      }
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    } finally {
-      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
-    }
+    await executeSendFileMessage({
+      file,
+      username: session.value.username,
+      uploadProgress,
+      messages,
+      actionError,
+      clearActionError,
+      scrollToBottom,
+      normalizeError,
+      doUpload: (f, onProgress) => client.uploadAndSendDirectFile(peerJid, f, onProgress),
+    });
   }
 
   async function toggleReaction(messageId: string, emoji: string) {

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -45,6 +45,7 @@ export function useDmMessaging(
   const typingUsers = ref<string[]>([]);
   const searchResults = ref<{ id: string; nick: string; body: string; createdAt: string }[]>([]);
   const isSearching = ref(false);
+  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const latestCallInvite = ref<{ peerJid: string; invite: CallInviteInfo; fromNick: string } | null>(null);
 
   let messageRequestId = 0;
@@ -263,6 +264,45 @@ export function useDmMessaging(
     }
   }
 
+  async function sendFileMessage(file: File | Blob) {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    if (!client || !peerJid || !session.value) return;
+
+    const filename = file instanceof File ? file.name : `image-${Date.now()}.png`;
+    uploadProgress.value = { uploading: true, progress: 0, filename };
+    clearActionError();
+
+    try {
+      const msgId = await client.uploadAndSendDirectFile(peerJid, file, (p) => {
+        uploadProgress.value = {
+          uploading: true,
+          progress: p.total > 0 ? p.loaded / p.total : 0,
+          filename,
+        };
+      });
+
+      if (msgId && session.value) {
+        messages.value = [
+          ...messages.value,
+          {
+            id: msgId,
+            author: session.value.username,
+            body: filename,
+            createdAt: new Date().toISOString(),
+            isSelf: true,
+            deliveryStatus: "sending",
+          },
+        ];
+        void scrollToBottom();
+      }
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    } finally {
+      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
+    }
+  }
+
   async function toggleReaction(messageId: string, emoji: string) {
     if (!xmppClient.value || !activePeerJid.value || !session.value) return;
     const msg = messages.value.find((m) => m.id === messageId);
@@ -413,6 +453,8 @@ export function useDmMessaging(
     latestCallInvite,
     loadMessages,
     sendMessage,
+    sendFileMessage,
+    uploadProgress,
     editMessage,
     retractMessage,
     toggleReaction,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -14,6 +14,7 @@ import {
   type RoomPresence,
 } from "@/lib/xmpp-client";
 import type { DeliveryStatus, MarkupSpan, TimelineMessage } from "@/lib/chat-ui";
+import { executeSendFileMessage } from "./sendFileMessageHelper";
 
 function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): TimelineMessage {
   const tm: TimelineMessage = {
@@ -537,36 +538,17 @@ export function useMessaging(
     const channelId = activeChannelId.value;
     if (!client || !waddleId || !channelId || !session.value) return;
 
-    const filename = file instanceof File ? file.name : `image-${Date.now()}.png`;
-    uploadProgress.value = { uploading: true, progress: 0, filename };
-    clearActionError();
-
-    try {
-      const msgId = await client.uploadAndSendGroupFile(waddleId, channelId, file, (p) => {
-        uploadProgress.value = {
-          uploading: true,
-          progress: p.total > 0 ? p.loaded / p.total : 0,
-          filename,
-        };
-      });
-
-      if (msgId && session.value) {
-        const optimistic: TimelineMessage = {
-          id: msgId,
-          author: session.value.username,
-          body: filename,
-          createdAt: new Date().toISOString(),
-          isSelf: true,
-          deliveryStatus: "sending",
-        };
-        messages.value = [...messages.value, optimistic];
-        void scrollToBottom();
-      }
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    } finally {
-      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
-    }
+    await executeSendFileMessage({
+      file,
+      username: session.value.username,
+      uploadProgress,
+      messages,
+      actionError,
+      clearActionError,
+      scrollToBottom,
+      normalizeError,
+      doUpload: (f, onProgress) => client.uploadAndSendGroupFile(waddleId, channelId, f, onProgress),
+    });
   }
 
   async function toggleReaction(messageId: string, emoji: string) {

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -78,6 +78,7 @@ export function useMessaging(
   const roomPresence = ref<RoomPresence>({});
   const roomLastSeen = ref<Record<string, number>>({});
   const slowModeCooldown = ref(0);
+  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const activeChannels = ref<Set<string>>(new Set());
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
@@ -530,6 +531,44 @@ export function useMessaging(
     }
   }
 
+  async function sendFileMessage(file: File | Blob) {
+    const client = xmppClient.value;
+    const waddleId = activeWaddleId.value;
+    const channelId = activeChannelId.value;
+    if (!client || !waddleId || !channelId || !session.value) return;
+
+    const filename = file instanceof File ? file.name : `image-${Date.now()}.png`;
+    uploadProgress.value = { uploading: true, progress: 0, filename };
+    clearActionError();
+
+    try {
+      const msgId = await client.uploadAndSendGroupFile(waddleId, channelId, file, (p) => {
+        uploadProgress.value = {
+          uploading: true,
+          progress: p.total > 0 ? p.loaded / p.total : 0,
+          filename,
+        };
+      });
+
+      if (msgId && session.value) {
+        const optimistic: TimelineMessage = {
+          id: msgId,
+          author: session.value.username,
+          body: filename,
+          createdAt: new Date().toISOString(),
+          isSelf: true,
+          deliveryStatus: "sending",
+        };
+        messages.value = [...messages.value, optimistic];
+        void scrollToBottom();
+      }
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    } finally {
+      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
+    }
+  }
+
   async function toggleReaction(messageId: string, emoji: string) {
     if (!xmppClient.value || !activeWaddleId.value || !activeChannelId.value || !session.value)
       return;
@@ -696,6 +735,8 @@ export function useMessaging(
     loadMessages,
     selectChannel,
     sendMessage,
+    sendFileMessage,
+    uploadProgress,
     editMessage,
     retractMessage,
     moderateMessage,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -20,6 +20,7 @@ import * as history from "./history";
 import * as dmMessaging from "./dm-messaging";
 import * as dmHistory from "./dm-history";
 import * as discovery from "./discovery";
+import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 
 type StanzaSaslMechanism = { name: string };
 type StanzaSaslFactory = {
@@ -185,6 +186,7 @@ export class BrowserXmppClient {
   private roomHats: RoomHats = {};
   private roomPresence: RoomPresence = {};
   private readonly mujiSessions = new Map<string, MujiSession>();
+  private uploadServiceJid: string | null = null;
 
   constructor(session: WaddleSession) { this.session = session; }
 
@@ -283,6 +285,7 @@ export class BrowserXmppClient {
     this.connected = false;
     this.currentRoom = null;
     this.mujiSessions.clear();
+    this.uploadServiceJid = null;
     try { xmpp.disconnect(); } catch { /* ignore */ }
   }
 
@@ -429,6 +432,55 @@ export class BrowserXmppClient {
     await this.connect();
     await this.switchRoom(w, c);
     if (this.xmpp) messaging.sendCallLeft(this.xmpp, roomBareJidFor(this.session, w, c), inviteId);
+  }
+
+  // -- File upload (XEP-0363 + XEP-0447) --
+
+  private async resolveUploadService(): Promise<string> {
+    if (this.uploadServiceJid) return this.uploadServiceJid;
+    await this.connect();
+    if (!this.xmpp) throw new Error("XMPP not connected");
+    const domain = this.session.jid.split("@")[1] ?? "localhost";
+    const jid = await discoverUploadService(this.xmpp, domain);
+    if (!jid) throw new Error("File upload service not available");
+    this.uploadServiceJid = jid;
+    return jid;
+  }
+
+  async uploadAndSendGroupFile(
+    w: string,
+    c: string,
+    file: File | Blob,
+    onProgress?: (progress: UploadProgress) => void,
+  ): Promise<string | null> {
+    await this.connect();
+    await this.switchRoom(w, c);
+    if (!this.xmpp) return null;
+    const uploadDomain = await this.resolveUploadService();
+    const result = await uploadFile(this.xmpp, file, uploadDomain, onProgress);
+    return messaging.sendGroupFileMessage(
+      this.xmpp,
+      roomBareJidFor(this.session, w, c),
+      result.getUrl,
+      { name: result.filename, mediaType: result.contentType, size: result.size },
+    );
+  }
+
+  async uploadAndSendDirectFile(
+    peerJid: string,
+    file: File | Blob,
+    onProgress?: (progress: UploadProgress) => void,
+  ): Promise<string | null> {
+    await this.connect();
+    if (!this.xmpp) return null;
+    const uploadDomain = await this.resolveUploadService();
+    const result = await uploadFile(this.xmpp, file, uploadDomain, onProgress);
+    return dmMessaging.sendDirectFileMessage(
+      this.xmpp,
+      barePeerJid(peerJid),
+      result.getUrl,
+      { name: result.filename, mediaType: result.contentType, size: result.size },
+    );
   }
 
   async sendDirectMessage(peerJid: string, body: string): Promise<string | null> {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -452,35 +452,37 @@ export class BrowserXmppClient {
     c: string,
     file: File | Blob,
     onProgress?: (progress: UploadProgress) => void,
-  ): Promise<string | null> {
+  ): Promise<{ msgId: string; fileUrl: string } | null> {
     await this.connect();
     await this.switchRoom(w, c);
     if (!this.xmpp) return null;
     const uploadDomain = await this.resolveUploadService();
     const result = await uploadFile(this.xmpp, file, uploadDomain, onProgress);
-    return messaging.sendGroupFileMessage(
+    const msgId = messaging.sendGroupFileMessage(
       this.xmpp,
       roomBareJidFor(this.session, w, c),
       result.getUrl,
       { name: result.filename, mediaType: result.contentType, size: result.size },
     );
+    return { msgId, fileUrl: result.getUrl };
   }
 
   async uploadAndSendDirectFile(
     peerJid: string,
     file: File | Blob,
     onProgress?: (progress: UploadProgress) => void,
-  ): Promise<string | null> {
+  ): Promise<{ msgId: string; fileUrl: string } | null> {
     await this.connect();
     if (!this.xmpp) return null;
     const uploadDomain = await this.resolveUploadService();
     const result = await uploadFile(this.xmpp, file, uploadDomain, onProgress);
-    return dmMessaging.sendDirectFileMessage(
+    const msgId = dmMessaging.sendDirectFileMessage(
       this.xmpp,
       barePeerJid(peerJid),
       result.getUrl,
       { name: result.filename, mediaType: result.contentType, size: result.size },
     );
+    return { msgId, fileUrl: result.getUrl };
   }
 
   async sendDirectMessage(peerJid: string, body: string): Promise<string | null> {

--- a/chat/src/lib/xmpp/dm-messaging.ts
+++ b/chat/src/lib/xmpp/dm-messaging.ts
@@ -73,7 +73,7 @@ export function sendDirectFileMessage(
     type: "chat",
     body: fileUrl,
     links: [{ url: fileUrl }],
-    fallback: { for: "urn:xmpp:sfs:0" },
+    fallback: { for: "urn:xmpp:sfs:0", body: true },
     receipt: { type: "request" },
     marker: { type: "markable" },
     processingHints: { store: true },

--- a/chat/src/lib/xmpp/dm-messaging.ts
+++ b/chat/src/lib/xmpp/dm-messaging.ts
@@ -86,6 +86,7 @@ export function sendDirectFileMessage(
       ...(file.height ? { height: String(file.height) } : {}),
       url: fileUrl,
     },
+  // stanza.js types don't include XEP-0447 fileSharing/fallback custom extensions
   } as Record<string, unknown>);
   return msgId;
 }

--- a/chat/src/lib/xmpp/dm-messaging.ts
+++ b/chat/src/lib/xmpp/dm-messaging.ts
@@ -59,6 +59,37 @@ export function sendDirectMessage(xmpp: Agent, peerJid: string, body: string): s
   return msgId;
 }
 
+/** XEP-0447: Send a file-sharing message in a DM. */
+export function sendDirectFileMessage(
+  xmpp: Agent,
+  peerJid: string,
+  fileUrl: string,
+  file: { name: string; mediaType: string; size: number; width?: number; height?: number },
+): string {
+  const msgId = crypto.randomUUID();
+  xmpp.sendMessage({
+    id: msgId,
+    to: peerJid,
+    type: "chat",
+    body: fileUrl,
+    links: [{ url: fileUrl }],
+    fallback: { for: "urn:xmpp:sfs:0" },
+    receipt: { type: "request" },
+    marker: { type: "markable" },
+    processingHints: { store: true },
+    fileSharing: {
+      disposition: "inline",
+      name: file.name,
+      mediaType: file.mediaType,
+      size: String(file.size),
+      ...(file.width ? { width: String(file.width) } : {}),
+      ...(file.height ? { height: String(file.height) } : {}),
+      url: fileUrl,
+    },
+  } as Record<string, unknown>);
+  return msgId;
+}
+
 export function sendDmCallInvite(
   xmpp: Agent,
   peerJid: string,

--- a/chat/src/lib/xmpp/extensions/fallback.ts
+++ b/chat/src/lib/xmpp/extensions/fallback.ts
@@ -1,0 +1,25 @@
+/**
+ * XEP-0428: Fallback Indication.
+ *
+ * Marks the message body as a fallback for a structured element:
+ *   <fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:sfs:0">
+ *     <body/>
+ *   </fallback>
+ */
+import type { DefinitionOptions } from "stanza/jxt";
+import { attribute } from "stanza/jxt";
+
+const NS_FALLBACK = "urn:xmpp:fallback:0";
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "message.fallback", multiple: false }],
+    element: "fallback",
+    fields: {
+      for: attribute("for"),
+    },
+    namespace: NS_FALLBACK,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/extensions/fallback.ts
+++ b/chat/src/lib/xmpp/extensions/fallback.ts
@@ -6,10 +6,23 @@
  *     <body/>
  *   </fallback>
  */
-import type { DefinitionOptions } from "stanza/jxt";
+import type { DefinitionOptions, FieldDefinition } from "stanza/jxt";
 import { attribute } from "stanza/jxt";
+import XMLElement from "stanza/jxt/Element";
 
 const NS_FALLBACK = "urn:xmpp:fallback:0";
+
+/** Always exports an empty <body/> child element inside <fallback/>. */
+const bodyChild: FieldDefinition<boolean> = {
+  importer(xml: XMLElement) {
+    return xml.getChild("body") !== undefined;
+  },
+  exporter(xml: XMLElement, value: boolean) {
+    if (value && !xml.getChild("body")) {
+      xml.appendChild(new XMLElement("body"));
+    }
+  },
+};
 
 const definitions: DefinitionOptions[] = [
   {
@@ -17,6 +30,7 @@ const definitions: DefinitionOptions[] = [
     element: "fallback",
     fields: {
       for: attribute("for"),
+      body: bodyChild,
     },
     namespace: NS_FALLBACK,
   },

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -4,6 +4,7 @@ import hats from "./hats";
 import references from "./references";
 import retraction from "./retraction";
 import reactions from "./reactions";
+import fallback from "./fallback";
 import fileSharing from "./file-sharing";
 import stickers from "./stickers";
 import calls from "./calls";
@@ -16,6 +17,7 @@ const allDefinitions = [
   ...references,
   ...retraction,
   ...reactions,
+  ...fallback,
   ...fileSharing,
   ...stickers,
   ...calls,

--- a/chat/src/lib/xmpp/file-upload.ts
+++ b/chat/src/lib/xmpp/file-upload.ts
@@ -1,6 +1,8 @@
 /** XEP-0363: HTTP File Upload for sharing images and files in chat. */
 import type { Agent } from "stanza";
 
+export const MAX_IMAGE_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+
 export interface UploadResult {
   getUrl: string;
   filename: string;
@@ -28,16 +30,17 @@ export async function discoverUploadService(xmpp: Agent, domain: string): Promis
   try {
     const items = await xmpp.getDiscoItems(domain);
 
-    for (const item of items.items ?? []) {
-      try {
+    const results = await Promise.allSettled(
+      (items.items ?? []).map(async (item) => {
         const info = await xmpp.getDiscoInfo(item.jid);
         const hasUpload = info.features?.some(
           (f: any) => f === "urn:xmpp:http:upload:0" || f.var === "urn:xmpp:http:upload:0",
         );
-        if (hasUpload) return item.jid ?? null;
-      } catch {
-        continue;
-      }
+        return hasUpload ? item.jid : null;
+      }),
+    );
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value) return r.value;
     }
     return null;
   } catch {

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -125,7 +125,7 @@ export function sendGroupFileMessage(
     type: "groupchat",
     body: fileUrl,
     links: [{ url: fileUrl }],
-    fallback: { for: "urn:xmpp:sfs:0" },
+    fallback: { for: "urn:xmpp:sfs:0", body: true },
     receipt: { type: "request" },
     marker: { type: "markable" },
     processingHints: { store: true },

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -111,6 +111,38 @@ export function sendGroupMessage(xmpp: Agent, roomJid: string, body: string, mar
   return msgId;
 }
 
+/** XEP-0447: Send a file-sharing message in a group chat (MUC). */
+export function sendGroupFileMessage(
+  xmpp: Agent,
+  roomJid: string,
+  fileUrl: string,
+  file: { name: string; mediaType: string; size: number; width?: number; height?: number },
+): string {
+  const msgId = crypto.randomUUID();
+  const msgData: Record<string, unknown> = {
+    id: msgId,
+    to: roomJid,
+    type: "groupchat",
+    body: fileUrl,
+    links: [{ url: fileUrl }],
+    fallback: { for: "urn:xmpp:sfs:0" },
+    receipt: { type: "request" },
+    marker: { type: "markable" },
+    processingHints: { store: true },
+    fileSharing: {
+      disposition: "inline",
+      name: file.name,
+      mediaType: file.mediaType,
+      size: String(file.size),
+      ...(file.width ? { width: String(file.width) } : {}),
+      ...(file.height ? { height: String(file.height) } : {}),
+      url: fileUrl,
+    },
+  };
+  xmpp.sendMessage(msgData as Parameters<Agent["sendMessage"]>[0]);
+  return msgId;
+}
+
 export interface SendCallInviteOptions {
   inviteId?: string;
   sid?: string;

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -139,6 +139,7 @@ export function sendGroupFileMessage(
       url: fileUrl,
     },
   };
+  // stanza.js types don't include XEP-0447 fileSharing/fallback custom extensions
   xmpp.sendMessage(msgData as Parameters<Agent["sendMessage"]>[0]);
   return msgId;
 }

--- a/chat/tests/dm-messaging.test.ts
+++ b/chat/tests/dm-messaging.test.ts
@@ -1,0 +1,45 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { Agent } from "stanza";
+import { sendDirectFileMessage, sendDirectMessage } from "../src/lib/xmpp/dm-messaging";
+
+function makeAgent() {
+  return {
+    sendMessage: mock(() => undefined),
+  } as unknown as Agent & {
+    sendMessage: ReturnType<typeof mock>;
+  };
+}
+
+describe("dm messaging", () => {
+  test("sends XEP-0447 file-sharing stanza with fallback and OOB", () => {
+    const xmpp = makeAgent();
+    const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
+
+    const messageId = sendDirectFileMessage(xmpp, "bob@waddle.social", fileUrl, {
+      name: "photo.jpg",
+      mediaType: "image/jpeg",
+      size: 12345,
+    });
+
+    expect(typeof messageId).toBe("string");
+    expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: messageId,
+        to: "bob@waddle.social",
+        type: "chat",
+        body: fileUrl,
+        links: [{ url: fileUrl }],
+        fallback: { for: "urn:xmpp:sfs:0", body: true },
+        processingHints: { store: true },
+        fileSharing: expect.objectContaining({
+          disposition: "inline",
+          name: "photo.jpg",
+          mediaType: "image/jpeg",
+          size: "12345",
+          url: fileUrl,
+        }),
+      }),
+    );
+  });
+});

--- a/chat/tests/groupchat-messaging.test.ts
+++ b/chat/tests/groupchat-messaging.test.ts
@@ -3,6 +3,7 @@ import type { Agent } from "stanza";
 import {
   sendCallInvite,
   sendCorrection,
+  sendGroupFileMessage,
   sendGroupMessage,
   sendModeration,
   sendReaction,
@@ -104,6 +105,38 @@ describe("groupchat messaging", () => {
           moderated: { retract: true, reason: "policy" },
         },
         processingHints: { store: true },
+      }),
+    );
+  });
+
+  test("sends XEP-0447 file-sharing stanza with fallback and OOB", () => {
+    const xmpp = makeAgent();
+    const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
+
+    const messageId = sendGroupFileMessage(xmpp, "general@muc.waddle.social", fileUrl, {
+      name: "photo.jpg",
+      mediaType: "image/jpeg",
+      size: 12345,
+    });
+
+    expect(typeof messageId).toBe("string");
+    expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: messageId,
+        to: "general@muc.waddle.social",
+        type: "groupchat",
+        body: fileUrl,
+        links: [{ url: fileUrl }],
+        fallback: { for: "urn:xmpp:sfs:0", body: true },
+        processingHints: { store: true },
+        fileSharing: expect.objectContaining({
+          disposition: "inline",
+          name: "photo.jpg",
+          mediaType: "image/jpeg",
+          size: "12345",
+          url: fileUrl,
+        }),
       }),
     );
   });

--- a/infrastructure/waddle.cloud/gitops/waddle-server/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/external-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: waddle-r2-credentials
+  namespace: waddle
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: waddle-r2-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: WADDLE_S3_ACCESS_KEY_ID
+      remoteRef:
+        key: waddle-server-files
+        property: s3-credentials.access-key-id
+    - secretKey: WADDLE_S3_SECRET_ACCESS_KEY
+      remoteRef:
+        key: waddle-server-files
+        property: s3-credentials.secret-access-key

--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
     config:
       baseUrl: https://xmpp.waddle.social
       corsOrigins: https://waddle.chat,http://localhost:4321
+      s3Endpoint: "https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com"
+      s3Bucket: "waddle-server-files"
+    extraSecretRefs:
+      - waddle-r2-credentials
     xmpp:
       domain: waddle.social
       mamDbPath: /data/mam.db

--- a/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - namespace.yaml
   - xmpp-certificate.yaml
+  - external-secret.yaml
   - helmrepository.yaml
   - helmrelease.yaml
   - httproute.yaml

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5761,6 +5761,7 @@ dependencies = [
  "axum 0.7.9",
  "axum-extra",
  "base64 0.22.1",
+ "bytes",
  "chrono",
  "clap",
  "config",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,6 +54,7 @@ dashmap = "6.0"
 xmpp = "0.6"
 
 # Object Storage
+bytes = "1"
 object_store = { version = "0.11", features = ["aws"] }
 
 # Serialization

--- a/server/charts/waddle-server/templates/configmap.yaml
+++ b/server/charts/waddle-server/templates/configmap.yaml
@@ -32,6 +32,12 @@ data:
   {{- if .Values.telemetry.serviceVersion }}
   OTEL_SERVICE_VERSION: {{ .Values.telemetry.serviceVersion | quote }}
   {{- end }}
+  {{- if .Values.config.s3Endpoint }}
+  WADDLE_S3_ENDPOINT: {{ .Values.config.s3Endpoint | quote }}
+  {{- end }}
+  {{- if .Values.config.s3Bucket }}
+  WADDLE_S3_BUCKET: {{ .Values.config.s3Bucket | quote }}
+  {{- end }}
   {{- range $key, $value := .Values.config.extraEnv }}
   {{ $key }}: {{ $value | quote }}
   {{- end }}

--- a/server/charts/waddle-server/templates/deployment.yaml
+++ b/server/charts/waddle-server/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
             - secretRef:
                 name: {{ include "waddle-server.secretName" . }}
             {{- end }}
+            {{- range .Values.extraSecretRefs }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
           env:
             - name: WADDLE_DB_PATH
               value: {{ printf "%s/%s" .Values.persistence.mountPath .Values.persistence.dbFileName | quote }}

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -104,8 +104,15 @@ config:
   authProvidersJson: ""
   drainTimeoutSeconds: 30
   rustLog: info
+  # S3-compatible blob storage (Cloudflare R2, AWS S3, MinIO).
+  # When s3Endpoint is set, file uploads use S3 instead of local disk.
+  s3Endpoint: ""
+  s3Bucket: ""
   # Extra key/value env vars rendered into ConfigMap data (non-sensitive).
   extraEnv: {}
+
+# Additional Kubernetes Secrets to inject as env vars (e.g. R2 credentials from ExternalSecrets).
+extraSecretRefs: []
 
 telemetry:
   otlpEndpoint: ""

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -41,6 +41,7 @@ xmpp = { workspace = true }
 xmpp-parsers = { workspace = true }
 
 # Object Storage
+bytes = { workspace = true }
 object_store = { workspace = true }
 
 # Serialization

--- a/server/crates/waddle-server/src/main.rs
+++ b/server/crates/waddle-server/src/main.rs
@@ -10,7 +10,7 @@ mod media;
 mod messages;
 mod permissions;
 mod server;
-pub mod storage;
+pub(crate) mod storage;
 mod telemetry;
 mod vcard;
 mod waddle;

--- a/server/crates/waddle-server/src/main.rs
+++ b/server/crates/waddle-server/src/main.rs
@@ -10,6 +10,7 @@ mod media;
 mod messages;
 mod permissions;
 mod server;
+pub mod storage;
 mod telemetry;
 mod vcard;
 mod waddle;

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -70,8 +70,8 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(db_pool: Arc<DatabasePool>) -> Self {
-        let blob_storage =
-            crate::storage::build_blob_storage().expect("failed to initialize blob storage");
+        let blob_storage = crate::storage::build_blob_storage()
+            .unwrap_or_else(|e| panic!("failed to initialize blob storage: {e}"));
         Self::new_with_deps(
             db_pool,
             build_media_backend(&MediaConfig::default()),
@@ -83,8 +83,8 @@ impl AppState {
         db_pool: Arc<DatabasePool>,
         media_backend: Arc<dyn MediaBackend>,
     ) -> Self {
-        let blob_storage =
-            crate::storage::build_blob_storage().expect("failed to initialize blob storage");
+        let blob_storage = crate::storage::build_blob_storage()
+            .unwrap_or_else(|e| panic!("failed to initialize blob storage: {e}"));
         Self::new_with_deps(db_pool, media_backend, blob_storage)
     }
 

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -64,20 +64,39 @@ pub struct AppState {
     pub db_pool: Arc<DatabasePool>,
     /// Media backend used for call session generation.
     pub media_backend: Arc<dyn MediaBackend>,
+    /// Blob storage backend for file uploads (XEP-0363).
+    pub blob_storage: Arc<dyn crate::storage::BlobStorage>,
 }
 
 impl AppState {
     pub fn new(db_pool: Arc<DatabasePool>) -> Self {
-        Self::new_with_media(db_pool, build_media_backend(&MediaConfig::default()))
+        let blob_storage =
+            crate::storage::build_blob_storage().expect("failed to initialize blob storage");
+        Self::new_with_deps(
+            db_pool,
+            build_media_backend(&MediaConfig::default()),
+            blob_storage,
+        )
     }
 
     pub fn new_with_media(
         db_pool: Arc<DatabasePool>,
         media_backend: Arc<dyn MediaBackend>,
     ) -> Self {
+        let blob_storage =
+            crate::storage::build_blob_storage().expect("failed to initialize blob storage");
+        Self::new_with_deps(db_pool, media_backend, blob_storage)
+    }
+
+    pub fn new_with_deps(
+        db_pool: Arc<DatabasePool>,
+        media_backend: Arc<dyn MediaBackend>,
+        blob_storage: Arc<dyn crate::storage::BlobStorage>,
+    ) -> Self {
         Self {
             db_pool,
             media_backend,
+            blob_storage,
         }
     }
 }
@@ -455,9 +474,12 @@ pub async fn start_with_config(
 
     // Create HTTP state (shares db_pool via Arc)
     let media_backend = build_media_backend(&server_config.media);
-    let state = Arc::new(AppState::new_with_media(
+    let blob_storage = crate::storage::build_blob_storage()
+        .map_err(|e| anyhow::anyhow!("Failed to initialize blob storage: {}", e))?;
+    let state = Arc::new(AppState::new_with_deps(
         Arc::clone(&db_pool),
         media_backend,
+        blob_storage,
     ));
     let websocket_mam_storage =
         create_websocket_mam_storage(xmpp_config.mam_db_path.clone()).await?;

--- a/server/crates/waddle-server/src/server/routes/uploads.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads.rs
@@ -18,32 +18,22 @@ use axum::{
     Json, Router,
 };
 use serde::Serialize;
-use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::fs;
-use tokio::io::AsyncWriteExt;
 use tracing::{debug, error, info, instrument, warn};
 
-/// Extended application state for upload routes
+/// Extended application state for upload routes.
+///
+/// File storage is delegated to the `BlobStorage` trait on `AppState`,
+/// which may be local filesystem or S3-compatible (e.g. Cloudflare R2).
 pub struct UploadState {
-    /// Core app state
+    /// Core app state (includes blob storage backend)
     pub app_state: Arc<AppState>,
-    /// Base directory for file storage
-    pub upload_dir: PathBuf,
 }
 
 impl UploadState {
     /// Create new upload state
     pub fn new(app_state: Arc<AppState>) -> Self {
-        // Get upload directory from environment or use default
-        let upload_dir = std::env::var("WADDLE_UPLOAD_DIR")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("./uploads"));
-
-        Self {
-            app_state,
-            upload_dir,
-        }
+        Self { app_state }
     }
 
     /// Get the global database reference
@@ -368,51 +358,18 @@ pub async fn upload_handler(
         }
     }
 
-    // Create storage directory if it doesn't exist
-    let slot_dir = state.upload_dir.join(&slot_id);
-    if let Err(err) = fs::create_dir_all(&slot_dir).await {
-        error!("Failed to create upload directory {:?}: {}", slot_dir, err);
-        return upload_error_to_response(UploadError::Storage(format!(
-            "Failed to create storage directory: {}",
-            err
-        )))
-        .into_response();
-    }
-
-    // Build file path: upload_dir/slot_id/filename
-    let file_path = slot_dir.join(&slot.filename);
+    // Store via blob storage backend (local filesystem or S3/R2)
     let storage_key = format!("{}/{}", slot_id, slot.filename);
 
-    // Write file to disk
-    let mut file = match fs::File::create(&file_path).await {
-        Ok(f) => f,
-        Err(err) => {
-            error!("Failed to create file {:?}: {}", file_path, err);
-            return upload_error_to_response(UploadError::Storage(format!(
-                "Failed to create file: {}",
-                err
-            )))
-            .into_response();
-        }
-    };
-
-    // Write the body bytes to file
-    if let Err(err) = file.write_all(&body).await {
-        error!("Failed to write to file: {}", err);
-        // Clean up partial file
-        let _ = fs::remove_file(&file_path).await;
+    if let Err(err) = state
+        .app_state
+        .blob_storage
+        .put(&storage_key, body.clone(), &slot.content_type)
+        .await
+    {
+        error!("Failed to store blob: {}", err);
         return upload_error_to_response(UploadError::Storage(format!(
-            "Failed to write file: {}",
-            err
-        )))
-        .into_response();
-    }
-
-    // Sync file to disk
-    if let Err(err) = file.sync_all().await {
-        error!("Failed to sync file: {}", err);
-        return upload_error_to_response(UploadError::Storage(format!(
-            "Failed to sync file: {}",
+            "Failed to store file: {}",
             err
         )))
         .into_response();
@@ -421,14 +378,12 @@ pub async fn upload_handler(
     // Update slot status in database
     if let Err(err) = mark_slot_uploaded(state.global_db(), &slot_id, &storage_key).await {
         error!("Failed to update slot status: {}", err);
-        // File is written but database update failed - this is a problem
-        // We should still return success since the file is stored
         warn!("File uploaded but database status update failed");
     }
 
     info!(
-        "Upload complete: {} bytes written to {:?}",
-        body_size, file_path
+        "Upload complete: {} bytes stored at {}",
+        body_size, storage_key
     );
 
     StatusCode::CREATED.into_response()
@@ -505,24 +460,19 @@ pub async fn download_handler(
         }
     };
 
-    // Build file path
-    let file_path = state.upload_dir.join(&storage_key);
-
-    // Check if file exists
-    if !file_path.exists() {
-        error!("File not found on disk: {:?}", file_path);
-        return upload_error_to_response(UploadError::FileNotFound(format!(
-            "File '{}' not found on server",
-            filename
-        )))
-        .into_response();
-    }
-
-    // Read file
-    let file_contents = match fs::read(&file_path).await {
-        Ok(data) => data,
+    // Retrieve from blob storage backend
+    let (file_contents, blob_meta) = match state.app_state.blob_storage.get(&storage_key).await {
+        Ok(result) => result,
+        Err(crate::storage::StorageError::NotFound(_)) => {
+            error!("File not found in storage: {}", storage_key);
+            return upload_error_to_response(UploadError::FileNotFound(format!(
+                "File '{}' not found on server",
+                filename
+            )))
+            .into_response();
+        }
         Err(err) => {
-            error!("Failed to read file {:?}: {}", file_path, err);
+            error!("Failed to read from storage: {}", err);
             return upload_error_to_response(UploadError::Storage(format!(
                 "Failed to read file: {}",
                 err
@@ -534,23 +484,25 @@ pub async fn download_handler(
     // Build response with appropriate headers
     let mut headers = HeaderMap::new();
 
-    // Set Content-Type
-    if let Ok(content_type) = slot.content_type.parse() {
-        headers.insert(header::CONTENT_TYPE, content_type);
+    // Use content-type from blob metadata (authoritative), fall back to DB
+    let content_type = if blob_meta.content_type != "application/octet-stream" {
+        blob_meta.content_type
+    } else {
+        slot.content_type
+    };
+    if let Ok(ct) = content_type.parse() {
+        headers.insert(header::CONTENT_TYPE, ct);
     }
 
-    // Set Content-Length
     if let Ok(content_length) = file_contents.len().to_string().parse() {
         headers.insert(header::CONTENT_LENGTH, content_length);
     }
 
-    // Set Content-Disposition for download
     let disposition = format!("inline; filename=\"{}\"", slot.filename);
     if let Ok(disp) = disposition.parse() {
         headers.insert(header::CONTENT_DISPOSITION, disp);
     }
 
-    // Set Cache-Control for immutable files
     if let Ok(cache) = "public, max-age=31536000, immutable".parse() {
         headers.insert(header::CACHE_CONTROL, cache);
     }
@@ -573,7 +525,7 @@ mod tests {
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
-    async fn create_test_upload_state() -> Arc<UploadState> {
+    async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         let config = DatabaseConfig::default();
         let pool_config = PoolConfig::default();
         let db_pool = DatabasePool::new(config, pool_config).await.unwrap();
@@ -582,16 +534,20 @@ mod tests {
         let runner = MigrationRunner::global();
         runner.run(db_pool.global()).await.unwrap();
 
-        let app_state = Arc::new(AppState::new(Arc::new(db_pool)));
-
-        // Create upload state with temp directory
+        // Create temp dir for local blob storage
         let upload_dir = std::env::temp_dir().join(format!("waddle-test-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&upload_dir).unwrap();
 
-        Arc::new(UploadState {
-            app_state,
-            upload_dir,
-        })
+        let blob_storage: Arc<dyn crate::storage::BlobStorage> =
+            Arc::new(crate::storage::LocalStorage::new(upload_dir.clone()));
+
+        let app_state = Arc::new(AppState::new_with_deps(
+            Arc::new(db_pool),
+            crate::media::build_media_backend(&crate::media::MediaConfig::default()),
+            blob_storage,
+        ));
+
+        (Arc::new(UploadState::new(app_state)), upload_dir)
     }
 
     async fn create_test_slot(
@@ -636,7 +592,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_upload_to_valid_slot() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
         let file_content = b"Hello, World!";
 
@@ -667,7 +623,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::CREATED);
 
         // Verify file was written
-        let file_path = state.upload_dir.join(&slot_id).join("test.txt");
+        let file_path = upload_dir.join(&slot_id).join("test.txt");
         assert!(file_path.exists());
 
         let saved_content = std::fs::read(&file_path).unwrap();
@@ -682,12 +638,12 @@ mod tests {
         assert!(slot.storage_key.is_some());
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_upload_options_cors_headers() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
         let app = router(state.clone());
 
@@ -722,12 +678,12 @@ mod tests {
             .headers()
             .contains_key("access-control-allow-headers"));
 
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_upload_to_nonexistent_slot() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let app = router(state.clone());
 
         let response = app
@@ -750,12 +706,12 @@ mod tests {
         assert_eq!(json["error"], "slot_not_found");
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_upload_to_expired_slot() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
 
         create_expired_slot(&state, &slot_id).await;
@@ -782,12 +738,12 @@ mod tests {
         assert_eq!(json["error"], "slot_expired");
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_upload_size_mismatch() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
 
         // Create slot expecting 100 bytes
@@ -816,12 +772,12 @@ mod tests {
         assert_eq!(json["error"], "size_mismatch");
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_download_uploaded_file() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
         let file_content = b"Test file content";
 
@@ -885,12 +841,12 @@ mod tests {
         assert_eq!(body.as_ref(), file_content);
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_download_nonexistent_file() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let app = router(state.clone());
 
         let response = app
@@ -907,12 +863,12 @@ mod tests {
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_download_pending_slot() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
 
         // Create a slot but don't upload to it
@@ -942,12 +898,12 @@ mod tests {
             .contains("not yet uploaded"));
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 
     #[tokio::test]
     async fn test_double_upload_fails() {
-        let state = create_test_upload_state().await;
+        let (state, upload_dir) = create_test_upload_state().await;
         let slot_id = uuid::Uuid::new_v4().to_string();
         let file_content = b"Hello, World!";
 
@@ -1000,6 +956,6 @@ mod tests {
         assert_eq!(json["error"], "slot_already_used");
 
         // Cleanup
-        std::fs::remove_dir_all(&state.upload_dir).ok();
+        std::fs::remove_dir_all(&upload_dir).ok();
     }
 }

--- a/server/crates/waddle-server/src/storage/mod.rs
+++ b/server/crates/waddle-server/src/storage/mod.rs
@@ -1,0 +1,337 @@
+//! Blob storage abstraction for file uploads (XEP-0363).
+//!
+//! Provides a `BlobStorage` trait with two implementations:
+//! - `LocalStorage`: stores files on the local filesystem
+//! - `S3Storage`: stores files in an S3-compatible bucket (e.g. Cloudflare R2)
+//!
+//! The active backend is selected by environment variables at startup via
+//! `build_blob_storage()`.
+
+use std::future::Future;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use object_store::aws::AmazonS3Builder;
+use object_store::ObjectStore;
+use tracing::{debug, info};
+
+/// Errors returned by blob storage operations.
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("blob not found: {0}")]
+    NotFound(String),
+    #[error("storage error: {0}")]
+    Internal(String),
+}
+
+/// Metadata returned alongside blob data on retrieval.
+pub struct BlobMeta {
+    pub content_type: String,
+}
+
+/// A boxed, Send future — used for dyn-compatible async trait methods.
+type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Trait abstracting binary object storage.
+///
+/// Uses boxed futures for dyn-compatibility so the trait can be used as
+/// `Arc<dyn BlobStorage>`.
+pub trait BlobStorage: Send + Sync {
+    /// Store bytes at the given key with the specified content type.
+    fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        content_type: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>>;
+
+    /// Retrieve bytes and metadata for the given key.
+    fn get(&self, key: &str) -> BoxFuture<'_, Result<(bytes::Bytes, BlobMeta), StorageError>>;
+
+    /// Check whether a key exists.
+    fn exists(&self, key: &str) -> BoxFuture<'_, Result<bool, StorageError>>;
+}
+
+// ---------------------------------------------------------------------------
+// LocalStorage — filesystem backend
+// ---------------------------------------------------------------------------
+
+/// Stores blobs on the local filesystem under a base directory.
+///
+/// Layout: `{base_dir}/{key}` for the data, `{base_dir}/{key}.meta` for the
+/// content-type sidecar (a plain text file containing just the MIME string).
+pub struct LocalStorage {
+    base_dir: PathBuf,
+}
+
+impl LocalStorage {
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    fn data_path(&self, key: &str) -> PathBuf {
+        self.base_dir.join(key)
+    }
+
+    fn meta_path(&self, key: &str) -> PathBuf {
+        self.base_dir.join(format!("{key}.meta"))
+    }
+}
+
+impl BlobStorage for LocalStorage {
+    fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        content_type: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let path = self.data_path(key);
+        let meta_path = self.meta_path(key);
+        let content_type = content_type.to_string();
+        let len = data.len();
+        let key = key.to_string();
+
+        Box::pin(async move {
+            if let Some(parent) = path.parent() {
+                tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                    StorageError::Internal(format!("failed to create directory: {e}"))
+                })?;
+            }
+
+            tokio::fs::write(&path, &data)
+                .await
+                .map_err(|e| StorageError::Internal(format!("failed to write blob: {e}")))?;
+
+            tokio::fs::write(&meta_path, content_type.as_bytes())
+                .await
+                .map_err(|e| StorageError::Internal(format!("failed to write meta: {e}")))?;
+
+            debug!(key = %key, "LocalStorage: wrote blob ({len} bytes)");
+            Ok(())
+        })
+    }
+
+    fn get(&self, key: &str) -> BoxFuture<'_, Result<(bytes::Bytes, BlobMeta), StorageError>> {
+        let path = self.data_path(key);
+        let meta_path = self.meta_path(key);
+        let key = key.to_string();
+
+        Box::pin(async move {
+            let data = tokio::fs::read(&path).await.map_err(|e| match e.kind() {
+                std::io::ErrorKind::NotFound => StorageError::NotFound(key.clone()),
+                _ => StorageError::Internal(format!("failed to read blob: {e}")),
+            })?;
+
+            let content_type = tokio::fs::read_to_string(&meta_path)
+                .await
+                .unwrap_or_else(|_| "application/octet-stream".to_string());
+
+            Ok((bytes::Bytes::from(data), BlobMeta { content_type }))
+        })
+    }
+
+    fn exists(&self, key: &str) -> BoxFuture<'_, Result<bool, StorageError>> {
+        let path = self.data_path(key);
+        Box::pin(async move { Ok(path.exists()) })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// S3Storage — S3-compatible backend (Cloudflare R2, AWS S3, MinIO, etc.)
+// ---------------------------------------------------------------------------
+
+/// Stores blobs in an S3-compatible object store.
+pub struct S3Storage {
+    store: Box<dyn ObjectStore>,
+}
+
+impl S3Storage {
+    pub fn new(
+        endpoint: String,
+        bucket: String,
+        access_key: String,
+        secret_key: String,
+    ) -> Result<Self, StorageError> {
+        let store = AmazonS3Builder::new()
+            .with_endpoint(endpoint)
+            .with_bucket_name(bucket)
+            .with_access_key_id(access_key)
+            .with_secret_access_key(secret_key)
+            // R2 and most S3-compatible stores use virtual-hosted–style by default,
+            // but path-style is more reliable for non-AWS endpoints.
+            .with_virtual_hosted_style_request(false)
+            .build()
+            .map_err(|e| StorageError::Internal(format!("failed to build S3 object store: {e}")))?;
+
+        Ok(Self {
+            store: Box::new(store),
+        })
+    }
+}
+
+impl BlobStorage for S3Storage {
+    fn put(
+        &self,
+        key: &str,
+        data: bytes::Bytes,
+        content_type: &str,
+    ) -> BoxFuture<'_, Result<(), StorageError>> {
+        let path = object_store::path::Path::from(key);
+        let content_type = content_type.to_string();
+        let key = key.to_string();
+
+        Box::pin(async move {
+            let attrs = object_store::Attributes::from_iter([(
+                object_store::Attribute::ContentType,
+                object_store::AttributeValue::from(content_type),
+            )]);
+            let opts = object_store::PutOptions {
+                attributes: attrs,
+                ..Default::default()
+            };
+
+            self.store
+                .put_opts(&path, data.into(), opts)
+                .await
+                .map_err(|e| StorageError::Internal(format!("S3 put failed: {e}")))?;
+
+            debug!(key = %key, "S3Storage: wrote blob");
+            Ok(())
+        })
+    }
+
+    fn get(&self, key: &str) -> BoxFuture<'_, Result<(bytes::Bytes, BlobMeta), StorageError>> {
+        let path = object_store::path::Path::from(key);
+        let key = key.to_string();
+
+        Box::pin(async move {
+            let result = self.store.get(&path).await.map_err(|e| match e {
+                object_store::Error::NotFound { .. } => StorageError::NotFound(key),
+                other => StorageError::Internal(format!("S3 get failed: {other}")),
+            })?;
+
+            let content_type = result
+                .attributes
+                .get(&object_store::Attribute::ContentType)
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+
+            let data = result
+                .bytes()
+                .await
+                .map_err(|e| StorageError::Internal(format!("S3 read body failed: {e}")))?;
+
+            Ok((data, BlobMeta { content_type }))
+        })
+    }
+
+    fn exists(&self, key: &str) -> BoxFuture<'_, Result<bool, StorageError>> {
+        let path = object_store::path::Path::from(key);
+
+        Box::pin(async move {
+            match self.store.head(&path).await {
+                Ok(_) => Ok(true),
+                Err(object_store::Error::NotFound { .. }) => Ok(false),
+                Err(e) => Err(StorageError::Internal(format!("S3 head failed: {e}"))),
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Build the blob storage backend from environment variables.
+///
+/// If `WADDLE_S3_ENDPOINT` is set, uses S3-compatible storage (requires
+/// `WADDLE_S3_BUCKET`, `WADDLE_S3_ACCESS_KEY_ID`, `WADDLE_S3_SECRET_ACCESS_KEY`).
+/// Otherwise falls back to local filesystem storage at `WADDLE_UPLOAD_DIR`
+/// (default: `./uploads`).
+pub fn build_blob_storage() -> Result<Arc<dyn BlobStorage>, StorageError> {
+    if let Ok(endpoint) = std::env::var("WADDLE_S3_ENDPOINT") {
+        let bucket = std::env::var("WADDLE_S3_BUCKET").map_err(|_| {
+            StorageError::Internal(
+                "WADDLE_S3_BUCKET is required when WADDLE_S3_ENDPOINT is set".into(),
+            )
+        })?;
+        let access_key = std::env::var("WADDLE_S3_ACCESS_KEY_ID").map_err(|_| {
+            StorageError::Internal(
+                "WADDLE_S3_ACCESS_KEY_ID is required when WADDLE_S3_ENDPOINT is set".into(),
+            )
+        })?;
+        let secret_key = std::env::var("WADDLE_S3_SECRET_ACCESS_KEY").map_err(|_| {
+            StorageError::Internal(
+                "WADDLE_S3_SECRET_ACCESS_KEY is required when WADDLE_S3_ENDPOINT is set".into(),
+            )
+        })?;
+
+        info!(
+            endpoint = %endpoint,
+            bucket = %bucket,
+            "Using S3-compatible blob storage"
+        );
+        Ok(Arc::new(S3Storage::new(
+            endpoint, bucket, access_key, secret_key,
+        )?))
+    } else {
+        let dir = std::env::var("WADDLE_UPLOAD_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("./uploads"));
+
+        info!(dir = %dir.display(), "Using local filesystem blob storage");
+        Ok(Arc::new(LocalStorage::new(dir)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn local_storage_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("waddle-blob-test-{}", uuid::Uuid::new_v4()));
+        let storage = LocalStorage::new(dir.clone());
+
+        let key = "test-slot/photo.jpg";
+        let data = bytes::Bytes::from_static(b"fake image data");
+
+        // Should not exist yet
+        assert!(!storage.exists(key).await.unwrap());
+
+        // Put
+        storage.put(key, data.clone(), "image/jpeg").await.unwrap();
+
+        // Exists
+        assert!(storage.exists(key).await.unwrap());
+
+        // Get
+        let (got_data, meta) = storage.get(key).await.unwrap();
+        assert_eq!(got_data, data);
+        assert_eq!(meta.content_type, "image/jpeg");
+
+        // Not found
+        let err = storage.get("nonexistent").await;
+        assert!(matches!(err, Err(StorageError::NotFound(_))));
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn dyn_dispatch_works() {
+        let dir = std::env::temp_dir().join(format!("waddle-blob-dyn-{}", uuid::Uuid::new_v4()));
+        let storage: Arc<dyn BlobStorage> = Arc::new(LocalStorage::new(dir.clone()));
+
+        let key = "dyn-test/file.txt";
+        let data = bytes::Bytes::from_static(b"hello");
+
+        storage.put(key, data.clone(), "text/plain").await.unwrap();
+        let (got, meta) = storage.get(key).await.unwrap();
+        assert_eq!(got, data);
+        assert_eq!(meta.content_type, "text/plain");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/server/crates/waddle-server/src/storage/mod.rs
+++ b/server/crates/waddle-server/src/storage/mod.rs
@@ -133,7 +133,11 @@ impl BlobStorage for LocalStorage {
 
     fn exists(&self, key: &str) -> BoxFuture<'_, Result<bool, StorageError>> {
         let path = self.data_path(key);
-        Box::pin(async move { Ok(path.exists()) })
+        Box::pin(async move {
+            tokio::fs::try_exists(&path)
+                .await
+                .map_err(|e| StorageError::Internal(format!("failed to check existence: {e}")))
+        })
     }
 }
 

--- a/server/env.cue
+++ b/server/env.cue
@@ -39,6 +39,7 @@ schema.#Project & {
 	env: environment: test: {
 		WADDLE_CERTS_EPHEMERAL:            "true"
 		WADDLE_TEST_FIXED_ACCOUNT_ENABLED: "true"
+		WADDLE_UPLOAD_DIR:                 "./uploads"
 	}
 
 	services: {


### PR DESCRIPTION
## Summary

- **BlobStorage trait** on the server abstracts file storage behind `LocalStorage` (filesystem) and `S3Storage` (Cloudflare R2 / S3-compatible), following the existing `MediaBackend` trait pattern
- **Drag-and-drop + paste** handlers in the chat client capture images and upload them via XEP-0363 HTTP File Upload
- **XEP-0447 compliant** file-sharing messages with XEP-0428 fallback indication and XEP-0066 OOB for interoperability
- **GitOps** wiring for R2 credentials via 1Password ExternalSecrets
- Local dev defaults to filesystem storage (`WADDLE_UPLOAD_DIR=./uploads`)

### Server changes
- `storage/mod.rs`: `BlobStorage` trait + `LocalStorage` + `S3Storage` implementations with factory
- `uploads.rs`: refactored to use `BlobStorage` trait instead of direct filesystem operations
- `AppState`: now holds `Arc<dyn BlobStorage>`
- Helm chart: `s3Endpoint`, `s3Bucket` config + `extraSecretRefs` for secret injection
- ExternalSecret for R2 credentials from 1Password (`waddle-server-files` item)

### Client changes
- `fallback.ts`: XEP-0428 Fallback Indication stanza extension
- `messaging.ts` / `dm-messaging.ts`: `sendGroupFileMessage` / `sendDirectFileMessage` with XEP-0447 + 0428 + 0066
- `client.ts`: upload service discovery caching + `uploadAndSendGroupFile/DirectFile`
- `useMessaging.ts` / `useDmMessaging.ts`: `uploadProgress` ref + `sendFileMessage()`
- `ContentArea.vue`: drag-and-drop overlay with visual drop zone
- `MessageComposer.vue`: clipboard paste handler + upload progress bar

## Test plan

- [x] `cargo test -p waddle-server -- storage uploads` — 11/11 pass
- [x] `cargo check` + `cargo fmt` clean
- [x] `astro build` succeeds
- [ ] Manual: paste screenshot in editor → progress bar → inline image
- [ ] Manual: drag image file over chat area → overlay → drop → upload
- [ ] Manual: test in DM conversation mode
- [ ] Manual: verify stanza XML contains `<file-sharing>`, `<fallback>`, `<x xmlns='jabber:x:oob'>`
- [ ] Staging: set `WADDLE_S3_*` env vars → verify files stored in R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)