### PR TITLE
feat: expose web+server commit SHA in chat sidebar

### DIFF
--- a/XEPS.md
+++ b/XEPS.md
@@ -144,7 +144,7 @@ XEPs for group chat, channels, and organizational structure (the core of a commu
 | **0012** | **Last Activity** | Final | "Last seen" | Implemented | Chat N/A |
 | **0054** | **vcard-temp** | Active | User profiles (legacy) |
 | **0084** | **User Avatar** | Draft | Profile pictures |
-| 0092 | Software Version | Draft | Client identification |
+| **0092** | **Software Version** | Draft | Client identification | Implemented | Chat ✓ |
 | 0107 | User Mood | Draft | Status moods |
 | 0108 | User Activity | Draft | Custom activity status |
 | **0153** | **vCard-Based Avatars** | Active | Avatar via vCard |

--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -1,8 +1,23 @@
+import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@astrojs/vue";
+
+function resolveCommitSha() {
+  const envSha = process.env.WADDLE_GIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA;
+  if (envSha && envSha.trim().length > 0) return envSha.trim().slice(0, 12);
+  try {
+    return execSync("git rev-parse --short=12 HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+const COMMIT_SHA = resolveCommitSha();
 
 export default defineConfig({
   output: "server",
@@ -14,6 +29,9 @@ export default defineConfig({
 
   vite: {
     plugins: [tailwindcss()],
+    define: {
+      "import.meta.env.PUBLIC_COMMIT_SHA": JSON.stringify(COMMIT_SHA),
+    },
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -7,6 +7,7 @@ import { useDmMessaging } from "@/composables/useDmMessaging";
 import { useMessaging } from "@/composables/useMessaging";
 import { useUiState } from "@/composables/useUiState";
 import { useNotifications } from "@/composables/useNotifications";
+import { useVersion } from "@/composables/useVersion";
 import { parseRoute, pushDmRoute, pushRoute, resolveWaddle, resolveChannel } from "@/composables/useRouting";
 import { barePeerJid } from "@/lib/xmpp-client";
 import { connectionStore } from "@/lib/connection-store";
@@ -147,6 +148,7 @@ const activeDmPeer = computed(() => {
 });
 
 const notifications = useNotifications();
+const version = useVersion(xmppClient);
 const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
   const avatars: Record<string, string | null> = {};
 
@@ -648,6 +650,8 @@ onUnmounted(() => {
             :active-sidebar-mode="ui.sidebarMode.value"
             :has-unread-dms="dmConversations.hasUnread.value"
             :session="null"
+            :web-commit-sha="version.webCommitSha.value"
+            :server-version="version.serverVersion.value"
             horizontal
             @select-waddle="selectWaddle($event)"
             @toggle-dms="ui.sidebarMode.value = 'dms'"
@@ -734,6 +738,8 @@ onUnmounted(() => {
           :session="connectionStore.session"
           :notification-permission="notifications.permissionState.value"
           :notifications-enabled="notifications.notificationsEnabled.value"
+          :web-commit-sha="version.webCommitSha.value"
+          :server-version="version.serverVersion.value"
           @select-waddle="selectWaddle($event)"
           @toggle-dms="ui.sidebarMode.value = 'dms'"
           @browse-public-waddles="openBrowsePublicWaddles"

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -3,6 +3,8 @@ import { computed } from "vue";
 import { Plus, Lock, Compass, MessageCircle } from "lucide-vue-next";
 import type { WaddleSummary } from "@/lib/waddle-api";
 import type { WaddleSession } from "@/lib/server-auth";
+import type { ServerVersion } from "@/composables/useVersion";
+import { extractServerSha } from "@/composables/useVersion";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 
 const props = defineProps<{
@@ -14,7 +16,16 @@ const props = defineProps<{
   notificationPermission?: NotificationPermission;
   notificationsEnabled?: boolean;
   horizontal?: boolean;
+  webCommitSha?: string;
+  serverVersion?: ServerVersion | null;
 }>();
+
+const webShortSha = computed(() => (props.webCommitSha ?? "unknown").slice(0, 7));
+const serverShortSha = computed(() => {
+  const sha = extractServerSha(props.serverVersion ?? null);
+  if (sha) return sha.slice(0, 7);
+  return props.serverVersion?.version ?? "…";
+});
 
 const emit = defineEmits<{
   selectWaddle: [id: string];
@@ -183,5 +194,25 @@ function waddleColor(waddle: WaddleSummary): string {
       @request-notifications="emit('request-notifications')"
       @toggle-notifications="emit('toggle-notifications')"
     />
+
+    <!-- Version / credits footer -->
+    <div
+      v-if="!horizontal"
+      class="flex flex-col items-center gap-0.5 text-[9px] leading-tight text-muted-foreground/60 select-text"
+      :title="`web ${webCommitSha ?? 'unknown'}\nserver ${serverVersion?.version ?? 'unknown'}`"
+    >
+      <span class="font-mono">w {{ webShortSha }}</span>
+      <span class="font-mono">s {{ serverShortSha }}</span>
+      <span aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+    </div>
+    <div
+      v-else
+      class="ml-auto flex items-center gap-2 text-[10px] text-muted-foreground/70 select-text"
+      :title="`web ${webCommitSha ?? 'unknown'}\nserver ${serverVersion?.version ?? 'unknown'}`"
+    >
+      <span class="font-mono">web {{ webShortSha }}</span>
+      <span class="font-mono">srv {{ serverShortSha }}</span>
+      <span aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+    </div>
   </div>
 </template>

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -203,7 +203,7 @@ function waddleColor(waddle: WaddleSummary): string {
     >
       <span class="font-mono">w {{ webShortSha }}</span>
       <span class="font-mono">s {{ serverShortSha }}</span>
-      <span aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      <span role="img" aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
     </div>
     <div
       v-else
@@ -212,7 +212,7 @@ function waddleColor(waddle: WaddleSummary): string {
     >
       <span class="font-mono">web {{ webShortSha }}</span>
       <span class="font-mono">srv {{ serverShortSha }}</span>
-      <span aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      <span role="img" aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
     </div>
   </div>
 </template>

--- a/chat/src/composables/useVersion.ts
+++ b/chat/src/composables/useVersion.ts
@@ -22,7 +22,12 @@ export function useVersion(xmppClient: Ref<BrowserXmppClient | null>) {
   watch(
     xmppClient,
     (client) => {
-      if (!client || client === fetchedForClient) return;
+      if (!client) {
+        fetchedForClient = null;
+        serverVersion.value = null;
+        return;
+      }
+      if (client === fetchedForClient) return;
       fetchedForClient = client;
       void client.getServerVersion().then((info) => {
         if (fetchedForClient === client) {

--- a/chat/src/composables/useVersion.ts
+++ b/chat/src/composables/useVersion.ts
@@ -1,0 +1,44 @@
+import { ref, watch, type Ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+
+const WEB_COMMIT_SHA = (import.meta.env.PUBLIC_COMMIT_SHA ?? "unknown").trim() || "unknown";
+
+export interface ServerVersion {
+  name?: string;
+  version?: string;
+  os?: string;
+}
+
+/**
+ * Expose the web app's build-time commit SHA and the server's XEP-0092
+ * software version so the sidebar can make deployment state visible.
+ */
+export function useVersion(xmppClient: Ref<BrowserXmppClient | null>) {
+  const webCommitSha = ref(WEB_COMMIT_SHA);
+  const serverVersion = ref<ServerVersion | null>(null);
+
+  let fetchedForClient: BrowserXmppClient | null = null;
+
+  watch(
+    xmppClient,
+    (client) => {
+      if (!client || client === fetchedForClient) return;
+      fetchedForClient = client;
+      void client.getServerVersion().then((info) => {
+        if (fetchedForClient === client) {
+          serverVersion.value = info;
+        }
+      });
+    },
+    { immediate: true },
+  );
+
+  return { webCommitSha, serverVersion };
+}
+
+/** Extract a short commit SHA from a server version string like "0.1.0 (abc123def456)". */
+export function extractServerSha(version: ServerVersion | null): string | null {
+  if (!version?.version) return null;
+  const match = version.version.match(/\(([0-9a-f]{6,})\)/i);
+  return match ? match[1] : null;
+}

--- a/chat/src/env.d.ts
+++ b/chat/src/env.d.ts
@@ -1,2 +1,10 @@
 /// <reference types="astro/client" />
 /// <reference path="../worker-configuration.d.ts" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_COMMIT_SHA: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -560,6 +560,26 @@ export class BrowserXmppClient {
       ? discovery.discoverWaddles(this.xmpp, this.session.jid)
       : [];
   }
+
+  /**
+   * XEP-0092 Software Version — ask the user's home server what it is running.
+   * Returns null if the query fails (e.g. federation, timeout, feature not
+   * supported by a third-party server).
+   */
+  async getServerVersion(): Promise<{ name?: string; version?: string; os?: string } | null> {
+    await this.connect();
+    if (!this.xmpp) return null;
+    const domain = this.session.jid.split("@")[1];
+    if (!domain) return null;
+    try {
+      return await this.xmpp.getSoftwareVersion(domain);
+    } catch (err) {
+      if (!isOptionalXmppFeatureError(err)) {
+        console.warn("Failed to query XEP-0092 software version", err);
+      }
+      return null;
+    }
+  }
   async discoverChannels(waddleId: string): Promise<DiscoveredChannel[]> {
     await this.connect();
     return this.xmpp

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 description = "Waddle Social - Native XMPP server library"
+build = "build.rs"
 
 [dependencies]
 # Core Runtime & Async

--- a/server/crates/waddle-xmpp/build.rs
+++ b/server/crates/waddle-xmpp/build.rs
@@ -1,0 +1,26 @@
+//! Build script that captures the git commit SHA at compile time so the
+//! server can advertise it through XEP-0092 Software Version.
+
+use std::process::Command;
+
+fn main() {
+    let sha = std::env::var("WADDLE_GIT_SHA")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            Command::new("git")
+                .args(["rev-parse", "--short=12", "HEAD"])
+                .output()
+                .ok()
+                .filter(|output| output.status.success())
+                .and_then(|output| String::from_utf8(output.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=WADDLE_GIT_SHA={sha}");
+    println!("cargo:rerun-if-env-changed=WADDLE_GIT_SHA");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+}

--- a/server/crates/waddle-xmpp/build.rs
+++ b/server/crates/waddle-xmpp/build.rs
@@ -21,6 +21,9 @@ fn main() {
 
     println!("cargo:rustc-env=WADDLE_GIT_SHA={sha}");
     println!("cargo:rerun-if-env-changed=WADDLE_GIT_SHA");
-    println!("cargo:rerun-if-changed=../../.git/HEAD");
-    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+    // The workspace root is three levels up from this crate
+    // (server/crates/waddle-xmpp/build.rs -> repo root).
+    println!("cargo:rerun-if-changed=../../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../../.git/refs/heads");
+    println!("cargo:rerun-if-changed=../../../.git/packed-refs");
 }

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -80,6 +80,7 @@ use crate::xep::xep0054::{
     build_empty_vcard_response, build_vcard_success, is_vcard_get, is_vcard_set,
 };
 use crate::xep::xep0077::RegistrationError;
+use crate::xep::xep0092::{build_version_response, is_version_query, SoftwareVersion};
 use crate::xep::xep0191::{
     build_block_push, build_blocking_error, build_blocking_success, build_blocklist_response,
     build_unblock_push, is_blocking_query, parse_blocking_request, BlockingRequest,
@@ -3724,6 +3725,11 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             return self.handle_ping(iq).await;
         }
 
+        // Check if this is a software version query (XEP-0092)
+        if is_version_query(&iq) {
+            return self.handle_version_query(iq).await;
+        }
+
         // Check if this is a last activity query (XEP-0012)
         if is_last_activity_query(&iq) {
             return self.handle_last_activity(iq).await;
@@ -4442,6 +4448,22 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
         // Default ping response (server or component)
         let response = build_ping_result(&iq);
+        self.stream.write_stanza(&Stanza::Iq(response)).await?;
+        Ok(())
+    }
+
+    /// Handle XEP-0092 Software Version query.
+    ///
+    /// Reports the server's name, version (package version + short git SHA),
+    /// and host OS so operators can verify what revision is deployed.
+    #[instrument(skip(self, iq), fields(iq_id = %iq.id))]
+    async fn handle_version_query(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
+        let info = SoftwareVersion {
+            name: "Waddle".to_string(),
+            version: format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("WADDLE_GIT_SHA")),
+            os: Some(std::env::consts::OS.to_string()),
+        };
+        let response = build_version_response(&iq, &info);
         self.stream.write_stanza(&Stanza::Iq(response)).await?;
         Ok(())
     }

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -167,6 +167,11 @@ impl Feature {
         Self::new("urn:xmpp:ping")
     }
 
+    /// XEP-0092 Software Version feature
+    pub fn software_version() -> Self {
+        Self::new("jabber:iq:version")
+    }
+
     /// XEP-0047 In-Band Bytestreams feature
     pub fn ibb() -> Self {
         Self::new("http://jabber.org/protocol/ibb")
@@ -450,6 +455,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::blocking(),
         Feature::last_activity(),
         Feature::ping(),
+        Feature::software_version(),
         Feature::server_info(),
         Feature::commands(),
         Feature::csi(),

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -13,6 +13,8 @@
 //!   sets via `<set>` elements with max, after, before, index, first, last, count.
 //! - **XEP-0085**: Chat State Notifications - Typing indicators and
 //!   conversational state (active, composing, paused, inactive, gone).
+//! - **XEP-0092**: Software Version - Name, version string (including
+//!   commit SHA), and host OS reported via `jabber:iq:version`.
 //! - **XEP-0184**: Message Delivery Receipts - Request and acknowledge
 //!   message delivery with `<request/>` and `<received/>` elements.
 //! - **XEP-0106**: JID Escaping - Escape/unescape special characters
@@ -133,6 +135,7 @@ pub mod xep0059;
 pub mod xep0077;
 pub mod xep0084;
 pub mod xep0085;
+pub mod xep0092;
 pub mod xep0106;
 pub mod xep0115;
 pub mod xep0153;
@@ -268,6 +271,11 @@ pub use xep0184::{
 };
 
 pub use xep0199::{build_ping_result, is_ping, NS_PING};
+
+pub use xep0092::{
+    build_version_element, build_version_response, is_version_query, parse_version_response,
+    SoftwareVersion, NS_VERSION,
+};
 
 pub use xep0106::{escape_node, is_escaped, needs_escaping, unescape_node, JidEscaping};
 

--- a/server/crates/waddle-xmpp/src/xep/xep0092.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0092.rs
@@ -1,0 +1,270 @@
+//! XEP-0092: Software Version
+//!
+//! Allows clients to query the server (or any entity) for its software
+//! name, version, and host operating system. Waddle uses this to expose
+//! the running commit SHA so operators can verify deployments.
+//!
+//! ## XML Format
+//!
+//! Query:
+//! ```xml
+//! <iq type='get' to='example.com' id='v-1'>
+//!   <query xmlns='jabber:iq:version'/>
+//! </iq>
+//! ```
+//!
+//! Response:
+//! ```xml
+//! <iq type='result' from='example.com' id='v-1'>
+//!   <query xmlns='jabber:iq:version'>
+//!     <name>Waddle</name>
+//!     <version>0.1.0 (abcdef123456)</version>
+//!     <os>Linux</os>
+//!   </query>
+//! </iq>
+//! ```
+
+use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
+
+/// Namespace for XEP-0092 Software Version.
+pub const NS_VERSION: &str = "jabber:iq:version";
+
+/// Parsed software version payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SoftwareVersion {
+    pub name: String,
+    pub version: String,
+    pub os: Option<String>,
+}
+
+/// Check if an IQ stanza is a software version query.
+pub fn is_version_query(iq: &Iq) -> bool {
+    matches!(&iq.payload, IqType::Get(elem) if elem.name() == "query" && elem.ns() == NS_VERSION)
+}
+
+/// Build a software version response element.
+pub fn build_version_element(info: &SoftwareVersion) -> Element {
+    let mut builder = Element::builder("query", NS_VERSION)
+        .append(
+            Element::builder("name", NS_VERSION)
+                .append(info.name.as_str())
+                .build(),
+        )
+        .append(
+            Element::builder("version", NS_VERSION)
+                .append(info.version.as_str())
+                .build(),
+        );
+
+    if let Some(os) = &info.os {
+        builder = builder.append(
+            Element::builder("os", NS_VERSION)
+                .append(os.as_str())
+                .build(),
+        );
+    }
+
+    builder.build()
+}
+
+/// Build a software version response IQ.
+pub fn build_version_response(original_iq: &Iq, info: &SoftwareVersion) -> Iq {
+    Iq {
+        from: original_iq.to.clone(),
+        to: original_iq.from.clone(),
+        id: original_iq.id.clone(),
+        payload: IqType::Result(Some(build_version_element(info))),
+    }
+}
+
+/// Parse a software version response back into a struct.
+pub fn parse_version_response(iq: &Iq) -> Option<SoftwareVersion> {
+    let elem = match &iq.payload {
+        IqType::Result(Some(elem)) if elem.name() == "query" && elem.ns() == NS_VERSION => elem,
+        _ => return None,
+    };
+
+    let name = elem
+        .children()
+        .find(|c| c.is("name", NS_VERSION))
+        .map(|c| c.text())?;
+
+    let version = elem
+        .children()
+        .find(|c| c.is("version", NS_VERSION))
+        .map(|c| c.text())?;
+
+    let os = elem
+        .children()
+        .find(|c| c.is("os", NS_VERSION))
+        .map(|c| c.text())
+        .filter(|s| !s.is_empty());
+
+    Some(SoftwareVersion { name, version, os })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_version_query() -> Iq {
+        let query_elem = Element::builder("query", NS_VERSION).build();
+        Iq {
+            from: Some("alice@example.com".parse().expect("valid jid")),
+            to: Some("example.com".parse().expect("valid jid")),
+            id: "v-1".to_string(),
+            payload: IqType::Get(query_elem),
+        }
+    }
+
+    fn sample_info() -> SoftwareVersion {
+        SoftwareVersion {
+            name: "Waddle".to_string(),
+            version: "0.1.0 (abcdef123456)".to_string(),
+            os: Some("Linux".to_string()),
+        }
+    }
+
+    #[test]
+    fn xep0092_positive_detects_version_get() {
+        let iq = make_version_query();
+        assert!(is_version_query(&iq));
+    }
+
+    #[test]
+    fn xep0092_negative_ignores_non_version_namespace() {
+        let other = Element::builder("query", "jabber:iq:roster").build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "v-ns".to_string(),
+            payload: IqType::Get(other),
+        };
+        assert!(!is_version_query(&iq));
+    }
+
+    #[test]
+    fn xep0092_negative_ignores_set_iq() {
+        let query = Element::builder("query", NS_VERSION).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "v-set".to_string(),
+            payload: IqType::Set(query),
+        };
+        assert!(!is_version_query(&iq));
+    }
+
+    #[test]
+    fn xep0092_negative_ignores_result_iq() {
+        let query = Element::builder("query", NS_VERSION).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "v-res".to_string(),
+            payload: IqType::Result(Some(query)),
+        };
+        assert!(!is_version_query(&iq));
+    }
+
+    #[test]
+    fn xep0092_positive_builds_response_with_expected_children() {
+        let query = make_version_query();
+        let info = sample_info();
+        let response = build_version_response(&query, &info);
+
+        assert_eq!(response.id, "v-1");
+        assert_eq!(response.from, query.to);
+        assert_eq!(response.to, query.from);
+
+        let IqType::Result(Some(elem)) = &response.payload else {
+            panic!("Expected Result payload");
+        };
+        assert_eq!(elem.name(), "query");
+        assert_eq!(elem.ns(), NS_VERSION);
+
+        let name = elem
+            .children()
+            .find(|c| c.is("name", NS_VERSION))
+            .expect("name");
+        assert_eq!(name.text(), "Waddle");
+
+        let version = elem
+            .children()
+            .find(|c| c.is("version", NS_VERSION))
+            .expect("version");
+        assert_eq!(version.text(), "0.1.0 (abcdef123456)");
+
+        let os = elem
+            .children()
+            .find(|c| c.is("os", NS_VERSION))
+            .expect("os");
+        assert_eq!(os.text(), "Linux");
+    }
+
+    #[test]
+    fn xep0092_positive_builds_response_without_os() {
+        let query = make_version_query();
+        let info = SoftwareVersion {
+            name: "Waddle".to_string(),
+            version: "0.1.0".to_string(),
+            os: None,
+        };
+        let response = build_version_response(&query, &info);
+
+        let IqType::Result(Some(elem)) = &response.payload else {
+            panic!("Expected Result payload");
+        };
+        assert!(elem.children().all(|c| !c.is("os", NS_VERSION)));
+    }
+
+    #[test]
+    fn xep0092_consistency_roundtrip_parse() {
+        let query = make_version_query();
+        let info = sample_info();
+        let response = build_version_response(&query, &info);
+
+        let parsed = parse_version_response(&response).expect("parseable");
+        assert_eq!(parsed, info);
+    }
+
+    #[test]
+    fn xep0092_negative_parse_rejects_get_iq() {
+        let query = make_version_query();
+        assert!(parse_version_response(&query).is_none());
+    }
+
+    #[test]
+    fn xep0092_negative_parse_requires_name_and_version() {
+        let incomplete = Element::builder("query", NS_VERSION)
+            .append(
+                Element::builder("name", NS_VERSION)
+                    .append("Waddle")
+                    .build(),
+            )
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "v-parse".to_string(),
+            payload: IqType::Result(Some(incomplete)),
+        };
+        assert!(parse_version_response(&iq).is_none());
+    }
+
+    #[test]
+    fn xep0092_consistency_namespace_constant() {
+        assert_eq!(NS_VERSION, "jabber:iq:version");
+    }
+
+    #[test]
+    fn xep0092_positive_response_swaps_to_from() {
+        let query = make_version_query();
+        let info = sample_info();
+        let response = build_version_response(&query, &info);
+
+        assert_eq!(response.from, query.to);
+        assert_eq!(response.to, query.from);
+    }
+}

--- a/server/crates/waddle-xmpp/tests/xep0092_software_version.rs
+++ b/server/crates/waddle-xmpp/tests/xep0092_software_version.rs
@@ -1,0 +1,121 @@
+#![recursion_limit = "256"]
+
+//! XEP-0092: Software Version dedicated integration suite.
+//!
+//! Verifies that the server both advertises `jabber:iq:version` in its
+//! disco#info features and answers version IQ queries with a result IQ
+//! carrying `<name/>` and `<version/>` children (with an optional `<os/>`).
+
+mod common;
+
+use common::{disco_info_query, establish_bound_session, init_test_env, RawXmppClient, TestServer};
+
+/// Send an XEP-0092 software version query and read a single IQ response.
+async fn version_query(client: &mut RawXmppClient, to: &str, id: &str) -> std::io::Result<String> {
+    client
+        .send(&format!(
+            "<iq type='get' id='{}' to='{}' xmlns='jabber:client'>\
+                <query xmlns='jabber:iq:version'/>\
+            </iq>",
+            id, to
+        ))
+        .await?;
+    client
+        .read_until(id, std::time::Duration::from_secs(5))
+        .await
+}
+
+#[tokio::test]
+async fn xep0092_server_disco_advertises_software_version() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    let response = disco_info_query(&mut client, "localhost", "version-disco-1")
+        .await
+        .expect("disco response");
+
+    assert!(
+        response.contains("jabber:iq:version"),
+        "Expected software version feature, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0092_version_query_returns_result_with_name_and_version() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    let response = version_query(&mut client, "localhost", "version-1")
+        .await
+        .expect("version response");
+
+    assert!(
+        response.contains("type='result'") || response.contains("type=\"result\""),
+        "Expected result IQ for version, got: {}",
+        response
+    );
+    assert!(
+        response.contains("<name"),
+        "Expected <name/> child in version response, got: {}",
+        response
+    );
+    assert!(
+        response.contains("<version"),
+        "Expected <version/> child in version response, got: {}",
+        response
+    );
+    assert!(
+        response.contains("Waddle"),
+        "Expected server name 'Waddle', got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0092_version_query_preserves_stanza_id() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    let response = version_query(&mut client, "localhost", "unique-version-42")
+        .await
+        .expect("version response");
+
+    assert!(
+        response.contains("unique-version-42"),
+        "Expected stanza id preserved in response, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0092_version_response_includes_os_element() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    let response = version_query(&mut client, "localhost", "version-os-1")
+        .await
+        .expect("version response");
+
+    assert!(
+        response.contains("<os"),
+        "Expected <os/> child in version response, got: {}",
+        response
+    );
+}


### PR DESCRIPTION
Adds XEP-0092 (Software Version) on the server, which reports the
package version plus the build-time git SHA (baked by build.rs and
overridable with $WADDLE_GIT_SHA). The chat client fetches it on
connect via stanza's getSoftwareVersion and the web app's own commit
SHA is injected at build time through Vite define. Both SHAs plus a
little "made in DE/NO/SCT" flag strip now live at the bottom of the
waddle rail so operators can tell at a glance what is deployed.

Includes dedicated Rust tests for XEP-0092 per the XEP test-suite rule.