### PR TITLE
fix(sfu): accept hostnames in WADDLE_SFU_CANDIDATE_ADDR

### DIFF
--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -3884,10 +3884,6 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         self.app_state.native_user_exists(node.as_str()).await
     }
 
-    /// Handle a disco#info query.
-    ///
-    /// Returns identity and supported features for:
-    /// - Server domain: Server identity + server features
     /// Handle a Jingle IQ addressed to the SFU component (`sfu.{domain}`).
     ///
     /// Forwards the IQ to the SfuServiceActor and sends the response back to

--- a/server/crates/waddle-xmpp/src/mam/query.rs
+++ b/server/crates/waddle-xmpp/src/mam/query.rs
@@ -194,7 +194,7 @@ pub fn build_result_messages(
 
 /// Build a single MAM result message.
 fn build_result_message(query_id: &str, to_jid: &str, archived: &ArchivedMessage) -> Message {
-    let inner_msg: Element = archived_inner_message(archived).into();
+    let inner_msg: Element = archived_inner_message(archived);
 
     // Build the delay element
     let delay = Element::builder("delay", DELAY_NS)

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -444,7 +444,7 @@ mod tests {
             .expect("create beta");
 
         let mut rooms: Vec<BareJid> = registry.ask(ListRooms).await.expect("list");
-        rooms.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+        rooms.sort_by_key(|a| a.to_string());
 
         assert_eq!(rooms.len(), 2);
         assert_eq!(rooms[0].to_string(), "alpha@muc.example.com");

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -261,7 +261,7 @@ mod tests {
 
         let mut users = registry.ask(ListUsers).await.expect("ask failed");
 
-        users.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+        users.sort_by_key(|a| a.to_string());
 
         assert_eq!(users.len(), 2);
         assert_eq!(users[0], bare("alice"));

--- a/server/crates/waddle-xmpp/src/sfu/net.rs
+++ b/server/crates/waddle-xmpp/src/sfu/net.rs
@@ -24,11 +24,15 @@ enum ForwardEvent {
         kind: MediaKind,
     },
     /// Media data received from a peer — forward to all others in the room.
+    ///
+    /// `MediaData` is boxed to keep `ForwardEvent` small: without this the
+    /// media variant dominates the enum size and every other variant pays the
+    /// cost (`clippy::large_enum_variant`).
     Media {
         source_sid: String,
         room_key: RoomKey,
         source_kind: MediaKind,
-        data: MediaData,
+        data: Box<MediaData>,
     },
     /// A peer requested a keyframe — forward to the source of that track.
     Keyframe {
@@ -191,7 +195,7 @@ pub async fn spawn_sfu_net_loop(
                                             source_sid: sid.clone(),
                                             room_key: peer_room_key.clone(),
                                             source_kind: kind,
-                                            data,
+                                            data: Box::new(data),
                                         });
                                     }
                                     Event::KeyframeRequest(req) => {

--- a/server/crates/waddle-xmpp/src/sfu/service_actor.rs
+++ b/server/crates/waddle-xmpp/src/sfu/service_actor.rs
@@ -38,13 +38,8 @@ impl SfuServiceActor {
 
     async fn resolve_candidate_addr(&self) -> SocketAddr {
         if let Ok(raw_addr) = std::env::var("WADDLE_SFU_CANDIDATE_ADDR") {
-            match raw_addr.parse::<SocketAddr>() {
-                Ok(candidate_addr) => return candidate_addr,
-                Err(err) => warn!(
-                    value = %raw_addr,
-                    error = %err,
-                    "Ignoring invalid WADDLE_SFU_CANDIDATE_ADDR"
-                ),
+            if let Some(candidate_addr) = Self::resolve_env_candidate(&raw_addr).await {
+                return candidate_addr;
             }
         }
 
@@ -90,6 +85,58 @@ impl SfuServiceActor {
             "Falling back to loopback SFU candidate address; set WADDLE_SFU_CANDIDATE_ADDR for production"
         );
         fallback
+    }
+
+    /// Parse `WADDLE_SFU_CANDIDATE_ADDR` as either an `ip:port` literal or a
+    /// `host:port` that resolves via DNS. Returns `None` for empty values or
+    /// when resolution yields no usable address (logging a warning in that
+    /// case), so callers can fall back to other discovery paths.
+    async fn resolve_env_candidate(raw_addr: &str) -> Option<SocketAddr> {
+        let trimmed = raw_addr.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        if let Ok(candidate_addr) = trimmed.parse::<SocketAddr>() {
+            return Some(candidate_addr);
+        }
+
+        match tokio::net::lookup_host(trimmed).await {
+            Ok(addresses) => {
+                let resolved: Vec<SocketAddr> = addresses
+                    .filter(|addr| {
+                        let ip = addr.ip();
+                        !ip.is_unspecified() && !ip.is_loopback()
+                    })
+                    .collect();
+                if let Some(addr) = resolved
+                    .iter()
+                    .copied()
+                    .find(|a| a.is_ipv4())
+                    .or_else(|| resolved.first().copied())
+                {
+                    info!(
+                        value = %trimmed,
+                        candidate = %addr,
+                        "Resolved WADDLE_SFU_CANDIDATE_ADDR via DNS"
+                    );
+                    return Some(addr);
+                }
+                warn!(
+                    value = %trimmed,
+                    "WADDLE_SFU_CANDIDATE_ADDR resolved but produced no usable addresses"
+                );
+                None
+            }
+            Err(err) => {
+                warn!(
+                    value = %trimmed,
+                    error = %err,
+                    "Failed to resolve WADDLE_SFU_CANDIDATE_ADDR; ignoring"
+                );
+                None
+            }
+        }
     }
 
     async fn handle_session_initiate(
@@ -323,5 +370,45 @@ mod tests {
         // Actor spawned successfully
         let key = RoomKey("test".to_string());
         assert!(registry.get_room(&key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_env_candidate_accepts_ip_literal() {
+        let addr = SfuServiceActor::resolve_env_candidate("198.51.100.7:30000").await;
+        assert_eq!(
+            addr,
+            Some("198.51.100.7:30000".parse().expect("valid addr"))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_env_candidate_trims_whitespace_around_ip_literal() {
+        let addr = SfuServiceActor::resolve_env_candidate("  198.51.100.7:30000  ").await;
+        assert_eq!(
+            addr,
+            Some("198.51.100.7:30000".parse().expect("valid addr"))
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_env_candidate_returns_none_for_empty() {
+        assert_eq!(SfuServiceActor::resolve_env_candidate("").await, None);
+        assert_eq!(SfuServiceActor::resolve_env_candidate("   ").await, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_env_candidate_returns_none_for_unresolvable_hostname() {
+        // RFC 2606 reserves .invalid for guaranteed non-resolution.
+        let addr = SfuServiceActor::resolve_env_candidate(
+            "definitely-not-a-real-host.waddle.invalid:30000",
+        )
+        .await;
+        assert_eq!(addr, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_env_candidate_returns_none_for_garbage() {
+        let addr = SfuServiceActor::resolve_env_candidate("not a socket addr").await;
+        assert_eq!(addr, None);
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0059.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0059.rs
@@ -708,8 +708,8 @@ mod tests {
         let response = RsmResponse::new().with_count(0);
         let elem = build_rsm_response_element(&response);
 
-        assert!(elem.children().find(|c| c.name() == "first").is_none());
-        assert!(elem.children().find(|c| c.name() == "last").is_none());
+        assert!(!elem.children().any(|c| c.name() == "first"));
+        assert!(!elem.children().any(|c| c.name() == "last"));
 
         let count = elem
             .children()

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -2,6 +2,13 @@
 //!
 //! Provides helpers for starting test servers, generating TLS certificates,
 //! and simulating XMPP client connections.
+//!
+//! Integration tests each compile as a standalone crate that re-includes this
+//! module, so helpers consumed by only some tests appear unused to the rest.
+//! Silence `dead_code` at module scope rather than fragmenting the shared
+//! helpers.
+
+#![allow(dead_code)]
 
 use std::io::{BufReader, Cursor};
 use std::net::SocketAddr;

--- a/server/crates/waddle-xmpp/tests/rfc6121_blocking_stanzas.rs
+++ b/server/crates/waddle-xmpp/tests/rfc6121_blocking_stanzas.rs
@@ -63,7 +63,7 @@ async fn rfc6121_s8_5_2_1_1_inbound_message_from_blocked_jid_dropped() {
         .expect("bind bob");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-1");
+    block_jid(&mut alice, "bob@localhost", "block-bob-1").await;
 
     // Bob sends message to Alice
     bob.send(
@@ -111,7 +111,7 @@ async fn rfc6121_s8_5_2_1_2_inbound_presence_from_blocked_jid_dropped() {
         .expect("bind bob");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-pres");
+    block_jid(&mut alice, "bob@localhost", "block-bob-pres").await;
 
     // Bob sends directed presence to Alice
     bob.send("<presence to='alice@localhost' xmlns='jabber:client'><status>Blocked presence</status></presence>")
@@ -152,7 +152,7 @@ async fn rfc6121_s8_5_2_1_3_inbound_iq_from_blocked_jid_returns_error() {
         .expect("bind bob");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-iq");
+    block_jid(&mut alice, "bob@localhost", "block-bob-iq").await;
 
     // Bob sends IQ to Alice
     bob.send(
@@ -198,7 +198,7 @@ async fn rfc6121_s8_5_3_2_1_outbound_message_to_blocked_jid_returns_error() {
         .expect("bind alice");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-out-msg");
+    block_jid(&mut alice, "bob@localhost", "block-bob-out-msg").await;
 
     // Alice tries to send message to blocked Bob
     alice
@@ -246,7 +246,7 @@ async fn rfc6121_s8_5_3_2_2_outbound_presence_to_blocked_jid_returns_error() {
         .expect("bind alice");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-out-pres");
+    block_jid(&mut alice, "bob@localhost", "block-bob-out-pres").await;
 
     // Alice sends directed presence to blocked Bob
     alice
@@ -294,7 +294,7 @@ async fn rfc6121_s8_5_3_2_3_outbound_iq_to_blocked_jid_returns_error() {
         .expect("bind alice");
 
     // Alice blocks Bob
-    block_jid(&mut alice, "bob@localhost", "block-bob-out-iq");
+    block_jid(&mut alice, "bob@localhost", "block-bob-out-iq").await;
 
     // Alice sends IQ to blocked Bob
     alice

--- a/server/crates/waddle-xmpp/tests/xep0199_ping.rs
+++ b/server/crates/waddle-xmpp/tests/xep0199_ping.rs
@@ -5,8 +5,7 @@
 mod common;
 
 use common::{
-    disco_info_query, establish_bound_session, init_test_env, ping_query, RawXmppClient,
-    TestServer, DEFAULT_TIMEOUT,
+    disco_info_query, establish_bound_session, init_test_env, ping_query, RawXmppClient, TestServer,
 };
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/tests/xep0202_entity_time.rs
+++ b/server/crates/waddle-xmpp/tests/xep0202_entity_time.rs
@@ -8,10 +8,7 @@
 
 mod common;
 
-use common::{
-    disco_info_query, establish_bound_session, init_test_env, RawXmppClient, TestServer,
-    DEFAULT_TIMEOUT,
-};
+use common::{establish_bound_session, init_test_env, RawXmppClient, TestServer, DEFAULT_TIMEOUT};
 
 #[tokio::test]
 async fn xep0202_time_query_to_server_returns_response() {

--- a/server/crates/waddle-xmpp/tests/xep0352_csi.rs
+++ b/server/crates/waddle-xmpp/tests/xep0352_csi.rs
@@ -4,10 +4,7 @@
 
 mod common;
 
-use common::{
-    disco_info_query, establish_bound_session, init_test_env, RawXmppClient, TestServer,
-    DEFAULT_TIMEOUT,
-};
+use common::{disco_info_query, establish_bound_session, init_test_env, RawXmppClient, TestServer};
 
 #[tokio::test]
 async fn xep0352_server_disco_advertises_csi() {


### PR DESCRIPTION
## Summary

- `WADDLE_SFU_CANDIDATE_ADDR` was parsed with `SocketAddr::from_str`, which only accepts IP literals. The production ConfigMap value `sfu.waddle.social:30000` was silently rejected, and the domain-resolution fallback reused the internal UDP bind port (`10000`) instead of the NodePort (`30000`). Clients received an unreachable ICE candidate and calls failed silently with no server-side error.
- Now resolves the env var via `tokio::net::lookup_host`, which accepts both `ip:port` literals and `host:port` hostnames while preserving the operator-specified port. Existing domain/loopback fallbacks kept for when the env var is unset.
- Incidentally clears pre-existing clippy/rustc debt in `waddle-xmpp` so `cargo clippy -p waddle-xmpp --all-targets -- -D warnings` is clean again (stale doc block, `sort_by`→`sort_by_key`, `large_enum_variant` box, useless `.into()`, `find(..).is_none()`→`!any(..)`, unused imports, module-scope `#![allow(dead_code)]` on shared test helpers).
- Also fixes a real latent bug: 6 `block_jid(...)` calls in `rfc6121_blocking_stanzas.rs` were never `.await`ed, so the block IQ was never sent — the tests passed because assertions didn't distinguish blocked from unblocked state. Worth a follow-up to verify those assertions actually fail without `.await` once the bug is fixed.

## What this does NOT do

- Does **not** guarantee end-to-end WebRTC calls work. It fixes the specific candidate-port advertisement bug seen in logs. Whether ICE actually completes depends on K8s NodePort UDP behavior (`externalTrafficPolicy`, kube-proxy SNAT for return traffic) — verify with `chrome://webrtc-internals` and `tcpdump -i any -n 'udp port 30000'` on the SFU node during a test call.
- Does **not** touch chart values. Existing `WADDLE_SFU_CANDIDATE_ADDR: sfu.waddle.social:30000` is now valid as-is.
- Does **not** touch `WADDLE_MEDIA_BACKEND` (separate HTTP media-session API path; disabled is correct for Jingle-native SFU).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p waddle-xmpp --all-targets -- -D warnings` clean
- [x] `cargo test -p waddle-xmpp` — all tests pass, including 5 new `resolve_env_candidate_*` unit tests
- [ ] Deploy to cluster; bump `RUST_LOG=waddle_xmpp=debug` temporarily; confirm startup log shows `Resolved WADDLE_SFU_CANDIDATE_ADDR via DNS ... candidate=51.159.109.202:30000` (not `:10000`)
- [ ] Initiate a test call; confirm `Dispatching Jingle IQ action=session-initiate` appears in logs; check `chrome://webrtc-internals` for ICE `Selected candidate pair` completion