### PR TITLE
feat: support XEP-0461 replies, XEP-0428 fallback, XEP-0201 threads

### DIFF
--- a/XEPS.md
+++ b/XEPS.md
@@ -43,6 +43,7 @@ These are foundational XEPs required for a functioning XMPP implementation.
 | 0182 | Application-Specific Error Conditions | Active |
 | **0198** | **Stream Management** | Draft |
 | **0199** | **XMPP Ping** | Final |
+| **0201** | **Best Practices for Message Threads** | Active | Thread grouping for replies | Implemented | Chat ✓ |
 | **0202** | **Entity Time** | Final | Implemented | Chat N/A |
 | **0203** | **Delayed Delivery** | Final | Implemented | Chat N/A |
 | 0206 | XMPP Over BOSH | Draft |
@@ -92,9 +93,9 @@ XEPs for rich messaging features expected in a modern community app.
 | 0394 | Message Markup | Experimental | Structured text markup |
 | **0424** | **Message Retraction** | Proposed | Delete messages | Implemented | Chat ✓ |
 | **0425** | **Moderated Message Retraction** | Experimental | Mod-delete messages | Implemented | Chat ✓ |
-| 0428 | Fallback Indication | Experimental | Graceful degradation |
+| **0428** | **Fallback Indication** | Experimental | Graceful degradation | Implemented | Chat ✓ |
 | **0444** | **Message Reactions** | Experimental | Emoji reactions | Implemented | Chat ✓ |
-| **0461** | **Message Replies** | Experimental | Threaded replies |
+| **0461** | **Message Replies** | Experimental | Threaded replies | Implemented | Chat ✓ |
 | **0490** | **Message Displayed Synchronization** | Draft | Cross-device read state | Implemented | Chat N/A |
 | **0513** | **Explicit Mentions** | Experimental | @user / @role mentions | Implemented | Chat ✓ |
 | 0511 | Link Metadata | Experimental | Link previews / unfurling |

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -284,12 +284,17 @@ const activeUploadProgress = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
 );
 
-async function sendActiveMessage(body?: string, markup?: MarkupSpan[], files?: Array<File | Blob>) {
+async function sendActiveMessage(
+  body?: string,
+  markup?: MarkupSpan[],
+  files?: Array<File | Blob>,
+  replyTo?: { id: string; author: string; body?: string },
+) {
   if (ui.sidebarMode.value === "dms") {
-    await dmMessaging.sendMessage(body, markup, files);
+    await dmMessaging.sendMessage(body, markup, files, replyTo);
     return;
   }
-  await messaging.sendMessage(body, markup, files);
+  await messaging.sendMessage(body, markup, files, replyTo);
 }
 
 function notifyActiveComposing() {

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 import { Hash, MessageCircle, Settings, Search, X, Upload } from "lucide-vue-next";
+import { findMessageElementById } from "@/lib/message-targeting";
+import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { extractImagesFromEvent } from "@/lib/xmpp/file-upload";
 import type { ChannelSummary, WaddleSummary } from "@/lib/waddle-api";
 import type { TimelineMessage, MarkupSpan } from "@/lib/chat-ui";
@@ -73,13 +75,38 @@ function cancelReply() {
   replyingTo.value = null;
 }
 
+const replyJumpNotice = ref("");
+let replyJumpNoticeTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function clearReplyJumpNotice() {
+  if (replyJumpNoticeTimeout) {
+    clearTimeout(replyJumpNoticeTimeout);
+    replyJumpNoticeTimeout = null;
+  }
+  replyJumpNotice.value = "";
+}
+
+function showReplyJumpNotice(message: string) {
+  clearReplyJumpNotice();
+  replyJumpNotice.value = message;
+  replyJumpNoticeTimeout = setTimeout(() => {
+    replyJumpNotice.value = "";
+    replyJumpNoticeTimeout = null;
+  }, 2800);
+}
+
 function scrollToMessage(messageId: string) {
-  const el = messagesContainer.value?.querySelector(`[data-message-id="${messageId}"]`);
-  if (el instanceof HTMLElement) {
+  const el = findMessageElementById(messagesContainer.value, messageId);
+  const notice = getReplyJumpNotice(el instanceof HTMLElement);
+  if (!notice && el instanceof HTMLElement) {
+    clearReplyJumpNotice();
     el.scrollIntoView({ behavior: "smooth", block: "center" });
     el.classList.add("ring-2", "ring-primary/40");
     setTimeout(() => el.classList.remove("ring-2", "ring-primary/40"), 1400);
+    return;
   }
+
+  showReplyJumpNotice(notice);
 }
 
 function onSend(body: string, markup: MarkupSpan[], files?: Array<File | Blob>) {
@@ -106,6 +133,12 @@ const showSearch = ref(false);
 const searchInput = ref("");
 const avatarUrlByAuthor = computed(() => props.avatarUrlByAuthor ?? {});
 const popoverAuthor = ref<{ username: string; jid: string } | null>(null);
+const conversationScope = computed(() => [
+  props.sidebarMode ?? "channels",
+  props.waddle?.id ?? "",
+  props.channel?.id ?? "",
+  props.dmPeer?.peerJid ?? "",
+].join(":"));
 
 defineExpose({ messagesContainer });
 
@@ -182,6 +215,17 @@ watch(
   },
   { deep: true },
 );
+
+watch(conversationScope, () => {
+  cancelReply();
+  clearReplyJumpNotice();
+});
+
+onBeforeUnmount(() => {
+  if (replyJumpNoticeTimeout) {
+    clearTimeout(replyJumpNoticeTimeout);
+  }
+});
 </script>
 
 <template>
@@ -291,6 +335,15 @@ watch(
       class="px-6 py-2.5 bg-destructive/10 border-b border-destructive/20 text-[13px] text-destructive animate-fade-in"
     >
       <div>{{ actionError }}</div>
+    </div>
+    <div
+      v-if="replyJumpNotice"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="px-6 py-2 text-[12px] text-muted-foreground bg-muted/35 border-b border-border animate-fade-in"
+    >
+      {{ replyJumpNotice }}
     </div>
 
     <!-- Messages -->

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -40,7 +40,12 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  send: [body: string, markup: MarkupSpan[], files?: Array<File | Blob>];
+  send: [
+    body: string,
+    markup: MarkupSpan[],
+    files?: Array<File | Blob>,
+    replyTo?: { id: string; author: string; body?: string },
+  ];
   typing: [];
   selectGif: [url: string];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[]];
@@ -52,6 +57,42 @@ const emit = defineEmits<{
   clearSearch: [];
   openDm: [peerJid: string];
 }>();
+
+const replyingTo = ref<{ id: string; author: string; body?: string; preview?: string } | null>(null);
+
+function beginReply(message: TimelineMessage) {
+  const author = message.author;
+  replyingTo.value = {
+    id: message.id,
+    author,
+    ...(message.body ? { body: message.body, preview: message.body } : {}),
+  };
+}
+
+function cancelReply() {
+  replyingTo.value = null;
+}
+
+function scrollToMessage(messageId: string) {
+  const el = messagesContainer.value?.querySelector(`[data-message-id="${messageId}"]`);
+  if (el instanceof HTMLElement) {
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.classList.add("ring-2", "ring-primary/40");
+    setTimeout(() => el.classList.remove("ring-2", "ring-primary/40"), 1400);
+  }
+}
+
+function onSend(body: string, markup: MarkupSpan[], files?: Array<File | Blob>) {
+  const pending = replyingTo.value;
+  emit(
+    "send",
+    body,
+    markup,
+    files,
+    pending ? { id: pending.id, author: pending.author, ...(pending.body ? { body: pending.body } : {}) } : undefined,
+  );
+  replyingTo.value = null;
+}
 
 const messagesContainer = ref<HTMLDivElement | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
@@ -296,6 +337,8 @@ watch(
           @edit="(id, body, m) => emit('editMessage', id, body, m)"
           @retract="(id) => emit('retractMessage', id)"
           @react="(id, emoji) => emit('reactMessage', id, emoji)"
+          @reply="beginReply"
+          @scroll-to-message="scrollToMessage"
           @avatar-click="onAvatarClick"
         />
       </div>
@@ -328,7 +371,9 @@ watch(
       :member-names="memberNames"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
-      @send="(body, markup, files) => emit('send', body, markup, files)"
+      :replying-to="replyingTo"
+      @send="onSend"
+      @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="(url) => emit('selectGif', url)"
     />

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, watch } from "vue";
-import { Pencil, SmilePlus, Trash2, FileDown } from "lucide-vue-next";
+import { Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
@@ -41,6 +41,8 @@ const emit = defineEmits<{
   edit: [messageId: string, newBody: string, markup?: MarkupSpan[]];
   retract: [messageId: string];
   react: [messageId: string, emoji: string];
+  reply: [message: TimelineMessage];
+  scrollToMessage: [messageId: string];
   avatarClick: [author: string];
 }>();
 
@@ -98,6 +100,13 @@ function formatFileSize(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+const replyAuthorName = computed(() => {
+  const author = props.message.replyTo?.author;
+  if (!author) return "";
+  const nickPart = author.includes("/") ? author.split("/").pop()! : author.split("@")[0];
+  return nickPart ?? author;
+});
+
 const isMentioned = computed(() => {
   if (props.message.broadcastMention) return true;
   if (!props.currentUser || !props.message.mentions) return false;
@@ -152,6 +161,7 @@ watch(
   <!-- Retracted tombstone -->
   <div
     v-if="message.isRetracted"
+    :data-message-id="message.id"
     class="flow-root px-3 py-2 opacity-30 animate-message-in"
   >
     <AppAvatar
@@ -174,9 +184,14 @@ watch(
   <!-- Normal message -->
   <div
     v-else
+    :data-message-id="message.id"
     class="group relative flow-root px-3 py-1.5 rounded-xl transition-all duration-200 animate-message-in"
     :class="[
-      isMentioned ? 'bg-warning/5 border-l-2 border-warning/30' : 'hover:bg-muted/40',
+      isMentioned
+        ? 'bg-warning/5 border-l-2 border-warning/30'
+        : message.threadId
+          ? 'border-l-2 border-primary/20 hover:bg-muted/40'
+          : 'hover:bg-muted/40',
       message.deliveryStatus === 'sending' ? 'opacity-50' : '',
     ]"
   >
@@ -208,6 +223,20 @@ watch(
         Read by {{ message.readBy.length }}
       </span>
     </div>
+
+    <!-- Reply preview chip -->
+    <button
+      v-if="message.replyTo"
+      type="button"
+      class="flex items-center gap-1.5 text-[11px] text-muted-foreground mb-0.5 hover:text-foreground transition-colors max-w-full"
+      :title="`Jump to replied message`"
+      @click="emit('scrollToMessage', message.replyTo.id)"
+    >
+      <CornerDownRight class="w-3 h-3 flex-shrink-0" />
+      <span class="text-primary/80 font-medium">@{{ replyAuthorName }}</span>
+      <span v-if="message.replyTo.preview" class="truncate opacity-70">{{ message.replyTo.preview }}</span>
+      <span v-else class="opacity-60 font-mono">{{ message.replyTo.id.slice(0, 8) }}</span>
+    </button>
 
     <!-- Edit mode -->
     <div v-if="isEditing" class="flex gap-2 mt-1 items-end">
@@ -333,6 +362,13 @@ watch(
         title="Add reaction"
       >
         <SmilePlus class="w-3.5 h-3.5" />
+      </button>
+      <button
+        class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
+        title="Reply"
+        @click="emit('reply', message)"
+      >
+        <Reply class="w-3.5 h-3.5" />
       </button>
       <template v-if="message.isSelf">
         <div class="w-px h-4 bg-border mx-0.5" />

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -355,36 +355,41 @@ watch(
         :key="e"
         class="h-6 w-6 flex items-center justify-center text-[14px] leading-none rounded-md hover:bg-muted hover:scale-110 transition-all duration-150"
         :title="`React with ${e}`"
+        :aria-label="`React to message with ${e}`"
         @click="emit('react', message.id, e)"
       >{{ e }}</button>
       <button
         class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
         title="Add reaction"
+        aria-label="Add reaction"
       >
-        <SmilePlus class="w-3.5 h-3.5" />
+        <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
       </button>
       <button
         class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
         title="Reply"
+        aria-label="Reply to message"
         @click="emit('reply', message)"
       >
-        <Reply class="w-3.5 h-3.5" />
+        <Reply class="w-3.5 h-3.5" aria-hidden="true" />
       </button>
       <template v-if="message.isSelf">
         <div class="w-px h-4 bg-border mx-0.5" />
         <button
           class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
           title="Edit message"
+          aria-label="Edit message"
           @click="startEdit"
         >
-          <Pencil class="w-3.5 h-3.5" />
+          <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
         </button>
         <button
           class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all duration-150"
           title="Delete message"
+          aria-label="Delete message"
           @click="emit('retract', message.id)"
         >
-          <Trash2 class="w-3.5 h-3.5" />
+          <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
         </button>
       </template>
     </div>

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -5,6 +5,7 @@ import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
+import { getComposerEscapeAction } from "@/lib/reply-ux";
 import { extractImagesFromEvent } from "@/lib/xmpp/file-upload";
 import type { MarkupSpan } from "@/lib/chat-ui";
 
@@ -228,9 +229,21 @@ function onSend(doc: Record<string, unknown>) {
 defineExpose({ addAttachments });
 
 function onEditorCancel() {
-  if (showMentions.value || showEmoji.value) {
+  const action = getComposerEscapeAction({
+    showMentions: showMentions.value,
+    showEmoji: showEmoji.value,
+    isReplyingTo: !!props.replyingTo,
+  });
+
+  if (action === "dismiss-autocomplete") {
     showMentions.value = false;
     showEmoji.value = false;
+    triggerRange.value = null;
+    return;
+  }
+
+  if (action === "cancel-reply") {
+    emit("cancelReply");
   }
 }
 
@@ -398,11 +411,12 @@ watch(
     <button
       class="h-10 w-10 flex items-center justify-center rounded-xl transition-all duration-200 flex-shrink-0"
       :class="showGifPicker ? 'bg-muted text-primary' : 'text-muted-foreground hover:bg-muted hover:text-primary'"
-      title="GIF"
+      title="Open GIF picker"
+      aria-label="Open GIF picker"
       :disabled="disabled"
       @click="showGifPicker = !showGifPicker"
     >
-      <Image class="w-4 h-4" />
+      <Image class="w-4 h-4" aria-hidden="true" />
     </button>
     <ChatEditor
       :ref="setEditorRef"
@@ -415,10 +429,11 @@ watch(
     <button
       class="h-10 w-10 flex items-center justify-center bg-primary text-primary-foreground rounded-xl hover:shadow-[0_0_20px_var(--glow-strong)] transition-all duration-300 disabled:opacity-20 flex-shrink-0"
       :disabled="isSending || disabled || isEmpty || slowModeCooldown > 0"
+      aria-label="Send message"
       @click="editorRef?.getJSON?.() && onSend(editorRef.getJSON()!)"
     >
       <span v-if="slowModeCooldown > 0" class="text-[10px] font-bold font-mono tabular-nums">{{ slowModeCooldown }}</span>
-      <Send v-else class="w-4 h-4" />
+      <Send v-else class="w-4 h-4" aria-hidden="true" />
     </button>
     </div>
   </div>

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -25,13 +25,21 @@ const props = defineProps<{
   memberNames: string[];
   slowModeCooldown: number;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
+  replyingTo?: { id: string; author: string; preview?: string } | null;
 }>();
 
 const emit = defineEmits<{
   send: [body: string, markup: MarkupSpan[], files?: Array<File | Blob>];
   typing: [];
   selectGif: [url: string];
+  cancelReply: [];
 }>();
+
+const replyAuthorName = computed(() => {
+  const author = props.replyingTo?.author;
+  if (!author) return "";
+  return author.includes("/") ? author.split("/").pop()! : author.split("@")[0] ?? author;
+});
 
 const showGifPicker = ref(false);
 const showMentions = ref(false);
@@ -280,6 +288,25 @@ watch(
 
 <template>
   <div class="relative px-4 py-3 flex-shrink-0" @keydown="onKeydown" @paste="onPaste">
+    <!-- Reply context chip -->
+    <div
+      v-if="replyingTo"
+      class="flex items-center gap-2 px-3 py-1.5 mb-2 rounded-xl bg-muted/70 border border-border text-[12px] animate-fade-in"
+    >
+      <span class="text-muted-foreground">Replying to</span>
+      <span class="font-medium text-primary/90">@{{ replyAuthorName }}</span>
+      <span v-if="replyingTo.preview" class="text-muted-foreground truncate flex-1">{{ replyingTo.preview }}</span>
+      <button
+        type="button"
+        class="ml-auto h-5 w-5 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        title="Cancel reply"
+        aria-label="Cancel reply"
+        @click="emit('cancelReply')"
+      >
+        <X class="w-3 h-3" />
+      </button>
+    </div>
+
     <!-- Pending attachment previews -->
     <div
       v-if="pendingAttachments.length > 0"

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -18,6 +18,7 @@ function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): Timeline
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
+    authorJid: msg.fromJid,
     body: msg.body,
     createdAt: msg.createdAt,
     isSelf: barePeerJid(msg.fromJid) === barePeerJid(session.jid),
@@ -322,10 +323,17 @@ export function useDmMessaging(
       }
 
       const parent = replyTo ? messages.value.find((m) => m.id === replyTo.id) : undefined;
-      const threadId = parent?.threadId ?? (replyTo ? replyTo.id : undefined);
+      const wireReplyTo = replyTo && parent
+        ? {
+            id: replyTo.id,
+            author: parent.authorJid ?? replyTo.author,
+            ...(replyTo.body ? { body: replyTo.body } : {}),
+          }
+        : undefined;
+      const threadId = parent ? (parent.threadId ?? replyTo?.id) : undefined;
       const msgId = await client.sendDirectMessage(peerJid, bodyText, {
         files: attachments,
-        ...(replyTo ? { replyTo } : {}),
+        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
       });
       const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
@@ -335,12 +343,13 @@ export function useDmMessaging(
           const optimistic: TimelineMessage = {
             id: msgId,
             author: session.value.username,
+            authorJid: session.value.jid,
             body: bodyText.trim() || (attachments?.[0]?.url ?? ""),
             createdAt: new Date().toISOString(),
             isSelf: true,
             deliveryStatus: "sending",
           };
-          if (replyTo) {
+          if (replyTo && parent) {
             optimistic.replyTo = {
               id: replyTo.id,
               author: replyTo.author,

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -26,6 +26,11 @@ function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): Timeline
   if (msg.markup?.length) tm.markup = msg.markup;
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;
   if (msg.isSticker) tm.isSticker = true;
+  if (msg.replyTo) {
+    tm.replyTo = { id: msg.replyTo.id, ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}) };
+  }
+  if (msg.threadId) tm.threadId = msg.threadId;
+  if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
   return tm;
 }
 
@@ -277,7 +282,12 @@ export function useDmMessaging(
     }
   }
 
-  async function sendMessage(explicitBody?: string, _markup?: unknown, files?: Array<File | Blob>) {
+  async function sendMessage(
+    explicitBody?: string,
+    _markup?: unknown,
+    files?: Array<File | Blob>,
+    replyTo?: { id: string; author: string; body?: string },
+  ) {
     const bodyText = explicitBody ?? draft.value;
     const fromComposer = _markup !== undefined;
     const client = xmppClient.value;
@@ -311,7 +321,13 @@ export function useDmMessaging(
         });
       }
 
-      const msgId = await client.sendDirectMessage(peerJid, bodyText, attachments);
+      const parent = replyTo ? messages.value.find((m) => m.id === replyTo.id) : undefined;
+      const threadId = parent?.threadId ?? (replyTo ? replyTo.id : undefined);
+      const msgId = await client.sendDirectMessage(peerJid, bodyText, {
+        files: attachments,
+        ...(replyTo ? { replyTo } : {}),
+        ...(threadId ? { threadId } : {}),
+      });
       const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
       if (isStillActive) {
         if (msgId) {
@@ -324,6 +340,14 @@ export function useDmMessaging(
             isSelf: true,
             deliveryStatus: "sending",
           };
+          if (replyTo) {
+            optimistic.replyTo = {
+              id: replyTo.id,
+              author: replyTo.author,
+              ...(replyTo.body ? { preview: replyTo.body } : {}),
+            };
+          }
+          if (threadId) optimistic.threadId = threadId;
           if (attachments && attachments.length > 0) {
             optimistic.sharedFiles = attachments.map((a) => ({
               url: a.url,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -39,6 +39,11 @@ function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): Timeline
   if (msg.markup && msg.markup.length > 0) {
     tm.markup = msg.markup;
   }
+  if (msg.replyTo) {
+    tm.replyTo = { id: msg.replyTo.id, ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}) };
+  }
+  if (msg.threadId) tm.threadId = msg.threadId;
+  if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
   return tm;
 }
 
@@ -537,7 +542,12 @@ export function useMessaging(
     await loadMessages(activeWaddleId.value, channelId);
   }
 
-  async function sendMessage(body?: string, markup?: MarkupSpan[], files?: Array<File | Blob>) {
+  async function sendMessage(
+    body?: string,
+    markup?: MarkupSpan[],
+    files?: Array<File | Blob>,
+    replyTo?: { id: string; author: string; body?: string },
+  ) {
     const bodyText = body ?? draft.value;
     // markup !== undefined means this came from the rich editor (composer send)
     // undefined means it came from a programmatic send (GIF, etc.)
@@ -575,7 +585,14 @@ export function useMessaging(
         });
       }
 
-      const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, markup, attachments);
+      const parent = replyTo ? messages.value.find((m) => m.id === replyTo.id) : undefined;
+      const threadId = parent?.threadId ?? (replyTo ? replyTo.id : undefined);
+      const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, {
+        markup,
+        files: attachments,
+        ...(replyTo ? { replyTo } : {}),
+        ...(threadId ? { threadId } : {}),
+      });
       const isStillCurrentChannel =
         xmppClient.value === client &&
         activeWaddleId.value === waddleId &&
@@ -592,6 +609,14 @@ export function useMessaging(
           deliveryStatus: "sending",
           markup,
         };
+        if (replyTo) {
+          optimistic.replyTo = {
+            id: replyTo.id,
+            author: replyTo.author,
+            ...(replyTo.body ? { preview: replyTo.body } : {}),
+          };
+        }
+        if (threadId) optimistic.threadId = threadId;
         if (attachments && attachments.length > 0) {
           optimistic.sharedFiles = attachments.map((a) => ({
             url: a.url,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -20,6 +20,7 @@ function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): Timeline
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
+    authorJid: `${msg.roomJid}/${msg.nick}`,
     body: msg.body,
     createdAt: msg.createdAt,
     isSelf: msg.nick === session.username,
@@ -586,11 +587,18 @@ export function useMessaging(
       }
 
       const parent = replyTo ? messages.value.find((m) => m.id === replyTo.id) : undefined;
-      const threadId = parent?.threadId ?? (replyTo ? replyTo.id : undefined);
+      const wireReplyTo = replyTo && parent
+        ? {
+            id: replyTo.id,
+            author: parent.authorJid ?? replyTo.author,
+            ...(replyTo.body ? { body: replyTo.body } : {}),
+          }
+        : undefined;
+      const threadId = parent ? (parent.threadId ?? replyTo?.id) : undefined;
       const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, {
         markup,
         files: attachments,
-        ...(replyTo ? { replyTo } : {}),
+        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
       });
       const isStillCurrentChannel =
@@ -603,13 +611,14 @@ export function useMessaging(
         const optimistic: TimelineMessage = {
           id: msgId,
           author: session.value.username,
+          authorJid: `${currentRoomJid.value}/${session.value.username}`,
           body: bodyText.trim() || (attachments?.[0]?.url ?? ""),
           createdAt: new Date().toISOString(),
           isSelf: true,
           deliveryStatus: "sending",
           markup,
         };
-        if (replyTo) {
+        if (replyTo && parent) {
           optimistic.replyTo = {
             id: replyTo.id,
             author: replyTo.author,

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -40,6 +40,11 @@ export interface TimelineMessage {
   broadcastMention?: "everyone" | "here";
   /** XEP-0394: Message Markup offset-based annotations. */
   markup?: MarkupSpan[];
+  /** XEP-0461: Parent message this replies to, with optional preview text. */
+  replyTo?: { id: string; author?: string; preview?: string };
+  /** RFC 6121 / XEP-0201: Thread identifier + optional parent thread. */
+  threadId?: string;
+  parentThreadId?: string;
 }
 
 export interface CommunityFormData {

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -15,6 +15,8 @@ export interface MarkupSpan {
 export interface TimelineMessage {
   id: string;
   author: string;
+  /** Actual JID / occupant JID for the author when known. */
+  authorJid?: string;
   body: string;
   createdAt: string;
   isSelf: boolean;

--- a/chat/src/lib/message-targeting.ts
+++ b/chat/src/lib/message-targeting.ts
@@ -1,0 +1,42 @@
+const DATA_MESSAGE_ID_ATTRIBUTE = "data-message-id";
+const ALL_MESSAGE_SELECTOR = `[${DATA_MESSAGE_ID_ATTRIBUTE}]`;
+
+type MessageTargetingElement = {
+  getAttribute(name: string): string | null;
+};
+
+type MessageTargetingRoot<T extends MessageTargetingElement> = {
+  querySelector(selector: string): T | null;
+  querySelectorAll(selector: string): Iterable<T>;
+};
+
+function hasExactMessageId<T extends MessageTargetingElement>(
+  candidate: T | null | undefined,
+  messageId: string,
+): candidate is T {
+  return candidate?.getAttribute(DATA_MESSAGE_ID_ATTRIBUTE) === messageId;
+}
+
+export function findMessageElementById<T extends MessageTargetingElement>(
+  root: MessageTargetingRoot<T> | null | undefined,
+  messageId: string,
+): T | null {
+  if (!root) return null;
+
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    const candidate = root.querySelector(
+      `[${DATA_MESSAGE_ID_ATTRIBUTE}="${CSS.escape(messageId)}"]`,
+    );
+    if (hasExactMessageId(candidate, messageId)) {
+      return candidate;
+    }
+  }
+
+  for (const candidate of root.querySelectorAll(ALL_MESSAGE_SELECTOR)) {
+    if (hasExactMessageId(candidate, messageId)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/chat/src/lib/reply-ux.ts
+++ b/chat/src/lib/reply-ux.ts
@@ -1,0 +1,21 @@
+export const REPLY_JUMP_TARGET_MISSING_MESSAGE = "Original message isn't in this loaded history yet.";
+
+export function getReplyJumpNotice(targetFound: boolean): string {
+  return targetFound ? "" : REPLY_JUMP_TARGET_MISSING_MESSAGE;
+}
+
+export function getComposerEscapeAction(state: {
+  showMentions: boolean;
+  showEmoji: boolean;
+  isReplyingTo: boolean;
+}): "dismiss-autocomplete" | "cancel-reply" | "none" {
+  if (state.showMentions || state.showEmoji) {
+    return "dismiss-autocomplete";
+  }
+
+  if (state.isReplyingTo) {
+    return "cancel-reply";
+  }
+
+  return "none";
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -120,22 +120,21 @@ function mapPresenceShow(pres: ReceivedPresence): PresenceUpdateEvent["show"] {
   }
 }
 
-/** Text-only messages buffered while the transport is unavailable. */
+/** Outbound messages buffered while the transport is unavailable. */
 type QueuedRoomMessage = {
   kind: "room";
   waddleId: string;
   channelId: string;
   roomJid: string;
   body: string;
-  markup?: import("@/lib/chat-ui").MarkupSpan[];
-  files?: messaging.OutboundFileAttachment[];
+  opts: messaging.SendGroupMessageOptions;
   msgId: string;
 };
 type QueuedDmMessage = {
   kind: "dm";
   peerJid: string;
   body: string;
-  files?: messaging.OutboundFileAttachment[];
+  opts: dmMessaging.SendDirectMessageOptions;
   msgId: string;
 };
 type QueuedOutboundMessage = QueuedRoomMessage | QueuedDmMessage;
@@ -445,9 +444,9 @@ export class BrowserXmppClient {
     w: string,
     c: string,
     body: string,
-    markup?: import("@/lib/chat-ui").MarkupSpan[],
-    files?: messaging.OutboundFileAttachment[],
+    opts: messaging.SendGroupMessageOptions = {},
   ): Promise<string | null> {
+    const { files } = opts;
     const text = body.trim();
     const hasFiles = !!files && files.length > 0;
     if (!text && !hasFiles) return null;
@@ -456,7 +455,15 @@ export class BrowserXmppClient {
     const roomJid = roomBareJidFor(this.session, w, c);
     // Queue immediately so the composable gets the ID back without waiting for
     // connect/room-join.  The queue flushes once the transport is ready.
-    this.outboundQueue.push({ kind: "room", waddleId: w, channelId: c, roomJid, body, markup, files, msgId });
+    this.outboundQueue.push({
+      kind: "room",
+      waddleId: w,
+      channelId: c,
+      roomJid,
+      body,
+      opts: { ...opts, id: msgId },
+      msgId,
+    });
     if (this.connected) void this.flushOutboundQueue();
     return msgId;
   }
@@ -506,14 +513,21 @@ export class BrowserXmppClient {
   async sendDirectMessage(
     peerJid: string,
     body: string,
-    files?: messaging.OutboundFileAttachment[],
+    opts: dmMessaging.SendDirectMessageOptions = {},
   ): Promise<string | null> {
+    const { files } = opts;
     const text = body.trim();
     const hasFiles = !!files && files.length > 0;
     if (!text && !hasFiles) return null;
 
     const msgId = crypto.randomUUID();
-    this.outboundQueue.push({ kind: "dm", peerJid: barePeerJid(peerJid), body, files, msgId });
+    this.outboundQueue.push({
+      kind: "dm",
+      peerJid: barePeerJid(peerJid),
+      body,
+      opts: { ...opts, id: msgId },
+      msgId,
+    });
     if (this.connected) void this.flushOutboundQueue();
     return msgId;
   }
@@ -668,13 +682,13 @@ export class BrowserXmppClient {
               await this.switchRoom(item.waddleId, item.channelId);
             }
             if (this.xmpp && !this.destroying) {
-              messaging.sendGroupMessage(this.xmpp, item.roomJid, item.body, item.markup, item.files, item.msgId);
+              messaging.sendGroupMessage(this.xmpp, item.roomJid, item.body, item.opts);
             } else {
               this.messageDeliveryFailureHandler?.(item.msgId);
             }
           } else {
             if (this.xmpp && !this.destroying) {
-              dmMessaging.sendDirectMessage(this.xmpp, item.peerJid, item.body, item.files, item.msgId);
+              dmMessaging.sendDirectMessage(this.xmpp, item.peerJid, item.body, item.opts);
             } else {
               this.messageDeliveryFailureHandler?.(item.msgId);
             }

--- a/chat/src/lib/xmpp/dm-messaging.ts
+++ b/chat/src/lib/xmpp/dm-messaging.ts
@@ -1,6 +1,12 @@
 import type { Agent } from "stanza";
 import type { ChatStateType } from "./types";
-import { fileSharingElement, type OutboundFileAttachment } from "./messaging";
+import {
+  buildReplyFallbackPrefix,
+  fileSharingElement,
+  type OutboundFileAttachment,
+  type ReplyTarget,
+} from "./messaging";
+import type { WaddleFallback } from "./extensions/fallback";
 
 export function sendDmChatState(xmpp: Agent, peerJid: string, state: ChatStateType): void {
   xmpp.sendMessage({ to: peerJid, type: "chat", chatState: state, processingHints: { noStore: true } });
@@ -44,9 +50,17 @@ export function sendDmCorrection(xmpp: Agent, peerJid: string, body: string, rep
   return msgId;
 }
 
+export interface SendDirectMessageOptions {
+  files?: OutboundFileAttachment[];
+  replyTo?: ReplyTarget;
+  threadId?: string;
+  parentThreadId?: string;
+  id?: string;
+}
+
 /**
- * Send a direct (type="chat") message. Optionally includes XEP-0447 file-sharing
- * attachments alongside the user's text body in a single stanza.
+ * Send a direct (type="chat") message. Supports XEP-0447 attachments, XEP-0461
+ * replies with XEP-0428 fallback prefix, and RFC 6121 / XEP-0201 threads.
  * Pass a pre-generated `id` when the caller already created an optimistic
  * timeline entry so the stanza ID matches.
  */
@@ -54,15 +68,23 @@ export function sendDirectMessage(
   xmpp: Agent,
   peerJid: string,
   body: string,
-  files?: OutboundFileAttachment[],
-  id?: string,
+  opts: SendDirectMessageOptions = {},
 ): string | null {
+  const { files, replyTo, threadId, parentThreadId, id } = opts;
   const text = body.trim();
   const hasFiles = !!files && files.length > 0;
   if (!text && !hasFiles) return null;
 
   const msgId = id ?? crypto.randomUUID();
-  const effectiveBody = text || (hasFiles ? files![0].url : "");
+  const { prefix, length: prefixLength } = replyTo
+    ? buildReplyFallbackPrefix(replyTo.body)
+    : { prefix: "", length: 0 };
+  const bodyText = text || (hasFiles ? files![0].url : "");
+  const effectiveBody = prefix + bodyText;
+  const fallbacks: WaddleFallback[] = [];
+  if (replyTo && prefixLength > 0) {
+    fallbacks.push({ for: "urn:xmpp:reply:0", body: { start: 0, end: prefixLength } });
+  }
 
   const msgData: Record<string, unknown> = {
     id: msgId,
@@ -73,13 +95,21 @@ export function sendDirectMessage(
     marker: { type: "markable" },
     processingHints: { store: true },
   };
+  if (replyTo) {
+    msgData.reply = { to: replyTo.author, id: replyTo.id };
+  }
+  if (threadId) {
+    msgData.thread = threadId;
+    if (parentThreadId) msgData.parentThread = parentThreadId;
+  }
   if (hasFiles) {
     msgData.fileSharing = files!.map(fileSharingElement);
     msgData.links = files!.map((f) => ({ url: f.url }));
     if (!text) {
-      msgData.fallback = { for: "urn:xmpp:sfs:0", body: true };
+      fallbacks.push({ for: "urn:xmpp:sfs:0" });
     }
   }
+  if (fallbacks.length > 0) msgData.fallbacks = fallbacks;
 
   xmpp.sendMessage(msgData as Parameters<Agent["sendMessage"]>[0]);
   return msgId;

--- a/chat/src/lib/xmpp/dm-parsing.ts
+++ b/chat/src/lib/xmpp/dm-parsing.ts
@@ -46,7 +46,7 @@ export function dispatchChat(msg: ReceivedMessage, h: DmHandlers): void {
     h.onMessage?.({
       id: msg.id ?? crypto.randomUUID(),
       peerJid,
-      fromJid: fromBare,
+      fromJid: msg.from ?? fromBare,
       nick,
       body: "",
       createdAt: new Date().toISOString(),
@@ -72,7 +72,7 @@ export function dispatchChat(msg: ReceivedMessage, h: DmHandlers): void {
   const liveMsg: LiveDmMessage = {
     id: msg.id ?? crypto.randomUUID(),
     peerJid,
-    fromJid: fromBare,
+    fromJid: msg.from ?? fromBare,
     nick,
     body: msg.body ?? msg.subject ?? "",
     createdAt: new Date().toISOString(),

--- a/chat/src/lib/xmpp/extensions/fallback.ts
+++ b/chat/src/lib/xmpp/extensions/fallback.ts
@@ -1,10 +1,13 @@
 /**
  * XEP-0428: Fallback Indication.
  *
- * Marks the message body as a fallback for a structured element:
- *   <fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:sfs:0">
- *     <body/>
+ *   <fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:reply:0">
+ *     <body start="0" end="18"/>
  *   </fallback>
+ *
+ * A message MAY carry several `<fallback/>` payloads (one per feature
+ * namespace). The inner `<body/>` is optional; when absent the entire
+ * message body is fallback.
  */
 import type { DefinitionOptions, FieldDefinition } from "stanza/jxt";
 import { attribute } from "stanza/jxt";
@@ -12,25 +15,43 @@ import XMLElement from "stanza/jxt/Element";
 
 const NS_FALLBACK = "urn:xmpp:fallback:0";
 
-/** Always exports an empty <body/> child element inside <fallback/>. */
-const bodyChild: FieldDefinition<boolean> = {
-  importer(xml: XMLElement) {
-    return xml.getChild("body") !== undefined;
+export interface WaddleFallbackBodyRange {
+  start?: number;
+  end?: number;
+}
+
+export interface WaddleFallback {
+  for: string;
+  body?: WaddleFallbackBodyRange;
+}
+
+const bodyField: FieldDefinition<WaddleFallbackBodyRange> = {
+  importer(xml: XMLElement): WaddleFallbackBodyRange | undefined {
+    const child = xml.getChild("body");
+    if (!child) return undefined;
+    const start = child.getAttribute("start");
+    const end = child.getAttribute("end");
+    const out: WaddleFallbackBodyRange = {};
+    if (start !== undefined && start !== "") out.start = Number(start);
+    if (end !== undefined && end !== "") out.end = Number(end);
+    return out;
   },
-  exporter(xml: XMLElement, value: boolean) {
-    if (value && !xml.getChild("body")) {
-      xml.appendChild(new XMLElement("body"));
-    }
+  exporter(xml: XMLElement, value: WaddleFallbackBodyRange | undefined): void {
+    if (value === undefined) return;
+    const attrs: Record<string, string> = {};
+    if (value.start !== undefined) attrs.start = String(value.start);
+    if (value.end !== undefined) attrs.end = String(value.end);
+    xml.appendChild(new XMLElement("body", attrs));
   },
 };
 
 const definitions: DefinitionOptions[] = [
   {
-    aliases: [{ path: "message.fallback", multiple: false }],
+    aliases: [{ path: "message.fallbacks", multiple: true }],
     element: "fallback",
     fields: {
       for: attribute("for"),
-      body: bodyChild,
+      body: bodyField,
     },
     namespace: NS_FALLBACK,
   },

--- a/chat/src/lib/xmpp/extensions/fallback.ts
+++ b/chat/src/lib/xmpp/extensions/fallback.ts
@@ -25,15 +25,22 @@ export interface WaddleFallback {
   body?: WaddleFallbackBodyRange;
 }
 
+function parseUtf16Offset(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+  return parsed;
+}
+
 const bodyField: FieldDefinition<WaddleFallbackBodyRange> = {
   importer(xml: XMLElement): WaddleFallbackBodyRange | undefined {
     const child = xml.getChild("body");
     if (!child) return undefined;
-    const start = child.getAttribute("start");
-    const end = child.getAttribute("end");
+    const start = parseUtf16Offset(child.getAttribute("start"));
+    const end = parseUtf16Offset(child.getAttribute("end"));
     const out: WaddleFallbackBodyRange = {};
-    if (start !== undefined && start !== "") out.start = Number(start);
-    if (end !== undefined && end !== "") out.end = Number(end);
+    if (start !== undefined) out.start = start;
+    if (end !== undefined) out.end = end;
     return out;
   },
   exporter(xml: XMLElement, value: WaddleFallbackBodyRange | undefined): void {

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -10,6 +10,7 @@ import stickers from "./stickers";
 import mentions from "./mentions";
 import push from "./push";
 import markup from "./markup";
+import replies from "./replies";
 
 const allDefinitions = [
   ...hats,
@@ -22,6 +23,7 @@ const allDefinitions = [
   ...mentions,
   ...push,
   ...markup,
+  ...replies,
 ];
 
 export function registerWaddleExtensions(client: Agent): void {

--- a/chat/src/lib/xmpp/extensions/markup.ts
+++ b/chat/src/lib/xmpp/extensions/markup.ts
@@ -11,6 +11,43 @@ export interface WaddleMarkupSpan {
   uri?: string;
 }
 
+type MarkupSpanWithOffsets = {
+  start: number;
+  end: number;
+};
+
+function hasValidOffsets(span: MarkupSpanWithOffsets): boolean {
+  return Number.isFinite(span.start) && Number.isFinite(span.end) && span.start >= 0 && span.end > span.start;
+}
+
+export function shiftMarkupSpans<T extends MarkupSpanWithOffsets>(spans: readonly T[], offset: number): T[] {
+  if (!Number.isFinite(offset)) return [];
+  return spans.flatMap((span) => {
+    if (!hasValidOffsets(span)) return [];
+    const shifted = { ...span, start: span.start + offset, end: span.end + offset };
+    return hasValidOffsets(shifted) ? [shifted] : [];
+  });
+}
+
+function rebaseOffsetAfterRemoval(offset: number, start: number, end: number): number {
+  if (offset <= start) return offset;
+  if (offset >= end) return offset - (end - start);
+  return start;
+}
+
+export function stripMarkupRange<T extends MarkupSpanWithOffsets>(spans: readonly T[], start: number, end: number): T[] {
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) return [];
+  return spans.flatMap((span) => {
+    if (!hasValidOffsets(span)) return [];
+    const rebased = {
+      ...span,
+      start: rebaseOffsetAfterRemoval(span.start, start, end),
+      end: rebaseOffsetAfterRemoval(span.end, start, end),
+    };
+    return hasValidOffsets(rebased) ? [rebased] : [];
+  });
+}
+
 const VALID_TYPES = new Set(["b", "i", "s", "code", "code-block", "blockquote", "link"]);
 
 /** Custom field: reads/writes child span elements inside <markup>. */

--- a/chat/src/lib/xmpp/extensions/replies.ts
+++ b/chat/src/lib/xmpp/extensions/replies.ts
@@ -1,0 +1,26 @@
+/** XEP-0461: Message Replies. */
+import type { DefinitionOptions } from "stanza/jxt";
+import { attribute } from "stanza/jxt";
+
+const NS_REPLY_0 = "urn:xmpp:reply:0";
+
+export interface WaddleReply {
+  /** The JID the reply is addressed to (original message sender). */
+  to?: string;
+  /** The stanza id of the message being replied to. */
+  id: string;
+}
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "message.reply", multiple: false }],
+    element: "reply",
+    fields: {
+      to: attribute("to"),
+      id: attribute("id"),
+    },
+    namespace: NS_REPLY_0,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -71,8 +71,13 @@ function stripReplyFallback(msg: ReceivedMessage, base: MessageExtensionsTarget)
   if (!fallbacks?.length || !base.body) return;
   const range = fallbacks.find((f) => f.for === "urn:xmpp:reply:0")?.body;
   if (!range) return;
-  const start = Math.max(0, Math.min(range.start ?? 0, base.body.length));
-  const end = Math.max(start, Math.min(range.end ?? start, base.body.length));
+  const rawStart = range.start ?? 0;
+  const rawEnd = range.end ?? rawStart;
+  if (!Number.isFinite(rawStart) || !Number.isFinite(rawEnd) || rawStart < 0 || rawEnd < 0) {
+    return;
+  }
+  const start = Math.max(0, Math.min(rawStart, base.body.length));
+  const end = Math.max(start, Math.min(rawEnd, base.body.length));
   base.body = base.body.slice(0, start) + base.body.slice(end);
 }
 

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -7,7 +7,16 @@ import type {
 
 type MessageExtensionsTarget = Pick<
   LiveRoomMessage,
-  "body" | "mentions" | "broadcastMention" | "sharedFiles" | "isSticker" | "replacesId" | "markup"
+  | "body"
+  | "mentions"
+  | "broadcastMention"
+  | "sharedFiles"
+  | "isSticker"
+  | "replacesId"
+  | "markup"
+  | "replyTo"
+  | "threadId"
+  | "parentThreadId"
 >;
 
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
@@ -28,10 +37,43 @@ export function extractMessageExtensions(
   extractExplicitMentions(msg, base);
   extractFileSharing(msg, base);
   extractMarkup(msg, base);
+  extractReplyAndThread(msg, base);
+  stripReplyFallback(msg, base);
 
   if (ext(msg).sticker) {
     base.isSticker = true;
   }
+}
+
+/** XEP-0461 reply pointer + RFC 6121 / XEP-0201 thread id + parent. */
+function extractReplyAndThread(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
+  const reply = ext(msg).reply as { to?: string; id?: string } | undefined;
+  if (reply?.id) {
+    base.replyTo = { id: reply.id, ...(reply.to ? { author: reply.to } : {}) };
+  }
+  const threadId = ext(msg).thread as string | undefined;
+  if (threadId) base.threadId = threadId;
+  const parentThread = ext(msg).parentThread as string | undefined;
+  if (parentThread) base.parentThreadId = parentThread;
+}
+
+interface FallbackPayload {
+  for?: string;
+  body?: { start?: number; end?: number };
+}
+
+/**
+ * XEP-0428: strip any `urn:xmpp:reply:0` fallback range from the displayed
+ * body so the `> quoted` prefix doesn't double-render on top of the reply chip.
+ */
+function stripReplyFallback(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
+  const fallbacks = ext(msg).fallbacks as FallbackPayload[] | undefined;
+  if (!fallbacks?.length || !base.body) return;
+  const range = fallbacks.find((f) => f.for === "urn:xmpp:reply:0")?.body;
+  if (!range) return;
+  const start = Math.max(0, Math.min(range.start ?? 0, base.body.length));
+  const end = Math.max(start, Math.min(range.end ?? start, base.body.length));
+  base.body = base.body.slice(0, start) + base.body.slice(end);
 }
 
 function extractReferences(msg: ReceivedMessage, base: MessageExtensionsTarget): void {

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -1,5 +1,6 @@
 /** Inbound message parsing — extracts XEP extension data from stanza messages. */
 import type { ReceivedMessage } from "stanza/protocol";
+import { stripMarkupRange } from "./extensions/markup";
 import type {
   ChatStateEvent, ChatStateType, DisplayedEvent,
   LiveDmMessage, LiveRoomMessage, ReactionEvent, RoomActivityEvent, SharedFileInfo,
@@ -22,6 +23,12 @@ type MessageExtensionsTarget = Pick<
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
 export function ext(msg: unknown): Record<string, unknown> {
   return msg as Record<string, unknown>;
+}
+
+const encoder = new TextEncoder();
+
+function byteLen(text: string): number {
+  return encoder.encode(text).byteLength;
 }
 
 /** Populate a LiveRoomMessage with data from XEP extensions on the stanza. */
@@ -78,7 +85,19 @@ function stripReplyFallback(msg: ReceivedMessage, base: MessageExtensionsTarget)
   }
   const start = Math.max(0, Math.min(rawStart, base.body.length));
   const end = Math.max(start, Math.min(rawEnd, base.body.length));
+  if (end <= start) return;
+  const prefixText = base.body.slice(0, start);
+  const strippedText = base.body.slice(start, end);
+  const markupRangeStart = byteLen(prefixText);
+  const markupRangeEnd = markupRangeStart + byteLen(strippedText);
   base.body = base.body.slice(0, start) + base.body.slice(end);
+  if (!base.markup?.length) return;
+  const rebasedMarkup = stripMarkupRange(base.markup, markupRangeStart, markupRangeEnd);
+  if (rebasedMarkup.length > 0) {
+    base.markup = rebasedMarkup;
+    return;
+  }
+  delete base.markup;
 }
 
 function extractReferences(msg: ReceivedMessage, base: MessageExtensionsTarget): void {

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -1,6 +1,7 @@
 /** Outbound message operations — all send* functions as standalone. */
 import type { Agent } from "stanza";
 import type { MarkupSpan } from "@/lib/chat-ui";
+import type { WaddleFallback } from "./extensions/fallback";
 import type { WaddleMarkupSpan } from "./extensions/markup";
 import type { ChatStateType } from "./types";
 
@@ -11,6 +12,15 @@ export interface OutboundFileAttachment {
   size: number;
   width?: number;
   height?: number;
+}
+
+export interface ReplyTarget {
+  /** Stanza id of the message being replied to. */
+  id: string;
+  /** JID (user or room occupant) of the original author. */
+  author: string;
+  /** Original message body, used to build the > quoted fallback prefix. */
+  body?: string;
 }
 
 /** Build one XEP-0447 <file-sharing> payload for a single attachment. */
@@ -24,6 +34,20 @@ export function fileSharingElement(file: OutboundFileAttachment): Record<string,
     ...(file.height ? { height: String(file.height) } : {}),
     url: file.url,
   };
+}
+
+/**
+ * Build a `> quoted\n\n` fallback prefix for a reply.
+ *
+ * Returns the prefix string and its UTF-16 code-unit length so callers can
+ * attach an XEP-0428 `<fallback/>` with a precise body range.
+ */
+export function buildReplyFallbackPrefix(parentBody: string | undefined): { prefix: string; length: number } {
+  if (!parentBody) return { prefix: "", length: 0 };
+  const lines = parentBody.split("\n");
+  const quoted = lines.map((line) => `> ${line}`).join("\n");
+  const prefix = `${quoted}\n\n`;
+  return { prefix, length: prefix.length };
 }
 
 export function sendChatState(xmpp: Agent, roomJid: string, state: ChatStateType): void {
@@ -95,9 +119,18 @@ export function sendCorrection(xmpp: Agent, roomJid: string, body: string, repla
   return msgId;
 }
 
+export interface SendGroupMessageOptions {
+  markup?: MarkupSpan[];
+  files?: OutboundFileAttachment[];
+  replyTo?: ReplyTarget;
+  threadId?: string;
+  parentThreadId?: string;
+  id?: string;
+}
+
 /**
- * Send a groupchat message. Optionally includes XEP-0447 file-sharing
- * attachments alongside the user's text body in a single stanza.
+ * Send a groupchat message. Supports XEP-0447 attachments, XEP-0461 replies with
+ * XEP-0428 fallback prefix, and RFC 6121 / XEP-0201 threads.
  * Pass a pre-generated `id` when the caller already created an optimistic
  * timeline entry so the stanza ID matches.
  */
@@ -105,16 +138,23 @@ export function sendGroupMessage(
   xmpp: Agent,
   roomJid: string,
   body: string,
-  markup?: MarkupSpan[],
-  files?: OutboundFileAttachment[],
-  id?: string,
+  opts: SendGroupMessageOptions = {},
 ): string | null {
+  const { markup, files, replyTo, threadId, parentThreadId, id } = opts;
   const text = body.trim();
   const hasFiles = !!files && files.length > 0;
   if (!text && !hasFiles) return null;
 
   const msgId = id ?? crypto.randomUUID();
-  const effectiveBody = text || (hasFiles ? files![0].url : "");
+  const { prefix, length: prefixLength } = replyTo
+    ? buildReplyFallbackPrefix(replyTo.body)
+    : { prefix: "", length: 0 };
+  const markupPrefixLength = byteLen(prefix);
+  const bodyText = text || (hasFiles ? files![0].url : "");
+  const effectiveBody = prefix + bodyText;
+  const rebasedMarkup = markup && markup.length > 0
+    ? shiftMarkupSpans(markup, markupPrefixLength)
+    : undefined;
 
   // XEP-0372: Build reference objects for @mentions (only scan user text)
   const references: Array<{ type: string; uri: string; begin: string; end: string }> = [];
@@ -123,7 +163,7 @@ export function sendGroupMessage(
     let match: RegExpExecArray | null;
     while ((match = mentionRe.exec(text)) !== null) {
       const nick = match[1]!;
-      const begin = match.index + (match[0].length - nick.length - 1);
+      const begin = prefixLength + match.index + (match[0].length - nick.length - 1);
       const end = begin + nick.length + 1;
       references.push({ type: "mention", begin: String(begin), end: String(end), uri: `xmpp:${nick}` });
     }
@@ -134,6 +174,11 @@ export function sendGroupMessage(
   if (text && /(?:^|\s)@everyone(?:\s|$)/i.test(text)) explicitMentionItems.push({ type: "everyone" });
   if (text && /(?:^|\s)@here(?:\s|$)/i.test(text)) explicitMentionItems.push({ type: "here" });
 
+  const fallbacks: WaddleFallback[] = [];
+  if (replyTo && prefixLength > 0) {
+    fallbacks.push({ for: "urn:xmpp:reply:0", body: { start: 0, end: prefixLength } });
+  }
+
   const msgData: Record<string, unknown> = {
     id: msgId, to: roomJid, type: "groupchat", body: effectiveBody,
     receipt: { type: "request" },
@@ -142,17 +187,25 @@ export function sendGroupMessage(
   };
   if (references.length > 0) msgData.references = references;
   if (explicitMentionItems.length > 0) msgData.explicitMentions = { items: explicitMentionItems };
-  if (markup && markup.length > 0) {
-    msgData.markup = { spans: toStanzaSpans(markup) };
+  if (rebasedMarkup && rebasedMarkup.length > 0) {
+    msgData.markup = { spans: toStanzaSpans(rebasedMarkup) };
+  }
+  if (replyTo) {
+    msgData.reply = { to: replyTo.author, id: replyTo.id };
+  }
+  if (threadId) {
+    msgData.thread = threadId;
+    if (parentThreadId) msgData.parentThread = parentThreadId;
   }
   if (hasFiles) {
     msgData.fileSharing = files!.map(fileSharingElement);
     msgData.links = files!.map((f) => ({ url: f.url }));
     if (!text) {
       // Body is acting as the SFS URL fallback — mark it so compliant clients skip it.
-      msgData.fallback = { for: "urn:xmpp:sfs:0", body: true };
+      fallbacks.push({ for: "urn:xmpp:sfs:0" });
     }
   }
+  if (fallbacks.length > 0) msgData.fallbacks = fallbacks;
 
   xmpp.sendMessage(msgData as Parameters<Agent["sendMessage"]>[0]);
   return msgId;

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -2,7 +2,7 @@
 import type { Agent } from "stanza";
 import type { MarkupSpan } from "@/lib/chat-ui";
 import type { WaddleFallback } from "./extensions/fallback";
-import type { WaddleMarkupSpan } from "./extensions/markup";
+import { shiftMarkupSpans, type WaddleMarkupSpan } from "./extensions/markup";
 import type { ChatStateType } from "./types";
 
 export interface OutboundFileAttachment {
@@ -23,6 +23,12 @@ export interface ReplyTarget {
   body?: string;
 }
 
+const encoder = new TextEncoder();
+
+function byteLen(text: string): number {
+  return encoder.encode(text).byteLength;
+}
+
 /** Build one XEP-0447 <file-sharing> payload for a single attachment. */
 export function fileSharingElement(file: OutboundFileAttachment): Record<string, unknown> {
   return {
@@ -39,8 +45,8 @@ export function fileSharingElement(file: OutboundFileAttachment): Record<string,
 /**
  * Build a `> quoted\n\n` fallback prefix for a reply.
  *
- * Returns the prefix string and its UTF-16 code-unit length so callers can
- * attach an XEP-0428 `<fallback/>` with a precise body range.
+ * Returns the prefix string and its string-length range so callers can attach
+ * an XEP-0428 `<fallback/>` body range alongside the outbound text.
  */
 export function buildReplyFallbackPrefix(parentBody: string | undefined): { prefix: string; length: number } {
   if (!parentBody) return { prefix: "", length: 0 };

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -13,6 +13,15 @@ export interface XmppStatusSnapshot {
  */
 export type SessionLifecycleEvent = { type: "resumed" } | { type: "fresh" };
 
+export interface ReplyPreview {
+  /** Stanza id of the parent message being replied to. */
+  id: string;
+  /** Author JID/occupant of the parent message, if known. */
+  author?: string;
+  /** Optional rendered preview text (populated by the UI, not the wire). */
+  preview?: string;
+}
+
 export interface LiveRoomMessage {
   id: string;
   roomJid: string;
@@ -34,6 +43,11 @@ export interface LiveRoomMessage {
   isSticker?: boolean;
   /** XEP-0513 */
   broadcastMention?: "everyone" | "here";
+  /** XEP-0461 */
+  replyTo?: ReplyPreview;
+  /** RFC 6121 / XEP-0201 */
+  threadId?: string;
+  parentThreadId?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }
@@ -54,6 +68,11 @@ export interface LiveDmMessage {
   markup?: import("@/lib/chat-ui").MarkupSpan[];
   sharedFiles?: SharedFileInfo[];
   isSticker?: boolean;
+  /** XEP-0461 */
+  replyTo?: ReplyPreview;
+  /** RFC 6121 / XEP-0201 */
+  threadId?: string;
+  parentThreadId?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }

--- a/chat/tests/dm-messaging.test.ts
+++ b/chat/tests/dm-messaging.test.ts
@@ -15,9 +15,9 @@ describe("dm messaging", () => {
     const xmpp = makeAgent();
     const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
 
-    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "", [
-      { url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 },
-    ]);
+    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "", {
+      files: [{ url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 }],
+    });
 
     expect(typeof messageId).toBe("string");
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
@@ -28,7 +28,7 @@ describe("dm messaging", () => {
       type: "chat",
       body: fileUrl,
       links: [{ url: fileUrl }],
-      fallback: { for: "urn:xmpp:sfs:0", body: true },
+      fallbacks: [{ for: "urn:xmpp:sfs:0" }],
       processingHints: { store: true },
     });
     expect(Array.isArray(call.fileSharing)).toBe(true);
@@ -45,14 +45,14 @@ describe("dm messaging", () => {
     const xmpp = makeAgent();
     const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
 
-    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "check this out", [
-      { url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 },
-    ]);
+    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "check this out", {
+      files: [{ url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 }],
+    });
 
     expect(typeof messageId).toBe("string");
     const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
     expect(call.body).toBe("check this out");
-    expect(call.fallback).toBeUndefined();
+    expect(call.fallbacks).toBeUndefined();
     expect(call.links).toEqual([{ url: fileUrl }]);
     expect(Array.isArray(call.fileSharing)).toBe(true);
     expect((call.fileSharing as unknown[]).length).toBe(1);
@@ -65,10 +65,12 @@ describe("dm messaging", () => {
       "https://xmpp.waddle.social/upload/a/2.jpg",
     ];
 
-    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "gallery", [
-      { url: urls[0], name: "1.jpg", mediaType: "image/jpeg", size: 1 },
-      { url: urls[1], name: "2.jpg", mediaType: "image/jpeg", size: 2 },
-    ]);
+    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "gallery", {
+      files: [
+        { url: urls[0], name: "1.jpg", mediaType: "image/jpeg", size: 1 },
+        { url: urls[1], name: "2.jpg", mediaType: "image/jpeg", size: 2 },
+      ],
+    });
 
     expect(typeof messageId).toBe("string");
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);

--- a/chat/tests/dm-parsing.test.ts
+++ b/chat/tests/dm-parsing.test.ts
@@ -3,6 +3,12 @@ import { dispatchChat, type DmHandlers } from "../src/lib/xmpp/dm-parsing";
 import type { ReceivedMessage } from "stanza/protocol";
 import type { LiveDmMessage, DmChatStateEvent, DmDisplayedEvent, DmReactionEvent } from "../src/lib/xmpp/types";
 
+const encoder = new TextEncoder();
+
+function byteLen(input: string): number {
+  return encoder.encode(input).byteLength;
+}
+
 function makeHandlers(overrides?: Partial<DmHandlers>): DmHandlers & {
   messages: LiveDmMessage[];
   chatStates: DmChatStateEvent[];
@@ -60,7 +66,7 @@ describe("dispatchChat", () => {
     );
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].peerJid).toBe("bob@example.com");
-    expect(h.messages[0].fromJid).toBe("alice@example.com");
+    expect(h.messages[0].fromJid).toBe("alice@example.com/web");
   });
 
   test("filters out MUC messages by domain", () => {
@@ -190,13 +196,42 @@ describe("dispatchChat", () => {
     expect(h.messages).toHaveLength(0);
   });
 
-  test("strips resource from JIDs", () => {
+  test("preserves the full author JID while normalizing the conversation peer", () => {
     const h = makeHandlers();
     dispatchChat(
       makeMsg({ id: "r-1", from: "bob@example.com/mobile-xyz", body: "hey" }),
       h,
     );
     expect(h.messages[0].peerJid).toBe("bob@example.com");
-    expect(h.messages[0].fromJid).toBe("bob@example.com");
+    expect(h.messages[0].fromJid).toBe("bob@example.com/mobile-xyz");
+  });
+
+  test("strips reply fallbacks and rebases incoming DM markup", () => {
+    const h = makeHandlers();
+    const body = "reply code";
+    const prefix = "> 👋 hi\n\n";
+    const prefixBytes = byteLen(prefix);
+
+    dispatchChat(
+      makeMsg({
+        id: "reply-1",
+        body: `${prefix}${body}`,
+        reply: { to: "bob@example.com", id: "dm-1" },
+        fallbacks: [{ for: "urn:xmpp:reply:0", body: { start: 0, end: prefix.length } }],
+        markup: {
+          spans: [
+            { type: "code", start: prefixBytes + byteLen("reply "), end: prefixBytes + byteLen(body) },
+          ],
+        },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe(body);
+    expect(h.messages[0].replyTo).toEqual({ id: "dm-1", author: "bob@example.com" });
+    expect(h.messages[0].markup).toEqual([
+      { type: "code", start: byteLen("reply "), end: byteLen(body) },
+    ]);
   });
 });

--- a/chat/tests/dm-replies.test.ts
+++ b/chat/tests/dm-replies.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { Agent } from "stanza";
+import { sendDirectMessage } from "../src/lib/xmpp/dm-messaging";
+
+function makeAgent() {
+  return {
+    sendMessage: mock(() => undefined),
+  } as unknown as Agent & {
+    sendMessage: ReturnType<typeof mock>;
+  };
+}
+
+describe("dm replies + threads", () => {
+  test("attaches reply pointer, fallback range, and thread id", () => {
+    const xmpp = makeAgent();
+
+    const messageId = sendDirectMessage(xmpp, "bob@waddle.social", "sure!", {
+      replyTo: { id: "dm-1", author: "bob@waddle.social", body: "want to grab lunch?" },
+      threadId: "dm-thread-1",
+    });
+
+    expect(typeof messageId).toBe("string");
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+
+    const expectedPrefix = "> want to grab lunch?\n\n";
+    expect(call.body).toBe(`${expectedPrefix}sure!`);
+    expect(call.reply).toEqual({ to: "bob@waddle.social", id: "dm-1" });
+    expect(call.fallbacks).toEqual([
+      { for: "urn:xmpp:reply:0", body: { start: 0, end: expectedPrefix.length } },
+    ]);
+    expect(call.thread).toBe("dm-thread-1");
+  });
+
+  test("emits parentThread when supplied alongside threadId", () => {
+    const xmpp = makeAgent();
+
+    sendDirectMessage(xmpp, "bob@waddle.social", "branch", {
+      threadId: "child",
+      parentThreadId: "parent",
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.thread).toBe("child");
+    expect(call.parentThread).toBe("parent");
+  });
+
+  test("omits fallback range when parent body is unknown", () => {
+    const xmpp = makeAgent();
+
+    sendDirectMessage(xmpp, "bob@waddle.social", "replying blind", {
+      replyTo: { id: "dm-1", author: "bob@waddle.social" },
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.body).toBe("replying blind");
+    expect(call.reply).toEqual({ to: "bob@waddle.social", id: "dm-1" });
+    expect(call.fallbacks).toBeUndefined();
+  });
+});

--- a/chat/tests/groupchat-messaging.test.ts
+++ b/chat/tests/groupchat-messaging.test.ts
@@ -111,9 +111,9 @@ describe("groupchat messaging", () => {
     const xmpp = makeAgent();
     const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
 
-    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "", undefined, [
-      { url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 },
-    ]);
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "", {
+      files: [{ url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 }],
+    });
 
     expect(typeof messageId).toBe("string");
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
@@ -124,7 +124,7 @@ describe("groupchat messaging", () => {
       type: "groupchat",
       body: fileUrl,
       links: [{ url: fileUrl }],
-      fallback: { for: "urn:xmpp:sfs:0", body: true },
+      fallbacks: [{ for: "urn:xmpp:sfs:0" }],
       processingHints: { store: true },
     });
     expect(Array.isArray(call.fileSharing)).toBe(true);
@@ -141,14 +141,14 @@ describe("groupchat messaging", () => {
     const xmpp = makeAgent();
     const fileUrl = "https://xmpp.waddle.social/upload/abc/photo.jpg";
 
-    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "check this out", undefined, [
-      { url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 },
-    ]);
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "check this out", {
+      files: [{ url: fileUrl, name: "photo.jpg", mediaType: "image/jpeg", size: 12345 }],
+    });
 
     expect(typeof messageId).toBe("string");
     const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
     expect(call.body).toBe("check this out");
-    expect(call.fallback).toBeUndefined();
+    expect(call.fallbacks).toBeUndefined();
     expect(call.links).toEqual([{ url: fileUrl }]);
     expect(Array.isArray(call.fileSharing)).toBe(true);
     expect((call.fileSharing as unknown[]).length).toBe(1);
@@ -161,10 +161,12 @@ describe("groupchat messaging", () => {
       "https://xmpp.waddle.social/upload/a/2.jpg",
     ];
 
-    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "gallery", undefined, [
-      { url: urls[0], name: "1.jpg", mediaType: "image/jpeg", size: 1 },
-      { url: urls[1], name: "2.jpg", mediaType: "image/jpeg", size: 2 },
-    ]);
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "gallery", {
+      files: [
+        { url: urls[0], name: "1.jpg", mediaType: "image/jpeg", size: 1 },
+        { url: urls[1], name: "2.jpg", mediaType: "image/jpeg", size: 2 },
+      ],
+    });
 
     expect(typeof messageId).toBe("string");
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -3,6 +3,12 @@ import { dispatchGroupchat, type GroupchatHandlers } from "../src/lib/xmpp/messa
 import type { ReceivedMessage } from "stanza/protocol";
 import type { LiveRoomMessage } from "../src/lib/xmpp/types";
 
+const encoder = new TextEncoder();
+
+function byteLen(input: string): number {
+  return encoder.encode(input).byteLength;
+}
+
 function makeHandlers(overrides?: Partial<GroupchatHandlers>): GroupchatHandlers & {
   messages: LiveRoomMessage[];
 } {
@@ -99,5 +105,41 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].replyTo).toBeUndefined();
     expect(h.messages[0].threadId).toBeUndefined();
+  });
+
+  test("rebases rich markup after stripping the reply fallback prefix", () => {
+    const h = makeHandlers();
+    const body = "bold code link";
+    const prefix = "> 👋 hi\n\n";
+    const prefixBytes = byteLen(prefix);
+
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-5",
+        body: `${prefix}${body}`,
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+        fallbacks: [{ for: "urn:xmpp:reply:0", body: { start: 0, end: prefix.length } }],
+        markup: {
+          spans: [
+            { type: "b", start: prefixBytes, end: prefixBytes + byteLen("bold") },
+            { type: "code", start: prefixBytes + byteLen("bold "), end: prefixBytes + byteLen("bold code") },
+            { type: "link", start: prefixBytes + byteLen("bold code "), end: prefixBytes + byteLen(body), uri: "https://example.com/docs" },
+            { type: "i", start: prefixBytes - byteLen("hi\n\n"), end: prefixBytes + byteLen("bo") },
+            { type: "s", start: byteLen("> "), end: byteLen("> 👋") },
+            { type: "code", start: prefixBytes + byteLen("bold"), end: prefixBytes + byteLen("bold") },
+          ],
+        },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe(body);
+    expect(h.messages[0].markup).toEqual([
+      { type: "b", start: 0, end: byteLen("bold") },
+      { type: "code", start: byteLen("bold "), end: byteLen("bold code") },
+      { type: "link", start: byteLen("bold code "), end: byteLen(body), uri: "https://example.com/docs" },
+      { type: "i", start: 0, end: byteLen("bo") },
+    ]);
   });
 });

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "bun:test";
+import { dispatchGroupchat, type GroupchatHandlers } from "../src/lib/xmpp/message-parsing";
+import type { ReceivedMessage } from "stanza/protocol";
+import type { LiveRoomMessage } from "../src/lib/xmpp/types";
+
+function makeHandlers(overrides?: Partial<GroupchatHandlers>): GroupchatHandlers & {
+  messages: LiveRoomMessage[];
+} {
+  const messages: LiveRoomMessage[] = [];
+  return {
+    currentRoom: "general@muc.waddle.social",
+    selfNick: "me",
+    onMessage: (msg) => messages.push(msg),
+    onChatState: null,
+    onDisplayed: null,
+    onReaction: null,
+    onActivity: null,
+    messages,
+    ...overrides,
+  };
+}
+
+function makeMsg(overrides: Record<string, unknown>): ReceivedMessage {
+  return {
+    from: "general@muc.waddle.social/alice",
+    type: "groupchat",
+    ...overrides,
+  } as ReceivedMessage;
+}
+
+describe("groupchat reply + thread parsing", () => {
+  test("extracts reply pointer into replyTo", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-2",
+        body: "yes",
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].replyTo).toEqual({
+      id: "msg-1",
+      author: "general@muc.waddle.social/bob",
+    });
+  });
+
+  test("strips the XEP-0428 reply fallback range from the displayed body", () => {
+    const h = makeHandlers();
+    const prefix = "> hi\n\n";
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-2",
+        body: `${prefix}actual reply`,
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+        fallbacks: [{ for: "urn:xmpp:reply:0", body: { start: 0, end: prefix.length } }],
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("actual reply");
+    expect(h.messages[0].replyTo?.id).toBe("msg-1");
+  });
+
+  test("ignores fallbacks for other namespaces", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-2",
+        body: "https://example.com/file.jpg",
+        fallbacks: [{ for: "urn:xmpp:sfs:0" }],
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("https://example.com/file.jpg");
+  });
+
+  test("extracts thread id and parent thread id", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-3",
+        body: "branch",
+        thread: "thread-xyz",
+        parentThread: "thread-root",
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].threadId).toBe("thread-xyz");
+    expect(h.messages[0].parentThreadId).toBe("thread-root");
+  });
+
+  test("leaves replyTo undefined when no reply element is present", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(makeMsg({ id: "msg-4", body: "plain" }), h);
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].replyTo).toBeUndefined();
+    expect(h.messages[0].threadId).toBeUndefined();
+  });
+});

--- a/chat/tests/groupchat-replies.test.ts
+++ b/chat/tests/groupchat-replies.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, mock } from "bun:test";
+import type { Agent } from "stanza";
+import { sendGroupMessage } from "../src/lib/xmpp/messaging";
+
+function makeAgent() {
+  return {
+    sendMessage: mock(() => undefined),
+  } as unknown as Agent & {
+    sendMessage: ReturnType<typeof mock>;
+  };
+}
+
+describe("groupchat replies + threads", () => {
+  test("attaches reply pointer, fallback range, and thread id", () => {
+    const xmpp = makeAgent();
+
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "sounds good", {
+      replyTo: { id: "msg-1", author: "general@muc.waddle.social/alice", body: "shall we ship?" },
+      threadId: "thread-xyz",
+    });
+
+    expect(typeof messageId).toBe("string");
+    expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+
+    const expectedPrefix = "> shall we ship?\n\n";
+    expect(call.body).toBe(`${expectedPrefix}sounds good`);
+    expect(call.reply).toEqual({ to: "general@muc.waddle.social/alice", id: "msg-1" });
+    expect(call.fallbacks).toEqual([
+      { for: "urn:xmpp:reply:0", body: { start: 0, end: expectedPrefix.length } },
+    ]);
+    expect(call.thread).toBe("thread-xyz");
+    expect(call.processingHints).toEqual({ store: true });
+  });
+
+  test("emits parentThread when supplied alongside threadId", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "general@muc.waddle.social", "branching off", {
+      threadId: "thread-child",
+      parentThreadId: "thread-parent",
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.thread).toBe("thread-child");
+    expect(call.parentThread).toBe("thread-parent");
+  });
+
+  test("offsets mention references by the reply fallback prefix length", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "general@muc.waddle.social", "ping @bob", {
+      replyTo: { id: "msg-1", author: "general@muc.waddle.social/alice", body: "hi" },
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    const prefixLength = "> hi\n\n".length;
+    expect(call.references).toEqual([
+      expect.objectContaining({
+        type: "mention",
+        uri: "xmpp:bob",
+        begin: String(prefixLength + "ping ".length),
+        end: String(prefixLength + "ping ".length + "@bob".length),
+      }),
+    ]);
+  });
+
+  test("omits fallback range when the parent body is empty", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "general@muc.waddle.social", "standalone reply", {
+      replyTo: { id: "msg-1", author: "general@muc.waddle.social/alice" },
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.body).toBe("standalone reply");
+    expect(call.reply).toEqual({ to: "general@muc.waddle.social/alice", id: "msg-1" });
+    expect(call.fallbacks).toBeUndefined();
+  });
+});

--- a/chat/tests/groupchat-replies.test.ts
+++ b/chat/tests/groupchat-replies.test.ts
@@ -2,6 +2,12 @@ import { describe, test, expect, mock } from "bun:test";
 import type { Agent } from "stanza";
 import { sendGroupMessage } from "../src/lib/xmpp/messaging";
 
+const encoder = new TextEncoder();
+
+function byteLen(input: string): number {
+  return encoder.encode(input).byteLength;
+}
+
 function makeAgent() {
   return {
     sendMessage: mock(() => undefined),
@@ -76,5 +82,31 @@ describe("groupchat replies + threads", () => {
     expect(call.body).toBe("standalone reply");
     expect(call.reply).toEqual({ to: "general@muc.waddle.social/alice", id: "msg-1" });
     expect(call.fallbacks).toBeUndefined();
+  });
+
+  test("rebases rich markup spans when a reply fallback prefix is prepended", () => {
+    const xmpp = makeAgent();
+    const body = "bold code link";
+    const prefix = "> 👋 hi\n\n";
+
+    sendGroupMessage(xmpp, "general@muc.waddle.social", body, {
+      replyTo: { id: "msg-1", author: "general@muc.waddle.social/alice", body: "👋 hi" },
+      markup: [
+        { type: "b", start: 0, end: byteLen("bold") },
+        { type: "code", start: byteLen("bold "), end: byteLen("bold code") },
+        { type: "link", start: byteLen("bold code "), end: byteLen(body), uri: "https://example.com/docs" },
+      ],
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    const prefixBytes = byteLen(prefix);
+    expect(call.body).toBe(`${prefix}${body}`);
+    expect(call.markup).toEqual({
+      spans: [
+        { type: "b", start: prefixBytes, end: prefixBytes + byteLen("bold") },
+        { type: "code", start: prefixBytes + byteLen("bold "), end: prefixBytes + byteLen("bold code") },
+        { type: "link", start: prefixBytes + byteLen("bold code "), end: prefixBytes + byteLen(body), uri: "https://example.com/docs" },
+      ],
+    });
   });
 });

--- a/chat/tests/message-targeting.test.ts
+++ b/chat/tests/message-targeting.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { findMessageElementById } from "../src/lib/message-targeting";
+
+type StubElement = {
+  getAttribute(name: string): string | null;
+};
+
+function makeElement(messageId: string): StubElement {
+  return {
+    getAttribute(name: string) {
+      return name === "data-message-id" ? messageId : null;
+    },
+  };
+}
+
+const originalCssDescriptor = Object.getOwnPropertyDescriptor(globalThis, "CSS");
+
+afterEach(() => {
+  if (originalCssDescriptor) {
+    Object.defineProperty(globalThis, "CSS", originalCssDescriptor);
+    return;
+  }
+
+  delete (globalThis as { CSS?: unknown }).CSS;
+});
+
+describe("findMessageElementById", () => {
+  test("uses CSS.escape before building the selector", () => {
+    const dangerId = 'reply"] [data-message-id="other';
+    const target = makeElement(dangerId);
+    const escape = mock(() => "escaped-id");
+    const querySelector = mock((selector: string) => {
+      expect(selector).toBe('[data-message-id="escaped-id"]');
+      return target;
+    });
+    const querySelectorAll = mock(() => []);
+
+    Object.defineProperty(globalThis, "CSS", {
+      value: { escape },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = findMessageElementById({ querySelector, querySelectorAll }, dangerId);
+
+    expect(result).toBe(target);
+    expect(escape).toHaveBeenCalledWith(dangerId);
+    expect(querySelectorAll).not.toHaveBeenCalled();
+  });
+
+  test("falls back to exact attribute matching when CSS.escape is unavailable", () => {
+    const dangerId = 'reply"] [data-message-id="other';
+    const wrong = makeElement("other");
+    const target = makeElement(dangerId);
+    const querySelector = mock(() => wrong);
+    const querySelectorAll = mock(() => [wrong, target]);
+
+    delete (globalThis as { CSS?: unknown }).CSS;
+
+    const result = findMessageElementById({ querySelector, querySelectorAll }, dangerId);
+
+    expect(result).toBe(target);
+    expect(querySelector).not.toHaveBeenCalled();
+    expect(querySelectorAll).toHaveBeenCalledWith("[data-message-id]");
+  });
+
+  test("rejects a mismatched selector result and scans for the exact message id", () => {
+    const dangerId = 'reply"] [data-message-id="other';
+    const wrong = makeElement("other");
+    const target = makeElement(dangerId);
+    const querySelector = mock(() => wrong);
+    const querySelectorAll = mock(() => [wrong, target]);
+
+    Object.defineProperty(globalThis, "CSS", {
+      value: { escape: (value: string) => value },
+      configurable: true,
+      writable: true,
+    });
+
+    const result = findMessageElementById({ querySelector, querySelectorAll }, dangerId);
+
+    expect(result).toBe(target);
+    expect(querySelector).toHaveBeenCalledTimes(1);
+    expect(querySelectorAll).toHaveBeenCalledWith("[data-message-id]");
+  });
+});

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { useDmMessaging } from "../src/composables/useDmMessaging";
+import { useMessaging } from "../src/composables/useMessaging";
+
+function session(partial: Partial<WaddleSession> = {}): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/xmpp",
+    ...partial,
+  } as WaddleSession;
+}
+
+describe("reply addressing", () => {
+  test("room replies serialize the parent occupant JID while keeping the reply UI label", async () => {
+    const sendGroupMessage = mock(async () => "reply-1");
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "parent-1",
+        author: "Friendly Bob",
+        authorJid: "w1_c1@muc.example.com/Friendly Bob",
+        body: "hello there",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    await messaging.sendMessage("sounds good", [], undefined, {
+      id: "parent-1",
+      author: "Friendly Bob",
+      body: "hello there",
+    });
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "sounds good",
+      expect.objectContaining({
+        replyTo: {
+          id: "parent-1",
+          author: "w1_c1@muc.example.com/Friendly Bob",
+          body: "hello there",
+        },
+      }),
+    );
+    expect(messaging.messages.value.at(-1)?.replyTo).toEqual({
+      id: "parent-1",
+      author: "Friendly Bob",
+      preview: "hello there",
+    });
+  });
+
+  test("DM replies serialize the parent author JID while keeping the reply UI label", async () => {
+    const sendDirectMessage = mock(async () => "reply-1");
+    const sendDmChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useDmMessaging(
+      ref(session()),
+      ref({ sendDirectMessage, sendDmChatState } as never),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "parent-1",
+        author: "Bob",
+        authorJid: "bob@example.com/mobile",
+        body: "want to grab lunch?",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    await messaging.sendMessage("sure!", undefined, undefined, {
+      id: "parent-1",
+      author: "Bob",
+      body: "want to grab lunch?",
+    });
+
+    expect(sendDirectMessage).toHaveBeenCalledWith(
+      "bob@example.com",
+      "sure!",
+      expect.objectContaining({
+        replyTo: {
+          id: "parent-1",
+          author: "bob@example.com/mobile",
+          body: "want to grab lunch?",
+        },
+      }),
+    );
+    expect(messaging.messages.value.at(-1)?.replyTo).toEqual({
+      id: "parent-1",
+      author: "Bob",
+      preview: "want to grab lunch?",
+    });
+  });
+
+  test("room sends drop stale reply context when the parent is not in the active timeline", async () => {
+    const sendGroupMessage = mock(async () => "reply-1");
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c2"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "current-1",
+        author: "Carol",
+        authorJid: "w1_c2@muc.example.com/Carol",
+        body: "different room",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    await messaging.sendMessage("fresh message", [], undefined, {
+      id: "stale-parent",
+      author: "Friendly Bob",
+      body: "hello there",
+    });
+
+    expect(sendGroupMessage).toHaveBeenCalledWith("w1", "c2", "fresh message", expect.any(Object));
+    const options = sendGroupMessage.mock.calls[0]?.[3] as Record<string, unknown>;
+    expect(options.replyTo).toBeUndefined();
+    expect(options.threadId).toBeUndefined();
+    expect(messaging.messages.value.at(-1)?.replyTo).toBeUndefined();
+    expect(messaging.messages.value.at(-1)?.threadId).toBeUndefined();
+  });
+
+  test("DM sends drop stale reply context when the parent is not in the active timeline", async () => {
+    const sendDirectMessage = mock(async () => "reply-1");
+    const sendDmChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useDmMessaging(
+      ref(session()),
+      ref({ sendDirectMessage, sendDmChatState } as never),
+      ref("carol@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "current-1",
+        author: "Carol",
+        authorJid: "carol@example.com/phone",
+        body: "different DM",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    await messaging.sendMessage("fresh dm", undefined, undefined, {
+      id: "stale-parent",
+      author: "Bob",
+      body: "want to grab lunch?",
+    });
+
+    expect(sendDirectMessage).toHaveBeenCalledWith("carol@example.com", "fresh dm", expect.any(Object));
+    const options = sendDirectMessage.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(options.replyTo).toBeUndefined();
+    expect(options.threadId).toBeUndefined();
+    expect(messaging.messages.value.at(-1)?.replyTo).toBeUndefined();
+    expect(messaging.messages.value.at(-1)?.threadId).toBeUndefined();
+  });
+});

--- a/chat/tests/reply-fallback-prefix.test.ts
+++ b/chat/tests/reply-fallback-prefix.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from "bun:test";
+import { buildReplyFallbackPrefix } from "../src/lib/xmpp/messaging";
+
+describe("buildReplyFallbackPrefix", () => {
+  test("returns empty values when parent body is missing", () => {
+    expect(buildReplyFallbackPrefix(undefined)).toEqual({ prefix: "", length: 0 });
+    expect(buildReplyFallbackPrefix("")).toEqual({ prefix: "", length: 0 });
+  });
+
+  test("quotes a single line and appends a blank line", () => {
+    const { prefix, length } = buildReplyFallbackPrefix("hello");
+    expect(prefix).toBe("> hello\n\n");
+    expect(length).toBe(prefix.length);
+  });
+
+  test("quotes each line of a multi-line parent body", () => {
+    const { prefix, length } = buildReplyFallbackPrefix("line one\nline two\nline three");
+    expect(prefix).toBe("> line one\n> line two\n> line three\n\n");
+    expect(length).toBe(prefix.length);
+  });
+
+  test("length matches the returned prefix character count", () => {
+    const parent = "hi 👋\nmultiline";
+    const { prefix, length } = buildReplyFallbackPrefix(parent);
+    expect(length).toBe(prefix.length);
+    expect(prefix.startsWith("> hi ")).toBe(true);
+    expect(prefix.endsWith("\n\n")).toBe(true);
+  });
+});

--- a/chat/tests/reply-ux.test.ts
+++ b/chat/tests/reply-ux.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { getComposerEscapeAction, getReplyJumpNotice, REPLY_JUMP_TARGET_MISSING_MESSAGE } from "../src/lib/reply-ux";
+
+describe("reply UX helpers", () => {
+  test("Escape dismisses autocomplete before cancelling reply context", () => {
+    expect(
+      getComposerEscapeAction({
+        showMentions: true,
+        showEmoji: false,
+        isReplyingTo: true,
+      }),
+    ).toBe("dismiss-autocomplete");
+
+    expect(
+      getComposerEscapeAction({
+        showMentions: false,
+        showEmoji: true,
+        isReplyingTo: true,
+      }),
+    ).toBe("dismiss-autocomplete");
+  });
+
+  test("Escape cancels the active reply when autocomplete is closed", () => {
+    expect(
+      getComposerEscapeAction({
+        showMentions: false,
+        showEmoji: false,
+        isReplyingTo: true,
+      }),
+    ).toBe("cancel-reply");
+  });
+
+  test("missing reply jump targets show a calm notice", () => {
+    expect(getReplyJumpNotice(true)).toBe("");
+    expect(getReplyJumpNotice(false)).toBe(REPLY_JUMP_TARGET_MISSING_MESSAGE);
+  });
+});

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -969,9 +969,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                 Ok(())
             }
             ParsedStanza::Message(element) => {
-                let msg = element
-                    .try_into()
-                    .map_err(|e| XmppError::xml_parse(format!("Invalid message: {:?}", e)))?;
+                let msg = crate::stream::element_to_message(element)?;
                 // Increment inbound count for SM
                 if self.sm_state.enabled {
                     self.sm_state.increment_inbound();
@@ -7337,7 +7335,7 @@ fn build_archived_message(
     let reply_ref = parse_reply_from_message(&normalized);
     let thread_id = thread_id_from_message(&normalized);
     let origin_id = extract_origin_id(&normalized);
-    let stanza_xml = match crate::parser::stanza_to_string(normalized.clone()) {
+    let stanza_xml = match crate::parser::message_to_string(&normalized) {
         Ok(xml) => Some(xml),
         Err(error) => {
             warn!(from = %from, to = %to, error = %error, "Failed to serialize archived stanza");

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -7365,7 +7365,7 @@ fn replay_archived_message(
 ) -> xmpp_parsers::message::Message {
     if let Some(stanza_xml) = archived.stanza_xml.as_deref() {
         match stanza_xml.parse::<minidom::Element>() {
-            Ok(element) => match xmpp_parsers::message::Message::try_from(element) {
+            Ok(element) => match crate::stream::element_to_message(element) {
                 Ok(message) => return message,
                 Err(error) => {
                     warn!(archive_id = %archived.id, error = %error, "Failed to parse archived stanza as message");

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -112,6 +112,16 @@ impl Feature {
         Self::new("urn:xmpp:reply:0")
     }
 
+    /// XEP-0428 Fallback Indication feature.
+    pub fn fallback_indication() -> Self {
+        Self::new("urn:xmpp:fallback:0")
+    }
+
+    /// XEP-0201 Message Threads discovery feature (waddle-local advertisement).
+    pub fn threads() -> Self {
+        Self::new("urn:xmpp:threads:0")
+    }
+
     /// Stream Management feature
     pub fn stream_management() -> Self {
         Self::new("urn:xmpp:sm:3")
@@ -449,6 +459,8 @@ pub fn server_features() -> Vec<Feature> {
         Feature::roster_versioning(),
         Feature::mam(),
         Feature::replies(),
+        Feature::fallback_indication(),
+        Feature::threads(),
         Feature::stream_management(),
         Feature::roster(),
         Feature::carbons(),
@@ -542,6 +554,8 @@ pub fn muc_room_features(persistent: bool, members_only: bool, moderated: bool) 
         Feature::muc(),
         Feature::mam(),
         Feature::replies(),
+        Feature::fallback_indication(),
+        Feature::threads(),
         Feature::vcard(),
         Feature::occupant_id(),
         Feature::muc_semianonymous(),

--- a/server/crates/waddle-xmpp/src/parser.rs
+++ b/server/crates/waddle-xmpp/src/parser.rs
@@ -795,7 +795,9 @@ pub fn message_to_string(msg: &xmpp_parsers::message::Message) -> Result<String,
 
     if let Some(id) = thread_id {
         if !id.trim().is_empty() && !element.children().any(|child| child.name() == "thread") {
-            let thread_elem = Element::builder("thread", "").append(id.as_str()).build();
+            let thread_elem = Element::builder("thread", element.ns())
+                .append(id.as_str())
+                .build();
             element.append_child(thread_elem);
         }
     }

--- a/server/crates/waddle-xmpp/src/parser.rs
+++ b/server/crates/waddle-xmpp/src/parser.rs
@@ -786,6 +786,23 @@ pub fn stanza_to_string<T: Into<Element>>(stanza: T) -> Result<String, XmppError
     element_to_string(&element)
 }
 
+/// Convert a `Message` to an XML string, preserving the RFC 6121 `<thread/>`
+/// element which `xmpp_parsers 0.21`'s `From<Message> for Element`
+/// incorrectly drops.
+pub fn message_to_string(msg: &xmpp_parsers::message::Message) -> Result<String, XmppError> {
+    let thread_id = msg.thread.as_ref().map(|t| t.0.clone());
+    let mut element: Element = msg.clone().into();
+
+    if let Some(id) = thread_id {
+        if !id.trim().is_empty() && !element.children().any(|child| child.name() == "thread") {
+            let thread_elem = Element::builder("thread", "").append(id.as_str()).build();
+            element.append_child(thread_elem);
+        }
+    }
+
+    element_to_string(&element)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/crates/waddle-xmpp/src/stream.rs
+++ b/server/crates/waddle-xmpp/src/stream.rs
@@ -1279,9 +1279,32 @@ fn pre_bind_target_is_unauthorized(
 }
 
 /// Convert a minidom Element to an xmpp_parsers Message.
-fn element_to_message(element: Element) -> Result<Message, XmppError> {
-    Message::try_from(element)
-        .map_err(|e| XmppError::xml_parse(format!("Invalid message: {:?}", e)))
+///
+/// Extracts any `<thread parent="..."/>` element from the raw XML before handing
+/// off to `xmpp_parsers::Message::try_from`, because the typed `Thread(String)`
+/// in xmpp_parsers 0.21 only carries the thread id — the XEP-0201 `parent`
+/// attribute would be lost otherwise. The thread is re-inserted as a raw
+/// payload so the attribute survives the round-trip.
+pub(crate) fn element_to_message(element: Element) -> Result<Message, XmppError> {
+    let thread_parent = element
+        .children()
+        .find(|child| child.name() == "thread")
+        .and_then(|child| child.attr("parent").map(str::to_owned));
+
+    let mut msg = Message::try_from(element)
+        .map_err(|e| XmppError::xml_parse(format!("Invalid message: {:?}", e)))?;
+
+    if let Some(parent) = thread_parent {
+        if let Some(thread) = msg.thread.take() {
+            let thread_elem = Element::builder("thread", "")
+                .attr("parent", parent)
+                .append(thread.0.as_str())
+                .build();
+            msg.payloads.push(thread_elem);
+        }
+    }
+
+    Ok(msg)
 }
 
 /// Convert a minidom Element to an xmpp_parsers Presence.
@@ -1299,7 +1322,18 @@ fn element_to_iq(element: Element) -> Result<Iq, XmppError> {
 fn stanza_to_xml(stanza: &Stanza) -> Result<String, XmppError> {
     match stanza {
         Stanza::Message(msg) => {
-            let element: Element = msg.clone().into();
+            let thread_id = msg.thread.as_ref().map(|t| t.0.clone());
+            let mut element: Element = msg.clone().into();
+            // xmpp_parsers 0.21 drops <thread/> when serializing Message back
+            // to Element. Re-attach it so RFC 6121 / XEP-0201 metadata survives.
+            if let Some(id) = thread_id {
+                if id.trim().is_empty() {
+                    // skip empty thread
+                } else if !element.children().any(|child| child.name() == "thread") {
+                    let thread_elem = Element::builder("thread", "").append(id.as_str()).build();
+                    element.append_child(thread_elem);
+                }
+            }
             element_to_string(&element)
         }
         Stanza::Presence(pres) => {

--- a/server/crates/waddle-xmpp/src/stream.rs
+++ b/server/crates/waddle-xmpp/src/stream.rs
@@ -1289,14 +1289,21 @@ pub(crate) fn element_to_message(element: Element) -> Result<Message, XmppError>
     let thread_parent = element
         .children()
         .find(|child| child.name() == "thread")
-        .and_then(|child| child.attr("parent").map(str::to_owned));
+        .and_then(|child| {
+            child
+                .attr("parent")
+                .map(str::trim)
+                .filter(|parent| !parent.is_empty())
+                .map(str::to_owned)
+        });
+    let stanza_ns = element.ns();
 
     let mut msg = Message::try_from(element)
         .map_err(|e| XmppError::xml_parse(format!("Invalid message: {:?}", e)))?;
 
     if let Some(parent) = thread_parent {
         if let Some(thread) = msg.thread.take() {
-            let thread_elem = Element::builder("thread", "")
+            let thread_elem = Element::builder("thread", stanza_ns)
                 .attr("parent", parent)
                 .append(thread.0.as_str())
                 .build();
@@ -1330,7 +1337,9 @@ fn stanza_to_xml(stanza: &Stanza) -> Result<String, XmppError> {
                 if id.trim().is_empty() {
                     // skip empty thread
                 } else if !element.children().any(|child| child.name() == "thread") {
-                    let thread_elem = Element::builder("thread", "").append(id.as_str()).build();
+                    let thread_elem = Element::builder("thread", element.ns())
+                        .append(id.as_str())
+                        .build();
                     element.append_child(thread_elem);
                 }
             }

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -143,6 +143,7 @@ pub mod xep0172;
 pub mod xep0184;
 pub mod xep0191;
 pub mod xep0199;
+pub mod xep0201;
 pub mod xep0202;
 pub mod xep0203;
 pub mod xep0223;
@@ -170,6 +171,7 @@ pub mod xep0410;
 pub mod xep0421;
 pub mod xep0424;
 pub mod xep0425;
+pub mod xep0428;
 pub mod xep0431;
 pub mod xep0433;
 pub mod xep0437;
@@ -271,6 +273,11 @@ pub use xep0184::{
 };
 
 pub use xep0199::{build_ping_result, is_ping, NS_PING};
+
+pub use xep0201::{
+    build_thread_element, install_thread_element, parse_thread_info, thread_parent_from_message,
+    ThreadInfo, NS_THREAD_FEATURE, THREAD_ELEMENT,
+};
 
 pub use xep0092::{
     build_version_element, build_version_response, is_version_query, parse_version_response,
@@ -412,6 +419,11 @@ pub use xep0444::{
     build_reaction_element, build_reaction_message, build_reactions_element, extract_reacted_id,
     extract_reactions_from_message, is_reaction_message, is_reactions_element, set_reactions,
     strip_reactions, ReactionCarrier, ReactionError, ReactionSet, NS_REACTIONS,
+};
+
+pub use xep0428::{
+    build_fallback_element, is_fallback_element, parse_fallbacks_from_message,
+    set_fallback_payloads, strip_fallback_ranges, FallbackIndication, FallbackRange, NS_FALLBACK,
 };
 
 pub use xep0402::{

--- a/server/crates/waddle-xmpp/src/xep/xep0201.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0201.rs
@@ -94,9 +94,14 @@ pub fn thread_parent_from_message(msg: &Message) -> Option<String> {
     parse_thread_info(&xml).and_then(|info| info.parent)
 }
 
-/// Build a `<thread/>` element with optional `parent` attribute.
-pub fn build_thread_element(info: &ThreadInfo) -> Element {
-    let mut builder = Element::builder(THREAD_ELEMENT, "");
+/// Build a `<thread/>` element with optional `parent` attribute in the given
+/// stanza namespace.
+///
+/// RFC 6121 scopes `<thread/>` to the enclosing message's namespace. Pass the
+/// parent message's namespace (typically `jabber:client` or `jabber:server`)
+/// so the serializer does not emit a spurious `xmlns=""`.
+pub fn build_thread_element(info: &ThreadInfo, ns: impl AsRef<str>) -> Element {
+    let mut builder = Element::builder(THREAD_ELEMENT, ns.as_ref());
     if let Some(parent) = info.parent.as_deref() {
         builder = builder.attr("parent", parent);
     }
@@ -104,10 +109,9 @@ pub fn build_thread_element(info: &ThreadInfo) -> Element {
 }
 
 /// Replace any `<thread/>` children on a raw message element with one built
-/// from `info`. Namespace-agnostic because RFC 6121 `<thread/>` may be emitted
-/// in `jabber:client`, `jabber:server`, or the empty namespace depending on
-/// the serializer.
+/// from `info`, inheriting the message's namespace.
 pub fn install_thread_element(msg_xml: &mut Element, info: &ThreadInfo) {
+    let stanza_ns = msg_xml.ns();
     let to_remove: Vec<(String, String)> = msg_xml
         .children()
         .filter(|c| c.name() == THREAD_ELEMENT)
@@ -116,7 +120,7 @@ pub fn install_thread_element(msg_xml: &mut Element, info: &ThreadInfo) {
     for (name, ns) in to_remove {
         msg_xml.remove_child(&name, ns.as_str());
     }
-    msg_xml.append_child(build_thread_element(info));
+    msg_xml.append_child(build_thread_element(info, stanza_ns));
 }
 
 #[cfg(test)]
@@ -163,8 +167,9 @@ mod tests {
     #[test]
     fn build_element_with_parent() {
         let info = ThreadInfo::child("child-a", "root-a");
-        let elem = build_thread_element(&info);
+        let elem = build_thread_element(&info, "jabber:client");
         assert_eq!(elem.name(), THREAD_ELEMENT);
+        assert_eq!(elem.ns(), "jabber:client");
         assert_eq!(elem.attr("parent"), Some("root-a"));
         assert_eq!(elem.text(), "child-a");
     }
@@ -172,9 +177,22 @@ mod tests {
     #[test]
     fn build_element_without_parent() {
         let info = ThreadInfo::root("root-a");
-        let elem = build_thread_element(&info);
+        let elem = build_thread_element(&info, "jabber:client");
         assert_eq!(elem.attr("parent"), None);
         assert_eq!(elem.text(), "root-a");
+    }
+
+    #[test]
+    fn install_thread_element_inherits_message_ns() {
+        let mut xml = "<message xmlns='jabber:client'/>"
+            .parse::<Element>()
+            .expect("valid xml");
+        install_thread_element(&mut xml, &ThreadInfo::child("c", "r"));
+        let thread = xml
+            .children()
+            .find(|c| c.name() == THREAD_ELEMENT)
+            .expect("thread child");
+        assert_eq!(thread.ns(), "jabber:client");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0201.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0201.rs
@@ -1,0 +1,208 @@
+//! XEP-0201: Best Practices for Message Threads
+//!
+//! The `<thread/>` element is defined by RFC 6121 (no namespace). XEP-0201 is
+//! an Informational XEP that standardises how clients and servers should
+//! generate, propagate, and optionally nest threads via the `parent` attribute.
+//!
+//! Wire shape:
+//!
+//! ```xml
+//! <thread parent='root-thread'>child-thread</thread>
+//! ```
+//!
+//! The typed `xmpp_parsers::message::Message::thread` field only carries the
+//! thread id; for the optional `parent=` attribute this module exposes helpers
+//! that operate on the raw `minidom::Element` form of the message.
+//!
+//! Waddle advertises `urn:xmpp:threads:0` in disco#info so that clients can
+//! discover thread-aware services/rooms.
+
+use minidom::Element;
+use xmpp_parsers::message::Message;
+
+pub use crate::xep::xep0461::{set_thread_id, thread_id_from_message};
+
+/// Waddle discovery feature string for XEP-0201 thread support.
+pub const NS_THREAD_FEATURE: &str = "urn:xmpp:threads:0";
+
+/// The RFC 6121 thread element name.
+pub const THREAD_ELEMENT: &str = "thread";
+
+/// Thread identifier plus an optional parent (XEP-0201 nesting).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadInfo {
+    /// The thread identifier (element text content).
+    pub id: String,
+    /// Optional parent thread (XEP-0201 `parent=` attribute).
+    pub parent: Option<String>,
+}
+
+impl ThreadInfo {
+    /// Build a root thread with no parent.
+    pub fn root(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            parent: None,
+        }
+    }
+
+    /// Build a nested thread with a parent id.
+    pub fn child(id: impl Into<String>, parent: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            parent: Some(parent.into()),
+        }
+    }
+}
+
+fn find_thread_element(msg_xml: &Element) -> Option<&Element> {
+    msg_xml
+        .children()
+        .find(|child| child.name() == THREAD_ELEMENT)
+}
+
+/// Parse thread info from a raw message element.
+///
+/// The `xmpp_parsers::message::Message::thread` field is a plain `String` and
+/// drops the `parent` attribute — callers that need `parent` must use this
+/// element-level helper.
+pub fn parse_thread_info(msg_xml: &Element) -> Option<ThreadInfo> {
+    let thread_elem = find_thread_element(msg_xml)?;
+    let text = thread_elem.text();
+    let id = text.trim();
+    if id.is_empty() {
+        return None;
+    }
+    let parent = thread_elem
+        .attr("parent")
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(ToOwned::to_owned);
+    Some(ThreadInfo {
+        id: id.to_owned(),
+        parent,
+    })
+}
+
+/// Read the optional thread parent from a parsed `Message`.
+///
+/// Round-trips through a `minidom::Element` because the typed field drops the
+/// attribute. Returns `None` if there is no `<thread/>` or if `parent=` is
+/// absent/blank.
+pub fn thread_parent_from_message(msg: &Message) -> Option<String> {
+    let xml: Element = Element::from(msg.clone());
+    parse_thread_info(&xml).and_then(|info| info.parent)
+}
+
+/// Build a `<thread/>` element with optional `parent` attribute.
+pub fn build_thread_element(info: &ThreadInfo) -> Element {
+    let mut builder = Element::builder(THREAD_ELEMENT, "");
+    if let Some(parent) = info.parent.as_deref() {
+        builder = builder.attr("parent", parent);
+    }
+    builder.append(info.id.as_str()).build()
+}
+
+/// Replace any `<thread/>` children on a raw message element with one built
+/// from `info`. Namespace-agnostic because RFC 6121 `<thread/>` may be emitted
+/// in `jabber:client`, `jabber:server`, or the empty namespace depending on
+/// the serializer.
+pub fn install_thread_element(msg_xml: &mut Element, info: &ThreadInfo) {
+    let to_remove: Vec<(String, String)> = msg_xml
+        .children()
+        .filter(|c| c.name() == THREAD_ELEMENT)
+        .map(|c| (c.name().to_owned(), c.ns()))
+        .collect();
+    for (name, ns) in to_remove {
+        msg_xml.remove_child(&name, ns.as_str());
+    }
+    msg_xml.append_child(build_thread_element(info));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_root_thread() {
+        let xml = "<message xmlns='jabber:client'><thread>root-1</thread></message>"
+            .parse::<Element>()
+            .expect("valid xml");
+        let info = parse_thread_info(&xml).expect("thread");
+        assert_eq!(info.id, "root-1");
+        assert_eq!(info.parent, None);
+    }
+
+    #[test]
+    fn parses_child_thread() {
+        let xml =
+            "<message xmlns='jabber:client'><thread parent='root-1'>child-2</thread></message>"
+                .parse::<Element>()
+                .expect("valid xml");
+        let info = parse_thread_info(&xml).expect("thread");
+        assert_eq!(info.id, "child-2");
+        assert_eq!(info.parent.as_deref(), Some("root-1"));
+    }
+
+    #[test]
+    fn empty_thread_returns_none() {
+        let xml = "<message xmlns='jabber:client'><thread></thread></message>"
+            .parse::<Element>()
+            .expect("valid xml");
+        assert_eq!(parse_thread_info(&xml), None);
+    }
+
+    #[test]
+    fn missing_thread_returns_none() {
+        let xml = "<message xmlns='jabber:client'/>"
+            .parse::<Element>()
+            .expect("valid xml");
+        assert_eq!(parse_thread_info(&xml), None);
+    }
+
+    #[test]
+    fn build_element_with_parent() {
+        let info = ThreadInfo::child("child-a", "root-a");
+        let elem = build_thread_element(&info);
+        assert_eq!(elem.name(), THREAD_ELEMENT);
+        assert_eq!(elem.attr("parent"), Some("root-a"));
+        assert_eq!(elem.text(), "child-a");
+    }
+
+    #[test]
+    fn build_element_without_parent() {
+        let info = ThreadInfo::root("root-a");
+        let elem = build_thread_element(&info);
+        assert_eq!(elem.attr("parent"), None);
+        assert_eq!(elem.text(), "root-a");
+    }
+
+    #[test]
+    fn set_thread_id_on_root_message() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        set_thread_id(&mut msg, "abc");
+        assert_eq!(thread_id_from_message(&msg).as_deref(), Some("abc"));
+        assert_eq!(thread_parent_from_message(&msg), None);
+    }
+
+    #[test]
+    fn install_thread_element_strips_existing() {
+        let mut xml = "<message xmlns='jabber:client'><thread>old</thread></message>"
+            .parse::<Element>()
+            .expect("valid xml");
+        install_thread_element(&mut xml, &ThreadInfo::child("new", "root"));
+        let count = xml
+            .children()
+            .filter(|c| c.name() == THREAD_ELEMENT)
+            .count();
+        assert_eq!(count, 1);
+        let info = parse_thread_info(&xml).expect("thread after install");
+        assert_eq!(info.id, "new");
+        assert_eq!(info.parent.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn thread_feature_constant() {
+        assert_eq!(NS_THREAD_FEATURE, "urn:xmpp:threads:0");
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0428.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0428.rs
@@ -1,0 +1,280 @@
+//! XEP-0428: Fallback Indication
+//!
+//! Marks text ranges inside a message `<body/>` as fallback content that
+//! reply-aware or other capability-aware clients should strip when rendering
+//! the primary payload (for example, the quoted prefix prepended in front of
+//! an XEP-0461 reply so legacy clients still see readable context).
+//!
+//! Wire shape:
+//!
+//! ```xml
+//! <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>
+//!   <body start='0' end='42'/>
+//! </fallback>
+//! ```
+//!
+//! A message may carry multiple `<fallback/>` payloads — one per feature
+//! namespace the fallback targets.
+
+use minidom::Element;
+use xmpp_parsers::message::Message;
+
+/// Namespace for XEP-0428 Fallback Indication.
+pub const NS_FALLBACK: &str = "urn:xmpp:fallback:0";
+
+/// A body character range `[start, end)` marked as fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FallbackRange {
+    /// Inclusive UTF-16 code-unit start offset into the body.
+    pub start: usize,
+    /// Exclusive UTF-16 code-unit end offset into the body.
+    pub end: usize,
+}
+
+/// A parsed `<fallback/>` payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FallbackIndication {
+    /// The feature namespace this fallback is for (e.g. `urn:xmpp:reply:0`).
+    pub for_ns: String,
+    /// Optional body range; absent means "the entire body is fallback".
+    pub body_range: Option<FallbackRange>,
+}
+
+impl FallbackIndication {
+    /// Construct a whole-body fallback for a feature namespace.
+    pub fn whole_body(for_ns: impl Into<String>) -> Self {
+        Self {
+            for_ns: for_ns.into(),
+            body_range: None,
+        }
+    }
+
+    /// Construct a body-range fallback.
+    pub fn for_range(for_ns: impl Into<String>, start: usize, end: usize) -> Self {
+        Self {
+            for_ns: for_ns.into(),
+            body_range: Some(FallbackRange { start, end }),
+        }
+    }
+}
+
+/// Check whether an element is an XEP-0428 `<fallback/>` payload.
+pub fn is_fallback_element(elem: &Element) -> bool {
+    elem.name() == "fallback" && elem.ns() == NS_FALLBACK
+}
+
+fn parse_usize_attr(elem: &Element, name: &str) -> Option<usize> {
+    elem.attr(name)
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .and_then(|v| v.parse::<usize>().ok())
+}
+
+fn parse_body_range(fallback_elem: &Element) -> Option<FallbackRange> {
+    let body_elem = fallback_elem
+        .children()
+        .find(|child| child.name() == "body" && child.ns() == NS_FALLBACK)?;
+    let start = parse_usize_attr(body_elem, "start").unwrap_or(0);
+    let end = parse_usize_attr(body_elem, "end").unwrap_or(start);
+    Some(FallbackRange { start, end })
+}
+
+/// Parse all `<fallback/>` payloads attached to a message.
+pub fn parse_fallbacks_from_message(msg: &Message) -> Vec<FallbackIndication> {
+    msg.payloads
+        .iter()
+        .filter(|elem| is_fallback_element(elem))
+        .filter_map(|elem| {
+            let for_ns = elem.attr("for").map(str::trim).filter(|v| !v.is_empty())?;
+            Some(FallbackIndication {
+                for_ns: for_ns.to_owned(),
+                body_range: parse_body_range(elem),
+            })
+        })
+        .collect()
+}
+
+/// Build an XEP-0428 `<fallback/>` element.
+pub fn build_fallback_element(fallback: &FallbackIndication) -> Element {
+    let mut builder =
+        Element::builder("fallback", NS_FALLBACK).attr("for", fallback.for_ns.as_str());
+    if let Some(range) = fallback.body_range {
+        let body = Element::builder("body", NS_FALLBACK)
+            .attr("start", range.start.to_string())
+            .attr("end", range.end.to_string())
+            .build();
+        builder = builder.append(body);
+    }
+    builder.build()
+}
+
+/// Replace all fallback payloads on a message with the given set.
+pub fn set_fallback_payloads(msg: &mut Message, fallbacks: &[FallbackIndication]) {
+    msg.payloads.retain(|elem| !is_fallback_element(elem));
+    for fallback in fallbacks {
+        msg.payloads.push(build_fallback_element(fallback));
+    }
+}
+
+/// Strip every fallback range matching `for_ns` from a body string, returning
+/// the caller-visible text. Ranges are applied in descending-start order so
+/// earlier offsets stay valid.
+pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
+    if ranges.is_empty() {
+        return body.to_string();
+    }
+    let chars: Vec<char> = body.chars().collect();
+    let total = chars.len();
+    let mut keep = vec![true; total];
+    for range in ranges {
+        let start = range.start.min(total);
+        let end = range.end.min(total).max(start);
+        for flag in keep.iter_mut().take(end).skip(start) {
+            *flag = false;
+        }
+    }
+    chars
+        .iter()
+        .zip(keep.iter())
+        .filter(|(_, k)| **k)
+        .map(|(c, _)| *c)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_fallback_element() {
+        let elem = Element::builder("fallback", NS_FALLBACK).build();
+        assert!(is_fallback_element(&elem));
+        let wrong = Element::builder("fallback", "other:ns").build();
+        assert!(!is_fallback_element(&wrong));
+    }
+
+    #[test]
+    fn test_parse_whole_body_fallback() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'/>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
+        assert_eq!(fallbacks[0].body_range, None);
+    }
+
+    #[test]
+    fn test_parse_body_range_fallback() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='42'/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(
+            fallbacks[0].body_range,
+            Some(FallbackRange { start: 0, end: 42 })
+        );
+    }
+
+    #[test]
+    fn test_parse_multiple_fallbacks() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+            </fallback>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:example:other'/>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 2);
+        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
+        assert_eq!(fallbacks[1].for_ns, "urn:example:other");
+    }
+
+    #[test]
+    fn test_parse_missing_for_attr_skipped() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0'/>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        assert!(parse_fallbacks_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_build_round_trip() {
+        let original = FallbackIndication::for_range("urn:xmpp:reply:0", 0, 17);
+        let elem = build_fallback_element(&original);
+        assert_eq!(elem.ns(), NS_FALLBACK);
+        assert_eq!(elem.attr("for"), Some("urn:xmpp:reply:0"));
+        let body = elem
+            .children()
+            .find(|c| c.name() == "body")
+            .expect("body child");
+        assert_eq!(body.attr("start"), Some("0"));
+        assert_eq!(body.attr("end"), Some("17"));
+    }
+
+    #[test]
+    fn test_set_fallback_payloads_replaces_existing() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:old'/>\
+        </message>";
+        let mut msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+
+        set_fallback_payloads(
+            &mut msg,
+            &[FallbackIndication::for_range("urn:xmpp:reply:0", 2, 5)],
+        );
+
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
+        assert_eq!(
+            fallbacks[0].body_range,
+            Some(FallbackRange { start: 2, end: 5 })
+        );
+    }
+
+    #[test]
+    fn test_strip_fallback_ranges_basic() {
+        let stripped = strip_fallback_ranges(
+            "> quoted\n\nreply body",
+            &[FallbackRange { start: 0, end: 10 }],
+        );
+        assert_eq!(stripped, "reply body");
+    }
+
+    #[test]
+    fn test_strip_fallback_ranges_multiple_overlapping() {
+        let stripped = strip_fallback_ranges(
+            "abcdefg",
+            &[
+                FallbackRange { start: 0, end: 2 },
+                FallbackRange { start: 4, end: 6 },
+            ],
+        );
+        assert_eq!(stripped, "cdg");
+    }
+
+    #[test]
+    fn test_strip_fallback_ranges_out_of_bounds_saturates() {
+        let stripped = strip_fallback_ranges(
+            "short",
+            &[FallbackRange {
+                start: 2,
+                end: 9999,
+            }],
+        );
+        assert_eq!(stripped, "sh");
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0428.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0428.rs
@@ -116,15 +116,17 @@ pub fn set_fallback_payloads(msg: &mut Message, fallbacks: &[FallbackIndication]
     }
 }
 
-/// Strip every fallback range matching `for_ns` from a body string, returning
-/// the caller-visible text. Ranges are applied in descending-start order so
-/// earlier offsets stay valid.
+/// Strip every fallback range from a body string, returning the caller-visible
+/// text. Offsets are treated as UTF-16 code units per XEP-0428 §2, which
+/// matches how JavaScript/browser clients slice strings; the body is
+/// round-tripped through UTF-16 so emoji and other non-BMP characters are
+/// stripped correctly.
 pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
     if ranges.is_empty() {
         return body.to_string();
     }
-    let chars: Vec<char> = body.chars().collect();
-    let total = chars.len();
+    let units: Vec<u16> = body.encode_utf16().collect();
+    let total = units.len();
     let mut keep = vec![true; total];
     for range in ranges {
         let start = range.start.min(total);
@@ -133,12 +135,12 @@ pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
             *flag = false;
         }
     }
-    chars
+    let kept: Vec<u16> = units
         .iter()
         .zip(keep.iter())
-        .filter(|(_, k)| **k)
-        .map(|(c, _)| *c)
-        .collect()
+        .filter_map(|(u, k)| if *k { Some(*u) } else { None })
+        .collect();
+    String::from_utf16_lossy(&kept)
 }
 
 #[cfg(test)]
@@ -264,6 +266,22 @@ mod tests {
             ],
         );
         assert_eq!(stripped, "cdg");
+    }
+
+    #[test]
+    fn test_strip_fallback_ranges_utf16_emoji_prefix() {
+        // "👋 hi\n\n" as a quoted prefix: 👋 is a surrogate pair (2 UTF-16 units),
+        // space is 1, 'h' is 1, 'i' is 1, '\n' is 1, '\n' is 1 — total 7 units.
+        let body = "👋 hi\n\nreply";
+        let prefix_units = "👋 hi\n\n".encode_utf16().count();
+        let stripped = strip_fallback_ranges(
+            body,
+            &[FallbackRange {
+                start: 0,
+                end: prefix_units,
+            }],
+        );
+        assert_eq!(stripped, "reply");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0461.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0461.rs
@@ -84,8 +84,20 @@ pub fn set_reply_payload(msg: &mut Message, reply: &ReplyReference) {
 }
 
 /// Read RFC 6121 `<thread/>` identifier from a message.
+///
+/// Checks both the typed `Message::thread` field and any raw `<thread/>`
+/// payload element — the latter is used to preserve the XEP-0201 `parent`
+/// attribute since `xmpp_parsers 0.21`'s typed `Thread(String)` drops it.
 pub fn thread_id_from_message(msg: &Message) -> Option<String> {
-    msg.thread.as_ref().map(|thread| thread.0.clone())
+    if let Some(thread) = msg.thread.as_ref() {
+        return Some(thread.0.clone());
+    }
+    msg.payloads
+        .iter()
+        .find(|elem| elem.name() == "thread")
+        .map(|elem| elem.text())
+        .map(|text| text.trim().to_owned())
+        .filter(|text| !text.is_empty())
 }
 
 /// Set RFC 6121 `<thread/>` identifier on a message.

--- a/server/crates/waddle-xmpp/tests/xep0201_threads.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_threads.rs
@@ -176,6 +176,92 @@ async fn xep0201_thread_survives_mam_query() {
         "Expected archived thread id in MAM result, got: {}",
         mam_output
     );
+    assert!(
+        mam_output.contains("parent='archive-root'")
+            || mam_output.contains("parent=\"archive-root\""),
+        "Expected archived thread parent in MAM result, got: {}",
+        mam_output
+    );
+}
+
+#[tokio::test]
+async fn xep0201_thread_parent_survives_muc_history_replay() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "thread-history@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "thread-history@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='thread-history@muc.localhost' id='thread-history-1' xmlns='jabber:client'>\
+            <body>Nested history reply</body>\
+            <thread parent='history-root'>history-child</thread>\
+        </message>",
+    )
+    .await
+    .expect("send nested history thread");
+    alice
+        .read_until("Nested history reply", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives nested history thread");
+    alice.clear();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut carol = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut carol, &server, "carol", "tablet")
+        .await
+        .expect("bind carol");
+    carol
+        .send(
+            "<presence to='thread-history@muc.localhost/Carol' xmlns='jabber:client'>\
+                <x xmlns='http://jabber.org/protocol/muc'>\
+                    <history maxstanzas='10'/>\
+                </x>\
+            </presence>",
+        )
+        .await
+        .expect("carol join with history");
+
+    let history_response = carol
+        .read_until("110", DEFAULT_TIMEOUT)
+        .await
+        .expect("carol receives join response");
+
+    assert!(
+        history_response.contains("Nested history reply"),
+        "Expected archived body in MUC history, got: {}",
+        history_response
+    );
+    assert!(
+        history_response.contains("history-child"),
+        "Expected archived thread id in MUC history, got: {}",
+        history_response
+    );
+    assert!(
+        history_response.contains("parent='history-root'")
+            || history_response.contains("parent=\"history-root\""),
+        "Expected archived thread parent in MUC history, got: {}",
+        history_response
+    );
+    assert!(
+        history_response.contains("urn:xmpp:delay"),
+        "Expected replayed history message with delay stamp, got: {}",
+        history_response
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/tests/xep0201_threads.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_threads.rs
@@ -1,0 +1,228 @@
+#![recursion_limit = "256"]
+
+//! XEP-0201: Best Practices for Message Threads dedicated integration suite.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::{
+    disco_info_query, establish_bound_session, init_test_env, join_muc_room, RawXmppClient,
+    TestServer, DEFAULT_TIMEOUT,
+};
+
+#[tokio::test]
+async fn xep0201_thread_broadcast_in_muc() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "thread@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "thread@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='thread@muc.localhost' id='thread-msg-1' xmlns='jabber:client'>\
+            <body>Starting a thread</body>\
+            <thread>root-thread-id</thread>\
+        </message>",
+    )
+    .await
+    .expect("send threaded message");
+
+    let alice_response = alice
+        .read_until("Starting a thread", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives thread");
+
+    assert!(
+        alice_response.contains("<thread"),
+        "Expected thread element in broadcast, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("root-thread-id"),
+        "Expected thread id in broadcast, got: {}",
+        alice_response
+    );
+}
+
+#[tokio::test]
+async fn xep0201_thread_parent_round_trip_in_muc() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "thread-parent@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "thread-parent@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='thread-parent@muc.localhost' id='thread-child-1' xmlns='jabber:client'>\
+            <body>Nested thread reply</body>\
+            <thread parent='root-thread-id'>child-thread-id</thread>\
+        </message>",
+    )
+    .await
+    .expect("send nested thread");
+
+    let alice_response = alice
+        .read_until("Nested thread reply", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives nested thread");
+
+    assert!(
+        alice_response.contains("child-thread-id"),
+        "Expected nested thread id in broadcast, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("parent='root-thread-id'")
+            || alice_response.contains("parent=\"root-thread-id\""),
+        "Expected thread parent attribute preserved, got: {}",
+        alice_response
+    );
+}
+
+#[tokio::test]
+async fn xep0201_thread_survives_mam_query() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "thread-mam@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "thread-mam@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='thread-mam@muc.localhost' id='thread-msg-1' xmlns='jabber:client'>\
+            <body>Thread starter</body>\
+            <thread parent='archive-root'>archive-child</thread>\
+        </message>",
+    )
+    .await
+    .expect("send threaded message");
+    alice
+        .read_until("Thread starter", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives thread");
+    alice.clear();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    alice
+        .send(
+            "<iq type='set' id='mam-thread-1' to='thread-mam@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='urn:xmpp:mam:2' queryid='thread-q1'>\
+                    <x xmlns='jabber:x:data' type='submit'>\
+                        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>\
+                    </x>\
+                </query>\
+            </iq>",
+        )
+        .await
+        .expect("send mam query");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut mam_output = String::new();
+    let mut fin_received = false;
+    while Instant::now() < deadline {
+        if alice.read(Duration::from_millis(500)).await.is_ok() {
+            let buffer = alice.take_buffer();
+            mam_output.push_str(&buffer);
+            if buffer.contains("<fin") && buffer.contains("urn:xmpp:mam:2") {
+                fin_received = true;
+                break;
+            }
+        }
+    }
+
+    assert!(fin_received, "Expected MAM fin, got: {}", mam_output);
+    assert!(
+        mam_output.contains("archive-child"),
+        "Expected archived thread id in MAM result, got: {}",
+        mam_output
+    );
+}
+
+#[tokio::test]
+async fn xep0201_thread_feature_advertised_in_server_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+
+    let response = disco_info_query(&mut alice, "localhost", "disco-threads-1")
+        .await
+        .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:threads:0"),
+        "Expected threads feature in disco#info, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0201_thread_feature_advertised_in_muc_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "thread-disco@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let response = disco_info_query(
+        &mut alice,
+        "thread-disco@muc.localhost",
+        "disco-threads-muc-1",
+    )
+    .await
+    .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:threads:0"),
+        "Expected threads feature in MUC disco#info, got: {}",
+        response
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep0428_fallback.rs
+++ b/server/crates/waddle-xmpp/tests/xep0428_fallback.rs
@@ -1,0 +1,197 @@
+#![recursion_limit = "256"]
+
+//! XEP-0428: Fallback Indication dedicated integration suite.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::{
+    disco_info_query, establish_bound_session, init_test_env, join_muc_room, RawXmppClient,
+    TestServer, DEFAULT_TIMEOUT,
+};
+
+#[tokio::test]
+async fn xep0428_fallback_broadcast_preserves_body_range() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "fallback@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "fallback@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='fallback@muc.localhost' id='msg-fallback-1' xmlns='jabber:client'>\
+            <body>&gt; original quote\n\nmy reply</body>\
+            <reply xmlns='urn:xmpp:reply:0' to='fallback@muc.localhost/Alice' id='parent-1'/>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='18'/>\
+            </fallback>\
+        </message>",
+    )
+    .await
+    .expect("send reply with fallback");
+
+    let alice_response = alice
+        .read_until("urn:xmpp:fallback:0", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives fallback");
+
+    assert!(
+        alice_response.contains("urn:xmpp:fallback:0"),
+        "Expected fallback namespace preserved, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("for='urn:xmpp:reply:0'")
+            || alice_response.contains("for=\"urn:xmpp:reply:0\""),
+        "Expected fallback for=urn:xmpp:reply:0, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("start='0'") || alice_response.contains("start=\"0\""),
+        "Expected fallback start attribute, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("end='18'") || alice_response.contains("end=\"18\""),
+        "Expected fallback end attribute, got: {}",
+        alice_response
+    );
+}
+
+#[tokio::test]
+async fn xep0428_fallback_survives_mam_query() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "fallback-mam@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "fallback-mam@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    bob.send(
+        "<message type='groupchat' to='fallback-mam@muc.localhost' id='msg-fallback-1' xmlns='jabber:client'>\
+            <body>&gt; parent\n\nreply</body>\
+            <reply xmlns='urn:xmpp:reply:0' to='fallback-mam@muc.localhost/Alice' id='parent-1'/>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+            </fallback>\
+        </message>",
+    )
+    .await
+    .expect("send reply with fallback");
+    alice
+        .read_until("urn:xmpp:fallback:0", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives fallback");
+    alice.clear();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    alice
+        .send(
+            "<iq type='set' id='mam-fallback-1' to='fallback-mam@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='urn:xmpp:mam:2' queryid='fallback-q1'>\
+                    <x xmlns='jabber:x:data' type='submit'>\
+                        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>\
+                    </x>\
+                </query>\
+            </iq>",
+        )
+        .await
+        .expect("send mam query");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut mam_output = String::new();
+    let mut fin_received = false;
+    while Instant::now() < deadline {
+        if alice.read(Duration::from_millis(500)).await.is_ok() {
+            let buffer = alice.take_buffer();
+            mam_output.push_str(&buffer);
+            if buffer.contains("<fin") && buffer.contains("urn:xmpp:mam:2") {
+                fin_received = true;
+                break;
+            }
+        }
+    }
+
+    assert!(fin_received, "Expected MAM fin, got: {}", mam_output);
+    assert!(
+        mam_output.contains("urn:xmpp:fallback:0"),
+        "Expected archived fallback payload in MAM result, got: {}",
+        mam_output
+    );
+}
+
+#[tokio::test]
+async fn xep0428_fallback_feature_advertised_in_server_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+
+    let response = disco_info_query(&mut alice, "localhost", "disco-fallback-1")
+        .await
+        .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:fallback:0"),
+        "Expected fallback feature in disco#info, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0428_fallback_feature_advertised_in_muc_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "fallback-disco@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let response = disco_info_query(
+        &mut alice,
+        "fallback-disco@muc.localhost",
+        "disco-fallback-muc-1",
+    )
+    .await
+    .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:fallback:0"),
+        "Expected fallback feature in MUC disco#info, got: {}",
+        response
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep0461_replies.rs
+++ b/server/crates/waddle-xmpp/tests/xep0461_replies.rs
@@ -1,0 +1,208 @@
+#![recursion_limit = "256"]
+
+//! XEP-0461: Message Replies dedicated integration suite.
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::{
+    disco_info_query, establish_bound_session, init_test_env, join_muc_room, RawXmppClient,
+    TestServer, DEFAULT_TIMEOUT,
+};
+
+#[tokio::test]
+async fn xep0461_reply_broadcast_in_muc() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "reply@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "reply@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    alice
+        .send(
+            "<message type='groupchat' to='reply@muc.localhost' id='msg-reply-1' xmlns='jabber:client'>\
+                <body>Original message</body>\
+            </message>",
+        )
+        .await
+        .expect("send original");
+    bob.read_until("Original message", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives original");
+    bob.clear();
+
+    bob.send(
+        "<message type='groupchat' to='reply@muc.localhost' id='reply-1' xmlns='jabber:client'>\
+            <body>Responding to you</body>\
+            <reply xmlns='urn:xmpp:reply:0' to='reply@muc.localhost/Alice' id='msg-reply-1'/>\
+        </message>",
+    )
+    .await
+    .expect("send reply");
+
+    let alice_response = alice
+        .read_until("urn:xmpp:reply:0", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives reply");
+
+    assert!(
+        alice_response.contains("urn:xmpp:reply:0"),
+        "Expected reply namespace in broadcast, got: {}",
+        alice_response
+    );
+    assert!(
+        alice_response.contains("id='msg-reply-1'")
+            || alice_response.contains("id=\"msg-reply-1\""),
+        "Expected reply target id preserved, got: {}",
+        alice_response
+    );
+}
+
+#[tokio::test]
+async fn xep0461_reply_survives_mam_query() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "reply-mam@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut bob, &server, "bob", "mobile")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "reply-mam@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    alice
+        .send(
+            "<message type='groupchat' to='reply-mam@muc.localhost' id='msg-reply-1' xmlns='jabber:client'>\
+                <body>Original</body>\
+            </message>",
+        )
+        .await
+        .expect("send original");
+    bob.read_until("Original", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives original");
+    bob.clear();
+
+    bob.send(
+        "<message type='groupchat' to='reply-mam@muc.localhost' id='reply-1' xmlns='jabber:client'>\
+            <body>Reply body</body>\
+            <reply xmlns='urn:xmpp:reply:0' to='reply-mam@muc.localhost/Alice' id='msg-reply-1'/>\
+        </message>",
+    )
+    .await
+    .expect("send reply");
+    alice
+        .read_until("urn:xmpp:reply:0", DEFAULT_TIMEOUT)
+        .await
+        .expect("alice receives reply");
+    alice.clear();
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    alice
+        .send(
+            "<iq type='set' id='mam-reply-1' to='reply-mam@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='urn:xmpp:mam:2' queryid='reply-q1'>\
+                    <x xmlns='jabber:x:data' type='submit'>\
+                        <field var='FORM_TYPE' type='hidden'><value>urn:xmpp:mam:2</value></field>\
+                    </x>\
+                </query>\
+            </iq>",
+        )
+        .await
+        .expect("send mam query");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut mam_output = String::new();
+    let mut fin_received = false;
+    while Instant::now() < deadline {
+        if alice.read(Duration::from_millis(500)).await.is_ok() {
+            let buffer = alice.take_buffer();
+            mam_output.push_str(&buffer);
+            if buffer.contains("<fin") && buffer.contains("urn:xmpp:mam:2") {
+                fin_received = true;
+                break;
+            }
+        }
+    }
+
+    assert!(fin_received, "Expected MAM fin, got: {}", mam_output);
+    assert!(
+        mam_output.contains("urn:xmpp:reply:0"),
+        "Expected archived reply payload in MAM result, got: {}",
+        mam_output
+    );
+    assert!(
+        mam_output.contains("id='msg-reply-1'") || mam_output.contains("id=\"msg-reply-1\""),
+        "Expected reply target id preserved in MAM result, got: {}",
+        mam_output
+    );
+}
+
+#[tokio::test]
+async fn xep0461_reply_feature_advertised_in_server_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+
+    let response = disco_info_query(&mut alice, "localhost", "disco-reply-1")
+        .await
+        .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:reply:0"),
+        "Expected reply feature in disco#info, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0461_reply_feature_advertised_in_muc_disco() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "reply-disco@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let response = disco_info_query(&mut alice, "reply-disco@muc.localhost", "disco-reply-muc-1")
+        .await
+        .expect("disco info");
+
+    assert!(
+        response.contains("urn:xmpp:reply:0"),
+        "Expected reply feature in MUC disco#info, got: {}",
+        response
+    );
+}


### PR DESCRIPTION
Server:
- Add xep0428 (fallback indication) and xep0201 (message threads) modules
- Advertise urn:xmpp:fallback:0 and urn:xmpp:threads:0 on server + MUC disco
- Preserve <thread parent="..."/> through element_to_message so the XEP-0201
  parent attribute survives MUC broadcast and MAM replay
- Route ParsedStanza::Message through element_to_message to patch both
  parsing paths
- Add integration test suites: xep0461_replies, xep0428_fallback,
  xep0201_threads (closes the missing test-suite hard-rule gap for 0461)

Chat:
- New stanza extensions: replies, fallback (array form)
- sendGroupMessage / sendDirectMessage accept { replyTo, threadId,
  parentThreadId, files, markup } options
- Build XEP-0428 '> quoted\\n\\n' fallback prefix with precise body range
- Parse <reply/>, <fallback/>, <thread/>; strip reply fallback from body;
  thread same-parent reply ids so replies converge on one thread id
- UI: reply button in MessageCard hover toolbar, quoted-preview chip that
  scrolls to the target, composer 'Replying to @user ✕' chip, subtle
  left-gutter for threaded messages
- New tests: groupchat-replies, groupchat-parsing-replies, dm-replies,
  reply-fallback-prefix

Docs:
- XEPS.md: flip 0461, 0428, 0201 to Implemented (+ Chat ✓)

https://claude.ai/code/session_016TqpxbHEt8w9rsQZzUj16v