### PR TITLE
fix(chat): stamp container builds with git SHA, harden version footer fallback

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -46,6 +46,8 @@ jobs:
           target: runtime
           platforms: linux/amd64
           push: false
+          build-args: |
+            WADDLE_GIT_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           cache-from: type=gha,scope=waddle-server-amd64
           cache-to: type=gha,mode=max,scope=waddle-server-amd64
 
@@ -88,6 +90,8 @@ jobs:
           target: runtime
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            WADDLE_GIT_SHA=${{ github.sha }}
           cache-from: |
             type=gha,scope=waddle-server-${{ matrix.arch }}
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.arch }}

--- a/chat/src/components/chat/VersionFooter.vue
+++ b/chat/src/components/chat/VersionFooter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { extractServerSha, type ServerVersion } from "@/composables/useVersion";
+import { extractServerSha, extractServerShortVersion, type ServerVersion } from "@/composables/useVersion";
 
 const props = defineProps<{
   webCommitSha?: string;
@@ -14,7 +14,8 @@ const webShortSha = computed(() => (props.webCommitSha ?? "unknown").slice(0, 7)
 const serverShortSha = computed(() => {
   const sha = extractServerSha(props.serverVersion ?? null);
   if (sha) return sha.slice(0, 7);
-  return props.serverVersion?.version ?? "…";
+  if (!props.serverVersion) return "…";
+  return extractServerShortVersion(props.serverVersion) ?? "unknown";
 });
 const tooltip = computed(
   () => `web ${props.webCommitSha ?? "unknown"}\nserver ${props.serverVersion?.version ?? "unknown"}`,

--- a/chat/src/composables/useVersion.ts
+++ b/chat/src/composables/useVersion.ts
@@ -47,3 +47,15 @@ export function extractServerSha(version: ServerVersion | null): string | null {
   const match = version.version.match(/\(([0-9a-f]{6,})\)/i);
   return match ? match[1] : null;
 }
+
+/**
+ * Strip the "(sha)" suffix from a version string, leaving just the semantic
+ * version. Used as a fallback when the SHA is missing or unparseable (e.g. a
+ * build that couldn't stamp the git SHA and reports "0.1.0 (unknown)").
+ */
+export function extractServerShortVersion(version: ServerVersion | null): string | null {
+  const raw = version?.version?.trim();
+  if (!raw) return null;
+  const stripped = raw.replace(/\s*\(.*\)\s*$/, "").trim();
+  return stripped.length > 0 ? stripped : null;
+}

--- a/server/Containerfile
+++ b/server/Containerfile
@@ -31,6 +31,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 # ── Cook + build for target arch ────────────────────────────────────
 FROM builder AS build
 ARG TARGETARCH
+# Commit SHA baked into the binary so XEP-0092 advertises a real revision.
+# Defaults to "unknown"; CI overrides via --build-arg WADDLE_GIT_SHA=$GITHUB_SHA.
+ARG WADDLE_GIT_SHA=unknown
+ENV WADDLE_GIT_SHA=${WADDLE_GIT_SHA}
 
 COPY --from=planner /workspace/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \

--- a/server/Containerfile
+++ b/server/Containerfile
@@ -34,7 +34,6 @@ ARG TARGETARCH
 # Commit SHA baked into the binary so XEP-0092 advertises a real revision.
 # Defaults to "unknown"; CI overrides via --build-arg WADDLE_GIT_SHA=$GITHUB_SHA.
 ARG WADDLE_GIT_SHA=unknown
-ENV WADDLE_GIT_SHA=${WADDLE_GIT_SHA}
 
 COPY --from=planner /workspace/recipe.json recipe.json
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
@@ -65,7 +64,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc ;; \
       *) echo "Unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
-    cargo build --release --locked --target "${RUST_TARGET}" --package waddle-server --bin waddle-server; \
+    WADDLE_GIT_SHA="${WADDLE_GIT_SHA}" cargo build --release --locked --target "${RUST_TARGET}" --package waddle-server --bin waddle-server; \
     mkdir -p /out; \
     cp "target/${RUST_TARGET}/release/waddle-server" /out/waddle-server
 

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -115,46 +115,6 @@ button {{ margin-top:12px; background:#2563eb; border-color:#1d4ed8; cursor:poin
     )
 }
 
-fn escape_html_attr(value: &str) -> String {
-    value
-        .replace('&', "&amp;")
-        .replace('"', "&quot;")
-        .replace('\'', "&#39;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-}
-
-fn render_device_verify_html(code: &str) -> String {
-    let escaped_code = escape_html_attr(code);
-    format!(
-        r#"<!doctype html>
-<html>
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Device Authorization</title>
-<style>
-body {{ font-family: sans-serif; background:#0f172a; color:#e2e8f0; display:grid; place-items:center; min-height:100vh; margin:0; }}
-.card {{ width:min(480px,92vw); background:#1e293b; border:1px solid #334155; border-radius:12px; padding:24px; }}
-input, button {{ width:100%; font-size:16px; padding:10px; border-radius:8px; border:1px solid #475569; background:#0f172a; color:#e2e8f0; }}
-button {{ margin-top:12px; background:#2563eb; border-color:#1d4ed8; cursor:pointer; }}
-.error {{ color:#fca5a5; margin-top:10px; }}
-</style>
-</head>
-<body>
-  <div class="card">
-    <h1>Authorize Device</h1>
-    <p>Enter the code shown in your terminal.</p>
-    <form id="f" method="post" action="/api/auth/device/verify">
-      <input name="user_code" value="{escaped_code}" placeholder="ABCD-1234" required />
-      <button type="submit">Continue</button>
-    </form>
-  </div>
-</body>
-</html>"#
-    )
-}
-
 fn generate_device_code() -> String {
     let bytes: [u8; 32] = rand::rng().random();
     hex::encode(bytes)


### PR DESCRIPTION
Container builds weren't plumbing WADDLE_GIT_SHA through, so build.rs fell
back to "unknown" (the .git dir isn't in the ./server docker context). The
server then advertised "0.1.0 (unknown)" via XEP-0092, which the chat
footer's SHA regex couldn't parse — it dropped back to rendering the full
"0.1.0 (unknown)" in a 64px-wide 9px-font rail, where the wrapped
"(unknown)" looks like a stray underscore.

- Containerfile: declare ARG WADDLE_GIT_SHA (default "unknown") and export
  it so cargo build can bake a real revision into the binary.
- container-image.yml: pass github.sha (or the PR head SHA) as
  --build-arg WADDLE_GIT_SHA for both the PR and push image builds.
- VersionFooter: when the SHA isn't extractable, fall back to the semver
  prefix (e.g. "0.1.0") instead of the full "0.1.0 (unknown)" string, so
  it fits the narrow rail cleanly.