### PR TITLE
fix(chat): improve connection reliability and composer ergonomics

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from "vue";
-import { Check, CheckCheck, Pencil, SmilePlus, Trash2, FileDown } from "lucide-vue-next";
+import { Pencil, SmilePlus, Trash2, FileDown } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import { renderStyledBody, isImageUrl, type TimelineMessage, type MarkupSpan } from "@/lib/chat-ui";
@@ -142,6 +142,7 @@ watch(
     class="group relative flex gap-3 px-3 py-1.5 rounded-xl transition-all duration-200 animate-message-in"
     :class="[
       isMentioned ? 'bg-warning/5 border-l-2 border-warning/30' : 'hover:bg-muted/40',
+      message.deliveryStatus === 'sending' ? 'opacity-50' : '',
     ]"
   >
     <button
@@ -165,13 +166,6 @@ watch(
           {{ formatStamp(message.createdAt) }}
         </span>
         <span v-if="message.isEdited" class="text-[11px] text-muted-foreground/50">(edited)</span>
-        <span
-          v-if="message.isSelf && message.deliveryStatus"
-          class="text-[11px] text-muted-foreground flex items-center gap-0.5"
-        >
-          <Check v-if="message.deliveryStatus === 'sending'" class="w-3 h-3" />
-          <CheckCheck v-else-if="message.deliveryStatus === 'delivered'" class="w-3 h-3 text-primary" />
-        </span>
         <span
           v-if="message.isSelf && message.readBy && message.readBy.length > 0"
           class="text-[11px] text-muted-foreground/50"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
-import { ref, computed, watch } from "vue";
-import { Send, Image } from "lucide-vue-next";
+import { ref, computed, watch, onBeforeUnmount } from "vue";
+import { Send, Image, X } from "lucide-vue-next";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
-import { extractImageFromEvent } from "@/lib/xmpp/file-upload";
+import { extractImagesFromEvent } from "@/lib/xmpp/file-upload";
 import type { MarkupSpan } from "@/lib/chat-ui";
+
+interface PendingAttachment {
+  id: string;
+  file: File | Blob;
+  previewUrl: string;
+  name: string;
+}
 
 const draft = defineModel<string>("draft", { required: true });
 
@@ -37,6 +44,33 @@ const editorRef = ref<InstanceType<typeof ChatEditor> | null>(null);
 const setEditorRef = (instance: InstanceType<typeof ChatEditor> | null) => {
   editorRef.value = instance;
 };
+
+const pendingAttachments = ref<PendingAttachment[]>([]);
+
+function addAttachments(files: Array<File | Blob>) {
+  for (const file of files) {
+    const name = file instanceof File ? file.name : `image-${Date.now()}.png`;
+    pendingAttachments.value = [
+      ...pendingAttachments.value,
+      {
+        id: crypto.randomUUID(),
+        file,
+        name,
+        previewUrl: URL.createObjectURL(file),
+      },
+    ];
+  }
+}
+
+function removeAttachment(id: string) {
+  const found = pendingAttachments.value.find((a) => a.id === id);
+  if (found) URL.revokeObjectURL(found.previewUrl);
+  pendingAttachments.value = pendingAttachments.value.filter((a) => a.id !== id);
+}
+
+onBeforeUnmount(() => {
+  for (const a of pendingAttachments.value) URL.revokeObjectURL(a.previewUrl);
+});
 
 /** Get the underlying TipTap Editor instance from the ChatEditor ref. */
 function getTiptapEditor() {
@@ -72,8 +106,8 @@ const activeResults = computed(() => {
   return [];
 });
 
-/** Whether the editor content is empty (for send button disabled state). */
-const isEmpty = computed(() => !draft.value.trim());
+/** Whether the composer has nothing sendable (no text and no pending attachments). */
+const isEmpty = computed(() => !draft.value.trim() && pendingAttachments.value.length === 0);
 
 function onEditorUpdate(doc: Record<string, unknown>) {
   // Keep draft in sync as a plain text representation
@@ -169,8 +203,24 @@ function onSend(doc: Record<string, unknown>) {
   }
 
   const serialized = serializeTiptapToXep0393(doc as any);
-  if (!serialized.body.trim()) return;
-  emit("send", serialized.body, serialized.markup);
+  const text = serialized.body.trim();
+  const attachments = pendingAttachments.value;
+
+  if (!text && attachments.length === 0) return;
+
+  // Detach attachments before emitting so re-entry (e.g. Enter burst) cannot
+  // double-send them. Revoke preview URLs after the parent has consumed files.
+  if (attachments.length > 0) {
+    pendingAttachments.value = [];
+    for (const a of attachments) {
+      emit("fileUpload", a.file);
+      URL.revokeObjectURL(a.previewUrl);
+    }
+  }
+
+  if (text) {
+    emit("send", serialized.body, serialized.markup);
+  }
 }
 
 function onEditorCancel() {
@@ -214,10 +264,10 @@ function onGifSelected(url: string) {
 }
 
 function onPaste(e: ClipboardEvent) {
-  const file = extractImageFromEvent(e);
-  if (file) {
+  const files = extractImagesFromEvent(e);
+  if (files.length > 0) {
     e.preventDefault();
-    emit("fileUpload", file);
+    addAttachments(files);
   }
 }
 
@@ -234,6 +284,32 @@ watch(
 
 <template>
   <div class="relative px-4 py-3 flex-shrink-0" @keydown="onKeydown" @paste="onPaste">
+    <!-- Pending attachment previews -->
+    <div
+      v-if="pendingAttachments.length > 0"
+      class="flex flex-wrap gap-2 mb-2 animate-fade-in"
+    >
+      <div
+        v-for="att in pendingAttachments"
+        :key="att.id"
+        class="relative group/att rounded-xl border border-border bg-muted overflow-hidden"
+      >
+        <img
+          :src="att.previewUrl"
+          :alt="att.name"
+          class="h-20 w-20 object-cover"
+        />
+        <button
+          type="button"
+          class="absolute top-1 right-1 h-5 w-5 flex items-center justify-center rounded-full bg-background/90 text-muted-foreground hover:text-destructive border border-border shadow-sm opacity-0 group-hover/att:opacity-100 focus:opacity-100 transition-opacity"
+          :title="`Remove ${att.name}`"
+          @click="removeAttachment(att.id)"
+        >
+          <X class="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+
     <!-- Upload progress bar -->
     <div
       v-if="uploadProgress.uploading"

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -150,6 +150,9 @@ export class BrowserXmppClient {
   private roomSwitchPromise: Promise<void> | null = null;
   private roomSwitchTarget: string | null = null;
   private selfPingTimer: ReturnType<typeof setInterval> | null = null;
+  private keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+  private visibilityListener: (() => void) | null = null;
+  private onlineListener: (() => void) | null = null;
   private roomHats: RoomHats = {};
   private roomPresence: RoomPresence = {};
   private uploadServiceJid: string | null = null;
@@ -260,6 +263,7 @@ export class BrowserXmppClient {
       try { await this.xmpp.leaveRoom(currentRoom, this.session.username); } catch { /* best-effort */ }
     }
     this.stopSelfPing();
+    this.stopKeepAlive();
     const xmpp = this.xmpp;
     this.xmpp = null;
     this.connectPromise = null;
@@ -577,10 +581,68 @@ export class BrowserXmppClient {
     catch { this.roomDisconnectHandler?.(); }
   }
 
+  /**
+   * Keep the websocket alive in the background by pinging the server every
+   * 30s. Also triggers an immediate ping when the tab becomes visible or the
+   * browser regains network, so users who return to a backgrounded tab aren't
+   * silently disconnected.
+   */
+  private startKeepAlive() {
+    this.stopKeepAlive();
+    this.keepAliveTimer = setInterval(() => { void this.pingServer(); }, 30_000);
+
+    if (typeof document !== "undefined") {
+      this.visibilityListener = () => {
+        if (document.visibilityState === "visible") void this.pingServer();
+      };
+      document.addEventListener("visibilitychange", this.visibilityListener);
+    }
+    if (typeof window !== "undefined") {
+      this.onlineListener = () => { void this.pingServer(); };
+      window.addEventListener("online", this.onlineListener);
+    }
+  }
+
+  private stopKeepAlive() {
+    if (this.keepAliveTimer) {
+      clearInterval(this.keepAliveTimer);
+      this.keepAliveTimer = null;
+    }
+    if (this.visibilityListener && typeof document !== "undefined") {
+      document.removeEventListener("visibilitychange", this.visibilityListener);
+      this.visibilityListener = null;
+    }
+    if (this.onlineListener && typeof window !== "undefined") {
+      window.removeEventListener("online", this.onlineListener);
+      this.onlineListener = null;
+    }
+  }
+
+  private async pingServer() {
+    const xmpp = this.xmpp;
+    if (!xmpp || !this.connected || this.destroying) return;
+    const domain = this.session.jid.split("@")[1];
+    if (!domain) return;
+    try {
+      await Promise.race([
+        xmpp.sendIQ({ type: "get", to: domain, ping: true } as Parameters<Agent["sendIQ"]>[0]),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("ping timeout")), 10_000)),
+      ]);
+    } catch (err) {
+      // Server-side XMPP errors (e.g. service-unavailable) mean the connection
+      // is alive — don't tear it down.
+      if (xmppErrorCondition(err)) return;
+      // Transport-level failure — drop the socket so autoReconnect re-opens it.
+      if (this.xmpp !== xmpp) return;
+      try { xmpp.disconnect(); } catch { /* ignore */ }
+    }
+  }
+
   private wireEvents(xmpp: Agent) {
     xmpp.on("session:started", async () => {
       if (this.xmpp !== xmpp) return;
       this.connected = true;
+      this.startKeepAlive();
       this.statusHandler?.({ state: "online", detail: "Connection ready" });
       try {
         await xmpp.enableCarbons();
@@ -621,6 +683,7 @@ export class BrowserXmppClient {
       this.connected = false;
       this.connectPromise = null;
       this.stopSelfPing();
+      this.stopKeepAlive();
 
       if (this.destroying) {
         // Intentional disconnect — full cleanup

--- a/chat/src/lib/xmpp/file-upload.ts
+++ b/chat/src/lib/xmpp/file-upload.ts
@@ -136,24 +136,32 @@ export async function uploadFile(
  * Returns null if no image is found.
  */
 export function extractImageFromEvent(event: ClipboardEvent | DragEvent): File | null {
+  const all = extractImagesFromEvent(event);
+  return all[0] ?? null;
+}
+
+/** Extract every image from a paste or drop event. */
+export function extractImagesFromEvent(event: ClipboardEvent | DragEvent): File[] {
+  const out: File[] = [];
   if (event instanceof ClipboardEvent) {
     const items = event.clipboardData?.items;
-    if (!items) return null;
+    if (!items) return out;
     for (let i = 0; i < items.length; i++) {
       if (items[i].type.startsWith("image/")) {
-        return items[i].getAsFile();
+        const f = items[i].getAsFile();
+        if (f) out.push(f);
       }
     }
   } else if (event instanceof DragEvent) {
     const files = event.dataTransfer?.files;
-    if (!files) return null;
+    if (!files) return out;
     for (let i = 0; i < files.length; i++) {
       if (files[i].type.startsWith("image/")) {
-        return files[i];
+        out.push(files[i]);
       }
     }
   }
-  return null;
+  return out;
 }
 
 function parseSlotResponse(response: any): SlotInfo {


### PR DESCRIPTION
- Ping the XMPP server every 30s (and on tab visibility/online events) so
  the websocket doesn't silently die in a backgrounded tab. If the ping
  fails at the transport layer, drop the socket so stanza autoReconnect
  re-opens it.
- Drop the send/delivered tick icons; dim self-sent messages at 50% opacity
  until the server echo confirms delivery, then undim.
- Stage pasted images in a previewable tray with per-image remove buttons.
  Users can paste multiple images, keep typing, and fire everything when
  they hit send instead of each paste shooting off immediately.