### PR TITLE
feat(chat): restore scroll to last-seen and add new-messages divider

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -112,6 +112,9 @@ watchEffect(() => {
 const activeMessages = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.messages.value : messaging.messages.value,
 );
+const activeFirstUnseenId = computed(() =>
+  ui.sidebarMode.value === "dms" ? dmMessaging.firstUnseenId.value : messaging.firstUnseenId.value,
+);
 
 // Thread panel state — stack = breadcrumb trail into nested sub-threads.
 // Empty stack = panel closed. Only meaningful for channel messages since DMs
@@ -891,6 +894,7 @@ onUnmounted(() => {
         :dm-peer="activeDmPeer"
         :sidebar-mode="ui.sidebarMode.value"
         :messages="activeMessages"
+        :first-unseen-id="activeFirstUnseenId"
         :xmpp-status="messaging.xmppStatus.value"
         :action-error="ui.actionError.value"
         :is-loading-messages="activeIsLoadingMessages"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -21,6 +21,7 @@ const props = defineProps<{
   dmPeer?: { peerJid: string; peerUsername: string; presenceShow?: string } | null;
   sidebarMode?: "channels" | "dms";
   messages: TimelineMessage[];
+  firstUnseenId: string | null;
   xmppStatus: XmppStatusSnapshot;
   actionError: string;
   isLoadingMessages: boolean;
@@ -420,25 +421,36 @@ onBeforeUnmount(() => {
       </div>
 
       <div v-else class="max-w-none">
-        <MessageCard
-          v-for="msg in feedMessages"
-          :key="msg.id"
-          :message="msg"
-          :current-user="props.currentUser"
-          :avatar-url="avatarUrlByAuthor[msg.author] ?? null"
-          :hats="roomHats[msg.author] ?? []"
-          :presence="roomPresence[msg.author] ?? 'offline'"
-          :last-seen="roomLastSeen[msg.author]"
-          :author-jid="authorJidByNick?.[msg.author]"
-          :thread-reply-count="threadIndex.get(msg.id)?.count ?? 0"
-          @edit="(id, body, m) => emit('editMessage', id, body, m)"
-          @retract="(id) => emit('retractMessage', id)"
-          @react="(id, emoji) => emit('reactMessage', id, emoji)"
-          @reply="beginReply"
-          @scroll-to-message="scrollToMessage"
-          @avatar-click="onAvatarClick"
-          @open-thread="(tid: string) => emit('openThread', tid)"
-        />
+        <template v-for="msg in feedMessages" :key="msg.id">
+          <div
+            v-if="msg.id === firstUnseenId"
+            class="flex items-center gap-3 py-2 text-[11px] font-medium uppercase tracking-wide text-destructive"
+            data-new-messages-divider
+            role="separator"
+            aria-label="New messages"
+          >
+            <div class="flex-1 h-px bg-destructive/40" />
+            <span>New messages</span>
+            <div class="flex-1 h-px bg-destructive/40" />
+          </div>
+          <MessageCard
+            :message="msg"
+            :current-user="props.currentUser"
+            :avatar-url="avatarUrlByAuthor[msg.author] ?? null"
+            :hats="roomHats[msg.author] ?? []"
+            :presence="roomPresence[msg.author] ?? 'offline'"
+            :last-seen="roomLastSeen[msg.author]"
+            :author-jid="authorJidByNick?.[msg.author]"
+            :thread-reply-count="threadIndex.get(msg.id)?.count ?? 0"
+            @edit="(id, body, m) => emit('editMessage', id, body, m)"
+            @retract="(id) => emit('retractMessage', id)"
+            @react="(id, emoji) => emit('reactMessage', id, emoji)"
+            @reply="beginReply"
+            @scroll-to-message="scrollToMessage"
+            @avatar-click="onAvatarClick"
+            @open-thread="(tid: string) => emit('openThread', tid)"
+          />
+        </template>
       </div>
     </div>
 

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -13,6 +13,10 @@ import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
+import { findMessageElementById } from "@/lib/message-targeting";
+import { dmKey, getLastSeen, setLastSeen } from "@/lib/last-seen-store";
+
+const AT_BOTTOM_THRESHOLD = 48;
 
 function fromLiveDmMessage(
   session: WaddleSession,
@@ -62,6 +66,7 @@ export function useDmMessaging(
   const searchResults = ref<{ id: string; nick: string; body: string; createdAt: string }[]>([]);
   const isSearching = ref(false);
   const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
+  const firstUnseenId = ref<string | null>(null);
 
   let messageRequestId = 0;
   let searchRequestId = 0;
@@ -73,11 +78,40 @@ export function useDmMessaging(
   // identical text doesn't mis-target already-reconciled messages.
   const pendingEchoClientIds = new Set<string>();
 
+  // Re-pin to bottom for a short window after the initial scroll so late DOM
+  // mutations (images, avatars) don't strand the user above the newest
+  // message. Same pattern as useMessaging.ts.
   async function scrollToBottom() {
     await nextTick();
     await nextTick();
-    if (timelineEl.value) {
-      timelineEl.value.scrollTop = timelineEl.value.scrollHeight;
+    const el = timelineEl.value;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+    observer.observe(el);
+    for (const child of Array.from(el.children)) {
+      observer.observe(child);
+    }
+    setTimeout(() => observer.disconnect(), 500);
+  }
+
+  function isAtBottom(): boolean {
+    const el = timelineEl.value;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= AT_BOTTOM_THRESHOLD;
+  }
+
+  async function scrollFirstUnseenIntoView(messageId: string) {
+    await nextTick();
+    await nextTick();
+    const el = timelineEl.value;
+    if (!el) return;
+    const target = findMessageElementById(el, messageId);
+    if (target && typeof (target as HTMLElement).scrollIntoView === "function") {
+      (target as HTMLElement).scrollIntoView({ block: "start" });
     }
   }
 
@@ -178,8 +212,13 @@ export function useDmMessaging(
       if (wasPending) pendingEchoClientIds.delete(existing.id);
       return;
     }
+    const peerJid = activePeerJid.value;
+    const wasAtBottom = isAtBottom();
     messages.value = [...messages.value, msg];
     void scrollToBottom();
+    if (wasAtBottom && peerJid) {
+      setLastSeen(dmKey(barePeerJid(peerJid)), msg.id);
+    }
   }
 
   /** XEP-0198: SM ack promotes the matching self-sent message to delivered. */
@@ -288,7 +327,28 @@ export function useDmMessaging(
       }
       messages.value = timeline;
       if (requestId === messageRequestId) isLoadingMessages.value = false;
-      await scrollToBottom();
+
+      // See useMessaging.loadMessages — same last-seen anchor semantics,
+      // keyed by peer bare JID.
+      const key = dmKey(barePeerJid(peerJid));
+      const lastSeenId = getLastSeen(key);
+      const lastSeenIdx = lastSeenId
+        ? timeline.findIndex((m) => m.id === lastSeenId)
+        : -1;
+      if (lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1) {
+        const firstUnseen = timeline[lastSeenIdx + 1];
+        firstUnseenId.value = firstUnseen?.id ?? null;
+        if (firstUnseen) {
+          await scrollFirstUnseenIntoView(firstUnseen.id);
+        } else {
+          await scrollToBottom();
+        }
+      } else {
+        firstUnseenId.value = null;
+        await scrollToBottom();
+        const newest = timeline[timeline.length - 1];
+        if (newest) setLastSeen(key, newest.id);
+      }
     } catch (e) {
       if (requestId === messageRequestId) {
         actionError.value = normalizeError(e);
@@ -540,6 +600,7 @@ export function useDmMessaging(
 
   return {
     messages,
+    firstUnseenId,
     draft,
     isLoadingMessages,
     isSending,

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -16,8 +16,6 @@ import type { OutboundFileAttachment } from "@/lib/xmpp";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { dmKey, getLastSeen, setLastSeen } from "@/lib/last-seen-store";
 
-const AT_BOTTOM_THRESHOLD = 48;
-
 function fromLiveDmMessage(
   session: WaddleSession,
   msg: LiveDmMessage,
@@ -78,16 +76,22 @@ export function useDmMessaging(
   // identical text doesn't mis-target already-reconciled messages.
   const pendingEchoClientIds = new Set<string>();
 
-  // Re-pin to bottom for a short window after the initial scroll so late DOM
-  // mutations (images, avatars) don't strand the user above the newest
-  // message. Same pattern as useMessaging.ts.
   async function scrollToBottom() {
     await nextTick();
     await nextTick();
     const el = timelineEl.value;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-    if (typeof ResizeObserver === "undefined") return;
+  }
+
+  // Initial-load variant: re-pin for ~500ms so late layout (images, avatars,
+  // markup reflow) doesn't strand the user above the newest message. Not
+  // used per-message — ResizeObserver allocation per live message would be
+  // O(n) overhead. Same pattern as useMessaging.ts.
+  async function scrollToBottomAndPin() {
+    await scrollToBottom();
+    const el = timelineEl.value;
+    if (!el || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => {
       el.scrollTop = el.scrollHeight;
     });
@@ -98,21 +102,26 @@ export function useDmMessaging(
     setTimeout(() => observer.disconnect(), 500);
   }
 
-  function isAtBottom(): boolean {
-    const el = timelineEl.value;
-    if (!el) return true;
-    return el.scrollHeight - el.scrollTop - el.clientHeight <= AT_BOTTOM_THRESHOLD;
-  }
-
   async function scrollFirstUnseenIntoView(messageId: string) {
     await nextTick();
     await nextTick();
     const el = timelineEl.value;
     if (!el) return;
+    // Prefer the divider so it stays on-screen; message-level fallback only
+    // if the divider hasn't rendered yet.
+    const divider = el.querySelector("[data-new-messages-divider]");
+    if (divider && typeof (divider as HTMLElement).scrollIntoView === "function") {
+      (divider as HTMLElement).scrollIntoView({ block: "start" });
+      return;
+    }
     const target = findMessageElementById(el, messageId);
     if (target && typeof (target as HTMLElement).scrollIntoView === "function") {
       (target as HTMLElement).scrollIntoView({ block: "start" });
     }
+  }
+
+  function isFeedVisible(m: TimelineMessage): boolean {
+    return !m.threadId || m.id === m.threadId;
   }
 
   function addTypingUser(nick: string) {
@@ -213,10 +222,10 @@ export function useDmMessaging(
       return;
     }
     const peerJid = activePeerJid.value;
-    const wasAtBottom = isAtBottom();
     messages.value = [...messages.value, msg];
+    // Always snaps to bottom, so last-seen advances in lockstep.
     void scrollToBottom();
-    if (wasAtBottom && peerJid) {
+    if (peerJid && isFeedVisible(msg)) {
       setLastSeen(dmKey(barePeerJid(peerJid)), msg.id);
     }
   }
@@ -265,6 +274,7 @@ export function useDmMessaging(
     if (!session.value) return;
     const requestId = ++messageRequestId;
     isLoadingMessages.value = true;
+    firstUnseenId.value = null;
     clearActionError();
     try {
       const mamResults = xmppClient.value ? await xmppClient.value.queryPersonalMam(peerJid, 100) : [];
@@ -329,24 +339,24 @@ export function useDmMessaging(
       if (requestId === messageRequestId) isLoadingMessages.value = false;
 
       // See useMessaging.loadMessages — same last-seen anchor semantics,
-      // keyed by peer bare JID.
+      // keyed by peer bare JID. Anchor is computed against feed-visible
+      // messages so it always matches something ContentArea renders.
       const key = dmKey(barePeerJid(peerJid));
       const lastSeenId = getLastSeen(key);
       const lastSeenIdx = lastSeenId
         ? timeline.findIndex((m) => m.id === lastSeenId)
         : -1;
-      if (lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1) {
-        const firstUnseen = timeline[lastSeenIdx + 1];
-        firstUnseenId.value = firstUnseen?.id ?? null;
-        if (firstUnseen) {
-          await scrollFirstUnseenIntoView(firstUnseen.id);
-        } else {
-          await scrollToBottom();
-        }
+      const firstUnseen =
+        lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1
+          ? timeline.slice(lastSeenIdx + 1).find(isFeedVisible)
+          : undefined;
+      if (firstUnseen) {
+        firstUnseenId.value = firstUnseen.id;
+        await scrollFirstUnseenIntoView(firstUnseen.id);
       } else {
         firstUnseenId.value = null;
-        await scrollToBottom();
-        const newest = timeline[timeline.length - 1];
+        await scrollToBottomAndPin();
+        const newest = [...timeline].reverse().find(isFeedVisible);
         if (newest) setLastSeen(key, newest.id);
       }
     } catch (e) {
@@ -554,6 +564,7 @@ export function useDmMessaging(
     messageRequestId++;
     messages.value = [];
     isLoadingMessages.value = false;
+    firstUnseenId.value = null;
     clearTypingState();
   }
 
@@ -562,6 +573,7 @@ export function useDmMessaging(
     searchRequestId++;
     isLoadingMessages.value = false;
     isSearching.value = false;
+    firstUnseenId.value = null;
     clearTypingState();
   }
 

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -18,10 +18,6 @@ import type { OutboundFileAttachment } from "@/lib/xmpp";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { getLastSeen, roomKey, setLastSeen } from "@/lib/last-seen-store";
 
-// Distance (px) from the bottom still considered "pinned"; a little slack
-// covers the typing-indicator reserve and sub-pixel rounding.
-const AT_BOTTOM_THRESHOLD = 48;
-
 export function fromLiveMessage(
   session: WaddleSession,
   msg: LiveRoomMessage,
@@ -294,17 +290,22 @@ export function useMessaging(
     }, 3000);
   }
 
-  // Re-pin to the bottom for a short window after the initial scroll, so
-  // late-arriving layout (images, markup reflow, avatars) doesn't strand the
-  // user part-way up the list. Observes size changes on the scroll container
-  // and its children; tears down on timeout.
   async function scrollToBottom() {
     await nextTick();
     await nextTick();
     const el = timelineEl.value;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-    if (typeof ResizeObserver === "undefined") return;
+  }
+
+  // Initial-load variant: after scrolling, re-pin for ~500ms via a
+  // ResizeObserver so late layout (images, avatars, markup reflow) doesn't
+  // strand the user above the newest message. Not used per-message —
+  // ResizeObserver allocation per live message would be O(n) overhead.
+  async function scrollToBottomAndPin() {
+    await scrollToBottom();
+    const el = timelineEl.value;
+    if (!el || typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => {
       el.scrollTop = el.scrollHeight;
     });
@@ -313,12 +314,6 @@ export function useMessaging(
       observer.observe(child);
     }
     setTimeout(() => observer.disconnect(), 500);
-  }
-
-  function isAtBottom(): boolean {
-    const el = timelineEl.value;
-    if (!el) return true;
-    return el.scrollHeight - el.scrollTop - el.clientHeight <= AT_BOTTOM_THRESHOLD;
   }
 
   function persistLastSeen(waddleId: string, channelId: string, messageId: string) {
@@ -330,6 +325,14 @@ export function useMessaging(
     await nextTick();
     const el = timelineEl.value;
     if (!el) return;
+    // Prefer scrolling to the "New messages" divider (rendered immediately
+    // above the first-unseen MessageCard). Aligning the message itself to
+    // `block: "start"` would push the divider off-screen.
+    const divider = el.querySelector("[data-new-messages-divider]");
+    if (divider && typeof (divider as HTMLElement).scrollIntoView === "function") {
+      (divider as HTMLElement).scrollIntoView({ block: "start" });
+      return;
+    }
     const target = findMessageElementById(el, messageId);
     if (target && typeof (target as HTMLElement).scrollIntoView === "function") {
       (target as HTMLElement).scrollIntoView({ block: "start" });
@@ -427,10 +430,12 @@ export function useMessaging(
     }
     const waddleId = activeWaddleId.value;
     const channelId = activeChannelId.value;
-    const wasAtBottom = isAtBottom();
     messages.value = [...messages.value, msg];
+    // mergeLiveMessage always snaps to bottom, so last-seen should advance
+    // in lockstep regardless of the user's prior scroll position — if we're
+    // scrolling them to the message, by definition they can see it.
     void scrollToBottom();
-    if (wasAtBottom && waddleId && channelId) {
+    if (waddleId && channelId && isFeedVisible(msg)) {
       persistLastSeen(waddleId, channelId, msg.id);
     }
   }
@@ -496,11 +501,22 @@ export function useMessaging(
     })();
   }
 
+  // Matches ContentArea.feedMessages: thread replies (messages with a
+  // threadId that isn't their own id) are hidden, so the last-seen anchor
+  // and the "New messages" divider must be computed against this predicate.
+  function isFeedVisible(m: TimelineMessage): boolean {
+    return !m.threadId || m.id === m.threadId;
+  }
+
   async function loadMessages(waddleId: string, channelId: string) {
     if (!session.value) return;
 
     const requestId = ++messageRequestId;
     isLoadingMessages.value = true;
+    // Reset the divider anchor up-front: a previous conversation's id could
+    // coincidentally match a message in the new timeline, and an aborted
+    // request (requestId mismatch) would otherwise leave stale state.
+    firstUnseenId.value = null;
     clearActionError();
 
     try {
@@ -591,26 +607,27 @@ export function useMessaging(
         isLoadingMessages.value = false;
       }
 
-      // Restore scroll position: if we have a last-seen anchor that's still in
-      // the MAM window AND there are unseen messages after it, park the view
-      // on the first unseen message and render a divider above it. Otherwise
-      // scroll to bottom and track the newest message as last-seen.
+      // Restore scroll position: if we have a last-seen anchor that's still
+      // in the MAM window AND there are unseen *feed-visible* messages after
+      // it, park the view on the first such message and render a divider
+      // above it. ContentArea renders `feedMessages` (thread replies hidden),
+      // so the anchor must match something actually rendered. Otherwise
+      // scroll to bottom and track the newest feed message as last-seen.
       const lastSeenId = getLastSeen(roomKey(waddleId, channelId));
       const lastSeenIdx = lastSeenId
         ? timeline.findIndex((m) => m.id === lastSeenId)
         : -1;
-      if (lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1) {
-        const firstUnseen = timeline[lastSeenIdx + 1];
-        firstUnseenId.value = firstUnseen?.id ?? null;
-        if (firstUnseen) {
-          await scrollFirstUnseenIntoView(firstUnseen.id);
-        } else {
-          await scrollToBottom();
-        }
+      const firstUnseen =
+        lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1
+          ? timeline.slice(lastSeenIdx + 1).find(isFeedVisible)
+          : undefined;
+      if (firstUnseen) {
+        firstUnseenId.value = firstUnseen.id;
+        await scrollFirstUnseenIntoView(firstUnseen.id);
       } else {
         firstUnseenId.value = null;
-        await scrollToBottom();
-        const newest = timeline[timeline.length - 1];
+        await scrollToBottomAndPin();
+        const newest = [...timeline].reverse().find(isFeedVisible);
         if (newest) persistLastSeen(waddleId, channelId, newest.id);
       }
     } catch (e) {
@@ -883,6 +900,7 @@ export function useMessaging(
     clearTypingState();
     isLoadingMessages.value = false;
     isSearching.value = false;
+    firstUnseenId.value = null;
   }
 
   function clearMessages() {
@@ -890,6 +908,7 @@ export function useMessaging(
     messages.value = [];
     isLoadingMessages.value = false;
     clearTypingState();
+    firstUnseenId.value = null;
   }
 
   async function searchMessages(query: string) {

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -15,6 +15,12 @@ import {
 import type { DeliveryStatus, MarkupSpan, TimelineMessage } from "@/lib/chat-ui";
 import { MAX_IMAGE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
+import { findMessageElementById } from "@/lib/message-targeting";
+import { getLastSeen, roomKey, setLastSeen } from "@/lib/last-seen-store";
+
+// Distance (px) from the bottom still considered "pinned"; a little slack
+// covers the typing-indicator reserve and sub-pixel rounding.
+const AT_BOTTOM_THRESHOLD = 48;
 
 export function fromLiveMessage(
   session: WaddleSession,
@@ -92,6 +98,7 @@ export function useMessaging(
   const roomLastSeen = ref<Record<string, number>>({});
   const slowModeCooldown = ref(0);
   const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
+  const firstUnseenId = ref<string | null>(null);
   const activeChannels = ref<Set<string>>(new Set());
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
@@ -287,12 +294,45 @@ export function useMessaging(
     }, 3000);
   }
 
+  // Re-pin to the bottom for a short window after the initial scroll, so
+  // late-arriving layout (images, markup reflow, avatars) doesn't strand the
+  // user part-way up the list. Observes size changes on the scroll container
+  // and its children; tears down on timeout.
   async function scrollToBottom() {
     await nextTick();
-    // Double nextTick ensures the DOM has fully rendered after reactive updates
     await nextTick();
-    if (timelineEl.value) {
-      timelineEl.value.scrollTop = timelineEl.value.scrollHeight;
+    const el = timelineEl.value;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+    observer.observe(el);
+    for (const child of Array.from(el.children)) {
+      observer.observe(child);
+    }
+    setTimeout(() => observer.disconnect(), 500);
+  }
+
+  function isAtBottom(): boolean {
+    const el = timelineEl.value;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= AT_BOTTOM_THRESHOLD;
+  }
+
+  function persistLastSeen(waddleId: string, channelId: string, messageId: string) {
+    setLastSeen(roomKey(waddleId, channelId), messageId);
+  }
+
+  async function scrollFirstUnseenIntoView(messageId: string) {
+    await nextTick();
+    await nextTick();
+    const el = timelineEl.value;
+    if (!el) return;
+    const target = findMessageElementById(el, messageId);
+    if (target && typeof (target as HTMLElement).scrollIntoView === "function") {
+      (target as HTMLElement).scrollIntoView({ block: "start" });
     }
   }
 
@@ -385,8 +425,14 @@ export function useMessaging(
       if (wasPending) pendingEchoClientIds.delete(existing.id);
       return;
     }
+    const waddleId = activeWaddleId.value;
+    const channelId = activeChannelId.value;
+    const wasAtBottom = isAtBottom();
     messages.value = [...messages.value, msg];
     void scrollToBottom();
+    if (wasAtBottom && waddleId && channelId) {
+      persistLastSeen(waddleId, channelId, msg.id);
+    }
   }
 
   /**
@@ -544,7 +590,29 @@ export function useMessaging(
       if (requestId === messageRequestId) {
         isLoadingMessages.value = false;
       }
-      await scrollToBottom();
+
+      // Restore scroll position: if we have a last-seen anchor that's still in
+      // the MAM window AND there are unseen messages after it, park the view
+      // on the first unseen message and render a divider above it. Otherwise
+      // scroll to bottom and track the newest message as last-seen.
+      const lastSeenId = getLastSeen(roomKey(waddleId, channelId));
+      const lastSeenIdx = lastSeenId
+        ? timeline.findIndex((m) => m.id === lastSeenId)
+        : -1;
+      if (lastSeenIdx !== -1 && lastSeenIdx < timeline.length - 1) {
+        const firstUnseen = timeline[lastSeenIdx + 1];
+        firstUnseenId.value = firstUnseen?.id ?? null;
+        if (firstUnseen) {
+          await scrollFirstUnseenIntoView(firstUnseen.id);
+        } else {
+          await scrollToBottom();
+        }
+      } else {
+        firstUnseenId.value = null;
+        await scrollToBottom();
+        const newest = timeline[timeline.length - 1];
+        if (newest) persistLastSeen(waddleId, channelId, newest.id);
+      }
     } catch (e) {
       if (requestId === messageRequestId) {
         actionError.value = normalizeError(e);
@@ -875,6 +943,7 @@ export function useMessaging(
   return {
     xmppStatus,
     messages,
+    firstUnseenId,
     draft,
     isLoadingMessages,
     isSending,

--- a/chat/src/lib/last-seen-store.ts
+++ b/chat/src/lib/last-seen-store.ts
@@ -1,0 +1,44 @@
+// Per-conversation "last message the local user has viewed" anchor, stored in
+// localStorage so the client can restore scroll position between sessions and
+// render a "new messages" divider. This is a local UX concern distinct from
+// XEP-0333 <displayed/> receipts, which communicate *other users'* read state.
+
+const PREFIX = "waddle.chat.last-seen";
+
+export function roomKey(waddleId: string, channelId: string): string {
+  return `${PREFIX}.room.${waddleId}.${channelId}`;
+}
+
+export function dmKey(peerBareJid: string): string {
+  return `${PREFIX}.dm.${peerBareJid}`;
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getLastSeen(key: string): string | null {
+  const s = storage();
+  if (!s) return null;
+  try {
+    return s.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setLastSeen(key: string, messageId: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.setItem(key, messageId);
+  } catch {
+    // Quota exceeded or storage disabled; silently drop — the worst outcome is
+    // that the divider shows up on the next visit instead of not at all.
+  }
+}


### PR DESCRIPTION
Chat opened at an arbitrary scroll offset because loadMessages' double
nextTick could fire before late layout (images, avatars, markup reflow)
settled. Two fixes:

- Persist the last message id the local user has viewed per channel and
  per DM peer in localStorage. On load, anchor the view on the first
  unseen message with a "New messages" divider above it. If caught up,
  scroll to bottom and track the newest message.
- Re-pin scrollToBottom for ~500ms via ResizeObserver so late layout
  shifts don't strand the user above the newest message.

The anchor is a local UX concern distinct from XEP-0333 <displayed/>
receipts, which communicate other users' read state and stay unchanged.