### PR TITLE
fix(chat): address PR #105 review nits

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -48,18 +48,17 @@ const setEditorRef = (instance: InstanceType<typeof ChatEditor> | null) => {
 const pendingAttachments = ref<PendingAttachment[]>([]);
 
 function addAttachments(files: Array<File | Blob>) {
+  const next = pendingAttachments.value.slice();
   for (const file of files) {
     const name = file instanceof File ? file.name : `image-${Date.now()}.png`;
-    pendingAttachments.value = [
-      ...pendingAttachments.value,
-      {
-        id: crypto.randomUUID(),
-        file,
-        name,
-        previewUrl: URL.createObjectURL(file),
-      },
-    ];
+    next.push({
+      id: crypto.randomUUID(),
+      file,
+      name,
+      previewUrl: URL.createObjectURL(file),
+    });
   }
+  pendingAttachments.value = next;
 }
 
 function removeAttachment(id: string) {
@@ -303,9 +302,10 @@ watch(
           type="button"
           class="absolute top-1 right-1 h-5 w-5 flex items-center justify-center rounded-full bg-background/90 text-muted-foreground hover:text-destructive border border-border shadow-sm opacity-0 group-hover/att:opacity-100 focus:opacity-100 transition-opacity"
           :title="`Remove ${att.name}`"
+          :aria-label="`Remove attachment ${att.name}`"
           @click="removeAttachment(att.id)"
         >
-          <X class="w-3 h-3" />
+          <X class="w-3 h-3" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -623,10 +623,14 @@ export class BrowserXmppClient {
     if (!xmpp || !this.connected || this.destroying) return;
     const domain = this.session.jid.split("@")[1];
     if (!domain) return;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     try {
+      const timeout = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error("ping timeout")), 10_000);
+      });
       await Promise.race([
         xmpp.sendIQ({ type: "get", to: domain, ping: true } as Parameters<Agent["sendIQ"]>[0]),
-        new Promise((_, reject) => setTimeout(() => reject(new Error("ping timeout")), 10_000)),
+        timeout,
       ]);
     } catch (err) {
       // Server-side XMPP errors (e.g. service-unavailable) mean the connection
@@ -635,6 +639,8 @@ export class BrowserXmppClient {
       // Transport-level failure — drop the socket so autoReconnect re-opens it.
       if (this.xmpp !== xmpp) return;
       try { xmpp.disconnect(); } catch { /* ignore */ }
+    } finally {
+      if (timeoutHandle !== null) clearTimeout(timeoutHandle);
     }
   }
 


### PR DESCRIPTION
Follow-up to #105 addressing three review comments from the Copilot reviewer.

## Summary
- **`pingServer()` timer leak** — the 10s `setTimeout` inside `Promise.race` was never cancelled when the IQ resolved first. Now tracked and cleared in a `finally`.
- **`addAttachments()` O(n²)** — the loop rebuilt `pendingAttachments.value` via spread on every iteration. Now builds a single array and assigns once.
- **Attachment remove button a11y** — icon-only button had only `title`. Added `aria-label` and `aria-hidden` on the icon so screen readers announce it.

## Test plan
- [ ] Paste an image, confirm the Remove button is announced correctly under VoiceOver/NVDA.
- [ ] Paste multiple images in one clipboard event — preview tray updates once.
- [ ] Leave chat tab open for ~1 minute, confirm no growing number of pending timers in devtools.

https://claude.ai/code/session_01GrtHaAk96sSkbPBNhXTgc9