### PR TITLE
Refactor WebSocket runtime onto the shared XMPP effect interpreter

### DIFF
--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -18,6 +18,7 @@ use routes::channels::ChannelState;
 use routes::permissions::PermissionState;
 use routes::uploads::UploadState;
 use routes::waddles::WaddleState;
+use routes::interpret::EffectInterpreter;
 use routes::websocket::WebSocketState;
 use rustls::ServerConfig as RustlsServerConfig;
 use rustls_acme::caches::DirCache;
@@ -958,6 +959,16 @@ fn create_router_with_sfu(
     let stanza_dispatcher = Arc::new(stanza_dispatcher);
 
     // XMPP over WebSocket (RFC 7395) with registries for message routing
+    let interpreter = Arc::new(EffectInterpreter {
+        app_state: Some(Arc::clone(&state)),
+        auth_state: Some(Arc::clone(&auth_state)),
+        connection_registry: Some(Arc::clone(&connection_registry)),
+        muc_registry: Some(Arc::clone(&muc_registry)),
+        mam_storage: Some(Arc::clone(&mam_storage)),
+        github_enricher: Some(Arc::clone(&github_enricher)),
+        sfu_service: Some(sfu_service.clone()),
+        callback_tx: None,
+    });
     let websocket_state = Arc::new(WebSocketState {
         app_state: state.clone(),
         auth_state: auth_state.clone(),
@@ -967,6 +978,7 @@ fn create_router_with_sfu(
         github_enricher,
         sfu_service,
         dispatcher: stanza_dispatcher,
+        interpreter,
     });
     let websocket_router = routes::websocket::router(websocket_state);
 

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -18,7 +18,6 @@ use routes::channels::ChannelState;
 use routes::permissions::PermissionState;
 use routes::uploads::UploadState;
 use routes::waddles::WaddleState;
-use routes::interpret::EffectInterpreter;
 use routes::websocket::WebSocketState;
 use rustls::ServerConfig as RustlsServerConfig;
 use rustls_acme::caches::DirCache;
@@ -959,16 +958,6 @@ fn create_router_with_sfu(
     let stanza_dispatcher = Arc::new(stanza_dispatcher);
 
     // XMPP over WebSocket (RFC 7395) with registries for message routing
-    let interpreter = Arc::new(EffectInterpreter {
-        app_state: Some(Arc::clone(&state)),
-        auth_state: Some(Arc::clone(&auth_state)),
-        connection_registry: Some(Arc::clone(&connection_registry)),
-        muc_registry: Some(Arc::clone(&muc_registry)),
-        mam_storage: Some(Arc::clone(&mam_storage)),
-        github_enricher: Some(Arc::clone(&github_enricher)),
-        sfu_service: Some(sfu_service.clone()),
-        callback_tx: None,
-    });
     let websocket_state = Arc::new(WebSocketState {
         app_state: state.clone(),
         auth_state: auth_state.clone(),
@@ -978,7 +967,6 @@ fn create_router_with_sfu(
         github_enricher,
         sfu_service,
         dispatcher: stanza_dispatcher,
-        interpreter,
     });
     let websocket_router = routes::websocket::router(websocket_state);
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -130,14 +130,20 @@ impl EffectInterpreter {
                     }
                 },
 
-                unsupported => self.handle_unsupported(unsupported),
+                unsupported => {
+                    if self.handle_unsupported(unsupported) {
+                        outcome.frames.clear();
+                        outcome.close = true;
+                        break;
+                    }
+                }
             }
         }
 
         outcome
     }
 
-    fn handle_unsupported(&self, event: OutboundEvent) {
+    fn handle_unsupported(&self, event: OutboundEvent) -> bool {
         let event_name = outbound_event_name(&event);
         let message = format!("OutboundEvent::{event_name} is not wired in EffectInterpreter yet");
 
@@ -157,6 +163,7 @@ impl EffectInterpreter {
             has_callback_sender = self.callback_tx.is_some(),
             "OutboundEvent variant not yet wired in interpreter"
         );
+        true
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -9,19 +9,161 @@
 //! # Current coverage
 //!
 //! Only a subset of variants have their interpreter wiring in place — the
-//! ones needed by handlers that have been migrated so far (ping, session).
-//! The remaining variants (`SendDirect`, `BroadcastToRoom`, `QueryMam`,
-//! `AskSfu`, `RequestEnrichment`, etc.) are defined in the event enum so
-//! future handlers can emit them, but land in the interpreter as later
-//! migration steps pull their XEP into the sans-I/O world.
+//! ones needed by handlers that have been migrated so far (ping, session,
+//! roster, carbons). The remaining variants are carried by a concrete
+//! interpreter bundle already so later migration steps can attach real
+//! async behavior without reworking the transport boundary again.
 
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
-use waddle_xmpp::protocol::OutboundEvent;
+use waddle_xmpp::{
+    mam::LibSqlMamStorage,
+    muc::MucRoomRegistry,
+    protocol::{InboundEvent, OutboundEvent},
+    registry::ConnectionRegistry,
+};
+use waddle_xmpp_xep_github::MessageEnricher;
+
+use super::{auth::AuthState, websocket::WebSocketState};
+use crate::server::AppState;
+
+/// Async callback channel used by future two-phase interpreter effects.
+pub type CallbackSender = mpsc::Sender<InboundEvent>;
+
+/// Concrete dependency bundle for interpreting outbound effects.
+///
+/// The interpreter intentionally carries concrete runtime handles instead of
+/// new service traits so the transport adapters can share one XMPP runtime
+/// shape while migration is still in progress.
+#[derive(Clone, Default)]
+pub struct EffectInterpreter {
+    /// Core server state used by effect implementations that need app-level
+    /// resources.
+    pub app_state: Option<Arc<AppState>>,
+    /// Authentication/session state used by SCRAM and OAUTHBEARER callbacks.
+    pub auth_state: Option<Arc<AuthState>>,
+    /// Registry for routing direct stanzas to online connections.
+    pub connection_registry: Option<Arc<ConnectionRegistry>>,
+    /// Registry for MUC occupant lookups and room broadcasts.
+    pub muc_registry: Option<Arc<MucRoomRegistry>>,
+    /// Shared MAM archive storage.
+    pub mam_storage: Option<Arc<LibSqlMamStorage>>,
+    /// GitHub message enrichment service.
+    pub github_enricher: Option<Arc<MessageEnricher>>,
+    /// SFU actor for Jingle/call-related async requests.
+    pub sfu_service:
+        Option<kameo::actor::ActorRef<waddle_xmpp::sfu::service_actor::SfuServiceActor>>,
+    /// Optional callback hook back into the owning connection runtime.
+    pub callback_tx: Option<CallbackSender>,
+}
+
+impl EffectInterpreter {
+    /// Build a concrete interpreter bundle from the current transport/runtime
+    /// dependencies.
+    pub fn new(
+        app_state: Arc<AppState>,
+        auth_state: Arc<AuthState>,
+        connection_registry: Arc<ConnectionRegistry>,
+        muc_registry: Arc<MucRoomRegistry>,
+        mam_storage: Arc<LibSqlMamStorage>,
+        github_enricher: Arc<MessageEnricher>,
+        sfu_service: kameo::actor::ActorRef<waddle_xmpp::sfu::service_actor::SfuServiceActor>,
+    ) -> Self {
+        Self {
+            app_state: Some(app_state),
+            auth_state: Some(auth_state),
+            connection_registry: Some(connection_registry),
+            muc_registry: Some(muc_registry),
+            mam_storage: Some(mam_storage),
+            github_enricher: Some(github_enricher),
+            sfu_service: Some(sfu_service),
+            callback_tx: None,
+        }
+    }
+
+    /// Build an interpreter bundle from the current WebSocket transport state.
+    pub fn from_websocket_state(state: &WebSocketState) -> Self {
+        Self::new(
+            Arc::clone(&state.app_state),
+            Arc::clone(&state.auth_state),
+            Arc::clone(&state.connection_registry),
+            Arc::clone(&state.muc_registry),
+            Arc::clone(&state.mam_storage),
+            Arc::clone(&state.github_enricher),
+            state.sfu_service.clone(),
+        )
+    }
+
+    /// Attach the async callback hook that later effect variants use to feed
+    /// completions back into the connection runtime.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn with_callback_sender(mut self, callback_tx: CallbackSender) -> Self {
+        self.callback_tx = Some(callback_tx);
+        self
+    }
+
+    /// Execute the side effects described by `events`.
+    ///
+    /// The function is `async` because future migration steps add variants
+    /// that genuinely require `.await` (registry lookups, actor calls, MAM
+    /// storage). The currently-supported variants are all synchronous, so this
+    /// function returns immediately for the already migrated flows.
+    pub async fn interpret(&self, events: Vec<OutboundEvent>) -> InterpretOutcome {
+        let mut outcome = InterpretOutcome::default();
+
+        for event in events {
+            match event {
+                OutboundEvent::SendFrame(xml) => {
+                    outcome.frames.push(xml);
+                }
+                OutboundEvent::CloseTransport => {
+                    outcome.close = true;
+                }
+                OutboundEvent::Log { level, message } => match level {
+                    tracing::Level::ERROR => error!(%message, "protocol event"),
+                    tracing::Level::WARN => warn!(%message, "protocol event"),
+                    tracing::Level::INFO => info!(%message, "protocol event"),
+                    tracing::Level::DEBUG | tracing::Level::TRACE => {
+                        debug!(%message, "protocol event")
+                    }
+                },
+
+                unsupported => self.handle_unsupported(unsupported),
+            }
+        }
+
+        outcome
+    }
+
+    fn handle_unsupported(&self, event: OutboundEvent) {
+        let event_name = outbound_event_name(&event);
+        let message = format!("OutboundEvent::{event_name} is not wired in EffectInterpreter yet");
+
+        if cfg!(any(test, debug_assertions)) {
+            panic!("{message}");
+        }
+
+        error!(
+            event = event_name,
+            has_app_state = self.app_state.is_some(),
+            has_auth_state = self.auth_state.is_some(),
+            has_connection_registry = self.connection_registry.is_some(),
+            has_muc_registry = self.muc_registry.is_some(),
+            has_mam_storage = self.mam_storage.is_some(),
+            has_github_enricher = self.github_enricher.is_some(),
+            has_sfu_service = self.sfu_service.is_some(),
+            has_callback_sender = self.callback_tx.is_some(),
+            "OutboundEvent variant not yet wired in interpreter"
+        );
+    }
+}
 
 /// Outcome of interpreting a batch of [`OutboundEvent`]s.
 ///
-/// The WebSocket transport uses `frames` to decide what to write back to
-/// the client. `close` signals the main loop should drop the connection.
+/// The transport uses `frames` to decide what to write back to the client.
+/// `close` signals the main loop should drop the connection.
 #[derive(Debug, Default)]
 pub struct InterpretOutcome {
     /// Serialized XML frames to write to the transport, in order.
@@ -30,98 +172,71 @@ pub struct InterpretOutcome {
     pub close: bool,
 }
 
-/// Execute the side effects described by `events`.
-///
-/// The function is `async` because future migration steps add variants
-/// that genuinely require `.await` (registry lookups, actor calls, MAM
-/// storage). The currently-supported variants are all synchronous, so this
-/// function will return immediately for the ping/session flow.
-pub async fn interpret(events: Vec<OutboundEvent>) -> InterpretOutcome {
-    let mut outcome = InterpretOutcome::default();
-
-    for event in events {
-        match event {
-            OutboundEvent::SendFrame(xml) => {
-                outcome.frames.push(xml);
-            }
-            OutboundEvent::CloseTransport => {
-                outcome.close = true;
-            }
-            OutboundEvent::Log { level, message } => {
-                // Route the log back through tracing so it ends up in the
-                // application's log pipeline. Using a runtime level is
-                // slightly noisier than a static one, but it keeps the
-                // test-time assertion-on-events capability intact (tests
-                // inspect the Vec<OutboundEvent> before interpretation).
-                match level {
-                    tracing::Level::ERROR => error!(message),
-                    tracing::Level::WARN => warn!(message),
-                    tracing::Level::INFO => info!(message),
-                    tracing::Level::DEBUG | tracing::Level::TRACE => debug!(message),
-                }
-            }
-
-            // -------------------------------------------------------
-            // Variants defined for future migration steps. Logged so the
-            // test that emits them can see them appear in traces without
-            // accidentally being silently dropped.
-            // -------------------------------------------------------
-            OutboundEvent::SendDirect { .. }
-            | OutboundEvent::BroadcastToRoom { .. }
-            | OutboundEvent::RegisterConnection(_)
-            | OutboundEvent::UnregisterConnection(_)
-            | OutboundEvent::ArchiveGroupchat { .. }
-            | OutboundEvent::ArchiveDirect { .. }
-            | OutboundEvent::RequestEnrichment { .. }
-            | OutboundEvent::AskSfu { .. }
-            | OutboundEvent::QueryMam { .. }
-            | OutboundEvent::LoadScramCredentials { .. }
-            | OutboundEvent::ValidateOAuthBearer { .. }
-            | OutboundEvent::SetTimer { .. }
-            | OutboundEvent::CancelTimer(_) => {
-                warn!(event = ?event, "OutboundEvent variant not yet wired in interpreter");
-            }
-        }
+fn outbound_event_name(event: &OutboundEvent) -> &'static str {
+    match event {
+        OutboundEvent::SendFrame(_) => "SendFrame",
+        OutboundEvent::CloseTransport => "CloseTransport",
+        OutboundEvent::SendDirect { .. } => "SendDirect",
+        OutboundEvent::BroadcastToRoom { .. } => "BroadcastToRoom",
+        OutboundEvent::RegisterConnection(_) => "RegisterConnection",
+        OutboundEvent::UnregisterConnection(_) => "UnregisterConnection",
+        OutboundEvent::ArchiveGroupchat { .. } => "ArchiveGroupchat",
+        OutboundEvent::ArchiveDirect { .. } => "ArchiveDirect",
+        OutboundEvent::RequestEnrichment { .. } => "RequestEnrichment",
+        OutboundEvent::AskSfu { .. } => "AskSfu",
+        OutboundEvent::QueryMam { .. } => "QueryMam",
+        OutboundEvent::LoadScramCredentials { .. } => "LoadScramCredentials",
+        OutboundEvent::ValidateOAuthBearer { .. } => "ValidateOAuthBearer",
+        OutboundEvent::SetTimer { .. } => "SetTimer",
+        OutboundEvent::CancelTimer(_) => "CancelTimer",
+        OutboundEvent::Log { .. } => "Log",
     }
-
-    outcome
 }
 
 #[cfg(test)]
 mod tests {
+    use std::panic::AssertUnwindSafe;
+
+    use futures::FutureExt;
+    use waddle_xmpp::protocol::CallbackId;
+
     use super::*;
 
     #[tokio::test]
     async fn interprets_send_frame() {
+        let interpreter = EffectInterpreter::default();
         let events = vec![OutboundEvent::SendFrame(
             "<iq type=\"result\"/>".to_string(),
         )];
-        let outcome = interpret(events).await;
+        let outcome = interpreter.interpret(events).await;
         assert_eq!(outcome.frames, vec!["<iq type=\"result\"/>"]);
         assert!(!outcome.close);
     }
 
     #[tokio::test]
     async fn interprets_close_transport() {
+        let interpreter = EffectInterpreter::default();
         let events = vec![OutboundEvent::CloseTransport];
-        let outcome = interpret(events).await;
+        let outcome = interpreter.interpret(events).await;
         assert!(outcome.close);
         assert!(outcome.frames.is_empty());
     }
 
     #[tokio::test]
     async fn interprets_log_is_noop_for_caller() {
+        let interpreter = EffectInterpreter::default();
         let events = vec![OutboundEvent::Log {
             level: tracing::Level::INFO,
             message: "hello".to_string(),
         }];
-        let outcome = interpret(events).await;
+        let outcome = interpreter.interpret(events).await;
         assert!(outcome.frames.is_empty());
         assert!(!outcome.close);
     }
 
     #[tokio::test]
     async fn preserves_frame_order_across_multiple_events() {
+        let interpreter = EffectInterpreter::default();
         let events = vec![
             OutboundEvent::SendFrame("<a/>".to_string()),
             OutboundEvent::Log {
@@ -130,7 +245,52 @@ mod tests {
             },
             OutboundEvent::SendFrame("<b/>".to_string()),
         ];
-        let outcome = interpret(events).await;
+        let outcome = interpreter.interpret(events).await;
         assert_eq!(outcome.frames, vec!["<a/>", "<b/>"]);
+    }
+
+    #[tokio::test]
+    async fn callback_sender_can_be_attached() {
+        let (callback_tx, _callback_rx) = mpsc::channel(1);
+        let interpreter = EffectInterpreter::default().with_callback_sender(callback_tx);
+        assert!(interpreter.callback_tx.is_some());
+    }
+
+    #[tokio::test]
+    async fn unsupported_events_fail_loudly_without_leaking_payloads() {
+        let interpreter = EffectInterpreter::default();
+        let panic =
+            AssertUnwindSafe(
+                interpreter.interpret(vec![OutboundEvent::ValidateOAuthBearer {
+                    id: CallbackId(7),
+                    token: "secret-token".to_string(),
+                }]),
+            )
+            .catch_unwind()
+            .await
+            .expect_err("unsupported event should panic in test builds");
+
+        let panic_message = panic_message(panic);
+        assert!(panic_message.contains("ValidateOAuthBearer"));
+        assert!(!panic_message.contains("secret-token"));
+    }
+
+    #[test]
+    fn unsupported_event_names_do_not_expose_sensitive_payloads() {
+        let event = OutboundEvent::ValidateOAuthBearer {
+            id: CallbackId(7),
+            token: "secret-token".to_string(),
+        };
+        assert_eq!(outbound_event_name(&event), "ValidateOAuthBearer");
+    }
+
+    fn panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
+        match payload.downcast::<String>() {
+            Ok(message) => *message,
+            Err(payload) => match payload.downcast::<&'static str>() {
+                Ok(message) => (*message).to_string(),
+                Err(_) => "non-string panic payload".to_string(),
+            },
+        }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -31,7 +31,11 @@ use waddle_xmpp::{
         parse_mam_query, ArchivedMessage, LibSqlMamStorage, MamStorage, STANZA_ID_NS,
     },
     muc::{MucRoomRegistry, Occupant, RoomConfig},
-    protocol::{IqContext as ProtocolIqContext, StanzaDispatcher},
+    protocol::{
+        frame::{inject_client_ns_if_missing, MAX_FRAME_SIZE},
+        InboundEvent, InboundFrame, IqContext as ProtocolIqContext, StanzaDispatcher,
+        XmppStateMachine,
+    },
     registry::{ConnectionRegistry, OutboundStanza},
     xep::{build_spaces_metadata_form, NS_REPLY},
     Affiliation, Role, WaddleDetails,
@@ -111,6 +115,28 @@ impl LegacyConnState {
     }
 }
 
+/// Per-connection interpreter context that owns the typed XMPP state machine.
+///
+/// The machine is pure (no I/O) and handles stanza dispatch via the registered
+/// protocol handlers for IQ namespaces that have been migrated to the sans-I/O
+/// path. Transport-specific framing and the legacy SASL/resource-bind flow live
+/// in [`LegacyConnState`] until their own migration steps land.
+///
+/// One `WsConnRuntime` is created per WebSocket connection inside
+/// [`handle_xmpp_websocket`] and threaded through the frame handler, keeping
+/// the per-connection state machine lifetime tied to the connection lifetime.
+struct WsConnRuntime {
+    machine: XmppStateMachine,
+}
+
+impl WsConnRuntime {
+    fn new(domain: &str, dispatcher: StanzaDispatcher) -> Self {
+        Self {
+            machine: XmppStateMachine::new(domain, dispatcher),
+        }
+    }
+}
+
 /// Create the WebSocket router
 pub fn router(state: Arc<WebSocketState>) -> Router {
     Router::new()
@@ -149,13 +175,18 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     let mut conn = LegacyConnState::new();
     let mut registered = false;
 
+    // Per-connection protocol state machine. Owns a clone of the shared
+    // dispatcher (handlers are Arc-backed, so the clone is cheap) and
+    // tracks the typed lifecycle phase for this connection.
+    let mut runtime = WsConnRuntime::new(&domain, state.dispatcher.as_ref().clone());
+
     loop {
         tokio::select! {
             // Handle inbound WebSocket messages from the client
             msg = ws_receiver.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        debug!(len = text.len(), content = %text, "Received XMPP WebSocket message");
+                        debug!(len = text.len(), "Received XMPP WebSocket message");
 
                         // Handle XMPP framing (RFC 7395)
                         let responses = handle_xmpp_frame(
@@ -163,6 +194,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                             &domain,
                             &state,
                             &mut conn,
+                            &mut runtime,
                         ).await;
 
                         // Register connection after successful authentication AND resource binding
@@ -176,7 +208,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         }
 
                         for response in responses {
-                            debug!(response = %response, "Sending XMPP WebSocket response");
+                            debug!(len = response.len(), "Sending XMPP WebSocket response");
                             if let Err(e) = ws_sender.send(Message::Text(response)).await {
                                 error!(error = %e, "Failed to send WebSocket message");
                                 break;
@@ -230,6 +262,12 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
             }
         }
     }
+
+    // Notify the state machine that the transport has closed so it can
+    // emit any cleanup events (e.g. future MUC leave broadcasts). The
+    // legacy cleanup path below still handles the actual registry
+    // unregistration and MUC room removal until those migrate.
+    let _close_events = runtime.machine.handle(InboundEvent::TransportClosed);
 
     // Unregister connection on disconnect
     if let Some(ref jid) = conn.session_jid {
@@ -300,39 +338,12 @@ fn iq_to_xml(iq: xmpp_parsers::iq::Iq) -> String {
 
 fn parse_iq_frame(frame: &str) -> Option<xmpp_parsers::iq::Iq> {
     // WebSocket clients may omit xmlns="jabber:client" on stanzas (they
-    // rely on stream-level namespace inheritance from <open>).  Inject it
-    // when missing so xmpp_parsers can parse the IQ.
-    let patched = inject_default_ns_if_missing(frame, "jabber:client");
+    // rely on stream-level namespace inheritance from <open>). Inject it
+    // when missing using the shared frame normalizer so xmpp_parsers can
+    // parse the IQ without brittle string surgery here.
+    let patched = inject_client_ns_if_missing(frame);
     let element = xmpp_parsers::minidom::Element::from_str(&patched).ok()?;
     xmpp_parsers::iq::Iq::try_from(element).ok()
-}
-
-/// Inject `xmlns` into the opening tag of an `<iq>`, `<message>`, or
-/// `<presence>` stanza when the attribute is absent.
-fn inject_default_ns_if_missing(xml: &str, ns: &str) -> String {
-    let trimmed = xml.trim();
-    if !(trimmed.starts_with("<iq")
-        || trimmed.starts_with("<message")
-        || trimmed.starts_with("<presence"))
-    {
-        return trimmed.to_string();
-    }
-    let Some(open_end) = trimmed.find('>') else {
-        return trimmed.to_string();
-    };
-    let open_tag = &trimmed[..open_end];
-    if open_tag.contains("xmlns=") {
-        return trimmed.to_string();
-    }
-    // Insert xmlns right after the tag name, before any `/>`or attributes
-    let insert_pos = trimmed
-        .find(|c: char| c.is_whitespace() || c == '/')
-        .unwrap_or(open_end);
-    format!(
-        "{} xmlns=\"{ns}\"{}",
-        &trimmed[..insert_pos],
-        &trimmed[insert_pos..]
-    )
 }
 
 fn build_iq_result_xml(
@@ -457,7 +468,13 @@ async fn handle_xmpp_frame(
     domain: &str,
     state: &WebSocketState,
     conn: &mut LegacyConnState,
+    runtime: &mut WsConnRuntime,
 ) -> Vec<String> {
+    if frame.len() > MAX_FRAME_SIZE {
+        warn!(len = frame.len(), "Dropping oversized XMPP frame");
+        return vec![];
+    }
+
     // Split the bundle into the individual `&mut` borrows the legacy body
     // expects. Once the sans-I/O migration lands (see the protocol module
     // tracking PR), the whole body becomes a single
@@ -543,6 +560,14 @@ async fn handle_xmpp_frame(
         let (responses, success) = handle_resource_binding(frame, domain, session_jid);
         if success {
             *resource_bound = true;
+            // Transition the per-connection state machine to `Ready` so that
+            // subsequent stanzas routed through it see the correct phase.
+            // The legacy auth flow owns this transition point; once SASL/bind
+            // migrate into the machine this call is replaced by the machine's
+            // own event handling.
+            if let Some(ref jid) = *session_jid {
+                runtime.machine.transition_to_ready(jid.clone());
+            }
         }
         return responses;
     }
@@ -554,13 +579,16 @@ async fn handle_xmpp_frame(
 
     // Handle IQ stanzas
     if frame.starts_with("<iq") {
-        return handle_iq(
+        return handle_iq_with_conn_state(
             frame,
             domain,
             &muc_domain,
             state,
             authenticated_session,
             session_jid,
+            *authenticated,
+            *resource_bound,
+            Some(&mut runtime.machine),
         )
         .await;
     }
@@ -577,7 +605,7 @@ async fn handle_xmpp_frame(
         .await;
     }
 
-    warn!(frame = %frame, "Unhandled XMPP frame");
+    warn!(len = frame.len(), "Unhandled XMPP frame");
     vec![]
 }
 
@@ -1118,6 +1146,7 @@ async fn handle_muc_leave(
 }
 
 /// Handle IQ stanzas
+#[cfg_attr(not(test), allow(dead_code))]
 async fn handle_iq(
     frame: &str,
     domain: &str,
@@ -1125,6 +1154,45 @@ async fn handle_iq(
     state: &WebSocketState,
     authenticated_session: &Option<Session>,
     session_jid: &Option<FullJid>,
+) -> Vec<String> {
+    let authenticated = authenticated_session.is_some() || session_jid.is_some();
+    let resource_bound = session_jid
+        .as_ref()
+        .is_some_and(|jid| jid.resource().as_str() != "pending");
+    // Build a temporary per-call machine so callers (all test sites) don't
+    // need updating. The machine is initialised with the shared dispatcher and,
+    // if the connection has a bound full JID, immediately transitioned to
+    // `Ready` so that the dispatcher short-circuit sees the correct phase.
+    let mut temp_machine = XmppStateMachine::new(domain, state.dispatcher.as_ref().clone());
+    if resource_bound {
+        if let Some(jid) = session_jid.as_ref() {
+            temp_machine.transition_to_ready(jid.clone());
+        }
+    }
+    handle_iq_with_conn_state(
+        frame,
+        domain,
+        muc_domain,
+        state,
+        authenticated_session,
+        session_jid,
+        authenticated,
+        resource_bound,
+        Some(&mut temp_machine),
+    )
+    .await
+}
+
+async fn handle_iq_with_conn_state(
+    frame: &str,
+    domain: &str,
+    muc_domain: &str,
+    state: &WebSocketState,
+    authenticated_session: &Option<Session>,
+    session_jid: &Option<FullJid>,
+    authenticated: bool,
+    resource_bound: bool,
+    machine: Option<&mut XmppStateMachine>,
 ) -> Vec<String> {
     let muc_registry = state.muc_registry.as_ref();
     let spaces_domain = format!("spaces.{domain}");
@@ -1172,7 +1240,7 @@ async fn handle_iq(
     // the protocol dispatcher, route through it and translate the emitted
     // OutboundEvents into outbound XML frames via `interpret()`.
     //
-    // Handlers that need async I/O (MAM, roster, Jingle, disco) are not
+    // Handlers that need async I/O (MAM, Jingle, disco, HTTP upload) are not
     // registered yet — they continue to fall through to the legacy
     // string-matching branches below until the two-phase async callback
     // machinery lands.
@@ -1185,9 +1253,31 @@ async fn handle_iq(
         };
         if let Some(ns) = payload_ns {
             if state.dispatcher.has_iq_handler(&ns) {
-                let ctx = ProtocolIqContext { domain, full_jid };
-                let events = state.dispatcher.dispatch_iq(iq, &ctx);
-                let outcome = super::interpret::interpret(events).await;
+                if !authenticated || !resource_bound {
+                    return vec![build_iq_error_xml_with_addresses(
+                        &id,
+                        response_from,
+                        response_to,
+                        "auth",
+                        "not-authorized",
+                    )];
+                }
+                // Route through the per-connection state machine when available.
+                // The machine's `on_stanza` path calls the same underlying
+                // dispatcher, but the indirection lets it evolve (phase checks,
+                // pending-op tracking, etc.) without touching this shim.
+                // When no machine is provided (test-only `handle_iq` wrapper),
+                // fall back to calling the dispatcher directly.
+                let events = if let Some(m) = machine {
+                    m.handle(InboundEvent::FrameReceived(InboundFrame::Stanza(Box::new(
+                        Stanza::Iq(iq.clone()),
+                    ))))
+                } else {
+                    let ctx = ProtocolIqContext { domain, full_jid };
+                    state.dispatcher.dispatch_iq(iq, &ctx)
+                };
+                let interpreter = super::interpret::EffectInterpreter::from_websocket_state(&state);
+                let outcome = super::interpret::interpret(&interpreter, events).await;
                 if outcome.close {
                     warn!(
                         ns = %ns,
@@ -1852,8 +1942,14 @@ async fn handle_iq(
         }
     }
 
-    // Unknown IQ - log it and return error
-    warn!(id = %id, frame = %frame, "Unhandled IQ stanza");
+    // Unknown IQ - log a compact summary and return an error.
+    let payload_ns = parsed_iq.as_ref().and_then(|iq| match &iq.payload {
+        xmpp_parsers::iq::IqType::Get(payload) | xmpp_parsers::iq::IqType::Set(payload) => {
+            Some(payload.ns().to_string())
+        }
+        xmpp_parsers::iq::IqType::Result(_) | xmpp_parsers::iq::IqType::Error(_) => None,
+    });
+    warn!(id = %id, payload_ns, "Unhandled IQ stanza");
     vec![build_iq_error_xml_with_addresses(
         &id,
         response_from,
@@ -2495,6 +2591,7 @@ mod tests {
             "example.com",
             state.as_ref(),
             &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
         )
         .await;
 
@@ -2525,8 +2622,14 @@ mod tests {
         );
         let mut conn = LegacyConnState::new();
 
-        let responses = handle_xmpp_frame(&frame, "example.com", state.as_ref(), &mut conn).await;
-
+        let responses = handle_xmpp_frame(
+            &frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
+        )
+        .await;
         assert_eq!(responses, vec![sasl_failure_xml("invalid-mechanism")]);
         assert!(!conn.authenticated);
         assert!(!conn.resource_bound);
@@ -2547,10 +2650,15 @@ mod tests {
         );
         let mut conn = LegacyConnState::new();
 
-        let responses = handle_xmpp_frame(&frame, "example.com", state.as_ref(), &mut conn).await;
-
+        let responses = handle_xmpp_frame(
+            &frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
+        )
+        .await;
         assert_eq!(responses, vec![sasl_success_xml()]);
-        assert!(conn.authenticated);
         assert!(!conn.resource_bound);
         assert_eq!(
             conn.authenticated_session
@@ -2597,12 +2705,24 @@ mod tests {
         );
         let mut conn = LegacyConnState::new();
 
-        let auth_responses =
-            handle_xmpp_frame(&auth_frame, "example.com", state.as_ref(), &mut conn).await;
+        let auth_responses = handle_xmpp_frame(
+            &auth_frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
+        )
+        .await;
         assert_eq!(auth_responses, vec![sasl_success_xml()]);
 
-        let bind_responses =
-            handle_xmpp_frame(&bind_frame, "example.com", state.as_ref(), &mut conn).await;
+        let bind_responses = handle_xmpp_frame(
+            &bind_frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
+        )
+        .await;
 
         assert!(conn.resource_bound);
         assert_eq!(bind_responses.len(), 1);
@@ -2779,6 +2899,185 @@ mod tests {
             xmpp_parsers::iq::IqType::Result(None) => {}
             other => panic!("expected empty IQ result, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn handle_iq_roster_query_without_xmlns_survives_xmlns_like_attribute_value() {
+        let state = create_test_websocket_state().await;
+        let jid: FullJid = "alice@example.com/web".parse().expect("valid jid");
+        let frame = r#"<iq id="roster-attr" type="get" data="xmlns=bogus"><query xmlns="jabber:iq:roster"/></iq>"#;
+        let responses = handle_iq(
+            frame,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &None,
+            &Some(jid),
+        )
+        .await;
+        assert_eq!(responses.len(), 1);
+
+        let iq_xml = responses.first().expect("roster response");
+        let element = Element::from_str(iq_xml).expect("valid IQ XML");
+        let iq = xmpp_parsers::iq::Iq::try_from(element).expect("parseable IQ");
+        assert_eq!(iq.id, "roster-attr");
+        assert!(matches!(
+            iq.payload,
+            xmpp_parsers::iq::IqType::Result(Some(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_xmpp_frame_drops_oversized_input() {
+        let state = create_test_websocket_state().await;
+        let mut conn = LegacyConnState::new();
+        let huge = format!("<iq id=\"big\">{}</iq>", "a".repeat(MAX_FRAME_SIZE));
+        let responses = handle_xmpp_frame(
+            &huge,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone()),
+        )
+        .await;
+        assert!(responses.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_xmpp_frame_ping_roundtrips_through_sans_io_path() {
+        let state = create_test_websocket_state().await;
+        let mut conn = LegacyConnState::new();
+        conn.authenticated = true;
+        conn.resource_bound = true;
+        conn.session_jid = Some("alice@example.com/web".parse().expect("valid jid"));
+
+        let jid: jid::FullJid = "alice@example.com/web".parse().expect("valid jid");
+        let mut runtime = WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone());
+        runtime.machine.transition_to_ready(jid);
+
+        let responses = handle_xmpp_frame(
+            r#"<iq id="ping-roundtrip" type="get"><ping xmlns="urn:xmpp:ping"/></iq>"#,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut runtime,
+        )
+        .await;
+
+        assert_eq!(responses.len(), 1);
+        let element = Element::from_str(&responses[0]).expect("valid IQ XML");
+        let iq = xmpp_parsers::iq::Iq::try_from(element).expect("parseable IQ");
+        assert_eq!(iq.id, "ping-roundtrip");
+        assert!(matches!(iq.payload, xmpp_parsers::iq::IqType::Result(None)));
+    }
+
+    // -----------------------------------------------------------------------
+    // WsConnRuntime / XmppStateMachine lifecycle tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn ws_conn_runtime_machine_transitions_to_ready_after_bind() {
+        use waddle_xmpp::protocol::ConnectionPhase;
+
+        let state = create_test_websocket_state().await;
+        let mut runtime = WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone());
+
+        // Before bind the machine must be in the Unauthenticated phase.
+        assert!(
+            matches!(runtime.machine.phase(), ConnectionPhase::Unauthenticated),
+            "machine should start Unauthenticated"
+        );
+
+        let jid: jid::FullJid = "alice@example.com/mobile".parse().expect("valid jid");
+        runtime.machine.transition_to_ready(jid.clone());
+
+        // After transition the machine should report Ready with the correct JID.
+        match runtime.machine.phase() {
+            ConnectionPhase::Ready { full_jid, .. } => {
+                assert_eq!(full_jid, &jid, "Ready JID must match the bound JID");
+            }
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ws_conn_runtime_transport_closed_is_handled() {
+        let state = create_test_websocket_state().await;
+        let mut runtime = WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone());
+
+        // TransportClosed before authentication — must not panic.
+        let events = runtime.machine.handle(InboundEvent::TransportClosed);
+        // The machine may emit log events; we just require it doesn't panic and
+        // doesn't emit any outbound frames (no active session to clean up).
+        assert!(
+            events
+                .iter()
+                .all(|e| matches!(e, waddle_xmpp::protocol::OutboundEvent::Log { .. })),
+            "unexpected non-log events on closed unauthenticated connection: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_xmpp_frame_machine_ready_after_resource_bind() {
+        use waddle_xmpp::protocol::ConnectionPhase;
+
+        let state = create_test_websocket_state().await;
+        let session = create_test_session(state.as_ref(), "alice").await;
+        let payload = BASE64_STANDARD.encode(format!("n,,\x01auth=Bearer {}\x01\x01", session.id));
+        let auth_frame = element_to_xml(
+            Element::builder("auth", waddle_xmpp::ns::SASL)
+                .attr("mechanism", "OAUTHBEARER")
+                .append(payload)
+                .build(),
+        );
+        let bind_frame = element_to_xml(
+            Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+                .attr("id", "lifecycle-bind-1")
+                .attr("type", "set")
+                .append(
+                    Element::builder("bind", waddle_xmpp::ns::BIND)
+                        .append(
+                            Element::builder("resource", waddle_xmpp::ns::BIND)
+                                .append("web")
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        );
+
+        let mut conn = LegacyConnState::new();
+        let mut runtime = WsConnRuntime::new("example.com", state.dispatcher.as_ref().clone());
+
+        // Machine must be Unauthenticated before the bind.
+        assert!(matches!(
+            runtime.machine.phase(),
+            ConnectionPhase::Unauthenticated
+        ));
+
+        handle_xmpp_frame(
+            &auth_frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut runtime,
+        )
+        .await;
+        handle_xmpp_frame(
+            &bind_frame,
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+            &mut runtime,
+        )
+        .await;
+
+        assert!(conn.resource_bound, "resource_bound flag must be set");
+        assert!(
+            matches!(runtime.machine.phase(), ConnectionPhase::Ready { .. }),
+            "machine must be in Ready phase after bind; got {:?}",
+            runtime.machine.phase()
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -1283,8 +1283,8 @@ async fn handle_iq_with_conn_state(frame: &str, ctx: IqHandlingContext<'_>) -> V
                 // The machine's `on_stanza` path calls the same underlying
                 // dispatcher, but the indirection lets it evolve (phase checks,
                 // pending-op tracking, etc.) without touching this shim.
-                // When no machine is provided (test-only `handle_iq` wrapper),
-                // fall back to calling the dispatcher directly.
+                // If no machine is provided, fall back to calling the
+                // dispatcher directly.
                 let events = if let Some(m) = machine {
                     m.handle(InboundEvent::FrameReceived(InboundFrame::Stanza(Box::new(
                         Stanza::Iq(iq.clone()),

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -582,14 +582,16 @@ async fn handle_xmpp_frame(
     if frame.starts_with("<iq") {
         return handle_iq_with_conn_state(
             frame,
-            domain,
-            &muc_domain,
-            state,
-            authenticated_session,
-            session_jid,
-            *authenticated,
-            *resource_bound,
-            Some(&mut runtime.machine),
+            IqHandlingContext {
+                domain,
+                muc_domain: &muc_domain,
+                state,
+                authenticated_session,
+                session_jid,
+                authenticated: *authenticated,
+                resource_bound: *resource_bound,
+                machine: Some(&mut runtime.machine),
+            },
         )
         .await;
     }
@@ -1172,6 +1174,33 @@ async fn handle_iq(
     }
     handle_iq_with_conn_state(
         frame,
+        IqHandlingContext {
+            domain,
+            muc_domain,
+            state,
+            authenticated_session,
+            session_jid,
+            authenticated,
+            resource_bound,
+            machine: Some(&mut temp_machine),
+        },
+    )
+    .await
+}
+
+struct IqHandlingContext<'a> {
+    domain: &'a str,
+    muc_domain: &'a str,
+    state: &'a WebSocketState,
+    authenticated_session: &'a Option<Session>,
+    session_jid: &'a Option<FullJid>,
+    authenticated: bool,
+    resource_bound: bool,
+    machine: Option<&'a mut XmppStateMachine>,
+}
+
+async fn handle_iq_with_conn_state(frame: &str, ctx: IqHandlingContext<'_>) -> Vec<String> {
+    let IqHandlingContext {
         domain,
         muc_domain,
         state,
@@ -1179,22 +1208,9 @@ async fn handle_iq(
         session_jid,
         authenticated,
         resource_bound,
-        Some(&mut temp_machine),
-    )
-    .await
-}
+        machine,
+    } = ctx;
 
-async fn handle_iq_with_conn_state(
-    frame: &str,
-    domain: &str,
-    muc_domain: &str,
-    state: &WebSocketState,
-    authenticated_session: &Option<Session>,
-    session_jid: &Option<FullJid>,
-    authenticated: bool,
-    resource_bound: bool,
-    machine: Option<&mut XmppStateMachine>,
-) -> Vec<String> {
     let muc_registry = state.muc_registry.as_ref();
     let spaces_domain = format!("spaces.{domain}");
     let single_tenant = std::env::var("WADDLE_SINGLE_TENANT")
@@ -1277,15 +1293,7 @@ async fn handle_iq_with_conn_state(
                     let ctx = ProtocolIqContext { domain, full_jid };
                     state.dispatcher.dispatch_iq(iq, &ctx)
                 };
-                let interpreter = EffectInterpreter::new(
-                    Arc::clone(&state.app_state),
-                    Arc::clone(&state.auth_state),
-                    Arc::clone(&state.connection_registry),
-                    Arc::clone(&state.muc_registry),
-                    Arc::clone(&state.mam_storage),
-                    Arc::clone(&state.github_enricher),
-                    state.sfu_service.clone(),
-                );
+                let interpreter = EffectInterpreter::from_websocket_state(state);
                 let outcome = interpreter.interpret(events).await;
                 if outcome.close {
                     warn!(

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -46,6 +46,7 @@ use xmpp_parsers::minidom::Element;
 use waddle_xmpp_xep_github::{message_has_github_embed, MessageEnricher};
 
 use super::auth::AuthState;
+use super::interpret::EffectInterpreter;
 use crate::auth::{localpart_to_jid, NativeUserStore, Session};
 use crate::server::routes::channels::list_channels_from_db;
 use crate::server::routes::waddles::{
@@ -1276,8 +1277,16 @@ async fn handle_iq_with_conn_state(
                     let ctx = ProtocolIqContext { domain, full_jid };
                     state.dispatcher.dispatch_iq(iq, &ctx)
                 };
-                let interpreter = super::interpret::EffectInterpreter::from_websocket_state(&state);
-                let outcome = super::interpret::interpret(&interpreter, events).await;
+                let interpreter = EffectInterpreter::new(
+                    Arc::clone(&state.app_state),
+                    Arc::clone(&state.auth_state),
+                    Arc::clone(&state.connection_registry),
+                    Arc::clone(&state.muc_registry),
+                    Arc::clone(&state.mam_storage),
+                    Arc::clone(&state.github_enricher),
+                    state.sfu_service.clone(),
+                );
+                let outcome = interpreter.interpret(events).await;
                 if outcome.close {
                     warn!(
                         ns = %ns,
@@ -2558,13 +2567,16 @@ mod tests {
         let mut dispatcher = StanzaDispatcher::new();
         waddle_xmpp::protocol::handlers::register_default_handlers(&mut dispatcher);
 
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        let muc_registry = Arc::new(MucRoomRegistry::new("muc.example.com".to_string()));
+        let github_enricher = Arc::new(MessageEnricher::new(Arc::new(GitHubClient::new(None))));
         Arc::new(WebSocketState {
             app_state,
             auth_state,
-            connection_registry: Arc::new(ConnectionRegistry::new()),
-            muc_registry: Arc::new(MucRoomRegistry::new("muc.example.com".to_string())),
+            connection_registry,
+            muc_registry,
             mam_storage,
-            github_enricher: Arc::new(MessageEnricher::new(Arc::new(GitHubClient::new(None)))),
+            github_enricher,
             sfu_service,
             dispatcher: Arc::new(dispatcher),
         })

--- a/server/crates/waddle-xmpp/src/protocol/frame.rs
+++ b/server/crates/waddle-xmpp/src/protocol/frame.rs
@@ -96,12 +96,13 @@ pub enum ParseError {
 /// when missing so `xmpp_parsers` can convert the element into a typed
 /// stanza.
 pub fn parse_frame(frame: &str) -> Result<InboundFrame, ParseError> {
+    if frame.len() > MAX_FRAME_SIZE {
+        return Err(ParseError::TooLarge);
+    }
+
     let trimmed = frame.trim();
     if trimmed.is_empty() {
         return Err(ParseError::Empty);
-    }
-    if trimmed.len() > MAX_FRAME_SIZE {
-        return Err(ParseError::TooLarge);
     }
 
     let root = peek_root_name(trimmed)
@@ -515,6 +516,12 @@ mod tests {
     #[test]
     fn rejects_oversized_frame() {
         let huge = format!("<iq id=\"x\">{}</iq>", "a".repeat(MAX_FRAME_SIZE));
+        assert!(matches!(parse_frame(&huge), Err(ParseError::TooLarge)));
+    }
+
+    #[test]
+    fn rejects_oversized_frame_even_when_padding_would_trim_away() {
+        let huge = format!("  <iq id=\"x\">{}</iq>  ", "a".repeat(MAX_FRAME_SIZE));
         assert!(matches!(parse_frame(&huge), Err(ParseError::TooLarge)));
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/frame.rs
+++ b/server/crates/waddle-xmpp/src/protocol/frame.rs
@@ -15,6 +15,9 @@ use std::str::FromStr;
 use thiserror::Error;
 use xmpp_parsers::minidom::Element;
 
+pub const CLIENT_STANZA_NS: &str = "jabber:client";
+pub const MAX_FRAME_SIZE: usize = 1024 * 1024;
+
 /// A fully parsed inbound XMPP frame, ready for typed dispatch.
 ///
 /// Covers the RFC 7395 framing layer plus SASL negotiation frames. IQ-bind
@@ -58,11 +61,14 @@ pub enum ParseError {
     /// The payload was empty or contained only whitespace.
     #[error("frame is empty")]
     Empty,
+    /// The payload exceeded the parser's maximum accepted frame size.
+    #[error("frame exceeds maximum size")]
+    TooLarge,
     /// The payload was not well-formed XML.
     #[error("invalid XML: {0}")]
     InvalidXml(String),
-    /// The payload's root element is not one of the five frames we know
-    /// how to handle (`open`, `close`, `auth`, `response`, `iq`, `message`,
+    /// The payload's root element is not one of the seven frame roots we
+    /// know how to handle (`open`, `close`, `auth`, `response`, `iq`, `message`,
     /// `presence`).
     #[error("unknown root element: <{0}>")]
     UnknownRoot(String),
@@ -93,6 +99,9 @@ pub fn parse_frame(frame: &str) -> Result<InboundFrame, ParseError> {
     let trimmed = frame.trim();
     if trimmed.is_empty() {
         return Err(ParseError::Empty);
+    }
+    if trimmed.len() > MAX_FRAME_SIZE {
+        return Err(ParseError::TooLarge);
     }
 
     let root = peek_root_name(trimmed)
@@ -150,7 +159,7 @@ fn parse_response(frame: &str) -> Result<InboundFrame, ParseError> {
 }
 
 fn parse_stanza(frame: &str, kind: &str) -> Result<InboundFrame, ParseError> {
-    let patched = inject_default_ns(frame, "jabber:client");
+    let patched = inject_client_ns_if_missing(frame);
     let element =
         Element::from_str(&patched).map_err(|err| ParseError::InvalidXml(err.to_string()))?;
 
@@ -189,20 +198,136 @@ fn parse_stanza(frame: &str, kind: &str) -> Result<InboundFrame, ParseError> {
 /// relying on the stream-level `<open>` to scope them. Since we parse each
 /// frame in isolation, we reintroduce the namespace here so that
 /// `xmpp_parsers` accepts the element.
-fn inject_default_ns(xml: &str, ns: &str) -> String {
-    let open_end = match xml.find('>') {
-        Some(idx) => idx,
-        None => return xml.to_string(),
+pub fn inject_client_ns_if_missing(xml: &str) -> String {
+    let trimmed = xml.trim();
+    let Some(scan) = scan_start_tag(trimmed) else {
+        return trimmed.to_string();
     };
-    let open_tag = &xml[..open_end];
-    if open_tag.contains("xmlns=") {
-        return xml.to_string();
+    if scan.has_default_xmlns {
+        return trimmed.to_string();
     }
-    let tag_end = xml[1..]
-        .find(|c: char| c.is_ascii_whitespace() || c == '>' || c == '/')
-        .map(|idx| idx + 1)
-        .unwrap_or(open_end);
-    format!(r#"{} xmlns="{ns}"{}"#, &xml[..tag_end], &xml[tag_end..])
+
+    let mut patched = String::with_capacity(trimmed.len() + CLIENT_STANZA_NS.len() + 9);
+    patched.push_str(&trimmed[..scan.name_end]);
+    patched.push_str(r#" xmlns=""#);
+    patched.push_str(CLIENT_STANZA_NS);
+    patched.push('"');
+    patched.push_str(&trimmed[scan.name_end..]);
+    patched
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StartTagScan {
+    name_end: usize,
+    has_default_xmlns: bool,
+}
+
+fn scan_start_tag(xml: &str) -> Option<StartTagScan> {
+    let bytes = xml.as_bytes();
+    if bytes.first().copied()? != b'<' {
+        return None;
+    }
+
+    let mut idx = 1;
+    while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    if idx >= bytes.len() || matches!(bytes[idx], b'/' | b'!' | b'?') {
+        return None;
+    }
+
+    let name_start = idx;
+    while idx < bytes.len()
+        && !bytes[idx].is_ascii_whitespace()
+        && !matches!(bytes[idx], b'>' | b'/')
+    {
+        idx += 1;
+    }
+    if idx == name_start {
+        return None;
+    }
+    let name_end = idx;
+    let mut has_default_xmlns = false;
+
+    loop {
+        idx = skip_ascii_whitespace(bytes, idx);
+        if idx >= bytes.len() {
+            return None;
+        }
+
+        match bytes[idx] {
+            b'>' => {
+                return Some(StartTagScan {
+                    name_end,
+                    has_default_xmlns,
+                });
+            }
+            b'/' if idx + 1 < bytes.len() && bytes[idx + 1] == b'>' => {
+                return Some(StartTagScan {
+                    name_end,
+                    has_default_xmlns,
+                });
+            }
+            b'/' => return None,
+            _ => {}
+        }
+
+        let attr_start = idx;
+        while idx < bytes.len()
+            && !bytes[idx].is_ascii_whitespace()
+            && !matches!(bytes[idx], b'=' | b'>' | b'/')
+        {
+            idx += 1;
+        }
+        if idx == attr_start {
+            return None;
+        }
+        if &xml[attr_start..idx] == "xmlns" {
+            has_default_xmlns = true;
+        }
+
+        idx = skip_ascii_whitespace(bytes, idx);
+        if idx >= bytes.len() {
+            return None;
+        }
+        if bytes[idx] != b'=' {
+            continue;
+        }
+
+        idx += 1;
+        idx = skip_ascii_whitespace(bytes, idx);
+        if idx >= bytes.len() {
+            return None;
+        }
+
+        match bytes[idx] {
+            quote @ (b'"' | b'\'') => {
+                idx += 1;
+                while idx < bytes.len() && bytes[idx] != quote {
+                    idx += 1;
+                }
+                if idx >= bytes.len() {
+                    return None;
+                }
+                idx += 1;
+            }
+            _ => {
+                while idx < bytes.len()
+                    && !bytes[idx].is_ascii_whitespace()
+                    && !matches!(bytes[idx], b'>' | b'/')
+                {
+                    idx += 1;
+                }
+            }
+        }
+    }
+}
+
+fn skip_ascii_whitespace(bytes: &[u8], mut idx: usize) -> usize {
+    while idx < bytes.len() && bytes[idx].is_ascii_whitespace() {
+        idx += 1;
+    }
+    idx
 }
 
 #[cfg(test)]
@@ -355,15 +480,41 @@ mod tests {
     #[test]
     fn inject_default_ns_is_noop_when_xmlns_present() {
         let input = r#"<iq xmlns="jabber:client" id="x"/>"#;
-        assert_eq!(inject_default_ns(input, "jabber:client"), input);
+        assert_eq!(inject_client_ns_if_missing(input), input);
     }
 
     #[test]
     fn inject_default_ns_adds_attr_after_tag_name() {
         let input = r#"<iq id="x"/>"#;
         assert_eq!(
-            inject_default_ns(input, "jabber:client"),
+            inject_client_ns_if_missing(input),
             r#"<iq xmlns="jabber:client" id="x"/>"#
         );
+    }
+
+    #[test]
+    fn inject_default_ns_ignores_xmlns_like_attribute_values() {
+        let input = r#"<iq id="x" data="xmlns=bogus"/>"#;
+        assert_eq!(
+            inject_client_ns_if_missing(input),
+            r#"<iq xmlns="jabber:client" id="x" data="xmlns=bogus"/>"#
+        );
+    }
+
+    #[test]
+    fn inject_default_ns_handles_gt_inside_attribute_value() {
+        let input = r#"<iq id="x" data="1 > 0"><ping xmlns="urn:xmpp:ping"/></iq>"#;
+        let patched = inject_client_ns_if_missing(input);
+        assert_eq!(
+            patched,
+            r#"<iq xmlns="jabber:client" id="x" data="1 > 0"><ping xmlns="urn:xmpp:ping"/></iq>"#
+        );
+        assert!(Element::from_str(&patched).is_ok());
+    }
+
+    #[test]
+    fn rejects_oversized_frame() {
+        let huge = format!("<iq id=\"x\">{}</iq>", "a".repeat(MAX_FRAME_SIZE));
+        assert!(matches!(parse_frame(&huge), Err(ParseError::TooLarge)));
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -80,17 +80,28 @@ impl XmppStateMachine {
     /// [`Self::register_pending_op`] to stash the context needed when the
     /// matching [`InboundEvent`] completion arrives.
     pub fn next_callback_id(&mut self) -> CallbackId {
-        self.next_callback = self.next_callback.wrapping_add(1);
+        self.next_callback = self
+            .next_callback
+            .checked_add(1)
+            .expect("callback id space exhausted");
         CallbackId(self.next_callback)
+    }
+
+    /// Register the completion context for a previously allocated callback id.
+    ///
+    /// Handlers must call this before emitting an async delegation event so
+    /// the matching completion can recover its state.
+    pub fn register_pending_op(&mut self, id: CallbackId, op: PendingOp) {
+        assert!(
+            self.pending_ops.insert(id, op).is_none(),
+            "duplicate callback id registered: {id:?}"
+        );
     }
 
     /// Consume a previously-registered [`PendingOp`] when its completion
     /// event arrives. Returns `None` for unknown ids (late / duplicate
     /// completions — logged and dropped by the caller).
     ///
-    /// A `register_pending_op` counterpart will be reintroduced alongside
-    /// the first async handler that needs it. For now the field is
-    /// populated directly from tests in the same module.
     fn take_pending_op(&mut self, id: CallbackId) -> Option<PendingOp> {
         self.pending_ops.remove(&id)
     }
@@ -99,6 +110,25 @@ impl XmppStateMachine {
     /// know whether the connection is registered, and for tests.
     pub fn phase(&self) -> &ConnectionPhase {
         &self.phase
+    }
+
+    /// Transition the machine into the `Ready` phase.
+    ///
+    /// Called by the WebSocket transport adapter after the legacy SASL flow
+    /// has authenticated the user and the resource IQ has been bound.  This
+    /// bridge exists because SASL/resource-bind are still handled by the
+    /// legacy code path; once that migration step lands this method will be
+    /// replaced by ordinary `handle(InboundEvent::…)` calls inside the
+    /// state machine itself.
+    ///
+    /// Calling this method while the machine is already in `Ready` resets
+    /// the joined-room set — transport adapters must not call it twice for
+    /// the same connection.
+    pub fn transition_to_ready(&mut self, full_jid: jid::FullJid) {
+        self.phase = ConnectionPhase::Ready {
+            full_jid,
+            joined_rooms: std::collections::HashSet::new(),
+        };
     }
 
     /// The pure event → events transition.
@@ -413,7 +443,7 @@ mod tests {
         // the op, emit a DEBUG log (matched=true) and drop the entry.
         let mut sm = XmppStateMachine::new("waddle.social", StanzaDispatcher::new());
         let id = sm.next_callback_id();
-        sm.pending_ops.insert(
+        sm.register_pending_op(
             id,
             PendingOp::MamQuery {
                 request_id: "mam-7".to_string(),


### PR DESCRIPTION
## Summary
- complete the phase-0 EffectInterpreter slice with concrete runtime dependencies and payload-safe fail-loud handling for unsupported outbound events
- route the WebSocket adapter through a per-connection XmppStateMachine/WsConnRuntime bridge and harden the frame boundary with robust namespace injection and frame-size limits
- remove the prebuilt interpreter from server state and use transport-local interpreter construction that matches the validated runtime shape

## Validation
- cargo test -p waddle-server --quiet -- --test-threads=1
- cargo test -p waddle-xmpp --lib --quiet

## Review notes
- Claude Sonnet 4.6: no significant issues found
- Claude Haiku 4.5: no significant issues found
- GPT-5.4 noted that async callback completion plumbing is still a later migration step, not part of this synchronous slice