### PR TITLE
fix(chat): align composer row by hoisting bubble toolbar out of editor

### DIFF
--- a/chat/src/components/chat/ChatEditor.vue
+++ b/chat/src/components/chat/ChatEditor.vue
@@ -5,7 +5,6 @@ import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
-import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -124,21 +123,20 @@ defineExpose({
 </script>
 
 <template>
-  <div class="relative" :class="compact ? '' : 'flex-1'" @click="editor?.commands.focus()">
-    <div
-      class="chat-editor flex items-center rounded-xl bg-muted text-[13px] px-4 transition-all duration-300 has-[:focus]:ring-2 has-[:focus]:ring-primary/20 has-[:focus]:shadow-[0_0_16px_var(--glow)] cursor-text"
-      :class="[
-        compact ? 'min-h-9 py-1' : 'min-h-10 py-1.5',
-        disabled ? 'opacity-40 pointer-events-none' : '',
-      ]"
-    >
-      <EditorContent
-        v-if="editor"
-        :editor="editor"
-        class="w-full"
-      />
-    </div>
-    <EditorBubbleToolbar v-if="editor && !compact" :editor="editor" />
+  <div
+    class="chat-editor flex items-center rounded-xl bg-muted text-[13px] px-4 transition-all duration-300 has-[:focus]:ring-2 has-[:focus]:ring-primary/20 has-[:focus]:shadow-[0_0_16px_var(--glow)] cursor-text"
+    :class="[
+      compact ? 'min-h-9 py-1' : 'min-h-10 py-1.5',
+      compact ? '' : 'flex-1',
+      disabled ? 'opacity-40 pointer-events-none' : '',
+    ]"
+    @click="editor?.commands.focus()"
+  >
+    <EditorContent
+      v-if="editor"
+      :editor="editor"
+      class="w-full"
+    />
   </div>
 </template>
 

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -3,6 +3,7 @@ import { ref, computed, watch, onBeforeUnmount } from "vue";
 import { Send, Image, X } from "lucide-vue-next";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
+import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
 import { getComposerEscapeAction } from "@/lib/reply-ux";
@@ -54,6 +55,11 @@ const editorRef = ref<InstanceType<typeof ChatEditor> | null>(null);
 const setEditorRef = (instance: InstanceType<typeof ChatEditor> | null) => {
   editorRef.value = instance;
 };
+
+const tiptapEditor = computed(() => {
+  const e = editorRef.value as any;
+  return e?.editor?.value ?? e?.editor ?? null;
+});
 
 const pendingAttachments = ref<PendingAttachment[]>([]);
 
@@ -478,5 +484,6 @@ watch(
       <Send v-else class="w-4 h-4" aria-hidden="true" />
     </button>
     </div>
+    <EditorBubbleToolbar v-if="tiptapEditor" :editor="tiptapEditor" />
   </div>
 </template>


### PR DESCRIPTION
The hidden bubble toolbar sat inside the editor's flex-1 wrapper, inflating its height and pushing the visible input above the image/send buttons. Render it as a sibling of the composer row so the three-item flex layout is purely 40px items.