### PR TITLE
fix(chat): keep sidebar footer on one line and label flag row

### DIFF
--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -203,16 +203,22 @@ function waddleColor(waddle: WaddleSummary): string {
     >
       <span class="font-mono">w {{ webShortSha }}</span>
       <span class="font-mono">s {{ serverShortSha }}</span>
-      <span role="img" aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      <span class="text-center leading-tight">
+        Made proudly in<br />
+        <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      </span>
     </div>
     <div
       v-else
-      class="ml-auto flex items-center gap-2 text-[10px] text-muted-foreground/70 select-text"
+      class="ml-auto flex items-center gap-2 shrink-0 whitespace-nowrap text-[10px] text-muted-foreground/70 select-text"
       :title="`web ${webCommitSha ?? 'unknown'}\nserver ${serverVersion?.version ?? 'unknown'}`"
     >
       <span class="font-mono">web {{ webShortSha }}</span>
       <span class="font-mono">srv {{ serverShortSha }}</span>
-      <span role="img" aria-label="Made in Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      <span class="flex items-center gap-1">
+        <span>Made proudly in</span>
+        <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+      </span>
     </div>
   </div>
 </template>


### PR DESCRIPTION
The horizontal WaddlesSidebar footer in the mobile nav drawer was
wrapping `web <sha>`, `srv <sha>`, and the three flag emoji onto
multiple lines, roughly doubling the bar's height. Add `shrink-0
whitespace-nowrap` to the horizontal version block so the waddle
rail absorbs narrow widths via its own `overflow-auto` instead of
pushing the credits into a wrap. Also prefix the flag row with
"Made proudly in" in both variants so the country emoji row is
self-explanatory.