### PR TITLE
fix(chat): XEP-0201 conformance — roots self-identify as their own thread

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -303,6 +303,14 @@ async function sendActiveMessage(
     return;
   }
   await messaging.sendMessage(body, markup, files, replyTo);
+  // A reply inherits the parent's thread and is then filtered out of the
+  // main feed (only roots stay). Open the thread panel so the user actually
+  // sees their reply land somewhere.
+  if (replyTo) {
+    const parent = messaging.messages.value.find((m) => m.id === replyTo.id);
+    const threadId = parent?.threadId ?? replyTo.id;
+    if (threadId) openThread(threadId);
+  }
 }
 
 async function sendThreadMessage(

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -937,6 +937,7 @@ onUnmounted(() => {
         v-if="ui.sidebarMode.value === 'channels'"
         :thread-stack="activeThreadStack"
         :thread-index="threads.index.value"
+        :resolve-entry="threads.resolveEntry"
         :current-user="connectionStore.session?.username"
         :avatar-url-by-author="avatarUrlByAuthor"
         :author-jid-by-nick="memberJidByNick"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -470,6 +470,7 @@ onBeforeUnmount(() => {
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
+      :reply-joins-thread="!dmPeer && !!replyingTo"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -655,7 +655,7 @@ watch(
             @click="startReplyInThreadFromMenu"
           >
             <MessageSquare class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
-            <span>{{ message.threadId ? "Open thread" : "Reply in thread" }}</span>
+            <span>{{ (threadReplyCount ?? 0) > 0 ? "Open thread" : "Reply in thread" }}</span>
           </button>
           <template v-if="message.isSelf">
             <button

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -27,6 +27,8 @@ const props = defineProps<{
   slowModeCooldown: number;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   replyingTo?: { id: string; author: string; preview?: string } | null;
+  /** True in channel mode, where a reply auto-joins its parent's thread. */
+  replyJoinsThread?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -301,17 +303,20 @@ watch(
 
 <template>
   <div class="relative px-4 py-3 flex-shrink-0" @keydown="onKeydown" @paste="onPaste">
-    <!-- Reply context chip -->
+    <!-- Reply context chip. In channel mode every reply joins a thread, so we
+         tell the user their message will show up in the thread panel. -->
     <div
       v-if="replyingTo"
-      class="flex items-center gap-2 px-3 py-1.5 mb-2 rounded-xl bg-muted/70 border border-border text-[12px] animate-fade-in"
+      class="flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-1.5 mb-2 rounded-xl bg-muted/70 border border-border text-[12px] animate-fade-in"
     >
       <span class="text-muted-foreground">Replying to</span>
       <span class="font-medium text-primary/90">@{{ replyAuthorName }}</span>
-      <span v-if="replyingTo.preview" class="text-muted-foreground truncate flex-1">{{ replyingTo.preview }}</span>
+      <span v-if="replyingTo.preview" class="text-muted-foreground truncate flex-1 min-w-0">{{ replyingTo.preview }}</span>
+      <span v-if="replyJoinsThread" class="text-[11px] text-primary/70 ml-auto">in thread</span>
       <button
         type="button"
-        class="ml-auto h-5 w-5 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        class="h-5 w-5 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        :class="{ 'ml-auto': !replyJoinsThread }"
         title="Cancel reply"
         aria-label="Cancel reply"
         @click="emit('cancelReply')"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -6,11 +6,17 @@ import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
 import type { TimelineMessage, MarkupSpan } from "@/lib/chat-ui";
 import type { OccupantHat, OccupantPresence, RoomHats, RoomPresence } from "@/lib/xmpp-client";
-import type { ThreadIndex } from "@/composables/useThreads";
+import type { ThreadEntry, ThreadIndex } from "@/composables/useThreads";
 
 const props = defineProps<{
   threadStack: string[];
   threadIndex: ThreadIndex;
+  /**
+   * Resolves a thread entry, synthesising an empty one when the id points
+   * at a known message with no replies yet (e.g. a freshly-started
+   * sub-thread). Returns undefined when the root hasn't been loaded.
+   */
+  resolveEntry: (threadId: string) => ThreadEntry | undefined;
   currentUser?: string;
   avatarUrlByAuthor: Record<string, string | null>;
   authorJidByNick?: Record<string, string>;
@@ -50,7 +56,7 @@ const parentThreadId = computed(() =>
   props.threadStack.length >= 2 ? props.threadStack[props.threadStack.length - 2] : undefined,
 );
 const activeEntry = computed(() =>
-  activeThreadId.value ? props.threadIndex.get(activeThreadId.value) ?? null : null,
+  activeThreadId.value ? props.resolveEntry(activeThreadId.value) ?? null : null,
 );
 
 const draft = ref("");
@@ -78,7 +84,7 @@ watch(activeThreadId, () => {
 
 const breadcrumbLabels = computed(() =>
   props.threadStack.map((id) => {
-    const entry = props.threadIndex.get(id);
+    const entry = props.resolveEntry(id);
     const body = entry?.root?.body?.trim() ?? "";
     return body.length > 0 ? body.slice(0, 40) : id.slice(0, 8);
   }),

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -555,11 +555,9 @@ export function useMessaging(
 
   /**
    * Backfill a thread via XEP-0313 MAM filtered by thread id. Fetches every
-   * archived message whose `<thread>` element matches `threadId`. Because
-   * waddle's root messages are composed without a `<thread>` child (threads
-   * are only tagged on replies), the thread root itself is never returned —
-   * this call populates the replies, and the panel's "root not loaded"
-   * notice is shown until the default channel window catches up.
+   * archived message whose `<thread>` element matches `threadId`, including
+   * the root itself (waddle now tags every groupchat message with `<thread>`
+   * per XEP-0201, so a thread-filtered MAM query returns the full conversation).
    */
   async function backfillThread(threadId: string): Promise<void> {
     const client = xmppClient.value;
@@ -682,7 +680,10 @@ export function useMessaging(
             ...(replyTo.body ? { preview: replyTo.body } : {}),
           };
         }
-        if (threadId) optimistic.threadId = threadId;
+        // XEP-0201: the wire always carries `<thread>`; root-of-thread falls
+        // back to the message's own id so the optimistic timeline matches the
+        // echo we'll receive back.
+        optimistic.threadId = threadId ?? msgId;
         if (parentThreadId) optimistic.parentThreadId = parentThreadId;
         if (attachments && attachments.length > 0) {
           optimistic.sharedFiles = attachments.map((a) => ({

--- a/chat/src/composables/useThreads.ts
+++ b/chat/src/composables/useThreads.ts
@@ -20,6 +20,13 @@ export type ThreadIndex = ReadonlyMap<string, ThreadEntry>;
 export interface UseThreadsResult {
   index: Readonly<Ref<ThreadIndex>>;
   getEntry: (threadId: string | null | undefined) => ThreadEntry | undefined;
+  /**
+   * Like `getEntry`, but synthesises an empty entry rooted at the matching
+   * message when no replies exist yet. Use this for the thread panel so
+   * opening an empty sub-thread renders the root and composer instead of
+   * "Loading…".
+   */
+  resolveEntry: (threadId: string | null | undefined) => ThreadEntry | undefined;
   hasChildren: (messageId: string) => boolean;
   rootOf: (message: TimelineMessage | null | undefined) => TimelineMessage | null;
 }
@@ -114,10 +121,31 @@ function buildIndex(messages: readonly TimelineMessage[]): ThreadIndex {
  */
 export function useThreads(messages: Ref<readonly TimelineMessage[]>): UseThreadsResult {
   const index = computed<ThreadIndex>(() => buildIndex(messages.value));
+  const byId = computed<ReadonlyMap<string, TimelineMessage>>(() => {
+    const map = new Map<string, TimelineMessage>();
+    for (const m of messages.value) map.set(m.id, m);
+    return map;
+  });
 
   function getEntry(threadId: string | null | undefined): ThreadEntry | undefined {
     if (!threadId) return undefined;
     return index.value.get(threadId);
+  }
+
+  function resolveEntry(threadId: string | null | undefined): ThreadEntry | undefined {
+    if (!threadId) return undefined;
+    const existing = index.value.get(threadId);
+    if (existing) return existing;
+    const root = byId.value.get(threadId);
+    if (!root) return undefined;
+    return {
+      threadId,
+      root,
+      directChildren: [],
+      allDescendants: [],
+      count: 0,
+      lastTs: root.createdAt,
+    };
   }
 
   function hasChildren(messageId: string): boolean {
@@ -131,5 +159,5 @@ export function useThreads(messages: Ref<readonly TimelineMessage[]>): UseThread
     return index.value.get(message.threadId)?.root ?? null;
   }
 
-  return { index, getEntry, hasChildren, rootOf };
+  return { index, getEntry, resolveEntry, hasChildren, rootOf };
 }

--- a/chat/src/lib/xmpp/dm-messaging.ts
+++ b/chat/src/lib/xmpp/dm-messaging.ts
@@ -61,6 +61,11 @@ export interface SendDirectMessageOptions {
 /**
  * Send a direct (type="chat") message. Supports XEP-0447 attachments, XEP-0461
  * replies with XEP-0428 fallback prefix, and RFC 6121 / XEP-0201 threads.
+ *
+ * Every message carries a `<thread>` child: replies inherit their parent's
+ * thread id, originals self-identify with `threadId === msgId` so the root
+ * can be discovered by MAM-by-thread and thread-aware UI.
+ *
  * Pass a pre-generated `id` when the caller already created an optimistic
  * timeline entry so the stanza ID matches.
  */
@@ -98,10 +103,9 @@ export function sendDirectMessage(
   if (replyTo) {
     msgData.reply = { to: replyTo.author, id: replyTo.id };
   }
-  if (threadId) {
-    msgData.thread = threadId;
-    if (parentThreadId) msgData.parentThread = parentThreadId;
-  }
+  // XEP-0201: always emit `<thread>`; originals use their own msgId.
+  msgData.thread = threadId ?? msgId;
+  if (parentThreadId) msgData.parentThread = parentThreadId;
   if (hasFiles) {
     msgData.fileSharing = files!.map(fileSharingElement);
     msgData.links = files!.map((f) => ({ url: f.url }));

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -137,6 +137,12 @@ export interface SendGroupMessageOptions {
 /**
  * Send a groupchat message. Supports XEP-0447 attachments, XEP-0461 replies with
  * XEP-0428 fallback prefix, and RFC 6121 / XEP-0201 threads.
+ *
+ * Every message carries a `<thread>` child: replies inherit their parent's
+ * thread id, and originals self-identify as the root of a new thread with
+ * `threadId === msgId`. Per XEP-0201 this lets MAM-by-thread return the root
+ * and lets clients detect "this message starts a thread" from the stanza alone.
+ *
  * Pass a pre-generated `id` when the caller already created an optimistic
  * timeline entry so the stanza ID matches.
  */
@@ -199,10 +205,10 @@ export function sendGroupMessage(
   if (replyTo) {
     msgData.reply = { to: replyTo.author, id: replyTo.id };
   }
-  if (threadId) {
-    msgData.thread = threadId;
-    if (parentThreadId) msgData.parentThread = parentThreadId;
-  }
+  // XEP-0201: always attach `<thread>`. Inherited id for replies; own msgId
+  // for originals so the root self-identifies and MAM thread queries return it.
+  msgData.thread = threadId ?? msgId;
+  if (parentThreadId) msgData.parentThread = parentThreadId;
   if (hasFiles) {
     msgData.fileSharing = files!.map(fileSharingElement);
     msgData.links = files!.map((f) => ({ url: f.url }));

--- a/chat/tests/groupchat-replies.test.ts
+++ b/chat/tests/groupchat-replies.test.ts
@@ -84,6 +84,32 @@ describe("groupchat replies + threads", () => {
     expect(call.fallbacks).toBeUndefined();
   });
 
+  test("original messages self-identify as their own thread root (XEP-0201)", () => {
+    // Per XEP-0201, every message SHOULD carry <thread>. Originals use their
+    // own msgId so MAM-by-thread can retrieve the whole conversation — root
+    // included — and the index can detect "this starts a thread" from the
+    // stanza alone.
+    const xmpp = makeAgent();
+
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "starting a topic");
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.thread).toBe(messageId);
+    expect(call.parentThread).toBeUndefined();
+  });
+
+  test("explicit threadId overrides the default self-thread id", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "general@muc.waddle.social", "reply body", {
+      replyTo: { id: "root-1", author: "general@muc.waddle.social/alice" },
+      threadId: "root-1",
+    });
+
+    const call = (xmpp.sendMessage as ReturnType<typeof mock>).mock.calls[0][0] as Record<string, unknown>;
+    expect(call.thread).toBe("root-1");
+  });
+
   test("rebases rich markup spans when a reply fallback prefix is prepended", () => {
     const xmpp = makeAgent();
     const body = "bold code link";

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -157,7 +157,10 @@ describe("reply addressing", () => {
     expect(options.replyTo).toBeUndefined();
     expect(options.threadId).toBeUndefined();
     expect(messaging.messages.value.at(-1)?.replyTo).toBeUndefined();
-    expect(messaging.messages.value.at(-1)?.threadId).toBeUndefined();
+    // XEP-0201: even when stale reply context is dropped, the new message
+    // becomes its own thread root, so threadId === id.
+    const sent = messaging.messages.value.at(-1);
+    expect(sent?.threadId).toBe(sent?.id);
   });
 
   test("DM sends drop stale reply context when the parent is not in the active timeline", async () => {

--- a/chat/tests/use-threads.test.ts
+++ b/chat/tests/use-threads.test.ts
@@ -83,4 +83,28 @@ describe("useThreads", () => {
     expect(getEntry(undefined)).toBeUndefined();
     expect(getEntry("nope")).toBeUndefined();
   });
+
+  test("resolveEntry synthesises an empty entry for a freshly-started sub-thread", () => {
+    // User clicks "Start sub-thread" on a reply (`c1`) before typing. The
+    // sub-thread has zero messages, so there's no index entry — but the
+    // panel still needs to render the root + composer instead of "Loading…".
+    const messages = ref<TimelineMessage[]>([
+      makeMessage({ id: "root", threadId: "root", createdAt: "2026-01-01T00:00:00Z", body: "root msg" }),
+      makeMessage({ id: "c1", threadId: "root", createdAt: "2026-01-01T00:01:00Z", body: "reply" }),
+    ]);
+    const { getEntry, resolveEntry } = useThreads(messages);
+    expect(getEntry("c1")).toBeUndefined();
+    const entry = resolveEntry("c1");
+    expect(entry).toBeTruthy();
+    expect(entry!.root?.id).toBe("c1");
+    expect(entry!.directChildren).toEqual([]);
+    expect(entry!.count).toBe(0);
+  });
+
+  test("resolveEntry returns undefined when the id doesn't match any loaded message", () => {
+    const messages = ref<TimelineMessage[]>([]);
+    const { resolveEntry } = useThreads(messages);
+    expect(resolveEntry("nope")).toBeUndefined();
+    expect(resolveEntry(undefined)).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

XEP-0201 says every message SHOULD carry a `<thread>` element identifying the conversation it belongs to. Waddle's client was only emitting `<thread>` on replies — root messages were bare, so a MAM-by-thread query could never return the root of a deep-linked thread. The ThreadPanel had to compensate with a "root not loaded" notice.

- **Protocol fix**: `sendGroupMessage` and `sendDirectMessage` now always attach `<thread>`: inherited id for replies, the message's own id for originals. The optimistic timeline entry matches the wire so echoes merge cleanly.
- **UX**: since replies in a channel now always join a thread (they're filtered out of the feed via `id !== threadId`), a feed-composer reply auto-opens the thread panel so the user sees their message land. The reply chip shows an "in thread" flag in channel mode.
- **Labels**: the action-menu switches between "Reply in thread" and "Open thread" based on reply count, not on the now-always-present `threadId`.
- **Backfill**: `backfillThread`'s docstring reflects reality — MAM-by-thread returns the root alongside replies now that roots carry `<thread>`.

## Test plan

- [x] `bun test` (121 tests pass, including new XEP-0201 root-self-identification assertions)
- [x] `bunx astro check` (3 pre-existing `cloudflare:workers` errors, unrelated)
- [ ] Manual: send a root message in a channel, confirm the stanza carries `<thread>id</thread>` with id === msgId
- [ ] Manual: reply to a root from the feed composer; the thread panel auto-opens and the reply appears there (not in the feed)
- [ ] Manual: the action-menu entry reads "Reply in thread" on a fresh root and switches to "Open thread" once there's at least one reply
- [ ] Manual: deep-link `?thread=rootId` where the root predates the loaded window; the panel now shows the root (no more "root not in loaded history" placeholder)

https://claude.ai/code/session_01SmrxGubBTcarnjSZUExKn7