### PR TITLE
Link preview enrichment + SFU/Jingle calls + cleanup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,34 @@
     "allow": [
       "WebFetch(domain:github.com)",
       "WebFetch(domain:raw.githubusercontent.com)",
-      "Bash(bun run:*)"
+      "Bash(bun run:*)",
+      "Bash(bun test *)",
+      "Bash(bun *)",
+      "Bash(bunx astro *)",
+      "Bash(cargo test *)",
+      "Bash(cat /Users/oyr/projects/waddle/waddle/chat/tests/*.test.ts)",
+      "Bash(grep -n \"sendGroupMessage\" /Users/oyr/projects/waddle/waddle/chat/src/lib/xmpp/*.ts /Users/oyr/projects/waddle/waddle/chat/src/lib/xmpp-client.ts)",
+      "Bash(bunx tsc *)",
+      "Bash(grep -E \"\\\\.rs$|^d\")",
+      "Bash(ls *)",
+      "Bash(cargo build *)",
+      "Bash(grep -rn \"pub fn \" /Users/oyr/.cargo/registry/src/index.crates.io-*/hickory-resolver-0.25*/src/resolver.rs)",
+      "Bash(grep -n \"lookup_ip\\\\|pub fn.*lookup\" /Users/oyr/.cargo/registry/src/index.crates.io-*/hickory-resolver-0.25*/src/resolver.rs)",
+      "Bash(cargo check *)",
+      "Bash(rm -r chat/src/lib/link-preview chat/src/pages/api)",
+      "Bash(rm chat/src/lib/editor/link-detection.ts chat/src/lib/xmpp/preview-reference-builder.ts chat/src/components/chat/LinkPreviewDraft.vue chat/tests/link-preview-ssrf.test.ts chat/tests/link-preview-distill.test.ts chat/tests/link-preview-html.test.ts chat/tests/link-preview-fetch.test.ts chat/tests/link-preview-endpoint.test.ts chat/tests/link-detection.test.ts chat/tests/preview-reference-builder.test.ts)",
+      "Bash(flux reconcile *)",
+      "Bash(flux get *)",
+      "Bash(kubectl config *)",
+      "Bash(kubectl get *)",
+      "Bash(git fetch *)",
+      "Bash(kubectl logs *)",
+      "Bash(host sfu.waddle.social)",
+      "Bash(host xmpp.waddle.social)",
+      "Bash(host waddle.social)",
+      "Bash(nc -u -vz -w 3 sfu.waddle.social 30000)",
+      "Bash(timeout 3 bash -c 'echo -n \"test\" | nc -u -w 2 sfu.waddle.social 30000')",
+      "Bash(echo \"exit=$?\")"
     ]
   }
 }

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -274,12 +274,16 @@ async function sendGif(url: string) {
   await activeTarget.value.sendMessage(url);
 }
 
-async function sendActiveMessage(body?: string, markup?: MarkupSpan[]) {
+async function sendActiveMessage(
+  body?: string,
+  markup?: MarkupSpan[],
+  suppressPreview?: boolean,
+) {
   if (ui.sidebarMode.value === "dms") {
     await dmMessaging.sendMessage();
     return;
   }
-  await messaging.sendMessage(body, markup);
+  await messaging.sendMessage(body, markup, suppressPreview);
 }
 
 function notifyActiveComposing() {

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -51,7 +51,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  send: [body: string, markup: MarkupSpan[]];
+  send: [body: string, markup: MarkupSpan[], suppressPreview?: boolean];
   typing: [];
   selectGif: [url: string];
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[]];
@@ -390,7 +390,7 @@ watch(
       :tenor-api-key="tenorApiKey"
       :member-names="memberNames"
       :slow-mode-cooldown="slowModeCooldown"
-      @send="(body, markup) => emit('send', body, markup)"
+      @send="(body, markup, suppressPreview) => emit('send', body, markup, suppressPreview)"
       @typing="emit('typing')"
       @select-gif="(url) => emit('selectGif', url)"
     />

--- a/chat/src/components/chat/LinkPreviewCard.vue
+++ b/chat/src/components/chat/LinkPreviewCard.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { WaddleLinkPreview } from "@/lib/xmpp/extensions/preview";
+
+const props = defineProps<{ preview: WaddleLinkPreview }>();
+
+const target = computed(() => props.preview.url);
+
+const hasTitle = computed(() => !!props.preview.title?.trim());
+</script>
+
+<template>
+  <a
+    v-if="hasTitle"
+    :href="target"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="mt-2 block rounded-xl border border-border bg-muted/40 hover:bg-muted transition-colors duration-200 overflow-hidden max-w-md"
+  >
+    <div class="flex items-stretch gap-3 p-2">
+      <img
+        v-if="preview.image?.src"
+        :src="preview.image.src"
+        :alt="preview.title ?? ''"
+        referrerpolicy="no-referrer"
+        loading="lazy"
+        decoding="async"
+        class="w-20 h-20 object-cover rounded-lg flex-shrink-0 bg-muted"
+      />
+      <div class="flex-1 min-w-0 py-0.5">
+        <div
+          v-if="preview.siteName"
+          class="text-[10px] font-bold uppercase tracking-wider text-muted-foreground/70 truncate"
+        >{{ preview.siteName }}</div>
+        <div class="text-[13px] font-semibold text-foreground truncate">{{ preview.title }}</div>
+        <div
+          v-if="preview.description"
+          class="text-[12px] text-muted-foreground line-clamp-2 mt-0.5"
+        >{{ preview.description }}</div>
+      </div>
+    </div>
+  </a>
+</template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -3,6 +3,7 @@ import { ref, computed, nextTick, watch } from "vue";
 import { Check, CheckCheck, Pencil, SmilePlus, Trash2, Phone, Video, FileDown } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
+import LinkPreviewCard from "@/components/chat/LinkPreviewCard.vue";
 import { renderStyledBody, isImageUrl, type TimelineMessage, type MarkupSpan } from "@/lib/chat-ui";
 import { serializeTiptapToXep0393 } from "@/lib/editor/xep0393-serializer";
 import { parseXep0393ToTiptap } from "@/lib/editor/xep0393-parser";
@@ -298,6 +299,9 @@ watch(
 
       <!-- Normal display -->
       <div v-else :ref="setStyledBodyRef" class="text-[13px] leading-relaxed break-words styled-body" v-html="styledHtml" />
+
+      <!-- Link preview -->
+      <LinkPreviewCard v-if="!isEditing && message.preview" :preview="message.preview" />
 
       <!-- Reactions -->
       <div v-if="message.reactions && Object.keys(message.reactions).length > 0" class="flex flex-wrap gap-1 mt-2">

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import { Send, Image } from "lucide-vue-next";
+import { Send, Image, Link2, Link2Off } from "lucide-vue-next";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import { searchEmoji } from "@/lib/emoji";
@@ -19,10 +19,18 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  send: [body: string, markup: MarkupSpan[]];
+  send: [body: string, markup: MarkupSpan[], suppressPreview?: boolean];
   typing: [];
   selectGif: [url: string];
 }>();
+
+/**
+ * Per-message "Preview link" toggle. Default on; flipping it off sends
+ * a `<no-preview xmlns='urn:waddle:link-preview:0'/>` hint that tells
+ * the server's link-preview enricher to skip this message. Resets back
+ * to true after each successful send so the next message starts fresh.
+ */
+const previewsEnabled = ref(true);
 
 const showGifPicker = ref(false);
 const showMentions = ref(false);
@@ -167,7 +175,11 @@ function onSend(doc: Record<string, unknown>) {
 
   const serialized = serializeTiptapToXep0393(doc as any);
   if (!serialized.body.trim()) return;
-  emit("send", serialized.body, serialized.markup);
+
+  emit("send", serialized.body, serialized.markup, !previewsEnabled.value || undefined);
+
+  // Reset the toggle for the next message.
+  previewsEnabled.value = true;
 }
 
 function onEditorCancel() {
@@ -276,6 +288,16 @@ watch(
       @click="showGifPicker = !showGifPicker"
     >
       <Image class="w-4 h-4" />
+    </button>
+    <button
+      class="h-9 w-9 flex items-center justify-center rounded-xl transition-all duration-200 flex-shrink-0"
+      :class="previewsEnabled ? 'text-muted-foreground hover:bg-muted hover:text-primary' : 'bg-muted text-muted-foreground'"
+      :title="previewsEnabled ? 'Link previews: on — click to skip preview for next message' : 'Link previews: off for next message — click to re-enable'"
+      :disabled="disabled"
+      @click="previewsEnabled = !previewsEnabled"
+    >
+      <Link2 v-if="previewsEnabled" class="w-4 h-4" />
+      <Link2Off v-else class="w-4 h-4" />
     </button>
     <ChatEditor
       :ref="setEditorRef"

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -25,6 +25,7 @@ function fromLiveDmMessage(session: WaddleSession, msg: LiveDmMessage): Timeline
   if (msg.sharedFile) tm.sharedFile = msg.sharedFile;
   if (msg.isSticker) tm.isSticker = true;
   if (msg.callInvite) tm.callInvite = msg.callInvite;
+  if (msg.preview) tm.preview = msg.preview;
   return tm;
 }
 

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -41,6 +41,9 @@ function fromLiveMessage(session: WaddleSession, msg: LiveRoomMessage): Timeline
   if (msg.markup && msg.markup.length > 0) {
     tm.markup = msg.markup;
   }
+  if (msg.preview) {
+    tm.preview = msg.preview;
+  }
   return tm;
 }
 
@@ -441,7 +444,11 @@ export function useMessaging(
     await loadMessages(activeWaddleId.value, channelId);
   }
 
-  async function sendMessage(body?: string, markup?: MarkupSpan[]) {
+  async function sendMessage(
+    body?: string,
+    markup?: MarkupSpan[],
+    suppressPreview?: boolean,
+  ) {
     const bodyText = body ?? draft.value;
     // markup !== undefined means this came from the rich editor (composer send)
     // undefined means it came from a programmatic send (GIF, etc.)
@@ -461,7 +468,7 @@ export function useMessaging(
     clearActionError();
 
     try {
-      const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, markup);
+      const msgId = await client.sendGroupMessage(waddleId, channelId, bodyText, markup, suppressPreview);
       const isStillCurrentChannel =
         xmppClient.value === client &&
         activeWaddleId.value === waddleId &&
@@ -469,6 +476,8 @@ export function useMessaging(
 
       if (msgId && session.value && isStillCurrentChannel) {
         // Optimistic insert: show message immediately with "sending" status
+        // Optimistic insert: server-generated preview arrives via the
+        // echoed stanza; no preview attached here.
         const optimistic: TimelineMessage = {
           id: msgId,
           author: session.value.username,

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -42,6 +42,8 @@ export interface TimelineMessage {
   callInvite?: { inviteId: string; muji: boolean; jingleSid?: string; jingleJid?: string; externalUri?: string; meetingDesc?: string };
   /** XEP-0394: Message Markup offset-based annotations. */
   markup?: MarkupSpan[];
+  /** Waddle link preview (first valid data-reference with nested preview payload). */
+  preview?: import("./xmpp/extensions/preview").WaddleLinkPreview;
 }
 
 export interface CommunityFormData {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -408,9 +408,17 @@ export class BrowserXmppClient {
   async sendCorrection(w: string, c: string, body: string, replacesId: string, markup?: import("@/lib/chat-ui").MarkupSpan[]): Promise<string | null> {
     return this.xmpp ? messaging.sendCorrection(this.xmpp, roomBareJidFor(this.session, w, c), body, replacesId, markup) : null;
   }
-  async sendGroupMessage(w: string, c: string, body: string, markup?: import("@/lib/chat-ui").MarkupSpan[]): Promise<string | null> {
+  async sendGroupMessage(
+    w: string,
+    c: string,
+    body: string,
+    markup?: import("@/lib/chat-ui").MarkupSpan[],
+    suppressPreview?: boolean,
+  ): Promise<string | null> {
     await this.connect(); await this.switchRoom(w, c);
-    return this.xmpp ? messaging.sendGroupMessage(this.xmpp, roomBareJidFor(this.session, w, c), body, markup) : null;
+    return this.xmpp
+      ? messaging.sendGroupMessage(this.xmpp, roomBareJidFor(this.session, w, c), body, markup, suppressPreview)
+      : null;
   }
   async sendCallInvite(
     w: string,

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -10,6 +10,7 @@ import calls from "./calls";
 import mentions from "./mentions";
 import push from "./push";
 import markup from "./markup";
+import noPreview from "./no-preview";
 
 const allDefinitions = [
   ...hats,
@@ -22,6 +23,7 @@ const allDefinitions = [
   ...mentions,
   ...push,
   ...markup,
+  ...noPreview,
 ];
 
 export function registerWaddleExtensions(client: Agent): void {

--- a/chat/src/lib/xmpp/extensions/no-preview.ts
+++ b/chat/src/lib/xmpp/extensions/no-preview.ts
@@ -1,0 +1,35 @@
+/**
+ * Sender hint: when present as a direct child of a `<message>`, the
+ * server's link-preview enricher MUST skip enrichment for that message.
+ * Used to implement the composer's per-message "Preview link: off"
+ * toggle.
+ *
+ * Wire format:
+ *   <message type='groupchat'>
+ *     <body>secret https://example.com/foo</body>
+ *     <no-preview xmlns='urn:waddle:link-preview:0'/>
+ *   </message>
+ *
+ * The element carries no children or attributes — its presence is the
+ * whole signal. Receiver doesn't need to parse it; it matters only to
+ * the server. On the sender side, set `msg.suppressLinkPreview = {}`
+ * when building the outbound message.
+ */
+import type { DefinitionOptions } from "stanza/jxt";
+
+const NS_WADDLE_PREVIEW_0 = "urn:waddle:link-preview:0";
+
+export interface WaddleSuppressLinkPreview {
+  // presence-only marker; no attributes or text
+}
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "message.suppressLinkPreview", multiple: false }],
+    element: "no-preview",
+    fields: {},
+    namespace: NS_WADDLE_PREVIEW_0,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/extensions/preview.ts
+++ b/chat/src/lib/xmpp/extensions/preview.ts
@@ -1,0 +1,106 @@
+/**
+ * Receiver-side parsing for Waddle link-preview payloads injected by the
+ * server (see `server/crates/waddle-xmpp-xep-link-preview`). The server
+ * is authoritative for this namespace; clients never emit it. A stray
+ * client-authored `<preview>` is stripped by the server before fan-out,
+ * but the receiver's offset-based anti-spoof check
+ * (`message-parsing.ts::extractLinkPreview`) remains as defense-in-depth.
+ *
+ * Wire format:
+ *   <reference xmlns='urn:xmpp:reference:0' type='data'
+ *              begin='...' end='...' uri='https://...'>
+ *     <preview xmlns='urn:waddle:link-preview:0' url='https://...'>
+ *       <title>...</title>
+ *       <description>...</description>
+ *       <site-name>...</site-name>
+ *       <image src='https://...' width='1200' height='630'/>
+ *       <type>article</type>
+ *     </preview>
+ *   </reference>
+ */
+import XMLElement from "stanza/jxt/Element";
+
+export const NS_WADDLE_PREVIEW_0 = "urn:waddle:link-preview:0";
+
+const TITLE_MAX = 200;
+const DESCRIPTION_MAX = 300;
+const SITE_NAME_MAX = 100;
+const TYPE_MAX = 50;
+
+export interface WaddleLinkPreview {
+  url: string;
+  title?: string;
+  description?: string;
+  siteName?: string;
+  type?: string;
+  image?: { src: string; width?: string; height?: string };
+}
+
+export function importPreview(reference: XMLElement): WaddleLinkPreview | undefined {
+  const previewEl = reference.getChild("preview", NS_WADDLE_PREVIEW_0);
+  if (!previewEl) return undefined;
+
+  const url = previewEl.getAttribute("url");
+  if (!url || !parsesAsUrl(url)) return undefined;
+
+  const preview: WaddleLinkPreview = { url };
+
+  const title = cap(previewEl.getChild("title", NS_WADDLE_PREVIEW_0)?.getText(), TITLE_MAX);
+  if (title !== undefined) preview.title = title;
+
+  const description = cap(
+    previewEl.getChild("description", NS_WADDLE_PREVIEW_0)?.getText(),
+    DESCRIPTION_MAX,
+  );
+  if (description !== undefined) preview.description = description;
+
+  const siteName = cap(
+    previewEl.getChild("site-name", NS_WADDLE_PREVIEW_0)?.getText(),
+    SITE_NAME_MAX,
+  );
+  if (siteName !== undefined) preview.siteName = siteName;
+
+  const type = cap(previewEl.getChild("type", NS_WADDLE_PREVIEW_0)?.getText(), TYPE_MAX);
+  if (type !== undefined) preview.type = type;
+
+  const imageEl = previewEl.getChild("image", NS_WADDLE_PREVIEW_0);
+  if (imageEl) {
+    const src = imageEl.getAttribute("src");
+    if (src && isSafeImageUrl(src)) {
+      const width = imageEl.getAttribute("width");
+      const height = imageEl.getAttribute("height");
+      preview.image = {
+        src,
+        ...(width ? { width } : {}),
+        ...(height ? { height } : {}),
+      };
+    }
+  }
+
+  return preview;
+}
+
+function cap(raw: string | undefined, max: number): string | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+function parsesAsUrl(raw: string): boolean {
+  try {
+    new URL(raw);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeImageUrl(raw: string): boolean {
+  try {
+    const u = new URL(raw);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/chat/src/lib/xmpp/extensions/references.ts
+++ b/chat/src/lib/xmpp/extensions/references.ts
@@ -1,6 +1,8 @@
-/** XEP-0372: References (mentions). */
-import type { DefinitionOptions } from "stanza/jxt";
+/** XEP-0372: References (mentions + server-injected data references with link previews). */
+import type { DefinitionOptions, FieldDefinition } from "stanza/jxt";
 import { attribute } from "stanza/jxt";
+import XMLElement from "stanza/jxt/Element";
+import { importPreview, type WaddleLinkPreview } from "./preview";
 
 const NS_REFERENCE_0 = "urn:xmpp:reference:0";
 
@@ -9,7 +11,24 @@ export interface WaddleReference {
   uri: string;
   begin?: string;
   end?: string;
+  /**
+   * Server-injected link preview payload. Clients never emit this —
+   * the waddle-xmpp-xep-link-preview crate authoritatively attaches
+   * it on outbound messages. Malformed/mismatched previews are
+   * silently dropped on import (with a further receiver-side
+   * anti-spoof check in `message-parsing.ts`).
+   */
+  preview?: WaddleLinkPreview;
 }
+
+const previewField: FieldDefinition<WaddleLinkPreview | undefined> = {
+  importer(xml: XMLElement) {
+    return importPreview(xml);
+  },
+  exporter() {
+    // Client never emits previews; server is authoritative.
+  },
+};
 
 const definitions: DefinitionOptions[] = [
   {
@@ -20,6 +39,7 @@ const definitions: DefinitionOptions[] = [
       uri: attribute("uri"),
       begin: attribute("begin"),
       end: attribute("end"),
+      preview: previewField,
     },
     namespace: NS_REFERENCE_0,
   },

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -7,7 +7,7 @@ import type {
 
 type MessageExtensionsTarget = Pick<
   LiveRoomMessage,
-  "body" | "mentions" | "broadcastMention" | "callInvite" | "sharedFile" | "isSticker" | "replacesId" | "markup"
+  "body" | "mentions" | "broadcastMention" | "callInvite" | "sharedFile" | "isSticker" | "replacesId" | "markup" | "preview"
 >;
 
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
@@ -29,6 +29,7 @@ export function extractMessageExtensions(
   extractCallInvite(msg, base);
   extractFileSharing(msg, base);
   extractMarkup(msg, base);
+  extractLinkPreview(msg, base);
 
   if (ext(msg).sticker) {
     base.isSticker = true;
@@ -164,6 +165,47 @@ function extractFileSharing(msg: ReceivedMessage, base: MessageExtensionsTarget)
   if (fs.height) info.height = parseInt(fs.height, 10);
   if (fs.desc) info.desc = fs.desc;
   base.sharedFile = info;
+}
+
+/**
+ * Attach the first valid link preview carried by a `type='data'` reference.
+ *
+ * Anti-spoof: the preview is accepted only if the reference's `begin`/`end`
+ * offsets slice the message body to a string equal to the reference's `uri`,
+ * and the nested `<preview url='...'>` matches that URI.
+ */
+function extractLinkPreview(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
+  const refs = ext(msg).references as Array<{
+    type?: string;
+    uri?: string;
+    begin?: string;
+    end?: string;
+    preview?: import("./extensions/preview").WaddleLinkPreview;
+  }> | undefined;
+  if (!refs?.length) return;
+
+  const body = base.body ?? "";
+
+  for (const ref of refs) {
+    if (ref.type !== "data" || !ref.preview || !ref.uri) continue;
+
+    const begin = parseOffset(ref.begin);
+    const end = parseOffset(ref.end);
+    if (begin === null || end === null) continue;
+    if (begin > end || end > body.length) continue;
+
+    if (body.slice(begin, end) !== ref.uri) continue;
+    if (ref.preview.url !== ref.uri) continue;
+
+    base.preview = ref.preview;
+    return;
+  }
+}
+
+function parseOffset(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
 /** XEP-0394: Extract Message Markup annotations. */

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -63,14 +63,20 @@ export function sendCorrection(xmpp: Agent, roomJid: string, body: string, repla
   return msgId;
 }
 
-export function sendGroupMessage(xmpp: Agent, roomJid: string, body: string, markup?: MarkupSpan[]): string | null {
+export function sendGroupMessage(
+  xmpp: Agent,
+  roomJid: string,
+  body: string,
+  markup?: MarkupSpan[],
+  suppressPreview?: boolean,
+): string | null {
   const text = body.trim();
   if (!text) return null;
 
   const msgId = crypto.randomUUID();
 
   // XEP-0372: Build reference objects for @mentions
-  const references: Array<{ type: string; uri: string; begin: string; end: string }> = [];
+  const references: Array<Record<string, unknown>> = [];
   const mentionRe = /(?:^|\s)@(\S+)/g;
   let match: RegExpExecArray | null;
   while ((match = mentionRe.exec(text)) !== null) {
@@ -95,6 +101,9 @@ export function sendGroupMessage(xmpp: Agent, roomJid: string, body: string, mar
   if (markup && markup.length > 0) {
     msgData.markup = { spans: toStanzaSpans(markup) };
   }
+  // `<no-preview xmlns='urn:waddle:link-preview:0'/>` — sender hint that
+  // tells the server's link-preview enricher to skip this message.
+  if (suppressPreview) msgData.suppressLinkPreview = {};
 
   xmpp.sendMessage(msgData as Parameters<Agent["sendMessage"]>[0]);
   return msgId;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -33,6 +33,8 @@ export interface LiveRoomMessage {
   broadcastMention?: "everyone" | "here";
   /** XEP-0482/0483 */
   callInvite?: CallInviteInfo;
+  /** Waddle link preview (first valid reference with nested preview payload). */
+  preview?: import("./extensions/preview").WaddleLinkPreview;
 }
 
 /** A direct message received/sent via type:"chat" stanzas */
@@ -52,6 +54,8 @@ export interface LiveDmMessage {
   sharedFile?: SharedFileInfo;
   isSticker?: boolean;
   callInvite?: CallInviteInfo;
+  /** Waddle link preview. */
+  preview?: import("./extensions/preview").WaddleLinkPreview;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }

--- a/chat/tests/message-parsing-preview.test.ts
+++ b/chat/tests/message-parsing-preview.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { extractMessageExtensions } from "../src/lib/xmpp/message-parsing";
+import type { LiveRoomMessage } from "../src/lib/xmpp/types";
+import type { WaddleLinkPreview } from "../src/lib/xmpp/extensions/preview";
+import type { ReceivedMessage } from "stanza/protocol";
+
+interface WaddleReferenceLike {
+  type?: string;
+  uri?: string;
+  begin?: string;
+  end?: string;
+  preview?: WaddleLinkPreview;
+}
+
+function buildMsg(body: string, references: WaddleReferenceLike[]): ReceivedMessage {
+  return {
+    type: "groupchat",
+    body,
+    references,
+  } as unknown as ReceivedMessage;
+}
+
+function newBase(body: string): LiveRoomMessage {
+  return {
+    id: "m-1",
+    roomJid: "r@example.com",
+    nick: "alice",
+    body,
+    createdAt: "2026-04-15T00:00:00Z",
+    type: "message",
+  };
+}
+
+describe("extractMessageExtensions — link preview", () => {
+  test("attaches preview when body[begin..end] equals uri", () => {
+    const body = "see https://example.com/a end";
+    const preview: WaddleLinkPreview = {
+      url: "https://example.com/a",
+      title: "T",
+    };
+    const msg = buildMsg(body, [
+      { type: "data", uri: "https://example.com/a", begin: "4", end: "25", preview },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toEqual(preview);
+  });
+
+  test("drops preview when body[begin..end] !== uri (anti-spoof)", () => {
+    const body = "see https://phish.example/ end";
+    const preview: WaddleLinkPreview = { url: "https://legit.example/", title: "Trust me" };
+    const msg = buildMsg(body, [
+      { type: "data", uri: "https://legit.example/", begin: "4", end: "26", preview },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toBeUndefined();
+  });
+
+  test("drops preview when begin/end missing", () => {
+    const body = "see https://example.com/a";
+    const preview: WaddleLinkPreview = { url: "https://example.com/a", title: "T" };
+    const msg = buildMsg(body, [
+      { type: "data", uri: "https://example.com/a", preview },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toBeUndefined();
+  });
+
+  test("drops preview when uri attr mismatches preview.url", () => {
+    const body = "see https://example.com/a end";
+    const preview: WaddleLinkPreview = {
+      url: "https://different.example/",
+      title: "T",
+    };
+    const msg = buildMsg(body, [
+      { type: "data", uri: "https://example.com/a", begin: "4", end: "25", preview },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toBeUndefined();
+  });
+
+  test("ignores previews on mention-type references", () => {
+    const body = "hi @bob";
+    const preview: WaddleLinkPreview = { url: "https://example.com/", title: "X" };
+    const msg = buildMsg(body, [
+      { type: "mention", uri: "xmpp:bob@example.com", preview },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toBeUndefined();
+  });
+
+  test("takes first valid preview when multiple references carry previews", () => {
+    const body = "one https://a.example/ two https://b.example/ end";
+    const pa: WaddleLinkPreview = { url: "https://a.example/", title: "A" };
+    const pb: WaddleLinkPreview = { url: "https://b.example/", title: "B" };
+    const msg = buildMsg(body, [
+      { type: "data", uri: "https://a.example/", begin: "4", end: "22", preview: pa },
+      { type: "data", uri: "https://b.example/", begin: "27", end: "45", preview: pb },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview?.title).toBe("A");
+  });
+
+  test("skips an invalid first preview but accepts a later valid one", () => {
+    const body = "x https://good.example/ y";
+    const bad: WaddleLinkPreview = { url: "https://good.example/", title: "B" };
+    const msg = buildMsg(body, [
+      // offsets are wrong for this one
+      { type: "data", uri: "https://good.example/", begin: "0", end: "1", preview: bad },
+      { type: "data", uri: "https://good.example/", begin: "2", end: "23", preview: bad },
+    ]);
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview?.title).toBe("B");
+  });
+
+  test("no preview when references missing", () => {
+    const body = "plain message";
+    const msg = {
+      type: "groupchat",
+      body,
+    } as unknown as ReceivedMessage;
+    const base = newBase(body);
+    extractMessageExtensions(msg, base);
+    expect(base.preview).toBeUndefined();
+  });
+});

--- a/chat/tests/no-preview-toggle.test.ts
+++ b/chat/tests/no-preview-toggle.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { createClient } from "stanza";
+import { registerWaddleExtensions } from "../src/lib/xmpp/extensions";
+
+/**
+ * Verifies that setting `message.suppressLinkPreview = {}` on an
+ * outgoing message serializes to a top-level
+ * `<no-preview xmlns='urn:waddle:link-preview:0'/>` child — the
+ * sender-side signal the server's link-preview enricher honors to
+ * skip enrichment for a single message.
+ */
+describe("<no-preview/> suppression marker on outbound", () => {
+  test("serializes to a top-level no-preview element", () => {
+    const client = createClient({ jid: "alice@localhost" });
+    registerWaddleExtensions(client);
+
+    const xml = client.stanzas.export("message", {
+      id: "m1",
+      to: "room@muc.localhost",
+      type: "groupchat",
+      body: "secret https://example.com/x",
+      // Presence-only alias set on the message to emit the hint.
+      suppressLinkPreview: {},
+    } as unknown as Record<string, unknown>);
+
+    const serialized = xml?.toString() ?? "";
+    expect(serialized).toContain("urn:waddle:link-preview:0");
+    expect(serialized).toContain("no-preview");
+  });
+
+  test("no marker when suppressLinkPreview omitted", () => {
+    const client = createClient({ jid: "alice@localhost" });
+    registerWaddleExtensions(client);
+
+    const xml = client.stanzas.export("message", {
+      id: "m1",
+      to: "room@muc.localhost",
+      type: "groupchat",
+      body: "see https://example.com/x",
+    } as unknown as Record<string, unknown>);
+
+    const serialized = xml?.toString() ?? "";
+    expect(serialized).not.toContain("no-preview");
+  });
+});

--- a/chat/tests/references-preview.test.ts
+++ b/chat/tests/references-preview.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from "bun:test";
+import XMLElement from "stanza/jxt/Element";
+import {
+  NS_WADDLE_PREVIEW_0,
+  importPreview,
+} from "../src/lib/xmpp/extensions/preview";
+
+const NS_REFERENCE_0 = "urn:xmpp:reference:0";
+
+function makeReferenceWithPreview(previewXml: XMLElement): XMLElement {
+  const ref = new XMLElement("reference", {
+    xmlns: NS_REFERENCE_0,
+    type: "data",
+    uri: "https://example.com/a",
+    begin: "0",
+    end: "22",
+  });
+  ref.appendChild(previewXml);
+  return ref;
+}
+
+function makePreviewXml(
+  overrides: Partial<{
+    xmlns: string;
+    url: string;
+    title: string;
+    description: string;
+    siteName: string;
+    type: string;
+    image: { src: string; width?: string; height?: string } | null;
+  }> = {},
+): XMLElement {
+  const {
+    xmlns = NS_WADDLE_PREVIEW_0,
+    url = "https://example.com/a",
+    title = "Title",
+    description = "Desc",
+    siteName = "Site",
+    type = "article",
+    image = { src: "https://cdn.example.com/a.png", width: "1200", height: "630" },
+  } = overrides;
+
+  const preview = new XMLElement("preview", { xmlns, url });
+
+  if (title !== "") {
+    const t = new XMLElement("title", { xmlns });
+    t.appendChild(title);
+    preview.appendChild(t);
+  }
+  if (description !== "") {
+    const d = new XMLElement("description", { xmlns });
+    d.appendChild(description);
+    preview.appendChild(d);
+  }
+  if (siteName !== "") {
+    const s = new XMLElement("site-name", { xmlns });
+    s.appendChild(siteName);
+    preview.appendChild(s);
+  }
+  if (type !== "") {
+    const ty = new XMLElement("type", { xmlns });
+    ty.appendChild(type);
+    preview.appendChild(ty);
+  }
+  if (image) {
+    const attrs: Record<string, string> = { xmlns, src: image.src };
+    if (image.width) attrs.width = image.width;
+    if (image.height) attrs.height = image.height;
+    preview.appendChild(new XMLElement("image", attrs));
+  }
+  return preview;
+}
+
+describe("importPreview", () => {
+  test("reads title/description/site-name/type/url and image", () => {
+    const ref = makeReferenceWithPreview(makePreviewXml());
+    const preview = importPreview(ref);
+    expect(preview).toEqual({
+      url: "https://example.com/a",
+      title: "Title",
+      description: "Desc",
+      siteName: "Site",
+      type: "article",
+      image: { src: "https://cdn.example.com/a.png", width: "1200", height: "630" },
+    });
+  });
+
+  test("returns undefined when no preview child present", () => {
+    const ref = new XMLElement("reference", {
+      xmlns: NS_REFERENCE_0,
+      type: "data",
+      uri: "https://example.com/a",
+    });
+    expect(importPreview(ref)).toBeUndefined();
+  });
+
+  test("silently drops preview in wrong namespace", () => {
+    const ref = makeReferenceWithPreview(
+      makePreviewXml({ xmlns: "urn:bogus:link-preview:99" }),
+    );
+    expect(importPreview(ref)).toBeUndefined();
+  });
+
+  test("silently drops preview with missing url attribute", () => {
+    const preview = new XMLElement("preview", { xmlns: NS_WADDLE_PREVIEW_0 });
+    preview.appendChild(
+      (() => {
+        const t = new XMLElement("title", { xmlns: NS_WADDLE_PREVIEW_0 });
+        t.appendChild("T");
+        return t;
+      })(),
+    );
+    const ref = new XMLElement("reference", {
+      xmlns: NS_REFERENCE_0,
+      type: "data",
+      uri: "https://example.com/a",
+    });
+    ref.appendChild(preview);
+    expect(importPreview(ref)).toBeUndefined();
+  });
+
+  test("silently drops image with non-http scheme", () => {
+    const ref = makeReferenceWithPreview(
+      makePreviewXml({ image: { src: "javascript:alert(1)" } }),
+    );
+    const preview = importPreview(ref);
+    expect(preview?.image).toBeUndefined();
+  });
+
+  test("truncates long title to 200 chars", () => {
+    const long = "a".repeat(500);
+    const ref = makeReferenceWithPreview(makePreviewXml({ title: long }));
+    expect(importPreview(ref)?.title?.length).toBe(200);
+  });
+
+  test("truncates long description to 300 chars", () => {
+    const long = "b".repeat(1000);
+    const ref = makeReferenceWithPreview(makePreviewXml({ description: long }));
+    expect(importPreview(ref)?.description?.length).toBe(300);
+  });
+
+  test("truncates long site-name to 100 chars", () => {
+    const long = "c".repeat(500);
+    const ref = makeReferenceWithPreview(makePreviewXml({ siteName: long }));
+    expect(importPreview(ref)?.siteName?.length).toBe(100);
+  });
+
+  test("works with only required fields", () => {
+    const preview = new XMLElement("preview", {
+      xmlns: NS_WADDLE_PREVIEW_0,
+      url: "https://example.com/a",
+    });
+    const title = new XMLElement("title", { xmlns: NS_WADDLE_PREVIEW_0 });
+    title.appendChild("T");
+    preview.appendChild(title);
+    const ref = new XMLElement("reference", {
+      xmlns: NS_REFERENCE_0,
+      type: "data",
+      uri: "https://example.com/a",
+    });
+    ref.appendChild(preview);
+    expect(importPreview(ref)).toEqual({ url: "https://example.com/a", title: "T" });
+  });
+
+  test("silently drops preview with unparseable url", () => {
+    const ref = makeReferenceWithPreview(makePreviewXml({ url: "not a url" }));
+    expect(importPreview(ref)).toBeUndefined();
+  });
+});

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -26,6 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy 0.8.48",
@@ -265,6 +266,17 @@ dependencies = [
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1054,6 +1066,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1222,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1321,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1360,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "either"
@@ -1496,6 +1563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1693,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1951,6 +2037,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
 dependencies = [
  "utf8-width",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -2744,6 +2842,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkify"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfa36d52c581e9ec783a7ce2a5e0143da6237be5811a0b3153fedfdbe9f780"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2799,6 +2906,37 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "matchers"
@@ -2880,10 +3018,13 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",
@@ -2907,6 +3048,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"
@@ -3358,6 +3505,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -3379,6 +3527,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3517,6 +3678,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy 0.8.48",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -4243,6 +4410,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e749d29b2064585327af5038a5a8eb73aeebad4a3472e83531a436563f7208"
+dependencies = [
+ "ahash",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "sctp-proto"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4306,6 +4489,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -4397,6 +4599,15 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4836,6 +5047,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4955,6 +5191,17 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -5854,6 +6101,8 @@ dependencies = [
  "url",
  "uuid",
  "waddle-xmpp-xep-github",
+ "waddle-xmpp-xep-link-preview",
+ "wiremock",
  "xmpp-parsers",
 ]
 
@@ -5870,6 +6119,28 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "xmpp-parsers",
+]
+
+[[package]]
+name = "waddle-xmpp-xep-link-preview"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "dashmap",
+ "futures",
+ "hickory-resolver 0.25.2",
+ "jid",
+ "linkify",
+ "minidom",
+ "moka",
+ "reqwest",
+ "scraper",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wiremock",
  "xmpp-parsers",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/waddle-cli",
     "crates/waddle-xmpp",
     "crates/waddle-xmpp-xep-github",
+    "crates/waddle-xmpp-xep-link-preview",
 ]
 
 [workspace.package]
@@ -66,7 +67,7 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # HTTP Client
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 
 # CLI Arguments & Config
 clap = { version = "4.5", features = ["derive"] }
@@ -102,6 +103,11 @@ hickory-resolver = "0.25"
 lru = "0.12"
 regex = "1.10"
 jsonwebtoken = "9.3"
+linkify = "0.10"
+scraper = "0.21"
+moka = { version = "0.12", features = ["future"] }
+bytes = "1.9"
+wiremock = "0.6"
 
 # Markdown/Syntax (CLI)
 pulldown-cmark = "0.12"

--- a/server/crates/waddle-xmpp-xep-link-preview/Cargo.toml
+++ b/server/crates/waddle-xmpp-xep-link-preview/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "waddle-xmpp-xep-link-preview"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Waddle Social - Server-side link preview enrichment via OpenGraph/Twitter Card metadata"
+
+[dependencies]
+minidom = { workspace = true }
+xmpp-parsers = { workspace = true }
+jid = { workspace = true }
+tracing = { workspace = true }
+reqwest = { workspace = true }
+futures = { workspace = true }
+tokio = { workspace = true }
+hickory-resolver = { workspace = true }
+dashmap = { workspace = true }
+thiserror = { workspace = true }
+url = { workspace = true }
+bytes = { workspace = true }
+linkify = { workspace = true }
+scraper = { workspace = true }
+moka = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "test-util"] }
+wiremock = { workspace = true }

--- a/server/crates/waddle-xmpp-xep-link-preview/src/cache.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/cache.rs
@@ -1,0 +1,168 @@
+//! URL-keyed LRU cache for parsed previews.
+//!
+//! Two separate caches share a URL key space:
+//! - *positive* — successful fetches returning a [`LinkPreview`], kept
+//!   for [`CacheConfig::positive_ttl`].
+//! - *negative* — URLs that recently failed to produce a preview, kept
+//!   for the shorter [`CacheConfig::negative_ttl`] so a transiently
+//!   broken upstream doesn't stay un-previewed for a full hour.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use moka::future::Cache;
+
+use crate::LinkPreview;
+
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    pub capacity: u64,
+    pub positive_ttl: Duration,
+    pub negative_ttl: Duration,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 10_000,
+            positive_ttl: Duration::from_secs(60 * 60),
+            negative_ttl: Duration::from_secs(5 * 60),
+        }
+    }
+}
+
+/// Cached lookup outcome — either a fresh preview, an explicit negative
+/// marker, or nothing remembered.
+#[derive(Debug, Clone)]
+pub enum Lookup {
+    Hit(Arc<LinkPreview>),
+    Negative,
+    Miss,
+}
+
+pub struct PreviewCache {
+    positive: Cache<String, Arc<LinkPreview>>,
+    negative: Cache<String, ()>,
+}
+
+impl PreviewCache {
+    pub fn new(config: &CacheConfig) -> Self {
+        Self {
+            positive: Cache::builder()
+                .max_capacity(config.capacity)
+                .time_to_live(config.positive_ttl)
+                .build(),
+            negative: Cache::builder()
+                .max_capacity(config.capacity)
+                .time_to_live(config.negative_ttl)
+                .build(),
+        }
+    }
+
+    pub async fn lookup(&self, url: &str) -> Lookup {
+        if let Some(hit) = self.positive.get(url).await {
+            return Lookup::Hit(hit);
+        }
+        if self.negative.get(url).await.is_some() {
+            return Lookup::Negative;
+        }
+        Lookup::Miss
+    }
+
+    pub async fn insert_positive(&self, url: String, preview: LinkPreview) {
+        self.positive.insert(url, Arc::new(preview)).await;
+    }
+
+    pub async fn insert_negative(&self, url: String) {
+        self.negative.insert(url, ()).await;
+    }
+
+    /// Sync the caches — ensures all pending tasks complete before a
+    /// subsequent lookup, primarily useful in tests.
+    pub async fn sync(&self) {
+        self.positive.run_pending_tasks().await;
+        self.negative.run_pending_tasks().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::LinkPreview;
+
+    fn test_config(positive: Duration, negative: Duration) -> CacheConfig {
+        CacheConfig {
+            capacity: 16,
+            positive_ttl: positive,
+            negative_ttl: negative,
+        }
+    }
+
+    fn sample() -> LinkPreview {
+        LinkPreview {
+            url: "https://example.com/a".to_owned(),
+            canonical_url: Some("https://example.com/a".to_owned()),
+            title: Some("T".to_owned()),
+            description: None,
+            site_name: None,
+            type_: None,
+            image: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn miss_on_empty_cache() {
+        let cache = PreviewCache::new(&CacheConfig::default());
+        assert!(matches!(cache.lookup("https://example.com/a").await, Lookup::Miss));
+    }
+
+    #[tokio::test]
+    async fn hit_after_insert_positive() {
+        let cache = PreviewCache::new(&CacheConfig::default());
+        cache
+            .insert_positive("https://example.com/a".to_owned(), sample())
+            .await;
+        cache.sync().await;
+        let lookup = cache.lookup("https://example.com/a").await;
+        match lookup {
+            Lookup::Hit(p) => assert_eq!(p.title.as_deref(), Some("T")),
+            other => panic!("expected hit, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn negative_marker_survives_separately() {
+        let cache = PreviewCache::new(&CacheConfig::default());
+        cache.insert_negative("https://broken.example/".to_owned()).await;
+        cache.sync().await;
+        assert!(matches!(
+            cache.lookup("https://broken.example/").await,
+            Lookup::Negative
+        ));
+        assert!(matches!(
+            cache.lookup("https://other.example/").await,
+            Lookup::Miss
+        ));
+    }
+
+    #[tokio::test]
+    async fn positive_entries_expire_after_ttl() {
+        let cache = PreviewCache::new(&test_config(
+            Duration::from_millis(20),
+            Duration::from_millis(20),
+        ));
+        cache
+            .insert_positive("https://x.example/".to_owned(), sample())
+            .await;
+        cache.sync().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        cache.sync().await;
+        assert!(matches!(cache.lookup("https://x.example/").await, Lookup::Miss));
+    }
+
+    #[tokio::test]
+    async fn negative_ttl_shorter_than_positive_by_default() {
+        let config = CacheConfig::default();
+        assert!(config.negative_ttl < config.positive_ttl);
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/circuit.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/circuit.rs
@@ -1,0 +1,217 @@
+//! Per-host circuit breaker.
+//!
+//! Keeps one [`Circuit`] per hostname. The circuit opens after
+//! [`CircuitConfig::failure_threshold`] consecutive failures within a
+//! [`CircuitConfig::window`] and stays open for
+//! [`CircuitConfig::open_duration`]. After that, the next request is a
+//! half-open probe: success closes the circuit, failure re-opens it.
+//!
+//! All clock interactions accept an explicit [`Instant`] so tests can
+//! advance time deterministically.
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+
+#[derive(Debug, Clone)]
+pub struct CircuitConfig {
+    pub failure_threshold: u32,
+    pub window: Duration,
+    pub open_duration: Duration,
+}
+
+impl Default for CircuitConfig {
+    fn default() -> Self {
+        Self {
+            failure_threshold: 5,
+            window: Duration::from_secs(60),
+            open_duration: Duration::from_secs(5 * 60),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct Circuit {
+    consecutive_failures: u32,
+    first_failure_in_window: Option<Instant>,
+    opened_at: Option<Instant>,
+}
+
+pub struct CircuitBreaker {
+    config: CircuitConfig,
+    hosts: DashMap<String, Circuit>,
+}
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitConfig) -> Self {
+        Self {
+            config,
+            hosts: DashMap::new(),
+        }
+    }
+
+    /// Is the host allowed to be tried right now?
+    ///
+    /// Returns `true` if the circuit is closed *or* the open-duration
+    /// has elapsed (granting a half-open probe).
+    pub fn should_allow(&self, host: &str, now: Instant) -> bool {
+        match self.hosts.get(host).as_deref().copied() {
+            None => true,
+            Some(circuit) => match circuit.opened_at {
+                Some(opened_at) => now.duration_since(opened_at) >= self.config.open_duration,
+                None => true,
+            },
+        }
+    }
+
+    pub fn record_success(&self, host: &str) {
+        self.hosts.remove(host);
+    }
+
+    pub fn record_failure(&self, host: &str, now: Instant) {
+        let mut entry = self.hosts.entry(host.to_owned()).or_default();
+
+        // If a previous open period elapsed, this failure is the half-open
+        // probe outcome. Treat it as a fresh window.
+        if let Some(opened_at) = entry.opened_at {
+            if now.duration_since(opened_at) >= self.config.open_duration {
+                entry.opened_at = Some(now);
+                entry.consecutive_failures = 1;
+                entry.first_failure_in_window = Some(now);
+                return;
+            }
+            // Still open — nothing to do.
+            return;
+        }
+
+        let start = entry.first_failure_in_window.unwrap_or(now);
+        if now.duration_since(start) > self.config.window {
+            // Window elapsed without crossing threshold — reset.
+            entry.consecutive_failures = 1;
+            entry.first_failure_in_window = Some(now);
+            return;
+        }
+
+        entry.first_failure_in_window.get_or_insert(now);
+        entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
+
+        if entry.consecutive_failures >= self.config.failure_threshold {
+            entry.opened_at = Some(now);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn breaker() -> CircuitBreaker {
+        CircuitBreaker::new(CircuitConfig {
+            failure_threshold: 3,
+            window: Duration::from_secs(60),
+            open_duration: Duration::from_secs(300),
+        })
+    }
+
+    #[test]
+    fn new_host_is_allowed() {
+        let cb = breaker();
+        assert!(cb.should_allow("example.com", Instant::now()));
+    }
+
+    #[test]
+    fn failures_below_threshold_keep_circuit_closed() {
+        let cb = breaker();
+        let now = Instant::now();
+        cb.record_failure("example.com", now);
+        cb.record_failure("example.com", now + Duration::from_secs(1));
+        assert!(cb.should_allow("example.com", now + Duration::from_secs(2)));
+    }
+
+    #[test]
+    fn reaching_threshold_opens_circuit() {
+        let cb = breaker();
+        let now = Instant::now();
+        for i in 0..3 {
+            cb.record_failure("example.com", now + Duration::from_secs(i));
+        }
+        assert!(!cb.should_allow("example.com", now + Duration::from_secs(4)));
+    }
+
+    #[test]
+    fn success_resets_consecutive_failures() {
+        let cb = breaker();
+        let now = Instant::now();
+        cb.record_failure("example.com", now);
+        cb.record_failure("example.com", now + Duration::from_secs(1));
+        cb.record_success("example.com");
+        // Two more failures must not trip because the counter reset.
+        cb.record_failure("example.com", now + Duration::from_secs(2));
+        cb.record_failure("example.com", now + Duration::from_secs(3));
+        assert!(cb.should_allow("example.com", now + Duration::from_secs(4)));
+    }
+
+    #[test]
+    fn open_circuit_half_opens_after_duration() {
+        let cb = breaker();
+        let now = Instant::now();
+        for i in 0..3 {
+            cb.record_failure("example.com", now + Duration::from_secs(i));
+        }
+        assert!(!cb.should_allow("example.com", now + Duration::from_secs(60)));
+        assert!(cb.should_allow(
+            "example.com",
+            now + Duration::from_secs(60 + 300)
+        ));
+    }
+
+    #[test]
+    fn failure_during_half_open_reopens_circuit() {
+        let cb = breaker();
+        let t0 = Instant::now();
+        for i in 0..3 {
+            cb.record_failure("example.com", t0 + Duration::from_secs(i));
+        }
+        let after_open = t0 + Duration::from_secs(305);
+        // Probe: should be allowed.
+        assert!(cb.should_allow("example.com", after_open));
+        // Probe fails.
+        cb.record_failure("example.com", after_open);
+        // Now open again for another 5 minutes.
+        assert!(!cb.should_allow(
+            "example.com",
+            after_open + Duration::from_secs(1)
+        ));
+        assert!(cb.should_allow(
+            "example.com",
+            after_open + Duration::from_secs(301)
+        ));
+    }
+
+    #[test]
+    fn window_rollover_resets_counter() {
+        let cb = breaker();
+        let t0 = Instant::now();
+        // Two failures, then long pause, then two more — must not trip.
+        cb.record_failure("example.com", t0);
+        cb.record_failure("example.com", t0 + Duration::from_secs(10));
+        let after_window = t0 + Duration::from_secs(120);
+        cb.record_failure("example.com", after_window);
+        cb.record_failure("example.com", after_window + Duration::from_secs(1));
+        assert!(cb.should_allow(
+            "example.com",
+            after_window + Duration::from_secs(2)
+        ));
+    }
+
+    #[test]
+    fn hosts_are_isolated() {
+        let cb = breaker();
+        let now = Instant::now();
+        for i in 0..3 {
+            cb.record_failure("broken.example", now + Duration::from_secs(i));
+        }
+        assert!(!cb.should_allow("broken.example", now + Duration::from_secs(3)));
+        assert!(cb.should_allow("ok.example", now + Duration::from_secs(3)));
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/detect.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/detect.rs
@@ -1,0 +1,262 @@
+//! URL detection in message body text.
+//!
+//! Uses `linkify` to locate HTTP(S) URLs, skips content inside fenced
+//! (```` ``` ````) and inline (`` ` ``) code blocks so shared snippets
+//! don't get unfurled, and deduplicates by raw URL text keeping first
+//! appearance order.
+//!
+//! Offsets are reported in **UTF-16 code units** to match the wire
+//! convention used by `XEP-0372 <reference begin='' end=''>` attributes
+//! and the receiver-side anti-spoof check (which slices the body using
+//! JavaScript string indexing).
+
+use linkify::{LinkFinder, LinkKind};
+
+/// A URL discovered in a message body, with UTF-16 code-unit offsets
+/// locating the URL span inside the body text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DetectedUrl {
+    pub url: String,
+    pub utf16_begin: usize,
+    pub utf16_end: usize,
+}
+
+/// Find HTTP(S) URLs in `body`, skipping fenced / inline code regions
+/// and deduplicating by URL text (keeping first occurrence).
+pub fn detect_urls(body: &str) -> Vec<DetectedUrl> {
+    let masks = build_code_mask(body);
+
+    let mut finder = LinkFinder::new();
+    finder.kinds(&[LinkKind::Url]);
+
+    let mut seen: Vec<String> = Vec::new();
+    let mut out: Vec<DetectedUrl> = Vec::new();
+
+    for link in finder.links(body) {
+        let url = link.as_str();
+
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            continue;
+        }
+
+        let byte_start = link.start();
+        let byte_end = link.end();
+
+        if is_inside_code(&masks, byte_start, byte_end) {
+            continue;
+        }
+
+        if seen.iter().any(|u| u == url) {
+            continue;
+        }
+        seen.push(url.to_owned());
+
+        let utf16_begin = utf16_offset(body, byte_start);
+        let utf16_end = utf16_begin + utf16_len(&body[byte_start..byte_end]);
+
+        out.push(DetectedUrl {
+            url: url.to_owned(),
+            utf16_begin,
+            utf16_end,
+        });
+    }
+
+    out
+}
+
+fn utf16_offset(s: &str, byte_index: usize) -> usize {
+    s[..byte_index].encode_utf16().count()
+}
+
+fn utf16_len(s: &str) -> usize {
+    s.encode_utf16().count()
+}
+
+/// A list of (start_byte, end_byte) byte ranges covering code regions
+/// where URLs must be ignored.
+fn build_code_mask(body: &str) -> Vec<(usize, usize)> {
+    let mut masks: Vec<(usize, usize)> = Vec::new();
+    let bytes = body.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        // Fenced code: ``` ... ```
+        if bytes[i..].starts_with(b"```") {
+            let fence_start = i;
+            i += 3;
+            // Find closing ```
+            let mut j = i;
+            let mut closed = false;
+            while j + 3 <= bytes.len() {
+                if bytes[j..].starts_with(b"```") {
+                    masks.push((fence_start, j + 3));
+                    i = j + 3;
+                    closed = true;
+                    break;
+                }
+                j += 1;
+            }
+            if !closed {
+                // Unterminated fence consumes to EOF.
+                masks.push((fence_start, bytes.len()));
+                i = bytes.len();
+            }
+            continue;
+        }
+
+        // Inline code: ` ... `
+        if bytes[i] == b'`' {
+            let tick_start = i;
+            i += 1;
+            // Find closing `
+            let mut j = i;
+            let mut closed = false;
+            while j < bytes.len() {
+                if bytes[j] == b'`' {
+                    masks.push((tick_start, j + 1));
+                    i = j + 1;
+                    closed = true;
+                    break;
+                }
+                // Don't span newlines for inline code (markdown convention).
+                if bytes[j] == b'\n' {
+                    break;
+                }
+                j += 1;
+            }
+            if !closed {
+                i += 1; // skip the lone backtick
+            }
+            continue;
+        }
+
+        i += 1;
+    }
+
+    masks
+}
+
+fn is_inside_code(masks: &[(usize, usize)], start: usize, end: usize) -> bool {
+    masks.iter().any(|&(s, e)| start >= s && end <= e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_single_http_url() {
+        let d = detect_urls("see http://example.com/a here");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].url, "http://example.com/a");
+    }
+
+    #[test]
+    fn finds_single_https_url() {
+        let d = detect_urls("see https://example.com/a here");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].url, "https://example.com/a");
+    }
+
+    #[test]
+    fn returns_empty_when_no_urls() {
+        assert!(detect_urls("hello world").is_empty());
+    }
+
+    #[test]
+    fn ignores_mailto_ftp() {
+        let d = detect_urls("mailto:bob@example.com or ftp://x.example/");
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn finds_multiple_urls_in_order() {
+        let d = detect_urls("a https://a.example/ b https://b.example/ c");
+        assert_eq!(d.len(), 2);
+        assert_eq!(d[0].url, "https://a.example/");
+        assert_eq!(d[1].url, "https://b.example/");
+    }
+
+    #[test]
+    fn dedupes_identical_urls() {
+        let d = detect_urls("https://example.com/ and again https://example.com/");
+        assert_eq!(d.len(), 1);
+    }
+
+    #[test]
+    fn skips_urls_inside_fenced_code() {
+        let d = detect_urls("before ``` https://hidden.example/ ``` after");
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn skips_urls_inside_fenced_code_multiline() {
+        let body = "pre\n```\nhttps://hidden.example/\n```\npost";
+        assert!(detect_urls(body).is_empty());
+    }
+
+    #[test]
+    fn detects_url_outside_fenced_code_when_body_has_fences() {
+        let body = "outer https://shown.example/\n```\nhttps://hidden.example/\n```\n";
+        let d = detect_urls(body);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].url, "https://shown.example/");
+    }
+
+    #[test]
+    fn skips_urls_inside_inline_code() {
+        let d = detect_urls("see `https://hidden.example/` end");
+        assert!(d.is_empty());
+    }
+
+    #[test]
+    fn inline_code_does_not_span_newlines() {
+        // The lone ` before the URL doesn't match an inline-code region
+        // (no closing ` on the same line), so the URL must be detected.
+        let body = "broken `\nhttps://shown.example/";
+        let d = detect_urls(body);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].url, "https://shown.example/");
+    }
+
+    #[test]
+    fn utf16_offsets_for_ascii_body() {
+        let d = detect_urls("see https://example.com/ end");
+        assert_eq!(d[0].utf16_begin, 4);
+        assert_eq!(d[0].utf16_end, 24);
+    }
+
+    #[test]
+    fn utf16_offsets_skip_surrogate_pairs() {
+        // 🚀 is a non-BMP codepoint (U+1F680) → 2 UTF-16 code units.
+        // Space after = 1 unit. Total prefix = 3 units.
+        let d = detect_urls("🚀 https://example.com/");
+        assert_eq!(d[0].utf16_begin, 3);
+        assert_eq!(d[0].utf16_end, 3 + "https://example.com/".len());
+    }
+
+    #[test]
+    fn utf16_offsets_for_multibyte_bmp_prefix() {
+        // café = 4 UTF-16 code units (each codepoint is BMP, 1 unit).
+        let d = detect_urls("café https://example.com/");
+        assert_eq!(d[0].utf16_begin, 5);
+    }
+
+    #[test]
+    fn receivers_can_slice_body_with_returned_offsets() {
+        // Verifies the core contract the receiver relies on: slicing the
+        // body with [utf16_begin..utf16_end] via UTF-16 yields the URL.
+        let body = "🚀 https://example.com/article end";
+        let d = detect_urls(body);
+        let u16: Vec<u16> = body.encode_utf16().collect();
+        let sliced: String = String::from_utf16(&u16[d[0].utf16_begin..d[0].utf16_end])
+            .expect("valid utf16");
+        assert_eq!(sliced, d[0].url);
+    }
+
+    #[test]
+    fn unterminated_fence_swallows_rest_of_body() {
+        let d = detect_urls("before\n```\nhttps://hidden.example/\nunclosed");
+        assert!(d.is_empty());
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/embed.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/embed.rs
@@ -1,0 +1,335 @@
+//! XEP-0372 reference + nested `<preview>` XML serializer.
+//!
+//! Produces the exact wire format the receiver TypeScript stack (in
+//! `chat/src/lib/xmpp/extensions/preview.ts`) already parses, so we do
+//! not need a Waddle-specific protocol change on the client.
+
+use minidom::Element;
+use xmpp_parsers::message::Message;
+
+use crate::detect::DetectedUrl;
+use crate::{
+    LinkPreview, LinkPreviewImage, DESCRIPTION_MAX, NS_REFERENCE, NS_WADDLE_PREVIEW,
+    SITE_NAME_MAX, TITLE_MAX, TYPE_MAX,
+};
+
+/// Build a `<reference type='data' begin='…' end='…' uri='…'>` element
+/// carrying a nested `<preview xmlns='urn:waddle:link-preview:0'>` child
+/// populated from `preview`.
+pub fn build_reference(detected: &DetectedUrl, preview: &LinkPreview) -> Element {
+    let mut reference = Element::builder("reference", NS_REFERENCE)
+        .attr("type", "data")
+        .attr("begin", detected.utf16_begin.to_string())
+        .attr("end", detected.utf16_end.to_string())
+        .attr("uri", detected.url.as_str())
+        .build();
+
+    let preview_el = build_preview(&detected.url, preview);
+    reference.append_child(preview_el);
+    reference
+}
+
+fn build_preview(url: &str, preview: &LinkPreview) -> Element {
+    let mut builder = Element::builder("preview", NS_WADDLE_PREVIEW).attr("url", url);
+
+    if let Some(ref title) = preview.title {
+        builder = builder.append(text_child("title", cap(title, TITLE_MAX)));
+    }
+    if let Some(ref desc) = preview.description {
+        builder = builder.append(text_child("description", cap(desc, DESCRIPTION_MAX)));
+    }
+    if let Some(ref site) = preview.site_name {
+        builder = builder.append(text_child("site-name", cap(site, SITE_NAME_MAX)));
+    }
+    if let Some(ref type_) = preview.type_ {
+        builder = builder.append(text_child("type", cap(type_, TYPE_MAX)));
+    }
+    if let Some(ref img) = preview.image {
+        builder = builder.append(build_image(img));
+    }
+    builder.build()
+}
+
+fn text_child(name: &str, text: String) -> Element {
+    Element::builder(name, NS_WADDLE_PREVIEW)
+        .append(text.as_str())
+        .build()
+}
+
+fn build_image(img: &LinkPreviewImage) -> Element {
+    let mut builder = Element::builder("image", NS_WADDLE_PREVIEW).attr("src", img.src.as_str());
+    if let Some(ref w) = img.width {
+        builder = builder.attr("width", w.as_str());
+    }
+    if let Some(ref h) = img.height {
+        builder = builder.attr("height", h.as_str());
+    }
+    builder.build()
+}
+
+fn cap(raw: &str, max: usize) -> String {
+    let mut s = String::new();
+    for (i, c) in raw.trim().chars().enumerate() {
+        if i >= max {
+            break;
+        }
+        s.push(c);
+    }
+    s
+}
+
+/// Is this element the server's own preview-carrying reference? Used by
+/// the sender-authoritative strip pass to remove any client-authored
+/// copy before enrichment runs.
+pub fn is_preview_reference(element: &Element) -> bool {
+    if element.ns() != NS_REFERENCE || element.name() != "reference" {
+        return false;
+    }
+    if element.attr("type") != Some("data") {
+        return false;
+    }
+    element
+        .children()
+        .any(|child| child.ns() == NS_WADDLE_PREVIEW && child.name() == "preview")
+}
+
+/// Does this message carry a top-level `<no-preview xmlns='urn:waddle:link-preview:0'/>`
+/// hint from the sender opting out of enrichment for this message?
+pub fn has_no_preview_hint(msg: &Message) -> bool {
+    msg.payloads
+        .iter()
+        .any(|el| el.ns() == NS_WADDLE_PREVIEW && el.name() == "no-preview")
+}
+
+/// Remove any client-authored preview references from `msg.payloads`,
+/// returning the number stripped. Always called before enrichment so
+/// receivers trust the server-injected preview exclusively.
+pub fn strip_client_preview_references(msg: &mut Message) -> usize {
+    let before = msg.payloads.len();
+    msg.payloads.retain(|el| !is_preview_reference(el));
+    before - msg.payloads.len()
+}
+
+/// Is this element a GitHub enrichment child (`<repo|issue|pr>` in
+/// `urn:waddle:github:0`) whose `url` attribute matches `target`? Used
+/// to avoid duplicating a preview for URLs already expanded by the
+/// GitHub enricher which ran earlier in the pipeline.
+pub fn is_github_embed_for(element: &Element, target: &str) -> bool {
+    if element.ns() != "urn:waddle:github:0" {
+        return false;
+    }
+    if !matches!(element.name(), "repo" | "issue" | "pr") {
+        return false;
+    }
+    element.attr("url") == Some(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detect::DetectedUrl;
+    use crate::LinkPreview;
+
+    fn detected(url: &str, begin: usize, end: usize) -> DetectedUrl {
+        DetectedUrl {
+            url: url.to_owned(),
+            utf16_begin: begin,
+            utf16_end: end,
+        }
+    }
+
+    fn full_preview() -> LinkPreview {
+        LinkPreview {
+            url: "https://example.com/a".to_owned(),
+            canonical_url: Some("https://example.com/a".to_owned()),
+            title: Some("T".to_owned()),
+            description: Some("D".to_owned()),
+            site_name: Some("Ex".to_owned()),
+            type_: Some("article".to_owned()),
+            image: Some(LinkPreviewImage {
+                src: "https://cdn.example.com/a.png".to_owned(),
+                width: Some("1200".to_owned()),
+                height: Some("630".to_owned()),
+            }),
+        }
+    }
+
+    #[test]
+    fn build_reference_has_expected_attrs() {
+        let d = detected("https://example.com/a", 4, 25);
+        let el = build_reference(&d, &full_preview());
+
+        assert_eq!(el.name(), "reference");
+        assert_eq!(el.ns(), NS_REFERENCE);
+        assert_eq!(el.attr("type"), Some("data"));
+        assert_eq!(el.attr("begin"), Some("4"));
+        assert_eq!(el.attr("end"), Some("25"));
+        assert_eq!(el.attr("uri"), Some("https://example.com/a"));
+    }
+
+    #[test]
+    fn build_reference_has_nested_preview_with_fields() {
+        let d = detected("https://example.com/a", 0, 21);
+        let el = build_reference(&d, &full_preview());
+        let preview = el
+            .get_child("preview", NS_WADDLE_PREVIEW)
+            .expect("preview child");
+        assert_eq!(preview.attr("url"), Some("https://example.com/a"));
+        assert_eq!(
+            preview.get_child("title", NS_WADDLE_PREVIEW).map(|c| c.text()),
+            Some("T".to_owned())
+        );
+        assert_eq!(
+            preview.get_child("description", NS_WADDLE_PREVIEW).map(|c| c.text()),
+            Some("D".to_owned())
+        );
+        assert_eq!(
+            preview.get_child("site-name", NS_WADDLE_PREVIEW).map(|c| c.text()),
+            Some("Ex".to_owned())
+        );
+        assert_eq!(
+            preview.get_child("type", NS_WADDLE_PREVIEW).map(|c| c.text()),
+            Some("article".to_owned())
+        );
+        let image = preview.get_child("image", NS_WADDLE_PREVIEW).expect("image");
+        assert_eq!(image.attr("src"), Some("https://cdn.example.com/a.png"));
+        assert_eq!(image.attr("width"), Some("1200"));
+        assert_eq!(image.attr("height"), Some("630"));
+    }
+
+    #[test]
+    fn build_reference_omits_missing_optional_fields() {
+        let preview = LinkPreview {
+            url: "https://example.com/a".to_owned(),
+            canonical_url: None,
+            title: Some("T".to_owned()),
+            description: None,
+            site_name: None,
+            type_: None,
+            image: None,
+        };
+        let el = build_reference(&detected("https://example.com/a", 0, 21), &preview);
+        let inner = el.get_child("preview", NS_WADDLE_PREVIEW).unwrap();
+        assert!(inner.get_child("title", NS_WADDLE_PREVIEW).is_some());
+        assert!(inner.get_child("description", NS_WADDLE_PREVIEW).is_none());
+        assert!(inner.get_child("site-name", NS_WADDLE_PREVIEW).is_none());
+        assert!(inner.get_child("image", NS_WADDLE_PREVIEW).is_none());
+    }
+
+    #[test]
+    fn build_reference_truncates_overlong_fields() {
+        let mut p = full_preview();
+        p.title = Some("x".repeat(500));
+        let el = build_reference(&detected("https://example.com/a", 0, 21), &p);
+        let title = el
+            .get_child("preview", NS_WADDLE_PREVIEW)
+            .and_then(|pr| pr.get_child("title", NS_WADDLE_PREVIEW))
+            .expect("title")
+            .text();
+        assert_eq!(title.chars().count(), TITLE_MAX);
+    }
+
+    #[test]
+    fn detects_own_preview_reference() {
+        let el = build_reference(&detected("https://example.com/a", 0, 21), &full_preview());
+        assert!(is_preview_reference(&el));
+    }
+
+    #[test]
+    fn is_preview_reference_rejects_mention_type() {
+        let el = Element::builder("reference", NS_REFERENCE)
+            .attr("type", "mention")
+            .attr("uri", "xmpp:alice@example.com")
+            .build();
+        assert!(!is_preview_reference(&el));
+    }
+
+    #[test]
+    fn is_preview_reference_rejects_data_ref_without_preview_child() {
+        let el = Element::builder("reference", NS_REFERENCE)
+            .attr("type", "data")
+            .attr("uri", "https://example.com/file.jpg")
+            .build();
+        assert!(!is_preview_reference(&el));
+    }
+
+    #[test]
+    fn is_preview_reference_rejects_wrong_namespace_on_child() {
+        let mut el = Element::builder("reference", NS_REFERENCE)
+            .attr("type", "data")
+            .attr("uri", "https://example.com/a")
+            .build();
+        el.append_child(
+            Element::builder("preview", "urn:bogus:link-preview:99").build(),
+        );
+        assert!(!is_preview_reference(&el));
+    }
+
+    #[test]
+    fn strip_client_preview_references_removes_only_preview_refs() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+            <body>hi</body>\
+            <reference xmlns='urn:xmpp:reference:0' type='mention' uri='xmpp:alice@example.com'/>\
+            <reference xmlns='urn:xmpp:reference:0' type='data' uri='https://example.com/file.jpg'/>\
+            <reference xmlns='urn:xmpp:reference:0' type='data' uri='https://example.com/a'>\
+                <preview xmlns='urn:waddle:link-preview:0' url='https://example.com/a'><title>forged</title></preview>\
+            </reference>\
+        </message>";
+        let root: Element = xml.parse().unwrap();
+        let mut msg = Message::try_from(root).unwrap();
+        let stripped = strip_client_preview_references(&mut msg);
+        assert_eq!(stripped, 1);
+        // Mention + file-data references survive.
+        let remaining_refs = msg
+            .payloads
+            .iter()
+            .filter(|el| el.ns() == NS_REFERENCE && el.name() == "reference")
+            .count();
+        assert_eq!(remaining_refs, 2);
+    }
+
+    #[test]
+    fn has_no_preview_hint_detects_top_level_marker() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+            <body>hi</body>\
+            <no-preview xmlns='urn:waddle:link-preview:0'/>\
+        </message>";
+        let msg = Message::try_from(xml.parse::<Element>().unwrap()).unwrap();
+        assert!(has_no_preview_hint(&msg));
+    }
+
+    #[test]
+    fn has_no_preview_hint_returns_false_without_marker() {
+        let xml =
+            "<message xmlns='jabber:client' type='chat'><body>hi</body></message>";
+        let msg = Message::try_from(xml.parse::<Element>().unwrap()).unwrap();
+        assert!(!has_no_preview_hint(&msg));
+    }
+
+    #[test]
+    fn is_github_embed_for_recognises_repo_issue_pr() {
+        let url = "https://github.com/rust-lang/rust";
+        for name in ["repo", "issue", "pr"] {
+            let el = Element::builder(name, "urn:waddle:github:0")
+                .attr("url", url)
+                .build();
+            assert!(is_github_embed_for(&el, url));
+        }
+    }
+
+    #[test]
+    fn is_github_embed_for_requires_matching_url() {
+        let el = Element::builder("repo", "urn:waddle:github:0")
+            .attr("url", "https://github.com/other/repo")
+            .build();
+        assert!(!is_github_embed_for(&el, "https://github.com/rust-lang/rust"));
+    }
+
+    #[test]
+    fn is_github_embed_for_rejects_wrong_namespace() {
+        let el = Element::builder("repo", "urn:unrelated:0")
+            .attr("url", "https://github.com/rust-lang/rust")
+            .build();
+        assert!(!is_github_embed_for(&el, "https://github.com/rust-lang/rust"));
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/enrich.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/enrich.rs
@@ -1,0 +1,404 @@
+//! Message enricher entry point.
+//!
+//! Ties together [`detect`], [`fetch`], [`cache`], [`circuit`],
+//! [`rate`], and [`embed`] to perform the "detect URLs → fetch OG →
+//! append reference" pipeline in place on an outbound `<message>`.
+//!
+//! Fail-open: every failure path logs and returns early, leaving the
+//! message free to deliver unenriched.
+
+use std::env;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use jid::BareJid;
+use reqwest::Client;
+use tracing::{debug, info, warn};
+use url::Url;
+use xmpp_parsers::message::Message;
+
+use crate::cache::{CacheConfig, Lookup, PreviewCache};
+use crate::circuit::{CircuitBreaker, CircuitConfig};
+use crate::detect::{detect_urls, DetectedUrl};
+use crate::embed::{
+    build_reference, has_no_preview_hint, is_github_embed_for, strip_client_preview_references,
+};
+use crate::fetch::{
+    build_client, build_client_allow_private, fetch_preview, FetchConfig, FetchError, FetchOutcome,
+};
+use crate::rate::{RateConfig, RateLimiter};
+use crate::{LinkPreview, MAX_PREVIEWS_PER_MESSAGE};
+
+#[derive(Debug, Clone)]
+pub struct EnricherConfig {
+    pub enabled: bool,
+    pub fetch: FetchConfig,
+    pub cache: CacheConfig,
+    pub circuit: CircuitConfig,
+    pub rate: RateConfig,
+    pub allowlist_hosts: Option<Vec<String>>,
+    pub max_previews: usize,
+    /// Test hook — when set, the HTTP client will not filter private
+    /// IPs at the resolver stage. Integration tests that hit wiremock
+    /// on loopback set this to `true`.
+    pub allow_private_addresses: bool,
+}
+
+impl Default for EnricherConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            fetch: FetchConfig::default(),
+            cache: CacheConfig::default(),
+            circuit: CircuitConfig::default(),
+            rate: RateConfig::default(),
+            allowlist_hosts: None,
+            max_previews: MAX_PREVIEWS_PER_MESSAGE,
+            allow_private_addresses: false,
+        }
+    }
+}
+
+pub struct LinkPreviewEnricher {
+    config: EnricherConfig,
+    client: Client,
+    cache: Arc<PreviewCache>,
+    circuit: Arc<CircuitBreaker>,
+    rate: Arc<RateLimiter>,
+}
+
+impl LinkPreviewEnricher {
+    /// Build a shared enricher from environment variables. See the
+    /// crate-level docs for the supported knobs. Defaults to enabled;
+    /// set `WADDLE_LINK_PREVIEW_DISABLE=1` to turn off.
+    pub fn from_env() -> Arc<Self> {
+        let config = EnricherConfig {
+            enabled: !env_flag("WADDLE_LINK_PREVIEW_DISABLE"),
+            fetch: FetchConfig {
+                user_agent: env::var("WADDLE_LINK_PREVIEW_USER_AGENT")
+                    .unwrap_or_else(|_| FetchConfig::default().user_agent),
+                timeout: Duration::from_millis(env_u64(
+                    "WADDLE_LINK_PREVIEW_TIMEOUT_MS",
+                    5_000,
+                )),
+                max_bytes: env_u64("WADDLE_LINK_PREVIEW_MAX_BYTES", 512 * 1024) as usize,
+                max_redirects: env_u64("WADDLE_LINK_PREVIEW_MAX_REDIRECTS", 3) as usize,
+                // Propagated from `allow_private_addresses` inside
+                // `with_config`; ignored here.
+                allow_private_addresses: false,
+            },
+            cache: CacheConfig {
+                capacity: env_u64("WADDLE_LINK_PREVIEW_CACHE_SIZE", 10_000),
+                positive_ttl: Duration::from_secs(env_u64(
+                    "WADDLE_LINK_PREVIEW_CACHE_TTL_SECS",
+                    3_600,
+                )),
+                negative_ttl: Duration::from_secs(env_u64(
+                    "WADDLE_LINK_PREVIEW_NEGATIVE_TTL_SECS",
+                    300,
+                )),
+            },
+            circuit: CircuitConfig::default(),
+            rate: RateConfig {
+                capacity: env_u64("WADDLE_LINK_PREVIEW_PER_USER_RATE", 30) as u32,
+                window: Duration::from_secs(60),
+            },
+            allowlist_hosts: env::var("WADDLE_LINK_PREVIEW_ALLOWLIST_HOSTS")
+                .ok()
+                .map(|v| {
+                    v.split(',')
+                        .map(|s| s.trim().to_ascii_lowercase())
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .filter(|v: &Vec<String>| !v.is_empty()),
+            max_previews: MAX_PREVIEWS_PER_MESSAGE,
+            // Test-only escape hatch: integration tests that point the
+            // fetcher at a wiremock instance on loopback set this flag
+            // via `WADDLE_LINK_PREVIEW_ALLOW_PRIVATE=1`. Production
+            // deployments must never set this.
+            allow_private_addresses: env_flag("WADDLE_LINK_PREVIEW_ALLOW_PRIVATE"),
+        };
+
+        if !config.enabled {
+            info!("link preview enrichment disabled via WADDLE_LINK_PREVIEW_DISABLE");
+        } else {
+            info!(
+                cache_capacity = config.cache.capacity,
+                timeout_ms = config.fetch.timeout.as_millis() as u64,
+                max_bytes = config.fetch.max_bytes,
+                rate_per_user_per_min = config.rate.capacity,
+                allowlist_hosts = config.allowlist_hosts.as_ref().map(|v| v.len()).unwrap_or(0),
+                "link preview enrichment enabled"
+            );
+        }
+
+        Arc::new(Self::with_config(config).expect("link preview client should build"))
+    }
+
+    pub fn with_config(mut config: EnricherConfig) -> Result<Self, FetchError> {
+        // Propagate the test-only allow-private flag into the fetch
+        // config so the literal-IP guard inside `fetch_preview` lines up
+        // with the permissive DNS resolver. In production both stay `false`.
+        config.fetch.allow_private_addresses = config.allow_private_addresses;
+
+        let client = if config.allow_private_addresses {
+            build_client_allow_private(&config.fetch)?
+        } else {
+            build_client(&config.fetch)?
+        };
+
+        Ok(Self {
+            cache: Arc::new(PreviewCache::new(&config.cache)),
+            circuit: Arc::new(CircuitBreaker::new(config.circuit.clone())),
+            rate: Arc::new(RateLimiter::new(config.rate.clone())),
+            client,
+            config,
+        })
+    }
+
+    /// Enrich `msg` in place. Returns the number of preview references
+    /// appended to `msg.payloads`. Fail-open: any error path returns a
+    /// partial count (zero if nothing succeeded) and leaves the message
+    /// safe to deliver.
+    pub async fn enrich_message(&self, msg: &mut Message, sender: &BareJid) -> usize {
+        // Sender-authoritative: always strip client-authored previews.
+        // This is a security invariant — even with the feature disabled,
+        // the server must not forward forged preview payloads.
+        let stripped = strip_client_preview_references(msg);
+        if stripped > 0 {
+            debug!(stripped, "stripped client-authored preview references");
+        }
+
+        if !self.config.enabled {
+            return 0;
+        }
+
+        if has_no_preview_hint(msg) {
+            return 0;
+        }
+
+        if !self.rate.try_acquire(sender, Instant::now()) {
+            debug!(%sender, "link preview rate-limited");
+            return 0;
+        }
+
+        let Some(body) = extract_body(msg) else {
+            return 0;
+        };
+
+        let detected = detect_urls(&body);
+        if detected.is_empty() {
+            return 0;
+        }
+
+        let mut added = 0usize;
+        for url in detected.into_iter().take(self.config.max_previews * 2) {
+            if added >= self.config.max_previews {
+                break;
+            }
+            if self.skip_because_github_handled(msg, &url.url) {
+                continue;
+            }
+            if !self.host_allowed(&url.url) {
+                continue;
+            }
+            match self.preview_for(&url).await {
+                Some(preview) => {
+                    let element = build_reference(&url, &preview);
+                    msg.payloads.push(element);
+                    added += 1;
+                }
+                None => continue,
+            }
+        }
+
+        added
+    }
+
+    fn skip_because_github_handled(&self, msg: &Message, target: &str) -> bool {
+        msg.payloads
+            .iter()
+            .any(|el| is_github_embed_for(el, target))
+    }
+
+    fn host_allowed(&self, url: &str) -> bool {
+        let Some(allow) = &self.config.allowlist_hosts else {
+            return true;
+        };
+        let parsed = match Url::parse(url) {
+            Ok(u) => u,
+            Err(_) => return false,
+        };
+        let host = match parsed.host_str() {
+            Some(h) => h.to_ascii_lowercase(),
+            None => return false,
+        };
+        allow.iter().any(|a| &host == a)
+    }
+
+    async fn preview_for(&self, detected: &DetectedUrl) -> Option<LinkPreview> {
+        match self.cache.lookup(&detected.url).await {
+            Lookup::Hit(hit) => return Some((*hit).clone()),
+            Lookup::Negative => return None,
+            Lookup::Miss => {}
+        }
+
+        let parsed = Url::parse(&detected.url).ok()?;
+        let host = parsed.host_str()?.to_ascii_lowercase();
+        let now = Instant::now();
+        if !self.circuit.should_allow(&host, now) {
+            debug!(%host, "link preview circuit breaker open, skipping");
+            return None;
+        }
+
+        match fetch_preview(&self.client, parsed, &self.config.fetch).await {
+            Ok(outcome) => {
+                let preview = match outcome {
+                    FetchOutcome::Html(p) => p,
+                    FetchOutcome::Image(p) => p,
+                };
+                self.circuit.record_success(&host);
+                self.cache
+                    .insert_positive(detected.url.clone(), preview.clone())
+                    .await;
+                Some(preview)
+            }
+            Err(err) => {
+                warn!(url = %detected.url, error = %err, "link preview fetch failed");
+                self.circuit.record_failure(&host, Instant::now());
+                self.cache.insert_negative(detected.url.clone()).await;
+                None
+            }
+        }
+    }
+}
+
+fn extract_body(msg: &Message) -> Option<String> {
+    msg.bodies
+        .iter()
+        .next()
+        .map(|(_, body)| body.0.clone())
+}
+
+fn env_flag(name: &str) -> bool {
+    matches!(
+        env::var(name).as_deref(),
+        Ok("1" | "true" | "yes" | "TRUE" | "YES")
+    )
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minidom::Element;
+    use std::str::FromStr;
+
+    fn alice() -> BareJid {
+        BareJid::from_str("alice@example.com").unwrap()
+    }
+
+    fn message_with(xml: &str) -> Message {
+        let root: Element = xml.parse().expect("valid xml");
+        Message::try_from(root).expect("valid message")
+    }
+
+    fn disabled_config() -> EnricherConfig {
+        EnricherConfig {
+            enabled: false,
+            ..EnricherConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_enricher_is_noop() {
+        let e = LinkPreviewEnricher::with_config(disabled_config()).unwrap();
+        let mut msg = message_with(
+            "<message xmlns='jabber:client' type='chat'><body>see https://a.example/</body></message>",
+        );
+        let count = e.enrich_message(&mut msg, &alice()).await;
+        assert_eq!(count, 0);
+        // Message untouched.
+        assert!(msg.payloads.is_empty());
+    }
+
+    #[tokio::test]
+    async fn no_preview_hint_short_circuits_before_fetch() {
+        let e = LinkPreviewEnricher::with_config(EnricherConfig::default()).unwrap();
+        let mut msg = message_with(
+            "<message xmlns='jabber:client' type='chat'>\
+                <body>see https://never-reached.example/</body>\
+                <no-preview xmlns='urn:waddle:link-preview:0'/>\
+            </message>",
+        );
+        let count = e.enrich_message(&mut msg, &alice()).await;
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn strips_client_authored_preview_even_without_hint() {
+        let e = LinkPreviewEnricher::with_config(disabled_config()).unwrap();
+        let mut msg = message_with(
+            "<message xmlns='jabber:client' type='chat'>\
+                <body>see https://a.example/</body>\
+                <reference xmlns='urn:xmpp:reference:0' type='data' uri='https://a.example/'>\
+                    <preview xmlns='urn:waddle:link-preview:0' url='https://a.example/'><title>forged</title></preview>\
+                </reference>\
+            </message>",
+        );
+        e.enrich_message(&mut msg, &alice()).await;
+        let refs = msg
+            .payloads
+            .iter()
+            .filter(|el| {
+                el.ns() == crate::NS_REFERENCE
+                    && el.name() == "reference"
+                    && el.attr("type") == Some("data")
+            })
+            .count();
+        assert_eq!(refs, 0, "forged preview reference must be stripped");
+    }
+
+    #[tokio::test]
+    async fn returns_zero_on_empty_body() {
+        let e = LinkPreviewEnricher::with_config(EnricherConfig::default()).unwrap();
+        let mut msg = message_with(
+            "<message xmlns='jabber:client' type='chat'><body></body></message>",
+        );
+        assert_eq!(e.enrich_message(&mut msg, &alice()).await, 0);
+    }
+
+    #[tokio::test]
+    async fn returns_zero_when_body_has_no_urls() {
+        let e = LinkPreviewEnricher::with_config(EnricherConfig::default()).unwrap();
+        let mut msg = message_with(
+            "<message xmlns='jabber:client' type='chat'><body>hello world</body></message>",
+        );
+        assert_eq!(e.enrich_message(&mut msg, &alice()).await, 0);
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_blocks_non_allowed() {
+        let mut config = EnricherConfig::default();
+        config.allowlist_hosts = Some(vec!["allowed.example".to_owned()]);
+        let e = LinkPreviewEnricher::with_config(config).unwrap();
+
+        // Allowlisted host passes host_allowed.
+        assert!(e.host_allowed("https://allowed.example/x"));
+        // Disallowed host rejected.
+        assert!(!e.host_allowed("https://other.example/"));
+    }
+
+    #[tokio::test]
+    async fn host_allowlist_none_allows_all() {
+        let e = LinkPreviewEnricher::with_config(EnricherConfig::default()).unwrap();
+        assert!(e.host_allowed("https://anywhere.example/"));
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/fetch.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/fetch.rs
@@ -1,0 +1,487 @@
+//! HTTP client with custom DNS-resolver SSRF filter.
+//!
+//! Wraps `reqwest::Client` with a [`SafeResolver`] that asks
+//! `hickory-resolver` for A/AAAA records and drops any result pointing at
+//! a disallowed IP per [`crate::ssrf::is_disallowed_ip`]. Combined with
+//! literal-IP checks on URL host parts at call time, this prevents the
+//! classic "public DNS name with a private A record" SSRF bypass.
+//!
+//! Other guardrails enforced by [`fetch_preview`]:
+//! - `http`/`https` schemes only.
+//! - 5-second default timeout.
+//! - 512 KiB default body cap (mid-stream abort).
+//! - `Content-Type` allowlist: `text/html`, `application/xhtml+xml`, `image/*`.
+//! - Max 3 redirects, each hop re-validated through the same URL filter.
+//! - No credentials, no cookies, no auth headers.
+//! - `User-Agent` set to identify the Waddle crawler so site admins have
+//!   a contact surface.
+
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use futures::StreamExt;
+use hickory_resolver::{
+    config::{ResolverConfig, ResolverOpts},
+    name_server::TokioConnectionProvider,
+    Resolver, TokioResolver,
+};
+use reqwest::{
+    dns::{Addrs, Name, Resolve, Resolving},
+    redirect::Policy,
+    Client,
+};
+use thiserror::Error;
+use tracing::debug;
+use url::Url;
+
+use crate::html::parse_html;
+use crate::ssrf::is_disallowed_ip;
+use crate::{LinkPreview, LinkPreviewImage};
+
+/// Outcome of a successful fetch.
+#[derive(Debug)]
+pub enum FetchOutcome {
+    /// HTML parsed into a preview.
+    Html(LinkPreview),
+    /// Direct-image URL — preview carries only the image reference.
+    Image(LinkPreview),
+}
+
+#[derive(Debug, Error)]
+pub enum FetchError {
+    #[error("url is not http/https")]
+    BadScheme,
+    #[error("url host resolved to a disallowed address")]
+    PrivateHost,
+    #[error("url host parse failed")]
+    BadUrl,
+    #[error("timed out")]
+    Timeout,
+    #[error("upstream responded {0}")]
+    BadStatus(u16),
+    #[error("content-type not allowed: {0}")]
+    BadContentType(String),
+    #[error("body exceeded {0} bytes")]
+    TooLarge(usize),
+    #[error("too many redirects")]
+    TooManyRedirects,
+    #[error("transport error: {0}")]
+    Transport(String),
+}
+
+/// Runtime knobs for the HTTP client.
+#[derive(Debug, Clone)]
+pub struct FetchConfig {
+    pub user_agent: String,
+    pub timeout: Duration,
+    pub max_bytes: usize,
+    pub max_redirects: usize,
+    /// Test-only escape hatch: when `true`, both the literal-IP guard
+    /// and the DNS-resolver filter allow private/loopback addresses.
+    /// Production must leave this `false`.
+    pub allow_private_addresses: bool,
+}
+
+impl Default for FetchConfig {
+    fn default() -> Self {
+        Self {
+            user_agent: "Waddle-LinkPreview/0.1 (+https://waddle.chat)".to_owned(),
+            timeout: Duration::from_secs(5),
+            max_bytes: 512 * 1024,
+            max_redirects: 3,
+            allow_private_addresses: false,
+        }
+    }
+}
+
+/// Build a reqwest client backed by a private-IP-filtering DNS resolver.
+pub fn build_client(config: &FetchConfig) -> Result<Client, FetchError> {
+    let resolver = Arc::new(SafeResolver::production()?);
+    build_client_with_resolver(config, resolver)
+}
+
+/// Test hook: build a client that allows every resolved IP through the
+/// filter. Used by wiremock-backed integration tests where the upstream
+/// is necessarily on loopback.
+pub fn build_client_allow_private(config: &FetchConfig) -> Result<Client, FetchError> {
+    let resolver = Arc::new(SafeResolver::allow_all()?);
+    build_client_with_resolver(config, resolver)
+}
+
+fn build_client_with_resolver(
+    config: &FetchConfig,
+    resolver: Arc<SafeResolver>,
+) -> Result<Client, FetchError> {
+    Client::builder()
+        .user_agent(config.user_agent.clone())
+        .timeout(config.timeout)
+        .redirect(Policy::none())
+        .dns_resolver(resolver)
+        .build()
+        .map_err(|e: reqwest::Error| FetchError::Transport(e.to_string()))
+}
+
+/// Fetch a preview for `target`, following up to `config.max_redirects`
+/// redirects and re-validating every hop.
+pub async fn fetch_preview(
+    client: &Client,
+    target: Url,
+    config: &FetchConfig,
+) -> Result<FetchOutcome, FetchError> {
+    validate_target_url(&target, config.allow_private_addresses)?;
+    let mut current = target;
+    let mut redirects_left = config.max_redirects;
+
+    loop {
+        let resp = match client.get(current.clone()).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                if e.is_timeout() {
+                    return Err(FetchError::Timeout);
+                }
+                return Err(FetchError::Transport(e.to_string()));
+            }
+        };
+
+        let status = resp.status().as_u16();
+        if (300..400).contains(&status) && status != 304 {
+            let Some(location) = resp.headers().get(reqwest::header::LOCATION) else {
+                return Err(FetchError::BadStatus(status));
+            };
+            let location_str = location
+                .to_str()
+                .map_err(|_| FetchError::Transport("invalid location header".to_owned()))?;
+            let next = current
+                .join(location_str)
+                .map_err(|_| FetchError::BadUrl)?;
+            if redirects_left == 0 {
+                return Err(FetchError::TooManyRedirects);
+            }
+            redirects_left -= 1;
+            validate_target_url(&next, config.allow_private_addresses)?;
+            current = next;
+            continue;
+        }
+
+        if !(200..300).contains(&status) {
+            return Err(FetchError::BadStatus(status));
+        }
+
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(normalize_content_type)
+            .unwrap_or_default();
+
+        match classify_content_type(&content_type) {
+            ContentKind::Image => {
+                return Ok(FetchOutcome::Image(image_only_preview(&current)));
+            }
+            ContentKind::Html => {
+                // fall through
+            }
+            ContentKind::Rejected => {
+                return Err(FetchError::BadContentType(content_type));
+            }
+        }
+
+        if let Some(len) = resp.content_length() {
+            if (len as usize) > config.max_bytes {
+                return Err(FetchError::TooLarge(config.max_bytes));
+            }
+        }
+
+        let body = read_capped_body(resp, config.max_bytes).await?;
+        let html = String::from_utf8_lossy(&body);
+        let preview = parse_html(&html, &current);
+        return Ok(FetchOutcome::Html(preview));
+    }
+}
+
+fn image_only_preview(url: &Url) -> LinkPreview {
+    LinkPreview {
+        url: url.to_string(),
+        canonical_url: Some(url.to_string()),
+        title: None,
+        description: None,
+        site_name: url
+            .host_str()
+            .map(|h| h.strip_prefix("www.").unwrap_or(h).to_owned()),
+        type_: Some("image".to_owned()),
+        image: Some(LinkPreviewImage {
+            src: url.to_string(),
+            width: None,
+            height: None,
+        }),
+    }
+}
+
+/// Validate a URL before any network egress: http/https + literal-IP
+/// host check. Public hostnames pass here; the DNS resolver does the
+/// second-stage filter.
+fn validate_target_url(url: &Url, allow_private: bool) -> Result<(), FetchError> {
+    match url.scheme() {
+        "http" | "https" => {}
+        _ => return Err(FetchError::BadScheme),
+    }
+    let Some(host) = url.host() else {
+        return Err(FetchError::BadUrl);
+    };
+    if allow_private {
+        return Ok(());
+    }
+    match host {
+        url::Host::Ipv4(ip) => {
+            if is_disallowed_ip(ip.into()) {
+                return Err(FetchError::PrivateHost);
+            }
+        }
+        url::Host::Ipv6(ip) => {
+            if is_disallowed_ip(ip.into()) {
+                return Err(FetchError::PrivateHost);
+            }
+        }
+        url::Host::Domain(_) => {}
+    }
+    Ok(())
+}
+
+/// Content type bucket.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ContentKind {
+    Html,
+    Image,
+    Rejected,
+}
+
+pub fn classify_content_type(normalized: &str) -> ContentKind {
+    match normalized {
+        "text/html" | "application/xhtml+xml" => ContentKind::Html,
+        other if other.starts_with("image/") => ContentKind::Image,
+        _ => ContentKind::Rejected,
+    }
+}
+
+/// Strip parameters and lowercase a Content-Type value.
+pub fn normalize_content_type(raw: &str) -> String {
+    let semi = raw.find(';').unwrap_or(raw.len());
+    raw[..semi].trim().to_ascii_lowercase()
+}
+
+async fn read_capped_body(
+    resp: reqwest::Response,
+    max_bytes: usize,
+) -> Result<Bytes, FetchError> {
+    let mut total = 0usize;
+    let mut buf = BytesMut::with_capacity(max_bytes.min(64 * 1024));
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e: reqwest::Error| FetchError::Transport(e.to_string()))?;
+        total += chunk.len();
+        if total > max_bytes {
+            return Err(FetchError::TooLarge(max_bytes));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf.freeze())
+}
+
+/// A `reqwest::dns::Resolve` implementation that filters A/AAAA results
+/// through [`is_disallowed_ip`] before returning them to the connector.
+pub struct SafeResolver {
+    inner: TokioResolver,
+    allow_private: bool,
+}
+
+impl SafeResolver {
+    pub fn production() -> Result<Self, FetchError> {
+        Self::build(false)
+    }
+
+    fn allow_all() -> Result<Self, FetchError> {
+        Self::build(true)
+    }
+
+    fn build(allow_private: bool) -> Result<Self, FetchError> {
+        let inner = Resolver::builder_with_config(
+            ResolverConfig::cloudflare(),
+            TokioConnectionProvider::default(),
+        )
+        .with_options(ResolverOpts::default())
+        .build();
+        Ok(Self {
+            inner,
+            allow_private,
+        })
+    }
+}
+
+impl Resolve for SafeResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let resolver = self.inner.clone();
+        let allow_private = self.allow_private;
+        let host = name.as_str().to_owned();
+        Box::pin(async move {
+            let lookup = match resolver.lookup_ip(host.as_str()).await {
+                Ok(l) => l,
+                Err(e) => return Err(Box::new(e) as _),
+            };
+            let addrs = filter_addresses(lookup.into_iter(), allow_private);
+            if addrs.is_empty() {
+                return Err(Box::new(std::io::Error::other(
+                    "all resolved addresses disallowed",
+                )) as _);
+            }
+            let iter: Addrs = Box::new(addrs.into_iter());
+            Ok(iter)
+        })
+    }
+}
+
+/// Drop disallowed IPs from a list of resolved addresses, wrapping each
+/// in a `SocketAddr` with port 0 (reqwest overrides the port from the URL).
+pub fn filter_addresses(
+    ips: impl Iterator<Item = IpAddr>,
+    allow_private: bool,
+) -> Vec<SocketAddr> {
+    ips.filter(|ip| allow_private || !is_disallowed_ip(*ip))
+        .map(|ip| SocketAddr::new(ip, 0))
+        .collect()
+}
+
+// `Name::from_str` is used by consumers that build their own Name objects.
+// Re-exported to ensure the crate's public surface doesn't depend on
+// reqwest internals leaking in tests.
+#[doc(hidden)]
+pub fn parse_name(host: &str) -> Option<Name> {
+    Name::from_str(host).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_html() {
+        assert_eq!(classify_content_type("text/html"), ContentKind::Html);
+        assert_eq!(classify_content_type("application/xhtml+xml"), ContentKind::Html);
+    }
+
+    #[test]
+    fn classify_image() {
+        assert_eq!(classify_content_type("image/png"), ContentKind::Image);
+        assert_eq!(classify_content_type("image/jpeg"), ContentKind::Image);
+        assert_eq!(classify_content_type("image/webp"), ContentKind::Image);
+    }
+
+    #[test]
+    fn classify_rejected() {
+        assert_eq!(classify_content_type("application/json"), ContentKind::Rejected);
+        assert_eq!(classify_content_type("application/zip"), ContentKind::Rejected);
+        assert_eq!(classify_content_type(""), ContentKind::Rejected);
+        assert_eq!(classify_content_type("text/plain"), ContentKind::Rejected);
+    }
+
+    #[test]
+    fn normalize_strips_charset_and_lowercases() {
+        assert_eq!(normalize_content_type("text/html; charset=utf-8"), "text/html");
+        assert_eq!(normalize_content_type("TEXT/HTML"), "text/html");
+        assert_eq!(normalize_content_type("  image/PNG ; x=1"), "image/png");
+    }
+
+    #[test]
+    fn validate_accepts_public_http_and_https() {
+        assert!(validate_target_url(&Url::parse("http://example.com/").unwrap(), false).is_ok());
+        assert!(validate_target_url(&Url::parse("https://example.com/").unwrap(), false).is_ok());
+        assert!(validate_target_url(&Url::parse("https://8.8.8.8/").unwrap(), false).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_non_http_schemes() {
+        assert!(matches!(
+            validate_target_url(&Url::parse("file:///etc/passwd").unwrap(), false),
+            Err(FetchError::BadScheme)
+        ));
+        assert!(matches!(
+            validate_target_url(&Url::parse("ftp://x.example/").unwrap(), false),
+            Err(FetchError::BadScheme)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_literal_private_ip() {
+        assert!(matches!(
+            validate_target_url(&Url::parse("http://192.168.1.1/").unwrap(), false),
+            Err(FetchError::PrivateHost)
+        ));
+        assert!(matches!(
+            validate_target_url(&Url::parse("http://127.0.0.1/").unwrap(), false),
+            Err(FetchError::PrivateHost)
+        ));
+        assert!(matches!(
+            validate_target_url(&Url::parse("http://169.254.169.254/").unwrap(), false),
+            Err(FetchError::PrivateHost)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_literal_private_ipv6() {
+        assert!(matches!(
+            validate_target_url(&Url::parse("http://[::1]/").unwrap(), false),
+            Err(FetchError::PrivateHost)
+        ));
+        assert!(matches!(
+            validate_target_url(&Url::parse("http://[fe80::1]/").unwrap(), false),
+            Err(FetchError::PrivateHost)
+        ));
+    }
+
+    #[test]
+    fn filter_drops_private_v4() {
+        let ips = ["10.0.0.1", "8.8.8.8", "127.0.0.1", "1.1.1.1"]
+            .into_iter()
+            .map(|s| s.parse().unwrap());
+        let out = filter_addresses(ips, false);
+        let hosts: Vec<IpAddr> = out.iter().map(|s| s.ip()).collect();
+        assert!(hosts.contains(&"8.8.8.8".parse::<IpAddr>().unwrap()));
+        assert!(hosts.contains(&"1.1.1.1".parse::<IpAddr>().unwrap()));
+        assert!(!hosts.contains(&"10.0.0.1".parse::<IpAddr>().unwrap()));
+        assert!(!hosts.contains(&"127.0.0.1".parse::<IpAddr>().unwrap()));
+    }
+
+    #[test]
+    fn filter_allow_private_keeps_everything() {
+        let ips = ["10.0.0.1", "127.0.0.1"]
+            .into_iter()
+            .map(|s| s.parse().unwrap());
+        let out = filter_addresses(ips, true);
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn filter_port_is_zero_for_reqwest_to_override() {
+        let ips = ["8.8.8.8"].into_iter().map(|s| s.parse().unwrap());
+        let out = filter_addresses(ips, false);
+        assert_eq!(out[0].port(), 0);
+    }
+
+    #[test]
+    fn image_only_preview_carries_only_image_fields() {
+        let url = Url::parse("https://cdn.example.com/photo.png").unwrap();
+        let p = image_only_preview(&url);
+        assert_eq!(p.type_.as_deref(), Some("image"));
+        assert_eq!(p.image.as_ref().unwrap().src, "https://cdn.example.com/photo.png");
+        assert_eq!(p.site_name.as_deref(), Some("cdn.example.com"));
+        assert!(p.title.is_none());
+    }
+}
+
+// Silence dead-code warning for test-only helper when compiled without tests.
+#[doc(hidden)]
+pub fn _touch() {
+    debug!("link-preview fetch helpers compiled");
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/html.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/html.rs
@@ -1,0 +1,407 @@
+//! OpenGraph / Twitter Card / HTML metadata extraction.
+//!
+//! Given raw HTML + the post-redirect request URL, produces a sanitized
+//! [`LinkPreview`]. Only `<head>` is inspected. Field selection order:
+//!
+//! - title: `og:title` → `twitter:title` → `<title>`
+//! - description: `og:description` → `twitter:description` → `<meta name="description">`
+//! - image: `og:image` → `og:image:url` → `twitter:image`, resolved against the base URL
+//! - site_name: `og:site_name` → hostname (with leading `www.` stripped)
+//! - canonical: `<link rel="canonical">` → request URL
+//! - type: `og:type`
+//!
+//! All text fields are trimmed and length-capped
+//! ([`crate::TITLE_MAX`], [`crate::DESCRIPTION_MAX`], [`crate::SITE_NAME_MAX`], [`crate::TYPE_MAX`]).
+//! Image URLs that fail to parse, use a non-http(s) scheme, or resolve to
+//! a private/reserved IP are dropped — but other fields are kept.
+
+use scraper::{Html, Selector};
+use url::Url;
+
+use crate::ssrf::is_disallowed_ip;
+use crate::{
+    LinkPreview, LinkPreviewImage, DESCRIPTION_MAX, SITE_NAME_MAX, TITLE_MAX, TYPE_MAX,
+};
+
+pub fn parse_html(html: &str, base_url: &Url) -> LinkPreview {
+    let doc = Html::parse_document(html);
+    let head = find_head(&doc);
+
+    let og = select_meta(&doc, &head, "property", "og:");
+    let twitter = select_meta(&doc, &head, "name", "twitter:");
+    let plain_description = select_meta(&doc, &head, "name", "description")
+        .into_iter()
+        .next()
+        .map(|(_, v)| v);
+
+    let og_get = |key: &str| first_content(&og, key);
+    let tw_get = |key: &str| first_content(&twitter, key);
+
+    let title = first_present([
+        og_get("og:title"),
+        tw_get("twitter:title"),
+        title_tag(&doc, &head),
+    ]);
+    let description = first_present([
+        og_get("og:description"),
+        tw_get("twitter:description"),
+        plain_description,
+    ]);
+    let site_name = og_get("og:site_name").or_else(|| Some(host_from(base_url)));
+    let type_ = og_get("og:type");
+
+    let image_src_raw = og_get("og:image")
+        .or_else(|| og_get("og:image:url"))
+        .or_else(|| tw_get("twitter:image"));
+    let image = image_src_raw.and_then(|src| build_image(&src, &og, base_url));
+
+    let canonical_url = canonical(&doc, &head, base_url);
+
+    LinkPreview {
+        url: base_url.to_string(),
+        canonical_url: Some(canonical_url),
+        title: cap(title, TITLE_MAX),
+        description: cap(description, DESCRIPTION_MAX),
+        site_name: cap(site_name, SITE_NAME_MAX),
+        type_: cap(type_, TYPE_MAX),
+        image,
+    }
+}
+
+/// Restrict a selection to descendants of `<head>` only. scraper doesn't
+/// have a `within` API so we return a cached `ElementRef` to walk.
+fn find_head(doc: &Html) -> Option<scraper::ElementRef<'_>> {
+    Selector::parse("head").ok().and_then(|sel| doc.select(&sel).next())
+}
+
+/// Pull out `(key, content)` pairs for every matching `<meta>` tag in
+/// the head, keyed by its `property`/`name` attribute. First occurrence
+/// wins when callers use [`first_content`] below.
+fn select_meta(
+    doc: &Html,
+    head: &Option<scraper::ElementRef<'_>>,
+    attr: &str,
+    prefix_or_exact: &str,
+) -> Vec<(String, String)> {
+    let sel = match Selector::parse(&format!("meta[{attr}]")) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    let iter: Box<dyn Iterator<Item = scraper::ElementRef<'_>>> = match head {
+        Some(head) => Box::new(head.select(&sel)),
+        None => Box::new(doc.select(&sel)),
+    };
+
+    iter.filter_map(|el| {
+        let key = el.value().attr(attr)?.to_owned();
+        let content = el.value().attr("content")?.to_owned();
+        if prefix_or_exact.ends_with(':') {
+            if !key.to_ascii_lowercase().starts_with(prefix_or_exact) {
+                return None;
+            }
+        } else if key.to_ascii_lowercase() != prefix_or_exact {
+            return None;
+        }
+        Some((key.to_ascii_lowercase(), content))
+    })
+    .collect()
+}
+
+fn first_content(pairs: &[(String, String)], key: &str) -> Option<String> {
+    pairs
+        .iter()
+        .find(|(k, _)| k == &key.to_ascii_lowercase())
+        .map(|(_, v)| v.clone())
+}
+
+fn title_tag(doc: &Html, head: &Option<scraper::ElementRef<'_>>) -> Option<String> {
+    let sel = Selector::parse("title").ok()?;
+    let node = match head {
+        Some(head) => head.select(&sel).next()?,
+        None => doc.select(&sel).next()?,
+    };
+    let text: String = node.text().collect();
+    Some(text)
+}
+
+fn canonical(doc: &Html, head: &Option<scraper::ElementRef<'_>>, base: &Url) -> String {
+    let sel = match Selector::parse("link[rel='canonical']") {
+        Ok(s) => s,
+        Err(_) => return base.to_string(),
+    };
+    let iter: Box<dyn Iterator<Item = scraper::ElementRef<'_>>> = match head {
+        Some(head) => Box::new(head.select(&sel)),
+        None => Box::new(doc.select(&sel)),
+    };
+    for el in iter {
+        if let Some(href) = el.value().attr("href") {
+            if let Ok(resolved) = base.join(href) {
+                return resolved.to_string();
+            }
+        }
+    }
+    base.to_string()
+}
+
+fn build_image(
+    raw: &str,
+    og_pairs: &[(String, String)],
+    base: &Url,
+) -> Option<LinkPreviewImage> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let resolved = base.join(trimmed).ok()?;
+    if !matches!(resolved.scheme(), "http" | "https") {
+        return None;
+    }
+
+    if let Some(host) = resolved.host() {
+        if let url::Host::Ipv4(ip) = host {
+            if is_disallowed_ip(ip.into()) {
+                return None;
+            }
+        }
+        if let url::Host::Ipv6(ip) = host {
+            if is_disallowed_ip(ip.into()) {
+                return None;
+            }
+        }
+    } else {
+        return None;
+    }
+
+    let width = first_content(og_pairs, "og:image:width").and_then(non_empty);
+    let height = first_content(og_pairs, "og:image:height").and_then(non_empty);
+
+    Some(LinkPreviewImage {
+        src: resolved.to_string(),
+        width,
+        height,
+    })
+}
+
+fn host_from(url: &Url) -> String {
+    url.host_str()
+        .map(|h| h.strip_prefix("www.").unwrap_or(h).to_owned())
+        .unwrap_or_default()
+}
+
+fn cap(raw: Option<String>, max: usize) -> Option<String> {
+    let trimmed = raw?.trim().to_owned();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.chars().count() > max {
+        let mut s = String::with_capacity(max);
+        for (i, c) in trimmed.chars().enumerate() {
+            if i >= max {
+                break;
+            }
+            s.push(c);
+        }
+        Some(s)
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn non_empty(s: String) -> Option<String> {
+    let t = s.trim();
+    if t.is_empty() {
+        None
+    } else {
+        Some(t.to_owned())
+    }
+}
+
+fn first_present<const N: usize>(options: [Option<String>; N]) -> Option<String> {
+    for opt in options {
+        if let Some(v) = opt {
+            if !v.trim().is_empty() {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> Url {
+        Url::parse("https://example.com/article?q=1").unwrap()
+    }
+
+    #[test]
+    fn extracts_og_title_description_image_site_name_type() {
+        let html = r#"
+            <html><head>
+              <meta property="og:title" content="Title">
+              <meta property="og:description" content="Desc">
+              <meta property="og:image" content="https://cdn.example.com/a.png">
+              <meta property="og:image:width" content="1200">
+              <meta property="og:image:height" content="630">
+              <meta property="og:site_name" content="Example">
+              <meta property="og:type" content="article">
+            </head></html>
+        "#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.title.as_deref(), Some("Title"));
+        assert_eq!(p.description.as_deref(), Some("Desc"));
+        assert_eq!(p.site_name.as_deref(), Some("Example"));
+        assert_eq!(p.type_.as_deref(), Some("article"));
+        let img = p.image.unwrap();
+        assert_eq!(img.src, "https://cdn.example.com/a.png");
+        assert_eq!(img.width.as_deref(), Some("1200"));
+        assert_eq!(img.height.as_deref(), Some("630"));
+    }
+
+    #[test]
+    fn falls_back_to_twitter_card() {
+        let html = r#"
+            <html><head>
+              <meta name="twitter:title" content="TTitle">
+              <meta name="twitter:description" content="TDesc">
+              <meta name="twitter:image" content="https://cdn.example.com/t.png">
+            </head></html>
+        "#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.title.as_deref(), Some("TTitle"));
+        assert_eq!(p.description.as_deref(), Some("TDesc"));
+        assert_eq!(p.image.unwrap().src, "https://cdn.example.com/t.png");
+    }
+
+    #[test]
+    fn falls_back_to_title_tag_and_meta_description() {
+        let html = r#"
+            <html><head>
+              <title>Plain Title</title>
+              <meta name="description" content="Plain description">
+            </head></html>
+        "#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.title.as_deref(), Some("Plain Title"));
+        assert_eq!(p.description.as_deref(), Some("Plain description"));
+    }
+
+    #[test]
+    fn og_wins_over_twitter_and_title() {
+        let html = r#"
+            <html><head>
+              <title>Plain</title>
+              <meta property="og:title" content="OG">
+              <meta name="twitter:title" content="TW">
+            </head></html>
+        "#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.title.as_deref(), Some("OG"));
+    }
+
+    #[test]
+    fn site_name_falls_back_to_hostname_without_www() {
+        let p = parse_html("<html></html>", &Url::parse("https://www.example.com/").unwrap());
+        assert_eq!(p.site_name.as_deref(), Some("example.com"));
+    }
+
+    #[test]
+    fn canonical_url_from_link_tag() {
+        let html = r#"<html><head><link rel="canonical" href="https://example.com/canonical"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.canonical_url.as_deref(), Some("https://example.com/canonical"));
+    }
+
+    #[test]
+    fn canonical_url_falls_back_to_base() {
+        let p = parse_html("<html></html>", &base());
+        assert_eq!(p.canonical_url.as_deref(), Some("https://example.com/article?q=1"));
+    }
+
+    #[test]
+    fn resolves_protocol_relative_image() {
+        let html = r#"<html><head><meta property="og:image" content="//cdn.example.com/a.png"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.image.unwrap().src, "https://cdn.example.com/a.png");
+    }
+
+    #[test]
+    fn resolves_root_relative_image() {
+        let html = r#"<html><head><meta property="og:image" content="/a.png"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.image.unwrap().src, "https://example.com/a.png");
+    }
+
+    #[test]
+    fn drops_image_with_non_http_scheme() {
+        let html = r#"<html><head><meta property="og:image" content="javascript:alert(1)"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert!(p.image.is_none());
+    }
+
+    #[test]
+    fn drops_image_with_data_url() {
+        let html = r#"<html><head><meta property="og:image" content="data:image/png;base64,xx"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert!(p.image.is_none());
+    }
+
+    #[test]
+    fn drops_image_hosted_on_private_ip() {
+        let html = r#"<html><head><meta property="og:image" content="http://192.168.1.1/og.png"></head></html>"#;
+        let p = parse_html(html, &base());
+        assert!(p.image.is_none());
+    }
+
+    #[test]
+    fn truncates_long_title() {
+        let long = "x".repeat(500);
+        let html = format!(
+            r#"<html><head><meta property="og:title" content="{long}"></head></html>"#
+        );
+        let p = parse_html(&html, &base());
+        assert_eq!(p.title.as_ref().map(|s| s.chars().count()), Some(TITLE_MAX));
+    }
+
+    #[test]
+    fn truncates_long_description() {
+        let long = "y".repeat(1000);
+        let html = format!(
+            r#"<html><head><meta property="og:description" content="{long}"></head></html>"#
+        );
+        let p = parse_html(&html, &base());
+        assert_eq!(p.description.as_ref().map(|s| s.chars().count()), Some(DESCRIPTION_MAX));
+    }
+
+    #[test]
+    fn trims_whitespace_and_drops_empty_fields() {
+        let html = r#"<html><head><meta property="og:title" content="   "><meta property="og:description" content=""></head></html>"#;
+        let p = parse_html(html, &base());
+        assert!(p.title.is_none());
+        assert!(p.description.is_none());
+    }
+
+    #[test]
+    fn first_duplicate_og_tag_wins() {
+        let html = r#"
+            <html><head>
+              <meta property="og:title" content="first">
+              <meta property="og:title" content="second">
+            </head></html>
+        "#;
+        let p = parse_html(html, &base());
+        assert_eq!(p.title.as_deref(), Some("first"));
+    }
+
+    #[test]
+    fn handles_html_with_no_metadata() {
+        let p = parse_html("<html><head></head><body>x</body></html>", &base());
+        assert!(p.title.is_none());
+        assert!(p.description.is_none());
+        assert!(p.image.is_none());
+        // site_name still falls back to hostname.
+        assert_eq!(p.site_name.as_deref(), Some("example.com"));
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/lib.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/lib.rs
@@ -1,0 +1,78 @@
+//! Waddle Link Preview (Custom XEP)
+//!
+//! Server-side message enrichment: detects HTTP(S) URLs in XMPP message
+//! bodies, fetches OpenGraph / Twitter Card / HTML metadata, and appends
+//! a structured `<reference type='data'><preview/>` payload to the stanza
+//! before fan-out. Every recipient — including carbons and MAM history —
+//! sees the same enriched message.
+//!
+//! The enricher is designed to be called **once before fan-out**, after
+//! the GitHub enricher (which wins for recognised GitHub URLs). Fail-open:
+//! all errors are logged but never block delivery.
+//!
+//! ## XML wire format
+//!
+//! ```xml
+//! <message type='groupchat'>
+//!   <body>see https://example.com/article</body>
+//!   <reference xmlns='urn:xmpp:reference:0' type='data'
+//!              begin='4' end='30' uri='https://example.com/article'>
+//!     <preview xmlns='urn:waddle:link-preview:0' url='https://example.com/article'>
+//!       <title>Example Article</title>
+//!       <description>Short summary.</description>
+//!       <site-name>Example</site-name>
+//!       <image src='https://example.com/og.png' width='1200' height='630'/>
+//!       <type>article</type>
+//!     </preview>
+//!   </reference>
+//! </message>
+//! ```
+//!
+//! Senders can suppress enrichment per-message by including a top-level
+//! `<no-preview xmlns='urn:waddle:link-preview:0'/>` hint.
+
+pub mod cache;
+pub mod circuit;
+pub mod detect;
+pub mod embed;
+pub mod enrich;
+pub mod fetch;
+pub mod html;
+pub mod rate;
+pub mod ssrf;
+
+pub use enrich::LinkPreviewEnricher;
+
+/// XML namespace for the Waddle link preview extension.
+pub const NS_WADDLE_PREVIEW: &str = "urn:waddle:link-preview:0";
+
+/// XML namespace for the XEP-0372 reference wrapper.
+pub const NS_REFERENCE: &str = "urn:xmpp:reference:0";
+
+/// Maximum number of previews to attach per message.
+pub const MAX_PREVIEWS_PER_MESSAGE: usize = 3;
+
+/// Length caps for embedded text fields (plaintext, truncated on overflow).
+pub const TITLE_MAX: usize = 200;
+pub const DESCRIPTION_MAX: usize = 300;
+pub const SITE_NAME_MAX: usize = 100;
+pub const TYPE_MAX: usize = 50;
+
+/// A sanitized, ready-to-embed link preview.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreview {
+    pub url: String,
+    pub canonical_url: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub site_name: Option<String>,
+    pub type_: Option<String>,
+    pub image: Option<LinkPreviewImage>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkPreviewImage {
+    pub src: String,
+    pub width: Option<String>,
+    pub height: Option<String>,
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/rate.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/rate.rs
@@ -1,0 +1,140 @@
+//! Per-sender fixed-window rate limiter.
+//!
+//! One bucket per bare JID. Up to [`RateConfig::capacity`] enrichments
+//! allowed in any rolling [`RateConfig::window`]. Exceeding the budget
+//! silently drops enrichment for that message.
+//!
+//! The limiter uses a fixed-window counter instead of a leaky-bucket
+//! because enrichment is a coarse, message-level operation — sub-second
+//! smoothing adds no value and complicates testing.
+
+use std::time::{Duration, Instant};
+
+use dashmap::DashMap;
+use jid::BareJid;
+
+#[derive(Debug, Clone)]
+pub struct RateConfig {
+    pub capacity: u32,
+    pub window: Duration,
+}
+
+impl Default for RateConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 30,
+            window: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Bucket {
+    count: u32,
+    window_start: Instant,
+}
+
+pub struct RateLimiter {
+    config: RateConfig,
+    buckets: DashMap<BareJid, Bucket>,
+}
+
+impl RateLimiter {
+    pub fn new(config: RateConfig) -> Self {
+        Self {
+            config,
+            buckets: DashMap::new(),
+        }
+    }
+
+    /// Try to consume a slot for `jid`; returns `true` if allowed,
+    /// `false` if the bucket is full.
+    pub fn try_acquire(&self, jid: &BareJid, now: Instant) -> bool {
+        let mut entry = self.buckets.entry(jid.clone()).or_insert(Bucket {
+            count: 0,
+            window_start: now,
+        });
+
+        if now.duration_since(entry.window_start) >= self.config.window {
+            entry.count = 0;
+            entry.window_start = now;
+        }
+
+        if entry.count < self.config.capacity {
+            entry.count += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn alice() -> BareJid {
+        BareJid::from_str("alice@example.com").unwrap()
+    }
+    fn bob() -> BareJid {
+        BareJid::from_str("bob@example.com").unwrap()
+    }
+
+    fn limiter(capacity: u32, window_secs: u64) -> RateLimiter {
+        RateLimiter::new(RateConfig {
+            capacity,
+            window: Duration::from_secs(window_secs),
+        })
+    }
+
+    #[test]
+    fn allows_up_to_capacity_in_window() {
+        let rl = limiter(3, 60);
+        let now = Instant::now();
+        assert!(rl.try_acquire(&alice(), now));
+        assert!(rl.try_acquire(&alice(), now));
+        assert!(rl.try_acquire(&alice(), now));
+        assert!(!rl.try_acquire(&alice(), now));
+    }
+
+    #[test]
+    fn refills_after_window() {
+        let rl = limiter(2, 60);
+        let t0 = Instant::now();
+        assert!(rl.try_acquire(&alice(), t0));
+        assert!(rl.try_acquire(&alice(), t0));
+        assert!(!rl.try_acquire(&alice(), t0 + Duration::from_secs(30)));
+        // After window elapses, reset.
+        assert!(rl.try_acquire(&alice(), t0 + Duration::from_secs(60)));
+        assert!(rl.try_acquire(&alice(), t0 + Duration::from_secs(60)));
+        assert!(!rl.try_acquire(&alice(), t0 + Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn buckets_are_per_jid() {
+        let rl = limiter(1, 60);
+        let now = Instant::now();
+        assert!(rl.try_acquire(&alice(), now));
+        assert!(!rl.try_acquire(&alice(), now));
+        assert!(rl.try_acquire(&bob(), now));
+    }
+
+    #[test]
+    fn default_config_is_30_per_60s() {
+        let cfg = RateConfig::default();
+        assert_eq!(cfg.capacity, 30);
+        assert_eq!(cfg.window, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn boundary_exact_window_duration_resets() {
+        // Requests at exactly t=0 and t=window should both succeed in a
+        // 1-capacity bucket, because the >= window check resets the bucket.
+        let rl = limiter(1, 60);
+        let t0 = Instant::now();
+        assert!(rl.try_acquire(&alice(), t0));
+        assert!(!rl.try_acquire(&alice(), t0 + Duration::from_secs(59)));
+        assert!(rl.try_acquire(&alice(), t0 + Duration::from_secs(60)));
+    }
+}

--- a/server/crates/waddle-xmpp-xep-link-preview/src/ssrf.rs
+++ b/server/crates/waddle-xmpp-xep-link-preview/src/ssrf.rs
@@ -1,0 +1,207 @@
+//! SSRF guard: classify IP addresses that must never be fetched from the
+//! server, regardless of whether they appear in a URL literal or are
+//! returned by DNS resolution of a user-supplied hostname.
+//!
+//! Rejects all private/loopback/link-local/reserved/documentation ranges.
+//! Used both at URL-parse time (literal IPs in the host component) and
+//! inside the custom DNS resolver (filtering resolved addresses).
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Returns `true` if fetching from this address must be blocked.
+///
+/// Covered ranges:
+/// - IPv4: `0.0.0.0/8`, `10.0.0.0/8`, `127.0.0.0/8`, `169.254.0.0/16`,
+///   `172.16.0.0/12`, `192.168.0.0/16`, multicast (`224.0.0.0/4`),
+///   broadcast, reserved (`240.0.0.0/4`), documentation ranges
+///   (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`),
+///   shared address space (`100.64.0.0/10`), benchmarking (`198.18.0.0/15`).
+/// - IPv6: loopback `::1`, unspecified `::`, unique-local `fc00::/7`,
+///   link-local `fe80::/10`, multicast `ff00::/8`, documentation
+///   `2001:db8::/32`, and IPv4-mapped addresses that resolve to a
+///   disallowed IPv4 address per the rules above.
+pub fn is_disallowed_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => is_disallowed_ipv4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(mapped) = v6.to_ipv4_mapped() {
+                return is_disallowed_ipv4(mapped);
+            }
+            is_disallowed_ipv6(v6)
+        }
+    }
+}
+
+fn is_disallowed_ipv4(ip: Ipv4Addr) -> bool {
+    let [a, b, _, _] = ip.octets();
+    if a == 0 { return true; }            // 0.0.0.0/8
+    if a == 10 { return true; }           // 10.0.0.0/8
+    if a == 127 { return true; }          // loopback
+    if a == 169 && b == 254 { return true; } // link-local
+    if a == 172 && (16..=31).contains(&b) { return true; } // 172.16/12
+    if a == 192 && b == 168 { return true; } // 192.168/16
+    if a == 192 && b == 0 { return true; }   // 192.0.0/24 (reserved), includes 192.0.2 (TEST-NET-1)
+    if a == 198 && b == 18 { return true; }  // 198.18/15 benchmarking
+    if a == 198 && b == 19 { return true; }
+    if a == 198 && b == 51 && ip.octets()[2] == 100 { return true; } // TEST-NET-2
+    if a == 203 && b == 0 && ip.octets()[2] == 113 { return true; }  // TEST-NET-3
+    if a == 100 && (64..=127).contains(&b) { return true; } // 100.64/10 CGNAT
+    if a >= 224 { return true; }          // multicast + reserved + broadcast
+    false
+}
+
+fn is_disallowed_ipv6(ip: Ipv6Addr) -> bool {
+    if ip.is_loopback() { return true; }
+    if ip.is_unspecified() { return true; }
+    if ip.is_multicast() { return true; }
+
+    let seg0 = ip.segments()[0];
+    if (seg0 & 0xfe00) == 0xfc00 { return true; } // fc00::/7 ULA
+    if (seg0 & 0xffc0) == 0xfe80 { return true; } // fe80::/10 link-local
+
+    // 2001:db8::/32 documentation
+    let segs = ip.segments();
+    if segs[0] == 0x2001 && segs[1] == 0x0db8 { return true; }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4(s: &str) -> IpAddr {
+        s.parse().expect("valid v4")
+    }
+    fn v6(s: &str) -> IpAddr {
+        s.parse().expect("valid v6")
+    }
+
+    #[test]
+    fn accepts_public_ipv4() {
+        assert!(!is_disallowed_ip(v4("8.8.8.8")));
+        assert!(!is_disallowed_ip(v4("1.1.1.1")));
+        assert!(!is_disallowed_ip(v4("140.82.114.4"))); // github.com
+    }
+
+    #[test]
+    fn rejects_ipv4_loopback() {
+        assert!(is_disallowed_ip(v4("127.0.0.1")));
+        assert!(is_disallowed_ip(v4("127.1.2.3")));
+    }
+
+    #[test]
+    fn rejects_ipv4_10_8() {
+        assert!(is_disallowed_ip(v4("10.0.0.1")));
+        assert!(is_disallowed_ip(v4("10.255.255.255")));
+    }
+
+    #[test]
+    fn rejects_ipv4_172_16_12() {
+        assert!(is_disallowed_ip(v4("172.16.0.1")));
+        assert!(is_disallowed_ip(v4("172.31.255.255")));
+        // Boundaries: 172.15 and 172.32 should be allowed
+        assert!(!is_disallowed_ip(v4("172.15.0.1")));
+        assert!(!is_disallowed_ip(v4("172.32.0.1")));
+    }
+
+    #[test]
+    fn rejects_ipv4_192_168_16() {
+        assert!(is_disallowed_ip(v4("192.168.0.1")));
+        assert!(is_disallowed_ip(v4("192.168.255.255")));
+    }
+
+    #[test]
+    fn rejects_ipv4_169_254_16() {
+        assert!(is_disallowed_ip(v4("169.254.169.254"))); // cloud metadata
+        assert!(is_disallowed_ip(v4("169.254.0.1")));
+    }
+
+    #[test]
+    fn rejects_ipv4_0_8() {
+        assert!(is_disallowed_ip(v4("0.0.0.0")));
+        assert!(is_disallowed_ip(v4("0.255.255.255")));
+    }
+
+    #[test]
+    fn rejects_ipv4_cgnat() {
+        assert!(is_disallowed_ip(v4("100.64.0.1")));
+        assert!(is_disallowed_ip(v4("100.127.255.255")));
+        // 100.63 and 100.128 are public
+        assert!(!is_disallowed_ip(v4("100.63.0.1")));
+        assert!(!is_disallowed_ip(v4("100.128.0.1")));
+    }
+
+    #[test]
+    fn rejects_ipv4_test_nets() {
+        assert!(is_disallowed_ip(v4("192.0.2.1")));    // TEST-NET-1
+        assert!(is_disallowed_ip(v4("198.51.100.1"))); // TEST-NET-2
+        assert!(is_disallowed_ip(v4("203.0.113.1"))); // TEST-NET-3
+    }
+
+    #[test]
+    fn rejects_ipv4_benchmark() {
+        assert!(is_disallowed_ip(v4("198.18.0.1")));
+        assert!(is_disallowed_ip(v4("198.19.255.255")));
+    }
+
+    #[test]
+    fn rejects_ipv4_multicast_and_reserved() {
+        assert!(is_disallowed_ip(v4("224.0.0.1")));   // multicast
+        assert!(is_disallowed_ip(v4("239.255.255.250")));
+        assert!(is_disallowed_ip(v4("255.255.255.255"))); // broadcast
+        assert!(is_disallowed_ip(v4("240.0.0.1")));   // reserved
+    }
+
+    #[test]
+    fn rejects_ipv6_loopback() {
+        assert!(is_disallowed_ip(v6("::1")));
+    }
+
+    #[test]
+    fn rejects_ipv6_unspecified() {
+        assert!(is_disallowed_ip(v6("::")));
+    }
+
+    #[test]
+    fn rejects_ipv6_link_local() {
+        assert!(is_disallowed_ip(v6("fe80::1")));
+        assert!(is_disallowed_ip(v6("febf:ffff::1")));
+    }
+
+    #[test]
+    fn rejects_ipv6_ula() {
+        assert!(is_disallowed_ip(v6("fc00::1")));
+        assert!(is_disallowed_ip(v6("fd00::1")));
+        assert!(is_disallowed_ip(v6("fdff:ffff::1")));
+    }
+
+    #[test]
+    fn rejects_ipv6_multicast() {
+        assert!(is_disallowed_ip(v6("ff00::1")));
+        assert!(is_disallowed_ip(v6("ff02::1")));
+    }
+
+    #[test]
+    fn rejects_ipv6_documentation() {
+        assert!(is_disallowed_ip(v6("2001:db8::1")));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_private_v6() {
+        assert!(is_disallowed_ip(v6("::ffff:10.0.0.1")));
+        assert!(is_disallowed_ip(v6("::ffff:192.168.1.1")));
+        assert!(is_disallowed_ip(v6("::ffff:127.0.0.1")));
+    }
+
+    #[test]
+    fn accepts_public_ipv4_mapped_v6() {
+        assert!(!is_disallowed_ip(v6("::ffff:8.8.8.8")));
+    }
+
+    #[test]
+    fn accepts_public_ipv6() {
+        // Google public DNS v6
+        assert!(!is_disallowed_ip(v6("2001:4860:4860::8888")));
+    }
+}

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -72,6 +72,9 @@ reqwest = { workspace = true }
 # GitHub link enrichment
 waddle-xmpp-xep-github = { path = "../waddle-xmpp-xep-github" }
 
+# Generic link preview enrichment
+waddle-xmpp-xep-link-preview = { path = "../waddle-xmpp-xep-link-preview" }
+
 # Database
 libsql = { workspace = true }
 
@@ -82,3 +85,4 @@ rcgen = "0.13"
 tempfile = "3.14"
 tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
+wiremock = { workspace = true }

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -99,6 +99,7 @@ use crate::xep::xep0398::AvatarConversion;
 use crate::xep::xep0461::{parse_reply_from_message, thread_id_from_message};
 use crate::{AppState, Session, XmppError};
 use waddle_xmpp_xep_github::{message_has_github_embed, MessageEnricher};
+use waddle_xmpp_xep_link_preview::LinkPreviewEnricher;
 
 /// Size of the outbound message channel buffer.
 const OUTBOUND_CHANNEL_SIZE: usize = 256;
@@ -169,6 +170,8 @@ pub struct ConnectionActor<S: AppState, M: MamStorage> {
     converting_avatar: bool,
     /// GitHub link enricher for expanding GitHub URLs in messages
     github_enricher: Option<Arc<MessageEnricher>>,
+    /// Generic OG/Twitter-Card link preview enricher for non-GitHub URLs
+    link_preview_enricher: Option<Arc<LinkPreviewEnricher>>,
     /// Whether the server operates in single-tenant mode (XEP-0503).
     /// When true, all spaces are publicly discoverable regardless of membership.
     single_tenant: bool,
@@ -184,7 +187,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
     /// Handle a new incoming connection.
     #[instrument(
         name = "xmpp.connection.handle",
-        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, github_enricher, push_store, push_sender, sfu_service),
+        skip(tcp_stream, tls_acceptor, app_state, room_registry, connection_registry, mam_storage, isr_token_store, sm_session_registry, pubsub_storage, github_enricher, link_preview_enricher, push_store, push_sender, sfu_service),
         fields(peer = %peer_addr)
     )]
     #[allow(clippy::too_many_arguments)]
@@ -202,6 +205,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         registration_enabled: bool,
         pubsub_storage: Arc<dyn PubSubStorage + Send + Sync>,
         github_enricher: Option<Arc<MessageEnricher>>,
+        link_preview_enricher: Option<Arc<LinkPreviewEnricher>>,
         single_tenant: bool,
         push_store: Arc<dyn crate::push::PushSubscriptionStore + Send + Sync>,
         push_sender: Arc<dyn crate::push::WebPushSender + Send + Sync>,
@@ -234,6 +238,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             last_available_presence: None,
             converting_avatar: false, // XEP-0398: guard against infinite conversion loops
             github_enricher,          // GitHub link enrichment (optional)
+            link_preview_enricher,    // Generic OG/Twitter-Card link preview (optional)
             single_tenant,            // XEP-0503: single-tenant mode for spaces
             push_store,               // XEP-0357: push subscription store
             push_sender,              // XEP-0357: push notification sender
@@ -1373,6 +1378,17 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             let embeds = enricher.enrich_message(&mut msg).await;
             let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
             crate::metrics::record_github_enrichment(elapsed_ms, embeds as u64);
+        }
+
+        // Generic OG/Twitter-Card link preview enrichment. Runs after
+        // GitHub so GitHub URLs get the richer embed; link-preview skips
+        // URLs already handled. Fail-open.
+        if let Some(ref enricher) = self.link_preview_enricher {
+            let sender_bare = sender_jid.to_bare();
+            let start = std::time::Instant::now();
+            let embeds = enricher.enrich_message(&mut msg, &sender_bare).await;
+            let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+            crate::metrics::record_link_preview_enrichment(elapsed_ms, embeds as u64);
         }
 
         // Route based on message type

--- a/server/crates/waddle-xmpp/src/metrics.rs
+++ b/server/crates/waddle-xmpp/src/metrics.rs
@@ -188,6 +188,36 @@ pub fn record_github_enrichment(latency_ms: f64, embeds: u64) {
 // can be added here when the github crate gains an opentelemetry dependency.
 
 // ============================================================================
+// Link Preview Enrichment Metrics
+// ============================================================================
+
+/// Histogram for generic link preview enrichment latency.
+pub fn link_preview_enrichment_latency() -> Histogram<f64> {
+    meter()
+        .f64_histogram("xmpp.link_preview.enrichment.latency")
+        .with_description("Generic link preview enrichment latency")
+        .with_unit("ms")
+        .build()
+}
+
+/// Counter for link preview embeds added to messages.
+pub fn link_preview_embeds_added() -> Counter<u64> {
+    meter()
+        .u64_counter("xmpp.link_preview.embeds.added")
+        .with_description("Link preview elements added to messages")
+        .with_unit("embed")
+        .build()
+}
+
+/// Record a link preview enrichment event.
+pub fn record_link_preview_enrichment(latency_ms: f64, embeds: u64) {
+    link_preview_enrichment_latency().record(latency_ms, &[]);
+    if embeds > 0 {
+        link_preview_embeds_added().add(embeds, &[]);
+    }
+}
+
+// ============================================================================
 // S2S Metrics
 // ============================================================================
 

--- a/server/crates/waddle-xmpp/src/server.rs
+++ b/server/crates/waddle-xmpp/src/server.rs
@@ -93,6 +93,8 @@ pub struct XmppServer<S: AppState> {
     pubsub_storage: Arc<dyn PubSubStorage + Send + Sync>,
     /// GitHub link enricher shared across all connections
     github_enricher: Option<Arc<waddle_xmpp_xep_github::MessageEnricher>>,
+    /// Generic OG/Twitter-Card link preview enricher shared across all connections
+    link_preview_enricher: Option<Arc<waddle_xmpp_xep_link_preview::LinkPreviewEnricher>>,
     /// XEP-0357 Push subscription store
     push_store: Arc<dyn PushSubscriptionStore + Send + Sync>,
     /// XEP-0357 Push notification sender
@@ -237,6 +239,12 @@ impl<S: AppState> XmppServer<S> {
             }
         };
 
+        // Create the generic link preview enricher from environment.
+        // Defaults to enabled; WADDLE_LINK_PREVIEW_DISABLE=1 turns it off.
+        let link_preview_enricher = Some(
+            waddle_xmpp_xep_link_preview::LinkPreviewEnricher::from_env(),
+        );
+
         Ok(Self {
             config,
             app_state,
@@ -248,6 +256,7 @@ impl<S: AppState> XmppServer<S> {
             sm_session_registry,
             pubsub_storage,
             github_enricher,
+            link_preview_enricher,
             push_store,
             push_sender,
             sfu_service,
@@ -425,6 +434,7 @@ impl<S: AppState> XmppServer<S> {
             let registration_enabled = self.config.registration_enabled;
             let single_tenant = self.config.single_tenant;
             let github_enricher = self.github_enricher;
+            let link_preview_enricher = self.link_preview_enricher;
             let sfu_service = self.sfu_service;
 
             tokio::spawn(async move {
@@ -457,6 +467,7 @@ impl<S: AppState> XmppServer<S> {
                     let push_store = Arc::clone(&push_store);
                     let push_sender = Arc::clone(&push_sender);
                     let github_enricher = github_enricher.clone();
+                    let link_preview_enricher = link_preview_enricher.clone();
                     let sfu_service = sfu_service.clone();
 
                     tokio::spawn(
@@ -475,6 +486,7 @@ impl<S: AppState> XmppServer<S> {
                                 registration_enabled,
                                 pubsub_storage,
                                 github_enricher,
+                                link_preview_enricher,
                                 single_tenant,
                                 push_store,
                                 push_sender,

--- a/server/crates/waddle-xmpp/src/xep/xep0372.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372.rs
@@ -450,4 +450,84 @@ mod tests {
         assert!(!d.is_mention());
         assert_eq!(d.ref_type, ReferenceType::Data);
     }
+
+    /// Unknown nested children of `<reference>` (e.g. Waddle's
+    /// `<preview xmlns='urn:waddle:link-preview:0'/>` link-preview payload)
+    /// must survive the full parse → payload-stored → serialize round-trip,
+    /// because routing relies on opaque passthrough of custom namespace
+    /// children to receivers.
+    #[test]
+    fn test_reference_preserves_unknown_nested_child() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+            <body>see https://example.com/a</body>\
+            <reference xmlns='urn:xmpp:reference:0' type='data' begin='4' end='27' uri='https://example.com/a'>\
+                <preview xmlns='urn:waddle:link-preview:0' url='https://example.com/a'>\
+                    <title>Example</title>\
+                    <image src='https://example.com/og.png' width='1200' height='630'/>\
+                </preview>\
+            </reference>\
+        </message>";
+
+        let parsed = xml.parse::<Element>().expect("parses as element");
+        let msg = Message::try_from(parsed).expect("parses as message");
+
+        let reference_elem = msg
+            .payloads
+            .iter()
+            .find(|e| is_reference_element(e))
+            .expect("reference payload preserved");
+
+        let preview = reference_elem
+            .get_child("preview", "urn:waddle:link-preview:0")
+            .expect("preview child preserved under custom namespace");
+
+        assert_eq!(preview.attr("url"), Some("https://example.com/a"));
+
+        let title = preview
+            .get_child("title", "urn:waddle:link-preview:0")
+            .expect("nested title preserved");
+        assert_eq!(title.text(), "Example");
+
+        let image = preview
+            .get_child("image", "urn:waddle:link-preview:0")
+            .expect("nested image preserved");
+        assert_eq!(image.attr("src"), Some("https://example.com/og.png"));
+        assert_eq!(image.attr("width"), Some("1200"));
+        assert_eq!(image.attr("height"), Some("630"));
+    }
+
+    /// After Reference parsing extracts attribute metadata, the original
+    /// `<reference>` element (with its unknown children) must still be
+    /// serializable back to XML for routing.
+    #[test]
+    fn test_reference_unknown_child_survives_serialize() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+            <body>x</body>\
+            <reference xmlns='urn:xmpp:reference:0' type='data' uri='https://example.com/a'>\
+                <preview xmlns='urn:waddle:link-preview:0' url='https://example.com/a'>\
+                    <title>T</title>\
+                </preview>\
+            </reference>\
+        </message>";
+
+        let parsed = xml.parse::<Element>().expect("parses");
+        let msg = Message::try_from(parsed).expect("parses");
+
+        // Round-trip: rebuild the message element and re-serialize.
+        let rebuilt: Element = msg.into();
+        let mut serialized = Vec::new();
+        rebuilt
+            .write_to(&mut serialized)
+            .expect("serialize");
+        let out = String::from_utf8(serialized).expect("utf8");
+
+        assert!(
+            out.contains("urn:waddle:link-preview:0"),
+            "custom namespace must be preserved in serialized output: {out}"
+        );
+        assert!(
+            out.contains("<title"),
+            "nested title must be preserved: {out}"
+        );
+    }
 }

--- a/server/crates/waddle-xmpp/tests/common/mod.rs
+++ b/server/crates/waddle-xmpp/tests/common/mod.rs
@@ -654,9 +654,11 @@ async fn run_test_server<S: AppState>(
                         // Enable registration for tests
                         let registration_enabled = true;
                         let st = single_tenant;
+                        let link_preview_enricher =
+                            Some(waddle_xmpp_xep_link_preview::LinkPreviewEnricher::from_env());
                         tokio::spawn(async move {
                             let _ = waddle_xmpp::connection::ConnectionActor::handle_connection(
-                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, None, st, push_store, push_sender, sfu
+                                stream, peer_addr, tls, dom, state, rooms, conns, mam, isr, sm_reg, registration_enabled, pubsub, None, link_preview_enricher, st, push_store, push_sender, sfu
                             ).await;
                         });
                     }

--- a/server/crates/waddle-xmpp/tests/link_preview.rs
+++ b/server/crates/waddle-xmpp/tests/link_preview.rs
@@ -1,0 +1,251 @@
+#![recursion_limit = "256"]
+
+//! Integration tests for server-side link preview enrichment.
+//!
+//! Each test stands up a wiremock instance on loopback as the fake
+//! origin, a `TestServer` as the XMPP server, and two clients (Alice
+//! sender, Bob receiver). Alice sends a message with a URL pointing at
+//! wiremock; Bob's inbound broadcast is asserted to include (or not
+//! include) the server-injected `<reference><preview>` child.
+
+mod common;
+
+use common::{
+    establish_bound_session, init_test_env, join_muc_room, RawXmppClient, TestServer,
+    DEFAULT_TIMEOUT,
+};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Configure env so [`waddle_xmpp_xep_link_preview::LinkPreviewEnricher::from_env`]
+/// (called inside `TestServer::start`) builds a permissive client that
+/// can reach wiremock on loopback.
+///
+/// MUST be invoked *before* `TestServer::start`.
+fn init_link_preview_env() {
+    init_test_env();
+    // SAFETY: tests in the same integration-test binary share env state;
+    // every test in this file needs these flags identically set, so we
+    // just re-assert them on each call.
+    unsafe {
+        std::env::set_var("WADDLE_LINK_PREVIEW_ALLOW_PRIVATE", "1");
+        std::env::remove_var("WADDLE_LINK_PREVIEW_DISABLE");
+    }
+}
+
+const OG_HTML_BODY: &str = "<html><head>\
+    <meta property='og:title' content='Example Title'>\
+    <meta property='og:description' content='Short summary'>\
+    <meta property='og:image' content='https://cdn.example.com/og.png'>\
+    <meta property='og:site_name' content='Example'>\
+    <meta property='og:type' content='article'>\
+</head><body>content</body></html>";
+
+async fn mount_ok_html(wiremock: &MockServer) {
+    Mock::given(method("GET"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(OG_HTML_BODY.as_bytes(), "text/html"),
+        )
+        .mount(wiremock)
+        .await;
+}
+
+#[tokio::test]
+async fn server_enriches_message_with_og_preview() {
+    init_link_preview_env();
+
+    let wiremock = MockServer::start().await;
+    mount_ok_html(&wiremock).await;
+
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect alice");
+    establish_bound_session(&mut alice, &server, "alice", "web")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "preview@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect bob");
+    establish_bound_session(&mut bob, &server, "bob", "web")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "preview@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    let target = format!("{}/article", wiremock.uri());
+    let body = format!("look at {target} cool");
+    alice
+        .send(&format!(
+            "<message type='groupchat' to='preview@muc.localhost' id='m1' xmlns='jabber:client'>\
+                <body>{body}</body>\
+            </message>"
+        ))
+        .await
+        .expect("send");
+
+    let received = bob
+        .read_until("look at", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives");
+
+    assert!(received.contains(&body), "body preserved");
+    assert!(
+        received.contains("urn:waddle:link-preview:0"),
+        "preview namespace present in broadcast: {received}"
+    );
+    assert!(
+        received.contains("Example Title"),
+        "og:title surfaced: {received}"
+    );
+    assert!(
+        received.contains("urn:xmpp:reference:0"),
+        "wrapping reference present"
+    );
+}
+
+#[tokio::test]
+async fn server_strips_client_authored_preview_before_fanout() {
+    init_link_preview_env();
+
+    let wiremock = MockServer::start().await;
+    mount_ok_html(&wiremock).await;
+
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect alice");
+    establish_bound_session(&mut alice, &server, "alice", "web")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "strip@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect bob");
+    establish_bound_session(&mut bob, &server, "bob", "web")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "strip@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    let target = format!("{}/article", wiremock.uri());
+    let body = format!("forge {target}");
+    alice
+        .send(&format!(
+            "<message type='groupchat' to='strip@muc.localhost' id='m2' xmlns='jabber:client'>\
+                <body>{body}</body>\
+                <reference xmlns='urn:xmpp:reference:0' type='data' begin='6' end='{}' uri='{target}'>\
+                    <preview xmlns='urn:waddle:link-preview:0' url='{target}'><title>FORGED</title></preview>\
+                </reference>\
+            </message>",
+            6 + target.chars().count(),
+        ))
+        .await
+        .expect("send");
+
+    let received = bob
+        .read_until("forge", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives");
+
+    assert!(
+        !received.contains("FORGED"),
+        "forged preview must be stripped: {received}"
+    );
+    // And the server-generated preview from wiremock should take its place.
+    assert!(
+        received.contains("Example Title"),
+        "server-generated preview present: {received}"
+    );
+}
+
+#[tokio::test]
+async fn no_preview_hint_skips_enrichment() {
+    init_link_preview_env();
+
+    let wiremock = MockServer::start().await;
+    mount_ok_html(&wiremock).await;
+
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect alice");
+    establish_bound_session(&mut alice, &server, "alice", "web")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "nohint@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect bob");
+    establish_bound_session(&mut bob, &server, "bob", "web")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "nohint@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    let target = format!("{}/article", wiremock.uri());
+    let body = format!("quiet {target}");
+    alice
+        .send(&format!(
+            "<message type='groupchat' to='nohint@muc.localhost' id='m3' xmlns='jabber:client'>\
+                <body>{body}</body>\
+                <no-preview xmlns='urn:waddle:link-preview:0'/>\
+            </message>"
+        ))
+        .await
+        .expect("send");
+
+    let received = bob
+        .read_until("quiet", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives");
+
+    assert!(
+        !received.contains("Example Title"),
+        "no-preview hint must suppress enrichment: {received}"
+    );
+}
+
+#[tokio::test]
+async fn messages_without_urls_are_untouched() {
+    init_link_preview_env();
+
+    let server = TestServer::start().await;
+
+    let mut alice = RawXmppClient::connect(server.addr).await.expect("connect alice");
+    establish_bound_session(&mut alice, &server, "alice", "web")
+        .await
+        .expect("bind alice");
+    join_muc_room(&mut alice, "plain@muc.localhost", "Alice")
+        .await
+        .expect("alice join");
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect bob");
+    establish_bound_session(&mut bob, &server, "bob", "web")
+        .await
+        .expect("bind bob");
+    join_muc_room(&mut bob, "plain@muc.localhost", "Bob")
+        .await
+        .expect("bob join");
+
+    alice
+        .send(
+            "<message type='groupchat' to='plain@muc.localhost' id='m4' xmlns='jabber:client'>\
+                <body>just plain text</body>\
+            </message>",
+        )
+        .await
+        .expect("send");
+
+    let received = bob
+        .read_until("just plain text", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives");
+
+    assert!(!received.contains("urn:waddle:link-preview:0"));
+}


### PR DESCRIPTION
## Summary

Branch was authored as `feature/link-preview`, but it bundles several independent changes. Flagging the scope mismatch up front so reviewers can decide whether to split before merge.

### 1. Link preview enrichment (primary)
- New crate `waddle-xmpp-xep-link-preview` with `detect`, `fetch`, `html`, `embed`, `enrich`, `cache`, `rate`, `circuit`, `ssrf` modules.
- Server-side OpenGraph/Twitter-Card enrichment injecting `<preview xmlns='urn:waddle:link-preview:0'/>`; strips forged previews from clients.
- Respects sender opt-out via `<no-preview xmlns='urn:waddle:link-preview:0'/>`.
- Chat UI: `LinkPreviewCard.vue`, TipTap extensions `preview.ts` / `no-preview.ts`, parser support in `message-parsing.ts`.
- Tests: `waddle-xmpp/tests/link_preview.rs`, `chat/tests/message-parsing-preview.test.ts`, `chat/tests/no-preview-toggle.test.ts`, `chat/tests/references-preview.test.ts`.

### 2. SFU group calls (Jingle stack)
- New `sfu/` module in `waddle-xmpp` (service actor, room actor, peer, net, SDP).
- XEPs added: 0166 (Jingle), 0167 (Jingle RTP), 0176 (ICE-UDP), 0215 (ExtDisco), 0272 (MUJI), 0320 (DTLS-SRTP), 0372 (References), 0482 (Call Invites), 0483 (HTTP Auth over XMPP).
- Server media glue: `media/embedded_sfu.rs`, `media/webrtc_rs_sfu.rs`.
- Chat UI: `CallOverlay.vue`, `extensions/calls.ts`.
- Plans under `docs/superpowers/plans/2026-04-15-sfu-*.md`, runbook at `server/docs/specs/call-stack-operator-runbook.md`.

### 3. Removals
- `apps/apple/` (Swift client) deleted.
- GitHub enricher extension moved from WASM extension to in-process crate `waddle-xmpp-xep-github`; old `server/extensions/` + `waddle-extensions` host crate removed, along with `wit/waddle-extension.wit`.
- Inbox (XEP-0430), ad-hoc commands registry, forums (XEP-0508), entity caps (XEP-0115), fallback (XEP-0428), encrypted SFS (XEP-0448), software version (XEP-0092), PEP-118 tune, stateful-protocol machine/handlers scaffold — all deleted.
- Chat: removes threads panel, emoji picker, image lightbox, user settings page, app-update composable, service-worker template, connection notice, offline queue, scroll-direction bits.

### 4. Infra / tooling
- `server/local/` dev scaffold + `generate-local-certs.sh` / `generate-dev-certs.sh`.
- `server/scripts/ralph-loop/` Bun helper for plan/review automation.
- CI: drops `container-image`, `extension-github-enricher`, `xmpp-compliance` subworkflow steps; simplifies chat/colony workflows.
- Flake/nix removed; cuenv config consolidated.

## Test plan
- [ ] `cd server && cargo test --workspace`
- [ ] `cd server && cargo test -p waddle-xmpp-xep-link-preview`
- [ ] `cd server && cargo test -p waddle-xmpp --test link_preview`
- [ ] `cd server && cargo test -p waddle-xmpp --test xep0166_jingle --test xep0167_rtp --test xep0176_ice_udp --test xep0215_extdisco --test xep0272_muji --test xep0482_call_invites`
- [ ] `cd chat && bun test && bun run lint`
- [ ] Manual: paste a URL in the composer, verify `LinkPreviewCard` renders; verify "no preview" toggle suppresses enrichment.
- [ ] Manual: place a 1:1 and group call end-to-end against a dev server (`cuenv task dev`).

## Notes for reviewers
- Single commit (`305d044 link preview`) covers everything above — consider requesting a split into link-preview / SFU / removals before merge.
- No backwards-compat shims per project policy; deleted XEPs and the Apple app are gone outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)