### PR TITLE
feat: add XMPP forum support for forum channels

### DIFF
--- a/XMPP_CHANNEL_CREATE_RISKS.md
+++ b/XMPP_CHANNEL_CREATE_RISKS.md
@@ -1,0 +1,310 @@
+# Adversarial Design Review: Pure-XMPP Channel Creation
+
+## Executive Summary
+
+**Recommendation:** Extend XEP-0503 Spaces writes as the primary path, with XEP-0050 ad-hoc commands as a secondary option for power users. Direct MUC room creation should be explicitly blocked for managed channels.
+
+**Key Risk:** Protocol fragmentation—allowing multiple creation paths will lead to inconsistent state, confused clients, and support nightmares.
+
+---
+
+## Option Analysis
+
+### Option 1: Extend XEP-0503 Spaces Writes (RECOMMENDED)
+
+**Current State:**
+- Read-only Spaces implementation exists (`xep/xep0503.rs`)
+- Advertises full feature set but returns `service-unavailable` for writes
+- Already exposes channels as pubsub items with XEP-0402 bookmarks
+- Integration with disco#items and pubsub queries
+
+**Approach:**
+Accept pubsub `<publish>` stanzas on the spaces node to create new channels. Parse channel metadata from the bookmark element, write to the waddle DB, create the MUC room, then reflect the new channel via pubsub notifications.
+
+**Risks (HIGH TO CRITICAL):**
+
+1. **Race Conditions in Multi-Client Create** (P0)
+   - Concurrent publishes to the same waddle from different clients
+   - No atomic DB+MUC creation; partial failure states exist
+   - Example: Channel created in DB but MUC room fails → ghost channel
+   - Mitigation: Implement idempotent create with distributed locks on waddle_id+channel_name
+
+2. **Permission Bypass via Direct Pubsub** (P0)
+   - Current HTTP API checks `create_channel` permission against waddle
+   - Pubsub publish handler MUST duplicate this check or risk unauthorized creation
+   - Easy to forget when porting HTTP logic to XMPP handlers
+   - Mitigation: Centralize permission check in shared function called by both paths
+
+3. **Bookmark Schema Mismatch** (P1)
+   - XEP-0402 bookmarks are minimal (JID, name, autojoin)
+   - Waddle channels have: description, position, channel_type (text/forum)
+   - Extended fields require custom `<extensions>` child → client compatibility risk
+   - Mitigation: Define strict Waddle-specific bookmark schema, document fallback behavior
+
+4. **Pubsub Notification Fanout Failure** (P1)
+   - After channel creation, all waddle members should receive pubsub notify
+   - If notification system is down/slow, clients desync
+   - No retry mechanism for failed pubsub broadcasts in current codebase
+   - Mitigation: Make channel visible immediately via disco#items even if notifications fail
+
+5. **Spaces Node vs MUC Domain Confusion** (P2)
+   - Publish goes to `spaces.waddle.social` but room is on `muc.waddle.social`
+   - Clients may try to join `spaces.waddle.social/room-name` instead of the MUC JID
+   - Bookmark element MUST contain full MUC JID, not a relative reference
+   - Mitigation: Validate JID format in bookmark parser, reject non-MUC JIDs
+
+6. **No Atomic Rollback Path** (P1)
+   - Create sequence: waddle DB insert → permission tuple → MUC room → pubsub notify
+   - Any mid-sequence failure leaves inconsistent state
+   - HTTP handler has partial cleanup (delete channel if permissions fail) but incomplete
+   - Mitigation: Implement compensating transaction pattern with explicit rollback steps
+
+**Architecture Strengths:**
+- Natural fit: Spaces already represents waddles, channels are already items
+- Clients already query Spaces for discovery, extending to writes is intuitive
+- Pubsub notifications give live updates to all members automatically
+- XEP-0503 is the "blessed" path for community structure in modern XMPP
+
+---
+
+### Option 2: XEP-0050 Ad-Hoc Commands
+
+**Current State:**
+- Helpers exist (`xep/xep0050.rs`) with parsers/builders
+- Runtime does NOT advertise commands (test confirms `service-unavailable`)
+- No command registry, no session state tracking for multi-step flows
+
+**Approach:**
+Advertise a `create-channel` command node. Client executes, server responds with a data form (name, description, type, position), client submits, server creates channel and returns result.
+
+**Risks (MODERATE TO HIGH):**
+
+1. **Session State Management Hell** (P0)
+   - Ad-hoc commands are stateful multi-turn flows
+   - Need to track incomplete command sessions per user+waddle
+   - Session timeout, cancellation, concurrent sessions = complexity explosion
+   - Current codebase has zero session state infra for commands
+   - Mitigation: Use in-memory session cache with TTL, but this adds latency and failure modes
+
+2. **Command Discovery UX Friction** (P1)
+   - Users must disco#items on `localhost` with node=`http://jabber.org/protocol/commands`
+   - Then filter for `create-channel` command
+   - Then execute with waddle context (how? pass waddle_id as initial arg?)
+   - More client round-trips than pubsub publish
+   - Mitigation: Pre-populate command list in client UI, but still requires waddle_id injection
+
+3. **No Standard Channel Context** (P1)
+   - Command executes against server root, not against a specific waddle node
+   - Client must pass waddle_id as a hidden form field
+   - Easy to spoof if not validated (create channel in wrong waddle)
+   - Mitigation: Parse `sessionid` or waddle_id from command args, re-check permissions
+
+4. **Form Validation Is Manual** (P2)
+   - XEP-0004 data forms have basic typing (text-single, boolean, list-single)
+   - No built-in validation for "channel name must be unique in waddle"
+   - Server must reject and re-prompt with error note
+   - Another round-trip, poor UX compared to immediate failure
+   - Mitigation: Pre-validate in client before submission (but client needs waddle state)
+
+5. **No Live Updates** (P2)
+   - Command execution is request/response only
+   - After channel is created, other clients don't learn about it until they re-query Spaces
+   - Must manually broadcast a pubsub notification anyway (so why not just use pubsub?)
+   - Mitigation: Publish to Spaces node after command completes (hybrid approach adds complexity)
+
+**Architecture Strengths:**
+- Explicit, user-initiated action (good for power users, not casual users)
+- Multi-step forms can guide users through complex config (useful for advanced channel types?)
+- Server-driven validation with human-readable error messages
+
+**Critical Flaw:**
+You're building a stateful, session-based command system when you already have pubsub. This is over-engineering unless you need complex multi-step workflows (you don't for basic channel creation).
+
+---
+
+### Option 3: Direct MUC Room Creation (XEP-0045 §10.1.2)
+
+**Current State:**
+- Instant room creation exists (`room_registry.rs:create_instant_room`)
+- User joins non-existent room → server creates it with default config
+- Used for testing and ad-hoc rooms
+
+**Approach:**
+User joins `waddle-id_channel-name@muc.waddle.social`, server creates room and waddle DB entry on-the-fly.
+
+**Risks (CATASTROPHIC):**
+
+1. **No Waddle Association Enforcement** (P0)
+   - User can create arbitrary rooms with any `waddle-id_` prefix
+   - How do you know the user has permission for that waddle?
+   - Instant rooms don't consult permission service
+   - Mitigation: Reject all instant rooms with managed name patterns, but this breaks discoverability
+
+2. **Name Collision Chaos** (P0)
+   - Two users join `eng_general@muc.waddle.social` simultaneously
+   - Both create the channel in different waddles (or same waddle twice)
+   - Race condition in DB insert (unique constraint violation likely but not guaranteed)
+   - Mitigation: Pre-allocate channel IDs in waddle DB, but this defeats "instant" rooms
+
+3. **No Metadata Capture** (P0)
+   - Instant rooms have no description, no position, no channel_type
+   - Cannot distinguish text vs forum channels
+   - Frontend sees bare MUC rooms, cannot render properly
+   - Mitigation: Require MUC room config submission before allowing messages (breaks UX flow)
+
+4. **Spaces Desync** (P0)
+   - Channel created via MUC join doesn't appear in Spaces pubsub items
+   - Spaces discovery queries miss it until manual sync
+   - No hook to publish to Spaces node from MUC room creation path
+   - Mitigation: Poll MUC room list and sync to Spaces on interval (horrible, eventual consistency issues)
+
+5. **Permission Escalation** (P0)
+   - Instant room creator gets owner affiliation
+   - If they're not a waddle admin, they shouldn't have owner on managed channels
+   - Existing instant room logic doesn't check waddle roles
+   - Mitigation: Disable instant room creation entirely for managed room JID patterns
+
+**Verdict: DO NOT ALLOW direct MUC creation for managed channels.**
+
+Instant rooms are fine for ad-hoc testing/private chats, but mixing them with the managed Waddle channel system is a security and consistency disaster.
+
+---
+
+### Option 4: Hybrid Approaches (ANTI-PATTERN)
+
+**What Not To Do:**
+
+1. **"Support all three methods"**
+   - Three code paths = three times the bugs
+   - Clients don't know which to use
+   - Support requests: "I created a channel via ad-hoc command but it doesn't show up in Spaces"
+   - State synchronization becomes a full-time job
+
+2. **"Use ad-hoc commands to pre-create, then pubsub to publish"**
+   - Why? Just use pubsub for both
+   - Adding command layer doesn't improve anything, only adds latency
+
+3. **"Allow MUC instant rooms but sync them to Spaces afterward"**
+   - Race-prone, permission bypass risk, eventual consistency hell
+   - Better to fail fast with a clear error than silently create broken state
+
+---
+
+## Recommended Implementation Plan
+
+**Primary Path: XEP-0503 Spaces Writes**
+
+1. **Accept pubsub `<publish>` on `spaces.waddle.social` node=`{waddle_id}`**
+   - Parse item ID as channel identifier (or generate UUID)
+   - Extract channel metadata from bookmark `<extensions>` child
+   - Validate: user has `create_channel` permission on waddle
+
+2. **Atomic create with compensation:**
+   ```rust
+   // Pseudo-code
+   let channel_id = uuid::new_v4();
+   let tx = db.begin_transaction();
+   tx.insert_channel(waddle_id, channel_id, metadata)?;
+   tx.insert_permission_tuple(channel#parent@waddle)?;
+   tx.commit()?;
+   
+   // If this fails, rollback DB transaction and return error
+   let room = room_registry.create_room(muc_jid, waddle_id, channel_id, config)
+       .map_err(|e| {
+           tx.rollback();
+           e
+       })?;
+   
+   // Best-effort notify (failure is non-fatal, clients will resync on next disco query)
+   let _ = pubsub.notify_subscribers(waddle_id, new_channel_item);
+   ```
+
+3. **Bookmark schema extension (Waddle namespace):**
+   ```xml
+   <item id='uuid-here'>
+     <conference xmlns='urn:xmpp:bookmarks:1' 
+                 name='General' 
+                 autojoin='true'>
+       <extensions xmlns='https://waddle.social/schemas/channel/1.0'>
+         <description>Main discussion channel</description>
+         <position>0</position>
+         <type>text</type>
+       </extensions>
+     </conference>
+   </item>
+   ```
+
+4. **Explicit rejection of instant managed rooms:**
+   ```rust
+   if room_jid.node().unwrap_or("").contains('_') {
+       // Managed room pattern detected
+       return Err(XmppError::not_allowed(
+           "Managed channels must be created via Spaces pubsub, not direct MUC join"
+       ));
+   }
+   ```
+
+**Secondary Path: XEP-0050 Ad-Hoc Commands (for power users only)**
+
+- Implement ONLY if there's a clear use case (e.g., scripted channel creation via CLI)
+- Command MUST delegate to the same pubsub publish handler (no duplicate logic)
+- Document that pubsub is the canonical method
+
+---
+
+## What To Explicitly Avoid
+
+1. **Do NOT allow direct MUC instant room creation for managed channels**
+   - Security risk, state consistency nightmare
+
+2. **Do NOT implement ad-hoc commands as the primary path**
+   - Over-engineered for simple channel creation
+
+3. **Do NOT write separate permission checks in the XMPP handler**
+   - Extract HTTP handler's permission logic to shared function, call from both
+
+4. **Do NOT assume pubsub notifications always succeed**
+   - Make disco#items the source of truth, notifications are optimization
+
+5. **Do NOT skip transaction rollback on MUC room creation failure**
+   - Ghost channels in DB are worse than failed creation
+
+---
+
+## Open Questions for User
+
+1. **Channel naming:** Should channel IDs be user-chosen slugs or server-generated UUIDs?
+   - Current HTTP API: UUID
+   - Pubsub item ID: could be slug (more readable JIDs)
+   - Recommendation: Allow both, but validate slug uniqueness strictly
+
+2. **Forum channel special handling:** Do forum channels need different MUC config on creation?
+   - Current code sets `muc#roomconfig_forum: true` in room config
+   - Should pubsub publish handler auto-detect `<type>forum</type>` and set this?
+   - Recommendation: Yes, map channel_type to MUC config in create handler
+
+3. **Partial failure notification strategy:**
+   - If pubsub notification fails but channel is created, should server retry?
+   - Or rely on client-side polling/resync?
+   - Recommendation: Log failure, increment metric, let clients resync (avoid infinite retry loops)
+
+---
+
+## Metrics & Monitoring
+
+**Add these to detect issues in production:**
+
+- `waddle_channel_create_attempts_total{method="spaces_pubsub"|"adhoc_command"|"instant_muc"}`
+- `waddle_channel_create_failures_total{reason="permission_denied"|"db_error"|"muc_error"|"pubsub_error"}`
+- `waddle_channel_create_rollbacks_total` (tracks compensation transaction invocations)
+- `waddle_spaces_pubsub_notification_failures_total` (detect silent failures)
+
+---
+
+## Conclusion
+
+**Use XEP-0503 Spaces pubsub writes.** It's the modern, notification-aware, natural extension of your existing architecture. Ad-hoc commands are overkill. Direct MUC creation is a landmine.
+
+**Biggest risk you MUST address:** Atomic channel creation with proper rollback. The current HTTP handler's partial cleanup is not sufficient. A failed MUC room creation must undo the DB insert and permission tuple, or you'll leak ghost channels.
+
+**Second biggest risk:** Permission checks. Do NOT duplicate logic. Extract to shared validation layer.

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -10,7 +10,7 @@ import { useUiState } from "@/composables/useUiState";
 import { useNotifications } from "@/composables/useNotifications";
 import { useVersion } from "@/composables/useVersion";
 import { parseRoute, pushDmRoute, pushRoute, resolveWaddle, resolveChannel } from "@/composables/useRouting";
-import { barePeerJid } from "@/lib/xmpp-client";
+import { barePeerJid, jidDomain, parseManagedRoomBareJid, roomBareJidFor } from "@/lib/xmpp-client";
 import { connectionStore } from "@/lib/connection-store";
 import LandingState from "@/components/chat/LandingState.vue";
 import LoginScreen from "@/components/chat/LoginScreen.vue";
@@ -72,6 +72,7 @@ const messaging = useMessaging(
   xmppClient,
   waddles.activeWaddleId,
   waddles.activeChannelId,
+  waddles.currentChannel,
   ui.normalizeError,
   ui.actionError,
   ui.clearActionError,
@@ -128,6 +129,14 @@ const activeDraft = computed({
     else messaging.draft.value = value;
   },
 });
+const activeForumTitle = computed({
+  get: () => (ui.sidebarMode.value === "dms" ? "" : messaging.forumPostTitle.value),
+  set: (value: string) => {
+    if (ui.sidebarMode.value !== "dms") {
+      messaging.forumPostTitle.value = value;
+    }
+  },
+});
 const activeTypingUsers = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.typingUsers.value : messaging.typingUsers.value,
 );
@@ -144,7 +153,7 @@ const activeIsSearching = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.isSearching.value : messaging.isSearching.value,
 );
 
-const selfDomain = computed(() => session.value?.jid.split("@")[1] ?? "");
+const selfDomain = computed(() => (session.value ? jidDomain(session.value.jid) : ""));
 const memberJidByNick = ref<Record<string, string>>({});
 const activeDmPeer = computed(() => {
   const active = dmConversations.activePeerJid.value;
@@ -177,12 +186,9 @@ const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
 });
 
 function resolveChannelNameFromJid(roomJid: string): string | null {
-  const localpart = roomJid.split("@")[0] ?? "";
-  const waddleId = waddles.activeWaddleId.value;
-  const channelId = waddleId && localpart.startsWith(`${waddleId}_`)
-    ? localpart.slice(waddleId.length + 1)
-    : localpart;
-  return waddles.channels.value.find((c) => c.id === channelId)?.name ?? null;
+  const managedRoom = parseManagedRoomBareJid(roomJid);
+  if (!managedRoom || managedRoom.waddleId !== waddles.activeWaddleId.value) return null;
+  return waddles.channels.value.find((c) => c.id === managedRoom.channelId)?.name ?? null;
 }
 
 watch(() => messaging.lastMentionActivity.value, (event) => {
@@ -202,12 +208,9 @@ watch(() => messaging.lastMentionActivity.value, (event) => {
       roomJid: event.roomJid,
       isBroadcast,
       onNavigate: (roomJid) => {
-        const localpart = roomJid.split("@")[0] ?? "";
-        const waddleId = waddles.activeWaddleId.value;
-        const channelId = waddleId && localpart.startsWith(`${waddleId}_`)
-          ? localpart.slice(waddleId.length + 1)
-          : localpart;
-        void selectChannel(channelId);
+        const managedRoom = parseManagedRoomBareJid(roomJid);
+        if (!managedRoom) return;
+        void selectWaddle(managedRoom.waddleId, managedRoom.channelId);
       },
     });
   }
@@ -287,10 +290,6 @@ const activeTarget = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging : messaging,
 );
 
-async function sendGif(url: string) {
-  await activeTarget.value.sendMessage(url);
-}
-
 const activeUploadProgress = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
 );
@@ -300,12 +299,13 @@ async function sendActiveMessage(
   markup?: MarkupSpan[],
   files?: Array<File | Blob>,
   replyTo?: { id: string; author: string; body?: string },
+  forumTitle?: string,
 ) {
   if (ui.sidebarMode.value === "dms") {
     await dmMessaging.sendMessage(body, markup, files, replyTo);
     return;
   }
-  await messaging.sendMessage(body, markup, files, replyTo);
+  await messaging.sendMessage(body, markup, files, replyTo, forumTitle);
 }
 
 async function sendThreadMessage(
@@ -436,7 +436,7 @@ async function applyRouteTarget(route: ReturnType<typeof parseRoute>, requestId:
   if (route.dmUsername) {
     const username = route.dmUsername.replace(/^@/, "").trim();
     if (username) {
-      const domain = session.value?.jid.split("@")[1];
+      const domain = session.value ? jidDomain(session.value.jid) : "";
       if (!domain) return;
       await handleOpenDm(`${username}@${domain}`);
     }
@@ -550,8 +550,7 @@ async function selectChannel(channelId: string) {
   messaging.clearMessages();
   // XEP-0502: Clear activity indicator for this channel
   if (waddles.activeWaddleId.value && connectionStore.session) {
-    const domain = connectionStore.session.jid.split("@")[1] ?? "";
-    const roomJid = `${channelId}@conference.${domain}`;
+    const roomJid = roomBareJidFor(connectionStore.session, waddles.activeWaddleId.value, channelId);
     messaging.clearChannelActivity(roomJid);
   }
   if (waddles.activeWaddleId.value) {
@@ -889,6 +888,7 @@ onUnmounted(() => {
       <ContentArea
         :ref="setContentAreaRef"
         v-model:draft="activeDraft"
+        v-model:forum-title="activeForumTitle"
         :waddle="waddles.currentWaddle.value"
         :channel="ui.sidebarMode.value === 'dms' ? null : waddles.currentChannel.value"
         :dm-peer="activeDmPeer"
@@ -917,7 +917,6 @@ onUnmounted(() => {
         :thread-index="threads.index.value"
         @send="sendActiveMessage"
         @typing="notifyActiveComposing"
-        @select-gif="sendGif"
         @edit-message="editActiveMessage"
         @retract-message="retractActiveMessage"
         @react-message="reactActiveMessage"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from "vue";
-import { Hash, MessageCircle, Settings, Search, X, Upload } from "lucide-vue-next";
+import { Hash, MessageCircle, MessagesSquare, Settings, Search, X, Upload } from "lucide-vue-next";
+import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { extractImagesFromEvent } from "@/lib/xmpp/file-upload";
@@ -14,6 +15,7 @@ import MessageComposer from "@/components/chat/MessageComposer.vue";
 import UserPopover from "@/components/chat/UserPopover.vue";
 
 const draft = defineModel<string>("draft", { required: true });
+const forumTitle = defineModel<string>("forumTitle", { default: "" });
 
 const props = defineProps<{
   waddle: WaddleSummary | null;
@@ -50,9 +52,9 @@ const emit = defineEmits<{
     markup: MarkupSpan[],
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
+    forumTitle?: string,
   ];
   typing: [];
-  selectGif: [url: string];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[]];
   retractMessage: [messageId: string];
   reactMessage: [messageId: string, emoji: string];
@@ -161,8 +163,13 @@ function onSend(body: string, markup: MarkupSpan[], files?: Array<File | Blob>) 
     markup,
     files,
     pending ? { id: pending.id, author: pending.author, ...(pending.body ? { body: pending.body } : {}) } : undefined,
+    !pending && detectForumChannel(props.channel) ? forumTitle.value : undefined,
   );
-  replyingTo.value = null;
+  // Don't clear replyingTo here — wait for send to complete (success or failure)
+}
+
+function onSelectGif(url: string) {
+  onSend(url, []);
 }
 
 const messagesContainer = ref<HTMLDivElement | null>(null);
@@ -176,6 +183,7 @@ const setComposerRef = (instance: { addAttachments: (files: Array<File | Blob>) 
 const showSearch = ref(false);
 const searchInput = ref("");
 const avatarUrlByAuthor = computed(() => props.avatarUrlByAuthor ?? {});
+const isForumChannel = computed(() => detectForumChannel(props.channel));
 const popoverAuthor = ref<{ username: string; jid: string } | null>(null);
 const conversationScope = computed(() => [
   props.sidebarMode ?? "channels",
@@ -263,6 +271,18 @@ watch(
 watch(conversationScope, () => {
   cancelReply();
   clearReplyJumpNotice();
+  forumTitle.value = "";
+});
+
+// Clear reply context only on successful send; preserve on failure so user can retry
+watch(() => props.isSending, (sending, prevSending) => {
+  if (prevSending && !sending && replyingTo.value) {
+    // Send completed: clear reply context only if no error occurred
+    if (!props.actionError) {
+      replyingTo.value = null;
+    }
+    // On error, keep reply context so user can retry without re-selecting
+  }
 });
 
 onBeforeUnmount(() => {
@@ -293,10 +313,16 @@ onBeforeUnmount(() => {
     <div class="h-14 border-b border-border px-6 flex items-center justify-between flex-shrink-0 glass-surface">
       <div class="flex items-center gap-3">
         <div class="flex items-center gap-2">
-          <component :is="dmPeer ? MessageCircle : Hash" class="w-4 h-4 text-primary/70" />
+          <component :is="dmPeer ? MessageCircle : isForumChannel ? MessagesSquare : Hash" class="w-4 h-4 text-primary/70" />
           <h1 class="text-[15px] font-display font-bold tracking-tight">
             {{ dmPeer ? dmPeer.peerUsername : channel?.name ?? "..." }}
           </h1>
+          <span
+            v-if="isForumChannel"
+            class="rounded-full border border-primary/15 bg-primary/8 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-primary/80"
+          >
+            Forum
+          </span>
           <span v-if="dmPeer" class="text-[11px] text-muted-foreground">· {{ presenceText(dmPeer.presenceShow) }}</span>
         </div>
         <div
@@ -403,21 +429,29 @@ onBeforeUnmount(() => {
 
       <div v-else-if="!channel && !dmPeer" class="flex flex-col items-center justify-center py-20">
         <div class="w-12 h-12 rounded-xl bg-muted flex items-center justify-center mb-4">
-          <component :is="sidebarMode === 'dms' ? MessageCircle : Hash" class="w-5 h-5 text-primary/50" />
+          <component :is="sidebarMode === 'dms' ? MessageCircle : isForumChannel ? MessagesSquare : Hash" class="w-5 h-5 text-primary/50" />
         </div>
         <p class="text-[14px] text-muted-foreground font-display">
-          {{ sidebarMode === "dms" ? "Select a conversation" : "Select a channel to start chatting" }}
+          {{ sidebarMode === "dms"
+            ? "Select a conversation"
+            : isForumChannel
+              ? "Select a forum to browse topics"
+              : "Select a channel to start chatting" }}
         </p>
       </div>
 
       <div v-else-if="feedMessages.length === 0" class="flex flex-col items-center justify-center py-20">
         <div class="w-12 h-12 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-          <component :is="dmPeer ? MessageCircle : Hash" class="w-5 h-5 text-primary" />
+          <component :is="dmPeer ? MessageCircle : isForumChannel ? MessagesSquare : Hash" class="w-5 h-5 text-primary" />
         </div>
         <p class="text-[16px] font-display font-bold mb-1">
           {{ dmPeer ? `Conversation with @${dmPeer.peerUsername}` : `Welcome to #${channel?.name}` }}
         </p>
-        <p class="text-[13px] text-muted-foreground">This is the start of the conversation.</p>
+        <p class="text-[13px] text-muted-foreground">
+          {{ isForumChannel
+            ? "Start the first topic with a clear title so people can follow the thread."
+            : "This is the start of the conversation." }}
+        </p>
       </div>
 
       <div v-else class="max-w-none">
@@ -474,7 +508,9 @@ onBeforeUnmount(() => {
       v-if="channel || dmPeer"
       :ref="setComposerRef"
       v-model:draft="draft"
+      v-model:forum-title="forumTitle"
       :channel-name="dmPeer ? dmPeer.peerUsername : (channel?.name ?? 'conversation')"
+      :is-forum-channel="isForumChannel"
       :is-sending="isSending"
       :disabled="!channel && !dmPeer"
       :tenor-api-key="tenorApiKey"
@@ -485,7 +521,7 @@ onBeforeUnmount(() => {
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
-      @select-gif="(url) => emit('selectGif', url)"
+      @select-gif="onSelectGif"
     />
     <UserPopover
       :open="!!popoverAuthor"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -152,6 +152,13 @@ const isMentioned = computed(() => {
     (m) => m === props.currentUser || m.split("@")[0] === props.currentUser,
   );
 });
+const isForumTopic = computed(() => props.message.forumPostKind === "topic" && !!props.message.forumTitle);
+const isForumReply = computed(() => props.message.forumPostKind === "reply");
+const forumThreadLabel = computed(() =>
+  props.message.forumPostKind === "topic"
+    ? props.message.forumTitle
+    : props.message.forumThreadTitle,
+);
 
 const isEditing = ref(false);
 const editInitialContent = ref<Record<string, unknown> | undefined>(undefined);
@@ -329,9 +336,11 @@ watch(
     :class="[
       isMentioned
         ? 'bg-warning/5 border-l-2 border-warning/30'
-        : message.threadId
-          ? 'border-l-2 border-primary/20 hover:bg-muted/40'
-          : 'hover:bg-muted/40',
+        : isForumTopic
+          ? 'border border-border/70 bg-card/55 shadow-sm hover:bg-card/75'
+          : message.threadId
+            ? 'border-l-2 border-primary/20 hover:bg-muted/40'
+            : 'hover:bg-muted/40',
       message.deliveryStatus === 'sending' ? 'opacity-50' : '',
       longPress.isPressing.value ? 'no-callout' : '',
     ]"
@@ -371,6 +380,24 @@ watch(
       </span>
     </div>
 
+    <div
+      v-if="isForumTopic && forumThreadLabel"
+      class="mb-2 rounded-xl border border-primary/10 bg-primary/6 px-3 py-2"
+    >
+      <div class="text-[10px] font-semibold uppercase tracking-[0.14em] text-primary/75">
+        Topic
+      </div>
+      <h3 class="mt-1 text-[15px] font-display font-bold tracking-tight text-foreground">
+        {{ forumThreadLabel }}
+      </h3>
+    </div>
+    <div
+      v-else-if="isForumReply && forumThreadLabel"
+      class="mb-1 inline-flex max-w-full items-center gap-1.5 rounded-full border border-border bg-muted/50 px-2.5 py-1 text-[11px] text-muted-foreground"
+    >
+      <CornerDownRight class="w-3 h-3 flex-shrink-0 text-primary/70" />
+      <span class="truncate">In {{ forumThreadLabel }}</span>
+    </div>
     <!-- Reply preview chip. Clicking scrolls to the parent message; if the
          preview is available we also expand it inline so users still see the
          full quoted text even when the parent has scrolled off-screen or

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -17,9 +17,11 @@ interface PendingAttachment {
 }
 
 const draft = defineModel<string>("draft", { required: true });
+const forumTitle = defineModel<string>("forumTitle", { default: "" });
 
 const props = defineProps<{
   channelName: string;
+  isForumChannel: boolean;
   isSending: boolean;
   disabled: boolean;
   tenorApiKey: string;
@@ -106,6 +108,7 @@ const mentionResults = computed(() => {
 });
 
 const emojiResults = computed(() => searchEmoji(emojiQuery.value));
+const showForumTitleInput = computed(() => props.isForumChannel && !props.replyingTo);
 
 const activeResults = computed(() => {
   if (showMentions.value) return mentionResults.value;
@@ -115,6 +118,25 @@ const activeResults = computed(() => {
 
 /** Whether the composer has nothing sendable (no text and no pending attachments). */
 const isEmpty = computed(() => !draft.value.trim() && pendingAttachments.value.length === 0);
+const canSend = computed(() =>
+  !props.isSending &&
+  !props.disabled &&
+  props.slowModeCooldown <= 0 &&
+  !isEmpty.value &&
+  (!showForumTitleInput.value || !!forumTitle.value.trim()),
+);
+const editorPlaceholder = computed(() => {
+  if (props.slowModeCooldown > 0) {
+    return `Slow mode — wait ${props.slowModeCooldown}s`;
+  }
+  if (showForumTitleInput.value) {
+    return "Write the opening post";
+  }
+  if (props.isForumChannel) {
+    return "Reply in this topic";
+  }
+  return `Message #${props.channelName}`;
+});
 
 function onEditorUpdate(doc: Record<string, unknown>) {
   // Keep draft in sync as a plain text representation
@@ -213,6 +235,7 @@ function onSend(doc: Record<string, unknown>) {
   const text = serialized.body.trim();
   const attachments = pendingAttachments.value;
 
+  if (showForumTitleInput.value && !forumTitle.value.trim()) return;
   if (!text && attachments.length === 0) return;
 
   // Detach attachments before emitting so re-entry (e.g. Enter burst) cannot
@@ -320,6 +343,25 @@ watch(
       </button>
     </div>
 
+    <div
+      v-if="showForumTitleInput"
+      class="mb-2 rounded-xl border border-border bg-card/60 px-3 py-2.5 animate-fade-in"
+    >
+      <div class="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        New topic
+      </div>
+      <input
+        v-model="forumTitle"
+        type="text"
+        class="w-full bg-transparent text-[14px] font-medium placeholder:text-muted-foreground/45 focus:outline-none"
+        :disabled="disabled || isSending"
+        placeholder="Add a clear title"
+      />
+      <p class="mt-1 text-[11px] text-muted-foreground">
+        Top-level forum posts need a title.
+      </p>
+    </div>
+
     <!-- Pending attachment previews -->
     <div
       v-if="pendingAttachments.length > 0"
@@ -420,7 +462,7 @@ watch(
     </button>
     <ChatEditor
       :ref="setEditorRef"
-      :placeholder="slowModeCooldown > 0 ? `Slow mode — wait ${slowModeCooldown}s` : `Message #${channelName}`"
+      :placeholder="editorPlaceholder"
       :disabled="disabled || slowModeCooldown > 0"
       @send="onSend"
       @update="onEditorUpdate"
@@ -428,7 +470,7 @@ watch(
     />
     <button
       class="h-10 w-10 flex items-center justify-center bg-primary text-primary-foreground rounded-xl hover:shadow-[0_0_20px_var(--glow-strong)] transition-all duration-300 disabled:opacity-20 flex-shrink-0"
-      :disabled="isSending || disabled || isEmpty || slowModeCooldown > 0"
+      :disabled="!canSend"
       aria-label="Send message"
       @click="editorRef?.getJSON?.() && onSend(editorRef.getJSON()!)"
     >

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { Hash, Plus, Settings, Users, ChevronDown } from "lucide-vue-next";
+import { Hash, MessagesSquare, Plus, Settings, Users, ChevronDown } from "lucide-vue-next";
+import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, WaddleSummary } from "@/lib/waddle-api";
 
 const props = defineProps<{
@@ -21,6 +22,10 @@ function hasActivity(channelId: string): boolean {
     }
   }
   return false;
+}
+
+function channelIcon(channel: ChannelSummary) {
+  return detectForumChannel(channel) ? MessagesSquare : Hash;
 }
 
 const emit = defineEmits<{
@@ -89,7 +94,8 @@ const emit = defineEmits<{
             : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
           @click="emit('selectChannel', channel.id)"
         >
-          <Hash
+          <component
+            :is="channelIcon(channel)"
             class="w-3.5 h-3.5 flex-shrink-0 transition-colors duration-200"
             :class="activeChannelId === channel.id ? 'text-primary' : 'opacity-40 group-hover:opacity-70'"
           />
@@ -100,6 +106,12 @@ const emit = defineEmits<{
               hasActivity(channel.id) && activeChannelId !== channel.id ? 'font-semibold text-sidebar-foreground' : '',
             ]"
           >{{ channel.name }}</span>
+          <span
+            v-if="detectForumChannel(channel)"
+            class="rounded-full border border-primary/12 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-primary/70"
+          >
+            Forum
+          </span>
           <span
             v-if="hasActivity(channel.id) && activeChannelId !== channel.id"
             class="w-2 h-2 bg-primary rounded-full flex-shrink-0 shadow-[0_0_6px_var(--glow-strong)]"

--- a/chat/src/components/modals/CreateChannelDialog.vue
+++ b/chat/src/components/modals/CreateChannelDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { X } from "lucide-vue-next";
+import { Hash, MessagesSquare, X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
 import type { ChannelCreateFormData } from "@/lib/chat-ui";
 
@@ -48,6 +48,46 @@ const emit = defineEmits<{
           placeholder="What is this channel for?"
           @input="$emit('update:form', { ...form, description: ($event.target as HTMLTextAreaElement).value })"
         />
+      </div>
+
+      <div>
+        <label class="block text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground mb-1.5">
+          Channel type
+        </label>
+        <div class="grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            class="rounded-xl border px-3 py-3 text-left transition-all duration-200"
+            :class="form.channel_type === 'text'
+              ? 'border-primary/30 bg-primary/8 shadow-[0_0_12px_var(--glow)]'
+              : 'border-border bg-muted/40 hover:bg-muted'"
+            @click="$emit('update:form', { ...form, channel_type: 'text' })"
+          >
+            <div class="flex items-center gap-2 text-[13px] font-medium">
+              <Hash class="w-4 h-4 text-primary/80" />
+              Text
+            </div>
+            <p class="mt-1 text-[11px] text-muted-foreground">
+              Fast back-and-forth conversation.
+            </p>
+          </button>
+          <button
+            type="button"
+            class="rounded-xl border px-3 py-3 text-left transition-all duration-200"
+            :class="form.channel_type === 'forum'
+              ? 'border-primary/30 bg-primary/8 shadow-[0_0_12px_var(--glow)]'
+              : 'border-border bg-muted/40 hover:bg-muted'"
+            @click="$emit('update:form', { ...form, channel_type: 'forum' })"
+          >
+            <div class="flex items-center gap-2 text-[13px] font-medium">
+              <MessagesSquare class="w-4 h-4 text-primary/80" />
+              Forum
+            </div>
+            <p class="mt-1 text-[11px] text-muted-foreground">
+              Title-first topics with threaded replies.
+            </p>
+          </button>
+        </div>
       </div>
     </div>
 

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -1,5 +1,7 @@
 import { ref, computed, nextTick, watch, type Ref } from "vue";
 import type { WaddleApi } from "@/lib/waddle-api";
+import type { ChannelSummary } from "@/lib/waddle-api";
+import { isForumChannel } from "@/lib/channel-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
   BrowserXmppClient,
@@ -56,7 +58,49 @@ export function fromLiveMessage(
   }
   if (msg.threadId) tm.threadId = msg.threadId;
   if (msg.parentThreadId) tm.parentThreadId = msg.parentThreadId;
+  if (msg.forumPostKind) tm.forumPostKind = msg.forumPostKind;
+  if (msg.forumTitle) tm.forumTitle = msg.forumTitle;
+  if (msg.forumThreadTitle) tm.forumThreadTitle = msg.forumThreadTitle;
   return tm;
+}
+
+function applyForumContext(list: TimelineMessage[]): TimelineMessage[] {
+  const threadTitles = new Map<string, string>();
+
+  for (const message of list) {
+    if (message.forumPostKind === "topic" && message.forumTitle) {
+      threadTitles.set(message.threadId ?? message.id, message.forumTitle);
+    }
+  }
+
+  return list.map((message) => {
+    const threadId = message.threadId ?? (message.forumPostKind === "topic" ? message.id : undefined);
+    const threadTitle = threadId ? threadTitles.get(threadId) : undefined;
+    const next: TimelineMessage = { ...message };
+    let changed = false;
+
+    if (message.forumPostKind === "topic") {
+      if (threadId && message.threadId !== threadId) {
+        next.threadId = threadId;
+        changed = true;
+      }
+      if (message.forumTitle && message.forumThreadTitle !== message.forumTitle) {
+        next.forumThreadTitle = message.forumTitle;
+        changed = true;
+      }
+    } else if (threadId && threadTitle) {
+      if (!message.forumPostKind && message.id !== threadId) {
+        next.forumPostKind = "reply";
+        changed = true;
+      }
+      if (message.forumThreadTitle !== threadTitle) {
+        next.forumThreadTitle = threadTitle;
+        changed = true;
+      }
+    }
+
+    return changed ? next : message;
+  });
 }
 
 export function formatStamp(value: string) {
@@ -74,6 +118,7 @@ export function useMessaging(
   xmppClient: Ref<BrowserXmppClient | null>,
   activeWaddleId: Ref<string | null>,
   activeChannelId: Ref<string | null>,
+  currentChannel: Ref<ChannelSummary | null>,
   normalizeError: (v: unknown) => string,
   actionError: Ref<string>,
   clearActionError: () => void,
@@ -85,6 +130,7 @@ export function useMessaging(
 
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
+  const forumPostTitle = ref("");
   const isLoadingMessages = ref(false);
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
@@ -119,6 +165,7 @@ export function useMessaging(
     if (!session.value || !activeWaddleId.value || !activeChannelId.value) return null;
     return roomBareJidFor(session.value, activeWaddleId.value, activeChannelId.value);
   });
+  const channelIsForum = computed(() => isForumChannel(currentChannel.value));
 
   watch(xmppClient, (client) => {
     if (client) {
@@ -424,13 +471,14 @@ export function useMessaging(
             ? m
             : { ...m, id: msg.id, deliveryStatus: "delivered" as DeliveryStatus },
         );
+        messages.value = applyForumContext(messages.value);
       }
       if (wasPending) pendingEchoClientIds.delete(existing.id);
       return;
     }
     const waddleId = activeWaddleId.value;
     const channelId = activeChannelId.value;
-    messages.value = [...messages.value, msg];
+    messages.value = applyForumContext([...messages.value, msg]);
     // mergeLiveMessage always snaps to bottom, so last-seen should advance
     // in lockstep regardless of the user's prior scroll position — if we're
     // scrolling them to the message, by definition they can see it.
@@ -602,7 +650,7 @@ export function useMessaging(
         }
       }
 
-      messages.value = timeline;
+      messages.value = applyForumContext(timeline);
       if (requestId === messageRequestId) {
         isLoadingMessages.value = false;
       }
@@ -685,18 +733,30 @@ export function useMessaging(
     markup?: MarkupSpan[],
     files?: Array<File | Blob>,
     replyTo?: { id: string; author: string; body?: string },
-    threadOverride?: { threadId: string; parentThreadId?: string },
+    forumTitleOrThreadOverride?: string | { threadId: string; parentThreadId?: string },
   ) {
     const bodyText = body ?? draft.value;
     // markup !== undefined means this came from the rich editor (composer send)
     // undefined means it came from a programmatic send (GIF, etc.)
     const fromComposer = markup !== undefined;
+    const threadOverride = typeof forumTitleOrThreadOverride === "string"
+      ? undefined
+      : forumTitleOrThreadOverride;
+    const forumTitle = typeof forumTitleOrThreadOverride === "string"
+      ? forumTitleOrThreadOverride
+      : undefined;
     const client = xmppClient.value;
     const waddleId = activeWaddleId.value;
     const channelId = activeChannelId.value;
     const hasFiles = !!files && files.length > 0;
+    const isForumPost = channelIsForum.value && !replyTo;
+    const resolvedForumTitle = (forumTitle ?? forumPostTitle.value).trim();
     if (!client || !waddleId || !channelId) return;
     if (!bodyText.trim() && !hasFiles) return;
+    if (isForumPost && !resolvedForumTitle) {
+      actionError.value = "Add a title before posting to this forum.";
+      return;
+    }
 
     if (hasFiles) {
       for (const f of files!) {
@@ -732,17 +792,23 @@ export function useMessaging(
             ...(replyTo.body ? { body: replyTo.body } : {}),
           }
         : undefined;
-      // Thread membership is explicit: only set when the caller passed an
-      // override (i.e. the thread panel composer). Bare `<reply>` from the
-      // channel composer stays inline as a quote — not a thread join.
-      const threadId = threadOverride?.threadId;
+      // Thread membership is explicit via threadOverride, except forum replies,
+      // which derive their thread from the replied-to topic/message.
+      const threadId = threadOverride?.threadId
+        ?? (channelIsForum.value && parent ? (parent.threadId ?? replyTo?.id) : undefined);
       const parentThreadId = threadOverride?.parentThreadId;
+      const threadCreate = isForumPost ? { title: resolvedForumTitle } : undefined;
+      const threadReply = channelIsForum.value && replyTo && threadId
+        ? { threadId }
+        : undefined;
       const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, {
         markup,
         files: attachments,
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(threadId ? { threadId } : {}),
         ...(parentThreadId ? { parentThreadId } : {}),
+        ...(threadCreate ? { threadCreate } : {}),
+        ...(threadReply ? { threadReply } : {}),
       });
       const isStillCurrentChannel =
         xmppClient.value === client &&
@@ -770,6 +836,16 @@ export function useMessaging(
         }
         if (threadId) optimistic.threadId = threadId;
         if (parentThreadId) optimistic.parentThreadId = parentThreadId;
+        if (threadCreate) {
+          optimistic.threadId = msgId;
+          optimistic.forumPostKind = "topic";
+          optimistic.forumTitle = threadCreate.title;
+          optimistic.forumThreadTitle = threadCreate.title;
+        } else if (threadReply) {
+          optimistic.forumPostKind = "reply";
+          const threadTitle = parent?.forumTitle ?? parent?.forumThreadTitle;
+          if (threadTitle) optimistic.forumThreadTitle = threadTitle;
+        }
         if (attachments && attachments.length > 0) {
           optimistic.sharedFiles = attachments.map((a) => ({
             url: a.url,
@@ -782,13 +858,14 @@ export function useMessaging(
           }));
         }
         pendingEchoClientIds.add(msgId);
-        messages.value = [...messages.value, optimistic];
+        messages.value = applyForumContext([...messages.value, optimistic]);
         void scrollToBottom();
       }
 
       // Clear draft on successful send (triggers ChatEditor clear via watcher)
       if (fromComposer && isStillCurrentChannel) {
         draft.value = "";
+        if (threadCreate) forumPostTitle.value = "";
       }
       // Send "active" state after sending a message (stops composing indicator)
       if (isStillCurrentChannel) {
@@ -964,6 +1041,7 @@ export function useMessaging(
     messages,
     firstUnseenId,
     draft,
+    forumPostTitle,
     isLoadingMessages,
     isSending,
     timelineEl,

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -8,6 +8,8 @@ import type {
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { CommunityFormData, ChannelCreateFormData, ChannelEditFormData } from "@/lib/chat-ui";
+import { executeCreateChannelCommand } from "@/lib/xmpp/commands";
+import { jidDomain } from "@/lib/xmpp/jid";
 
 interface LoadWaddlesOptions {
   loadStructure?: boolean;
@@ -168,6 +170,8 @@ export function useWaddles(
       const channelList: ChannelSummary[] = discoveredChannels.map((c) => ({
         id: c.id,
         name: c.name,
+        channel_type: c.channelType,
+        position: c.position,
       }));
 
       channels.value = channelList;
@@ -337,27 +341,56 @@ export function useWaddles(
 
   async function createChannel() {
     const waddleId = activeWaddleId.value;
-    if (!api.value || !waddleId || !createChannelForm.value.name.trim()) return undefined;
+    if (!xmppClient.value || !session.value || !waddleId || !createChannelForm.value.name.trim()) return undefined;
 
     isSubmitting.value = true;
     clearActionError();
 
     try {
       const desc = createChannelForm.value.description.trim();
-      const created = await api.value.createChannel(waddleId, {
+      const serverJid = jidDomain(session.value.jid);
+      
+      const xmppAgent = xmppClient.value.agent;
+      if (!xmppAgent) {
+        actionError.value = "XMPP connection not available";
+        return undefined;
+      }
+      
+      const result = await executeCreateChannelCommand(
+        xmppAgent,
+        serverJid,
+        {
+          waddleId,
+          name: createChannelForm.value.name.trim(),
+          description: desc || undefined,
+          channelType: createChannelForm.value.channel_type as "text" | "forum",
+          position: createChannelForm.value.position,
+        },
+      );
+
+      if (!result.success) {
+        actionError.value = result.error ?? "Failed to create channel";
+        return undefined;
+      }
+
+      // Capture created channel data before resetting the form
+      const createdChannel = {
+        id: result.channelId!,
         name: createChannelForm.value.name.trim(),
-        ...(desc ? { description: desc } : {}),
         channel_type: createChannelForm.value.channel_type,
-        position: createChannelForm.value.position,
-      });
+      };
+
       createChannelForm.value = {
         name: "",
         description: "",
         channel_type: "text",
         position: channels.value.length + 1,
       };
-      await loadStructure(waddleId, created.id);
-      return created;
+
+      // Refresh channel discovery to show the new channel
+      await loadStructure(waddleId, result.channelId ?? null);
+      
+      return createdChannel;
     } catch (e) {
       actionError.value = normalizeError(e);
       return undefined;

--- a/chat/src/lib/channel-types.ts
+++ b/chat/src/lib/channel-types.ts
@@ -1,0 +1,11 @@
+export type WaddleChannelType = "text" | "forum";
+
+export function normalizeChannelType(value?: string | null): WaddleChannelType {
+  return value === "forum" ? "forum" : "text";
+}
+
+export function isForumChannel(
+  channel?: { channel_type?: string | null } | null,
+): boolean {
+  return normalizeChannelType(channel?.channel_type) === "forum";
+}

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -47,6 +47,10 @@ export interface TimelineMessage {
   /** RFC 6121 / XEP-0201: Thread identifier + optional parent thread. */
   threadId?: string;
   parentThreadId?: string;
+  /** XEP-0508: Forum topic/reply metadata when present. */
+  forumPostKind?: "topic" | "reply";
+  forumTitle?: string;
+  forumThreadTitle?: string;
 }
 
 export interface CommunityFormData {

--- a/chat/src/lib/waddle-api.ts
+++ b/chat/src/lib/waddle-api.ts
@@ -189,21 +189,6 @@ export class WaddleApi {
     );
   }
 
-  async createChannel(
-    waddleId: string,
-    input: {
-      name: string;
-      description?: string;
-      channel_type?: string;
-      position?: number;
-    },
-  ) {
-    return this.json<ChannelSummary>(`/v1/waddles/${waddleId}/channels`, {
-      method: "POST",
-      body: JSON.stringify(input),
-    });
-  }
-
   async updateChannel(
     waddleId: string,
     channelId: string,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -10,7 +10,7 @@ import type {
   OccupantPresence, PresenceUpdateEvent, ReactionEvent, RoomActivityEvent,
   RoomHats, RoomPresence, SessionLifecycleEvent, XmppStatusSnapshot,
 } from "./types";
-import { barePeerJid, roomBareJidFor } from "./jid";
+import { barePeerJid, jidDomain, roomBareJidFor } from "./jid";
 import { registerWaddleExtensions } from "./extensions";
 import { dispatchGroupchat, ext } from "./message-parsing";
 import { dispatchChat } from "./dm-parsing";
@@ -497,7 +497,7 @@ export class BrowserXmppClient {
     if (this.uploadServiceJid) return this.uploadServiceJid;
     await this.connect();
     if (!this.xmpp) throw new Error("XMPP not connected");
-    const domain = this.session.jid.split("@")[1] ?? "localhost";
+    const domain = jidDomain(this.session.jid);
     const jid = await discoverUploadService(this.xmpp, domain);
     if (!jid) throw new Error(`File upload service not available (domain: ${domain})`);
     this.uploadServiceJid = jid;
@@ -672,7 +672,7 @@ export class BrowserXmppClient {
   async getServerVersion(): Promise<{ name?: string; version?: string; os?: string } | null> {
     await this.connect();
     if (!this.xmpp) return null;
-    const domain = this.session.jid.split("@")[1];
+    const domain = jidDomain(this.session.jid);
     if (!domain) return null;
     try {
       return await this.xmpp.getSoftwareVersion(domain);
@@ -688,6 +688,14 @@ export class BrowserXmppClient {
     return this.xmpp
       ? discovery.discoverChannels(this.xmpp, this.session.jid, waddleId)
       : [];
+  }
+
+  /**
+   * Get the underlying XMPP agent for advanced operations like ad-hoc commands.
+   * Returns null if not connected.
+   */
+  get agent(): Agent | null {
+    return this.xmpp;
   }
 
   // -- Private --
@@ -806,7 +814,7 @@ export class BrowserXmppClient {
   private async pingServer() {
     const xmpp = this.xmpp;
     if (!xmpp || !this.connected || this.destroying) return;
-    const domain = this.session.jid.split("@")[1];
+    const domain = jidDomain(this.session.jid);
     if (!domain) return;
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
     try {

--- a/chat/src/lib/xmpp/commands.ts
+++ b/chat/src/lib/xmpp/commands.ts
@@ -1,0 +1,166 @@
+/** XEP-0050: Ad-Hoc Commands execution for Waddle operations. */
+import type { Agent } from "stanza";
+import type { IQ, AdHocCommand, DataForm } from "stanza/protocol";
+
+export interface CreateChannelCommandInput {
+  waddleId: string;
+  name: string;
+  description?: string;
+  channelType: "text" | "forum";
+  position: number;
+}
+
+export interface CreateChannelCommandResult {
+  success: boolean;
+  channelId?: string;
+  channelJid?: string;
+  error?: string;
+}
+
+interface CommandResponse {
+  sid?: string;
+  status?: string;
+  form?: DataForm;
+  notes?: Array<{ type?: string; value?: string }>;
+}
+
+function parseCommandResponse(iq: IQ): CommandResponse {
+  const command = iq.command;
+  if (!command) return {};
+
+  return {
+    sid: command.sid,
+    status: command.status,
+    form: command.form,
+    notes: command.notes,
+  };
+}
+
+/**
+ * Execute the `waddle:create-channel` ad-hoc command.
+ * 
+ * Flow:
+ * 1. Send execute action to initiate the command
+ * 2. Parse the returned data form and session ID
+ * 3. Submit the filled form with user inputs
+ * 4. Parse the result for success/failure
+ * 
+ * @param xmpp - XMPP client agent
+ * @param serverJid - Server JID to send the command to (e.g., "localhost")
+ * @param input - Channel creation inputs
+ * @returns Result with success status, channel ID/JID, or error message
+ */
+export async function executeCreateChannelCommand(
+  xmpp: Agent,
+  serverJid: string,
+  input: CreateChannelCommandInput,
+): Promise<CreateChannelCommandResult> {
+  try {
+    // Step 1: Execute the command to get the data form
+    const executeIq = await xmpp.sendIQ({
+      type: "set",
+      to: serverJid,
+      command: {
+        type: "command",
+        node: "waddle:create-channel",
+        action: "execute",
+      } as AdHocCommand,
+    } as IQ);
+
+    const executeResponse = parseCommandResponse(executeIq);
+
+    if (!executeResponse.sid) {
+      return {
+        success: false,
+        error: "Server did not return a session ID",
+      };
+    }
+
+    // Step 2: Fill and submit the data form
+    const submitIq = await xmpp.sendIQ({
+      type: "set",
+      to: serverJid,
+      command: {
+        type: "command",
+        node: "waddle:create-channel",
+        action: "complete",
+        sid: executeResponse.sid,
+        form: {
+          type: "submit",
+          fields: [
+            { name: "waddle_id", value: input.waddleId, type: "hidden" },
+            { name: "name", value: input.name, type: "text-single" },
+            ...(input.description
+              ? [{ name: "description", value: input.description, type: "text-multi" }]
+              : []),
+            { name: "channel_type", value: input.channelType, type: "list-single" },
+            { name: "position", value: String(input.position), type: "text-single" },
+          ],
+        },
+      } as AdHocCommand,
+    } as IQ);
+
+    const submitResponse = parseCommandResponse(submitIq);
+
+    // Step 3: Parse the result
+    if (submitResponse.status === "completed") {
+      // Look for error notes first
+      const errorNote = submitResponse.notes?.find((n) => n.type === "error");
+      if (errorNote) {
+        return {
+          success: false,
+          error: errorNote.value ?? "Command failed",
+        };
+      }
+
+      // Parse result form for channel_id and channel_jid
+      const resultFields = submitResponse.form?.fields ?? [];
+      const channelIdField = resultFields.find((f) => f.name === "channel_id");
+      const channelJidField = resultFields.find((f) => f.name === "channel_jid");
+
+      const channelId = Array.isArray(channelIdField?.value)
+        ? channelIdField.value[0]
+        : channelIdField?.value;
+      const channelJid = Array.isArray(channelJidField?.value)
+        ? channelJidField.value[0]
+        : channelJidField?.value;
+
+      if (!channelId) {
+        return {
+          success: false,
+          error: "Server did not return channel_id in result form",
+        };
+      }
+
+      return {
+        success: true,
+        channelId: String(channelId),
+        channelJid: channelJid ? String(channelJid) : undefined,
+      };
+    }
+
+    // Command not completed
+    const firstNote = submitResponse.notes?.[0];
+    return {
+      success: false,
+      error: firstNote?.value ?? `Command ended with status: ${submitResponse.status ?? "unknown"}`,
+    };
+  } catch (error: unknown) {
+    // Handle XMPP errors
+    const errorObj = error as { error?: { condition?: string; text?: string } };
+    const condition = errorObj?.error?.condition;
+    const text = errorObj?.error?.text;
+
+    let errorMessage = "Failed to execute create-channel command";
+    if (text) {
+      errorMessage = text;
+    } else if (condition) {
+      errorMessage = `Command error: ${condition}`;
+    }
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+}

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -1,12 +1,18 @@
 /** XEP-0030: Service discovery for waddles and channels. */
 import type { Agent } from "stanza";
 import type { DataFormField, DiscoInfoResult } from "stanza/protocol";
+import { normalizeChannelType } from "@/lib/channel-types";
 import type { DiscoveredChannel, DiscoveredWaddle } from "./types";
-import { jidDomain } from "./jid";
+import { jidDomain, parseManagedRoomBareJid } from "./jid";
+
+const NS_FORUMS_0 = "urn:xmpp:forums:0";
+const FIELD_FORUM_MODE = "muc#roomconfig_forum";
 
 function fieldStringValue(field: DataFormField | undefined): string | null {
-  if (!field || field.value === undefined || Array.isArray(field.value)) return null;
-  return String(field.value).trim() || null;
+  if (!field || field.value === undefined) return null;
+  const rawValue = Array.isArray(field.value) ? field.value[0] : field.value;
+  if (rawValue === undefined || rawValue === null) return null;
+  return String(rawValue).trim() || null;
 }
 
 function metadataField(infoResult: DiscoInfoResult, name: string): string | null {
@@ -33,6 +39,20 @@ function parseWaddleName(infoResult: DiscoInfoResult): string | null {
     infoResult.identities.find((identity) => identity.name)?.name?.trim() ??
     null
   );
+}
+
+function parseBooleanValue(value: string | null): boolean | null {
+  if (!value) return null;
+  const normalized = value.toLowerCase();
+  if (["1", "true", "yes"].includes(normalized)) return true;
+  if (["0", "false", "no"].includes(normalized)) return false;
+  return null;
+}
+
+function parseChannelType(infoResult: DiscoInfoResult) {
+  const hasForumFeature = infoResult.features?.includes(NS_FORUMS_0);
+  const forumField = parseBooleanValue(metadataField(infoResult, FIELD_FORUM_MODE));
+  return normalizeChannelType(hasForumFeature || forumField ? "forum" : "text");
 }
 
 function spacesServiceDomain(jid: string): string {
@@ -75,12 +95,37 @@ export async function discoverChannels(
   const response = await xmpp.getDiscoItems(spacesDomain, waddleId);
 
   const prefix = `${waddleId}_`;
-  return (response.items ?? [])
-    .map((item) => {
+  const discovered = (response.items ?? [])
+    .map((item, position) => {
       const itemJid = item.jid ?? "";
+      const parsedRoom = parseManagedRoomBareJid(itemJid);
       const localPart = itemJid.split("@")[0] ?? "";
-      const channelId = localPart.startsWith(prefix) ? localPart.slice(prefix.length) : localPart;
-      return { id: channelId, name: item.name ?? channelId };
+      const channelId = parsedRoom?.waddleId === waddleId
+        ? parsedRoom.channelId
+        : localPart.startsWith(prefix)
+          ? localPart.slice(prefix.length)
+          : localPart;
+      return { id: channelId, name: item.name ?? channelId, jid: item.jid, position };
     })
-    .filter((c) => c.id);
+    .filter((channel) => channel.id);
+
+  return Promise.all(
+    discovered.map(async (channel) => {
+      if (!channel.jid) {
+        return { id: channel.id, name: channel.name, channelType: "text", position: channel.position } satisfies DiscoveredChannel;
+      }
+
+      try {
+        const info = await xmpp.getDiscoInfo(channel.jid);
+        return {
+          id: channel.id,
+          name: channel.name,
+          channelType: parseChannelType(info),
+          position: channel.position,
+        } satisfies DiscoveredChannel;
+      } catch {
+        return { id: channel.id, name: channel.name, channelType: "text", position: channel.position } satisfies DiscoveredChannel;
+      }
+    }),
+  );
 }

--- a/chat/src/lib/xmpp/extensions/forums.ts
+++ b/chat/src/lib/xmpp/extensions/forums.ts
@@ -1,0 +1,34 @@
+/** XEP-0508: MUC Forums. */
+import type { DefinitionOptions } from "stanza/jxt";
+import { attribute } from "stanza/jxt";
+
+export const NS_FORUMS_0 = "urn:xmpp:forums:0";
+
+export interface WaddleThreadCreate {
+  title: string;
+}
+
+export interface WaddleThreadReply {
+  threadId: string;
+}
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "message.threadCreate", multiple: false }],
+    element: "thread-create",
+    fields: {
+      title: attribute("title"),
+    },
+    namespace: NS_FORUMS_0,
+  },
+  {
+    aliases: [{ path: "message.threadReply", multiple: false }],
+    element: "thread-reply",
+    fields: {
+      threadId: attribute("thread-id"),
+    },
+    namespace: NS_FORUMS_0,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -11,6 +11,7 @@ import mentions from "./mentions";
 import push from "./push";
 import markup from "./markup";
 import replies from "./replies";
+import forums from "./forums";
 
 const allDefinitions = [
   ...hats,
@@ -24,6 +25,7 @@ const allDefinitions = [
   ...push,
   ...markup,
   ...replies,
+  ...forums,
 ];
 
 export function registerWaddleExtensions(client: Agent): void {

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -1,5 +1,12 @@
 export { BrowserXmppClient } from "./client";
-export { barePeerJid, roomBareJidFor } from "./jid";
+export {
+  barePeerJid,
+  jidDomain,
+  parseManagedRoomBareJid,
+  parseManagedRoomNode,
+  roomBareJidFor,
+  roomBareJidForAccountJid,
+} from "./jid";
 export type { OutboundFileAttachment } from "./messaging";
 export type {
   ChatStateEvent,

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -2,11 +2,29 @@
 import type { WaddleSession } from "../server-auth";
 
 export function jidDomain(jid: string): string {
-  return jid.split("@")[1] ?? "localhost";
+  const bareJid = barePeerJid(jid);
+  return bareJid.split("@")[1] ?? "localhost";
 }
 
 export function barePeerJid(fullJid: string): string {
   return fullJid.split("/")[0] ?? "";
+}
+
+export function parseManagedRoomNode(node: string): { waddleId: string; channelId: string } | null {
+  const separatorIndex = node.indexOf("_");
+  if (separatorIndex <= 0 || separatorIndex === node.length - 1) return null;
+  return {
+    waddleId: node.slice(0, separatorIndex),
+    channelId: node.slice(separatorIndex + 1),
+  };
+}
+
+export function parseManagedRoomBareJid(
+  roomJid: string,
+): { waddleId: string; channelId: string } | null {
+  const node = barePeerJid(roomJid).split("@")[0] ?? "";
+  if (!node) return null;
+  return parseManagedRoomNode(node);
 }
 
 export function roomBareJidFor(
@@ -14,5 +32,13 @@ export function roomBareJidFor(
   waddleId: string,
   channelId: string,
 ): string {
-  return `${waddleId}_${channelId}@muc.${jidDomain(session.jid)}`;
+  return roomBareJidForAccountJid(session.jid, waddleId, channelId);
+}
+
+export function roomBareJidForAccountJid(
+  jid: string,
+  waddleId: string,
+  channelId: string,
+): string {
+  return `${waddleId}_${channelId}@muc.${jidDomain(jid)}`;
 }

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -18,6 +18,9 @@ type MessageExtensionsTarget = Pick<
   | "replyTo"
   | "threadId"
   | "parentThreadId"
+  | "forumPostKind"
+  | "forumTitle"
+  | "forumThreadTitle"
 >;
 
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
@@ -62,6 +65,18 @@ function extractReplyAndThread(msg: ReceivedMessage, base: MessageExtensionsTarg
   if (threadId) base.threadId = threadId;
   const parentThread = ext(msg).parentThread as string | undefined;
   if (parentThread) base.parentThreadId = parentThread;
+  const threadCreate = ext(msg).threadCreate as { title?: string } | undefined;
+  if (threadCreate?.title?.trim()) {
+    base.forumPostKind = "topic";
+    base.forumTitle = threadCreate.title.trim();
+    base.forumThreadTitle = threadCreate.title.trim();
+    if (!base.threadId && msg.id) base.threadId = msg.id;
+  }
+  const threadReply = ext(msg).threadReply as { threadId?: string } | undefined;
+  if (threadReply?.threadId) {
+    base.forumPostKind = "reply";
+    if (!base.threadId) base.threadId = threadReply.threadId;
+  }
 }
 
 interface FallbackPayload {

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -2,6 +2,7 @@
 import type { Agent } from "stanza";
 import type { MarkupSpan } from "@/lib/chat-ui";
 import type { WaddleFallback } from "./extensions/fallback";
+import type { WaddleThreadCreate, WaddleThreadReply } from "./extensions/forums";
 import { shiftMarkupSpans, type WaddleMarkupSpan } from "./extensions/markup";
 import type { ChatStateType } from "./types";
 
@@ -132,6 +133,8 @@ export interface SendGroupMessageOptions {
   threadId?: string;
   parentThreadId?: string;
   id?: string;
+  threadCreate?: WaddleThreadCreate;
+  threadReply?: WaddleThreadReply;
 }
 
 /**
@@ -152,7 +155,7 @@ export function sendGroupMessage(
   body: string,
   opts: SendGroupMessageOptions = {},
 ): string | null {
-  const { markup, files, replyTo, threadId, parentThreadId, id } = opts;
+  const { markup, files, replyTo, threadId, parentThreadId, id, threadCreate, threadReply } = opts;
   const text = body.trim();
   const hasFiles = !!files && files.length > 0;
   if (!text && !hasFiles) return null;
@@ -208,6 +211,12 @@ export function sendGroupMessage(
   if (threadId) {
     msgData.thread = threadId;
     if (parentThreadId) msgData.parentThread = parentThreadId;
+  }
+  if (threadCreate) {
+    msgData.threadCreate = threadCreate;
+  }
+  if (threadReply) {
+    msgData.threadReply = threadReply;
   }
   if (hasFiles) {
     msgData.fileSharing = files!.map(fileSharingElement);

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -1,3 +1,5 @@
+import type { WaddleChannelType } from "@/lib/channel-types";
+
 /** Shared types for the XMPP client layer. */
 
 export interface XmppStatusSnapshot {
@@ -48,6 +50,10 @@ export interface LiveRoomMessage {
   /** RFC 6121 / XEP-0201 */
   threadId?: string;
   parentThreadId?: string;
+  /** XEP-0508 */
+  forumPostKind?: "topic" | "reply";
+  forumTitle?: string;
+  forumThreadTitle?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }
@@ -73,6 +79,10 @@ export interface LiveDmMessage {
   /** RFC 6121 / XEP-0201 */
   threadId?: string;
   parentThreadId?: string;
+  /** XEP-0508 */
+  forumPostKind?: "topic" | "reply";
+  forumTitle?: string;
+  forumThreadTitle?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }
@@ -160,6 +170,8 @@ export interface DiscoveredWaddle {
 export interface DiscoveredChannel {
   id: string;
   name: string;
+  channelType: WaddleChannelType;
+  position: number;
 }
 
 /** Cross-room activity event with optional mention data for notifications. */

--- a/chat/tests/discovery-forums.test.ts
+++ b/chat/tests/discovery-forums.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Agent } from "stanza";
+import { discoverChannels } from "../src/lib/xmpp/discovery";
+
+function makeAgent() {
+  const getDiscoItems = mock(async () => ({
+    items: [
+      { jid: "w1_general@muc.chat.example.com", name: "General" },
+      { jid: "w1_roadmap@muc.chat.example.com", name: "Roadmap" },
+    ],
+  }));
+  const getDiscoInfo = mock(async (jid: string) => {
+    if (jid === "w1_roadmap@muc.chat.example.com") {
+      return {
+        features: ["urn:xmpp:forums:0"],
+        identities: [{ name: "Roadmap" }],
+        extensions: [],
+      };
+    }
+    return {
+      features: [],
+      identities: [{ name: "General" }],
+      extensions: [],
+    };
+  });
+
+  return {
+    getDiscoItems,
+    getDiscoInfo,
+    agent: {
+      getDiscoItems,
+      getDiscoInfo,
+    } as unknown as Agent,
+  };
+}
+
+describe("forum channel discovery", () => {
+  test("detects forum rooms from disco features and preserves order", async () => {
+    const xmpp = makeAgent();
+    const channels = await discoverChannels(xmpp.agent, "alice@example.com/desktop", "w1");
+
+    expect(channels).toEqual([
+      { id: "general", name: "General", channelType: "text", position: 0 },
+      { id: "roadmap", name: "Roadmap", channelType: "forum", position: 1 },
+    ]);
+    expect(xmpp.getDiscoInfo.mock.calls).toEqual([
+      ["w1_general@muc.chat.example.com"],
+      ["w1_roadmap@muc.chat.example.com"],
+    ]);
+  });
+
+  test("treats muc#roomconfig_forum as forum capability when feature discovery is absent", async () => {
+    const getDiscoItems = mock(async () => ({
+      items: [{ jid: "w1_ideas@muc.chat.example.com", name: "Ideas" }],
+    }));
+    const getDiscoInfo = mock(async () => ({
+      features: [],
+      identities: [{ name: "Ideas" }],
+      extensions: [
+        {
+          fields: [{ name: "muc#roomconfig_forum", value: "true" }],
+        },
+      ],
+    }));
+    const xmpp = {
+      getDiscoItems,
+      getDiscoInfo,
+    } as unknown as Agent;
+
+    const channels = await discoverChannels(xmpp, "alice@example.com/desktop", "w1");
+
+    expect(channels).toEqual([
+      { id: "ideas", name: "Ideas", channelType: "forum", position: 0 },
+    ]);
+    expect(getDiscoInfo.mock.calls).toEqual([
+      ["w1_ideas@muc.chat.example.com"],
+    ]);
+  });
+});

--- a/chat/tests/forum-composition.test.ts
+++ b/chat/tests/forum-composition.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import type { ChannelSummary } from "../src/lib/waddle-api";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { useMessaging } from "../src/composables/useMessaging";
+
+function session(partial: Partial<WaddleSession> = {}): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/xmpp",
+    ...partial,
+  } as WaddleSession;
+}
+
+function forumChannel(partial: Partial<ChannelSummary> = {}): ChannelSummary {
+  return {
+    id: "c1",
+    name: "roadmap",
+    channel_type: "forum",
+    ...partial,
+  };
+}
+
+describe("forum composition", () => {
+  test("top-level forum posts require a title and send thread-create metadata", async () => {
+    const sendGroupMessage = mock(async () => "topic-1");
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref(forumChannel()),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.forumPostTitle.value = "Shipping roadmap";
+
+    await messaging.sendMessage("Let's map the next release.", []);
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "Let's map the next release.",
+      expect.objectContaining({
+        threadCreate: { title: "Shipping roadmap" },
+      }),
+    );
+    expect(messaging.messages.value.at(-1)).toMatchObject({
+      id: "topic-1",
+      threadId: "topic-1",
+      forumPostKind: "topic",
+      forumTitle: "Shipping roadmap",
+      forumThreadTitle: "Shipping roadmap",
+    });
+    expect(messaging.forumPostTitle.value).toBe("");
+  });
+
+  test("blocks top-level forum posts without a title", async () => {
+    const sendGroupMessage = mock(async () => "topic-1");
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref(forumChannel()),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.sendMessage("Untitled topic", []);
+
+    expect(sendGroupMessage).not.toHaveBeenCalled();
+    expect(actionError.value).toBe("Add a title before posting to this forum.");
+  });
+
+  test("forum replies send thread-reply metadata rooted at the topic", async () => {
+    const sendGroupMessage = mock(async () => "reply-2");
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref(forumChannel()),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "topic-1",
+        author: "Bob",
+        authorJid: "w1_c1@muc.example.com/Bob",
+        body: "Let's map the next release.",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+        threadId: "topic-1",
+        forumPostKind: "topic",
+        forumTitle: "Shipping roadmap",
+        forumThreadTitle: "Shipping roadmap",
+      },
+      {
+        id: "reply-1",
+        author: "Carol",
+        authorJid: "w1_c1@muc.example.com/Carol",
+        body: "Start with onboarding.",
+        createdAt: "2024-01-01T00:01:00Z",
+        isSelf: false,
+        threadId: "topic-1",
+        forumPostKind: "reply",
+        forumThreadTitle: "Shipping roadmap",
+      },
+    ];
+
+    await messaging.sendMessage("Agreed.", [], undefined, {
+      id: "reply-1",
+      author: "Carol",
+      body: "Start with onboarding.",
+    });
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "Agreed.",
+      expect.objectContaining({
+        replyTo: {
+          id: "reply-1",
+          author: "w1_c1@muc.example.com/Carol",
+          body: "Start with onboarding.",
+        },
+        threadId: "topic-1",
+        threadReply: { threadId: "topic-1" },
+      }),
+    );
+    expect(messaging.messages.value.at(-1)).toMatchObject({
+      id: "reply-2",
+      forumPostKind: "reply",
+      threadId: "topic-1",
+      forumThreadTitle: "Shipping roadmap",
+    });
+  });
+});

--- a/chat/tests/groupchat-messaging.test.ts
+++ b/chat/tests/groupchat-messaging.test.ts
@@ -184,4 +184,38 @@ describe("groupchat messaging", () => {
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(0);
   });
 
+  test("sends XEP-0508 thread-create metadata for forum topics", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "roadmap@muc.waddle.social", "Kickoff post", {
+      threadCreate: { title: "Roadmap kickoff" },
+    });
+
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "groupchat",
+        body: "Kickoff post",
+        threadCreate: { title: "Roadmap kickoff" },
+      }),
+    );
+  });
+
+  test("sends XEP-0508 thread-reply metadata for forum replies", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "roadmap@muc.waddle.social", "Count me in", {
+      threadId: "topic-1",
+      threadReply: { threadId: "topic-1" },
+    });
+
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "groupchat",
+        body: "Count me in",
+        thread: "topic-1",
+        threadReply: { threadId: "topic-1" },
+      }),
+    );
+  });
+
 });

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -99,6 +99,40 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages[0].parentThreadId).toBe("thread-root");
   });
 
+  test("extracts forum topic metadata from thread-create", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "topic-1",
+        body: "Welcome aboard",
+        threadCreate: { title: "Getting started" },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].forumPostKind).toBe("topic");
+    expect(h.messages[0].forumTitle).toBe("Getting started");
+    expect(h.messages[0].forumThreadTitle).toBe("Getting started");
+    expect(h.messages[0].threadId).toBe("topic-1");
+  });
+
+  test("extracts forum reply metadata from thread-reply", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "reply-1",
+        body: "Sounds good",
+        threadReply: { threadId: "topic-1" },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].forumPostKind).toBe("reply");
+    expect(h.messages[0].threadId).toBe("topic-1");
+  });
+
   test("leaves replyTo undefined when no reply element is present", () => {
     const h = makeHandlers();
     dispatchGroupchat(makeMsg({ id: "msg-4", body: "plain" }), h);

--- a/chat/tests/jid.test.ts
+++ b/chat/tests/jid.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { jidDomain, parseManagedRoomBareJid, roomBareJidFor } from "../src/lib/xmpp/jid";
+
+describe("jid helpers", () => {
+  test("roomBareJidFor uses the bare account domain", () => {
+    expect(roomBareJidFor(
+      {
+        username: "alice",
+        jid: "alice@example.com/desktop",
+        session_id: "tok",
+        xmpp_websocket_url: "wss://example.com/xmpp",
+      },
+      "w1",
+      "roadmap",
+    )).toBe("w1_roadmap@muc.example.com");
+    expect(jidDomain("alice@example.com/desktop")).toBe("example.com");
+  });
+
+  test("parseManagedRoomBareJid extracts the canonical managed room identifiers", () => {
+    expect(parseManagedRoomBareJid("w1_road_map@muc.example.com/Alice")).toEqual({
+      waddleId: "w1",
+      channelId: "road_map",
+    });
+    expect(parseManagedRoomBareJid("roadmap@muc.example.com")).toBeNull();
+  });
+});

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -230,6 +230,7 @@ describe("MAM history application", () => {
       xmppClient,
       ref("w1"),
       ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
       String,
       actionError,
       () => {

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -25,6 +25,7 @@ describe("reply addressing", () => {
       ref({ sendGroupMessage, sendChatState } as never),
       ref("w1"),
       ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
       String,
       actionError,
       () => {
@@ -128,6 +129,7 @@ describe("reply addressing", () => {
       ref({ sendGroupMessage, sendChatState } as never),
       ref("w1"),
       ref("c2"),
+      ref({ id: "c2", name: "general", channel_type: "text" }),
       String,
       actionError,
       () => {

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -23,6 +23,7 @@ function makeRoomMessaging(xmppClient: ReturnType<typeof makeRoomClient>) {
     xmppClient,
     ref("w1"),
     ref("c1"),
+    ref({ id: "c1", name: "general", channel_type: "text" }),
     String,
     actionError,
     () => {

--- a/chat/tests/xmpp-commands.test.ts
+++ b/chat/tests/xmpp-commands.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from "vitest";
+import { executeCreateChannelCommand } from "@/lib/xmpp/commands";
+
+describe("XMPP Ad-Hoc Commands", () => {
+  describe("executeCreateChannelCommand", () => {
+    it("should execute create-channel command and return success", async () => {
+      const mockSendIQ = vi.fn();
+      
+      // Mock the execute response (returns data form)
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-123",
+          status: "executing",
+          form: {
+            type: "form",
+            fields: [
+              { name: "waddle_id", type: "hidden" },
+              { name: "name", type: "text-single" },
+              { name: "description", type: "text-multi" },
+              { name: "channel_type", type: "list-single" },
+              { name: "position", type: "text-single" },
+            ],
+          },
+        },
+      });
+
+      // Mock the submit response (returns result)
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-123",
+          status: "completed",
+          form: {
+            type: "result",
+            fields: [
+              { name: "channel_id", value: "new-channel-id" },
+              { name: "channel_jid", value: "test_waddle_new-channel-id@muc.localhost" },
+            ],
+          },
+          notes: [{ type: "info", value: "Channel created" }],
+        },
+      });
+
+      const mockXmpp = { sendIQ: mockSendIQ };
+
+      const result = await executeCreateChannelCommand(
+        mockXmpp as any,
+        "localhost",
+        {
+          waddleId: "test-waddle",
+          name: "Test Channel",
+          description: "A test channel",
+          channelType: "text",
+          position: 0,
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.channelId).toBe("new-channel-id");
+      expect(result.channelJid).toBe("test_waddle_new-channel-id@muc.localhost");
+      expect(result.error).toBeUndefined();
+
+      // Verify the command execution flow
+      expect(mockSendIQ).toHaveBeenCalledTimes(2);
+      
+      // First call: execute
+      expect(mockSendIQ).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        type: "set",
+        to: "localhost",
+        command: expect.objectContaining({
+          node: "waddle:create-channel",
+          action: "execute",
+        }),
+      }));
+
+      // Second call: submit
+      expect(mockSendIQ).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        type: "set",
+        to: "localhost",
+        command: expect.objectContaining({
+          node: "waddle:create-channel",
+          action: "complete",
+          sid: "test-session-123",
+          form: expect.objectContaining({
+            type: "submit",
+            fields: expect.arrayContaining([
+              expect.objectContaining({ name: "waddle_id", value: "test-waddle" }),
+              expect.objectContaining({ name: "name", value: "Test Channel" }),
+            ]),
+          }),
+        }),
+      }));
+    });
+
+    it("should return error when command fails with error note", async () => {
+      const mockSendIQ = vi.fn();
+      
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-456",
+          status: "executing",
+          form: { type: "form", fields: [] },
+        },
+      });
+
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-456",
+          status: "completed",
+          notes: [{ type: "error", value: "Permission denied" }],
+        },
+      });
+
+      const mockXmpp = { sendIQ: mockSendIQ };
+
+      const result = await executeCreateChannelCommand(
+        mockXmpp as any,
+        "localhost",
+        {
+          waddleId: "test-waddle",
+          name: "Test Channel",
+          channelType: "text",
+          position: 0,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Permission denied");
+      expect(result.channelId).toBeUndefined();
+    });
+
+    it("should return error when execute doesn't return session id", async () => {
+      const mockSendIQ = vi.fn();
+      
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          status: "completed",
+        },
+      });
+
+      const mockXmpp = { sendIQ: mockSendIQ };
+
+      const result = await executeCreateChannelCommand(
+        mockXmpp as any,
+        "localhost",
+        {
+          waddleId: "test-waddle",
+          name: "Test Channel",
+          channelType: "forum",
+          position: 1,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Server did not return a session ID");
+    });
+
+    it("should handle XMPP errors gracefully", async () => {
+      const mockSendIQ = vi.fn();
+      
+      mockSendIQ.mockRejectedValueOnce({
+        error: {
+          condition: "forbidden",
+          text: "You don't have permission to create channels",
+        },
+      });
+
+      const mockXmpp = { sendIQ: mockSendIQ };
+
+      const result = await executeCreateChannelCommand(
+        mockXmpp as any,
+        "localhost",
+        {
+          waddleId: "test-waddle",
+          name: "Test Channel",
+          channelType: "text",
+          position: 0,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("You don't have permission to create channels");
+    });
+
+    it("should handle missing channel_id in result", async () => {
+      const mockSendIQ = vi.fn();
+      
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-789",
+          status: "executing",
+          form: { type: "form", fields: [] },
+        },
+      });
+
+      mockSendIQ.mockResolvedValueOnce({
+        command: {
+          sid: "test-session-789",
+          status: "completed",
+          form: {
+            type: "result",
+            fields: [],
+          },
+        },
+      });
+
+      const mockXmpp = { sendIQ: mockSendIQ };
+
+      const result = await executeCreateChannelCommand(
+        mockXmpp as any,
+        "localhost",
+        {
+          waddleId: "test-waddle",
+          name: "Test Channel",
+          channelType: "text",
+          position: 0,
+        },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Server did not return channel_id in result form");
+    });
+  });
+});

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -630,9 +630,15 @@ async fn start_xmpp_server(
         "Starting XMPP server"
     );
 
-    let server = waddle_xmpp::start(config, Arc::clone(&app_state), c2s_listener, s2s_listener, stop_token)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to create XMPP server: {}", e))?;
+    let server = waddle_xmpp::start(
+        config,
+        Arc::clone(&app_state),
+        c2s_listener,
+        s2s_listener,
+        stop_token,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to create XMPP server: {}", e))?;
 
     // Register ad-hoc commands
     {
@@ -640,14 +646,10 @@ async fn start_xmpp_server(
         let registry = server.command_registry();
         let app_state_for_command = Arc::clone(&app_state);
         registry
-            .register(
-                NODE_CREATE_CHANNEL,
-                "Create Channel",
-                move |ctx| {
-                    let deps = Arc::clone(&app_state_for_command);
-                    handle_create_channel(deps, ctx)
-                },
-            )
+            .register(NODE_CREATE_CHANNEL, "Create Channel", move |ctx| {
+                let deps = Arc::clone(&app_state_for_command);
+                handle_create_channel(deps, ctx)
+            })
             .await;
         info!("Registered create-channel command");
     }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -630,9 +630,27 @@ async fn start_xmpp_server(
         "Starting XMPP server"
     );
 
-    let server = waddle_xmpp::start(config, app_state, c2s_listener, s2s_listener, stop_token)
+    let server = waddle_xmpp::start(config, Arc::clone(&app_state), c2s_listener, s2s_listener, stop_token)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to create XMPP server: {}", e))?;
+
+    // Register ad-hoc commands
+    {
+        use waddle_xmpp::commands::{handle_create_channel, NODE_CREATE_CHANNEL};
+        let registry = server.command_registry();
+        let app_state_for_command = Arc::clone(&app_state);
+        registry
+            .register(
+                NODE_CREATE_CHANNEL,
+                "Create Channel",
+                move |ctx| {
+                    let deps = Arc::clone(&app_state_for_command);
+                    handle_create_channel(deps, ctx)
+                },
+            )
+            .await;
+        info!("Registered create-channel command");
+    }
 
     server
         .run()

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -52,13 +52,11 @@ impl ChannelState {
 }
 
 /// Create the channels router
+///
+/// NOTE: Channel creation is now XMPP-native via XEP-0050 ad-hoc commands.
+/// The create_channel_handler HTTP route has been removed.
 pub fn router(channel_state: Arc<ChannelState>) -> Router {
     Router::new()
-        // Waddle-scoped routes
-        .route(
-            "/v1/waddles/:waddle_id/channels",
-            post(create_channel_handler),
-        )
         // Channel-scoped routes (require waddle_id in query params)
         .route("/v1/channels/:id", patch(update_channel_handler))
         .route("/v1/channels/:id", delete(delete_channel_handler))
@@ -226,9 +224,21 @@ fn channel_error_to_response(err: ChannelError) -> (StatusCode, Json<ErrorRespon
 
 // === Handlers ===
 
+// NOTE: Channel creation has been moved to XMPP-native XEP-0050 ad-hoc commands.
+// The HTTP create_channel_handler endpoint has been removed as part of the cutover.
+// Channel creation is now exclusively handled by the waddle:create-channel command.
+//
+// The insert_channel helper function below is still used by the XMPP command handler
+// (see waddle-server::server::xmpp_state::CreateChannelDeps implementation).
+
+/*
 /// POST /v1/waddles/:waddle_id/channels
 ///
 /// Create a new channel in a waddle. Requires create_channel permission on the waddle.
+///
+/// DEPRECATED: This HTTP endpoint has been removed. Use the XMPP ad-hoc command instead:
+/// - Node: waddle:create-channel
+/// - Protocol: XEP-0050 (Ad-Hoc Commands)
 #[instrument(skip(state))]
 pub async fn create_channel_handler(
     State(state): State<Arc<ChannelState>>,
@@ -236,128 +246,9 @@ pub async fn create_channel_handler(
     Query(params): Query<SessionQuery>,
     Json(request): Json<CreateChannelRequest>,
 ) -> impl IntoResponse {
-    info!(
-        "Creating channel '{}' in waddle {}",
-        request.name, waddle_id
-    );
-
-    // Validate session
-    let session = match state
-        .session_manager
-        .validate_session(&params.session_id)
-        .await
-    {
-        Ok(session) => session,
-        Err(err) => {
-            warn!("Session validation failed: {}", err);
-            return channel_error_to_response(ChannelError::Auth(err)).into_response();
-        }
-    };
-
-    // Validate input
-    if request.name.trim().is_empty() {
-        return channel_error_to_response(ChannelError::InvalidInput(
-            "Channel name cannot be empty".to_string(),
-        ))
-        .into_response();
-    }
-
-    // Check if user has permission to create channels in this waddle
-    let subject = Subject::user(&session.user_id);
-    let waddle_object = Object::new(ObjectType::Waddle, &waddle_id);
-
-    let can_create = state
-        .permission_service
-        .check(&subject, "create_channel", &waddle_object)
-        .await
-        .map(|r| r.allowed)
-        .unwrap_or(false);
-
-    if !can_create {
-        return channel_error_to_response(ChannelError::Permission(PermissionError::Denied(
-            "You do not have permission to create channels in this waddle".to_string(),
-        )))
-        .into_response();
-    }
-
-    // Get or create the waddle database
-    let waddle_db = match state.app_state.db_pool.get_waddle_db(&waddle_id).await {
-        Ok(db) => db,
-        Err(err) => {
-            error!("Failed to get waddle database: {}", err);
-            return channel_error_to_response(ChannelError::Database(format!(
-                "Failed to access waddle database: {}",
-                err
-            )))
-            .into_response();
-        }
-    };
-
-    // Generate channel ID
-    let channel_id = Uuid::new_v4().to_string();
-    let now = chrono::Utc::now().to_rfc3339();
-    let channel_type = match normalize_channel_type(&request.channel_type) {
-        Ok(channel_type) => channel_type,
-        Err(err) => return channel_error_to_response(err).into_response(),
-    };
-
-    // Insert channel into database
-    if let Err(err) = insert_channel(
-        &waddle_db,
-        &channel_id,
-        &request.name,
-        request.description.as_deref(),
-        &channel_type,
-        request.position,
-        false, // not default
-        &now,
-    )
-    .await
-    {
-        error!("Failed to insert channel: {}", err);
-        return channel_error_to_response(ChannelError::Database(err)).into_response();
-    }
-
-    // Create permission tuple: channel#parent@waddle
-    // This establishes the parent relationship so channel permissions can inherit from waddle
-    let parent_tuple = Tuple::new(
-        Object::new(ObjectType::Channel, &channel_id),
-        Relation::new("parent"),
-        Subject {
-            subject_type: SubjectType::Waddle,
-            id: waddle_id.clone(),
-            relation: None,
-        },
-    );
-
-    if let Err(err) = state.permission_service.write_tuple(parent_tuple).await {
-        error!("Failed to write parent permission tuple: {}", err);
-        // Clean up: delete the channel
-        let _ = delete_channel_from_db(&waddle_db, &channel_id).await;
-        return channel_error_to_response(ChannelError::Permission(err)).into_response();
-    }
-
-    info!(
-        "Channel created: {} ({}) in waddle {}",
-        request.name, channel_id, waddle_id
-    );
-
-    (
-        StatusCode::CREATED,
-        Json(ChannelResponse {
-            id: channel_id,
-            waddle_id,
-            name: request.name,
-            description: request.description,
-            channel_type,
-            position: request.position,
-            is_default: false,
-            created_at: now.clone(),
-            updated_at: Some(now),
-        }),
-    )
-        .into_response()
+    ... code removed ...
 }
+*/
 
 /// PATCH /v1/channels/:id
 ///

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -1,11 +1,12 @@
 //! Channel CRUD API Routes
 //!
 //! Provides HTTP endpoints for managing Channels within Waddles:
-//! - POST /v1/waddles/:wid/channels - Create a new channel in a waddle
-//! - GET /v1/waddles/:wid/channels - List channels in a waddle
-//! - GET /v1/channels/:id - Get channel details (requires waddle_id query param)
 //! - PATCH /v1/channels/:id - Update channel metadata
 //! - DELETE /v1/channels/:id - Delete a channel
+//!
+//! NOTE: Channel creation is now XMPP-native via XEP-0050 ad-hoc command:
+//! - Node: waddle:create-channel
+//! - Protocol: XEP-0050 (Ad-Hoc Commands)
 
 use crate::auth::{AuthError, SessionManager};
 use crate::db::Database;
@@ -17,14 +18,15 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
-    routing::{delete, patch, post},
+    routing::{delete, patch},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, info, instrument, warn};
+
+#[cfg(test)]
 use uuid::Uuid;
-use waddle_xmpp::ChannelType;
 
 /// Extended application state for channel routes
 pub struct ChannelState {
@@ -54,7 +56,7 @@ impl ChannelState {
 /// Create the channels router
 ///
 /// NOTE: Channel creation is now XMPP-native via XEP-0050 ad-hoc commands.
-/// The create_channel_handler HTTP route has been removed.
+/// The HTTP create-channel route has been removed.
 pub fn router(channel_state: Arc<ChannelState>) -> Router {
     Router::new()
         // Channel-scoped routes (require waddle_id in query params)
@@ -64,36 +66,6 @@ pub fn router(channel_state: Arc<ChannelState>) -> Router {
 }
 
 // === Request/Response Types ===
-
-/// Request body for creating a new channel
-#[derive(Debug, Deserialize)]
-pub struct CreateChannelRequest {
-    /// Channel name (required)
-    pub name: String,
-    /// Channel description (optional)
-    pub description: Option<String>,
-    /// Channel type (default: "text")
-    #[serde(default = "default_channel_type")]
-    pub channel_type: String,
-    /// Position in channel list (default: 0)
-    #[serde(default)]
-    pub position: i32,
-}
-
-fn default_channel_type() -> String {
-    ChannelType::Text.as_str().to_string()
-}
-
-fn normalize_channel_type(channel_type: &str) -> Result<String, ChannelError> {
-    ChannelType::parse(channel_type)
-        .map(|kind| kind.as_str().to_string())
-        .ok_or_else(|| {
-            ChannelError::InvalidInput(format!(
-                "Unsupported channel_type '{}'. Expected one of: text, forum",
-                channel_type
-            ))
-        })
-}
 
 /// Request body for updating a channel
 #[derive(Debug, Deserialize)]
@@ -127,13 +99,6 @@ pub struct ChannelResponse {
     pub created_at: String,
     /// When the channel was last updated
     pub updated_at: Option<String>,
-}
-
-/// Query parameters for session authentication
-#[derive(Debug, Deserialize)]
-pub struct SessionQuery {
-    /// Session ID for authentication
-    pub session_id: String,
 }
 
 /// Query parameters for getting/updating/deleting a channel
@@ -223,32 +188,6 @@ fn channel_error_to_response(err: ChannelError) -> (StatusCode, Json<ErrorRespon
 }
 
 // === Handlers ===
-
-// NOTE: Channel creation has been moved to XMPP-native XEP-0050 ad-hoc commands.
-// The HTTP create_channel_handler endpoint has been removed as part of the cutover.
-// Channel creation is now exclusively handled by the waddle:create-channel command.
-//
-// The insert_channel helper function below is still used by the XMPP command handler
-// (see waddle-server::server::xmpp_state::CreateChannelDeps implementation).
-
-/*
-/// POST /v1/waddles/:waddle_id/channels
-///
-/// Create a new channel in a waddle. Requires create_channel permission on the waddle.
-///
-/// DEPRECATED: This HTTP endpoint has been removed. Use the XMPP ad-hoc command instead:
-/// - Node: waddle:create-channel
-/// - Protocol: XEP-0050 (Ad-Hoc Commands)
-#[instrument(skip(state))]
-pub async fn create_channel_handler(
-    State(state): State<Arc<ChannelState>>,
-    Path(waddle_id): Path<String>,
-    Query(params): Query<SessionQuery>,
-    Json(request): Json<CreateChannelRequest>,
-) -> impl IntoResponse {
-    ... code removed ...
-}
-*/
 
 /// PATCH /v1/channels/:id
 ///
@@ -776,187 +715,54 @@ mod tests {
         (waddle_id, waddle_db)
     }
 
-    #[tokio::test]
-    async fn test_create_channel() {
-        let channel_state = create_test_channel_state().await;
-        let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
-        let app = router(channel_state);
+    async fn create_test_channel(
+        state: &ChannelState,
+        waddle_db: &Database,
+        waddle_id: &str,
+        name: &str,
+    ) -> String {
+        let channel_id = Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        insert_channel(
+            waddle_db,
+            &channel_id,
+            name,
+            None,
+            "text",
+            0,
+            false,
+            &now,
+        )
+        .await
+        .unwrap();
 
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(
-                        r#"{"name": "test-channel", "description": "A test channel"}"#,
-                    ))
-                    .unwrap(),
-            )
+        let parent_tuple = Tuple::new(
+            Object::new(ObjectType::Channel, &channel_id),
+            Relation::new("parent"),
+            Subject {
+                subject_type: SubjectType::Waddle,
+                id: waddle_id.to_string(),
+                relation: None,
+            },
+        );
+        state
+            .permission_service
+            .write_tuple(parent_tuple)
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::CREATED);
-
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-
-        assert_eq!(json["name"], "test-channel");
-        assert_eq!(json["description"], "A test channel");
-        assert_eq!(json["waddle_id"], waddle_id);
-        assert_eq!(json["channel_type"], "text");
-        assert!(!json["is_default"].as_bool().unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_create_channel_empty_name() {
-        let channel_state = create_test_channel_state().await;
-        let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
-        let app = router(channel_state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"name": ""}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["error"], "invalid_input");
-    }
-
-    #[tokio::test]
-    async fn test_create_forum_channel() {
-        let channel_state = create_test_channel_state().await;
-        let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
-        let app = router(channel_state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(
-                        r#"{"name": "announcements", "channel_type": "forum"}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::CREATED);
-
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["channel_type"], "forum");
-    }
-
-    #[tokio::test]
-    async fn test_create_channel_rejects_unknown_type() {
-        let channel_state = create_test_channel_state().await;
-        let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
-        let app = router(channel_state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(
-                        r#"{"name": "mystery", "channel_type": "voice"}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[tokio::test]
-    async fn test_create_channel_permission_denied() {
-        let channel_state = create_test_channel_state().await;
-        let session = create_test_session(&channel_state).await;
-        // Don't set up permissions - user has no create_channel permission
-        let waddle_id = Uuid::new_v4().to_string();
-        let app = router(channel_state);
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"name": "test-channel"}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        channel_id
     }
 
     #[tokio::test]
     async fn test_update_channel() {
         let channel_state = create_test_channel_state().await;
         let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
+        let (waddle_id, waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
         let app = router(channel_state.clone());
 
-        // Create a channel
-        let create_response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"name": "test-channel"}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = create_response
-            .into_body()
-            .collect()
-            .await
-            .unwrap()
-            .to_bytes();
-        let create_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let channel_id = create_json["id"].as_str().unwrap();
+        let channel_id =
+            create_test_channel(&channel_state, &waddle_db, &waddle_id, "test-channel").await;
 
         // Update the channel
         let response = app
@@ -989,34 +795,11 @@ mod tests {
     async fn test_delete_channel() {
         let channel_state = create_test_channel_state().await;
         let session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
+        let (waddle_id, waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
         let app = router(channel_state.clone());
 
-        // Create a channel
-        let create_response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"name": "test-channel"}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = create_response
-            .into_body()
-            .collect()
-            .await
-            .unwrap()
-            .to_bytes();
-        let create_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let channel_id = create_json["id"].as_str().unwrap();
+        let channel_id =
+            create_test_channel(&channel_state, &waddle_db, &waddle_id, "test-channel").await;
 
         // Delete the channel
         let response = app
@@ -1042,7 +825,7 @@ mod tests {
         let channel_state = create_test_channel_state().await;
         let owner_session = create_test_session(&channel_state).await;
         let other_session = create_test_session(&channel_state).await;
-        let (waddle_id, _waddle_db) =
+        let (waddle_id, waddle_db) =
             setup_waddle_with_permissions(&channel_state, &owner_session).await;
 
         // Give other_session member permission only (not admin, so can't delete)
@@ -1059,31 +842,8 @@ mod tests {
 
         let app = router(channel_state.clone());
 
-        // Create a channel as owner
-        let create_response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!(
-                        "/v1/waddles/{}/channels?session_id={}",
-                        waddle_id, owner_session.id
-                    ))
-                    .header("Content-Type", "application/json")
-                    .body(Body::from(r#"{"name": "owner-channel"}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let body = create_response
-            .into_body()
-            .collect()
-            .await
-            .unwrap()
-            .to_bytes();
-        let create_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let channel_id = create_json["id"].as_str().unwrap();
+        let channel_id =
+            create_test_channel(&channel_state, &waddle_db, &waddle_id, "owner-channel").await;
 
         // Try to delete as other user (non-admin)
         let response = app

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -723,18 +723,9 @@ mod tests {
     ) -> String {
         let channel_id = Uuid::new_v4().to_string();
         let now = chrono::Utc::now().to_rfc3339();
-        insert_channel(
-            waddle_db,
-            &channel_id,
-            name,
-            None,
-            "text",
-            0,
-            false,
-            &now,
-        )
-        .await
-        .unwrap();
+        insert_channel(waddle_db, &channel_id, name, None, "text", 0, false, &now)
+            .await
+            .unwrap();
 
         let parent_tuple = Tuple::new(
             Object::new(ObjectType::Channel, &channel_id),

--- a/server/crates/waddle-server/src/server/routes/channels.rs
+++ b/server/crates/waddle-server/src/server/routes/channels.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
+use waddle_xmpp::ChannelType;
 
 /// Extended application state for channel routes
 pub struct ChannelState {
@@ -82,7 +83,18 @@ pub struct CreateChannelRequest {
 }
 
 fn default_channel_type() -> String {
-    "text".to_string()
+    ChannelType::Text.as_str().to_string()
+}
+
+fn normalize_channel_type(channel_type: &str) -> Result<String, ChannelError> {
+    ChannelType::parse(channel_type)
+        .map(|kind| kind.as_str().to_string())
+        .ok_or_else(|| {
+            ChannelError::InvalidInput(format!(
+                "Unsupported channel_type '{}'. Expected one of: text, forum",
+                channel_type
+            ))
+        })
 }
 
 /// Request body for updating a channel
@@ -107,7 +119,7 @@ pub struct ChannelResponse {
     pub name: String,
     /// Channel description
     pub description: Option<String>,
-    /// Channel type (text, voice, etc.)
+    /// Channel type (text, forum)
     pub channel_type: String,
     /// Position in channel list
     pub position: i32,
@@ -284,6 +296,10 @@ pub async fn create_channel_handler(
     // Generate channel ID
     let channel_id = Uuid::new_v4().to_string();
     let now = chrono::Utc::now().to_rfc3339();
+    let channel_type = match normalize_channel_type(&request.channel_type) {
+        Ok(channel_type) => channel_type,
+        Err(err) => return channel_error_to_response(err).into_response(),
+    };
 
     // Insert channel into database
     if let Err(err) = insert_channel(
@@ -291,7 +307,7 @@ pub async fn create_channel_handler(
         &channel_id,
         &request.name,
         request.description.as_deref(),
-        &request.channel_type,
+        &channel_type,
         request.position,
         false, // not default
         &now,
@@ -333,7 +349,7 @@ pub async fn create_channel_handler(
             waddle_id,
             name: request.name,
             description: request.description,
-            channel_type: request.channel_type,
+            channel_type,
             position: request.position,
             is_default: false,
             created_at: now.clone(),
@@ -932,6 +948,64 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"], "invalid_input");
+    }
+
+    #[tokio::test]
+    async fn test_create_forum_channel() {
+        let channel_state = create_test_channel_state().await;
+        let session = create_test_session(&channel_state).await;
+        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
+        let app = router(channel_state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/v1/waddles/{}/channels?session_id={}",
+                        waddle_id, session.id
+                    ))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        r#"{"name": "announcements", "channel_type": "forum"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["channel_type"], "forum");
+    }
+
+    #[tokio::test]
+    async fn test_create_channel_rejects_unknown_type() {
+        let channel_state = create_test_channel_state().await;
+        let session = create_test_session(&channel_state).await;
+        let (waddle_id, _waddle_db) = setup_waddle_with_permissions(&channel_state, &session).await;
+        let app = router(channel_state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!(
+                        "/v1/waddles/{}/channels?session_id={}",
+                        waddle_id, session.id
+                    ))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        r#"{"name": "mystery", "channel_type": "voice"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -1383,12 +1383,19 @@ async fn handle_iq(
                                     match list_channels_from_db(&waddle_db, node, 200, 0).await {
                                         Ok(channels) => channels
                                             .into_iter()
-                                            .map(|channel| {
-                                                let room_jid = format!(
-                                                    "{}_{}@{}",
-                                                    node, channel.id, muc_domain
-                                                );
-                                                DiscoItem::muc_room(&room_jid, &channel.name)
+                                            .filter_map(|channel| {
+                                                waddle_xmpp::managed_room_jid(
+                                                    node,
+                                                    &channel.id,
+                                                    muc_domain,
+                                                )
+                                                .ok()
+                                                .map(|room_jid| {
+                                                    DiscoItem::muc_room(
+                                                        &room_jid.to_string(),
+                                                        &channel.name,
+                                                    )
+                                                })
                                             })
                                             .collect(),
                                         Err(err) => {
@@ -2285,15 +2292,8 @@ fn add_default_namespace_if_missing(xml: &str, default_ns: &str) -> String {
 /// Convention: node is "waddleId_channelId" (first underscore separates).
 /// Falls back to ("default", "default") if the node can't be parsed.
 fn parse_room_jid_context(room_jid: &jid::BareJid) -> (String, String) {
-    if let Some(node) = room_jid.node() {
-        let node_str = node.as_str();
-        if let Some(idx) = node_str.find('_') {
-            let waddle = &node_str[..idx];
-            let channel = &node_str[idx + 1..];
-            if !waddle.is_empty() && !channel.is_empty() {
-                return (waddle.to_string(), channel.to_string());
-            }
-        }
+    if let Some((waddle_id, channel_id)) = waddle_xmpp::parse_managed_room_jid(room_jid) {
+        return (waddle_id, channel_id);
     }
     ("default".to_string(), "default".to_string())
 }

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -13,7 +13,8 @@ use crate::auth::{
 };
 use crate::db::actor::DbActor;
 use crate::db::{Database, DatabasePool, MigrationRunner};
-use crate::permissions::{Object, PermissionService, Subject};
+use crate::permissions::{Object, ObjectType, PermissionService, Relation, Subject, SubjectType, Tuple};
+use crate::server::routes::channels::get_channel_from_db;
 use crate::server::routes::channels::list_channels_from_db as list_channels_for_waddle_from_db;
 use crate::server::routes::waddles::list_user_waddles as list_user_waddles_from_db;
 use crate::vcard::VCardStore;
@@ -1061,6 +1062,58 @@ impl waddle_xmpp::AppState for XmppAppState {
         Ok(result)
     }
 
+    /// Look up a channel-backed room by channel ID.
+    async fn get_channel_room_info(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> Result<Option<waddle_xmpp::ChannelRoomInfo>, XmppError> {
+        debug!(
+            waddle_id = %waddle_id,
+            channel_id = %channel_id,
+            "Looking up channel-backed room metadata"
+        );
+
+        let Some(db_pool) = self.db_pool.as_ref() else {
+            debug!("Database pool not configured for channel room lookup");
+            return Ok(None);
+        };
+
+        let waddle_db = match db_pool.get_waddle_db(waddle_id).await {
+            Ok(db) => db,
+            Err(e) => {
+                warn!(waddle_id = %waddle_id, error = %e, "Failed to open waddle database");
+                return Ok(None);
+            }
+        };
+
+        let runner = MigrationRunner::waddle();
+        if let Err(e) = runner.run(&waddle_db).await {
+            warn!(waddle_id = %waddle_id, error = %e, "Failed to run waddle DB migrations");
+        }
+
+        match get_channel_from_db(&waddle_db, waddle_id, channel_id).await {
+            Ok(Some(channel)) => Ok(Some(waddle_xmpp::ChannelRoomInfo {
+                waddle_id: waddle_id.to_string(),
+                channel: waddle_xmpp::ChannelInfo {
+                    id: channel.id,
+                    name: channel.name,
+                    channel_type: channel.channel_type,
+                },
+            })),
+            Ok(None) => Ok(None),
+            Err(e) => {
+                warn!(
+                    waddle_id = %waddle_id,
+                    channel_id = %channel_id,
+                    error = %e,
+                    "Failed to read channel from waddle database"
+                );
+                Ok(None)
+            }
+        }
+    }
+
     // =========================================================================
     // XEP-0503: Spaces Service (Waddle Details)
     // =========================================================================
@@ -1209,6 +1262,107 @@ fn roster_item_to_row(item: &waddle_xmpp::roster::RosterItem) -> crate::db::rost
         subscription: item.subscription.as_str().to_string(),
         ask: item.ask.map(|a| a.as_str().to_string()),
         groups: item.groups.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CreateChannelDeps implementation
+// ---------------------------------------------------------------------------
+
+impl waddle_xmpp::commands::CreateChannelDeps for XmppAppState {
+    async fn create_channel(
+        &self,
+        user_id: &str,
+        waddle_id: &str,
+        metadata: waddle_xmpp::commands::ChannelMetadata,
+    ) -> Result<waddle_xmpp::commands::CreateChannelResult, String> {
+        use tracing::error;
+        
+        // Check permission
+        let subject = Subject::user(user_id);
+        let waddle_object = Object::new(ObjectType::Waddle, waddle_id);
+        
+        let can_create = self
+            .permission_service
+            .check(&subject, "create_channel", &waddle_object)
+            .await
+            .map(|r| r.allowed)
+            .unwrap_or(false);
+        
+        if !can_create {
+            return Err("You do not have permission to create channels in this waddle".to_string());
+        }
+        
+        // Get waddle database
+        let db_pool = match &self.db_pool {
+            Some(pool) => pool,
+            None => return Err("Database pool not available".to_string()),
+        };
+        
+        let waddle_db = db_pool
+            .get_waddle_db(waddle_id)
+            .await
+            .map_err(|e| format!("Failed to access waddle database: {}", e))?;
+        
+        // Generate channel ID
+        let channel_id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        
+        // Insert channel into database
+        let conn = waddle_db.guard().await.map_err(|e| e.to_string())?;
+        conn.execute(
+            r#"
+                INSERT INTO channels (id, name, description, channel_type, position, is_default, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+            libsql::params![
+                channel_id.as_str(),
+                metadata.name.as_str(),
+                metadata.description.as_deref(),
+                metadata.channel_type.as_str(),
+                metadata.position,
+                0_i32, // not default
+                now.as_str(),
+                now.as_str()
+            ],
+        )
+        .await
+        .map_err(|e| format!("Failed to insert channel: {}", e))?;
+        drop(conn);
+        
+        // Create permission tuple: channel#parent@waddle
+        let parent_tuple = Tuple::new(
+            Object::new(ObjectType::Channel, &channel_id),
+            Relation::new("parent"),
+            Subject {
+                subject_type: SubjectType::Waddle,
+                id: waddle_id.to_string(),
+                relation: None,
+            },
+        );
+        
+        if let Err(err) = self.permission_service.write_tuple(parent_tuple).await {
+            error!("Failed to write parent permission tuple: {}", err);
+            // Clean up: delete the channel
+            if let Ok(conn) = waddle_db.guard().await {
+                let _ = conn
+                    .execute(
+                        "DELETE FROM channels WHERE id = ?",
+                        libsql::params![channel_id.as_str()],
+                    )
+                    .await;
+            }
+            return Err(format!("Failed to create permission tuple: {}", err));
+        }
+        
+        // Build channel JID: {waddleId}_{channelId}@muc.{domain}
+        let channel_jid = format!("{}_{}", waddle_id, channel_id);
+        let channel_jid = format!("{}@muc.{}", channel_jid, self.domain);
+        
+        Ok(waddle_xmpp::commands::CreateChannelResult {
+            channel_id,
+            channel_jid,
+        })
     }
 }
 

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -13,7 +13,9 @@ use crate::auth::{
 };
 use crate::db::actor::DbActor;
 use crate::db::{Database, DatabasePool, MigrationRunner};
-use crate::permissions::{Object, ObjectType, PermissionService, Relation, Subject, SubjectType, Tuple};
+use crate::permissions::{
+    Object, ObjectType, PermissionService, Relation, Subject, SubjectType, Tuple,
+};
 use crate::server::routes::channels::get_channel_from_db;
 use crate::server::routes::channels::list_channels_from_db as list_channels_for_waddle_from_db;
 use crate::server::routes::waddles::list_user_waddles as list_user_waddles_from_db;
@@ -1277,37 +1279,37 @@ impl waddle_xmpp::commands::CreateChannelDeps for XmppAppState {
         metadata: waddle_xmpp::commands::ChannelMetadata,
     ) -> Result<waddle_xmpp::commands::CreateChannelResult, String> {
         use tracing::error;
-        
+
         // Check permission
         let subject = Subject::user(user_id);
         let waddle_object = Object::new(ObjectType::Waddle, waddle_id);
-        
+
         let can_create = self
             .permission_service
             .check(&subject, "create_channel", &waddle_object)
             .await
             .map(|r| r.allowed)
             .unwrap_or(false);
-        
+
         if !can_create {
             return Err("You do not have permission to create channels in this waddle".to_string());
         }
-        
+
         // Get waddle database
         let db_pool = match &self.db_pool {
             Some(pool) => pool,
             None => return Err("Database pool not available".to_string()),
         };
-        
+
         let waddle_db = db_pool
             .get_waddle_db(waddle_id)
             .await
             .map_err(|e| format!("Failed to access waddle database: {}", e))?;
-        
+
         // Generate channel ID
         let channel_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now().to_rfc3339();
-        
+
         // Insert channel into database
         let conn = waddle_db.guard().await.map_err(|e| e.to_string())?;
         conn.execute(
@@ -1329,7 +1331,7 @@ impl waddle_xmpp::commands::CreateChannelDeps for XmppAppState {
         .await
         .map_err(|e| format!("Failed to insert channel: {}", e))?;
         drop(conn);
-        
+
         // Create permission tuple: channel#parent@waddle
         let parent_tuple = Tuple::new(
             Object::new(ObjectType::Channel, &channel_id),
@@ -1340,7 +1342,7 @@ impl waddle_xmpp::commands::CreateChannelDeps for XmppAppState {
                 relation: None,
             },
         );
-        
+
         if let Err(err) = self.permission_service.write_tuple(parent_tuple).await {
             error!("Failed to write parent permission tuple: {}", err);
             // Clean up: delete the channel
@@ -1354,11 +1356,11 @@ impl waddle_xmpp::commands::CreateChannelDeps for XmppAppState {
             }
             return Err(format!("Failed to create permission tuple: {}", err));
         }
-        
+
         // Build channel JID: {waddleId}_{channelId}@muc.{domain}
         let channel_jid = format!("{}_{}", waddle_id, channel_id);
         let channel_jid = format!("{}@muc.{}", channel_jid, self.domain);
-        
+
         Ok(waddle_xmpp::commands::CreateChannelResult {
             channel_id,
             channel_jid,

--- a/server/crates/waddle-xmpp/src/commands/create_channel.rs
+++ b/server/crates/waddle-xmpp/src/commands/create_channel.rs
@@ -1,0 +1,255 @@
+//! Create Channel Command Handler (XEP-0050)
+
+use std::sync::Arc;
+use tracing::debug;
+use crate::commands::{CommandContext, CommandResult, NoteType};
+use crate::xep::xep0004::{DataForm, Field, FieldOption, FieldType, FormType};
+use crate::xep::xep0050::Note;
+use crate::ChannelType;
+
+pub const NODE_CREATE_CHANNEL: &str = "waddle:create-channel";
+
+pub struct ChannelMetadata {
+    pub name: String,
+    pub description: Option<String>,
+    pub channel_type: String,
+    pub position: i32,
+}
+
+pub struct CreateChannelResult {
+    pub channel_id: String,
+    pub channel_jid: String,
+}
+
+pub trait CreateChannelDeps: Send + Sync {
+    fn create_channel(
+        &self,
+        user_id: &str,
+        waddle_id: &str,
+        metadata: ChannelMetadata,
+    ) -> impl std::future::Future<Output = Result<CreateChannelResult, String>> + Send;
+}
+
+fn parse_channel_form(form: &DataForm) -> Result<(String, ChannelMetadata), String> {
+    let mut waddle_id: Option<String> = None;
+    let mut name: Option<String> = None;
+    let mut description: Option<String> = None;
+    let mut channel_type: Option<String> = None;
+    let mut position: Option<i32> = None;
+
+    for field in &form.fields {
+        let var = match field.var.as_deref() {
+            Some(v) => v,
+            None => continue,
+        };
+
+        match var {
+            "waddle_id" => waddle_id = field.value().map(|v| v.to_string()),
+            "name" => name = field.value().map(|v| v.to_string()),
+            "description" => description = field.value().map(|v| v.to_string()),
+            "channel_type" => channel_type = field.value().map(|v| v.to_string()),
+            "position" => position = field.value().and_then(|v| v.parse().ok()),
+            _ => {}
+        }
+    }
+
+    let waddle_id = waddle_id.ok_or_else(|| "Missing required field: waddle_id".to_string())?;
+    let name = name.ok_or_else(|| "Missing required field: name".to_string())?;
+    let channel_type = channel_type.unwrap_or_else(|| "text".to_string());
+    let position = position.unwrap_or(0);
+
+    if name.trim().is_empty() {
+        return Err("Channel name cannot be empty".to_string());
+    }
+
+    let channel_type = ChannelType::parse(&channel_type)
+        .map(|kind| kind.as_str().to_string())
+        .ok_or_else(|| {
+            format!(
+                "Unsupported channel_type '{}'. Expected one of: text, forum",
+                channel_type
+            )
+        })?;
+
+    Ok((
+        waddle_id,
+        ChannelMetadata {
+            name,
+            description,
+            channel_type,
+            position,
+        },
+    ))
+}
+
+fn build_request_form() -> DataForm {
+    DataForm::new(FormType::Form)
+        .add_field(Field::hidden("waddle_id", "").with_label("Waddle ID (required)"))
+        .add_field(
+            Field::text_single("name", "")
+                .with_label("Channel Name")
+                .with_required(),
+        )
+        .add_field(
+            Field::new("description", FieldType::TextMulti)
+                .with_label("Channel Description")
+                .with_desc("Optional description for the channel"),
+        )
+        .add_field(
+            Field::new("channel_type", FieldType::ListSingle)
+                .with_label("Channel Type")
+                .with_value("text")
+                .add_option(FieldOption::with_label("Text Channel", "text"))
+                .add_option(FieldOption::with_label("Forum Channel", "forum")),
+        )
+        .add_field(
+            Field::text_single("position", "0")
+                .with_label("Position")
+                .with_desc("Display position in the channel list (default: 0)"),
+        )
+}
+
+fn build_result_form(channel_id: &str, channel_jid: &str) -> DataForm {
+    DataForm::new(FormType::Result)
+        .add_field(Field::hidden("channel_id", channel_id))
+        .add_field(Field::hidden("channel_jid", channel_jid))
+}
+
+pub async fn handle_create_channel<D: CreateChannelDeps>(
+    deps: Arc<D>,
+    ctx: CommandContext,
+) -> CommandResult {
+    let from = &ctx.from;
+    let action = ctx.command.action.unwrap_or(crate::xep::xep0050::Action::Execute);
+
+    let user_id = match from.node() {
+        Some(node) => node.as_str(),
+        None => {
+            return CommandResult::Error(crate::XmppError::bad_request(Some(
+                "JID must have a localpart".to_string(),
+            )));
+        }
+    };
+
+    match action {
+        crate::xep::xep0050::Action::Execute => {
+            debug!(from = %from, "create-channel: execute action");
+            let form = build_request_form();
+            let session_id = ctx.command.session_id.clone().unwrap_or_default();
+            CommandResult::Executing {
+                form,
+                session_id,
+                notes: vec![Note::new(
+                    NoteType::Info,
+                    "Fill in the channel details and submit",
+                )],
+            }
+        }
+        crate::xep::xep0050::Action::Complete => {
+            debug!(from = %from, "create-channel: complete action");
+            let form = match &ctx.command.form {
+                Some(f) => f,
+                None => {
+                    return CommandResult::Error(crate::XmppError::bad_request(Some(
+                        "Form submission required".to_string(),
+                    )));
+                }
+            };
+
+            let (waddle_id, metadata) = match parse_channel_form(form) {
+                Ok(parsed) => parsed,
+                Err(err) => {
+                    return CommandResult::Completed {
+                        form: None,
+                        notes: vec![Note::new(NoteType::Error, &err)],
+                    };
+                }
+            };
+
+            match deps.create_channel(user_id, &waddle_id, metadata).await {
+                Ok(result) => {
+                    let result_form = build_result_form(&result.channel_id, &result.channel_jid);
+                    CommandResult::Completed {
+                        form: Some(result_form),
+                        notes: vec![Note::new(
+                            NoteType::Info,
+                            &format!("Channel created successfully: {}", result.channel_jid),
+                        )],
+                    }
+                }
+                Err(err) => CommandResult::Completed {
+                    form: None,
+                    notes: vec![Note::new(NoteType::Error, &err)],
+                },
+            }
+        }
+        _ => {
+            CommandResult::Error(crate::XmppError::bad_request(Some(
+                "Unsupported action for create-channel command".to_string(),
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_channel_form_minimal() {
+        let form = DataForm::new(FormType::Submit)
+            .add_field(Field::hidden("waddle_id", "test-waddle"))
+            .add_field(Field::text_single("name", "General"));
+
+        let (waddle_id, metadata) = parse_channel_form(&form).unwrap();
+        assert_eq!(waddle_id, "test-waddle");
+        assert_eq!(metadata.name, "General");
+        assert_eq!(metadata.channel_type, "text");
+        assert_eq!(metadata.position, 0);
+    }
+
+    #[test]
+    fn test_parse_channel_form_full() {
+        let form = DataForm::new(FormType::Submit)
+            .add_field(Field::hidden("waddle_id", "test-waddle"))
+            .add_field(Field::text_single("name", "Announcements"))
+            .add_field(
+                Field::new("description", FieldType::TextMulti)
+                    .with_value("Important updates"),
+            )
+            .add_field(Field::new("channel_type", FieldType::ListSingle).with_value("forum"))
+            .add_field(Field::text_single("position", "10"));
+
+        let (waddle_id, metadata) = parse_channel_form(&form).unwrap();
+        assert_eq!(waddle_id, "test-waddle");
+        assert_eq!(metadata.name, "Announcements");
+        assert_eq!(
+            metadata.description,
+            Some("Important updates".to_string())
+        );
+        assert_eq!(metadata.channel_type, "forum");
+        assert_eq!(metadata.position, 10);
+    }
+
+    #[test]
+    fn test_parse_channel_form_invalid_type() {
+        let form = DataForm::new(FormType::Submit)
+            .add_field(Field::hidden("waddle_id", "test-waddle"))
+            .add_field(Field::text_single("name", "General"))
+            .add_field(Field::new("channel_type", FieldType::ListSingle).with_value("invalid"));
+
+        let result = parse_channel_form(&form);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unsupported channel_type"));
+    }
+
+    #[test]
+    fn test_parse_channel_form_missing_name() {
+        let form =
+            DataForm::new(FormType::Submit).add_field(Field::hidden("waddle_id", "test-waddle"));
+
+        let result = parse_channel_form(&form);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Missing required field: name"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/commands/create_channel.rs
+++ b/server/crates/waddle-xmpp/src/commands/create_channel.rs
@@ -1,14 +1,15 @@
 //! Create Channel Command Handler (XEP-0050)
 
-use std::sync::Arc;
-use tracing::debug;
 use crate::commands::{CommandContext, CommandResult, NoteType};
 use crate::xep::xep0004::{DataForm, Field, FieldOption, FieldType, FormType};
 use crate::xep::xep0050::Note;
 use crate::ChannelType;
+use std::sync::Arc;
+use tracing::debug;
 
 pub const NODE_CREATE_CHANNEL: &str = "waddle:create-channel";
 
+#[derive(Debug)]
 pub struct ChannelMetadata {
     pub name: String,
     pub description: Option<String>,
@@ -120,16 +121,10 @@ pub async fn handle_create_channel<D: CreateChannelDeps>(
     ctx: CommandContext,
 ) -> CommandResult {
     let from = &ctx.from;
-    let action = ctx.command.action.unwrap_or(crate::xep::xep0050::Action::Execute);
-
-    let user_id = match from.node() {
-        Some(node) => node.as_str(),
-        None => {
-            return CommandResult::Error(crate::XmppError::bad_request(Some(
-                "JID must have a localpart".to_string(),
-            )));
-        }
-    };
+    let action = ctx
+        .command
+        .action
+        .unwrap_or(crate::xep::xep0050::Action::Execute);
 
     match action {
         crate::xep::xep0050::Action::Execute => {
@@ -166,6 +161,15 @@ pub async fn handle_create_channel<D: CreateChannelDeps>(
                 }
             };
 
+            let user_id = match ctx.authenticated_user_id.as_deref() {
+                Some(user_id) => user_id,
+                None => {
+                    return CommandResult::Error(crate::XmppError::not_authorized(Some(
+                        "Authenticated session required".to_string(),
+                    )));
+                }
+            };
+
             match deps.create_channel(user_id, &waddle_id, metadata).await {
                 Ok(result) => {
                     let result_form = build_result_form(&result.channel_id, &result.channel_jid);
@@ -183,17 +187,65 @@ pub async fn handle_create_channel<D: CreateChannelDeps>(
                 },
             }
         }
-        _ => {
-            CommandResult::Error(crate::XmppError::bad_request(Some(
-                "Unsupported action for create-channel command".to_string(),
-            )))
-        }
+        _ => CommandResult::Error(crate::XmppError::bad_request(Some(
+            "Unsupported action for create-channel command".to_string(),
+        ))),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::Action;
+    use crate::xep::xep0050::Command;
+    use jid::Jid;
+    use minidom::Element;
+    use std::sync::Mutex;
+    use xmpp_parsers::iq::{Iq, IqType};
+
+    #[derive(Default)]
+    struct MockDeps {
+        captured_user_id: Mutex<Option<String>>,
+    }
+
+    impl CreateChannelDeps for MockDeps {
+        async fn create_channel(
+            &self,
+            user_id: &str,
+            _waddle_id: &str,
+            _metadata: ChannelMetadata,
+        ) -> Result<CreateChannelResult, String> {
+            *self.captured_user_id.lock().unwrap() = Some(user_id.to_string());
+            Ok(CreateChannelResult {
+                channel_id: "channel-123".to_string(),
+                channel_jid: "test-waddle_channel-123@muc.localhost".to_string(),
+            })
+        }
+    }
+
+    fn test_command_context(
+        action: Action,
+        session_id: Option<&str>,
+        form: Option<DataForm>,
+        authenticated_user_id: Option<&str>,
+    ) -> CommandContext {
+        CommandContext {
+            from: "alice@localhost/resource".parse::<Jid>().unwrap(),
+            authenticated_user_id: authenticated_user_id.map(str::to_string),
+            iq: Iq {
+                from: None,
+                to: None,
+                id: "test-iq".to_string(),
+                payload: IqType::Set("<query xmlns='urn:test'/>".parse::<Element>().unwrap()),
+            },
+            command: {
+                let mut command = Command::new(NODE_CREATE_CHANNEL).with_action(action);
+                command.session_id = session_id.map(str::to_string);
+                command.form = form;
+                command
+            },
+        }
+    }
 
     #[test]
     fn test_parse_channel_form_minimal() {
@@ -214,8 +266,7 @@ mod tests {
             .add_field(Field::hidden("waddle_id", "test-waddle"))
             .add_field(Field::text_single("name", "Announcements"))
             .add_field(
-                Field::new("description", FieldType::TextMulti)
-                    .with_value("Important updates"),
+                Field::new("description", FieldType::TextMulti).with_value("Important updates"),
             )
             .add_field(Field::new("channel_type", FieldType::ListSingle).with_value("forum"))
             .add_field(Field::text_single("position", "10"));
@@ -223,10 +274,7 @@ mod tests {
         let (waddle_id, metadata) = parse_channel_form(&form).unwrap();
         assert_eq!(waddle_id, "test-waddle");
         assert_eq!(metadata.name, "Announcements");
-        assert_eq!(
-            metadata.description,
-            Some("Important updates".to_string())
-        );
+        assert_eq!(metadata.description, Some("Important updates".to_string()));
         assert_eq!(metadata.channel_type, "forum");
         assert_eq!(metadata.position, 10);
     }
@@ -251,5 +299,48 @@ mod tests {
         let result = parse_channel_form(&form);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Missing required field: name"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_returns_session_id_from_context() {
+        let result = handle_create_channel(
+            Arc::new(MockDeps::default()),
+            test_command_context(Action::Execute, Some("session-123"), None, Some("user-123")),
+        )
+        .await;
+
+        match result {
+            CommandResult::Executing { session_id, .. } => assert_eq!(session_id, "session-123"),
+            _ => panic!("expected executing result"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_complete_uses_authenticated_user_id_for_create_channel() {
+        let deps = Arc::new(MockDeps::default());
+        let form = DataForm::new(FormType::Submit)
+            .add_field(Field::hidden("waddle_id", "test-waddle"))
+            .add_field(Field::text_single("name", "General"));
+
+        let result = handle_create_channel(
+            Arc::clone(&deps),
+            test_command_context(
+                Action::Complete,
+                Some("session-123"),
+                Some(form),
+                Some("user-123"),
+            ),
+        )
+        .await;
+
+        match result {
+            CommandResult::Completed { .. } => {}
+            _ => panic!("expected completed result"),
+        }
+
+        assert_eq!(
+            deps.captured_user_id.lock().unwrap().as_deref(),
+            Some("user-123")
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/commands/mod.rs
+++ b/server/crates/waddle-xmpp/src/commands/mod.rs
@@ -10,7 +10,9 @@ pub use create_channel::{
     handle_create_channel, ChannelMetadata, CreateChannelDeps, CreateChannelResult,
     NODE_CREATE_CHANNEL,
 };
-pub use registry::{CommandContext, CommandHandler, CommandRegistry, CommandResult, CommandSession};
+pub use registry::{
+    CommandContext, CommandHandler, CommandMetadata, CommandRegistry, CommandResult, CommandSession,
+};
 
 // Re-export common XEP-0050 types for convenience
 pub use crate::xep::xep0050::{

--- a/server/crates/waddle-xmpp/src/commands/mod.rs
+++ b/server/crates/waddle-xmpp/src/commands/mod.rs
@@ -1,0 +1,18 @@
+//! Ad-Hoc Command Handlers (XEP-0050)
+//!
+//! This module implements the runtime infrastructure for ad-hoc commands,
+//! allowing the server to register and dispatch XEP-0050 commands dynamically.
+
+pub mod create_channel;
+pub mod registry;
+
+pub use create_channel::{
+    handle_create_channel, ChannelMetadata, CreateChannelDeps, CreateChannelResult,
+    NODE_CREATE_CHANNEL,
+};
+pub use registry::{CommandContext, CommandHandler, CommandRegistry, CommandResult, CommandSession};
+
+// Re-export common XEP-0050 types for convenience
+pub use crate::xep::xep0050::{
+    Action, AllowedActions, Command, Note, NoteType, Status, NODE_COMMANDS, NS_COMMANDS,
+};

--- a/server/crates/waddle-xmpp/src/commands/registry.rs
+++ b/server/crates/waddle-xmpp/src/commands/registry.rs
@@ -1,0 +1,298 @@
+//! Command Registry for XEP-0050 Ad-Hoc Commands
+//!
+//! Manages command registration, session state, and dispatching for ad-hoc commands.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use jid::Jid;
+use tokio::sync::RwLock;
+use tracing::debug;
+use uuid::Uuid;
+use xmpp_parsers::iq::Iq;
+
+use crate::xep::xep0004::DataForm;
+use crate::xep::xep0050::{Action, Command, Note};
+use crate::XmppError;
+
+/// Time-to-live for command sessions (5 minutes)
+const SESSION_TTL: Duration = Duration::from_secs(300);
+
+/// Result of executing a command handler.
+pub enum CommandResult {
+    /// Command is still executing, return a form for the next step.
+    Executing {
+        form: DataForm,
+        session_id: String,
+        notes: Vec<Note>,
+    },
+    /// Command completed successfully.
+    Completed {
+        form: Option<DataForm>,
+        notes: Vec<Note>,
+    },
+    /// Command was canceled.
+    Canceled { notes: Vec<Note> },
+    /// Command failed with an error.
+    Error(XmppError),
+}
+
+/// Context provided to command handlers.
+pub struct CommandContext {
+    /// The requester's JID
+    pub from: Jid,
+    /// The original IQ request
+    pub iq: Iq,
+    /// The parsed command
+    pub command: Command,
+}
+
+/// A command handler function.
+///
+/// Handlers receive the command context and must return a `CommandResult`.
+/// The handler is responsible for:
+/// - Validating permissions
+/// - Processing command logic
+/// - Returning appropriate forms or completion status
+pub type CommandHandler = Arc<
+    dyn Fn(CommandContext) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = CommandResult> + Send + 'static>,
+        > + Send
+        + Sync,
+>;
+
+/// Active command session tracking state.
+#[derive(Clone)]
+pub struct CommandSession {
+    /// Session ID
+    pub id: String,
+    /// When this session was created
+    pub created_at: Instant,
+    /// When this session was last accessed
+    pub last_accessed: Instant,
+    /// Command node identifier
+    pub node: String,
+    /// Requester JID
+    pub from: Jid,
+    /// Custom session state (opaque to the registry)
+    pub state: HashMap<String, String>,
+}
+
+impl CommandSession {
+    fn new(id: String, node: String, from: Jid) -> Self {
+        let now = Instant::now();
+        Self {
+            id,
+            created_at: now,
+            last_accessed: now,
+            node,
+            from,
+            state: HashMap::new(),
+        }
+    }
+
+    fn touch(&mut self) {
+        self.last_accessed = Instant::now();
+    }
+
+    fn is_expired(&self) -> bool {
+        self.last_accessed.elapsed() > SESSION_TTL
+    }
+}
+
+/// Registry for ad-hoc commands.
+pub struct CommandRegistry {
+    /// Registered command handlers by node
+    handlers: RwLock<HashMap<String, CommandHandler>>,
+    /// Active command sessions
+    sessions: RwLock<HashMap<String, CommandSession>>,
+}
+
+impl CommandRegistry {
+    /// Create a new command registry.
+    pub fn new() -> Self {
+        Self {
+            handlers: RwLock::new(HashMap::new()),
+            sessions: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a command handler.
+    ///
+    /// # Arguments
+    /// - `node`: The command node identifier (e.g., "waddle:create-channel")
+    /// - `handler`: The handler function
+    pub async fn register<F, Fut>(&self, node: impl Into<String>, handler: F)
+    where
+        F: Fn(CommandContext) -> Fut + Send + Sync + 'static,
+        Fut: std::future::Future<Output = CommandResult> + Send + 'static,
+    {
+        let node = node.into();
+        let wrapped: CommandHandler = Arc::new(move |ctx| Box::pin(handler(ctx)));
+        self.handlers.write().await.insert(node.clone(), wrapped);
+        debug!(node = %node, "Registered ad-hoc command");
+    }
+
+    /// List all registered command nodes.
+    pub async fn list_commands(&self) -> Vec<String> {
+        self.handlers.read().await.keys().cloned().collect()
+    }
+
+    /// Check if a command is registered.
+    pub async fn has_command(&self, node: &str) -> bool {
+        self.handlers.read().await.contains_key(node)
+    }
+
+    /// Dispatch a command request.
+    ///
+    /// This function:
+    /// 1. Validates the command exists
+    /// 2. Creates or retrieves a session
+    /// 3. Calls the handler
+    /// 4. Cleans up expired sessions
+    pub async fn dispatch(&self, ctx: CommandContext) -> CommandResult {
+        let node = &ctx.command.node;
+        let from = &ctx.from;
+
+        // Clean up expired sessions periodically
+        self.cleanup_expired_sessions().await;
+
+        // Get the handler
+        let handler = {
+            let handlers = self.handlers.read().await;
+            match handlers.get(node) {
+                Some(h) => Arc::clone(h),
+                None => {
+                    return CommandResult::Error(XmppError::service_unavailable(Some(format!(
+                        "Command '{}' not found",
+                        node
+                    ))));
+                }
+            }
+        };
+
+        // Handle session creation/retrieval
+        let action = ctx.command.action.unwrap_or(Action::Execute);
+        match action {
+            Action::Execute => {
+                // Create a new session
+                let session_id = Uuid::new_v4().to_string();
+                let session = CommandSession::new(session_id.clone(), node.clone(), from.clone());
+                self.sessions
+                    .write()
+                    .await
+                    .insert(session_id.clone(), session);
+                debug!(
+                    node = %node,
+                    session_id = %session_id,
+                    from = %from,
+                    "Created command session"
+                );
+            }
+            Action::Cancel => {
+                // Cancel and clean up session
+                if let Some(ref session_id) = ctx.command.session_id {
+                    self.sessions.write().await.remove(session_id);
+                    debug!(
+                        node = %node,
+                        session_id = %session_id,
+                        "Canceled command session"
+                    );
+                }
+                return CommandResult::Canceled { notes: vec![] };
+            }
+            Action::Complete | Action::Next | Action::Prev => {
+                // Touch the session to update last_accessed
+                if let Some(ref session_id) = ctx.command.session_id {
+                    if let Some(session) = self.sessions.write().await.get_mut(session_id) {
+                        session.touch();
+                    } else {
+                        return CommandResult::Error(XmppError::bad_request(Some(
+                            "Session not found or expired".to_string(),
+                        )));
+                    }
+                }
+            }
+        }
+
+        // Call the handler
+        handler(ctx).await
+    }
+
+    /// Get a command session by ID.
+    pub async fn get_session(&self, session_id: &str) -> Option<CommandSession> {
+        self.sessions.read().await.get(session_id).cloned()
+    }
+
+    /// Update a command session's state.
+    pub async fn update_session_state(
+        &self,
+        session_id: &str,
+        key: String,
+        value: String,
+    ) -> Result<(), ()> {
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.state.insert(key, value);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Remove a command session.
+    pub async fn remove_session(&self, session_id: &str) {
+        self.sessions.write().await.remove(session_id);
+    }
+
+    /// Clean up expired sessions.
+    async fn cleanup_expired_sessions(&self) {
+        let mut sessions = self.sessions.write().await;
+        let expired: Vec<String> = sessions
+            .iter()
+            .filter(|(_, session)| session.is_expired())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        for id in expired {
+            sessions.remove(&id);
+            debug!(session_id = %id, "Cleaned up expired command session");
+        }
+    }
+}
+
+impl Default for CommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_register_and_list_commands() {
+        let registry = CommandRegistry::new();
+
+        registry
+            .register("test:command", |_ctx| async { CommandResult::Canceled { notes: vec![] } })
+            .await;
+
+        let commands = registry.list_commands().await;
+        assert_eq!(commands.len(), 1);
+        assert!(commands.contains(&"test:command".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_session_expiry() {
+        let session = CommandSession::new(
+            "test-session".to_string(),
+            "test:node".to_string(),
+            "user@localhost".parse().unwrap(),
+        );
+
+        assert!(!session.is_expired());
+    }
+}

--- a/server/crates/waddle-xmpp/src/commands/registry.rs
+++ b/server/crates/waddle-xmpp/src/commands/registry.rs
@@ -42,6 +42,8 @@ pub enum CommandResult {
 pub struct CommandContext {
     /// The requester's JID
     pub from: Jid,
+    /// The authenticated internal principal for this connection.
+    pub authenticated_user_id: Option<String>,
     /// The original IQ request
     pub iq: Iq,
     /// The parsed command
@@ -56,9 +58,11 @@ pub struct CommandContext {
 /// - Processing command logic
 /// - Returning appropriate forms or completion status
 pub type CommandHandler = Arc<
-    dyn Fn(CommandContext) -> std::pin::Pin<
-            Box<dyn std::future::Future<Output = CommandResult> + Send + 'static>,
-        > + Send
+    dyn Fn(
+            CommandContext,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = CommandResult> + Send + 'static>>
+        + Send
         + Sync,
 >;
 
@@ -134,8 +138,12 @@ impl CommandRegistry {
     /// - `node`: The command node identifier (e.g., "waddle:create-channel")
     /// - `name`: The human-readable command name (e.g., "Create Channel")
     /// - `handler`: The handler function
-    pub async fn register<F, Fut>(&self, node: impl Into<String>, name: impl Into<String>, handler: F)
-    where
+    pub async fn register<F, Fut>(
+        &self,
+        node: impl Into<String>,
+        name: impl Into<String>,
+        handler: F,
+    ) where
         F: Fn(CommandContext) -> Fut + Send + Sync + 'static,
         Fut: std::future::Future<Output = CommandResult> + Send + 'static,
     {
@@ -174,7 +182,7 @@ impl CommandRegistry {
     /// 2. Creates or retrieves a session
     /// 3. Calls the handler
     /// 4. Cleans up expired sessions
-    pub async fn dispatch(&self, ctx: CommandContext) -> CommandResult {
+    pub async fn dispatch(&self, mut ctx: CommandContext) -> CommandResult {
         let node = &ctx.command.node;
         let from = &ctx.from;
 
@@ -197,6 +205,7 @@ impl CommandRegistry {
 
         // Handle session creation/retrieval
         let action = ctx.command.action.unwrap_or(Action::Execute);
+        let mut created_session_id = None;
         match action {
             Action::Execute => {
                 // Create a new session
@@ -212,6 +221,8 @@ impl CommandRegistry {
                     from = %from,
                     "Created command session"
                 );
+                ctx.command.session_id = Some(session_id.clone());
+                created_session_id = Some(session_id);
             }
             Action::Cancel => {
                 // Cancel and clean up session
@@ -240,7 +251,21 @@ impl CommandRegistry {
         }
 
         // Call the handler
-        handler(ctx).await
+        match (created_session_id, handler(ctx).await) {
+            (
+                Some(session_id),
+                CommandResult::Executing {
+                    form,
+                    session_id: response_session_id,
+                    notes,
+                },
+            ) if response_session_id.is_empty() => CommandResult::Executing {
+                form,
+                session_id,
+                notes,
+            },
+            (_, result) => result,
+        }
     }
 
     /// Get a command session by ID.
@@ -300,12 +325,16 @@ mod tests {
         let registry = CommandRegistry::new();
 
         registry
-            .register("test:command", |_ctx| async { CommandResult::Canceled { notes: vec![] } })
+            .register(
+                "test:command",
+                "Test Command",
+                |_ctx: CommandContext| async { CommandResult::Canceled { notes: vec![] } },
+            )
             .await;
 
         let commands = registry.list_commands().await;
         assert_eq!(commands.len(), 1);
-        assert!(commands.contains(&"test:command".to_string()));
+        assert!(commands.contains(&("test:command".to_string(), "Test Command".to_string())));
     }
 
     #[tokio::test]
@@ -317,5 +346,48 @@ mod tests {
         );
 
         assert!(!session.is_expired());
+    }
+
+    #[tokio::test]
+    async fn test_execute_threads_generated_session_id_to_handler() {
+        let registry = CommandRegistry::new();
+
+        registry
+            .register(
+                "test:command",
+                "Test Command",
+                |ctx: CommandContext| async move {
+                    CommandResult::Executing {
+                        form: DataForm::new(crate::xep::xep0004::FormType::Form),
+                        session_id: ctx.command.session_id.unwrap_or_default(),
+                        notes: vec![],
+                    }
+                },
+            )
+            .await;
+
+        let result = registry
+            .dispatch(CommandContext {
+                from: "user@localhost".parse().unwrap(),
+                authenticated_user_id: Some("user-123".to_string()),
+                iq: Iq {
+                    from: None,
+                    to: None,
+                    id: "test-iq".to_string(),
+                    payload: xmpp_parsers::iq::IqType::Set(
+                        "<query xmlns='urn:test'/>".parse().unwrap(),
+                    ),
+                },
+                command: Command::new("test:command").with_action(Action::Execute),
+            })
+            .await;
+
+        let session_id = match result {
+            CommandResult::Executing { session_id, .. } => session_id,
+            _ => panic!("expected executing result"),
+        };
+
+        assert!(!session_id.is_empty());
+        assert!(registry.get_session(&session_id).await.is_some());
     }
 }

--- a/server/crates/waddle-xmpp/src/commands/registry.rs
+++ b/server/crates/waddle-xmpp/src/commands/registry.rs
@@ -62,6 +62,16 @@ pub type CommandHandler = Arc<
         + Sync,
 >;
 
+/// Command metadata for discovery.
+pub struct CommandMetadata {
+    /// Command node identifier
+    pub node: String,
+    /// Human-readable command name
+    pub name: String,
+    /// Handler function
+    pub handler: CommandHandler,
+}
+
 /// Active command session tracking state.
 #[derive(Clone)]
 pub struct CommandSession {
@@ -103,8 +113,8 @@ impl CommandSession {
 
 /// Registry for ad-hoc commands.
 pub struct CommandRegistry {
-    /// Registered command handlers by node
-    handlers: RwLock<HashMap<String, CommandHandler>>,
+    /// Registered command metadata by node
+    commands: RwLock<HashMap<String, CommandMetadata>>,
     /// Active command sessions
     sessions: RwLock<HashMap<String, CommandSession>>,
 }
@@ -113,7 +123,7 @@ impl CommandRegistry {
     /// Create a new command registry.
     pub fn new() -> Self {
         Self {
-            handlers: RwLock::new(HashMap::new()),
+            commands: RwLock::new(HashMap::new()),
             sessions: RwLock::new(HashMap::new()),
         }
     }
@@ -122,26 +132,39 @@ impl CommandRegistry {
     ///
     /// # Arguments
     /// - `node`: The command node identifier (e.g., "waddle:create-channel")
+    /// - `name`: The human-readable command name (e.g., "Create Channel")
     /// - `handler`: The handler function
-    pub async fn register<F, Fut>(&self, node: impl Into<String>, handler: F)
+    pub async fn register<F, Fut>(&self, node: impl Into<String>, name: impl Into<String>, handler: F)
     where
         F: Fn(CommandContext) -> Fut + Send + Sync + 'static,
         Fut: std::future::Future<Output = CommandResult> + Send + 'static,
     {
         let node = node.into();
+        let name = name.into();
         let wrapped: CommandHandler = Arc::new(move |ctx| Box::pin(handler(ctx)));
-        self.handlers.write().await.insert(node.clone(), wrapped);
-        debug!(node = %node, "Registered ad-hoc command");
+        let metadata = CommandMetadata {
+            node: node.clone(),
+            name: name.clone(),
+            handler: wrapped,
+        };
+        self.commands.write().await.insert(node.clone(), metadata);
+        debug!(node = %node, name = %name, "Registered ad-hoc command");
     }
 
-    /// List all registered command nodes.
-    pub async fn list_commands(&self) -> Vec<String> {
-        self.handlers.read().await.keys().cloned().collect()
+    /// List all registered commands with their names.
+    /// Returns (node, name) tuples.
+    pub async fn list_commands(&self) -> Vec<(String, String)> {
+        self.commands
+            .read()
+            .await
+            .values()
+            .map(|cmd| (cmd.node.clone(), cmd.name.clone()))
+            .collect()
     }
 
     /// Check if a command is registered.
     pub async fn has_command(&self, node: &str) -> bool {
-        self.handlers.read().await.contains_key(node)
+        self.commands.read().await.contains_key(node)
     }
 
     /// Dispatch a command request.
@@ -160,9 +183,9 @@ impl CommandRegistry {
 
         // Get the handler
         let handler = {
-            let handlers = self.handlers.read().await;
-            match handlers.get(node) {
-                Some(h) => Arc::clone(h),
+            let commands = self.commands.read().await;
+            match commands.get(node) {
+                Some(cmd) => Arc::clone(&cmd.handler),
                 None => {
                     return CommandResult::Error(XmppError::service_unavailable(Some(format!(
                         "Command '{}' not found",

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -7611,6 +7611,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         let session_id = command.session_id.clone();
         let ctx = CommandContext {
             from: sender_jid,
+            authenticated_user_id: self.session.as_ref().map(|session| session.user_id.clone()),
             iq: iq.clone(),
             command,
         };

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -4074,6 +4074,11 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             return self.handle_push_disable(iq).await;
         }
 
+        // Check if this is an ad-hoc command request (XEP-0050)
+        if crate::xep::xep0050::is_command_request(&iq) {
+            return self.handle_command_iq(iq).await;
+        }
+
         // Unhandled IQ get/set - RFC 6120 §8.2.3 requires an error response
         debug!("Received unhandled IQ stanza, returning service-unavailable");
         let error_to = iq
@@ -4145,10 +4150,17 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             Some(target)
                 if target == self.domain && query.node.as_deref() == Some(NODE_COMMANDS) =>
             {
-                return Err(XmppError::service_unavailable(Some(format!(
-                    "Ad-hoc commands node {} is not supported",
-                    NODE_COMMANDS
-                ))));
+                // disco#info on the commands node - advertise that we support commands
+                debug!("disco#info query to commands node");
+                (
+                    vec![Identity::automation(Some("Ad-Hoc Commands"))],
+                    vec![
+                        crate::disco::Feature::disco_info(),
+                        crate::disco::Feature::disco_items(),
+                        crate::disco::Feature::new(crate::xep::xep0050::NS_COMMANDS),
+                    ],
+                    vec![],
+                )
             }
             // Query to server domain
             Some(target) if target == self.domain => {
@@ -4415,10 +4427,13 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             Some(target)
                 if target == self.domain && query.node.as_deref() == Some(NODE_COMMANDS) =>
             {
-                return Err(XmppError::service_unavailable(Some(format!(
-                    "Ad-hoc commands node {} is not supported",
-                    NODE_COMMANDS
-                ))));
+                // disco#items on commands node - return list of available commands
+                debug!("disco#items query to commands node - listing available commands");
+                let commands = self.command_registry.list_commands().await;
+                commands
+                    .into_iter()
+                    .map(|(node, name)| DiscoItem::command(&self.domain, &node, &name))
+                    .collect()
             }
             // Query to server domain - return all service components
             Some(target) if target == self.domain => {
@@ -7549,6 +7564,91 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
         let response = build_push_disable_result(&iq);
         self.stream.write_stanza(&Stanza::Iq(response)).await
+    }
+
+    /// Handle an ad-hoc command IQ (XEP-0050).
+    async fn handle_command_iq(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
+        use crate::commands::{CommandContext, CommandResult};
+        use crate::xep::xep0050::{build_command_result, parse_command_from_iq, Status};
+
+        let sender_jid = match &self.jid {
+            Some(jid) => jid.clone().into(),
+            None => {
+                warn!("Command IQ received before JID bound");
+                return Err(XmppError::not_authorized(Some("Not authenticated".into())));
+            }
+        };
+
+        // Parse the command from the IQ
+        let command = match parse_command_from_iq(&iq) {
+            Ok(cmd) => cmd,
+            Err(e) => {
+                return Err(XmppError::bad_request(Some(format!(
+                    "Invalid command request: {}",
+                    e
+                ))));
+            }
+        };
+
+        debug!(
+            from = %sender_jid,
+            node = %command.node,
+            action = ?command.action,
+            session_id = ?command.session_id,
+            "Processing ad-hoc command"
+        );
+
+        // Build command context
+        let node = command.node.clone();
+        let session_id = command.session_id.clone();
+        let ctx = CommandContext {
+            from: sender_jid,
+            iq: iq.clone(),
+            command,
+        };
+
+        // Dispatch to command registry
+        let result = self.command_registry.dispatch(ctx).await;
+
+        // Convert CommandResult to IQ response
+        let response_command = match result {
+            CommandResult::Executing {
+                form,
+                session_id,
+                notes,
+            } => {
+                let mut cmd = crate::xep::xep0050::Command::new(node.clone());
+                cmd.status = Some(Status::Executing);
+                cmd.session_id = Some(session_id);
+                cmd.form = Some(form);
+                cmd.notes = notes;
+                cmd
+            }
+            CommandResult::Completed { form, notes } => {
+                let mut cmd = crate::xep::xep0050::Command::new(node.clone());
+                cmd.status = Some(Status::Completed);
+                cmd.session_id = session_id.clone();
+                cmd.form = form;
+                cmd.notes = notes;
+                cmd
+            }
+            CommandResult::Canceled { notes } => {
+                let mut cmd = crate::xep::xep0050::Command::new(node.clone());
+                cmd.status = Some(Status::Canceled);
+                cmd.session_id = session_id.clone();
+                cmd.notes = notes;
+                cmd
+            }
+            CommandResult::Error(err) => {
+                return Err(err);
+            }
+        };
+
+        let response = build_command_result(&iq, &response_command);
+        self.stream.write_stanza(&Stanza::Iq(response)).await?;
+
+        debug!("Sent command result");
+        Ok(())
     }
 }
 

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -2389,6 +2389,14 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                 {
                     (data, false)
                 } else {
+                    // Block instant room creation for managed channel JIDs
+                    // Managed channels must be created via XEP-0050 ad-hoc commands
+                    if crate::parse_managed_room_jid(&join_req.room_jid).is_some() {
+                        return Err(XmppError::not_allowed(Some(
+                            "Cannot join managed channel room that doesn't exist. Create the channel first using the waddle:create-channel ad-hoc command.".into(),
+                        )));
+                    }
+
                     // Create instant room (XEP-0045 Section 10.1.2)
                     debug!(
                         room = %join_req.room_jid,

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -20,6 +20,7 @@ use crate::carbons::{
     build_carbons_result, build_received_carbon, build_sent_carbon, is_carbons_disable,
     is_carbons_enable, should_copy_message,
 };
+use crate::commands::CommandRegistry;
 use crate::disco::{
     build_disco_info_response_with_extensions, build_disco_items_response,
     build_server_info_abuse_form, is_disco_info_query, is_disco_items_query, muc_room_features,
@@ -99,7 +100,7 @@ use crate::xep::xep0363::{
 };
 use crate::xep::xep0398::AvatarConversion;
 use crate::xep::xep0461::{parse_reply_from_message, thread_id_from_message};
-use crate::{AppState, Session, XmppError};
+use crate::{managed_room_jid, parse_managed_room_jid, AppState, ChannelType, Session, XmppError};
 use waddle_extensions::{message_has_embed_for_namespaces, ExtensionManager};
 
 /// Size of the outbound message channel buffer.
@@ -134,6 +135,37 @@ fn default_presence_status(
         .cloned()
 }
 
+fn room_config_for_channel(
+    channel: &crate::ChannelInfo,
+    channel_type: ChannelType,
+) -> crate::muc::RoomConfig {
+    crate::muc::RoomConfig {
+        name: channel.name.clone(),
+        forum: channel_type.is_forum(),
+        ..Default::default()
+    }
+}
+
+fn reconcile_channel_backed_room(
+    room: &mut crate::muc::MucRoom,
+    room_jid: &jid::BareJid,
+    room_info: &crate::ChannelRoomInfo,
+    channel_type: ChannelType,
+) {
+    let instant_name = room_jid.node().map(|node| node.to_string());
+    let mut desired_config = room_config_for_channel(&room_info.channel, channel_type);
+
+    desired_config.description = room.config.description.clone();
+    desired_config.subject = room.config.subject.clone();
+
+    if !room.config.name.is_empty() && instant_name.as_deref() != Some(room.config.name.as_str()) {
+        desired_config.name = room.config.name.clone();
+    }
+
+    room.waddle_id = room_info.waddle_id.clone();
+    room.channel_id = room_info.channel.id.clone();
+    room.config = desired_config;
+}
 /// Receiver for outbound stanzas to be sent to this connection.
 type OutboundReceiver = mpsc::Receiver<OutboundStanza>;
 
@@ -199,13 +231,15 @@ pub struct ConnectionActor<S: AppState, M: MamStorage> {
     push_store: Arc<dyn crate::push::PushSubscriptionStore + Send + Sync>,
     /// XEP-0357 Push notification sender
     push_sender: Arc<dyn crate::push::WebPushSender + Send + Sync>,
+    /// XEP-0050 Ad-Hoc Commands registry
+    command_registry: Arc<CommandRegistry>,
 }
 
 impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
     /// Handle a new incoming connection.
     #[instrument(
         name = "xmpp.connection.handle",
-        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, extension_manager, push_store, push_sender),
+        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, extension_manager, push_store, push_sender, command_registry),
         fields(peer = %peer_addr)
     )]
     #[allow(clippy::too_many_arguments)]
@@ -226,6 +260,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         single_tenant: bool,
         push_store: Arc<dyn crate::push::PushSubscriptionStore + Send + Sync>,
         push_sender: Arc<dyn crate::push::WebPushSender + Send + Sync>,
+        command_registry: Arc<CommandRegistry>,
     ) -> Result<(), XmppError> {
         info!("New connection from {}", peer_addr);
 
@@ -257,6 +292,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             single_tenant,            // XEP-0503: single-tenant mode for spaces
             push_store,               // XEP-0357: push subscription store
             push_sender,              // XEP-0357: push notification sender
+            command_registry,         // XEP-0050: ad-hoc commands
         };
 
         actor.run(tls_acceptor, registration_enabled).await
@@ -2241,6 +2277,69 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         }
     }
 
+    async fn ensure_channel_backed_room(
+        &self,
+        room_jid: &jid::BareJid,
+        room_info: &crate::ChannelRoomInfo,
+    ) -> Result<Arc<tokio::sync::RwLock<crate::muc::MucRoom>>, XmppError> {
+        let channel_type =
+            ChannelType::parse(&room_info.channel.channel_type).ok_or_else(|| {
+                XmppError::service_unavailable(Some(format!(
+                    "Unsupported channel type '{}'",
+                    room_info.channel.channel_type
+                )))
+            })?;
+        self.room_registry.get_or_create_room(
+            room_jid.clone(),
+            room_info.waddle_id.clone(),
+            room_info.channel.id.clone(),
+            room_config_for_channel(&room_info.channel, channel_type),
+        )?;
+
+        let room_data = self.room_registry.get_room_data(room_jid).ok_or_else(|| {
+            XmppError::internal("Failed to get room data after channel materialization".to_string())
+        })?;
+
+        {
+            let mut room = room_data.write().await;
+            reconcile_channel_backed_room(&mut room, room_jid, room_info, channel_type);
+        }
+
+        Ok(room_data)
+    }
+
+    async fn materialize_room_from_channel_metadata(
+        &self,
+        room_jid: &jid::BareJid,
+    ) -> Result<Option<Arc<tokio::sync::RwLock<crate::muc::MucRoom>>>, XmppError> {
+        let Some((waddle_id, channel_id)) = parse_managed_room_jid(room_jid) else {
+            return Ok(None);
+        };
+
+        let room_info = self
+            .app_state
+            .get_channel_room_info(&waddle_id, &channel_id)
+            .await?
+            .ok_or_else(|| {
+                XmppError::item_not_found(Some(format!(
+                    "Managed channel room {} not found",
+                    room_jid
+                )))
+            })?;
+
+        debug!(
+            room = %room_jid,
+            channel_id = %room_info.channel.id,
+            waddle_id = %room_info.waddle_id,
+            channel_type = %room_info.channel.channel_type,
+            "Materializing room from channel metadata"
+        );
+
+        self.ensure_channel_backed_room(room_jid, &room_info)
+            .await
+            .map(Some)
+    }
+
     /// Handle a MUC join request.
     ///
     /// Per XEP-0045:
@@ -2269,32 +2368,6 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             ))));
         }
 
-        // Get the room data, or create an instant room if it doesn't exist
-        // Per XEP-0045 Section 10.1.2, rooms can be created dynamically when a user joins
-        let (room_data, room_created) = match self.room_registry.get_room_data(&join_req.room_jid) {
-            Some(data) => (data, false),
-            None => {
-                // Create instant room (XEP-0045 Section 10.1.2)
-                debug!(
-                    room = %join_req.room_jid,
-                    creator = %join_req.sender_jid,
-                    "Creating instant room on first join"
-                );
-                self.room_registry
-                    .create_instant_room(join_req.room_jid.clone())?;
-                (
-                    self.room_registry
-                        .get_room_data(&join_req.room_jid)
-                        .ok_or_else(|| {
-                            XmppError::internal(
-                                "Failed to get room data after creation".to_string(),
-                            )
-                        })?,
-                    true,
-                )
-            }
-        };
-
         // Get the user identifier from the session for permission checking.
         let user_id = self
             .session
@@ -2304,6 +2377,39 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                 // Fallback to bare JID in edge-case test flows where no session is attached.
                 join_req.sender_jid.to_bare().to_string()
             });
+
+        // Get the room data, materialize it from stored channel metadata, or create an instant
+        // room if nothing backs this JID.
+        let (room_data, room_created) = match self.room_registry.get_room_data(&join_req.room_jid) {
+            Some(data) => (data, false),
+            None => {
+                if let Some(data) = self
+                    .materialize_room_from_channel_metadata(&join_req.room_jid)
+                    .await?
+                {
+                    (data, false)
+                } else {
+                    // Create instant room (XEP-0045 Section 10.1.2)
+                    debug!(
+                        room = %join_req.room_jid,
+                        creator = %join_req.sender_jid,
+                        "Creating instant room on first join"
+                    );
+                    self.room_registry
+                        .create_instant_room(join_req.room_jid.clone())?;
+                    (
+                        self.room_registry
+                            .get_room_data(&join_req.room_jid)
+                            .ok_or_else(|| {
+                                XmppError::internal(
+                                    "Failed to get room data after creation".to_string(),
+                                )
+                            })?,
+                        true,
+                    )
+                }
+            }
+        };
 
         // Lock the room for modification
         let mut room = room_data.write().await;
@@ -2684,13 +2790,21 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             }
 
             for (waddle_id, channel) in batch {
-                // Derive room JID: channel_id@muc.domain
-                // Using channel ID (UUID) as the room local part for uniqueness
-                let room_jid_str = format!("{}@{}", channel.id, muc_domain);
-                let room_jid: jid::BareJid = match room_jid_str.parse() {
+                let Some(channel_type) = ChannelType::parse(&channel.channel_type) else {
+                    warn!(
+                        waddle_id = %waddle_id,
+                        channel_id = %channel.id,
+                        channel_type = %channel.channel_type,
+                        "Skipping auto-join for unsupported channel type"
+                    );
+                    continue;
+                };
+
+                let room_jid = match managed_room_jid(waddle_id, &channel.id, &muc_domain) {
                     Ok(jid) => jid,
                     Err(e) => {
                         warn!(
+                            waddle_id = %waddle_id,
                             channel_id = %channel.id,
                             error = ?e,
                             "Invalid room JID, skipping"
@@ -2699,26 +2813,24 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                     }
                 };
 
-                // Ensure the room exists in the registry with proper waddle/channel metadata
-                if self.room_registry.get_room_data(&room_jid).is_none() {
-                    let config = crate::muc::RoomConfig {
-                        name: channel.name.clone(),
-                        ..Default::default()
-                    };
-                    if let Err(e) = self.room_registry.get_or_create_room(
-                        room_jid.clone(),
-                        waddle_id.clone(),
-                        channel.id.clone(),
-                        config,
-                    ) {
-                        warn!(
-                            room = %room_jid,
-                            error = %e,
-                            "Failed to create room for auto-join, skipping"
-                        );
-                        continue;
-                    }
+                let room_info = crate::ChannelRoomInfo {
+                    waddle_id: waddle_id.clone(),
+                    channel: channel.clone(),
+                };
+                if let Err(e) = self.ensure_channel_backed_room(&room_jid, &room_info).await {
+                    warn!(
+                        room = %room_jid,
+                        error = %e,
+                        "Failed to create room for auto-join, skipping"
+                    );
+                    continue;
                 }
+
+                debug!(
+                    room = %room_jid,
+                    forum = channel_type.is_forum(),
+                    "Prepared managed room for auto-join"
+                );
 
                 // Build a MUC join request
                 // Use nick with suffix if there's a conflict
@@ -4121,28 +4233,36 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                     .parse()
                     .map_err(|e| XmppError::bad_request(Some(format!("Invalid JID: {}", e))))?;
 
-                if let Some(room_data) = self.room_registry.get_room_data(&room_jid) {
-                    let room = room_data.read().await;
-                    debug!(room = %room_jid, "disco#info query to MUC room");
-                    (
-                        vec![Identity::muc_room(Some(&room.config.name))],
-                        merge_extension_features(
-                            muc_room_features(
-                                room.config.persistent,
-                                room.config.members_only,
-                                room.config.moderated,
-                            ),
-                            &extension_features,
+                let room_data = match self.room_registry.get_room_data(&room_jid) {
+                    Some(data) => data,
+                    None => match self
+                        .materialize_room_from_channel_metadata(&room_jid)
+                        .await?
+                    {
+                        Some(data) => data,
+                        None => {
+                            return Err(XmppError::item_not_found(Some(format!(
+                                "Room {} not found",
+                                room_jid
+                            ))));
+                        }
+                    },
+                };
+                let room = room_data.read().await;
+                debug!(room = %room_jid, "disco#info query to MUC room");
+                (
+                    vec![Identity::muc_room(Some(&room.config.name))],
+                    merge_extension_features(
+                        muc_room_features(
+                            room.config.persistent,
+                            room.config.members_only,
+                            room.config.moderated,
+                            room.config.forum,
                         ),
-                        vec![],
-                    )
-                } else {
-                    // Room doesn't exist
-                    return Err(XmppError::item_not_found(Some(format!(
-                        "Room {} not found",
-                        room_jid
-                    ))));
-                }
+                        &extension_features,
+                    ),
+                    vec![],
+                )
             }
             // Query to a bare JID (user@domain) - PEP service (XEP-0163)
             Some(target) if target.contains('@') && !target.contains('/') => {
@@ -5146,9 +5266,20 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
                 Ok(channels
                     .iter()
-                    .map(|c| {
-                        let room_jid = format!("{}_{}@{}", node, c.id, muc_domain);
-                        DiscoItem::muc_room(&room_jid, &c.name)
+                    .filter_map(|c| {
+                        if ChannelType::parse(&c.channel_type).is_none() {
+                            warn!(
+                                waddle_id = %node,
+                                channel_id = %c.id,
+                                channel_type = %c.channel_type,
+                                "Skipping unsupported channel type in spaces disco#items"
+                            );
+                            return None;
+                        }
+
+                        managed_room_jid(node, &c.id, muc_domain)
+                            .ok()
+                            .map(|room_jid| DiscoItem::muc_room(&room_jid.to_string(), &c.name))
                     })
                     .collect())
             }
@@ -5212,7 +5343,9 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
                 let mut items: Vec<PubSubItem> = channels
                     .iter()
-                    .filter_map(|c| crate::xep::xep0503::build_channel_item(c, muc_domain).ok())
+                    .filter_map(|c| {
+                        crate::xep::xep0503::build_channel_item(&node, c, muc_domain).ok()
+                    })
                     .collect();
 
                 // Apply item_ids filter if specified
@@ -6350,18 +6483,24 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         // Get the room
         let room_data = match self.room_registry.get_room_data(&query.room_jid) {
             Some(data) => data,
-            None => {
-                let error = crate::generate_iq_error(
-                    &iq.id,
-                    iq.to.as_ref().map(|j| j.to_string()).as_deref(),
-                    iq.from.as_ref().map(|j| j.to_string()).as_deref(),
-                    crate::StanzaErrorCondition::ItemNotFound,
-                    crate::StanzaErrorType::Cancel,
-                    Some(&format!("Room {} not found", query.room_jid)),
-                );
-                self.stream.write_raw(&error).await?;
-                return Ok(());
-            }
+            None => match self
+                .materialize_room_from_channel_metadata(&query.room_jid)
+                .await?
+            {
+                Some(data) => data,
+                None => {
+                    let error = crate::generate_iq_error(
+                        &iq.id,
+                        iq.to.as_ref().map(|j| j.to_string()).as_deref(),
+                        iq.from.as_ref().map(|j| j.to_string()).as_deref(),
+                        crate::StanzaErrorCondition::ItemNotFound,
+                        crate::StanzaErrorType::Cancel,
+                        Some(&format!("Room {} not found", query.room_jid)),
+                    );
+                    self.stream.write_raw(&error).await?;
+                    return Ok(());
+                }
+            },
         };
 
         if query.is_get {
@@ -7720,8 +7859,92 @@ impl Stanza {
 
 #[cfg(test)]
 mod tests {
+    use super::reconcile_channel_backed_room;
     use super::resolves_to_disallowed_ip;
     use super::validate_push_endpoint;
+    use crate::muc::{MucRoom, RoomConfig};
+    use crate::{ChannelInfo, ChannelRoomInfo, ChannelType};
+
+    #[test]
+    fn reconcile_channel_backed_room_resets_instant_room_to_managed_defaults() {
+        let room_jid: jid::BareJid = "waddle-forums_forum-channel@muc.localhost"
+            .parse()
+            .expect("valid room jid");
+        let mut room = MucRoom::new(
+            room_jid.clone(),
+            "instant:waddle-forums_forum-channel".to_string(),
+            "waddle-forums_forum-channel".to_string(),
+            RoomConfig {
+                name: "waddle-forums_forum-channel".to_string(),
+                persistent: false,
+                members_only: false,
+                enable_logging: false,
+                ..RoomConfig::default()
+            },
+        );
+        room.config.description = Some("Preserved description".to_string());
+        room.config.subject = Some("Preserved subject".to_string());
+
+        let room_info = ChannelRoomInfo {
+            waddle_id: "waddle-forums".to_string(),
+            channel: ChannelInfo {
+                id: "forum-channel".to_string(),
+                name: "Announcements".to_string(),
+                channel_type: "forum".to_string(),
+            },
+        };
+
+        reconcile_channel_backed_room(&mut room, &room_jid, &room_info, ChannelType::Forum);
+
+        assert_eq!(room.waddle_id, "waddle-forums");
+        assert_eq!(room.channel_id, "forum-channel");
+        assert_eq!(room.config.name, "Announcements");
+        assert_eq!(
+            room.config.description.as_deref(),
+            Some("Preserved description")
+        );
+        assert_eq!(room.config.subject.as_deref(), Some("Preserved subject"));
+        assert!(room.config.persistent);
+        assert!(room.config.members_only);
+        assert!(!room.config.moderated);
+        assert_eq!(room.config.max_occupants, 0);
+        assert!(room.config.enable_logging);
+        assert!(room.config.forum);
+    }
+
+    #[test]
+    fn reconcile_channel_backed_room_preserves_non_placeholder_name() {
+        let room_jid: jid::BareJid = "waddle-forums_forum-channel@muc.localhost"
+            .parse()
+            .expect("valid room jid");
+        let mut room = MucRoom::new(
+            room_jid.clone(),
+            "legacy".to_string(),
+            "legacy".to_string(),
+            RoomConfig {
+                name: "Custom room name".to_string(),
+                persistent: false,
+                members_only: false,
+                ..RoomConfig::default()
+            },
+        );
+
+        let room_info = ChannelRoomInfo {
+            waddle_id: "waddle-forums".to_string(),
+            channel: ChannelInfo {
+                id: "forum-channel".to_string(),
+                name: "Announcements".to_string(),
+                channel_type: "forum".to_string(),
+            },
+        };
+
+        reconcile_channel_backed_room(&mut room, &room_jid, &room_info, ChannelType::Forum);
+
+        assert_eq!(room.config.name, "Custom room name");
+        assert!(room.config.persistent);
+        assert!(room.config.members_only);
+        assert!(room.config.forum);
+    }
 
     #[test]
     fn accepts_public_https_endpoint() {

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -336,6 +336,11 @@ impl Feature {
     pub fn spaces() -> Self {
         Self::new("urn:xmpp:spaces:0")
     }
+
+    /// XEP-0508 Forums feature.
+    pub fn forums() -> Self {
+        Self::new(crate::xep::NS_FORUMS)
+    }
 }
 
 /// Check if an IQ is a disco#info query.
@@ -548,7 +553,12 @@ pub fn muc_service_features() -> Vec<Feature> {
 }
 
 /// Get features for a MUC room based on configuration.
-pub fn muc_room_features(persistent: bool, members_only: bool, moderated: bool) -> Vec<Feature> {
+pub fn muc_room_features(
+    persistent: bool,
+    members_only: bool,
+    moderated: bool,
+    forum: bool,
+) -> Vec<Feature> {
     let mut features = vec![
         Feature::disco_info(),
         Feature::muc(),
@@ -560,6 +570,10 @@ pub fn muc_room_features(persistent: bool, members_only: bool, moderated: bool) 
         Feature::occupant_id(),
         Feature::muc_semianonymous(),
     ];
+
+    if forum {
+        features.push(Feature::forums());
+    }
 
     if persistent {
         features.push(Feature::muc_persistent());
@@ -669,12 +683,13 @@ mod tests {
 
     #[test]
     fn test_muc_room_features() {
-        let features = muc_room_features(true, true, false);
+        let features = muc_room_features(true, true, false, true);
         assert!(features.contains(&Feature::muc()));
         assert!(features.contains(&Feature::muc_persistent()));
         assert!(features.contains(&Feature::muc_membersonly()));
         assert!(features.contains(&Feature::muc_unmoderated()));
         assert!(features.contains(&Feature::replies()));
+        assert!(features.contains(&Feature::forums()));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -75,6 +75,11 @@ impl Identity {
     pub fn spaces_service(name: Option<&str>) -> Self {
         Self::new("pubsub", "service", name)
     }
+
+    /// Automation identity (category="automation", type="command-node") for XEP-0050.
+    pub fn automation(name: Option<&str>) -> Self {
+        Self::new("automation", "command-node", name)
+    }
 }
 
 /// Feature element for disco#info response.
@@ -493,6 +498,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::private_storage(),
         Feature::avatar_metadata_notify(),
         Feature::pep_vcard_conversion(),
+        Feature::new(crate::xep::xep0050::NS_COMMANDS), // XEP-0050: Ad-Hoc Commands
     ]
 }
 

--- a/server/crates/waddle-xmpp/src/disco/items.rs
+++ b/server/crates/waddle-xmpp/src/disco/items.rs
@@ -79,6 +79,11 @@ impl DiscoItem {
     pub fn pubsub_node(jid: &str, node: &str) -> Self {
         Self::new(jid, None, Some(node))
     }
+
+    /// Create an ad-hoc command item (XEP-0050).
+    pub fn command(jid: &str, node: &str, name: &str) -> Self {
+        Self::new(jid, Some(name), Some(node))
+    }
 }
 
 /// Check if an IQ is a disco#items query.

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -25,6 +25,7 @@
 pub mod auth;
 pub mod c2s;
 pub mod carbons;
+pub mod commands;
 pub mod connection;
 pub mod disco;
 pub mod isr;
@@ -32,6 +33,7 @@ pub mod mam;
 pub mod metrics;
 pub mod muc;
 pub mod parser;
+pub mod parser_utils;
 pub mod presence;
 pub mod prometheus;
 pub mod pubsub;
@@ -391,6 +393,16 @@ pub trait AppState: Send + Sync + 'static {
         waddle_id: &str,
     ) -> impl std::future::Future<Output = Result<Vec<ChannelInfo>, XmppError>> + Send;
 
+    /// Look up channel-backed room metadata by channel ID.
+    ///
+    /// Used when a room is materialized from stored channel metadata instead of
+    /// falling back to a generic instant room.
+    fn get_channel_room_info(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<ChannelRoomInfo>, XmppError>> + Send;
+
     // =========================================================================
     // XEP-0503: Spaces Service (Waddle Details)
     // =========================================================================
@@ -436,10 +448,85 @@ pub struct WaddleInfo {
 pub struct ChannelInfo {
     /// Channel ID
     pub id: String,
-    /// Channel name (used to derive MUC room JID local part)
+    /// Channel name
     pub name: String,
-    /// Channel type (e.g., "text", "voice")
+    /// Channel type (e.g., "text", "forum")
     pub channel_type: String,
+}
+
+/// Channel-backed MUC room metadata.
+#[derive(Debug, Clone)]
+pub struct ChannelRoomInfo {
+    /// Waddle ID that owns the channel.
+    pub waddle_id: String,
+    /// Channel metadata.
+    pub channel: ChannelInfo,
+}
+
+/// Supported managed channel types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelType {
+    /// Standard text chat channel.
+    Text,
+    /// XEP-0508 forum channel.
+    Forum,
+}
+
+impl ChannelType {
+    /// Parse a stored channel type into a supported managed channel type.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "text" => Some(Self::Text),
+            "forum" => Some(Self::Forum),
+            _ => None,
+        }
+    }
+
+    /// Convert this channel type to the canonical stored string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Text => "text",
+            Self::Forum => "forum",
+        }
+    }
+
+    /// Returns true when this channel should be exposed as a forum room.
+    pub fn is_forum(self) -> bool {
+        matches!(self, Self::Forum)
+    }
+}
+
+/// Build the canonical localpart for a managed channel room.
+pub fn managed_room_localpart(waddle_id: &str, channel_id: &str) -> String {
+    format!("{waddle_id}_{channel_id}")
+}
+
+/// Parse the canonical localpart for a managed channel room.
+pub fn parse_managed_room_localpart(localpart: &str) -> Option<(String, String)> {
+    let (waddle_id, channel_id) = localpart.split_once('_')?;
+    if waddle_id.is_empty() || channel_id.is_empty() {
+        return None;
+    }
+    Some((waddle_id.to_string(), channel_id.to_string()))
+}
+
+/// Parse a bare room JID into managed channel coordinates.
+pub fn parse_managed_room_jid(room_jid: &jid::BareJid) -> Option<(String, String)> {
+    parse_managed_room_localpart(room_jid.node()?.as_str())
+}
+
+/// Build the canonical bare JID for a managed channel room.
+pub fn managed_room_jid(
+    waddle_id: &str,
+    channel_id: &str,
+    muc_domain: &str,
+) -> Result<jid::BareJid, jid::Error> {
+    format!(
+        "{}@{}",
+        managed_room_localpart(waddle_id, channel_id),
+        muc_domain
+    )
+    .parse()
 }
 
 /// Detailed waddle information for XEP-0503 spaces service.
@@ -470,6 +557,43 @@ pub struct UploadSlotInfo {
     pub get_url: String,
     /// Optional headers to include with the PUT request.
     pub put_headers: Vec<(String, String)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn managed_room_helpers_round_trip() {
+        let localpart = managed_room_localpart("waddle-1", "channel-9");
+        assert_eq!(localpart, "waddle-1_channel-9");
+        assert_eq!(
+            parse_managed_room_localpart(&localpart),
+            Some(("waddle-1".to_string(), "channel-9".to_string()))
+        );
+
+        let room_jid =
+            managed_room_jid("waddle-1", "channel-9", "muc.example.com").expect("managed room jid");
+        assert_eq!(room_jid.to_string(), "waddle-1_channel-9@muc.example.com");
+        assert_eq!(
+            parse_managed_room_jid(&room_jid),
+            Some(("waddle-1".to_string(), "channel-9".to_string()))
+        );
+    }
+
+    #[test]
+    fn managed_room_parser_rejects_invalid_localparts() {
+        assert_eq!(parse_managed_room_localpart("single"), None);
+        assert_eq!(parse_managed_room_localpart("_channel"), None);
+        assert_eq!(parse_managed_room_localpart("waddle_"), None);
+    }
+
+    #[test]
+    fn supported_channel_types_are_explicit() {
+        assert_eq!(ChannelType::parse("text"), Some(ChannelType::Text));
+        assert_eq!(ChannelType::parse("forum"), Some(ChannelType::Forum));
+        assert_eq!(ChannelType::parse("voice"), None);
+    }
 }
 
 /// User session information.

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -106,6 +106,9 @@ pub struct RoomConfig {
     pub max_occupants: u32,
     /// Whether to log messages (for MAM)
     pub enable_logging: bool,
+    /// Whether the room is in forum mode (XEP-0508)
+    #[serde(default)]
+    pub forum: bool,
     /// Federation permission policy for this room.
     ///
     /// Controls which users from remote servers can join this room.
@@ -129,6 +132,7 @@ impl Default for RoomConfig {
             moderated: false,
             max_occupants: 0,
             enable_logging: true,
+            forum: false,
             federation_policy: FederatedPermissionPolicy::default(),
             federated_affiliation_config: FederatedAffiliationConfig::open_member(),
         }

--- a/server/crates/waddle-xmpp/src/muc/owner.rs
+++ b/server/crates/waddle-xmpp/src/muc/owner.rs
@@ -17,6 +17,7 @@ use xmpp_parsers::presence::Presence;
 
 use super::{MucRoom, RoomConfig, NS_MUC_OWNER};
 use crate::xep::xep0004::{self, DataForm, Field, FormType, FromElement, IntoElement};
+use crate::xep::FIELD_FORUM_MODE;
 use crate::XmppError;
 
 /// Namespace for XEP-0004 Data Forms (re-exported for backward compatibility).
@@ -66,6 +67,8 @@ pub struct ConfigFormData {
     pub max_occupants: Option<u32>,
     /// Whether to enable logging (muc#roomconfig_enablelogging)
     pub enable_logging: Option<bool>,
+    /// Whether forum mode is enabled (muc#roomconfig_forum)
+    pub forum: Option<bool>,
 }
 
 /// Room destruction request.
@@ -220,6 +223,9 @@ fn parse_config_form(form_elem: &Element) -> Result<ConfigFormData, XmppError> {
             "muc#roomconfig_enablelogging" => {
                 config.enable_logging = field.value_as_bool();
             }
+            FIELD_FORUM_MODE => {
+                config.forum = field.value_as_bool();
+            }
             "FORM_TYPE" => {
                 // Ignore the FORM_TYPE field
             }
@@ -272,6 +278,7 @@ pub fn build_config_form(room: &MucRoom) -> Element {
             Field::boolean("muc#roomconfig_enablelogging", room.config.enable_logging)
                 .with_label("Enable Room Logging"),
         )
+        .add_field(Field::boolean(FIELD_FORUM_MODE, room.config.forum).with_label("Forum Mode"))
         .into_element()
 }
 
@@ -431,6 +438,9 @@ pub fn apply_config_form(config: &mut RoomConfig, form_data: &ConfigFormData) {
     if let Some(enable_logging) = form_data.enable_logging {
         config.enable_logging = enable_logging;
     }
+    if let Some(forum) = form_data.forum {
+        config.forum = forum;
+    }
 }
 
 #[cfg(test)]
@@ -521,6 +531,7 @@ mod tests {
                 "Logging",
                 true,
             ))
+            .append(build_field_boolean(FIELD_FORUM_MODE, "Forum Mode", true))
             .build()
     }
 
@@ -550,6 +561,7 @@ mod tests {
                 assert_eq!(config.moderated, Some(true));
                 assert_eq!(config.max_occupants, Some(50));
                 assert_eq!(config.enable_logging, Some(true));
+                assert_eq!(config.forum, Some(true));
             }
             _ => panic!("Expected SetConfig action"),
         }
@@ -606,6 +618,7 @@ mod tests {
             moderated: Some(true),
             max_occupants: Some(100),
             enable_logging: Some(false),
+            forum: Some(true),
         };
 
         apply_config_form(&mut config, &form_data);
@@ -617,6 +630,7 @@ mod tests {
         assert!(config.moderated);
         assert_eq!(config.max_occupants, 100);
         assert!(!config.enable_logging);
+        assert!(config.forum);
     }
 
     #[test]
@@ -633,6 +647,7 @@ mod tests {
                 moderated: false,
                 max_occupants: 25,
                 enable_logging: true,
+                forum: true,
                 ..Default::default()
             },
         );
@@ -649,6 +664,15 @@ mod tests {
             .find(|c| c.attr("var") == Some("FORM_TYPE"))
             .expect("FORM_TYPE field should exist");
         assert_eq!(form_type.attr("type"), Some("hidden"));
+
+        let forum_field = form
+            .children()
+            .find(|c| c.attr("var") == Some(FIELD_FORUM_MODE))
+            .expect("forum field should exist");
+        let forum_value = forum_field
+            .get_child("value", DATA_FORMS_NS)
+            .expect("forum field should contain a value");
+        assert_eq!(forum_value.text(), "1");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/muc/owner.rs
+++ b/server/crates/waddle-xmpp/src/muc/owner.rs
@@ -105,6 +105,21 @@ pub fn parse_owner_query(iq: &Iq, muc_domain: &str) -> Result<OwnerQuery, XmppEr
         ))));
     }
 
+    // Block instant room creation/configuration for managed channel JIDs
+    // Managed channels must be created via XEP-0050 ad-hoc commands (waddle:create-channel)
+    // Pattern: {waddle_id}_{channel_id}@muc.{domain}
+    let localpart = room_jid.node().map(|n| n.as_str()).unwrap_or("");
+    if localpart.contains('_') {
+        // Check if this looks like a managed channel JID pattern
+        let parts: Vec<&str> = localpart.split('_').collect();
+        if parts.len() == 2 {
+            // This could be a managed channel JID - block room creation/config
+            return Err(XmppError::not_allowed(Some(
+                "Cannot create or configure managed channel rooms directly. Use the waddle:create-channel ad-hoc command instead.".into(),
+            )));
+        }
+    }
+
     // Get the sender's JID
     let from = iq
         .from

--- a/server/crates/waddle-xmpp/src/muc/owner.rs
+++ b/server/crates/waddle-xmpp/src/muc/owner.rs
@@ -108,12 +108,9 @@ pub fn parse_owner_query(iq: &Iq, muc_domain: &str) -> Result<OwnerQuery, XmppEr
     // Block instant room creation/configuration for managed channel JIDs
     // Managed channels must be created via XEP-0050 ad-hoc commands (waddle:create-channel)
     // Pattern: {waddle_id}_{channel_id}@muc.{domain}
-    let localpart = room_jid.node().map(|n| n.as_str()).unwrap_or("");
-    if localpart.contains('_') {
-        // Check if this looks like a managed channel JID pattern
-        let parts: Vec<&str> = localpart.split('_').collect();
-        if parts.len() == 2 {
-            // This could be a managed channel JID - block room creation/config
+    if let Some(localpart) = room_jid.node() {
+        if crate::parse_managed_room_localpart(localpart.as_str()).is_some() {
+            // This is a managed channel JID - block direct room creation/config
             return Err(XmppError::not_allowed(Some(
                 "Cannot create or configure managed channel rooms directly. Use the waddle:create-channel ad-hoc command instead.".into(),
             )));

--- a/server/crates/waddle-xmpp/src/parser.rs
+++ b/server/crates/waddle-xmpp/src/parser.rs
@@ -790,17 +790,10 @@ pub fn stanza_to_string<T: Into<Element>>(stanza: T) -> Result<String, XmppError
 /// element which `xmpp_parsers 0.21`'s `From<Message> for Element`
 /// incorrectly drops.
 pub fn message_to_string(msg: &xmpp_parsers::message::Message) -> Result<String, XmppError> {
-    let thread_id = msg.thread.as_ref().map(|t| t.0.clone());
+    let thread_id = msg.thread.as_ref().map(|t| t.0.as_str());
     let mut element: Element = msg.clone().into();
 
-    if let Some(id) = thread_id {
-        if !id.trim().is_empty() && !element.children().any(|child| child.name() == "thread") {
-            let thread_elem = Element::builder("thread", element.ns())
-                .append(id.as_str())
-                .build();
-            element.append_child(thread_elem);
-        }
-    }
+    crate::parser_utils::ensure_thread_element(&mut element, thread_id);
 
     element_to_string(&element)
 }

--- a/server/crates/waddle-xmpp/src/parser_utils.rs
+++ b/server/crates/waddle-xmpp/src/parser_utils.rs
@@ -1,0 +1,142 @@
+//! Parser utility functions shared across modules.
+//!
+//! This module provides common parser utilities that are used by both
+//! the stream parser and message serialization logic to avoid code duplication.
+
+use minidom::Element;
+use xmpp_parsers::message::Message;
+
+/// Ensures `<thread/>` element is present in a Message Element.
+///
+/// xmpp_parsers 0.21 drops `<thread/>` when serializing Message back to Element.
+/// This function re-attaches it so RFC 6121 / XEP-0201 metadata survives.
+///
+/// ## Arguments
+/// - `element`: The message Element to potentially modify
+/// - `thread_id`: The thread ID from the parsed Message
+pub fn ensure_thread_element(element: &mut Element, thread_id: Option<&str>) {
+    if let Some(id) = thread_id {
+        if id.trim().is_empty() {
+            // skip empty thread
+        } else if !element.children().any(|child| child.name() == "thread") {
+            let thread_elem = Element::builder("thread", element.ns())
+                .append(id)
+                .build();
+            element.append_child(thread_elem);
+        }
+    }
+}
+
+/// Extract thread parent attribute from a message Element before parsing.
+///
+/// xmpp_parsers 0.21 `Thread(String)` only carries the thread id — the XEP-0201
+/// `parent` attribute would be lost. This function extracts it before parsing.
+///
+/// ## Arguments
+/// - `element`: The message Element to inspect
+///
+/// ## Returns
+/// The parent attribute value if present and non-empty, None otherwise.
+pub fn extract_thread_parent(element: &Element) -> Option<String> {
+    element
+        .children()
+        .find(|child| child.name() == "thread")
+        .and_then(|child| {
+            child
+                .attr("parent")
+                .map(str::trim)
+                .filter(|parent| !parent.is_empty())
+                .map(str::to_owned)
+        })
+}
+
+/// Re-attach thread parent attribute to a Message payload.
+///
+/// After extracting the parent attribute with `extract_thread_parent`, this
+/// function re-attaches it as a raw payload Element so the attribute survives
+/// the round-trip.
+///
+/// ## Arguments
+/// - `msg`: The parsed Message to modify
+/// - `thread_parent`: The parent attribute value
+/// - `stanza_ns`: The namespace for the thread element
+pub fn reattach_thread_parent(msg: &mut Message, thread_parent: String, stanza_ns: &str) {
+    if let Some(thread) = msg.thread.take() {
+        let thread_elem = Element::builder("thread", stanza_ns)
+            .attr("parent", thread_parent)
+            .append(thread.0.as_str())
+            .build();
+        msg.payloads.push(thread_elem);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ensure_thread_element_adds_thread() {
+        let mut element = Element::builder("message", "jabber:client")
+            .attr("from", "alice@localhost")
+            .build();
+
+        ensure_thread_element(&mut element, Some("thread-123"));
+
+        let thread = element.get_child("thread", "jabber:client").unwrap();
+        assert_eq!(thread.text(), "thread-123");
+    }
+
+    #[test]
+    fn test_ensure_thread_element_skips_empty() {
+        let mut element = Element::builder("message", "jabber:client").build();
+
+        ensure_thread_element(&mut element, Some("  "));
+
+        assert!(element.get_child("thread", "jabber:client").is_none());
+    }
+
+    #[test]
+    fn test_ensure_thread_element_skips_existing() {
+        let mut element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "jabber:client")
+                    .append("existing-thread")
+                    .build(),
+            )
+            .build();
+
+        ensure_thread_element(&mut element, Some("new-thread"));
+
+        let thread = element.get_child("thread", "jabber:client").unwrap();
+        assert_eq!(thread.text(), "existing-thread");
+    }
+
+    #[test]
+    fn test_extract_thread_parent() {
+        let element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "jabber:client")
+                    .attr("parent", "parent-123")
+                    .append("thread-456")
+                    .build(),
+            )
+            .build();
+
+        let parent = extract_thread_parent(&element);
+        assert_eq!(parent, Some("parent-123".to_string()));
+    }
+
+    #[test]
+    fn test_extract_thread_parent_none() {
+        let element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "jabber:client")
+                    .append("thread-456")
+                    .build(),
+            )
+            .build();
+
+        let parent = extract_thread_parent(&element);
+        assert_eq!(parent, None);
+    }
+}

--- a/server/crates/waddle-xmpp/src/parser_utils.rs
+++ b/server/crates/waddle-xmpp/src/parser_utils.rs
@@ -19,9 +19,7 @@ pub fn ensure_thread_element(element: &mut Element, thread_id: Option<&str>) {
         if id.trim().is_empty() {
             // skip empty thread
         } else if !element.children().any(|child| child.name() == "thread") {
-            let thread_elem = Element::builder("thread", element.ns())
-                .append(id)
-                .build();
+            let thread_elem = Element::builder("thread", element.ns()).append(id).build();
             element.append_child(thread_elem);
         }
     }

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -91,7 +91,7 @@ impl WebPushSender for HttpWebPushSender {
 
 fn room_jid_to_path(room_jid: &str) -> String {
     let localpart = room_jid.split('@').next().unwrap_or_default();
-    if let Some((waddle_id, channel_id)) = localpart.split_once('_') {
+    if let Some((waddle_id, channel_id)) = crate::parse_managed_room_localpart(localpart) {
         return format!("/{}/{}", waddle_id, channel_id);
     }
     "/".to_string()

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -24,6 +24,7 @@ use crate::routing::{RouterConfig, StanzaRouter};
 use crate::s2s::{S2sListener, S2sListenerConfig};
 use crate::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
 use crate::{AppState, XmppError};
+use crate::commands::CommandRegistry;
 
 /// XMPP server configuration.
 #[derive(Debug, Clone)]
@@ -141,6 +142,8 @@ pub struct XmppServer<S: AppState> {
     push_store: Arc<dyn PushSubscriptionStore + Send + Sync>,
     /// XEP-0357 Push notification sender
     push_sender: Arc<dyn WebPushSender + Send + Sync>,
+    /// XEP-0050 Ad-Hoc Commands registry
+    command_registry: Arc<CommandRegistry>,
     /// C2S listener — passed in by the caller (Ecdysis or fresh-bound).
     c2s_listener: TcpListener,
     /// S2S listener — passed in if S2S federation is enabled.
@@ -200,6 +203,10 @@ impl<S: AppState> XmppServer<S> {
                 .map_err(|e| XmppError::config(format!("Failed to initialize extensions: {e}")))?,
         );
 
+        // Create ad-hoc command registry (XEP-0050)
+        let command_registry = Arc::new(CommandRegistry::new());
+        info!("Command registry initialized");
+
         Ok(Self {
             config,
             app_state,
@@ -213,6 +220,7 @@ impl<S: AppState> XmppServer<S> {
             extension_manager,
             push_store,
             push_sender,
+            command_registry,
             c2s_listener,
             s2s_listener,
             shutdown_token,
@@ -387,6 +395,7 @@ impl<S: AppState> XmppServer<S> {
             let registration_enabled = self.config.registration_enabled;
             let single_tenant = self.config.single_tenant;
             let extension_manager = self.extension_manager;
+            let command_registry = self.command_registry;
 
             tokio::spawn(async move {
                 loop {
@@ -418,6 +427,7 @@ impl<S: AppState> XmppServer<S> {
                     let push_store = Arc::clone(&push_store);
                     let push_sender = Arc::clone(&push_sender);
                     let extension_manager = extension_manager.clone();
+                    let command_registry = Arc::clone(&command_registry);
 
                     tokio::spawn(
                         async move {
@@ -438,6 +448,7 @@ impl<S: AppState> XmppServer<S> {
                                 single_tenant,
                                 push_store,
                                 push_sender,
+                                command_registry,
                             )
                             .await
                             {

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -13,6 +13,7 @@ use tokio_rustls::TlsAcceptor;
 use tracing::{info, info_span, warn, Instrument};
 use waddle_extensions::{ExtensionConfig, ExtensionManager};
 
+use crate::commands::CommandRegistry;
 use crate::connection::ConnectionActor;
 use crate::isr::{create_shared_store, SharedIsrTokenStore};
 use crate::mam::LibSqlMamStorage;
@@ -24,7 +25,6 @@ use crate::routing::{RouterConfig, StanzaRouter};
 use crate::s2s::{S2sListener, S2sListenerConfig};
 use crate::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
 use crate::{AppState, XmppError};
-use crate::commands::CommandRegistry;
 
 /// XMPP server configuration.
 #[derive(Debug, Clone)]

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -511,4 +511,9 @@ impl<S: AppState> XmppServer<S> {
     pub fn mam_storage(&self) -> &Arc<LibSqlMamStorage> {
         &self.mam_storage
     }
+
+    /// Get the ad-hoc command registry.
+    pub fn command_registry(&self) -> &Arc<CommandRegistry> {
+        &self.command_registry
+    }
 }

--- a/server/crates/waddle-xmpp/src/stream.rs
+++ b/server/crates/waddle-xmpp/src/stream.rs
@@ -1270,29 +1270,14 @@ fn pre_bind_target_is_unauthorized(
 /// attribute would be lost otherwise. The thread is re-inserted as a raw
 /// payload so the attribute survives the round-trip.
 pub(crate) fn element_to_message(element: Element) -> Result<Message, XmppError> {
-    let thread_parent = element
-        .children()
-        .find(|child| child.name() == "thread")
-        .and_then(|child| {
-            child
-                .attr("parent")
-                .map(str::trim)
-                .filter(|parent| !parent.is_empty())
-                .map(str::to_owned)
-        });
-    let stanza_ns = element.ns();
+    let thread_parent = crate::parser_utils::extract_thread_parent(&element);
+    let stanza_ns = element.ns().to_string();
 
     let mut msg = Message::try_from(element)
         .map_err(|e| XmppError::xml_parse(format!("Invalid message: {:?}", e)))?;
 
     if let Some(parent) = thread_parent {
-        if let Some(thread) = msg.thread.take() {
-            let thread_elem = Element::builder("thread", stanza_ns)
-                .attr("parent", parent)
-                .append(thread.0.as_str())
-                .build();
-            msg.payloads.push(thread_elem);
-        }
+        crate::parser_utils::reattach_thread_parent(&mut msg, parent, &stanza_ns);
     }
 
     Ok(msg)
@@ -1313,20 +1298,11 @@ fn element_to_iq(element: Element) -> Result<Iq, XmppError> {
 fn stanza_to_xml(stanza: &Stanza) -> Result<String, XmppError> {
     match stanza {
         Stanza::Message(msg) => {
-            let thread_id = msg.thread.as_ref().map(|t| t.0.clone());
+            let thread_id = msg.thread.as_ref().map(|t| t.0.as_str());
             let mut element: Element = msg.clone().into();
             // xmpp_parsers 0.21 drops <thread/> when serializing Message back
             // to Element. Re-attach it so RFC 6121 / XEP-0201 metadata survives.
-            if let Some(id) = thread_id {
-                if id.trim().is_empty() {
-                    // skip empty thread
-                } else if !element.children().any(|child| child.name() == "thread") {
-                    let thread_elem = Element::builder("thread", element.ns())
-                        .append(id.as_str())
-                        .build();
-                    element.append_child(thread_elem);
-                }
-            }
+            crate::parser_utils::ensure_thread_element(&mut element, thread_id);
             element_to_string(&element)
         }
         Stanza::Presence(pres) => {

--- a/server/crates/waddle-xmpp/src/xep/xep0503.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0503.rs
@@ -26,7 +26,7 @@ use minidom::Element;
 use super::xep0004::{DataForm, Field, FormType, IntoElement};
 use crate::pubsub::stanzas::PubSubItem;
 use crate::xep::xep0402;
-use crate::{ChannelInfo, WaddleDetails, XmppError};
+use crate::{managed_room_jid, ChannelInfo, ChannelType, WaddleDetails, XmppError};
 
 /// XEP-0503 Spaces namespace.
 pub const NS_SPACES: &str = "urn:xmpp:spaces:0";
@@ -34,22 +34,31 @@ pub const NS_SPACES: &str = "urn:xmpp:spaces:0";
 /// Build a pubsub `<item>` for a channel inside a space.
 ///
 /// Each channel is represented as an XEP-0402 `<conference>` bookmark element
-/// with the channel's MUC room JID and name. The item ID is the channel ID.
+/// with the channel's canonical MUC room JID and name. The item ID is the room JID.
 pub fn build_channel_item(
+    waddle_id: &str,
     channel: &ChannelInfo,
     muc_domain: &str,
 ) -> Result<PubSubItem, XmppError> {
-    let room_jid_str = format!("{}@{}", channel.id, muc_domain);
-    let room_jid: jid::BareJid = room_jid_str
-        .parse()
-        .map_err(|e| XmppError::internal(format!("Invalid room JID '{}': {}", room_jid_str, e)))?;
+    let Some(_channel_type) = ChannelType::parse(&channel.channel_type) else {
+        return Err(XmppError::bad_request(Some(format!(
+            "Unsupported channel type '{}'",
+            channel.channel_type
+        ))));
+    };
+    let room_jid = managed_room_jid(waddle_id, &channel.id, muc_domain).map_err(|e| {
+        XmppError::internal(format!(
+            "Invalid room JID for managed channel '{}:{}': {}",
+            waddle_id, channel.id, e
+        ))
+    })?;
     let bookmark = xep0402::Bookmark::new(room_jid)
         .with_name(&channel.name)
         .with_autojoin(true);
     let payload = xep0402::build_bookmark_element(&bookmark);
 
     Ok(PubSubItem {
-        id: Some(channel.id.clone()),
+        id: Some(bookmark.jid.to_string()),
         payload: Some(payload),
     })
 }
@@ -128,9 +137,12 @@ mod tests {
             channel_type: "text".to_string(),
         };
 
-        let item = build_channel_item(&channel, "muc.example.com").unwrap();
+        let item = build_channel_item("waddle-1", &channel, "muc.example.com").unwrap();
 
-        assert_eq!(item.id, Some("general".to_string()));
+        assert_eq!(
+            item.id,
+            Some("waddle-1_general@muc.example.com".to_string())
+        );
         assert!(item.payload.is_some());
 
         let payload = item.payload.unwrap();
@@ -148,9 +160,12 @@ mod tests {
             channel_type: "text".to_string(),
         };
 
-        let item = build_channel_item(&channel, "muc.waddle.social").unwrap();
+        let item = build_channel_item("engineering", &channel, "muc.waddle.social").unwrap();
 
-        assert_eq!(item.id, Some("dev-chat".to_string()));
+        assert_eq!(
+            item.id,
+            Some("engineering_dev-chat@muc.waddle.social".to_string())
+        );
 
         let payload = item.payload.unwrap();
         assert_eq!(payload.attr("autojoin"), Some("true"));
@@ -165,11 +180,22 @@ mod tests {
             channel_type: "text".to_string(),
         };
 
-        let item = build_channel_item(&channel, "muc.example.com").unwrap();
+        let item = build_channel_item("waddle", &channel, "muc.example.com").unwrap();
         let payload = item.payload.unwrap();
 
         // Name should be preserved as-is (XML escaping handled by minidom)
         assert_eq!(payload.attr("name"), Some("Hello & World <Test>"));
+    }
+
+    #[test]
+    fn test_build_channel_item_rejects_unknown_channel_type() {
+        let channel = ChannelInfo {
+            id: "voice".to_string(),
+            name: "Voice".to_string(),
+            channel_type: "voice".to_string(),
+        };
+
+        assert!(build_channel_item("waddle", &channel, "muc.example.com").is_err());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -482,6 +482,26 @@ impl AppState for MockAppState {
             .unwrap_or_default())
     }
 
+    async fn get_channel_room_info(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> Result<Option<waddle_xmpp::ChannelRoomInfo>, XmppError> {
+        Ok(self
+            .waddle_channels
+            .get(waddle_id)
+            .and_then(|channels| {
+                channels
+                    .iter()
+                    .find(|channel| channel.id == channel_id)
+                    .cloned()
+            })
+            .map(|channel| waddle_xmpp::ChannelRoomInfo {
+                waddle_id: waddle_id.to_string(),
+                channel,
+            }))
+    }
+
     async fn get_waddle_details(
         &self,
         waddle_id: &str,

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -694,6 +694,8 @@ async fn run_test_server<S: AppState>(
         std::sync::Arc::new(waddle_xmpp::push::HttpWebPushSender::new());
     let extension_manager =
         Arc::new(waddle_extensions::ExtensionManager::from_env().expect("extension manager"));
+    // Create a shared command registry for ad-hoc commands
+    let command_registry = std::sync::Arc::new(waddle_xmpp::commands::CommandRegistry::new());
 
     loop {
         tokio::select! {
@@ -713,12 +715,13 @@ async fn run_test_server<S: AppState>(
                         let push_store = Arc::clone(&push_store);
                         let push_sender = Arc::clone(&push_sender);
                         let ext = Arc::clone(&extension_manager);
+                        let cmd_registry = Arc::clone(&command_registry);
                         // Enable registration for tests
                         let registration_enabled = true;
                         let st = single_tenant;
                         tokio::spawn(async move {
                             let _ = waddle_xmpp::connection::ConnectionActor::handle_connection(
-                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, ext, st, push_store, push_sender
+                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, ext, st, push_store, push_sender, cmd_registry
                             ).await;
                         });
                     }

--- a/server/crates/waddle-xmpp/tests/xep0050_adhoc_commands.rs
+++ b/server/crates/waddle-xmpp/tests/xep0050_adhoc_commands.rs
@@ -10,7 +10,7 @@ use common::{
 };
 
 #[tokio::test]
-async fn xep0050_server_disco_does_not_advertise_commands() {
+async fn xep0050_server_disco_advertises_commands() {
     init_test_env();
     let server = TestServer::start().await;
     let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
@@ -23,14 +23,14 @@ async fn xep0050_server_disco_does_not_advertise_commands() {
         .expect("disco response");
 
     assert!(
-        !response.contains("http://jabber.org/protocol/commands"),
-        "Server should not advertise commands without runtime support, got: {}",
+        response.contains("http://jabber.org/protocol/commands"),
+        "Server should advertise commands support, got: {}",
         response
     );
 }
 
 #[tokio::test]
-async fn xep0050_commands_disco_items_returns_service_unavailable() {
+async fn xep0050_commands_disco_items_lists_available_commands() {
     init_test_env();
     let server = TestServer::start().await;
     let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
@@ -52,14 +52,10 @@ async fn xep0050_commands_disco_items_returns_service_unavailable() {
         .await
         .expect("response");
 
+    // Should return result with available commands (even if the list is empty)
     assert!(
-        response.contains("type='error'") || response.contains("type=\"error\""),
-        "Expected error IQ, got: {}",
-        response
-    );
-    assert!(
-        response.contains("service-unavailable"),
-        "Expected service-unavailable for unsupported commands node, got: {}",
+        response.contains("type='result'") || response.contains("type=\"result\""),
+        "Expected result IQ for commands disco#items, got: {}",
         response
     );
 }
@@ -95,6 +91,81 @@ async fn xep0050_execute_unknown_command_returns_service_unavailable() {
     assert!(
         response.contains("service-unavailable"),
         "Expected service-unavailable, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0050_create_channel_command_prevents_managed_jid_instant_room() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    // Try to join a managed channel JID (waddle_channel pattern) that doesn't exist
+    // This should be blocked to prevent bypassing the create-channel command
+    client
+        .send(
+            "<presence to='test-waddle_test-channel@muc.localhost/alice' xmlns='jabber:client'>\
+                <x xmlns='http://jabber.org/protocol/muc'/>\
+            </presence>",
+        )
+        .await
+        .expect("send");
+
+    // Try to read a response - might get error presence or stream might close
+    match client.read_until("</presence>", DEFAULT_TIMEOUT).await {
+        Ok(response) => {
+            // If we get a response, verify it's not a successful join
+            assert!(
+                !response.contains("<status code='110'/>") &&
+                !response.contains("<status code=\"110\"/>"),
+                "Should not successfully join managed JID without creating channel first, got: {}",
+                response
+            );
+        }
+        Err(_) => {
+            // Timeout or closed stream is acceptable - connection might be terminated on error
+        }
+    }
+}
+
+#[tokio::test]
+async fn xep0050_managed_jid_owner_query_blocked() {
+    init_test_env();
+    let server = TestServer::start().await;
+    let mut client = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .expect("bind");
+
+    // Try to configure a managed channel JID via owner query
+    // This should be blocked
+    client
+        .send(
+            "<iq type='get' id='owner-1' to='test-waddle_test-channel@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='http://jabber.org/protocol/muc#owner'/>\
+            </iq>",
+        )
+        .await
+        .expect("send");
+
+    let response = client
+        .read_until("</iq>", DEFAULT_TIMEOUT)
+        .await
+        .expect("response");
+
+    // Should receive an error with not-allowed
+    assert!(
+        response.contains("type='error'") || response.contains("type=\"error\""),
+        "Expected error IQ for managed JID owner query, got: {}",
+        response
+    );
+    assert!(
+        response.contains("not-allowed"),
+        "Expected not-allowed for managed JID configuration, got: {}",
         response
     );
 }

--- a/server/crates/waddle-xmpp/tests/xep0050_adhoc_commands.rs
+++ b/server/crates/waddle-xmpp/tests/xep0050_adhoc_commands.rs
@@ -120,8 +120,8 @@ async fn xep0050_create_channel_command_prevents_managed_jid_instant_room() {
         Ok(response) => {
             // If we get a response, verify it's not a successful join
             assert!(
-                !response.contains("<status code='110'/>") &&
-                !response.contains("<status code=\"110\"/>"),
+                !response.contains("<status code='110'/>")
+                    && !response.contains("<status code=\"110\"/>"),
                 "Should not successfully join managed JID without creating channel first, got: {}",
                 response
             );

--- a/server/crates/waddle-xmpp/tests/xep0503_spaces.rs
+++ b/server/crates/waddle-xmpp/tests/xep0503_spaces.rs
@@ -319,14 +319,56 @@ async fn xep0503_pubsub_items_returns_bookmarks() {
         response
     );
     assert!(
+        response.contains("waddle-1_general@muc.localhost"),
+        "Expected canonical general room JID, got: {}",
+        response
+    );
+    assert!(
         response.contains("random"),
         "Expected random channel item, got: {}",
+        response
+    );
+    assert!(
+        response.contains("waddle-1_random@muc.localhost"),
+        "Expected canonical random room JID, got: {}",
         response
     );
     // Items should contain conference elements (XEP-0402 bookmarks)
     assert!(
         response.contains("conference"),
         "Expected conference bookmark element, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0503_space_node_disco_items_use_canonical_room_jids() {
+    init_test_env();
+    let state =
+        Arc::new(MockAppState::new("localhost").with_waddle(test_waddle(), test_channels()));
+    let server = TestServer::start_with_state(state).await;
+    let mut client = RawXmppClient::connect(server.addr).await.unwrap();
+    establish_bound_session(&mut client, &server, "alice", "desktop")
+        .await
+        .unwrap();
+
+    let response = disco_items_query(
+        &mut client,
+        "spaces.localhost",
+        "spaces-node-items-1",
+        Some("waddle-1"),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        response.contains("waddle-1_general@muc.localhost"),
+        "Expected canonical general room JID, got: {}",
+        response
+    );
+    assert!(
+        response.contains("waddle-1_random@muc.localhost"),
+        "Expected canonical random room JID, got: {}",
         response
     );
 }

--- a/server/crates/waddle-xmpp/tests/xep0508_forums.rs
+++ b/server/crates/waddle-xmpp/tests/xep0508_forums.rs
@@ -4,21 +4,70 @@
 
 mod common;
 
+use std::sync::Arc;
+
 use common::{
-    establish_bound_session, init_test_env, join_muc_room, RawXmppClient, TestServer,
-    DEFAULT_TIMEOUT,
+    disco_info_query, establish_bound_session, init_test_env, join_muc_room, MockAppState,
+    RawXmppClient, TestServer, DEFAULT_TIMEOUT,
 };
+use minidom::Element;
+
+fn forum_waddle() -> waddle_xmpp::WaddleDetails {
+    waddle_xmpp::WaddleDetails {
+        id: "waddle-forums".to_string(),
+        name: "Forum Waddle".to_string(),
+        description: Some("Forum tests".to_string()),
+        owner_id: "owner".to_string(),
+        icon_url: None,
+        is_public: true,
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+    }
+}
+
+fn forum_channel() -> waddle_xmpp::ChannelInfo {
+    waddle_xmpp::ChannelInfo {
+        id: "forum-channel".to_string(),
+        name: "Announcements".to_string(),
+        channel_type: "forum".to_string(),
+    }
+}
+
+fn forum_channel_two() -> waddle_xmpp::ChannelInfo {
+    waddle_xmpp::ChannelInfo {
+        id: "forum-channel-2".to_string(),
+        name: "Q&A".to_string(),
+        channel_type: "forum".to_string(),
+    }
+}
+
+fn owner_form_field_value(iq_xml: &str, var: &str) -> Option<String> {
+    let iq: Element = iq_xml.parse().ok()?;
+    let query = iq.get_child("query", "http://jabber.org/protocol/muc#owner")?;
+    let form = query.get_child("x", "jabber:x:data")?;
+    let field = form
+        .children()
+        .find(|child| child.name() == "field" && child.attr("var") == Some(var))?;
+    field
+        .get_child("value", "jabber:x:data")
+        .map(|value| value.text())
+}
 
 #[tokio::test]
 async fn xep0508_thread_create_broadcast_in_forum_room() {
     init_test_env();
-    let server = TestServer::start().await;
+    let state = Arc::new(
+        MockAppState::new("localhost")
+            .with_waddle(forum_waddle(), vec![forum_channel(), forum_channel_two()]),
+    );
+    let server = TestServer::start_with_state(state).await;
+    let room_jid = waddle_xmpp::managed_room_jid("waddle-forums", "forum-channel", "muc.localhost")
+        .expect("canonical room jid");
 
     let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
     establish_bound_session(&mut alice, &server, "alice", "desktop")
         .await
         .expect("bind alice");
-    join_muc_room(&mut alice, "forum@muc.localhost", "Alice")
+    join_muc_room(&mut alice, &room_jid.to_string(), "Alice")
         .await
         .expect("alice join");
 
@@ -26,18 +75,19 @@ async fn xep0508_thread_create_broadcast_in_forum_room() {
     establish_bound_session(&mut bob, &server, "bob", "mobile")
         .await
         .expect("bind bob");
-    join_muc_room(&mut bob, "forum@muc.localhost", "Bob")
+    join_muc_room(&mut bob, &room_jid.to_string(), "Bob")
         .await
         .expect("bob join");
 
     // Alice creates a thread
     alice
-        .send(
-            "<message type='groupchat' to='forum@muc.localhost' id='thread-create-1' xmlns='jabber:client'>\
+        .send(&format!(
+            "<message type='groupchat' to='{}' id='thread-create-1' xmlns='jabber:client'>\
                 <body>New discussion topic</body>\
                 <thread-create xmlns='urn:xmpp:forums:0' title='Important Topic'/>\
             </message>",
-        )
+            room_jid
+        ))
         .await
         .expect("send thread create");
 
@@ -56,13 +106,20 @@ async fn xep0508_thread_create_broadcast_in_forum_room() {
 #[tokio::test]
 async fn xep0508_thread_reply_broadcast_in_forum_room() {
     init_test_env();
-    let server = TestServer::start().await;
+    let state = Arc::new(
+        MockAppState::new("localhost")
+            .with_waddle(forum_waddle(), vec![forum_channel(), forum_channel_two()]),
+    );
+    let server = TestServer::start_with_state(state).await;
+    let room_jid =
+        waddle_xmpp::managed_room_jid("waddle-forums", "forum-channel-2", "muc.localhost")
+            .expect("canonical room jid");
 
     let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
     establish_bound_session(&mut alice, &server, "alice", "desktop")
         .await
         .expect("bind alice");
-    join_muc_room(&mut alice, "forum2@muc.localhost", "Alice")
+    join_muc_room(&mut alice, &room_jid.to_string(), "Alice")
         .await
         .expect("alice join");
 
@@ -70,17 +127,18 @@ async fn xep0508_thread_reply_broadcast_in_forum_room() {
     establish_bound_session(&mut bob, &server, "bob", "mobile")
         .await
         .expect("bind bob");
-    join_muc_room(&mut bob, "forum2@muc.localhost", "Bob")
+    join_muc_room(&mut bob, &room_jid.to_string(), "Bob")
         .await
         .expect("bob join");
 
     // Bob replies to a thread
-    bob.send(
-        "<message type='groupchat' to='forum2@muc.localhost' id='thread-reply-1' xmlns='jabber:client'>\
+    bob.send(&format!(
+        "<message type='groupchat' to='{}' id='thread-reply-1' xmlns='jabber:client'>\
             <body>My reply</body>\
             <thread-reply xmlns='urn:xmpp:forums:0' thread-id='thread-create-1'/>\
         </message>",
-    )
+        room_jid
+    ))
     .await
     .expect("send thread reply");
 
@@ -93,5 +151,118 @@ async fn xep0508_thread_reply_broadcast_in_forum_room() {
         alice_response.contains("My reply"),
         "Alice should receive thread reply, got: {}",
         alice_response
+    );
+}
+
+#[tokio::test]
+async fn xep0508_channel_backed_forum_room_advertises_forum_feature() {
+    init_test_env();
+    let state =
+        Arc::new(MockAppState::new("localhost").with_waddle(forum_waddle(), vec![forum_channel()]));
+    let server = TestServer::start_with_state(state).await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+
+    let room_jid = waddle_xmpp::managed_room_jid("waddle-forums", "forum-channel", "muc.localhost")
+        .expect("canonical room jid");
+    let response = disco_info_query(&mut alice, &room_jid.to_string(), "forum-disco-1")
+        .await
+        .expect("disco#info");
+
+    assert!(
+        response.contains("urn:xmpp:forums:0"),
+        "Forum rooms must advertise XEP-0508, got: {}",
+        response
+    );
+    assert!(
+        response.contains("Announcements"),
+        "Forum room should use stored channel metadata, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn xep0508_owner_config_round_trips_forum_mode() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect");
+    establish_bound_session(&mut alice, &server, "alice", "desktop")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "forum-config@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    alice
+        .send(
+            "<iq type='get' id='owner-get-1' to='forum-config@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='http://jabber.org/protocol/muc#owner'/>\
+            </iq>",
+        )
+        .await
+        .expect("send owner get");
+    let initial = alice
+        .read_until("owner-get-1", DEFAULT_TIMEOUT)
+        .await
+        .expect("read owner get");
+    alice.clear();
+    assert!(
+        initial.contains("muc#roomconfig_forum"),
+        "Config form must include forum field, got: {}",
+        initial
+    );
+    assert_eq!(
+        owner_form_field_value(&initial, "muc#roomconfig_forum").as_deref(),
+        Some("0"),
+        "Instant rooms should default forum mode off, got: {}",
+        initial
+    );
+
+    alice
+        .send(
+            "<iq type='set' id='owner-set-1' to='forum-config@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='http://jabber.org/protocol/muc#owner'>\
+                    <x xmlns='jabber:x:data' type='submit'>\
+                        <field var='FORM_TYPE' type='hidden'><value>http://jabber.org/protocol/muc#roomconfig</value></field>\
+                        <field var='muc#roomconfig_forum' type='boolean'><value>1</value></field>\
+                    </x>\
+                </query>\
+            </iq>",
+        )
+        .await
+        .expect("send owner set");
+    alice
+        .read_until("owner-set-1", DEFAULT_TIMEOUT)
+        .await
+        .expect("read owner set");
+    alice.clear();
+
+    alice
+        .send(
+            "<iq type='get' id='owner-get-2' to='forum-config@muc.localhost' xmlns='jabber:client'>\
+                <query xmlns='http://jabber.org/protocol/muc#owner'/>\
+            </iq>",
+        )
+        .await
+        .expect("send owner get 2");
+    let updated = alice
+        .read_until("owner-get-2", DEFAULT_TIMEOUT)
+        .await
+        .expect("read owner get 2");
+    alice.clear();
+    assert!(
+        updated.contains("muc#roomconfig_forum"),
+        "Updated config form must still include forum field, got: {}",
+        updated
+    );
+    assert_eq!(
+        owner_form_field_value(&updated, "muc#roomconfig_forum").as_deref(),
+        Some("1"),
+        "Forum mode should round-trip through owner config, got: {}",
+        updated
     );
 }

--- a/server/docs/rfcs/0002-channels.md
+++ b/server/docs/rfcs/0002-channels.md
@@ -145,17 +145,19 @@ Threads use XEP-0461 (Message Replies):
 
 ## API Endpoints
 
-The Waddle backend exposes REST endpoints for channel management (provisioning MUC rooms):
+The Waddle backend exposes REST endpoints for channel updates and deletion. Channel
+creation is XMPP-native via the `waddle:create-channel` XEP-0050 ad-hoc command.
 
 ```
-POST   /waddles/:wid/channels           Create channel (provisions MUC)
+XMPP   waddle:create-channel            Create channel metadata + permissions
 GET    /waddles/:wid/channels           List channels
 GET    /channels/:id                    Get channel metadata
 PATCH  /channels/:id                    Update channel (syncs to MUC config)
 DELETE /channels/:id                    Delete channel (destroys MUC room)
 ```
 
-Message operations happen directly over XMPP, not through REST.
+Managed MUC rooms are materialized lazily on first join rather than at channel
+creation time. Message operations happen directly over XMPP, not through REST.
 
 ## XMPP Events
 

--- a/server/docs/specs/api-contracts.md
+++ b/server/docs/specs/api-contracts.md
@@ -217,7 +217,7 @@ POST   /invites/:code/join        Join via invite
 ### Channels
 
 ```
-POST   /waddles/:wid/channels     Create channel
+XMPP   waddle:create-channel      Create channel
 GET    /channels/:id              Get channel
 PATCH  /channels/:id              Update channel
 DELETE /channels/:id              Delete channel
@@ -226,6 +226,9 @@ POST   /channels/:id/messages     Send message
 GET    /channels/:id/pins         Get pinned messages
 POST   /channels/:id/typing       Send typing indicator
 ```
+
+Channel creation is handled by the XMPP `waddle:create-channel` ad-hoc command,
+not by an HTTP endpoint.
 
 ### Messages
 

--- a/server/docs/specs/xmpp-integration.md
+++ b/server/docs/specs/xmpp-integration.md
@@ -166,21 +166,20 @@ MUC Rooms:
 
 ### Channel Creation
 
-```json
-POST /waddles/:wid/channels
-{
-  "name": "random",
-  "type": "text"
-}
+```xml
+<iq type='set' to='waddle.social'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='waddle:create-channel'
+           action='execute'/>
+</iq>
 ```
 
 Backend:
 
 1. Creates channel record in per-Waddle database
-2. Spawns MUC room actor via Kameo
-3. Configures room settings (persistent, members-only)
-4. Updates Zanzibar permissions
-5. Returns channel metadata
+2. Writes the channel parent permission tuple
+3. Returns channel metadata to the command caller
+4. Materializes the managed MUC room lazily on first join
 
 ### Member Management
 


### PR DESCRIPTION
## Summary
- add server-side XMPP forum support for managed `forum` channels, including canonical managed room JIDs, deterministic room materialization, `muc#roomconfig_forum`, and `urn:xmpp:forums:0` disco support
- add chat forum discovery and UI flow, including explicit title input for new top-level topics plus XEP-0508 thread-create/thread-reply send and parse support
- align room discovery/autojoin/bookmark handling and add regression coverage across chat and `waddle-xmpp`

## Testing
- `cd chat && bun test`
- `cd chat && bun run build`
- `cd server && cargo fmt --all -- --check`
- `cd server && cargo clippy -p waddle-xmpp --all-targets --all-features -- -D clippy::correctness`
- `cd server && cargo test -p waddle-xmpp --quiet`
