### PR TITLE
Focus composer when starting replies

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import { Hash, MessageCircle, MessagesSquare, Settings, Search, X, Upload } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { findMessageElementById } from "@/lib/message-targeting";
@@ -74,6 +74,17 @@ const feedMessages = computed(() =>
 
 const replyingTo = ref<{ id: string; author: string; body?: string; preview?: string } | null>(null);
 
+type MessageComposerHandle = {
+  addAttachments: (files: Array<File | Blob>) => void;
+  focus: () => void;
+};
+
+function focusComposer() {
+  // Wait for the reply chip/state update so the editor focus wins over the
+  // message action button that was just clicked.
+  void nextTick(() => composerRef.value?.focus());
+}
+
 function beginReply(message: TimelineMessage) {
   const author = message.author;
   replyingTo.value = {
@@ -81,6 +92,7 @@ function beginReply(message: TimelineMessage) {
     author,
     ...(message.body ? { body: message.body, preview: message.body } : {}),
   };
+  focusComposer();
 }
 
 function cancelReply() {
@@ -176,8 +188,8 @@ const messagesContainer = ref<HTMLDivElement | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
   messagesContainer.value = el;
 };
-const composerRef = ref<{ addAttachments: (files: Array<File | Blob>) => void } | null>(null);
-const setComposerRef = (instance: { addAttachments: (files: Array<File | Blob>) => void } | null) => {
+const composerRef = ref<MessageComposerHandle | null>(null);
+const setComposerRef = (instance: MessageComposerHandle | null) => {
   composerRef.value = instance;
 };
 const showSearch = ref(false);

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -249,7 +249,11 @@ function onSend(doc: Record<string, unknown>) {
   emit("send", serialized.body, serialized.markup, files.length > 0 ? files : undefined);
 }
 
-defineExpose({ addAttachments });
+function focus() {
+  editorRef.value?.focus();
+}
+
+defineExpose({ addAttachments, focus });
 
 function onEditorCancel() {
   const action = getComposerEscapeAction({

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { X, CornerDownRight, MessageSquarePlus, ChevronRight } from "lucide-vue-next";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
@@ -63,12 +63,26 @@ const draft = ref("");
 
 const replyingTo = ref<{ id: string; author: string; body?: string; preview?: string } | null>(null);
 
+type MessageComposerHandle = {
+  focus: () => void;
+};
+
+const composerRef = ref<MessageComposerHandle | null>(null);
+const setComposerRef = (instance: MessageComposerHandle | null) => {
+  composerRef.value = instance;
+};
+
+function focusComposer() {
+  void nextTick(() => composerRef.value?.focus());
+}
+
 function beginReplyInThread(message: TimelineMessage) {
   replyingTo.value = {
     id: message.id,
     author: message.author,
     ...(message.body ? { body: message.body, preview: message.body } : {}),
   };
+  focusComposer();
 }
 
 function cancelReplyInThread() {
@@ -242,6 +256,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
 
       <div class="border-t border-border flex-shrink-0">
         <MessageComposer
+          :ref="setComposerRef"
           v-model:draft="draft"
           :channel-name="`thread in ${channelName}`"
           :is-sending="isSending"


### PR DESCRIPTION
## Summary\n- expose a focus handle from the desktop message composer\n- focus the main composer after selecting Reply from a message\n- mirror the same reply-focus behavior inside the thread panel\n\n## Validation\n- cd chat && bun test\n- cd chat && bun run generate-types && bun run build