### PR TITLE
fix(chat): fit mobile drawer to iOS visible viewport

### DIFF
--- a/chat/src/components/ui/AppDrawer.vue
+++ b/chat/src/components/ui/AppDrawer.vue
@@ -12,14 +12,14 @@ function close() {
 <template>
   <Teleport to="body">
     <Transition name="drawer">
-      <div v-if="open" class="fixed inset-0 z-50">
-        <div class="fixed inset-0 bg-background/60 backdrop-blur-md animate-fade-in" @click="close" />
+      <div v-if="open" class="fixed top-0 left-0 right-0 z-50 h-[100dvh]">
+        <div class="absolute inset-0 bg-background/60 backdrop-blur-md animate-fade-in" @click="close" />
         <div
-          class="fixed inset-y-0 w-[min(88vw,22rem)] glass-panel border-border overflow-auto shadow-2xl"
+          class="absolute top-0 w-[min(88vw,22rem)] h-[100dvh] glass-panel border-border shadow-2xl flex flex-col"
           :class="side === 'left' ? 'left-0 border-r' : 'right-0 border-l'"
           @click.stop
         >
-          <div class="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b border-border glass-panel">
+          <div class="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-border glass-panel">
             <slot name="title" />
             <button
               class="p-1.5 rounded-lg hover:bg-muted transition-all duration-200"
@@ -28,7 +28,9 @@ function close() {
               <X class="w-4 h-4" />
             </button>
           </div>
-          <slot />
+          <div class="flex-1 min-h-0 overflow-auto">
+            <slot />
+          </div>
         </div>
       </div>
     </Transition>


### PR DESCRIPTION
## Summary
- Anchor the mobile nav drawer to `100dvh` instead of `inset-y-0` (=`100vh`) so iOS Safari no longer renders the bottom of the drawer behind the URL / tab bar, which was hiding the profile row and the "Made proudly in" footer.
- Split the drawer into a flex column (non-scrolling header + scrollable body) so channel lists still scroll internally while the footer stays pinned at the bottom.

## Test plan
- [ ] On iOS Safari (with browser chrome visible), open the nav drawer and confirm the profile row + version/credits footer are visible without scrolling.
- [ ] Verify channel list still scrolls inside the drawer when many channels are present.
- [ ] Desktop: drawer is unused on `lg:` but verify no regression by resizing down and reopening.

https://claude.ai/code/session_01RU1Xp6gfRLxE5BC7cETT6i