### PR TITLE
fix(chat): pin version/credits footer to sidebar bottom

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -14,6 +14,7 @@ import { connectionStore } from "@/lib/connection-store";
 import LandingState from "@/components/chat/LandingState.vue";
 import LoginScreen from "@/components/chat/LoginScreen.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
+import VersionFooter from "@/components/chat/VersionFooter.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import ContentArea from "@/components/chat/ContentArea.vue";
@@ -650,8 +651,6 @@ onUnmounted(() => {
             :active-sidebar-mode="ui.sidebarMode.value"
             :has-unread-dms="dmConversations.hasUnread.value"
             :session="null"
-            :web-commit-sha="version.webCommitSha.value"
-            :server-version="version.serverVersion.value"
             horizontal
             @select-waddle="selectWaddle($event)"
             @toggle-dms="ui.sidebarMode.value = 'dms'"
@@ -692,6 +691,13 @@ onUnmounted(() => {
           @request-notifications="handleRequestNotifications"
           @toggle-notifications="handleToggleNotifications"
         />
+        <div class="mt-auto border-t border-border">
+          <VersionFooter
+            :web-commit-sha="version.webCommitSha.value"
+            :server-version="version.serverVersion.value"
+            layout="inline"
+          />
+        </div>
       </div>
     </AppDrawer>
 

--- a/chat/src/components/chat/VersionFooter.vue
+++ b/chat/src/components/chat/VersionFooter.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { extractServerSha, type ServerVersion } from "@/composables/useVersion";
+
+const props = defineProps<{
+  webCommitSha?: string;
+  serverVersion?: ServerVersion | null;
+  layout?: "stacked" | "inline";
+}>();
+
+const layout = computed(() => props.layout ?? "stacked");
+
+const webShortSha = computed(() => (props.webCommitSha ?? "unknown").slice(0, 7));
+const serverShortSha = computed(() => {
+  const sha = extractServerSha(props.serverVersion ?? null);
+  if (sha) return sha.slice(0, 7);
+  return props.serverVersion?.version ?? "…";
+});
+const tooltip = computed(
+  () => `web ${props.webCommitSha ?? "unknown"}\nserver ${props.serverVersion?.version ?? "unknown"}`,
+);
+</script>
+
+<template>
+  <div
+    v-if="layout === 'stacked'"
+    class="flex flex-col items-center gap-0.5 text-[9px] leading-tight text-muted-foreground/60 select-text"
+    :title="tooltip"
+  >
+    <span class="font-mono">w {{ webShortSha }}</span>
+    <span class="font-mono">s {{ serverShortSha }}</span>
+    <span class="text-center leading-tight">
+      Made proudly in<br />
+      <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+    </span>
+  </div>
+  <div
+    v-else
+    class="flex items-center justify-center gap-3 px-3 py-2 text-[10px] text-muted-foreground/70 select-text whitespace-nowrap"
+    :title="tooltip"
+  >
+    <span class="font-mono">web {{ webShortSha }}</span>
+    <span class="font-mono">srv {{ serverShortSha }}</span>
+    <span class="flex items-center gap-1">
+      <span>Made proudly in</span>
+      <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
+    </span>
+  </div>
+</template>

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -4,8 +4,8 @@ import { Plus, Lock, Compass, MessageCircle } from "lucide-vue-next";
 import type { WaddleSummary } from "@/lib/waddle-api";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { ServerVersion } from "@/composables/useVersion";
-import { extractServerSha } from "@/composables/useVersion";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
+import VersionFooter from "@/components/chat/VersionFooter.vue";
 
 const props = defineProps<{
   waddles: WaddleSummary[];
@@ -19,13 +19,6 @@ const props = defineProps<{
   webCommitSha?: string;
   serverVersion?: ServerVersion | null;
 }>();
-
-const webShortSha = computed(() => (props.webCommitSha ?? "unknown").slice(0, 7));
-const serverShortSha = computed(() => {
-  const sha = extractServerSha(props.serverVersion ?? null);
-  if (sha) return sha.slice(0, 7);
-  return props.serverVersion?.version ?? "…";
-});
 
 const emit = defineEmits<{
   selectWaddle: [id: string];
@@ -195,30 +188,11 @@ function waddleColor(waddle: WaddleSummary): string {
       @toggle-notifications="emit('toggle-notifications')"
     />
 
-    <!-- Version / credits footer -->
-    <div
+    <!-- Version / credits footer (vertical only; mobile drawer renders its own) -->
+    <VersionFooter
       v-if="!horizontal"
-      class="flex flex-col items-center gap-0.5 text-[9px] leading-tight text-muted-foreground/60 select-text"
-      :title="`web ${webCommitSha ?? 'unknown'}\nserver ${serverVersion?.version ?? 'unknown'}`"
-    >
-      <span class="font-mono">w {{ webShortSha }}</span>
-      <span class="font-mono">s {{ serverShortSha }}</span>
-      <span class="text-center leading-tight">
-        Made proudly in<br />
-        <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
-      </span>
-    </div>
-    <div
-      v-else
-      class="ml-auto flex items-center gap-2 shrink-0 whitespace-nowrap text-[10px] text-muted-foreground/70 select-text"
-      :title="`web ${webCommitSha ?? 'unknown'}\nserver ${serverVersion?.version ?? 'unknown'}`"
-    >
-      <span class="font-mono">web {{ webShortSha }}</span>
-      <span class="font-mono">srv {{ serverShortSha }}</span>
-      <span class="flex items-center gap-1">
-        <span>Made proudly in</span>
-        <span role="img" aria-label="Germany, Norway, and Scotland">🇩🇪🇳🇴🏴󠁧󠁢󠁳󠁣󠁴󠁿</span>
-      </span>
-    </div>
+      :web-commit-sha="webCommitSha"
+      :server-version="serverVersion"
+    />
   </div>
 </template>


### PR DESCRIPTION
The horizontal sidebar variant was cramming the commit SHAs and
"Made proudly in" credits inline with the waddle switcher buttons, taking
over the top rail on mobile. Extract a VersionFooter component and render
it at the bottom of the mobile nav drawer instead, while the desktop icon
rail keeps the stacked variant at its foot.

https://claude.ai/code/session_01RU1Xp6gfRLxE5BC7cETT6i