### PR TITLE
fix(chat): route body-less reactions via generic message event

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -12,8 +12,9 @@ import type {
 } from "./types";
 import { barePeerJid, jidDomain, roomBareJidFor } from "./jid";
 import { registerWaddleExtensions } from "./extensions";
-import { dispatchGroupchat, ext } from "./message-parsing";
+import { ext } from "./message-parsing";
 import { dispatchChat } from "./dm-parsing";
+import { buildMessageDispatcher } from "./message-dispatch";
 import * as messaging from "./messaging";
 import * as history from "./history";
 import * as dmMessaging from "./dm-messaging";
@@ -1266,23 +1267,24 @@ export class BrowserXmppClient {
       }
     });
 
-    xmpp.on("groupchat", (msg) => dispatchGroupchat(msg, {
-      currentRoom: this.currentRoom,
-      selfNick: this.session.username,
-      onMessage: this.messageHandler,
-      onChatState: this.chatStateHandler,
-      onDisplayed: this.displayedHandler,
-      onReaction: this.reactionHandler,
-      onActivity: this.activityHandler,
-    }));
-
-    xmpp.on("chat", (msg) => dispatchChat(msg, {
-      selfBareJid: barePeerJid(this.session.jid),
-      onMessage: this.directMessageHandler,
-      onChatState: this.dmChatStateHandler,
-      onDisplayed: this.dmDisplayedHandler,
-      onReaction: this.dmReactionHandler,
-    }));
+    xmpp.on("message", buildMessageDispatcher(
+      () => ({
+        currentRoom: this.currentRoom,
+        selfNick: this.session.username,
+        onMessage: this.messageHandler,
+        onChatState: this.chatStateHandler,
+        onDisplayed: this.displayedHandler,
+        onReaction: this.reactionHandler,
+        onActivity: this.activityHandler,
+      }),
+      () => ({
+        selfBareJid: barePeerJid(this.session.jid),
+        onMessage: this.directMessageHandler,
+        onChatState: this.dmChatStateHandler,
+        onDisplayed: this.dmDisplayedHandler,
+        onReaction: this.dmReactionHandler,
+      }),
+    ));
 
     xmpp.on("carbon:sent", (msg) => {
       const forwarded = msg.carbon?.forward?.message;

--- a/chat/src/lib/xmpp/message-dispatch.ts
+++ b/chat/src/lib/xmpp/message-dispatch.ts
@@ -1,0 +1,36 @@
+import type { ReceivedMessage } from "stanza/protocol";
+import { dispatchChat, type DmHandlers } from "./dm-parsing";
+import { dispatchGroupchat, type GroupchatHandlers } from "./message-parsing";
+
+/**
+ * Returns a handler for the stanza library's generic `message` event that
+ * routes groupchat + 1:1 messages to the right parser.
+ *
+ * We intentionally listen on `message` rather than on the more specific
+ * `groupchat` / `chat` events because stanzajs only emits those when the
+ * message carries a body or embedded link (see `stanza/Client.js`'s
+ * `isChat` gate). Body-less payloads — reactions, chat states, delivery
+ * markers — never fire `groupchat`/`chat`, so anything registered there
+ * would silently miss them.
+ *
+ * Carbon-wrapped messages are skipped here; `carbon:sent` /
+ * `carbon:received` listeners unwrap and forward them separately.
+ */
+export function buildMessageDispatcher(
+  groupchatHandlers: () => GroupchatHandlers,
+  chatHandlers: () => DmHandlers,
+): (msg: ReceivedMessage) => void {
+  return (msg) => {
+    if (msg.type === "error") return;
+    if ((msg as { carbon?: unknown }).carbon) return;
+
+    if (msg.type === "groupchat") {
+      dispatchGroupchat(msg, groupchatHandlers());
+      return;
+    }
+
+    if (msg.type === "chat" || msg.type === "normal" || !msg.type) {
+      dispatchChat(msg, chatHandlers());
+    }
+  };
+}

--- a/chat/tests/message-dispatch.test.ts
+++ b/chat/tests/message-dispatch.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect } from "bun:test";
+import type { ReceivedMessage } from "stanza/protocol";
+import { buildMessageDispatcher } from "../src/lib/xmpp/message-dispatch";
+import type { GroupchatHandlers } from "../src/lib/xmpp/message-parsing";
+import type { DmHandlers } from "../src/lib/xmpp/dm-parsing";
+import type {
+  DmChatStateEvent,
+  DmDisplayedEvent,
+  DmReactionEvent,
+  LiveDmMessage,
+  LiveRoomMessage,
+  ReactionEvent,
+  RoomActivityEvent,
+  RoomChatStateEvent,
+  RoomDisplayedEvent,
+} from "../src/lib/xmpp/types";
+
+type GroupchatCapture = {
+  messages: LiveRoomMessage[];
+  reactions: ReactionEvent[];
+  chatStates: RoomChatStateEvent[];
+  displayed: RoomDisplayedEvent[];
+  activity: RoomActivityEvent[];
+};
+
+type DmCapture = {
+  messages: LiveDmMessage[];
+  reactions: DmReactionEvent[];
+  chatStates: DmChatStateEvent[];
+  displayed: DmDisplayedEvent[];
+};
+
+function makeDispatcher() {
+  const groupchat: GroupchatCapture = {
+    messages: [],
+    reactions: [],
+    chatStates: [],
+    displayed: [],
+    activity: [],
+  };
+  const dm: DmCapture = {
+    messages: [],
+    reactions: [],
+    chatStates: [],
+    displayed: [],
+  };
+
+  const groupchatHandlers = (): GroupchatHandlers => ({
+    currentRoom: "room@muc.example.com",
+    selfNick: "alice",
+    onMessage: (msg) => groupchat.messages.push(msg),
+    onChatState: (event) => groupchat.chatStates.push(event),
+    onDisplayed: (event) => groupchat.displayed.push(event),
+    onReaction: (event) => groupchat.reactions.push(event),
+    onActivity: (event) => groupchat.activity.push(event),
+  });
+
+  const dmHandlers = (): DmHandlers => ({
+    selfBareJid: "alice@example.com",
+    onMessage: (msg) => dm.messages.push(msg),
+    onChatState: (event) => dm.chatStates.push(event),
+    onDisplayed: (event) => dm.displayed.push(event),
+    onReaction: (event) => dm.reactions.push(event),
+  });
+
+  const dispatch = buildMessageDispatcher(groupchatHandlers, dmHandlers);
+
+  return { dispatch, groupchat, dm };
+}
+
+describe("buildMessageDispatcher", () => {
+  // Regression: the stanzajs `groupchat` / `chat` events only fire when the
+  // incoming message carries a body or link. Body-less reaction stanzas never
+  // trip those events — listening on `groupchat`/`chat` silently loses every
+  // reaction, chat-state, and delivery marker. This suite guards against a
+  // regression to that wiring.
+
+  test("routes body-less groupchat reactions to the room reaction handler", () => {
+    const { dispatch, groupchat } = makeDispatcher();
+
+    dispatch({
+      from: "room@muc.example.com/bob",
+      to: "alice@example.com/web",
+      type: "groupchat",
+      id: "stanza-1",
+      reactions: { id: "target-msg-id", items: ["👍"] },
+    } as unknown as ReceivedMessage);
+
+    expect(groupchat.reactions).toHaveLength(1);
+    expect(groupchat.reactions[0]).toEqual({
+      roomJid: "room@muc.example.com",
+      nick: "bob",
+      messageId: "target-msg-id",
+      emojis: ["👍"],
+    });
+    expect(groupchat.messages).toHaveLength(0);
+  });
+
+  test("routes body-less 1:1 reactions to the DM reaction handler", () => {
+    const { dispatch, dm } = makeDispatcher();
+
+    dispatch({
+      from: "bob@example.com/web",
+      to: "alice@example.com/web",
+      type: "chat",
+      id: "stanza-1",
+      reactions: { id: "target-dm-id", items: ["🎉"] },
+    } as unknown as ReceivedMessage);
+
+    expect(dm.reactions).toHaveLength(1);
+    expect(dm.reactions[0]).toEqual({
+      peerJid: "bob@example.com",
+      messageId: "target-dm-id",
+      emojis: ["🎉"],
+    });
+    expect(dm.messages).toHaveLength(0);
+  });
+
+  test("still routes body-carrying groupchat messages", () => {
+    const { dispatch, groupchat } = makeDispatcher();
+
+    dispatch({
+      from: "room@muc.example.com/bob",
+      to: "alice@example.com/web",
+      type: "groupchat",
+      id: "stanza-2",
+      body: "hello room",
+    } as unknown as ReceivedMessage);
+
+    expect(groupchat.messages).toHaveLength(1);
+    expect(groupchat.messages[0].body).toBe("hello room");
+  });
+
+  test("skips carbon-wrapped messages (handled by carbon listeners)", () => {
+    const { dispatch, dm, groupchat } = makeDispatcher();
+
+    dispatch({
+      from: "alice@example.com",
+      to: "alice@example.com",
+      type: "chat",
+      carbon: {
+        type: "sent",
+        forward: {
+          message: {
+            from: "alice@example.com/phone",
+            to: "bob@example.com",
+            type: "chat",
+            id: "inner-1",
+            body: "from my other device",
+          },
+        },
+      },
+    } as unknown as ReceivedMessage);
+
+    expect(dm.messages).toHaveLength(0);
+    expect(groupchat.messages).toHaveLength(0);
+  });
+
+  test("ignores error-typed messages", () => {
+    const { dispatch, dm, groupchat } = makeDispatcher();
+
+    dispatch({
+      from: "bob@example.com",
+      to: "alice@example.com",
+      type: "error",
+      id: "err-1",
+      body: "bounce",
+    } as unknown as ReceivedMessage);
+
+    expect(dm.messages).toHaveLength(0);
+    expect(groupchat.messages).toHaveLength(0);
+  });
+
+  test("routes body-less groupchat chat-states", () => {
+    const { dispatch, groupchat } = makeDispatcher();
+
+    dispatch({
+      from: "room@muc.example.com/bob",
+      to: "alice@example.com/web",
+      type: "groupchat",
+      chatState: "composing",
+    } as unknown as ReceivedMessage);
+
+    expect(groupchat.chatStates).toHaveLength(1);
+    expect(groupchat.chatStates[0].nick).toBe("bob");
+    expect(groupchat.chatStates[0].state).toBe("composing");
+  });
+});


### PR DESCRIPTION
## Summary

- XEP-0444 reactions reflected back from the MUC were silently dropped client-side. stanzajs only emits its `groupchat` / `chat` events when a message passes an internal `isChat` gate (body or embedded link). Body-less reactions never trip it, so the reflection lived on the generic `message` event only — the registered `on("groupchat", …)` handler never fired and no pill ever rendered.
- Replaces `xmpp.on("groupchat", …)` + `xmpp.on("chat", …)` with a single `xmpp.on("message", …)` that routes by `type` and skips carbon-wrapped envelopes (still owned by `carbon:sent` / `carbon:received`).
- Extracts the routing into a pure `buildMessageDispatcher()` helper so it can be unit-tested without instantiating `BrowserXmppClient`.

## Evidence

Confirmed with live instrumentation against the running app:

1. `raw:outgoing` — correctly-formed `<message type="groupchat">` with `<reactions xmlns="urn:xmpp:reactions:0">` left the browser ✓
2. `raw:incoming` — the MUC reflected it back with `type='groupchat'` from the sender's own MUC nick ✓
3. The generic `message` event fired with the reactions payload intact ✓
4. `xmpp.on("groupchat", …)` **did not fire** ✗ — the bug

Verified against `stanza/Client.js:241-252`:

```js
this.on('message', msg => {
    const isChat = (msg.alternateLanguageBodies && msg.alternateLanguageBodies.length)
                 || (msg.links && msg.links.length);
    const isMarker = msg.marker && msg.marker.type !== 'markable';
    if (isChat && !isMarker) {
        if (msg.type === 'chat' || msg.type === 'normal') this.emit('chat', msg);
        else if (msg.type === 'groupchat') this.emit('groupchat', msg);
    }
    ...
});
```

## Likely side-effect wins

The old event-gating also silently dropped other body-less MUC/DM payloads. With this fix in place, the following should start working where they were previously broken:

- MUC chat states (typing indicators from other occupants)
- MUC + DM `<displayed/>` read markers (XEP-0333)
- DM reactions

## Tests

New `chat/tests/message-dispatch.test.ts` — 6 regression tests:

- body-less groupchat reaction → room reaction handler
- body-less 1:1 reaction → DM reaction handler
- body-carrying groupchat message still routes to message handler
- carbon-wrapped messages are skipped (carbon listeners own them)
- error-typed messages are skipped
- body-less groupchat chat-states route to the chat-state handler

Full `chat/` suite: **216 pass / 0 fail** (one pre-existing unrelated teardown error in `forum-composition` from `useLongPress`).

## Test plan

- [ ] `cd chat && bun test`
- [ ] Hard-refresh the chat tab, click a quick-emoji on a channel message → pill appears with `👍 1`, clicking again toggles off
- [ ] Open a DM, click a quick-emoji → pill appears
- [ ] Second device on the same account typing in a channel → "typing…" now appears (side-effect win — confirms the fix applies beyond reactions)
- [ ] Another user reading your last DM → read marker appears (side-effect win)

## Not in this PR

- Server-side disco advertisement of `urn:xmpp:reactions:0` (interop polish, optional per spec)
- Server integration test for sender self-reflection of a body-less reaction — existing `xep0444_reaction_broadcast_in_muc` only covers peer reception; a Bob→Bob variant would have caught the client bug at the integration level

🤖 Generated with [Claude Code](https://claude.com/claude-code)