### PR TITLE
feat(chat): mobile reactions via tap-and-hold + emoji picker + a11y menu

### DIFF
--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { Search, X } from "lucide-vue-next";
 import { searchEmoji } from "@/lib/emoji";
 
-defineProps<{
+const props = defineProps<{
   open: boolean;
 }>();
 
@@ -84,30 +84,36 @@ function onKey(event: KeyboardEvent) {
   if (event.key === "Escape") emit("close");
 }
 
-onMounted(() => {
-  loadRecents();
+function attachWindowListeners() {
+  if (typeof window === "undefined") return;
   window.addEventListener("pointerdown", onWindowPointer, true);
   window.addEventListener("keydown", onKey);
-});
+}
 
-onUnmounted(() => {
+function detachWindowListeners() {
+  if (typeof window === "undefined") return;
   window.removeEventListener("pointerdown", onWindowPointer, true);
   window.removeEventListener("keydown", onKey);
-});
+}
 
 watch(
-  () => query.value,
-  () => {
-    // noop — computed handles results.
+  () => props.open,
+  (open) => {
+    if (open) {
+      loadRecents();
+      attachWindowListeners();
+      query.value = "";
+      void nextTick().then(() => {
+        searchInputEl.value?.focus();
+      });
+    } else {
+      detachWindowListeners();
+    }
   },
+  { immediate: true },
 );
 
-watch(
-  () => searchInputEl.value,
-  (el) => {
-    if (el) el.focus();
-  },
-);
+onBeforeUnmount(detachWindowListeners);
 </script>
 
 <template>

--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { Search, X } from "lucide-vue-next";
+import { searchEmoji } from "@/lib/emoji";
+
+defineProps<{
+  open: boolean;
+}>();
+
+const emit = defineEmits<{
+  select: [emoji: string];
+  close: [];
+}>();
+
+const RECENT_KEY = "waddle:recent-emojis";
+const RECENT_CAP = 24;
+
+const COMMON_EMOJIS = [
+  "👍", "❤️", "😂", "🎉", "👀", "🔥", "🙌", "💯",
+  "😍", "🤔", "😊", "😭", "🙏", "✨", "👏", "💪",
+  "🤣", "😎", "🥳", "😅", "🫡", "🫶", "🤝", "👋",
+  "😀", "😁", "😆", "🥹", "😇", "🙃", "😉", "😌",
+  "🤩", "🥰", "😘", "😋", "🤗", "🤭", "🤫", "🤐",
+  "😐", "😑", "🙄", "😴", "🤤", "😪", "😮‍💨", "😤",
+  "😡", "🤬", "🤯", "😳", "🥶", "🥵", "😨", "😰",
+  "😥", "😓", "🤒", "🤕", "🤧", "🤮", "🤢", "😵",
+  "🤠", "😈", "👻", "💀", "👽", "🤖", "💩", "🙈",
+  "🙉", "🙊", "💖", "💔", "💕", "💞", "💓", "💗",
+  "💘", "💝", "💟", "⚡", "🌟", "⭐", "☀️", "🌈",
+  "🌸", "🌺", "🌻", "🌷", "🍀", "🎂", "🍰", "🍕",
+  "🍔", "🍟", "🍜", "🍣", "🍺", "🍷", "🍾", "☕",
+];
+
+const query = ref("");
+const recents = ref<string[]>([]);
+
+function loadRecents() {
+  if (typeof localStorage === "undefined") return;
+  try {
+    const raw = localStorage.getItem(RECENT_KEY);
+    if (!raw) return;
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      recents.value = parsed.filter((x): x is string => typeof x === "string").slice(0, RECENT_CAP);
+    }
+  } catch {
+    // Corrupt storage — ignore.
+  }
+}
+
+function saveRecent(emoji: string) {
+  const next = [emoji, ...recents.value.filter((e) => e !== emoji)].slice(0, RECENT_CAP);
+  recents.value = next;
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  } catch {
+    // Quota or private mode — ignore.
+  }
+}
+
+const searchResults = computed(() => {
+  const q = query.value.trim();
+  if (q.length < 2) return [];
+  return searchEmoji(q, 60).map((r) => r.emoji);
+});
+
+const panelEl = ref<HTMLElement | null>(null);
+const searchInputEl = ref<HTMLInputElement | null>(null);
+
+function onSelect(emoji: string) {
+  saveRecent(emoji);
+  emit("select", emoji);
+}
+
+function onWindowPointer(event: PointerEvent | MouseEvent) {
+  if (!panelEl.value) return;
+  const target = event.target as Node | null;
+  if (!target) return;
+  if (!panelEl.value.contains(target)) emit("close");
+}
+
+function onKey(event: KeyboardEvent) {
+  if (event.key === "Escape") emit("close");
+}
+
+onMounted(() => {
+  loadRecents();
+  window.addEventListener("pointerdown", onWindowPointer, true);
+  window.addEventListener("keydown", onKey);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("pointerdown", onWindowPointer, true);
+  window.removeEventListener("keydown", onKey);
+});
+
+watch(
+  () => query.value,
+  () => {
+    // noop — computed handles results.
+  },
+);
+
+watch(
+  () => searchInputEl.value,
+  (el) => {
+    if (el) el.focus();
+  },
+);
+</script>
+
+<template>
+  <div
+    v-if="open"
+    ref="panelEl"
+    role="dialog"
+    aria-label="Choose a reaction"
+    class="absolute top-full right-0 mt-1 w-72 glass-panel border border-border rounded-xl z-50 shadow-2xl animate-fade-in overflow-hidden flex flex-col max-h-80"
+    @pointerdown.stop
+  >
+    <div class="flex items-center gap-2.5 px-3 py-2 border-b border-border">
+      <Search class="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" aria-hidden="true" />
+      <input
+        ref="searchInputEl"
+        v-model="query"
+        type="text"
+        placeholder="Search emoji…"
+        aria-label="Search emoji"
+        class="flex-1 text-[13px] bg-transparent border-none focus:outline-none placeholder:text-muted-foreground/40"
+      />
+      <button
+        type="button"
+        class="p-1 rounded-md text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+        aria-label="Close emoji picker"
+        @click="emit('close')"
+      >
+        <X class="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-auto p-2">
+      <template v-if="searchResults.length > 0">
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Results</div>
+        <div class="grid grid-cols-8 gap-0.5">
+          <button
+            v-for="e in searchResults"
+            :key="`s-${e}`"
+            type="button"
+            class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+            :aria-label="`React with ${e}`"
+            @click="onSelect(e)"
+          >{{ e }}</button>
+        </div>
+      </template>
+      <template v-else-if="query.trim().length >= 2">
+        <div class="text-center py-4 text-[12px] text-muted-foreground">No emoji found</div>
+      </template>
+      <template v-else>
+        <template v-if="recents.length > 0">
+          <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Recent</div>
+          <div class="grid grid-cols-8 gap-0.5 mb-2">
+            <button
+              v-for="e in recents"
+              :key="`r-${e}`"
+              type="button"
+              class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+              :aria-label="`React with ${e}`"
+              @click="onSelect(e)"
+            >{{ e }}</button>
+          </div>
+        </template>
+        <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Common</div>
+        <div class="grid grid-cols-8 gap-0.5">
+          <button
+            v-for="e in COMMON_EMOJIS"
+            :key="`c-${e}`"
+            type="button"
+            class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+            :aria-label="`React with ${e}`"
+            @click="onSelect(e)"
+          >{{ e }}</button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, nextTick, onBeforeUnmount, watch } from "vue";
 import { MoreHorizontal, Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
@@ -155,10 +155,26 @@ const mobileToolbarOpen = ref(false);
 const pickerOpen = ref(false);
 const menuOpen = ref(false);
 
+const anyOverlayOpen = computed(
+  () => mobileToolbarOpen.value || pickerOpen.value || menuOpen.value,
+);
+
 function closeAllMenus() {
   mobileToolbarOpen.value = false;
   pickerOpen.value = false;
   menuOpen.value = false;
+}
+
+function togglePicker() {
+  const next = !pickerOpen.value;
+  closeAllMenus();
+  pickerOpen.value = next;
+}
+
+function toggleMenu() {
+  const next = !menuOpen.value;
+  closeAllMenus();
+  menuOpen.value = next;
 }
 
 function react(emoji: string) {
@@ -182,12 +198,13 @@ function retractFromMenu() {
 }
 
 function openPickerFromMenu() {
-  menuOpen.value = false;
+  closeAllMenus();
   pickerOpen.value = true;
 }
 
 const longPress = useLongPress({
   onLongPress: () => {
+    closeAllMenus();
     mobileToolbarOpen.value = true;
   },
 });
@@ -206,12 +223,31 @@ function onWindowPointerDown(event: PointerEvent) {
   closeAllMenus();
 }
 
-onMounted(() => {
-  window.addEventListener("pointerdown", onWindowPointerDown, true);
-});
+function onWindowKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") closeAllMenus();
+}
 
-onUnmounted(() => {
+// Only listen globally while an overlay is actually open. Otherwise every
+// MessageCard in a long timeline would attach its own capture-phase handler
+// and run on every pointerdown anywhere on the page.
+watch(
+  anyOverlayOpen,
+  (open) => {
+    if (typeof window === "undefined") return;
+    if (open) {
+      window.addEventListener("pointerdown", onWindowPointerDown, true);
+      window.addEventListener("keydown", onWindowKeydown);
+    } else {
+      window.removeEventListener("pointerdown", onWindowPointerDown, true);
+      window.removeEventListener("keydown", onWindowKeydown);
+    }
+  },
+);
+
+onBeforeUnmount(() => {
+  if (typeof window === "undefined") return;
   window.removeEventListener("pointerdown", onWindowPointerDown, true);
+  window.removeEventListener("keydown", onWindowKeydown);
 });
 
 watch(
@@ -252,7 +288,7 @@ watch(
     v-else
     ref="bubbleEl"
     :data-message-id="message.id"
-    :data-mobile-open="mobileToolbarOpen || pickerOpen ? 'true' : 'false'"
+    :data-mobile-open="anyOverlayOpen ? 'true' : 'false'"
     class="group relative flow-root px-3 py-1.5 rounded-xl transition-all duration-200 animate-message-in"
     :class="[
       isMentioned
@@ -444,7 +480,7 @@ watch(
           aria-label="Add reaction"
           :aria-expanded="pickerOpen"
           aria-haspopup="dialog"
-          @click="pickerOpen = !pickerOpen; mobileToolbarOpen = false"
+          @click="togglePicker"
         >
           <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
         </button>
@@ -497,14 +533,14 @@ watch(
         title="Message actions"
         aria-label="Message actions"
         :aria-expanded="menuOpen"
-        aria-haspopup="menu"
-        @click="menuOpen = !menuOpen; mobileToolbarOpen = false"
+        aria-haspopup="dialog"
+        @click="toggleMenu"
       >
         <MoreHorizontal class="w-3.5 h-3.5" aria-hidden="true" />
       </button>
       <div
         v-if="menuOpen"
-        role="menu"
+        role="dialog"
         aria-label="Message actions"
         class="absolute top-full right-0 mt-1 min-w-40 glass-panel border border-border rounded-xl shadow-2xl p-1 animate-fade-in"
         @pointerdown.stop
@@ -514,7 +550,6 @@ watch(
             v-for="e in quickEmojis"
             :key="`menu-${e}`"
             type="button"
-            role="menuitem"
             class="h-8 w-8 flex items-center justify-center text-[16px] leading-none rounded-md hover:bg-muted transition-colors"
             :aria-label="`React with ${e}`"
             @click="react(e)"
@@ -522,7 +557,6 @@ watch(
         </div>
         <button
           type="button"
-          role="menuitem"
           class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
           @click="openPickerFromMenu"
         >
@@ -531,7 +565,6 @@ watch(
         </button>
         <button
           type="button"
-          role="menuitem"
           class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
           @click="startReplyFromMenu"
         >
@@ -542,7 +575,6 @@ watch(
           <div class="my-1 h-px bg-border" />
           <button
             type="button"
-            role="menuitem"
             class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
             @click="startEditFromMenu"
           >
@@ -551,7 +583,6 @@ watch(
           </button>
           <button
             type="button"
-            role="menuitem"
             class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-destructive/10 text-destructive transition-colors text-left"
             @click="retractFromMenu"
           >

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { ref, computed, nextTick, watch } from "vue";
-import { Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight } from "lucide-vue-next";
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
+import { MoreHorizontal, Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
+import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import { renderStyledBody, isImageUrl, type TimelineMessage, type MarkupSpan } from "@/lib/chat-ui";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
@@ -10,6 +11,7 @@ import { parseXep0393ToTiptap } from "@/lib/editor/xep0393-parser";
 import { applyShikiToCodeBlocks } from "@/lib/shiki";
 import type { OccupantHat, OccupantPresence } from "@/lib/xmpp-client";
 import { formatStamp } from "@/composables/useMessaging";
+import { useLongPress } from "@/composables/useLongPress";
 
 const HAT_LABELS: Record<string, string> = {
   "urn:xmpp:hats:owner": "OWNER",
@@ -148,6 +150,70 @@ function emitAvatarClick() {
   }
 }
 
+const bubbleEl = ref<HTMLElement | null>(null);
+const mobileToolbarOpen = ref(false);
+const pickerOpen = ref(false);
+const menuOpen = ref(false);
+
+function closeAllMenus() {
+  mobileToolbarOpen.value = false;
+  pickerOpen.value = false;
+  menuOpen.value = false;
+}
+
+function react(emoji: string) {
+  emit("react", props.message.id, emoji);
+  closeAllMenus();
+}
+
+function startReplyFromMenu() {
+  emit("reply", props.message);
+  closeAllMenus();
+}
+
+function startEditFromMenu() {
+  startEdit();
+  closeAllMenus();
+}
+
+function retractFromMenu() {
+  emit("retract", props.message.id);
+  closeAllMenus();
+}
+
+function openPickerFromMenu() {
+  menuOpen.value = false;
+  pickerOpen.value = true;
+}
+
+const longPress = useLongPress({
+  onLongPress: () => {
+    mobileToolbarOpen.value = true;
+  },
+});
+
+function onBubbleContextMenu(event: MouseEvent) {
+  // Suppress iOS Safari / Android native long-press menu while the gesture is
+  // being handled. Desktop right-click (pointerType 'mouse' never sets
+  // isPressing) remains untouched.
+  if (longPress.isPressing.value) event.preventDefault();
+}
+
+function onWindowPointerDown(event: PointerEvent) {
+  if (!bubbleEl.value) return;
+  const target = event.target as Node | null;
+  if (target && bubbleEl.value.contains(target)) return;
+  closeAllMenus();
+}
+
+onMounted(() => {
+  window.addEventListener("pointerdown", onWindowPointerDown, true);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("pointerdown", onWindowPointerDown, true);
+});
+
 watch(
   styledHtml,
   () => {
@@ -184,7 +250,9 @@ watch(
   <!-- Normal message -->
   <div
     v-else
+    ref="bubbleEl"
     :data-message-id="message.id"
+    :data-mobile-open="mobileToolbarOpen || pickerOpen ? 'true' : 'false'"
     class="group relative flow-root px-3 py-1.5 rounded-xl transition-all duration-200 animate-message-in"
     :class="[
       isMentioned
@@ -193,7 +261,14 @@ watch(
           ? 'border-l-2 border-primary/20 hover:bg-muted/40'
           : 'hover:bg-muted/40',
       message.deliveryStatus === 'sending' ? 'opacity-50' : '',
+      longPress.isPressing.value ? 'no-callout' : '',
     ]"
+    @pointerdown="longPress.handlers.onPointerdown"
+    @pointermove="longPress.handlers.onPointermove"
+    @pointerup="longPress.handlers.onPointerup"
+    @pointercancel="longPress.handlers.onPointercancel"
+    @pointerleave="longPress.handlers.onPointerleave"
+    @contextmenu="onBubbleContextMenu"
   >
     <button
       class="float-left mr-3 mt-0.5 rounded-lg"
@@ -345,53 +420,146 @@ watch(
       </button>
     </div>
 
-    <!-- Floating action toolbar — absolute so no layout space when hidden -->
+    <!-- Floating action toolbar — absolute so no layout space when hidden.
+         Revealed by hover (mouse), focus-within (keyboard), or long-press (touch). -->
     <div
       v-if="!isEditing"
-      class="absolute -top-3 right-3 z-10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto transition-opacity duration-150 flex items-center gap-0.5 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1"
+      class="absolute -top-3 right-3 z-10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 group-data-[mobile-open=true]:opacity-100 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto group-data-[mobile-open=true]:pointer-events-auto transition-opacity duration-150 flex items-center gap-0.5 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1"
     >
       <button
         v-for="e in quickEmojis"
         :key="e"
+        type="button"
         class="h-6 w-6 flex items-center justify-center text-[14px] leading-none rounded-md hover:bg-muted hover:scale-110 transition-all duration-150"
         :title="`React with ${e}`"
         :aria-label="`React to message with ${e}`"
-        @click="emit('react', message.id, e)"
+        @click="react(e)"
       >{{ e }}</button>
+      <div class="relative">
+        <button
+          type="button"
+          class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
+          :class="pickerOpen ? 'bg-muted text-foreground' : ''"
+          title="Add reaction"
+          aria-label="Add reaction"
+          :aria-expanded="pickerOpen"
+          aria-haspopup="dialog"
+          @click="pickerOpen = !pickerOpen; mobileToolbarOpen = false"
+        >
+          <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
+        </button>
+        <EmojiPicker
+          :open="pickerOpen"
+          @select="react"
+          @close="pickerOpen = false"
+        />
+      </div>
       <button
-        class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
-        title="Add reaction"
-        aria-label="Add reaction"
-      >
-        <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
-      </button>
-      <button
+        type="button"
         class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
         title="Reply"
         aria-label="Reply to message"
-        @click="emit('reply', message)"
+        @click="startReplyFromMenu"
       >
         <Reply class="w-3.5 h-3.5" aria-hidden="true" />
       </button>
       <template v-if="message.isSelf">
         <div class="w-px h-4 bg-border mx-0.5" />
         <button
+          type="button"
           class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
           title="Edit message"
           aria-label="Edit message"
-          @click="startEdit"
+          @click="startEditFromMenu"
         >
           <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
         </button>
         <button
+          type="button"
           class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-all duration-150"
           title="Delete message"
           aria-label="Delete message"
-          @click="emit('retract', message.id)"
+          @click="retractFromMenu"
         >
           <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
         </button>
       </template>
+    </div>
+
+    <!-- Accessible always-reachable affordance: keyboard / screen-reader users
+         (and anyone who prefers a button to a long-press) get the same actions
+         via a standard menu. Positioned at the top-right of the bubble, low
+         contrast on desktop, prominent on touch where hover never fires. -->
+    <div v-if="!isEditing" class="absolute top-1 right-1 z-10">
+      <button
+        type="button"
+        class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted opacity-40 hover:opacity-100 focus-visible:opacity-100 group-data-[mobile-open=true]:opacity-100 transition-all duration-150"
+        title="Message actions"
+        aria-label="Message actions"
+        :aria-expanded="menuOpen"
+        aria-haspopup="menu"
+        @click="menuOpen = !menuOpen; mobileToolbarOpen = false"
+      >
+        <MoreHorizontal class="w-3.5 h-3.5" aria-hidden="true" />
+      </button>
+      <div
+        v-if="menuOpen"
+        role="menu"
+        aria-label="Message actions"
+        class="absolute top-full right-0 mt-1 min-w-40 glass-panel border border-border rounded-xl shadow-2xl p-1 animate-fade-in"
+        @pointerdown.stop
+      >
+        <div class="flex items-center gap-0.5 px-1 py-1">
+          <button
+            v-for="e in quickEmojis"
+            :key="`menu-${e}`"
+            type="button"
+            role="menuitem"
+            class="h-8 w-8 flex items-center justify-center text-[16px] leading-none rounded-md hover:bg-muted transition-colors"
+            :aria-label="`React with ${e}`"
+            @click="react(e)"
+          >{{ e }}</button>
+        </div>
+        <button
+          type="button"
+          role="menuitem"
+          class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
+          @click="openPickerFromMenu"
+        >
+          <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
+          <span>More reactions…</span>
+        </button>
+        <button
+          type="button"
+          role="menuitem"
+          class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
+          @click="startReplyFromMenu"
+        >
+          <Reply class="w-3.5 h-3.5" aria-hidden="true" />
+          <span>Reply</span>
+        </button>
+        <template v-if="message.isSelf">
+          <div class="my-1 h-px bg-border" />
+          <button
+            type="button"
+            role="menuitem"
+            class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
+            @click="startEditFromMenu"
+          >
+            <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
+            <span>Edit</span>
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-destructive/10 text-destructive transition-colors text-left"
+            @click="retractFromMenu"
+          >
+            <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
+            <span>Delete</span>
+          </button>
+        </template>
+      </div>
     </div>
   </div>
 </template>

--- a/chat/src/composables/useLongPress.ts
+++ b/chat/src/composables/useLongPress.ts
@@ -1,0 +1,179 @@
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
+
+export interface UseLongPressOptions {
+  /** Delay in ms before the press fires. Default 500. */
+  delay?: number;
+  /** Max pointer movement in CSS pixels before the press cancels. Default 10. */
+  moveThreshold?: number;
+  /** Called when the press crosses the delay threshold without being cancelled. */
+  onLongPress: (event: PointerEvent) => void;
+}
+
+export interface UseLongPressReturn {
+  handlers: {
+    onPointerdown: (event: PointerEvent) => void;
+    onPointermove: (event: PointerEvent) => void;
+    onPointerup: (event: PointerEvent) => void;
+    onPointercancel: (event: PointerEvent) => void;
+    onPointerleave: (event: PointerEvent) => void;
+    onContextmenu: (event: MouseEvent) => void;
+  };
+  isPressing: Ref<boolean>;
+  cancel: () => void;
+}
+
+/**
+ * Touch-only long-press detector built on Pointer Events.
+ *
+ * Fires `onLongPress` after {@link UseLongPressOptions.delay}ms of a stationary
+ * `pointerType === "touch"` press. Movement beyond `moveThreshold` cancels.
+ * Mouse and pen pointers are ignored so desktop hover behaviour is untouched.
+ * The synthetic click that follows a long-press is swallowed at the window
+ * level so buttons underneath the press don't double-fire.
+ */
+export function useLongPress(options: UseLongPressOptions): UseLongPressReturn {
+  const { delay = 500, moveThreshold = 10, onLongPress } = options;
+
+  const isPressing = ref(false);
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let startY = 0;
+  let activePointerId: number | null = null;
+  let fired = false;
+  let capturedTarget: Element | null = null;
+
+  function clearTimer() {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function releaseCapture() {
+    if (capturedTarget && activePointerId !== null) {
+      try {
+        capturedTarget.releasePointerCapture(activePointerId);
+      } catch {
+        // Ignore — some browsers throw when capture was never granted.
+      }
+    }
+    capturedTarget = null;
+  }
+
+  function reset() {
+    clearTimer();
+    releaseCapture();
+    isPressing.value = false;
+    activePointerId = null;
+    fired = false;
+  }
+
+  function swallowNextClick() {
+    const handler = (event: MouseEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+    };
+    window.addEventListener("click", handler, { capture: true, once: true });
+    // Safety net: if no click arrives, remove after a tick.
+    setTimeout(() => {
+      window.removeEventListener("click", handler, { capture: true } as EventListenerOptions);
+    }, 400);
+  }
+
+  function onPointerdown(event: PointerEvent) {
+    if (event.pointerType !== "touch") return;
+    // Ignore multi-touch: only track the first pointer.
+    if (activePointerId !== null) return;
+
+    activePointerId = event.pointerId;
+    startX = event.clientX;
+    startY = event.clientY;
+    isPressing.value = true;
+    fired = false;
+
+    timer = setTimeout(() => {
+      if (activePointerId === null) return;
+      fired = true;
+      timer = null;
+
+      const target = event.target;
+      if (
+        target &&
+        typeof (target as { setPointerCapture?: unknown }).setPointerCapture === "function"
+      ) {
+        try {
+          (target as Element).setPointerCapture(event.pointerId);
+          capturedTarget = target as Element;
+        } catch {
+          // Ignore — capture is a best-effort optimisation.
+        }
+      }
+
+      if (typeof navigator !== "undefined" && typeof navigator.vibrate === "function") {
+        try {
+          navigator.vibrate(10);
+        } catch {
+          // Some browsers throw when vibration is blocked by user settings.
+        }
+      }
+
+      swallowNextClick();
+      onLongPress(event);
+    }, delay);
+  }
+
+  function onPointermove(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+    if (fired) return;
+    const dx = event.clientX - startX;
+    const dy = event.clientY - startY;
+    if (dx * dx + dy * dy > moveThreshold * moveThreshold) {
+      reset();
+    }
+  }
+
+  function onPointerup(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+    reset();
+  }
+
+  function onPointercancel(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+    reset();
+  }
+
+  function onPointerleave(event: PointerEvent) {
+    if (event.pointerId !== activePointerId) return;
+    reset();
+  }
+
+  function onContextmenu(event: MouseEvent) {
+    // Touch long-press on iOS Safari synthesises a contextmenu event we want
+    // to suppress when we handled the gesture ourselves. Leaving mouse
+    // right-click alone keeps desktop devtools / native menus usable.
+    if (isPressing.value || fired) {
+      event.preventDefault();
+    }
+  }
+
+  function cancel() {
+    reset();
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(cancel);
+  }
+
+  return {
+    handlers: {
+      onPointerdown,
+      onPointermove,
+      onPointerup,
+      onPointercancel,
+      onPointerleave,
+      onContextmenu,
+    },
+    isPressing,
+    cancel,
+  };
+}

--- a/chat/src/composables/useLongPress.ts
+++ b/chat/src/composables/useLongPress.ts
@@ -69,6 +69,7 @@ export function useLongPress(options: UseLongPressOptions): UseLongPressReturn {
   }
 
   function swallowNextClick() {
+    if (typeof window === "undefined") return;
     const handler = (event: MouseEvent) => {
       event.stopPropagation();
       event.preventDefault();

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -275,6 +275,15 @@
   50% { box-shadow: 0 0 0 2px var(--glow-strong), 0 0 20px 4px var(--glow); }
 }
 
+/* Suppress the iOS Safari callout / selection while a long-press is in progress.
+   Tailwind's `select-none` omits the iOS-only -webkit-touch-callout property,
+   and without it the system "Copy / Share" magnifier appears mid-gesture. */
+.no-callout {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 /* Glass panel utility */
 .glass-panel {
   background: var(--card);

--- a/chat/tests/use-long-press.test.ts
+++ b/chat/tests/use-long-press.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { effectScope } from "vue";
+import { useLongPress } from "../src/composables/useLongPress";
+
+type PointerInit = {
+  pointerId?: number;
+  pointerType?: "touch" | "mouse" | "pen";
+  clientX?: number;
+  clientY?: number;
+  target?: EventTarget | null;
+};
+
+function makePointerEvent(init: PointerInit = {}): PointerEvent {
+  const {
+    pointerId = 1,
+    pointerType = "touch",
+    clientX = 0,
+    clientY = 0,
+    target = null,
+  } = init;
+  // Happy-DOM/jsdom may not ship PointerEvent; fall back to a plain object
+  // with the fields the composable actually reads.
+  return {
+    pointerId,
+    pointerType,
+    clientX,
+    clientY,
+    target,
+    preventDefault() {},
+    stopPropagation() {},
+  } as unknown as PointerEvent;
+}
+
+async function waitMs(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("useLongPress", () => {
+  // Node's globalThis needs a stub window for the click-swallow path.
+  const originalWindow = globalThis.window;
+  const originalNavigator = globalThis.navigator;
+  const clickListeners: Array<(event: MouseEvent) => void> = [];
+
+  beforeEach(() => {
+    clickListeners.length = 0;
+    globalThis.window = {
+      addEventListener(type: string, listener: (event: MouseEvent) => void) {
+        if (type === "click") clickListeners.push(listener);
+      },
+      removeEventListener(type: string, listener: (event: MouseEvent) => void) {
+        if (type !== "click") return;
+        const idx = clickListeners.indexOf(listener);
+        if (idx >= 0) clickListeners.splice(idx, 1);
+      },
+    } as unknown as Window & typeof globalThis;
+    globalThis.navigator = { vibrate: () => true } as unknown as Navigator;
+  });
+
+  afterEach(() => {
+    globalThis.window = originalWindow;
+    globalThis.navigator = originalNavigator;
+  });
+
+  test("fires after the delay when the finger stays still", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 20, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent({ clientX: 0, clientY: 0 }));
+    });
+    await waitMs(40);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    scope.stop();
+  });
+
+  test("cancels when the pointer moves beyond the threshold", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 20, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent({ clientX: 0, clientY: 0 }));
+      lp.handlers.onPointermove(makePointerEvent({ clientX: 50, clientY: 0 }));
+    });
+    await waitMs(40);
+    expect(onLongPress).not.toHaveBeenCalled();
+    scope.stop();
+  });
+
+  test("cancels when the pointer lifts before the delay", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 30, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent());
+      lp.handlers.onPointerup(makePointerEvent());
+    });
+    await waitMs(50);
+    expect(onLongPress).not.toHaveBeenCalled();
+    scope.stop();
+  });
+
+  test("ignores non-touch pointer types", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 20, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent({ pointerType: "mouse" }));
+      lp.handlers.onPointerdown(makePointerEvent({ pointerType: "pen", pointerId: 2 }));
+    });
+    await waitMs(40);
+    expect(onLongPress).not.toHaveBeenCalled();
+    scope.stop();
+  });
+
+  test("swallows the synthetic click that follows a long-press", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 20, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent());
+    });
+    await waitMs(40);
+    expect(clickListeners).toHaveLength(1);
+    let defaultPrevented = false;
+    let propagationStopped = false;
+    const fakeClick = {
+      preventDefault() {
+        defaultPrevented = true;
+      },
+      stopPropagation() {
+        propagationStopped = true;
+      },
+    } as unknown as MouseEvent;
+    clickListeners[0](fakeClick);
+    expect(defaultPrevented).toBe(true);
+    expect(propagationStopped).toBe(true);
+    scope.stop();
+  });
+
+  test("cancel() aborts a pending press", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 30, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent());
+      lp.cancel();
+    });
+    await waitMs(50);
+    expect(onLongPress).not.toHaveBeenCalled();
+    scope.stop();
+  });
+
+  test("unmounting the owning scope clears pending timers", async () => {
+    const onLongPress = mock(() => {});
+    const scope = effectScope();
+    scope.run(() => {
+      const lp = useLongPress({ delay: 30, moveThreshold: 10, onLongPress });
+      lp.handlers.onPointerdown(makePointerEvent());
+    });
+    scope.stop();
+    await waitMs(50);
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The reaction toolbar was hover-only, so mobile users could neither add a
reaction nor edit/delete their own messages. This adds a 500ms long-press
(touch only) that reveals the same floating toolbar, wires the SmilePlus
button to a new searchable emoji picker with recents, and introduces an
always-reachable "more actions" menu for keyboard and screen-reader users.

Desktop hover behaviour is unchanged; non-touch pointer types are ignored
to avoid double-fire on hybrid devices.