### PR TITLE
feat(chat): detect web app updates

### DIFF
--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -1,21 +1,9 @@
-import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@astrojs/vue";
-
-function resolveCommitSha() {
-  const envSha = process.env.WADDLE_GIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA;
-  if (envSha && envSha.trim().length > 0) return envSha.trim().slice(0, 12);
-  try {
-    return execSync("git rev-parse --short=12 HEAD", { stdio: ["ignore", "pipe", "ignore"] })
-      .toString()
-      .trim();
-  } catch {
-    return "unknown";
-  }
-}
+import { resolveCommitSha } from "./scripts/resolve-commit-sha.mjs";
 
 const COMMIT_SHA = resolveCommitSha();
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -7,12 +7,13 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro check && astro build",
-    "preview": "astro preview",
+    "generate-service-worker": "bun run scripts/generate-service-worker.mjs",
+    "dev": "bun run generate-service-worker && astro dev",
+    "build": "bun run generate-service-worker && astro check && astro build",
+    "preview": "bun run generate-service-worker && astro preview",
     "astro": "astro",
     "generate-types": "wrangler types",
-    "deploy": "wrangler deploy"
+    "deploy": "bun run generate-service-worker && wrangler deploy"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.1.3",

--- a/chat/scripts/generate-service-worker.mjs
+++ b/chat/scripts/generate-service-worker.mjs
@@ -1,0 +1,16 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveCommitSha } from "./resolve-commit-sha.mjs";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(scriptDir, "..");
+const templatePath = resolve(projectRoot, "src", "service-worker", "sw-template.js");
+const outputPath = resolve(projectRoot, "public", "sw.js");
+
+const commitSha = resolveCommitSha();
+const template = readFileSync(templatePath, "utf8");
+const output = template.replaceAll("__WADDLE_BUILD_SHA__", commitSha);
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(outputPath, output);

--- a/chat/scripts/resolve-commit-sha.mjs
+++ b/chat/scripts/resolve-commit-sha.mjs
@@ -1,0 +1,13 @@
+import { execSync } from "node:child_process";
+
+export function resolveCommitSha() {
+  const envSha = process.env.WADDLE_GIT_SHA ?? process.env.CF_PAGES_COMMIT_SHA;
+  if (envSha && envSha.trim().length > 0) return envSha.trim().slice(0, 12);
+  try {
+    return execSync("git rev-parse --short=12 HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return "unknown";
+  }
+}

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -7,6 +7,7 @@ import { useDmMessaging } from "@/composables/useDmMessaging";
 import { useMessaging } from "@/composables/useMessaging";
 import { useThreads } from "@/composables/useThreads";
 import { useUiState } from "@/composables/useUiState";
+import { useAppUpdate } from "@/composables/useAppUpdate";
 import { useNotifications } from "@/composables/useNotifications";
 import { useVersion } from "@/composables/useVersion";
 import { buildDmPath, buildPath, buildSettingsPath, parseRoute, pushDmRoute, pushRoute, pushSettingsRoute, resolveWaddle, resolveChannel } from "@/composables/useRouting";
@@ -169,6 +170,7 @@ const activeDmPeer = computed(() => {
 });
 
 const notifications = useNotifications();
+const appUpdate = useAppUpdate();
 const version = useVersion(xmppClient);
 const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
   const avatars: Record<string, string | null> = {};
@@ -300,6 +302,10 @@ async function handleToggleNotifications() {
   } else if (xmppClient.value && connectionStore.session) {
     await notifications.disablePushSubscription(xmppClient.value, connectionStore.session.jid);
   }
+}
+
+async function refreshAppUpdate() {
+  await appUpdate.applyUpdate();
 }
 
 const activeTarget = computed(() =>
@@ -751,6 +757,19 @@ let hasBootstrapped = false;
 watch(
   () => connectionStore.appState,
   (state) => {
+    if (state === "ready") {
+      void appUpdate.start();
+      return;
+    }
+
+    appUpdate.stop();
+  },
+  { immediate: true },
+);
+
+watch(
+  () => connectionStore.appState,
+  (state) => {
     if (state === "ready" && !hasBootstrapped) {
       hasBootstrapped = true;
       void onConnectionReady();
@@ -765,6 +784,7 @@ onMounted(() => {
 
 onUnmounted(() => {
   window.removeEventListener("popstate", onPopState);
+  appUpdate.stop();
   messaging.disconnect();
   dmMessaging.disconnect();
 });
@@ -973,6 +993,8 @@ onUnmounted(() => {
           :first-unseen-id="activeFirstUnseenId"
           :xmpp-status="messaging.xmppStatus.value"
           :action-error="ui.actionError.value"
+          :update-available="appUpdate.updateAvailable.value"
+          :is-applying-update="appUpdate.isApplyingUpdate.value"
           :is-loading-messages="activeIsLoadingMessages"
           :is-sending="activeIsSending"
           :can-manage-channels="waddles.canManageChannels.value"
@@ -1002,6 +1024,7 @@ onUnmounted(() => {
           @edit-channel="openChannelEdit"
           @open-dm="handleOpenDm"
           @open-thread="openThread"
+          @refresh-update="refreshAppUpdate"
         />
 
         <ThreadPanel

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -32,6 +32,8 @@ const props = defineProps<{
   firstUnseenId: string | null;
   xmppStatus: XmppStatusSnapshot;
   actionError: string;
+  updateAvailable: boolean;
+  isApplyingUpdate: boolean;
   isLoadingMessages: boolean;
   isSending: boolean;
   canManageChannels: boolean;
@@ -70,6 +72,7 @@ const emit = defineEmits<{
   clearSearch: [];
   openDm: [peerJid: string];
   openThread: [threadId: string];
+  refreshUpdate: [];
 }>();
 
 // Hide thread members from the main feed — they live inside the thread panel.
@@ -306,6 +309,11 @@ const connectionStatusClasses = computed(() => {
       return null;
   }
 });
+const updateNoticeBody = computed(() =>
+  props.isApplyingUpdate
+    ? "Refreshing to load the latest version."
+    : "A newer version is ready. Refresh to load it.",
+);
 
 defineExpose({ messagesContainer });
 
@@ -512,6 +520,44 @@ function showDividerAfter(messageId: string): boolean {
             {{ connectionNotice.body }}
           </p>
         </div>
+      </div>
+    </div>
+    <div
+      v-if="updateAvailable"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="border-b border-primary/12 bg-primary/8 text-foreground"
+    >
+      <div class="px-6 py-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-start gap-3">
+          <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/15 bg-background/75 text-primary">
+            <RefreshCw
+              class="h-4 w-4"
+              :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
+            />
+          </div>
+          <div class="min-w-0 space-y-0.5">
+            <p class="text-[13px] font-medium tracking-tight">
+              Update ready
+            </p>
+            <p class="max-w-[72ch] text-[12px] leading-5 text-foreground/75">
+              {{ updateNoticeBody }}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-primary px-3.5 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-wait disabled:opacity-75"
+          :disabled="isApplyingUpdate"
+          @click="emit('refreshUpdate')"
+        >
+          <RefreshCw
+            class="h-3.5 w-3.5"
+            :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
+          />
+          <span>{{ isApplyingUpdate ? "Refreshing…" : "Refresh" }}</span>
+        </button>
       </div>
     </div>
 

--- a/chat/src/composables/useAppUpdate.ts
+++ b/chat/src/composables/useAppUpdate.ts
@@ -1,0 +1,328 @@
+import { computed, ref } from "vue";
+import {
+	getOrRegisterServiceWorker,
+	getServiceWorkerRegistration,
+	supportsServiceWorker,
+} from "@/lib/service-worker-registration";
+
+const UPDATE_CHECK_INTERVAL_MS = 15 * 60_000;
+const UPDATE_CHECK_THROTTLE_MS = 60_000;
+
+const registration = ref<ServiceWorkerRegistration | null>(null);
+const installingState = ref<ServiceWorkerState | null>(null);
+const hasWaitingWorker = ref(false);
+const isChecking = ref(false);
+const isApplyingUpdate = ref(false);
+const controllerChanged = ref(false);
+const lastCheckedAt = ref<number | null>(null);
+
+const updateAvailable = computed(() => hasWaitingWorker.value);
+const canApplyUpdate = computed(
+	() => hasWaitingWorker.value && !isApplyingUpdate.value,
+);
+
+let started = false;
+let updateCheckTimer: number | null = null;
+let observedRegistration: ServiceWorkerRegistration | null = null;
+let observedInstallingWorker: ServiceWorker | null = null;
+let pendingCheck: Promise<ServiceWorkerRegistration | null> | null = null;
+let lastCheckStartedAt = 0;
+let didReloadForControllerChange = false;
+let lifecycleToken = 0;
+
+const handleFocus = () => {
+	void checkForUpdate();
+};
+
+const handleVisibilityChange = () => {
+	if (document.visibilityState === "visible") {
+		void checkForUpdate();
+	}
+};
+
+const handleControllerChange = () => {
+	controllerChanged.value = true;
+	hasWaitingWorker.value = false;
+	installingState.value = null;
+
+	if (isApplyingUpdate.value && !didReloadForControllerChange) {
+		didReloadForControllerChange = true;
+		isApplyingUpdate.value = false;
+		window.location.reload();
+		return;
+	}
+
+	isApplyingUpdate.value = false;
+	void refreshObservedRegistration();
+};
+
+const handleUpdateFound = () => {
+	observeInstallingWorker(observedRegistration?.installing ?? null);
+	syncRegistrationState(observedRegistration);
+};
+
+const handleInstallingStateChange = () => {
+	if (!observedInstallingWorker) {
+		installingState.value = null;
+		return;
+	}
+
+	installingState.value = observedInstallingWorker.state;
+
+	if (observedInstallingWorker.state === "installed") {
+		if (navigator.serviceWorker.controller) {
+			hasWaitingWorker.value = true;
+		}
+		void refreshObservedRegistration();
+		return;
+	}
+
+	if (
+		observedInstallingWorker.state === "activating" ||
+		observedInstallingWorker.state === "activated" ||
+		observedInstallingWorker.state === "redundant"
+	) {
+		if (observedInstallingWorker.state === "redundant") {
+			isApplyingUpdate.value = false;
+		}
+		void refreshObservedRegistration();
+	}
+};
+
+function removeRegistrationObserver() {
+	observedRegistration?.removeEventListener("updatefound", handleUpdateFound);
+	observedRegistration = null;
+}
+
+function removeInstallingWorkerObserver() {
+	observedInstallingWorker?.removeEventListener(
+		"statechange",
+		handleInstallingStateChange,
+	);
+	observedInstallingWorker = null;
+}
+
+function observeInstallingWorker(worker: ServiceWorker | null) {
+	if (observedInstallingWorker === worker) {
+		if (!worker) {
+			installingState.value = null;
+		}
+		return;
+	}
+
+	removeInstallingWorkerObserver();
+	observedInstallingWorker = worker;
+
+	if (!worker) {
+		installingState.value = null;
+		return;
+	}
+
+	installingState.value = worker.state;
+	worker.addEventListener("statechange", handleInstallingStateChange);
+}
+
+function syncRegistrationState(
+	nextRegistration: ServiceWorkerRegistration | null,
+) {
+	registration.value = nextRegistration;
+	observeInstallingWorker(
+		nextRegistration?.installing ?? nextRegistration?.waiting ?? null,
+	);
+	hasWaitingWorker.value = Boolean(
+		navigator.serviceWorker.controller && nextRegistration?.waiting,
+	);
+}
+
+function observeRegistration(
+	nextRegistration: ServiceWorkerRegistration | null,
+) {
+	if (observedRegistration === nextRegistration) {
+		syncRegistrationState(nextRegistration);
+		return;
+	}
+
+	removeRegistrationObserver();
+	observedRegistration = nextRegistration;
+
+	if (nextRegistration) {
+		nextRegistration.addEventListener("updatefound", handleUpdateFound);
+	}
+
+	syncRegistrationState(nextRegistration);
+}
+
+async function refreshObservedRegistration() {
+	const currentRegistration = await getServiceWorkerRegistration();
+	observeRegistration(currentRegistration);
+	return registration.value;
+}
+
+function clearUpdateCheckTimer() {
+	if (updateCheckTimer !== null) {
+		window.clearInterval(updateCheckTimer);
+		updateCheckTimer = null;
+	}
+}
+
+function resetState() {
+	removeInstallingWorkerObserver();
+	removeRegistrationObserver();
+	registration.value = null;
+	installingState.value = null;
+	hasWaitingWorker.value = false;
+	isChecking.value = false;
+	isApplyingUpdate.value = false;
+	controllerChanged.value = false;
+	lastCheckedAt.value = null;
+	pendingCheck = null;
+	lastCheckStartedAt = 0;
+	didReloadForControllerChange = false;
+}
+
+async function checkForUpdate(
+	force = false,
+): Promise<ServiceWorkerRegistration | null> {
+	if (!supportsServiceWorker()) return null;
+
+	if (pendingCheck) {
+		return pendingCheck;
+	}
+
+	const now = Date.now();
+	if (!force && now - lastCheckStartedAt < UPDATE_CHECK_THROTTLE_MS) {
+		return registration.value;
+	}
+
+	lastCheckStartedAt = now;
+	const currentLifecycleToken = lifecycleToken;
+
+	pendingCheck = (async () => {
+		isChecking.value = true;
+
+		try {
+			const currentRegistration = await getOrRegisterServiceWorker();
+			if (currentLifecycleToken !== lifecycleToken) {
+				return null;
+			}
+
+			observeRegistration(currentRegistration);
+
+			if (currentRegistration) {
+				try {
+					await currentRegistration.update();
+				} catch {
+					// ignore update check failures
+				}
+			}
+
+			if (currentLifecycleToken !== lifecycleToken) {
+				return null;
+			}
+
+			await refreshObservedRegistration();
+			if (currentLifecycleToken !== lifecycleToken) {
+				return null;
+			}
+
+			lastCheckedAt.value = Date.now();
+			return registration.value;
+		} finally {
+			isChecking.value = false;
+			pendingCheck = null;
+		}
+	})();
+
+	return pendingCheck;
+}
+
+async function applyUpdate() {
+	if (!supportsServiceWorker()) return false;
+	if (isApplyingUpdate.value) return true;
+
+	ensureStarted();
+
+	const currentRegistration = registration.value?.waiting
+		? registration.value
+		: await checkForUpdate(true);
+	const waitingWorker = currentRegistration?.waiting ?? null;
+	if (!waitingWorker) {
+		await refreshObservedRegistration();
+		return controllerChanged.value && !registration.value?.waiting;
+	}
+
+	controllerChanged.value = false;
+	isApplyingUpdate.value = true;
+	didReloadForControllerChange = false;
+
+	try {
+		waitingWorker.postMessage({ type: "SKIP_WAITING" });
+		return true;
+	} catch {
+		isApplyingUpdate.value = false;
+		return false;
+	}
+}
+
+function ensureStarted() {
+	if (started || !supportsServiceWorker()) {
+		return;
+	}
+
+	started = true;
+	lifecycleToken += 1;
+	window.addEventListener("focus", handleFocus);
+	document.addEventListener("visibilitychange", handleVisibilityChange);
+	navigator.serviceWorker.addEventListener(
+		"controllerchange",
+		handleControllerChange,
+	);
+	updateCheckTimer = window.setInterval(() => {
+		void checkForUpdate();
+	}, UPDATE_CHECK_INTERVAL_MS);
+}
+
+async function start() {
+	if (!supportsServiceWorker()) return null;
+
+	ensureStarted();
+
+	return checkForUpdate(true);
+}
+
+function stop() {
+	if (!started || !supportsServiceWorker()) {
+		resetState();
+		started = false;
+		return;
+	}
+
+	started = false;
+	lifecycleToken += 1;
+	clearUpdateCheckTimer();
+	window.removeEventListener("focus", handleFocus);
+	document.removeEventListener("visibilitychange", handleVisibilityChange);
+	navigator.serviceWorker.removeEventListener(
+		"controllerchange",
+		handleControllerChange,
+	);
+	resetState();
+}
+
+export function useAppUpdate() {
+	return {
+		registration,
+		installingState,
+		hasWaitingWorker,
+		updateAvailable,
+		canApplyUpdate,
+		isChecking,
+		isApplyingUpdate,
+		controllerChanged,
+		lastCheckedAt,
+		start,
+		stop,
+		checkForUpdate,
+		applyUpdate,
+	};
+}

--- a/chat/src/composables/useNotifications.ts
+++ b/chat/src/composables/useNotifications.ts
@@ -1,5 +1,6 @@
 import { ref, watch } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import { getOrRegisterServiceWorker, registerServiceWorker as registerChatServiceWorker } from "@/lib/service-worker-registration";
 
 const STORAGE_KEY = "waddle.chat.notifications-enabled";
 const VAPID_PUBLIC_KEY = (import.meta.env.PUBLIC_WADDLE_WEB_PUSH_VAPID_PUBLIC_KEY ?? "").trim();
@@ -90,22 +91,14 @@ export function useNotifications() {
 
   // -- Service worker + Web Push --
 
-  let swRegistration: ServiceWorkerRegistration | null = null;
-
   async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
-    if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return null;
-    try {
-      swRegistration = await navigator.serviceWorker.register("/sw.js");
-      return swRegistration;
-    } catch {
-      return null;
-    }
+    return registerChatServiceWorker();
   }
 
   async function subscribeToPush(
     vapidPublicKey: string,
   ): Promise<PushSubscription | null> {
-    const reg = swRegistration ?? (await registerServiceWorker());
+    const reg = await getOrRegisterServiceWorker();
     if (!reg) return null;
     try {
       const keyBytes = urlBase64ToUint8Array(vapidPublicKey);
@@ -145,7 +138,7 @@ export function useNotifications() {
   }
 
   async function disablePushSubscription(xmppClient: BrowserXmppClient, userJid: string): Promise<boolean> {
-    const reg = swRegistration ?? (await registerServiceWorker());
+    const reg = await getOrRegisterServiceWorker();
     if (reg) {
       const existing = await reg.pushManager.getSubscription();
       if (existing) {

--- a/chat/src/lib/service-worker-registration.ts
+++ b/chat/src/lib/service-worker-registration.ts
@@ -1,0 +1,51 @@
+const SERVICE_WORKER_URL = "/sw.js";
+
+let cachedRegistration: ServiceWorkerRegistration | null = null;
+let registrationPromise: Promise<ServiceWorkerRegistration | null> | null = null;
+
+export function supportsServiceWorker() {
+  return typeof navigator !== "undefined" && "serviceWorker" in navigator;
+}
+
+export async function getServiceWorkerRegistration(): Promise<ServiceWorkerRegistration | null> {
+  if (!supportsServiceWorker()) return null;
+
+  try {
+    const registration = await navigator.serviceWorker.getRegistration();
+    if (registration) {
+      cachedRegistration = registration;
+      return registration;
+    }
+  } catch {
+    // ignore lookup failures and fall back to the last known registration
+  }
+
+  return cachedRegistration;
+}
+
+export async function registerServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (!supportsServiceWorker()) return null;
+
+  const existingRegistration = await getServiceWorkerRegistration();
+  if (existingRegistration) {
+    return existingRegistration;
+  }
+
+  if (!registrationPromise) {
+    registrationPromise = navigator.serviceWorker.register(SERVICE_WORKER_URL, {
+      updateViaCache: "none",
+    }).then((registration) => {
+      cachedRegistration = registration;
+      return registration;
+    }).catch(() => {
+      registrationPromise = null;
+      return null;
+    });
+  }
+
+  return registrationPromise;
+}
+
+export async function getOrRegisterServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  return (await getServiceWorkerRegistration()) ?? registerServiceWorker();
+}

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -1,4 +1,4 @@
-/** Generated from src/service-worker/sw-template.js for build 07164d116900. */
+/** Generated from src/service-worker/sw-template.js for build __WADDLE_BUILD_SHA__. */
 
 self.addEventListener("message", (event) => {
   if (event.data?.type === "SKIP_WAITING") {

--- a/chat/tests/app-update-activation.test.ts
+++ b/chat/tests/app-update-activation.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useAppUpdate } from "../src/composables/useAppUpdate";
+
+class FakeServiceWorker extends EventTarget {
+	state: ServiceWorkerState;
+	postMessage = mock((_message: unknown) => {});
+
+	constructor(state: ServiceWorkerState) {
+		super();
+		this.state = state;
+	}
+}
+
+class FakeServiceWorkerRegistration extends EventTarget {
+	active: ServiceWorker | null = null;
+	installing: ServiceWorker | null = null;
+	waiting: ServiceWorker | null = null;
+	update = mock(async () => {});
+}
+
+class FakeServiceWorkerContainer extends EventTarget {
+	controller: ServiceWorker | null = null;
+	registration: ServiceWorkerRegistration | null = null;
+	getRegistration = mock(async () => this.registration);
+	register = mock(async () => this.registration);
+}
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+const originalNavigator = globalThis.navigator;
+const originalDateNow = Date.now;
+
+let serviceWorker: FakeServiceWorkerContainer;
+let reload: ReturnType<typeof mock>;
+let setIntervalMock: ReturnType<typeof mock>;
+let clearIntervalMock: ReturnType<typeof mock>;
+let now = 1_000_000;
+let nextIntervalId = 0;
+const intervalCallbacks = new Map<number, () => void>();
+
+async function flushPromises() {
+	await Promise.resolve();
+	await Promise.resolve();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function advanceTime(ms: number) {
+	now += ms;
+}
+
+function runScheduledUpdateCheck() {
+	const callback = intervalCallbacks.values().next().value;
+	callback?.();
+}
+
+beforeEach(() => {
+	serviceWorker = new FakeServiceWorkerContainer();
+	serviceWorker.controller = new FakeServiceWorker(
+		"activated",
+	) as unknown as ServiceWorker;
+	reload = mock(() => {});
+	now = 1_000_000;
+	nextIntervalId = 0;
+	intervalCallbacks.clear();
+	setIntervalMock = mock((callback: TimerHandler) => {
+		const id = ++nextIntervalId;
+		intervalCallbacks.set(id, callback as () => void);
+		return id;
+	});
+	clearIntervalMock = mock((id: number) => {
+		intervalCallbacks.delete(id);
+	});
+	Date.now = () => now;
+
+	const windowMock = Object.assign(new EventTarget(), {
+		setInterval: setIntervalMock,
+		clearInterval: clearIntervalMock,
+		location: {
+			reload,
+		},
+	});
+
+	const documentMock = Object.assign(new EventTarget(), {
+		visibilityState: "visible" as DocumentVisibilityState,
+	});
+
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		writable: true,
+		value: windowMock,
+	});
+	Object.defineProperty(globalThis, "document", {
+		configurable: true,
+		writable: true,
+		value: documentMock,
+	});
+	Object.defineProperty(globalThis, "navigator", {
+		configurable: true,
+		writable: true,
+		value: {
+			serviceWorker,
+		},
+	});
+});
+
+afterEach(() => {
+	useAppUpdate().stop();
+	Date.now = originalDateNow;
+
+	if (originalWindow === undefined) {
+		Reflect.deleteProperty(globalThis, "window");
+	} else {
+		Object.defineProperty(globalThis, "window", {
+			configurable: true,
+			writable: true,
+			value: originalWindow,
+		});
+	}
+
+	if (originalDocument === undefined) {
+		Reflect.deleteProperty(globalThis, "document");
+	} else {
+		Object.defineProperty(globalThis, "document", {
+			configurable: true,
+			writable: true,
+			value: originalDocument,
+		});
+	}
+
+	if (originalNavigator === undefined) {
+		Reflect.deleteProperty(globalThis, "navigator");
+	} else {
+		Object.defineProperty(globalThis, "navigator", {
+			configurable: true,
+			writable: true,
+			value: originalNavigator,
+		});
+	}
+});
+
+describe("useAppUpdate activation flow", () => {
+	test("tracks an installing worker until it becomes a waiting refresh", async () => {
+		const appUpdate = useAppUpdate();
+		const registration = new FakeServiceWorkerRegistration();
+		const installingWorker = new FakeServiceWorker("installing");
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		await appUpdate.start();
+
+		registration.installing = installingWorker as unknown as ServiceWorker;
+		registration.dispatchEvent(new Event("updatefound"));
+
+		expect(appUpdate.installingState.value).toBe("installing");
+		expect(appUpdate.updateAvailable.value).toBe(false);
+
+		registration.installing = null;
+		registration.waiting = installingWorker as unknown as ServiceWorker;
+		installingWorker.state = "installed";
+		installingWorker.dispatchEvent(new Event("statechange"));
+		await flushPromises();
+
+		expect(appUpdate.installingState.value).toBe("installed");
+		expect(appUpdate.updateAvailable.value).toBe(true);
+		expect(appUpdate.canApplyUpdate.value).toBe(true);
+	});
+
+	test("checks for updates again on focus and polling, then cleans up listeners", async () => {
+		const appUpdate = useAppUpdate();
+		const registration = new FakeServiceWorkerRegistration();
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		await appUpdate.start();
+
+		expect(registration.update).toHaveBeenCalledTimes(1);
+		expect(appUpdate.lastCheckedAt.value).toBe(now);
+		expect(setIntervalMock).toHaveBeenCalledTimes(1);
+		expect(intervalCallbacks.size).toBe(1);
+
+		window.dispatchEvent(new Event("focus"));
+		await flushPromises();
+		expect(registration.update).toHaveBeenCalledTimes(1);
+
+		advanceTime(61_000);
+		window.dispatchEvent(new Event("focus"));
+		await flushPromises();
+		expect(registration.update).toHaveBeenCalledTimes(2);
+
+		advanceTime(61_000);
+		runScheduledUpdateCheck();
+		await flushPromises();
+		expect(registration.update).toHaveBeenCalledTimes(3);
+
+		appUpdate.stop();
+		expect(clearIntervalMock).toHaveBeenCalledTimes(1);
+		expect(intervalCallbacks.size).toBe(0);
+	});
+
+	test("deduplicates repeat apply requests while activation is pending", async () => {
+		const appUpdate = useAppUpdate();
+		const waitingWorker = new FakeServiceWorker("installed");
+		const registration = new FakeServiceWorkerRegistration();
+		registration.waiting = waitingWorker as unknown as ServiceWorker;
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		await appUpdate.start();
+
+		expect(appUpdate.updateAvailable.value).toBe(true);
+		expect(await appUpdate.applyUpdate()).toBe(true);
+		expect(await appUpdate.applyUpdate()).toBe(true);
+		expect(waitingWorker.postMessage).toHaveBeenCalledTimes(1);
+		expect(waitingWorker.postMessage).toHaveBeenCalledWith({
+			type: "SKIP_WAITING",
+		});
+		expect(appUpdate.canApplyUpdate.value).toBe(false);
+		expect(appUpdate.isApplyingUpdate.value).toBe(true);
+	});
+
+	test("reloads the current tab after controllerchange and treats repeat clicks as safe", async () => {
+		const appUpdate = useAppUpdate();
+		const waitingWorker = new FakeServiceWorker("installed");
+		const activeWorker = new FakeServiceWorker("activated");
+		const registration = new FakeServiceWorkerRegistration();
+		registration.waiting = waitingWorker as unknown as ServiceWorker;
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		expect(await appUpdate.applyUpdate()).toBe(true);
+		expect(reload).not.toHaveBeenCalled();
+
+		registration.waiting = null;
+		registration.active = activeWorker as unknown as ServiceWorker;
+		serviceWorker.controller = activeWorker as unknown as ServiceWorker;
+		serviceWorker.dispatchEvent(new Event("controllerchange"));
+
+		expect(reload).toHaveBeenCalledTimes(1);
+		expect(appUpdate.controllerChanged.value).toBe(true);
+		expect(appUpdate.isApplyingUpdate.value).toBe(false);
+		expect(await appUpdate.applyUpdate()).toBe(true);
+	});
+
+	test("does not reload when another source changes the controller", async () => {
+		const appUpdate = useAppUpdate();
+		const registration = new FakeServiceWorkerRegistration();
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		await appUpdate.start();
+		serviceWorker.dispatchEvent(new Event("controllerchange"));
+
+		expect(reload).not.toHaveBeenCalled();
+		expect(appUpdate.controllerChanged.value).toBe(true);
+	});
+
+	test("resets applying state when skip-waiting fails", async () => {
+		const appUpdate = useAppUpdate();
+		const waitingWorker = new FakeServiceWorker("installed");
+		waitingWorker.postMessage = mock(() => {
+			throw new Error("boom");
+		});
+		const registration = new FakeServiceWorkerRegistration();
+		registration.waiting = waitingWorker as unknown as ServiceWorker;
+		serviceWorker.registration =
+			registration as unknown as ServiceWorkerRegistration;
+
+		expect(await appUpdate.applyUpdate()).toBe(false);
+		expect(waitingWorker.postMessage).toHaveBeenCalledTimes(1);
+		expect(appUpdate.isApplyingUpdate.value).toBe(false);
+		expect(appUpdate.canApplyUpdate.value).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- generate a deploy-aware `sw.js` from a tracked service-worker template so updates are detectable across deploys
- add signed-in app update lifecycle handling plus a calm in-app refresh banner
- cover update detection and manual apply flows with focused tests

## Validation
- `cd chat && bun run build`
- `cd chat && bun test tests/app-update-activation.test.ts`

## Notes
- `cd chat && bun test` still reports a pre-existing unrelated `useLongPress` / `scroll-direction` failure outside this change