### PR TITLE
fix(chat): pin composer to dynamic viewport on mobile

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -641,7 +641,7 @@ onUnmounted(() => {
   />
 
   <!-- Ready -->
-  <div v-else class="h-screen flex flex-col bg-background">
+  <div v-else class="h-dvh flex flex-col bg-background">
     <!-- Mobile header -->
     <MobileHeader
       :waddle="waddles.currentWaddle.value"


### PR DESCRIPTION
Swap the app shell from h-screen (100vh) to h-dvh so the composer stays
at the bottom of the visible area when the mobile keyboard opens instead
of scrolling off the bottom of the viewport.

https://claude.ai/code/session_01DV7jrzufBN4SUkoXXEEXun