### PR TITLE
feat(chat): add emoji picker and self-reaction highlighting

### DIFF
--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import { Search, X } from "lucide-vue-next";
+import { searchEmoji } from "@/lib/emoji";
+import { COMMON_REACTIONS, loadRecents, pushRecent } from "@/lib/emoji-picker-data";
+
+const props = defineProps<{
+  open: boolean;
+  anchor: HTMLElement | null;
+}>();
+
+const emit = defineEmits<{
+  select: [emoji: string];
+  close: [];
+}>();
+
+const panelEl = ref<HTMLElement | null>(null);
+const searchInputEl = ref<HTMLInputElement | null>(null);
+const query = ref("");
+const recents = ref<string[]>([]);
+const position = ref<{ top: number; left: number }>({ top: 0, left: 0 });
+
+const PANEL_WIDTH = 288;
+const PANEL_MAX_HEIGHT = 320;
+const GAP = 8;
+const VIEWPORT_MARGIN = 8;
+
+const searchResults = computed(() => {
+  const q = query.value.trim();
+  if (q.length < 2) return [];
+  return searchEmoji(q, 64).map((r) => r.emoji);
+});
+
+const hasQuery = computed(() => query.value.trim().length >= 2);
+
+const gridEmojis = computed<readonly string[]>(() =>
+  hasQuery.value ? searchResults.value : COMMON_REACTIONS,
+);
+
+const firstVisibleEmoji = computed(() => {
+  if (hasQuery.value) return searchResults.value[0] ?? null;
+  return recents.value[0] ?? COMMON_REACTIONS[0] ?? null;
+});
+
+function computePosition() {
+  const anchor = props.anchor;
+  if (!anchor) return;
+  const rect = anchor.getBoundingClientRect();
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+
+  const spaceBelow = vh - rect.bottom;
+  const spaceAbove = rect.top;
+  const placeAbove = spaceBelow < PANEL_MAX_HEIGHT + GAP && spaceAbove > spaceBelow;
+
+  let top = placeAbove
+    ? Math.max(VIEWPORT_MARGIN, rect.top - GAP - PANEL_MAX_HEIGHT)
+    : rect.bottom + GAP;
+
+  let left = rect.right - PANEL_WIDTH;
+  if (left < VIEWPORT_MARGIN) left = VIEWPORT_MARGIN;
+  if (left + PANEL_WIDTH > vw - VIEWPORT_MARGIN) left = vw - VIEWPORT_MARGIN - PANEL_WIDTH;
+
+  position.value = { top, left };
+}
+
+function onWindowClick(event: MouseEvent) {
+  if (!props.open) return;
+  const target = event.target as Node | null;
+  if (!panelEl.value || !target) return;
+  if (panelEl.value.contains(target)) return;
+  if (props.anchor && props.anchor.contains(target)) return;
+  emit("close");
+}
+
+function onKey(event: KeyboardEvent) {
+  if (!props.open) return;
+  if (event.key === "Escape") {
+    event.stopPropagation();
+    emit("close");
+    return;
+  }
+  if (event.key === "Enter" && document.activeElement === searchInputEl.value) {
+    event.preventDefault();
+    const pick = firstVisibleEmoji.value;
+    if (pick) selectEmoji(pick);
+  }
+}
+
+function selectEmoji(emoji: string) {
+  recents.value = pushRecent(emoji);
+  emit("select", emoji);
+  emit("close");
+}
+
+function onResize() {
+  if (props.open) computePosition();
+}
+
+watch(
+  () => props.open,
+  async (open) => {
+    if (!open) return;
+    recents.value = loadRecents();
+    query.value = "";
+    await nextTick();
+    computePosition();
+    searchInputEl.value?.focus();
+  },
+);
+
+onMounted(() => {
+  window.addEventListener("mousedown", onWindowClick);
+  window.addEventListener("keydown", onKey);
+  window.addEventListener("resize", onResize);
+  window.addEventListener("scroll", onResize, true);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("mousedown", onWindowClick);
+  window.removeEventListener("keydown", onKey);
+  window.removeEventListener("resize", onResize);
+  window.removeEventListener("scroll", onResize, true);
+});
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      v-if="open"
+      ref="panelEl"
+      class="fixed z-50 w-72 rounded-xl border border-border bg-card/95 backdrop-blur shadow-xl overflow-hidden flex flex-col"
+      :style="{ top: `${position.top}px`, left: `${position.left}px`, maxHeight: `${PANEL_MAX_HEIGHT}px` }"
+    >
+      <div class="flex items-center gap-2 px-3 py-2 border-b border-border">
+        <Search class="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+        <input
+          ref="searchInputEl"
+          v-model="query"
+          type="text"
+          placeholder="Search emoji..."
+          class="flex-1 text-[13px] bg-transparent border-none focus:outline-none placeholder:text-muted-foreground/50"
+        />
+        <button
+          class="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          title="Close"
+          @click="emit('close')"
+        >
+          <X class="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div class="flex-1 overflow-auto p-2">
+        <div v-if="!hasQuery && recents.length > 0" class="mb-2">
+          <div class="text-[10px] uppercase tracking-wide text-muted-foreground/70 px-1 pb-1">
+            Recently used
+          </div>
+          <div class="grid grid-cols-8 gap-0.5">
+            <button
+              v-for="e in recents"
+              :key="`recent-${e}`"
+              class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted hover:scale-110 transition-all duration-150"
+              :title="e"
+              @click="selectEmoji(e)"
+            >{{ e }}</button>
+          </div>
+        </div>
+
+        <div v-if="!hasQuery" class="text-[10px] uppercase tracking-wide text-muted-foreground/70 px-1 pb-1">
+          Common
+        </div>
+
+        <div v-if="gridEmojis.length > 0" class="grid grid-cols-8 gap-0.5">
+          <button
+            v-for="e in gridEmojis"
+            :key="e"
+            class="h-8 w-8 flex items-center justify-center text-[18px] leading-none rounded-md hover:bg-muted hover:scale-110 transition-all duration-150"
+            :title="e"
+            @click="selectEmoji(e)"
+          >{{ e }}</button>
+        </div>
+        <div v-else class="py-6 text-center text-[12px] text-muted-foreground">
+          No emoji found
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -3,6 +3,7 @@ import { ref, computed, nextTick, watch } from "vue";
 import { Check, CheckCheck, Pencil, SmilePlus, Trash2, Phone, Video, FileDown } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
+import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import { renderStyledBody, isImageUrl, type TimelineMessage, type MarkupSpan } from "@/lib/chat-ui";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
 import { parseXep0393ToTiptap } from "@/lib/editor/xep0393-parser";
@@ -119,6 +120,23 @@ watch(
   },
   { immediate: true },
 );
+
+const pickerOpen = ref(false);
+const pickerAnchor = ref<HTMLElement | null>(null);
+
+function openPicker(event: MouseEvent) {
+  pickerAnchor.value = event.currentTarget as HTMLElement;
+  pickerOpen.value = true;
+}
+
+function onPickerSelect(emoji: string) {
+  emit("react", props.message.id, emoji);
+  pickerOpen.value = false;
+}
+
+function hasSelfReacted(nicks: string[]): boolean {
+  return !!props.currentUser && nicks.includes(props.currentUser);
+}
 </script>
 
 <template>
@@ -287,12 +305,20 @@ watch(
         <button
           v-for="(nicks, emoji) in message.reactions"
           :key="emoji"
-          class="inline-flex items-center gap-1 px-2 py-0.5 text-[12px] rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
+          class="inline-flex items-center gap-1 px-2 py-0.5 text-[12px] rounded-lg transition-all duration-200"
+          :class="hasSelfReacted(nicks) ? 'bg-primary/10 ring-1 ring-primary hover:bg-primary/15' : 'bg-muted/60 hover:bg-muted'"
           :title="nicks.join(', ')"
           @click="emit('react', message.id, emoji)"
         >
           <span>{{ emoji }}</span>
           <span class="text-muted-foreground font-mono text-[10px] tabular-nums">{{ nicks.length }}</span>
+        </button>
+        <button
+          class="inline-flex items-center px-2 py-0.5 rounded-lg bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground transition-all duration-200"
+          title="Add reaction"
+          @click="openPicker"
+        >
+          <SmilePlus class="w-3 h-3" />
         </button>
       </div>
     </div>
@@ -312,6 +338,7 @@ watch(
       <button
         class="h-6 w-6 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
         title="Add reaction"
+        @click="openPicker"
       >
         <SmilePlus class="w-3.5 h-3.5" />
       </button>
@@ -333,6 +360,13 @@ watch(
         </button>
       </template>
     </div>
+
+    <EmojiPicker
+      :open="pickerOpen"
+      :anchor="pickerAnchor"
+      @select="onPickerSelect"
+      @close="pickerOpen = false"
+    />
   </div>
 </template>
 

--- a/chat/src/lib/emoji-picker-data.ts
+++ b/chat/src/lib/emoji-picker-data.ts
@@ -1,0 +1,33 @@
+export const COMMON_REACTIONS: readonly string[] = [
+  "👍", "👎", "❤️", "🔥", "🎉", "👀", "😂", "😍",
+  "🙏", "👏", "🙌", "💯", "✅", "❌", "⭐", "🚀",
+  "🤔", "😢", "😮", "😡", "🤯", "🤝", "💪", "🧠",
+  "👋", "😎", "🥳", "🙈", "💩", "🍕", "☕", "🐛",
+];
+
+export const RECENTS_STORAGE_KEY = "waddle:emoji-recents";
+
+const RECENTS_CAP = 8;
+
+export function loadRecents(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENTS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string").slice(0, RECENTS_CAP);
+  } catch {
+    return [];
+  }
+}
+
+export function pushRecent(emoji: string): string[] {
+  const current = loadRecents();
+  const next = [emoji, ...current.filter((e) => e !== emoji)].slice(0, RECENTS_CAP);
+  try {
+    localStorage.setItem(RECENTS_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore (SSR / privacy mode / quota)
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
- Add `EmojiPicker` component wired into `MessageCard` for both the reactions row and the floating actions bar
- Highlight reactions that include the current user so self-reactions stand out from others
- Add `emoji-picker-data` with a curated common set plus a localStorage-backed recents list (cap 8)

## Test plan
- [ ] Open a message's floating actions and verify the picker opens anchored to the button
- [ ] Pick an emoji and confirm it appears as a reaction and is persisted as a recent
- [ ] Click an existing reaction you authored and verify the self-reaction styling (primary ring)
- [ ] Refresh the page and confirm recents survive via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)