### PR TITLE
fix(chat): populate inbound reply previews + unify mobile action UX

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -95,19 +95,47 @@ function showReplyJumpNotice(message: string) {
   }, 2800);
 }
 
+// Tracks pending flash timers so repeated jumps don't race each other — a
+// stale fade/cleanup from the previous animation would otherwise remove the
+// classes in the middle of the new flash.
+let flashEl: HTMLElement | null = null;
+let flashFadeTimer: ReturnType<typeof setTimeout> | null = null;
+let flashCleanupTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelPendingFlash() {
+  if (flashFadeTimer !== null) {
+    clearTimeout(flashFadeTimer);
+    flashFadeTimer = null;
+  }
+  if (flashCleanupTimer !== null) {
+    clearTimeout(flashCleanupTimer);
+    flashCleanupTimer = null;
+  }
+  if (flashEl) {
+    flashEl.classList.remove("message-jump-flash", "message-jump-flash-fade");
+    flashEl = null;
+  }
+}
+
 function scrollToMessage(messageId: string) {
   const el = findMessageElementById(messagesContainer.value, messageId);
   const notice = getReplyJumpNotice(el instanceof HTMLElement);
   if (!notice && el instanceof HTMLElement) {
     clearReplyJumpNotice();
+    cancelPendingFlash();
     el.scrollIntoView({ behavior: "smooth", block: "center" });
     // Force a reflow before re-adding so repeat clicks re-trigger the animation.
-    el.classList.remove("message-jump-flash", "message-jump-flash-fade");
     void el.offsetWidth;
     el.classList.add("message-jump-flash");
-    setTimeout(() => el.classList.add("message-jump-flash-fade"), 200);
-    setTimeout(() => {
+    flashEl = el;
+    flashFadeTimer = setTimeout(() => {
+      flashFadeTimer = null;
+      el.classList.add("message-jump-flash-fade");
+    }, 200);
+    flashCleanupTimer = setTimeout(() => {
+      flashCleanupTimer = null;
       el.classList.remove("message-jump-flash", "message-jump-flash-fade");
+      if (flashEl === el) flashEl = null;
     }, 2000);
     return;
   }

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -101,8 +101,14 @@ function scrollToMessage(messageId: string) {
   if (!notice && el instanceof HTMLElement) {
     clearReplyJumpNotice();
     el.scrollIntoView({ behavior: "smooth", block: "center" });
-    el.classList.add("ring-2", "ring-primary/40");
-    setTimeout(() => el.classList.remove("ring-2", "ring-primary/40"), 1400);
+    // Force a reflow before re-adding so repeat clicks re-trigger the animation.
+    el.classList.remove("message-jump-flash", "message-jump-flash-fade");
+    void el.offsetWidth;
+    el.classList.add("message-jump-flash");
+    setTimeout(() => el.classList.add("message-jump-flash-fade"), 200);
+    setTimeout(() => {
+      el.classList.remove("message-jump-flash", "message-jump-flash-fade");
+    }, 2000);
     return;
   }
 

--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -133,7 +133,7 @@ onBeforeUnmount(detachWindowListeners);
   <div
     v-if="open"
     ref="panelEl"
-    role="dialog"
+    :role="variant === 'popover' ? 'dialog' : 'group'"
     aria-label="Choose a reaction"
     :class="[
       'flex flex-col overflow-hidden',

--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -3,9 +3,19 @@ import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { Search, X } from "lucide-vue-next";
 import { searchEmoji } from "@/lib/emoji";
 
-const props = defineProps<{
-  open: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    open: boolean;
+    /**
+     * "popover" (default): absolutely positioned panel anchored to an anchor
+     * element outside this component — desktop inline-toolbar usage.
+     * "sheet": renders as a full-width in-flow grid that assumes its parent
+     * controls positioning — used inside the mobile action sheet.
+     */
+    variant?: "popover" | "sheet";
+  }>(),
+  { variant: "popover" },
+);
 
 const emit = defineEmits<{
   select: [emoji: string];
@@ -86,6 +96,9 @@ function onKey(event: KeyboardEvent) {
 
 function attachWindowListeners() {
   if (typeof window === "undefined") return;
+  // Sheet variant is embedded inside a modal that already owns outside-tap
+  // and Escape handling; attaching here would double-close on every click.
+  if (props.variant === "sheet") return;
   window.addEventListener("pointerdown", onWindowPointer, true);
   window.addEventListener("keydown", onKey);
 }
@@ -122,7 +135,12 @@ onBeforeUnmount(detachWindowListeners);
     ref="panelEl"
     role="dialog"
     aria-label="Choose a reaction"
-    class="absolute top-full right-0 mt-1 w-72 glass-panel border border-border rounded-xl z-50 shadow-2xl animate-fade-in overflow-hidden flex flex-col max-h-80"
+    :class="[
+      'flex flex-col overflow-hidden',
+      variant === 'popover'
+        ? 'absolute top-full right-0 mt-1 w-72 glass-panel border border-border rounded-xl z-50 shadow-2xl animate-fade-in max-h-80'
+        : 'w-full max-h-[60vh]',
+    ]"
     @pointerdown.stop
   >
     <div class="flex items-center gap-2.5 px-3 py-2 border-b border-border">
@@ -148,12 +166,15 @@ onBeforeUnmount(detachWindowListeners);
     <div class="flex-1 overflow-auto p-2">
       <template v-if="searchResults.length > 0">
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Results</div>
-        <div class="grid grid-cols-8 gap-0.5">
+        <div :class="['grid gap-0.5', variant === 'sheet' ? 'grid-cols-7' : 'grid-cols-8']">
           <button
             v-for="e in searchResults"
             :key="`s-${e}`"
             type="button"
-            class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+            :class="[
+              'flex items-center justify-center leading-none rounded-md hover:bg-muted transition-all duration-150',
+              variant === 'sheet' ? 'h-11 text-[24px]' : 'h-8 w-8 text-[18px]',
+            ]"
             :aria-label="`React with ${e}`"
             @click="onSelect(e)"
           >{{ e }}</button>
@@ -165,24 +186,30 @@ onBeforeUnmount(detachWindowListeners);
       <template v-else>
         <template v-if="recents.length > 0">
           <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Recent</div>
-          <div class="grid grid-cols-8 gap-0.5 mb-2">
+          <div :class="['grid gap-0.5 mb-2', variant === 'sheet' ? 'grid-cols-7' : 'grid-cols-8']">
             <button
               v-for="e in recents"
               :key="`r-${e}`"
               type="button"
-              class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+              :class="[
+              'flex items-center justify-center leading-none rounded-md hover:bg-muted transition-all duration-150',
+              variant === 'sheet' ? 'h-11 text-[24px]' : 'h-8 w-8 text-[18px]',
+            ]"
               :aria-label="`React with ${e}`"
               @click="onSelect(e)"
             >{{ e }}</button>
           </div>
         </template>
         <div class="text-[10px] uppercase tracking-wider text-muted-foreground/70 px-1 pb-1">Common</div>
-        <div class="grid grid-cols-8 gap-0.5">
+        <div :class="['grid gap-0.5', variant === 'sheet' ? 'grid-cols-7' : 'grid-cols-8']">
           <button
             v-for="e in COMMON_EMOJIS"
             :key="`c-${e}`"
             type="button"
-            class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted transition-all duration-150"
+            :class="[
+              'flex items-center justify-center leading-none rounded-md hover:bg-muted transition-all duration-150',
+              variant === 'sheet' ? 'h-11 text-[24px]' : 'h-8 w-8 text-[18px]',
+            ]"
             :aria-label="`React with ${e}`"
             @click="onSelect(e)"
           >{{ e }}</button>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -109,6 +109,16 @@ const replyAuthorName = computed(() => {
   return nickPart ?? author;
 });
 
+const replyChipExpanded = ref(false);
+
+function onReplyChipClick() {
+  if (!props.message.replyTo) return;
+  if (props.message.replyTo.preview) {
+    replyChipExpanded.value = !replyChipExpanded.value;
+  }
+  emit("scrollToMessage", props.message.replyTo.id);
+}
+
 const isMentioned = computed(() => {
   if (props.message.broadcastMention) return true;
   if (!props.currentUser || !props.message.mentions) return false;
@@ -151,61 +161,58 @@ function emitAvatarClick() {
 }
 
 const bubbleEl = ref<HTMLElement | null>(null);
-const mobileToolbarOpen = ref(false);
+// Inline hover toolbar's SmilePlus popover. Desktop-only; bound to hover.
 const pickerOpen = ref(false);
-const menuOpen = ref(false);
+// Unified action sheet: touch long-press, MoreHorizontal click, and keyboard
+// focus all open the same surface so there is never more than one emoji rail
+// on screen at a time.
+const sheetOpen = ref(false);
+type SheetView = "actions" | "emoji";
+const sheetView = ref<SheetView>("actions");
 
-const anyOverlayOpen = computed(
-  () => mobileToolbarOpen.value || pickerOpen.value || menuOpen.value,
-);
+const anyOverlayOpen = computed(() => pickerOpen.value || sheetOpen.value);
 
-function closeAllMenus() {
-  mobileToolbarOpen.value = false;
+function closeSheet() {
+  sheetOpen.value = false;
+  sheetView.value = "actions";
+}
+
+function openSheet() {
   pickerOpen.value = false;
-  menuOpen.value = false;
+  sheetView.value = "actions";
+  sheetOpen.value = true;
 }
 
 function togglePicker() {
   const next = !pickerOpen.value;
-  closeAllMenus();
+  closeSheet();
   pickerOpen.value = next;
-}
-
-function toggleMenu() {
-  const next = !menuOpen.value;
-  closeAllMenus();
-  menuOpen.value = next;
 }
 
 function react(emoji: string) {
   emit("react", props.message.id, emoji);
-  closeAllMenus();
+  pickerOpen.value = false;
+  closeSheet();
 }
 
 function startReplyFromMenu() {
   emit("reply", props.message);
-  closeAllMenus();
+  closeSheet();
 }
 
 function startEditFromMenu() {
   startEdit();
-  closeAllMenus();
+  closeSheet();
 }
 
 function retractFromMenu() {
   emit("retract", props.message.id);
-  closeAllMenus();
-}
-
-function openPickerFromMenu() {
-  closeAllMenus();
-  pickerOpen.value = true;
+  closeSheet();
 }
 
 const longPress = useLongPress({
   onLongPress: () => {
-    closeAllMenus();
-    mobileToolbarOpen.value = true;
+    openSheet();
   },
 });
 
@@ -217,14 +224,17 @@ function onBubbleContextMenu(event: MouseEvent) {
 }
 
 function onWindowPointerDown(event: PointerEvent) {
+  if (sheetOpen.value) return;
   if (!bubbleEl.value) return;
   const target = event.target as Node | null;
   if (target && bubbleEl.value.contains(target)) return;
-  closeAllMenus();
+  pickerOpen.value = false;
 }
 
 function onWindowKeydown(event: KeyboardEvent) {
-  if (event.key === "Escape") closeAllMenus();
+  if (event.key !== "Escape") return;
+  if (sheetOpen.value) closeSheet();
+  else pickerOpen.value = false;
 }
 
 // Only listen globally while an overlay is actually open. Otherwise every
@@ -288,7 +298,7 @@ watch(
     v-else
     ref="bubbleEl"
     :data-message-id="message.id"
-    :data-mobile-open="anyOverlayOpen ? 'true' : 'false'"
+    :data-sheet-open="sheetOpen ? 'true' : 'false'"
     class="group relative flow-root px-3 py-1.5 rounded-xl transition-all duration-200 animate-message-in"
     :class="[
       isMentioned
@@ -335,19 +345,27 @@ watch(
       </span>
     </div>
 
-    <!-- Reply preview chip -->
-    <button
-      v-if="message.replyTo"
-      type="button"
-      class="flex items-center gap-1.5 text-[11px] text-muted-foreground mb-0.5 hover:text-foreground transition-colors max-w-full"
-      :title="`Jump to replied message`"
-      @click="emit('scrollToMessage', message.replyTo.id)"
-    >
-      <CornerDownRight class="w-3 h-3 flex-shrink-0" />
-      <span class="text-primary/80 font-medium">@{{ replyAuthorName }}</span>
-      <span v-if="message.replyTo.preview" class="truncate opacity-70">{{ message.replyTo.preview }}</span>
-      <span v-else class="opacity-60 font-mono">{{ message.replyTo.id.slice(0, 8) }}</span>
-    </button>
+    <!-- Reply preview chip. Clicking scrolls to the parent message; if the
+         preview is available we also expand it inline so users still see the
+         full quoted text even when the parent has scrolled off-screen or
+         hasn't loaded from history yet. -->
+    <div v-if="message.replyTo" class="mb-0.5">
+      <button
+        type="button"
+        class="flex items-start gap-1.5 text-[11px] text-muted-foreground hover:text-foreground transition-colors max-w-full text-left"
+        :aria-expanded="replyChipExpanded"
+        :title="message.replyTo.preview ? 'Show full quoted message and jump to it' : 'Jump to replied message'"
+        @click="onReplyChipClick"
+      >
+        <CornerDownRight class="w-3 h-3 flex-shrink-0 mt-0.5" />
+        <span class="text-primary/80 font-medium">@{{ replyAuthorName }}</span>
+        <span
+          v-if="message.replyTo.preview"
+          :class="['flex-1 min-w-0 opacity-70', replyChipExpanded ? 'whitespace-pre-wrap break-words' : 'truncate']"
+        >{{ message.replyTo.preview }}</span>
+        <span v-else class="opacity-60 font-mono">{{ message.replyTo.id.slice(0, 8) }}</span>
+      </button>
+    </div>
 
     <!-- Edit mode -->
     <div v-if="isEditing" class="flex gap-2 mt-1 items-end">
@@ -456,11 +474,13 @@ watch(
       </button>
     </div>
 
-    <!-- Floating action toolbar — absolute so no layout space when hidden.
-         Revealed by hover (mouse), focus-within (keyboard), or long-press (touch). -->
+    <!-- Floating action toolbar — desktop-only hover/focus affordance. On
+         touch devices (where hover never fires) long-press opens the action
+         sheet instead, so this toolbar stays hidden and we never show two
+         emoji rails at once. -->
     <div
       v-if="!isEditing"
-      class="absolute -top-3 right-3 z-10 opacity-0 group-hover:opacity-100 focus-within:opacity-100 group-data-[mobile-open=true]:opacity-100 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto group-data-[mobile-open=true]:pointer-events-auto transition-opacity duration-150 flex items-center gap-0.5 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1"
+      class="absolute -top-3 right-3 z-10 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto transition-opacity duration-150 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1 [@media(pointer:coarse)]:hidden"
     >
       <button
         v-for="e in quickEmojis"
@@ -522,77 +542,109 @@ watch(
       </template>
     </div>
 
-    <!-- Accessible always-reachable affordance: keyboard / screen-reader users
-         (and anyone who prefers a button to a long-press) get the same actions
-         via a standard menu. Positioned at the top-right of the bubble, low
-         contrast on desktop, prominent on touch where hover never fires. -->
-    <div v-if="!isEditing" class="absolute top-1 right-1 z-10">
-      <button
-        type="button"
-        class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted opacity-40 hover:opacity-100 focus-visible:opacity-100 group-data-[mobile-open=true]:opacity-100 transition-all duration-150"
-        title="Message actions"
-        aria-label="Message actions"
-        :aria-expanded="menuOpen"
-        aria-haspopup="dialog"
-        @click="toggleMenu"
-      >
-        <MoreHorizontal class="w-3.5 h-3.5" aria-hidden="true" />
-      </button>
+    <!-- Action-sheet trigger. Small and low-contrast on desktop (where hover
+         already reveals the inline toolbar) and enlarged on touch so fingers
+         can actually hit it when long-press feels awkward. -->
+    <button
+      v-if="!isEditing"
+      type="button"
+      class="absolute top-1 right-1 z-10 h-6 w-6 [@media(pointer:coarse)]:h-10 [@media(pointer:coarse)]:w-10 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted opacity-40 hover:opacity-100 focus-visible:opacity-100 [@media(pointer:coarse)]:opacity-70 transition-all duration-150"
+      title="Message actions"
+      aria-label="Message actions"
+      :aria-expanded="sheetOpen"
+      aria-haspopup="dialog"
+      @click="openSheet"
+    >
+      <MoreHorizontal class="w-3.5 h-3.5 [@media(pointer:coarse)]:w-5 [@media(pointer:coarse)]:h-5" aria-hidden="true" />
+    </button>
+  </div>
+
+  <!-- Unified action sheet: opened by touch long-press, the MoreHorizontal
+       trigger, or keyboard focus. Teleported so it escapes overflow-hidden
+       ancestors; anchored at the bottom on mobile for large touch targets
+       and centred as a modal on desktop. -->
+  <Teleport to="body">
+    <div
+      v-if="sheetOpen"
+      class="fixed inset-0 z-[55] flex items-end sm:items-center justify-center animate-fade-in"
+      role="presentation"
+    >
+      <div class="absolute inset-0 bg-background/60 backdrop-blur-sm" @click="closeSheet" />
       <div
-        v-if="menuOpen"
         role="dialog"
+        aria-modal="true"
         aria-label="Message actions"
-        class="absolute top-full right-0 mt-1 min-w-40 glass-panel border border-border rounded-xl shadow-2xl p-1 animate-fade-in"
+        class="relative w-full sm:max-w-sm glass-panel border border-border rounded-t-2xl sm:rounded-2xl shadow-2xl animate-slide-up p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]"
         @pointerdown.stop
       >
-        <div class="flex items-center gap-0.5 px-1 py-1">
-          <button
-            v-for="e in quickEmojis"
-            :key="`menu-${e}`"
-            type="button"
-            class="h-8 w-8 flex items-center justify-center text-[16px] leading-none rounded-md hover:bg-muted transition-colors"
-            :aria-label="`React with ${e}`"
-            @click="react(e)"
-          >{{ e }}</button>
+        <div class="sm:hidden flex justify-center mb-2">
+          <div class="h-1 w-10 rounded-full bg-muted-foreground/30" />
         </div>
-        <button
-          type="button"
-          class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
-          @click="openPickerFromMenu"
-        >
-          <SmilePlus class="w-3.5 h-3.5" aria-hidden="true" />
-          <span>More reactions…</span>
-        </button>
-        <button
-          type="button"
-          class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
-          @click="startReplyFromMenu"
-        >
-          <Reply class="w-3.5 h-3.5" aria-hidden="true" />
-          <span>Reply</span>
-        </button>
-        <template v-if="message.isSelf">
-          <div class="my-1 h-px bg-border" />
+
+        <template v-if="sheetView === 'actions'">
+          <div class="grid grid-cols-6 gap-1 mb-3">
+            <button
+              v-for="e in quickEmojis"
+              :key="`sheet-${e}`"
+              type="button"
+              class="h-12 flex items-center justify-center text-[26px] leading-none rounded-xl hover:bg-muted active:bg-muted transition-colors"
+              :aria-label="`React with ${e}`"
+              @click="react(e)"
+            >{{ e }}</button>
+            <button
+              type="button"
+              class="h-12 flex items-center justify-center rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted active:bg-muted transition-colors"
+              aria-label="More reactions"
+              @click="sheetView = 'emoji'"
+            >
+              <SmilePlus class="w-5 h-5" aria-hidden="true" />
+            </button>
+          </div>
+
           <button
             type="button"
-            class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-muted transition-colors text-left"
-            @click="startEditFromMenu"
+            class="w-full flex items-center gap-3 px-3 h-12 rounded-xl text-[15px] hover:bg-muted active:bg-muted transition-colors text-left"
+            @click="startReplyFromMenu"
           >
-            <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
-            <span>Edit</span>
+            <Reply class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+            <span>Reply</span>
           </button>
+          <template v-if="message.isSelf">
+            <button
+              type="button"
+              class="w-full flex items-center gap-3 px-3 h-12 rounded-xl text-[15px] hover:bg-muted active:bg-muted transition-colors text-left"
+              @click="startEditFromMenu"
+            >
+              <Pencil class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+              <span>Edit</span>
+            </button>
+            <button
+              type="button"
+              class="w-full flex items-center gap-3 px-3 h-12 rounded-xl text-[15px] text-destructive hover:bg-destructive/10 active:bg-destructive/10 transition-colors text-left"
+              @click="retractFromMenu"
+            >
+              <Trash2 class="w-5 h-5" aria-hidden="true" />
+              <span>Delete</span>
+            </button>
+          </template>
           <button
             type="button"
-            class="w-full flex items-center gap-2 px-2 py-1.5 text-[13px] rounded-md hover:bg-destructive/10 text-destructive transition-colors text-left"
-            @click="retractFromMenu"
-          >
-            <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
-            <span>Delete</span>
-          </button>
+            class="sm:hidden mt-2 w-full h-12 rounded-xl text-[14px] text-muted-foreground hover:bg-muted active:bg-muted transition-colors"
+            @click="closeSheet"
+          >Cancel</button>
+        </template>
+
+        <template v-else>
+          <EmojiPicker
+            :open="true"
+            variant="sheet"
+            @select="react"
+            @close="sheetView = 'actions'"
+          />
         </template>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <style scoped>

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -14,7 +14,11 @@ import type { WaddleSession } from "@/lib/server-auth";
 import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
 
-function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): TimelineMessage {
+function fromLiveDmMessage(
+  session: WaddleSession,
+  msg: LiveDmMessage,
+  parentLookup?: (id: string) => { body?: string } | undefined,
+): TimelineMessage {
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
@@ -28,7 +32,12 @@ function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): Timeline
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;
   if (msg.isSticker) tm.isSticker = true;
   if (msg.replyTo) {
-    tm.replyTo = { id: msg.replyTo.id, ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}) };
+    const parent = parentLookup?.(msg.replyTo.id);
+    tm.replyTo = {
+      id: msg.replyTo.id,
+      ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}),
+      ...(parent?.body ? { preview: parent.body } : {}),
+    };
   }
   if (msg.threadId) tm.threadId = msg.threadId;
   if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
@@ -244,7 +253,12 @@ export function useDmMessaging(
           regular.push(msg);
         }
       }
-      const timeline = regular.map((m) => fromLiveDmMessage(session.value!, m));
+      const byId = new Map<string, TimelineMessage>();
+      const timeline = regular.map((m) => {
+        const tm = fromLiveDmMessage(session.value!, m, (id) => byId.get(id));
+        byId.set(tm.id, tm);
+        return tm;
+      });
       for (const update of correctionUpdates) {
         const target = timeline.find((m) => m.id === update.targetId);
         if (!target) continue;
@@ -502,7 +516,9 @@ export function useDmMessaging(
       applyCorrection(msg.replacesId, msg.body, msg.markup);
       return;
     }
-    mergeLiveMessage(fromLiveDmMessage(session.value, msg));
+    mergeLiveMessage(
+      fromLiveDmMessage(session.value, msg, (id) => messages.value.find((m) => m.id === id)),
+    );
   }
 
   function onChatState(event: DmChatStateEvent) {

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -16,7 +16,11 @@ import type { DeliveryStatus, MarkupSpan, TimelineMessage } from "@/lib/chat-ui"
 import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
 
-function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): TimelineMessage {
+export function fromLiveMessage(
+  session: WaddleSession,
+  msg: LiveRoomMessage,
+  parentLookup?: (id: string) => { body?: string } | undefined,
+): TimelineMessage {
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
@@ -41,7 +45,12 @@ function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): Timeline
     tm.markup = msg.markup;
   }
   if (msg.replyTo) {
-    tm.replyTo = { id: msg.replyTo.id, ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}) };
+    const parent = parentLookup?.(msg.replyTo.id);
+    tm.replyTo = {
+      id: msg.replyTo.id,
+      ...(msg.replyTo.author ? { author: msg.replyTo.author } : {}),
+      ...(parent?.body ? { preview: parent.body } : {}),
+    };
   }
   if (msg.threadId) tm.threadId = msg.threadId;
   if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
@@ -132,7 +141,9 @@ export function useMessaging(
           return;
         }
 
-        mergeLiveMessage(fromLiveMessage(session.value!, msg));
+        mergeLiveMessage(
+          fromLiveMessage(session.value!, msg, (id) => messages.value.find((m) => m.id === id)),
+        );
 
         // Trigger notification for mentions when tab is unfocused
         const isTabHidden = typeof document !== "undefined"
@@ -486,8 +497,14 @@ export function useMessaging(
         }
       }
 
-      // Convert to timeline messages
-      const timeline = regularMessages.map((m) => fromLiveMessage(session.value!, m));
+      // Convert to timeline messages; accumulate in a map so replies that land
+      // after their parent in the MAM batch can resolve a preview.
+      const byId = new Map<string, TimelineMessage>();
+      const timeline = regularMessages.map((m) => {
+        const tm = fromLiveMessage(session.value!, m, (id) => byId.get(id));
+        byId.set(tm.id, tm);
+        return tm;
+      });
 
       for (const update of correctionUpdates) {
         const target = timeline.find((m) => m.id === update.targetId);

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -284,6 +284,25 @@
   user-select: none;
 }
 
+/* Visible flash when a user jumps to a replied-to message via the reply chip.
+   Uses an outline + background pulse so it can't be clipped by overflow:hidden
+   on ancestor elements the way Tailwind's `ring-*` utilities can be, and is
+   vivid enough to be noticed at a glance. */
+@keyframes message-jump-flash {
+  0% { background-color: color-mix(in oklab, var(--primary) 20%, transparent); }
+  100% { background-color: transparent; }
+}
+.message-jump-flash {
+  animation: message-jump-flash 1.8s ease-out both;
+  outline: 2px solid var(--primary);
+  outline-offset: -2px;
+  border-radius: 0.75rem;
+  transition: outline-color 1.6s ease-out 0.2s;
+}
+.message-jump-flash.message-jump-flash-fade {
+  outline-color: transparent;
+}
+
 /* Glass panel utility */
 .glass-panel {
   background: var(--card);

--- a/chat/tests/reply-preview-population.test.ts
+++ b/chat/tests/reply-preview-population.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { fromLiveMessage } from "../src/composables/useMessaging";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+const session: WaddleSession = {
+  session_id: "sess",
+  user_id: "u1",
+  username: "bob",
+  avatar_url: null,
+  xmpp_localpart: "bob",
+  jid: "bob@waddle.social",
+  xmpp_websocket_url: "wss://example/xmpp",
+  is_expired: false,
+  expires_at: null,
+};
+
+function mkMsg(partial: Partial<LiveRoomMessage> & { id: string }): LiveRoomMessage {
+  return {
+    roomJid: "lobby@muc.waddle.social",
+    nick: "alice",
+    body: "",
+    createdAt: new Date().toISOString(),
+    type: "message",
+    ...partial,
+  } as LiveRoomMessage;
+}
+
+describe("fromLiveMessage reply-preview population", () => {
+  test("copies parent body into replyTo.preview when parent lookup resolves", () => {
+    const parentBody = "shall we ship?";
+    const inbound = mkMsg({
+      id: "reply-1",
+      body: "yes",
+      replyTo: { id: "parent-1", author: "lobby@muc.waddle.social/alice" },
+    });
+
+    const tm = fromLiveMessage(session, inbound, (id) =>
+      id === "parent-1" ? { body: parentBody } : undefined,
+    );
+
+    expect(tm.replyTo).toBeDefined();
+    expect(tm.replyTo?.id).toBe("parent-1");
+    expect(tm.replyTo?.preview).toBe(parentBody);
+    expect(tm.replyTo?.author).toBe("lobby@muc.waddle.social/alice");
+  });
+
+  test("omits preview when parent lookup returns undefined", () => {
+    const inbound = mkMsg({
+      id: "reply-2",
+      body: "ok",
+      replyTo: { id: "missing", author: "lobby@muc.waddle.social/alice" },
+    });
+
+    const tm = fromLiveMessage(session, inbound, () => undefined);
+
+    expect(tm.replyTo?.preview).toBeUndefined();
+    expect(tm.replyTo?.id).toBe("missing");
+  });
+
+  test("omits preview when no lookup is provided (legacy callers)", () => {
+    const inbound = mkMsg({
+      id: "reply-3",
+      body: "ok",
+      replyTo: { id: "parent-3", author: "lobby@muc.waddle.social/alice" },
+    });
+
+    const tm = fromLiveMessage(session, inbound);
+
+    expect(tm.replyTo?.preview).toBeUndefined();
+  });
+
+  test("does not set replyTo when the inbound message has none", () => {
+    const inbound = mkMsg({ id: "plain-1", body: "hi" });
+
+    const tm = fromLiveMessage(session, inbound, () => ({ body: "x" }));
+
+    expect(tm.replyTo).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Three fixes to the reply feature shipped in #120 and the mobile-reactions UX shipped in #122.

### 1. Recipients now see the full quoted text, not a short id

`fromLiveMessage` / `fromLiveDmMessage` never populated `replyTo.preview` — only the optimistic send path on the replier's session did. Every other session received a stanza with `<reply id="…">` (no body) and fell back to rendering the first 8 chars of the id. Both composables now take an optional `parentLookup` and the live + MAM paths pass one that reads from the current timeline, so the preview is resolved the moment the parent is loaded.

### 2. Click-to-jump actually shows you the message

The previous `ring-2 ring-primary/40` approach relied on Tailwind utilities that can be clipped by `overflow-hidden` ancestors and were easy to miss. Replaced with a deterministic `.message-jump-flash` class defined in `global.css` (outline + background pulse). The reply chip also expands inline when the preview is available, so users get immediate visible feedback even if the parent has scrolled out of the loaded window.

### 3. One action surface on screen at a time, with proper touch targets

The `MoreHorizontal` dropdown was driving the `group-data-[mobile-open]` attribute the floating toolbar keyed off, so both appeared together — two emoji rails stacked on top of the message, at tiny desktop-size tap targets on mobile. Replaced both the long-press popup and the tiny dropdown with a single unified action sheet that teleports to `<body>`:

- Bottom-anchored on mobile (`items-end`), with 48px tap targets and a drag handle.
- Centred modal on desktop (`sm:items-center`), reachable by keyboard via the `MoreHorizontal` trigger.
- Inline "More reactions" swap to an `EmojiPicker` rendered in a new `variant="sheet"` (bigger buttons, no positioning of its own) instead of opening a second popover on top.
- The hover toolbar is now desktop-only (`[@media(pointer:coarse)]:hidden`) so there is no way to see two rails at once.

## Test plan

- [x] `bun test` — 105/105 (includes new `reply-preview-population.test.ts`, 4 cases).
- [x] `bunx astro check` — no new diagnostics. (3 pre-existing `cloudflare:workers` errors in `.astro` files are unrelated.)
- [ ] Manual (two browser sessions, same room):
  - [ ] A replies to B. B's reply chip shows the full preview, not just an id.
  - [ ] Click reply chip on either session → parent scrolls into view and flashes.
  - [ ] Click reply chip when preview is available → chip expands inline to show the full quoted body.
- [ ] Manual mobile:
  - [ ] Long-press message → single bottom sheet with big emojis, Reply/Edit/Delete rows, Cancel button.
  - [ ] Tap `…` menu → same sheet.
  - [ ] "More reactions" → sheet swaps to the emoji picker grid, not a popover on top of the sheet.
  - [ ] Hover toolbar never appears.
- [ ] Manual desktop:
  - [ ] Hover still reveals the small inline toolbar.
  - [ ] Clicking `…` opens the centred action-sheet modal, not a tiny dropdown.
  - [ ] Escape closes; backdrop click closes.

https://claude.ai/code/session_01RwgxNJ6JHiHt6kyYAxP3jQ