### PR TITLE
Fix multi-device sync: desktop → iPhone messages

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -198,6 +198,7 @@ export class BrowserXmppClient {
   private onlineListener: (() => void) | null = null;
   private reconnectNudgeAt = 0;
   private lastStanzaKickAt = 0;
+  private serverClockOffsetMs = 0;
   private directQueueFlushPromise: Promise<void> | null = null;
   private readonly roomQueueFlushes = new Map<string, Promise<void>>();
 
@@ -1011,6 +1012,26 @@ export class BrowserXmppClient {
 
   // -- Private --
 
+  private catchupTimestampIso(msg: ReceivedMessage): string {
+    return msg.delay?.timestamp?.toISOString()
+      ?? new Date(Date.now() + this.serverClockOffsetMs).toISOString();
+  }
+
+  private async syncServerClockOffset(xmpp: Agent) {
+    const domain = jidDomain(this.session.jid);
+    if (!domain) return;
+    try {
+      const time = await xmpp.getTime(domain);
+      if (time.utc && !Number.isNaN(time.utc.getTime())) {
+        this.serverClockOffsetMs = time.utc.getTime() - Date.now();
+      }
+    } catch (error) {
+      if (!isOptionalXmppFeatureError(error)) {
+        console.warn("Failed to sync XEP-0202 server time", error);
+      }
+    }
+  }
+
   /**
    * XEP-0313 MAM catch-up after a `session:started`.
    *
@@ -1025,6 +1046,7 @@ export class BrowserXmppClient {
     if (entries.length === 0) return;
 
     const selfBare = barePeerJid(this.session.jid);
+    const catchupEnd = new Date(Date.now() + this.serverClockOffsetMs).toISOString();
     for (const entry of entries) {
       // Bail if the agent has been swapped out mid-catch-up (e.g. user
       // signed out during reconnect).
@@ -1038,6 +1060,7 @@ export class BrowserXmppClient {
             entry.key,
             CATCHUP_MAX_PER_CONVERSATION,
             since,
+            catchupEnd,
           );
           for (const m of messages) {
             this.catchup.recordDmSeen(m.peerJid, m.createdAt);
@@ -1050,6 +1073,7 @@ export class BrowserXmppClient {
             entry.key,
             CATCHUP_MAX_PER_CONVERSATION,
             since,
+            catchupEnd,
           );
           for (const m of messages) {
             this.catchup.recordRoomSeen(m.roomJid, m.createdAt);
@@ -1147,6 +1171,7 @@ export class BrowserXmppClient {
       // it here, it's a fresh session — consumers may close MAM gaps.
       this.sessionLifecycleHandler?.({ type: "fresh" });
       void this.flushQueuedDirectMessages();
+      await this.syncServerClockOffset(xmpp);
       try {
         await xmpp.enableCarbons();
       } catch (error) {
@@ -1195,6 +1220,7 @@ export class BrowserXmppClient {
       });
       this.sessionLifecycleHandler?.({ type: "resumed" });
       void this.flushQueuedDirectMessages();
+      void this.syncServerClockOffset(xmpp);
       if (this.currentRoom) {
         void this.flushQueuedRoomMessages(this.currentRoom);
       }
@@ -1321,11 +1347,12 @@ export class BrowserXmppClient {
     });
 
     xmpp.on("message", buildMessageDispatcher(
-      () => ({
+      (msg) => ({
         currentRoom: this.currentRoom,
         selfNick: this.session.username,
         onMessage: (m) => {
-          this.catchup.recordRoomSeen(m.roomJid, m.createdAt);
+          if (!msg) return;
+          this.catchup.recordRoomSeen(m.roomJid, this.catchupTimestampIso(msg));
           this.messageHandler?.(m);
         },
         onChatState: this.chatStateHandler,
@@ -1333,10 +1360,11 @@ export class BrowserXmppClient {
         onReaction: this.reactionHandler,
         onActivity: this.activityHandler,
       }),
-      () => ({
+      (msg) => ({
         selfBareJid: barePeerJid(this.session.jid),
         onMessage: (m) => {
-          this.catchup.recordDmSeen(m.peerJid, m.createdAt);
+          if (!msg) return;
+          this.catchup.recordDmSeen(m.peerJid, this.catchupTimestampIso(msg));
           this.directMessageHandler?.(m);
         },
         onChatState: this.dmChatStateHandler,
@@ -1353,7 +1381,7 @@ export class BrowserXmppClient {
       dispatchChat(forwarded as ReceivedMessage, {
         selfBareJid: barePeerJid(this.session.jid),
         onMessage: (m) => {
-          this.catchup.recordDmSeen(m.peerJid, m.createdAt);
+          this.catchup.recordDmSeen(m.peerJid, this.catchupTimestampIso(forwarded as ReceivedMessage));
           this.directMessageHandler?.(m);
         },
         onChatState: this.dmChatStateHandler,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -32,6 +32,11 @@ import {
 } from "../outbound-queue-store";
 import * as inboxApi from "./inbox";
 import * as pep from "./pep-publications";
+import { ReconnectCatchup } from "./reconnect-catchup";
+
+// Cap MAM catch-up per conversation so a long offline period can't drown the
+// client. In practice, web clients reconnect within minutes; 200 is generous.
+const CATCHUP_MAX_PER_CONVERSATION = 200;
 
 type StanzaSaslMechanism = { name: string };
 type StanzaSaslFactory = {
@@ -178,6 +183,9 @@ export class BrowserXmppClient {
   private connectPromise: Promise<void> | null = null;
   private connected = false;
   private destroying = false;
+  // Slice A: MAM-on-reconnect tracker. Updated on every live room / DM /
+  // carbon message, consulted on every `session:started` after the first.
+  private readonly catchup = new ReconnectCatchup();
   private refreshSession: (() => Promise<WaddleSession | null>) | null = null;
   private currentRoom: string | null = null;
   private roomSwitchPromise: Promise<void> | null = null;
@@ -388,6 +396,8 @@ export class BrowserXmppClient {
     this.connected = false;
     this.currentRoom = null;
     this.uploadServiceJid = null;
+    // Intentional teardown — next connect is a fresh session, not a resume.
+    this.catchup.reset();
     try { xmpp.disconnect(); } catch { /* ignore */ }
   }
 
@@ -1001,6 +1011,62 @@ export class BrowserXmppClient {
 
   // -- Private --
 
+  /**
+   * XEP-0313 MAM catch-up after a `session:started`.
+   *
+   * Empty on the first session:started (initial login); for each subsequent
+   * resume it queries MAM with `start=<lastSeen>` for every tracked
+   * conversation and feeds the results through the same handlers as live
+   * messages. This closes the gap when mobile Safari (or any suspended tab)
+   * silently drops its WebSocket and reconnects after missing stanzas.
+   */
+  private async runReconnectCatchup(xmpp: Agent) {
+    const entries = this.catchup.onSessionStarted();
+    if (entries.length === 0) return;
+
+    const selfBare = barePeerJid(this.session.jid);
+    for (const entry of entries) {
+      // Bail if the agent has been swapped out mid-catch-up (e.g. user
+      // signed out during reconnect).
+      if (this.xmpp !== xmpp) return;
+      try {
+        if (entry.kind === "dm") {
+          const since = this.catchup.getDmLastSeen(entry.key);
+          const messages = await dmHistory.queryPersonalMam(
+            xmpp,
+            selfBare,
+            entry.key,
+            CATCHUP_MAX_PER_CONVERSATION,
+            since,
+          );
+          for (const m of messages) {
+            this.catchup.recordDmSeen(m.peerJid, m.createdAt);
+            this.directMessageHandler?.(m);
+          }
+        } else {
+          const since = this.catchup.getRoomLastSeen(entry.key);
+          const messages = await history.queryMam(
+            xmpp,
+            entry.key,
+            CATCHUP_MAX_PER_CONVERSATION,
+            since,
+          );
+          for (const m of messages) {
+            this.catchup.recordRoomSeen(m.roomJid, m.createdAt);
+            this.messageHandler?.(m);
+          }
+        }
+      } catch (error) {
+        if (!isOptionalXmppFeatureError(error)) {
+          console.warn(
+            `MAM catch-up failed for ${entry.kind}:${entry.key}`,
+            error,
+          );
+        }
+      }
+    }
+  }
+
   private startSelfPing() {
     this.stopSelfPing();
     this.selfPingTimer = setInterval(() => { void this.doSelfPing(); }, 60_000);
@@ -1113,6 +1179,11 @@ export class BrowserXmppClient {
           console.warn("Failed to rejoin room after reconnect", error);
         }
       }
+
+      // Slice A: MAM catch-up for every tracked conversation. Empty on the
+      // first session:started (initial login — nothing missed), populated on
+      // subsequent ones (resume after a dropped socket or Safari backgrounding).
+      await this.runReconnectCatchup(xmpp);
     });
     xmpp.on("stream:management:resumed", () => {
       if (this.xmpp !== xmpp) return;
@@ -1253,7 +1324,10 @@ export class BrowserXmppClient {
       () => ({
         currentRoom: this.currentRoom,
         selfNick: this.session.username,
-        onMessage: this.messageHandler,
+        onMessage: (m) => {
+          this.catchup.recordRoomSeen(m.roomJid, m.createdAt);
+          this.messageHandler?.(m);
+        },
         onChatState: this.chatStateHandler,
         onDisplayed: this.displayedHandler,
         onReaction: this.reactionHandler,
@@ -1261,7 +1335,10 @@ export class BrowserXmppClient {
       }),
       () => ({
         selfBareJid: barePeerJid(this.session.jid),
-        onMessage: this.directMessageHandler,
+        onMessage: (m) => {
+          this.catchup.recordDmSeen(m.peerJid, m.createdAt);
+          this.directMessageHandler?.(m);
+        },
         onChatState: this.dmChatStateHandler,
         onDisplayed: this.dmDisplayedHandler,
         onReaction: this.dmReactionHandler,
@@ -1275,7 +1352,10 @@ export class BrowserXmppClient {
       (forwarded as ReceivedMessage & { carbon?: unknown }).carbon = msg.carbon;
       dispatchChat(forwarded as ReceivedMessage, {
         selfBareJid: barePeerJid(this.session.jid),
-        onMessage: this.directMessageHandler,
+        onMessage: (m) => {
+          this.catchup.recordDmSeen(m.peerJid, m.createdAt);
+          this.directMessageHandler?.(m);
+        },
         onChatState: this.dmChatStateHandler,
         onDisplayed: this.dmDisplayedHandler,
         onReaction: this.dmReactionHandler,

--- a/chat/src/lib/xmpp/dm-history.ts
+++ b/chat/src/lib/xmpp/dm-history.ts
@@ -36,6 +36,7 @@ export async function queryPersonalMam(
   peerBareJid: string,
   max: number,
   since?: string,
+  until?: string,
 ): Promise<LiveDmMessage[]> {
   // XEP-0313 §4.1.5: when fetching the most recent page (no `since`), we use
   // `paging.before: ""` to page backwards from the end of the archive.
@@ -46,7 +47,11 @@ export async function queryPersonalMam(
     { name: "with", value: peerBareJid },
   ];
   const fields = since
-    ? [...baseFields, { name: "start", value: since }]
+    ? [
+        ...baseFields,
+        { name: "start", value: since },
+        ...(until ? [{ name: "end", value: until }] : []),
+      ]
     : baseFields;
   const paging = since ? { max } : { max, before: "" };
 

--- a/chat/src/lib/xmpp/dm-history.ts
+++ b/chat/src/lib/xmpp/dm-history.ts
@@ -35,18 +35,26 @@ export async function queryPersonalMam(
   selfBareJid: string,
   peerBareJid: string,
   max: number,
+  since?: string,
 ): Promise<LiveDmMessage[]> {
+  // XEP-0313 §4.1.5: when fetching the most recent page (no `since`), we use
+  // `paging.before: ""` to page backwards from the end of the archive.
+  // For catch-up (`since` set), we instead page forward from the cursor by
+  // adding a `start` form field and dropping `before`.
+  const baseFields = [
+    { name: "FORM_TYPE", type: "hidden" as const, value: "urn:xmpp:mam:2" },
+    { name: "with", value: peerBareJid },
+  ];
+  const fields = since
+    ? [...baseFields, { name: "start", value: since }]
+    : baseFields;
+  const paging = since ? { max } : { max, before: "" };
+
   let result;
   try {
     result = await xmpp.searchHistory(selfBareJid, {
-      paging: { max, before: "" },
-      form: {
-        type: "submit",
-        fields: [
-          { name: "FORM_TYPE", type: "hidden", value: "urn:xmpp:mam:2" },
-          { name: "with", value: peerBareJid },
-        ],
-      },
+      paging,
+      form: { type: "submit", fields },
     });
   } catch (err) {
     if (isItemNotFound(err)) return [];

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -28,6 +28,7 @@ export async function queryMam(
   roomJid: string,
   max: number,
   since?: string,
+  until?: string,
 ): Promise<LiveRoomMessage[]> {
   const result = await xmpp.searchHistory(
     roomJid,
@@ -39,6 +40,7 @@ export async function queryMam(
             fields: [
               { name: "FORM_TYPE", type: "hidden" as const, value: "urn:xmpp:mam:2" },
               { name: "start", value: since },
+              ...(until ? [{ name: "end", value: until }] : []),
             ],
           },
         }

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -14,13 +14,36 @@ function withArchivedMessageId(
   } as ReceivedMessage;
 }
 
-/** Query message archive for a room. Throws on IQ/transport errors. */
+/**
+ * Query message archive for a room.
+ *
+ * Without `since`: fetches the newest page (`before: ""`) for initial load.
+ * With `since`: XEP-0313 §4.1.5 catch-up — pages forward from the cursor via
+ * the `start` form field, used after a socket drop to pull anything missed.
+ *
+ * Throws on IQ/transport errors.
+ */
 export async function queryMam(
   xmpp: Agent,
   roomJid: string,
   max: number,
+  since?: string,
 ): Promise<LiveRoomMessage[]> {
-  const result = await xmpp.searchHistory(roomJid, { paging: { max, before: "" } });
+  const result = await xmpp.searchHistory(
+    roomJid,
+    since
+      ? {
+          paging: { max },
+          form: {
+            type: "submit",
+            fields: [
+              { name: "FORM_TYPE", type: "hidden" as const, value: "urn:xmpp:mam:2" },
+              { name: "start", value: since },
+            ],
+          },
+        }
+      : { paging: { max, before: "" } },
+  );
   const collected: LiveRoomMessage[] = [];
 
   if (result.results) {

--- a/chat/src/lib/xmpp/message-dispatch.ts
+++ b/chat/src/lib/xmpp/message-dispatch.ts
@@ -17,20 +17,20 @@ import { dispatchGroupchat, type GroupchatHandlers } from "./message-parsing";
  * `carbon:received` listeners unwrap and forward them separately.
  */
 export function buildMessageDispatcher(
-  groupchatHandlers: () => GroupchatHandlers,
-  chatHandlers: () => DmHandlers,
+  groupchatHandlers: (msg?: ReceivedMessage) => GroupchatHandlers,
+  chatHandlers: (msg?: ReceivedMessage) => DmHandlers,
 ): (msg: ReceivedMessage) => void {
   return (msg) => {
     if (msg.type === "error") return;
     if ((msg as { carbon?: unknown }).carbon) return;
 
     if (msg.type === "groupchat") {
-      dispatchGroupchat(msg, groupchatHandlers());
+      dispatchGroupchat(msg, groupchatHandlers(msg));
       return;
     }
 
     if (msg.type === "chat" || msg.type === "normal" || !msg.type) {
-      dispatchChat(msg, chatHandlers());
+      dispatchChat(msg, chatHandlers(msg));
     }
   };
 }

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-conversation "last-seen" tracker for XEP-0313 MAM catch-up on reconnect.
+ *
+ * Why: mobile Safari (and any long-lived WebSocket on a sleeping device)
+ * aggressively suspends the socket. When it resumes, any messages delivered
+ * during the suspend are already gone from the server's live routing. Without
+ * a catch-up step, the UI silently misses them. This helper lets the client:
+ *
+ *   1. Remember the most recent message timestamp seen for each open
+ *      conversation (DM peer bare JID or MUC room bare JID).
+ *   2. Distinguish the very first `session:started` (initial login — nothing
+ *      to catch up on) from subsequent ones (resume — catch up on all
+ *      tracked conversations via `MAM start=lastSeen`).
+ *
+ * DM peers and rooms are tracked in separate namespaces so the two can never
+ * collide even if a bare JID were somehow valid in both worlds.
+ *
+ * Kept as a tiny pure class so the orchestration in `BrowserXmppClient` has
+ * zero state of its own and the logic is trivially testable.
+ */
+export type CatchupEntry =
+  | { kind: "dm"; key: string }
+  | { kind: "room"; key: string };
+
+export class ReconnectCatchup {
+  private readonly dmLastSeen = new Map<string, string>();
+  private readonly roomLastSeen = new Map<string, string>();
+  private sessionStartedOnce = false;
+
+  /**
+   * Record that a DM with `peerBareJid` was seen at `timestamp`. Only
+   * advances the cursor — out-of-order or older arrivals are ignored so the
+   * next catch-up can't re-pull already-applied messages.
+   */
+  recordDmSeen(peerBareJid: string, timestamp: string): void {
+    advance(this.dmLastSeen, peerBareJid, timestamp);
+  }
+
+  /** As `recordDmSeen`, but for a MUC room JID. */
+  recordRoomSeen(roomBareJid: string, timestamp: string): void {
+    advance(this.roomLastSeen, roomBareJid, timestamp);
+  }
+
+  getDmLastSeen(peerBareJid: string): string | undefined {
+    return this.dmLastSeen.get(peerBareJid);
+  }
+
+  getRoomLastSeen(roomBareJid: string): string | undefined {
+    return this.roomLastSeen.get(roomBareJid);
+  }
+
+  /**
+   * Notify that `session:started` just fired. Returns the conversations to
+   * catch up on. On the first call after construction or `reset()` the
+   * result is empty (initial login has no missed history); on subsequent
+   * calls it contains every tracked DM peer and room.
+   */
+  onSessionStarted(): CatchupEntry[] {
+    if (!this.sessionStartedOnce) {
+      this.sessionStartedOnce = true;
+      return [];
+    }
+    const entries: CatchupEntry[] = [];
+    for (const key of this.dmLastSeen.keys()) entries.push({ kind: "dm", key });
+    for (const key of this.roomLastSeen.keys()) entries.push({ kind: "room", key });
+    return entries;
+  }
+
+  /** Clear all state (cursors and the session-started flag). */
+  reset(): void {
+    this.dmLastSeen.clear();
+    this.roomLastSeen.clear();
+    this.sessionStartedOnce = false;
+  }
+}
+
+function advance(map: Map<string, string>, key: string, timestamp: string): void {
+  const current = map.get(key);
+  if (current === undefined || timestamp > current) {
+    map.set(key, timestamp);
+  }
+}

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -18,7 +18,7 @@
  * Kept as a tiny pure class so the orchestration in `BrowserXmppClient` has
  * zero state of its own and the logic is trivially testable.
  */
-export type CatchupEntry =
+type CatchupEntry =
   | { kind: "dm"; key: string }
   | { kind: "room"; key: string };
 

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -203,6 +203,23 @@ describe("MAM history parsing", () => {
     ).toBeUndefined();
   });
 
+  test("MAM DM catch-up query includes an `end` form field when until is given", async () => {
+    const xmpp = makeMamAgent([]);
+    await queryPersonalMam(
+      xmpp,
+      "alice@example.com",
+      "bob@example.com",
+      20,
+      "2024-01-02T03:04:05.000Z",
+      "2024-01-02T03:05:00.000Z",
+    );
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    const fields =
+      ((callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form?.fields) ?? [];
+    const endField = fields.find((f) => f.name === "end");
+    expect(endField?.value).toBe("2024-01-02T03:05:00.000Z");
+  });
+
   test("MAM DM query omits `start` when no since cursor is given", async () => {
     const xmpp = makeMamAgent([]);
     await queryPersonalMam(xmpp, "alice@example.com", "bob@example.com", 20);
@@ -226,6 +243,22 @@ describe("MAM history parsing", () => {
     expect(formType?.value).toBe("urn:xmpp:mam:2");
     const startField = fields.find((f) => f.name === "start");
     expect(startField?.value).toBe("2024-01-02T03:04:05.000Z");
+  });
+
+  test("MAM room catch-up query includes an `end` form field when until is given", async () => {
+    const xmpp = makeMamAgent([]);
+    await queryMam(
+      xmpp,
+      "general@muc.example.com",
+      20,
+      "2024-01-02T03:04:05.000Z",
+      "2024-01-02T03:05:00.000Z",
+    );
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    const fields =
+      ((callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form?.fields) ?? [];
+    const endField = fields.find((f) => f.name === "end");
+    expect(endField?.value).toBe("2024-01-02T03:05:00.000Z");
   });
 });
 

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -175,6 +175,58 @@ describe("MAM history parsing", () => {
       }),
     );
   });
+
+  // Reconnect catch-up: an iPhone/Safari session that drops its websocket
+  // and resumes must be able to request "everything after my last-seen stanza"
+  // via XEP-0313 §4.1.5's `start` form field. These tests fix the shape of
+  // the outgoing MAM query so the client can drive MAM-on-reconnect.
+  test("MAM DM query includes a `start` form field when a since cursor is given", async () => {
+    const xmpp = makeMamAgent([]);
+
+    await queryPersonalMam(
+      xmpp,
+      "alice@example.com",
+      "bob@example.com",
+      20,
+      "2024-01-02T03:04:05.000Z",
+    );
+
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    expect(callArgs?.[0]).toBe("alice@example.com");
+    const form = (callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form;
+    const fields = form?.fields ?? [];
+    const startField = fields.find((f) => f.name === "start");
+    expect(startField?.value).toBe("2024-01-02T03:04:05.000Z");
+    // Catch-up page wants oldest-first with no `before`, not newest-first.
+    expect(
+      (callArgs?.[1] as { paging?: { before?: string } })?.paging?.before,
+    ).toBeUndefined();
+  });
+
+  test("MAM DM query omits `start` when no since cursor is given", async () => {
+    const xmpp = makeMamAgent([]);
+    await queryPersonalMam(xmpp, "alice@example.com", "bob@example.com", 20);
+
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    const fields =
+      ((callArgs?.[1] as { form?: { fields?: { name: string }[] } })?.form?.fields) ?? [];
+    expect(fields.find((f) => f.name === "start")).toBeUndefined();
+  });
+
+  test("MAM room query includes a `start` form field when a since cursor is given", async () => {
+    const xmpp = makeMamAgent([]);
+
+    await queryMam(xmpp, "general@muc.example.com", 20, "2024-01-02T03:04:05.000Z");
+
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    expect(callArgs?.[0]).toBe("general@muc.example.com");
+    const form = (callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form;
+    const fields = form?.fields ?? [];
+    const formType = fields.find((f) => f.name === "FORM_TYPE");
+    expect(formType?.value).toBe("urn:xmpp:mam:2");
+    const startField = fields.find((f) => f.name === "start");
+    expect(startField?.value).toBe("2024-01-02T03:04:05.000Z");
+  });
 });
 
 describe("MAM history application", () => {

--- a/chat/tests/reconnect-catchup.test.ts
+++ b/chat/tests/reconnect-catchup.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+
+// The ReconnectCatchup helper underpins Slice A of the multi-device sync fix.
+// It tracks a per-conversation "last-seen" cursor and distinguishes the first
+// session:started (initial login) from subsequent ones (resumed after a
+// socket drop). Mobile Safari aggressively suspends WebSockets when the tab
+// backgrounds; without reconnect catch-up, messages sent during the suspend
+// are lost to that session forever.
+
+describe("ReconnectCatchup", () => {
+  test("first onSessionStarted returns no keys to catch up on", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+
+    expect(c.onSessionStarted()).toEqual([]);
+  });
+
+  test("subsequent onSessionStarted returns all tracked conversations with their kind", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+    c.recordRoomSeen("general@muc.example.com", "2024-01-02T00:00:00Z");
+
+    // First session:started = initial login; skip catch-up.
+    c.onSessionStarted();
+    // Second session:started = resume after drop; catch up everywhere.
+    const entries = c.onSessionStarted();
+
+    expect(entries).toHaveLength(2);
+    expect(entries).toContainEqual({ kind: "dm", key: "bob@example.com" });
+    expect(entries).toContainEqual({
+      kind: "room",
+      key: "general@muc.example.com",
+    });
+  });
+
+  test("getDmLastSeen returns the most recent timestamp recorded for a peer", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z");
+
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00Z");
+  });
+
+  test("recordSeen ignores out-of-order (older) timestamps", () => {
+    // Carbons / MAM results can arrive out of order. We must not rewind the
+    // cursor, or the next catch-up will re-pull already-applied messages
+    // and drown the UI in duplicates.
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z");
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00Z");
+  });
+
+  test("DM and room namespaces are independent — same JID in both kinds does not collide", () => {
+    // Defensive: a bare JID `foo@bar` could theoretically appear as both a
+    // DM peer and a room. Their cursors must not interfere.
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("foo@bar", "2024-01-01T00:00:00Z");
+    c.recordRoomSeen("foo@bar", "2024-02-02T00:00:00Z");
+
+    expect(c.getDmLastSeen("foo@bar")).toBe("2024-01-01T00:00:00Z");
+    expect(c.getRoomLastSeen("foo@bar")).toBe("2024-02-02T00:00:00Z");
+  });
+
+  test("getDmLastSeen returns undefined for untracked peers", () => {
+    const c = new ReconnectCatchup();
+    expect(c.getDmLastSeen("nobody@example.com")).toBeUndefined();
+  });
+
+  test("reset clears session-started state so the next session:started is treated as initial", () => {
+    // Called on intentional disconnect so a subsequent login starts fresh.
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+    c.onSessionStarted();
+    c.reset();
+
+    expect(c.onSessionStarted()).toEqual([]);
+  });
+
+  test("reset clears tracked cursors", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+    c.recordRoomSeen("general@muc.example.com", "2024-01-01T00:00:00Z");
+    c.reset();
+
+    expect(c.getDmLastSeen("bob@example.com")).toBeUndefined();
+    expect(c.getRoomLastSeen("general@muc.example.com")).toBeUndefined();
+  });
+});

--- a/server/crates/waddle-server/src/server/routes/websocket.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use waddle_xmpp::{
     auth::{parse_oauthbearer, OAuthBearerResult},
+    carbons::CARBONS_NS,
     commands::{CommandContext, CommandRegistry, CommandResult},
     connection::Stanza,
     disco::{
@@ -148,6 +149,10 @@ struct LegacyConnState {
     /// loop (when `pending_tx.take()` fires after authenticated+bound
     /// become true), regardless of the path that set those flags.
     resumed: bool,
+    /// Per-connection XEP-0280 opt-in state. Updated when this resource
+    /// sends `<enable/>` / `<disable/>` and restored from detached SM state
+    /// on resume so re-registration preserves carbons behavior.
+    carbons_enabled: bool,
     /// One-shot flag: when set, the main loop must NOT push the current
     /// frame's responses into `sm_state.record_outbound`. The flag is
     /// raised by `handle_sm_resume` because the responses it returns are
@@ -168,6 +173,7 @@ impl LegacyConnState {
             pending_scram: None,
             sm_state: StreamManagementState::new(),
             resumed: false,
+            carbons_enabled: false,
             suppress_sm_record_next_batch: false,
         }
     }
@@ -241,8 +247,17 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         // This ensures the JID in ConnectionRegistry matches the JID stored in MUC room occupants
                         if conn.authenticated && conn.resource_bound && conn.session_jid.is_some() {
                             if let (Some(jid), Some(tx)) = (conn.session_jid.as_ref(), pending_tx.take()) {
-                                state.connection_registry.register(jid.clone(), tx);
-                                info!(jid = %jid, resumed = conn.resumed, "WebSocket connection registered");
+                                state.connection_registry.register_with_carbons(
+                                    jid.clone(),
+                                    tx,
+                                    conn.carbons_enabled,
+                                );
+                                info!(
+                                    jid = %jid,
+                                    resumed = conn.resumed,
+                                    carbons_enabled = conn.carbons_enabled,
+                                    "WebSocket connection registered"
+                                );
                             }
                         }
 
@@ -364,7 +379,11 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     if !superseded {
         if let Some(jid) = conn.session_jid.clone() {
             if conn.sm_state.is_resumable() {
-                if let Some(detached) = conn.sm_state.to_detached_session(jid.clone()) {
+                let carbons_enabled = conn.carbons_enabled;
+                if let Some(detached) = conn
+                    .sm_state
+                    .to_detached_session(jid.clone(), carbons_enabled)
+                {
                     let stream_id = detached.stream_id.clone();
                     if let Some(session) = conn.authenticated_session.clone() {
                         state.resumable_sessions.insert(stream_id.clone(), session);
@@ -651,6 +670,7 @@ struct SmCtx<'a> {
     resource_bound: &'a mut bool,
     authenticated_session: &'a mut Option<Session>,
     resumed: &'a mut bool,
+    carbons_enabled: &'a mut bool,
     /// Set by `handle_sm_resume` so the main loop skips SM recording for
     /// the responses it returns — those are replay stanzas already tracked
     /// in the unacked queue.
@@ -718,6 +738,7 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
         resource_bound,
         authenticated_session,
         resumed,
+        carbons_enabled,
         suppress_sm_record_next_batch,
     } = ctx;
 
@@ -766,6 +787,7 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
     *resource_bound = true;
     *authenticated_session = restored_session;
     *resumed = true;
+    *carbons_enabled = detached.carbons_enabled;
     // Responses below include replayed stanzas straight from the restored
     // unacked queue. They already carry their original sequence numbers —
     // the main loop must NOT push them through `record_outbound` again.
@@ -812,6 +834,7 @@ async fn handle_xmpp_frame(
         pending_scram,
         sm_state,
         resumed,
+        carbons_enabled,
         suppress_sm_record_next_batch,
     } = conn;
     let frame = frame.trim();
@@ -897,6 +920,7 @@ async fn handle_xmpp_frame(
                 resource_bound,
                 authenticated_session,
                 resumed,
+                carbons_enabled,
                 suppress_sm_record_next_batch,
             };
             return handle_sm_stanza(sm, state, ctx).await;
@@ -935,6 +959,7 @@ async fn handle_xmpp_frame(
             session_jid,
             *authenticated,
             *resource_bound,
+            carbons_enabled,
         )
         .await;
     }
@@ -1536,6 +1561,9 @@ async fn handle_iq(
     let resource_bound = session_jid
         .as_ref()
         .is_some_and(|jid| jid.resource().as_str() != "pending");
+    let mut carbons_enabled = session_jid
+        .as_ref()
+        .is_some_and(|jid| state.connection_registry.is_carbons_enabled(jid));
     handle_iq_with_conn_state(
         frame,
         domain,
@@ -1545,6 +1573,7 @@ async fn handle_iq(
         session_jid,
         authenticated,
         resource_bound,
+        &mut carbons_enabled,
     )
     .await
 }
@@ -1558,6 +1587,7 @@ async fn handle_iq_with_conn_state(
     session_jid: &Option<FullJid>,
     authenticated: bool,
     resource_bound: bool,
+    carbons_enabled: &mut bool,
 ) -> Vec<String> {
     let muc_registry = state.muc_registry.as_ref();
     let spaces_domain = format!("spaces.{domain}");
@@ -1616,6 +1646,14 @@ async fn handle_iq_with_conn_state(
             }
             _ => None,
         };
+        let carbons_toggle = match &iq.payload {
+            xmpp_parsers::iq::IqType::Set(e)
+                if e.ns() == CARBONS_NS && (e.name() == "enable" || e.name() == "disable") =>
+            {
+                Some(e.name() == "enable")
+            }
+            _ => None,
+        };
         if let Some(ns) = payload_ns {
             if state.dispatcher.has_iq_handler(&ns) {
                 if !authenticated || !resource_bound {
@@ -1626,6 +1664,12 @@ async fn handle_iq_with_conn_state(
                         "auth",
                         "not-authorized",
                     )];
+                }
+                if let Some(enabled) = carbons_toggle {
+                    *carbons_enabled = enabled;
+                    let _ = state
+                        .connection_registry
+                        .set_carbons_enabled(full_jid, enabled);
                 }
                 let ctx = ProtocolStanzaContext { domain, full_jid };
                 let events = state.dispatcher.dispatch_iq(iq, &ctx);
@@ -3965,6 +4009,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_iq_carbons_toggle_updates_registry_flag() {
+        let state = create_test_websocket_state().await;
+        let jid: FullJid = "alice@example.com/web".parse().expect("valid jid");
+        let (tx, _rx) = tokio::sync::mpsc::channel(8);
+        state.connection_registry.register(jid.clone(), tx);
+        assert!(!state.connection_registry.is_carbons_enabled(&jid));
+
+        let enable = r#"<iq xmlns="jabber:client" id="carbons-enable" type="set"><enable xmlns="urn:xmpp:carbons:2"/></iq>"#;
+        let enable_responses = handle_iq(
+            enable,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &None,
+            &Some(jid.clone()),
+        )
+        .await;
+        assert_eq!(enable_responses.len(), 1);
+        assert!(state.connection_registry.is_carbons_enabled(&jid));
+
+        let disable = r#"<iq xmlns="jabber:client" id="carbons-disable" type="set"><disable xmlns="urn:xmpp:carbons:2"/></iq>"#;
+        let disable_responses = handle_iq(
+            disable,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &None,
+            &Some(jid.clone()),
+        )
+        .await;
+        assert_eq!(disable_responses.len(), 1);
+        assert!(!state.connection_registry.is_carbons_enabled(&jid));
+    }
+
+    #[tokio::test]
     async fn handle_iq_unknown_includes_routing_addresses_in_error() {
         let state = create_test_websocket_state().await;
         let frame = r#"<iq xmlns="jabber:client" id="unknown-1" type="get" from="alice@example.com/web" to="example.com"><foo xmlns="urn:waddle:test:0"/></iq>"#;
@@ -5147,6 +5226,7 @@ mod tests {
             ],
             max_resume_time: Some(300),
             detached_at: std::time::Instant::now(),
+            carbons_enabled: true,
         };
         state
             .sm_session_registry
@@ -5180,6 +5260,7 @@ mod tests {
         assert!(conn.resource_bound);
         assert_eq!(conn.session_jid, Some(jid));
         assert!(conn.resumed);
+        assert!(conn.carbons_enabled);
     }
 
     #[tokio::test]
@@ -5221,6 +5302,7 @@ mod tests {
             ],
             max_resume_time: Some(300),
             detached_at: std::time::Instant::now(),
+            carbons_enabled: false,
         };
         state
             .sm_session_registry
@@ -5281,6 +5363,7 @@ mod tests {
                 unacked_stanzas: Vec::new(),
                 max_resume_time: Some(0), // already expired
                 detached_at: std::time::Instant::now(),
+                carbons_enabled: false,
             })
             .await
             .expect("store");

--- a/server/crates/waddle-xmpp/src/connection.rs
+++ b/server/crates/waddle-xmpp/src/connection.rs
@@ -1,6 +1,7 @@
 //! Connection actor for handling individual XMPP client connections.
 
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -204,8 +205,12 @@ pub struct ConnectionActor<S: AppState, M: MamStorage> {
     sm_state: StreamManagementState,
     /// XEP-0198 Stream Management session registry (for resumption)
     sm_session_registry: Arc<dyn SmSessionRegistry>,
-    /// XEP-0280 Message Carbons enabled state
-    carbons_enabled: bool,
+    /// XEP-0280 Message Carbons enabled state.
+    ///
+    /// Shared with the `ConnectionRegistry`'s `ConnectionEntry` so that other
+    /// actors routing messages can gate carbon delivery on this resource's
+    /// per-resource opt-in (XEP-0280 §5 requires this to be per-resource).
+    carbons_enabled: Arc<AtomicBool>,
     /// XEP-0397 ISR token store for instant stream resumption
     isr_token_store: SharedIsrTokenStore,
     /// Current ISR token for this connection (if any)
@@ -285,7 +290,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             outbound_rx: None,
             sm_state: StreamManagementState::new(),
             sm_session_registry,
-            carbons_enabled: false,
+            carbons_enabled: Arc::new(AtomicBool::new(false)),
             isr_token_store,
             current_isr_token: None,
             stanza_router: None, // Federation routing disabled by default; can be set via set_stanza_router()
@@ -361,9 +366,12 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         self.jid = Some(full_jid.clone());
         self.state = ConnectionState::Established;
 
-        // Register this connection with the connection registry for message routing
+        // Register this connection with the connection registry for message routing.
+        // The returned handle shares the registry entry's carbons flag so we can
+        // toggle per-resource XEP-0280 opt-in from this actor.
         let (outbound_tx, outbound_rx) = mpsc::channel(OUTBOUND_CHANNEL_SIZE);
-        self.connection_registry
+        self.carbons_enabled = self
+            .connection_registry
             .register(full_jid.clone(), outbound_tx);
         self.outbound_rx = Some(outbound_rx);
 
@@ -400,7 +408,13 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
 
         // Store SM session for potential resumption (if enabled and resumable)
         if let Some(ref jid) = self.jid {
-            if let Some(detached) = self.sm_state.to_detached_session(jid.clone()) {
+            // Capture XEP-0280 carbons opt-in so resume restores it instead of
+            // creating a fresh entry with carbons disabled.
+            let carbons_enabled = self.carbons_enabled.load(Ordering::Relaxed);
+            if let Some(detached) = self
+                .sm_state
+                .to_detached_session(jid.clone(), carbons_enabled)
+            {
                 debug!(
                     stream_id = %detached.stream_id,
                     jid = %jid,
@@ -1357,9 +1371,17 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
                     self.stream.write_raw(&stanza_xml).await?;
                 }
 
-                // Re-register in connection registry with the restored JID
+                // Re-register in connection registry with the restored JID.
+                // XEP-0198 §5: `<resumed/>` continues the same stream, so the
+                // pre-detach XEP-0280 carbons opt-in must be preserved —
+                // seed the fresh `ConnectionEntry` with the flag that was
+                // captured when the session detached.
                 let (tx, rx) = mpsc::channel(OUTBOUND_CHANNEL_SIZE);
-                self.connection_registry.register(session.jid.clone(), tx);
+                self.carbons_enabled = self.connection_registry.register_with_carbons(
+                    session.jid.clone(),
+                    tx,
+                    session.carbons_enabled,
+                );
                 self.outbound_rx = Some(rx);
 
                 info!(
@@ -4652,7 +4674,10 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
     async fn handle_carbons_enable(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
         debug!("Enabling message carbons for connection");
 
-        self.carbons_enabled = true;
+        // Relaxed is sufficient: the registry's `get_other_carbon_resources_for_user`
+        // only needs eventual visibility; there's no happens-before ordering we
+        // depend on with any other memory.
+        self.carbons_enabled.store(true, Ordering::Relaxed);
 
         // Send success response
         let response = build_carbons_result(&iq);
@@ -4669,7 +4694,7 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
     async fn handle_carbons_disable(&mut self, iq: xmpp_parsers::iq::Iq) -> Result<(), XmppError> {
         debug!("Disabling message carbons for connection");
 
-        self.carbons_enabled = false;
+        self.carbons_enabled.store(false, Ordering::Relaxed);
 
         // Send success response
         let response = build_carbons_result(&iq);
@@ -5698,10 +5723,12 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         // Get the bare JID to find all resources
         let bare_jid = sender_jid.to_bare();
 
-        // Get all other resources for this user with carbons enabled
+        // Get all other resources for this user with carbons enabled.
+        // XEP-0280 §5: only resources that opted in (via `<enable/>`) receive
+        // carbon-wrapped copies.
         let other_resources = self
             .connection_registry
-            .get_other_resources_for_user(&bare_jid, sender_jid);
+            .get_other_carbon_resources_for_user(&bare_jid, sender_jid);
 
         if other_resources.is_empty() {
             return;
@@ -5744,10 +5771,10 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
         // Get the bare JID to find all resources
         let bare_jid = recipient_jid.to_bare();
 
-        // Get all other resources for this user
+        // Get all other carbons-opted-in resources for this user (XEP-0280 §5).
         let other_resources = self
             .connection_registry
-            .get_other_resources_for_user(&bare_jid, recipient_jid);
+            .get_other_carbon_resources_for_user(&bare_jid, recipient_jid);
 
         if other_resources.is_empty() {
             return;
@@ -5813,10 +5840,13 @@ impl<S: AppState, M: MamStorage> ConnectionActor<S, M> {
             return;
         }
 
-        // Find resources that didn't get the original message
+        // Find resources that didn't get the original message and have
+        // opted into carbons (XEP-0280 §5: carbons are per-resource opt-in).
         let other_resources: Vec<&FullJid> = all_resources
             .iter()
-            .filter(|r| !delivered_resources.contains(r))
+            .filter(|r| {
+                !delivered_resources.contains(r) && self.connection_registry.is_carbons_enabled(r)
+            })
             .collect();
 
         if other_resources.is_empty() {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -392,6 +392,21 @@ impl ConnectionRegistry {
             .unwrap_or(false)
     }
 
+    /// Update the XEP-0280 Message Carbons opt-in flag for a connected resource.
+    ///
+    /// Returns false when the resource is not currently connected.
+    pub fn set_carbons_enabled(&self, jid: &FullJid, enabled: bool) -> bool {
+        if let Some(entry) = self.connections.get(jid) {
+            entry
+                .value()
+                .carbons_enabled
+                .store(enabled, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Get all connected resources for a bare JID.
     ///
     /// Returns all full JIDs that match the given bare JID.
@@ -921,5 +936,26 @@ mod tests {
 
         assert!(!handle.load(Ordering::Relaxed));
         assert!(!registry.is_carbons_enabled(&jid));
+    }
+
+    #[test]
+    fn test_set_carbons_enabled_updates_existing_entry() {
+        let registry = ConnectionRegistry::new();
+        let jid = test_jid("user3");
+        let (tx, _rx) = mpsc::channel(16);
+        registry.register(jid.clone(), tx);
+
+        assert!(registry.set_carbons_enabled(&jid, true));
+        assert!(registry.is_carbons_enabled(&jid));
+
+        assert!(registry.set_carbons_enabled(&jid, false));
+        assert!(!registry.is_carbons_enabled(&jid));
+    }
+
+    #[test]
+    fn test_set_carbons_enabled_returns_false_for_missing_entry() {
+        let registry = ConnectionRegistry::new();
+        let jid = test_jid("missing");
+        assert!(!registry.set_carbons_enabled(&jid, true));
     }
 }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -175,7 +175,24 @@ impl ConnectionRegistry {
     /// the same resource before the old connection is cleaned up.
     #[instrument(skip(self, sender), fields(jid = %jid))]
     pub fn register(&self, jid: FullJid, sender: mpsc::Sender<OutboundStanza>) -> Arc<AtomicBool> {
+        self.register_with_carbons(jid, sender, false)
+    }
+
+    /// Register a connection and seed its XEP-0280 carbons opt-in to
+    /// `carbons_enabled`. Used by the XEP-0198 stream-resume path so a
+    /// resumed stream keeps the carbons flag it negotiated before the
+    /// disconnect instead of silently reverting to the disabled default.
+    #[instrument(skip(self, sender), fields(jid = %jid, carbons = carbons_enabled))]
+    pub fn register_with_carbons(
+        &self,
+        jid: FullJid,
+        sender: mpsc::Sender<OutboundStanza>,
+        carbons_enabled: bool,
+    ) -> Arc<AtomicBool> {
         let entry = ConnectionEntry::new(sender);
+        if carbons_enabled {
+            entry.carbons_enabled.store(true, Ordering::Relaxed);
+        }
         let carbons_handle = entry.carbons_handle();
         let existing = self.connections.insert(jid.clone(), entry);
         if existing.is_some() {
@@ -322,8 +339,10 @@ impl ConnectionRegistry {
 
     /// Get all connected resources for a bare JID, excluding a specific full JID.
     ///
-    /// Used by message carbons to find other connected clients for the same user.
     /// Returns all full JIDs that match the bare JID except the excluded one.
+    /// This does NOT filter by carbons status — callers that are routing
+    /// XEP-0280 carbon copies should use [`Self::get_other_carbon_resources_for_user`]
+    /// instead so that non-opted-in resources are not sent carbon-wrapped stanzas.
     pub fn get_other_resources_for_user(
         &self,
         bare_jid: &BareJid,
@@ -338,6 +357,39 @@ impl ConnectionRegistry {
             })
             .map(|entry| entry.key().clone())
             .collect()
+    }
+
+    /// Get all resources for a bare JID that have XEP-0280 Message Carbons
+    /// enabled, excluding a specific full JID.
+    ///
+    /// Per XEP-0280 §5, carbons must be enabled per-resource. The server must
+    /// only deliver `<sent>` and `<received>` carbon copies to resources that
+    /// have explicitly opted in via `<enable xmlns='urn:xmpp:carbons:2'/>`.
+    pub fn get_other_carbon_resources_for_user(
+        &self,
+        bare_jid: &BareJid,
+        exclude_jid: &FullJid,
+    ) -> Vec<FullJid> {
+        self.connections
+            .iter()
+            .filter(|entry| {
+                let jid = entry.key();
+                jid.to_bare() == *bare_jid
+                    && jid != exclude_jid
+                    && entry.value().is_carbons_enabled()
+            })
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    /// Check whether the given full JID has XEP-0280 Message Carbons enabled.
+    ///
+    /// Returns false if the JID is not connected.
+    pub fn is_carbons_enabled(&self, jid: &FullJid) -> bool {
+        self.connections
+            .get(jid)
+            .map(|entry| entry.value().is_carbons_enabled())
+            .unwrap_or(false)
     }
 
     /// Get all connected resources for a bare JID.
@@ -835,5 +887,39 @@ mod tests {
         // Clean up on unregister
         registry.unregister(&jid);
         assert!(registry.get_presence_state(&jid).is_none());
+    }
+
+    /// XEP-0198 + XEP-0280: when a stream resumes the client expects its
+    /// previous carbons opt-in to still be in effect. `register` creates a
+    /// fresh entry with carbons disabled, so the resume path needs a variant
+    /// that seeds the flag to the value captured when the session detached.
+    #[test]
+    fn test_register_with_carbons_seeds_initial_flag() {
+        let registry = ConnectionRegistry::new();
+        let jid = test_jid("user1");
+        let (tx, _rx) = mpsc::channel(16);
+
+        let handle = registry.register_with_carbons(jid.clone(), tx, true);
+
+        assert!(
+            handle.load(Ordering::Relaxed),
+            "handle returned by register_with_carbons(.., true) should start enabled"
+        );
+        assert!(
+            registry.is_carbons_enabled(&jid),
+            "registry should report carbons as enabled for the seeded entry"
+        );
+    }
+
+    #[test]
+    fn test_register_with_carbons_false_leaves_disabled() {
+        let registry = ConnectionRegistry::new();
+        let jid = test_jid("user2");
+        let (tx, _rx) = mpsc::channel(16);
+
+        let handle = registry.register_with_carbons(jid.clone(), tx, false);
+
+        assert!(!handle.load(Ordering::Relaxed));
+        assert!(!registry.is_carbons_enabled(&jid));
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -487,8 +487,14 @@ impl StreamManagementState {
 
     /// Create a detached session for storage in the registry.
     ///
-    /// This captures all the state needed to resume this stream later.
-    pub fn to_detached_session(&self, jid: jid::FullJid) -> Option<DetachedSession> {
+    /// `carbons_enabled` is the actor's current XEP-0280 opt-in value.
+    /// Carbons opt-in is per-stream, so XEP-0198 resumption must preserve
+    /// it — storing it on the detached session is what makes that possible.
+    pub fn to_detached_session(
+        &self,
+        jid: jid::FullJid,
+        carbons_enabled: bool,
+    ) -> Option<DetachedSession> {
         if !self.is_resumable() {
             return None;
         }
@@ -502,6 +508,7 @@ impl StreamManagementState {
             unacked_stanzas: self.unacked_queue.get_all_unacked(),
             max_resume_time: self.max_resume_time,
             detached_at: Instant::now(),
+            carbons_enabled,
         })
     }
 
@@ -793,5 +800,35 @@ mod tests {
 
         state.enable("test-id".to_string(), true, Some(300));
         assert!(state.is_resumable());
+    }
+
+    /// XEP-0198 §5 stream resumption is meant to continue the exact same
+    /// stream — the client doesn't expect to re-negotiate per-stream add-ons
+    /// like XEP-0280 carbons after a successful `<resumed/>`. So the
+    /// detached session the server stashes at disconnect MUST carry the
+    /// carbons opt-in flag, and a resumed actor must be able to read it
+    /// back. If this regresses, every SM-resume will silently disable
+    /// carbons until the client re-enables them.
+    #[test]
+    fn test_to_detached_session_carries_carbons_flag() {
+        let mut state = StreamManagementState::new();
+        state.enable("stream-carb".to_string(), true, Some(300));
+        let jid: jid::FullJid = "user@example.com/resource".parse().unwrap();
+
+        let detached_off = state
+            .to_detached_session(jid.clone(), false)
+            .expect("resumable state must produce detached session");
+        assert!(
+            !detached_off.carbons_enabled,
+            "carbons_enabled=false must round-trip through DetachedSession"
+        );
+
+        let detached_on = state
+            .to_detached_session(jid, true)
+            .expect("resumable state must produce detached session");
+        assert!(
+            detached_on.carbons_enabled,
+            "carbons_enabled=true must round-trip so resume preserves opt-in"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -59,6 +59,12 @@ pub struct DetachedSession {
     pub max_resume_time: Option<u32>,
     /// When the session was detached
     pub detached_at: Instant,
+    /// XEP-0280 Message Carbons opt-in at detach time.
+    ///
+    /// XEP-0198 §5 defines `<resumed/>` as continuing the same stream, so any
+    /// per-stream add-ons the client previously enabled (here: carbons) must
+    /// survive resumption without requiring the client to re-negotiate them.
+    pub carbons_enabled: bool,
 }
 
 impl DetachedSession {
@@ -335,6 +341,7 @@ mod tests {
             ],
             max_resume_time: Some(300),
             detached_at: Instant::now(),
+            carbons_enabled: false,
         }
     }
 

--- a/server/crates/waddle-xmpp/tests/xep0280_carbons.rs
+++ b/server/crates/waddle-xmpp/tests/xep0280_carbons.rs
@@ -1,0 +1,248 @@
+#![recursion_limit = "256"]
+
+//! XEP-0280 Message Carbons integration suite.
+//!
+//! These tests exercise the per-resource opt-in requirement of XEP-0280 §5:
+//! "Carbons MUST be enabled for each online resource separately."
+//!
+//! The server must only deliver `<sent>` and `<received>` carbon wrappers to
+//! resources that have explicitly sent `<enable xmlns='urn:xmpp:carbons:2'/>`.
+//! Resources that never opted in (or disabled carbons after enabling) must not
+//! receive carbon-wrapped copies of messages from their siblings.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{establish_bound_session, init_test_env, RawXmppClient, TestServer, DEFAULT_TIMEOUT};
+
+/// How long to wait for a carbon that should NOT arrive. Long enough that
+/// the server has had any reasonable chance to misdeliver, short enough that
+/// the test suite stays fast.
+const CARBON_SETTLE: Duration = Duration::from_millis(400);
+
+/// Establish a bound session, then send initial `<presence/>` so the server
+/// marks the resource available and will route bare-JID addressed messages.
+async fn bind_and_announce(
+    client: &mut RawXmppClient,
+    server: &TestServer,
+    user: &str,
+    resource: &str,
+) -> String {
+    let full_jid = establish_bound_session(client, server, user, resource)
+        .await
+        .unwrap_or_else(|e| panic!("bind {}/{}: {}", user, resource, e));
+    client
+        .send("<presence xmlns='jabber:client'/>")
+        .await
+        .expect("send initial presence");
+    full_jid
+}
+
+async fn enable_carbons(client: &mut RawXmppClient, id: &str) {
+    client
+        .send(&format!(
+            "<iq type='set' id='{}' xmlns='jabber:client'>\
+                <enable xmlns='urn:xmpp:carbons:2'/>\
+            </iq>",
+            id
+        ))
+        .await
+        .expect("send carbons enable");
+    // IDs are unique; match the raw id string so we're agnostic to single vs
+    // double quote styling in the serialized stanza.
+    client
+        .read_until(id, DEFAULT_TIMEOUT)
+        .await
+        .expect("carbons enable result");
+    client.clear();
+}
+
+async fn disable_carbons(client: &mut RawXmppClient, id: &str) {
+    client
+        .send(&format!(
+            "<iq type='set' id='{}' xmlns='jabber:client'>\
+                <disable xmlns='urn:xmpp:carbons:2'/>\
+            </iq>",
+            id
+        ))
+        .await
+        .expect("send carbons disable");
+    client
+        .read_until(id, DEFAULT_TIMEOUT)
+        .await
+        .expect("carbons disable result");
+    client.clear();
+}
+
+/// Drain any stanzas delivered within `window` so later assertions examine a
+/// fresh buffer.
+async fn settle(client: &mut RawXmppClient, window: Duration) {
+    let _ = client.read(window).await;
+}
+
+#[tokio::test]
+async fn sent_carbon_skipped_for_resource_that_did_not_opt_in() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    // Alice has two resources. Desktop opts in; mobile does not.
+    let mut alice_desktop = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_desktop, &server, "alice", "desktop").await;
+    enable_carbons(&mut alice_desktop, "carbons-enable-desktop").await;
+
+    let mut alice_mobile = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_mobile, &server, "alice", "mobile").await;
+
+    // Bob exists as the recipient so the sent message has somewhere to go.
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut bob, &server, "bob", "laptop").await;
+
+    // Desktop sends a chat message to Bob.
+    alice_desktop
+        .send(
+            "<message type='chat' to='bob@localhost' id='dm-1' xmlns='jabber:client'>\
+                <body>hello bob</body>\
+            </message>",
+        )
+        .await
+        .expect("send dm");
+
+    // Bob must receive the original message (sanity check on routing).
+    bob.read_until("hello bob", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives original");
+
+    // Mobile did NOT opt in; give the server plenty of time to (mis)deliver.
+    settle(&mut alice_mobile, CARBON_SETTLE).await;
+    let mobile_buffer = alice_mobile.take_buffer();
+    assert!(
+        !mobile_buffer.contains("urn:xmpp:carbons:2"),
+        "mobile resource did not opt into carbons but received carbon-wrapped stanza:\n{}",
+        mobile_buffer
+    );
+}
+
+#[tokio::test]
+async fn sent_carbon_delivered_to_opted_in_sibling() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice_desktop = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_desktop, &server, "alice", "desktop").await;
+    enable_carbons(&mut alice_desktop, "carbons-enable-desktop").await;
+
+    let mut alice_mobile = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_mobile, &server, "alice", "mobile").await;
+    enable_carbons(&mut alice_mobile, "carbons-enable-mobile").await;
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut bob, &server, "bob", "laptop").await;
+
+    alice_desktop
+        .send(
+            "<message type='chat' to='bob@localhost' id='dm-2' xmlns='jabber:client'>\
+                <body>synced note</body>\
+            </message>",
+        )
+        .await
+        .expect("send dm");
+
+    bob.read_until("synced note", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives original");
+
+    let mobile_buffer = alice_mobile
+        .read_until("synced note", DEFAULT_TIMEOUT)
+        .await
+        .expect("mobile receives sent carbon");
+    assert!(
+        mobile_buffer.contains("<sent"),
+        "mobile should receive a <sent> carbon wrapper, got:\n{}",
+        mobile_buffer
+    );
+    assert!(
+        mobile_buffer.contains("urn:xmpp:carbons:2"),
+        "carbon stanza should carry urn:xmpp:carbons:2, got:\n{}",
+        mobile_buffer
+    );
+}
+
+#[tokio::test]
+async fn sent_carbon_stops_after_disable() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice_desktop = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_desktop, &server, "alice", "desktop").await;
+    enable_carbons(&mut alice_desktop, "carbons-enable-desktop").await;
+
+    let mut alice_mobile = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_mobile, &server, "alice", "mobile").await;
+    enable_carbons(&mut alice_mobile, "carbons-enable-mobile").await;
+    disable_carbons(&mut alice_mobile, "carbons-disable-mobile").await;
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut bob, &server, "bob", "laptop").await;
+
+    alice_desktop
+        .send(
+            "<message type='chat' to='bob@localhost' id='dm-3' xmlns='jabber:client'>\
+                <body>after disable</body>\
+            </message>",
+        )
+        .await
+        .expect("send dm");
+
+    bob.read_until("after disable", DEFAULT_TIMEOUT)
+        .await
+        .expect("bob receives original");
+
+    settle(&mut alice_mobile, CARBON_SETTLE).await;
+    let mobile_buffer = alice_mobile.take_buffer();
+    assert!(
+        !mobile_buffer.contains("urn:xmpp:carbons:2"),
+        "mobile disabled carbons but still received carbon stanza:\n{}",
+        mobile_buffer
+    );
+}
+
+#[tokio::test]
+async fn received_carbon_skipped_for_resource_that_did_not_opt_in() {
+    init_test_env();
+    let server = TestServer::start().await;
+
+    let mut alice_desktop = RawXmppClient::connect(server.addr).await.expect("connect");
+    let desktop_jid = bind_and_announce(&mut alice_desktop, &server, "alice", "desktop").await;
+    enable_carbons(&mut alice_desktop, "carbons-enable-desktop").await;
+
+    let mut alice_mobile = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut alice_mobile, &server, "alice", "mobile").await;
+
+    let mut bob = RawXmppClient::connect(server.addr).await.expect("connect");
+    bind_and_announce(&mut bob, &server, "bob", "laptop").await;
+
+    // Bob targets Alice's desktop resource specifically so that received carbons
+    // are generated for the other resources (see send_received_carbons_to_user).
+    bob.send(&format!(
+        "<message type='chat' to='{}' id='dm-in-1' xmlns='jabber:client'>\
+            <body>direct to desktop</body>\
+        </message>",
+        desktop_jid
+    ))
+    .await
+    .expect("bob sends");
+
+    alice_desktop
+        .read_until("direct to desktop", DEFAULT_TIMEOUT)
+        .await
+        .expect("desktop receives original");
+
+    settle(&mut alice_mobile, CARBON_SETTLE).await;
+    let mobile_buffer = alice_mobile.take_buffer();
+    assert!(
+        !mobile_buffer.contains("urn:xmpp:carbons:2"),
+        "mobile did not opt into carbons but received a <received> carbon:\n{}",
+        mobile_buffer
+    );
+}


### PR DESCRIPTION
## Summary

Messages sent from the desktop web client were not appearing on an iPhone web session signed in as the same user, for both 1:1 DMs and MUC channels. Two independent bugs contributed; both are fixed here as separate commits that can be reviewed independently.

### Commit 1 — `fix(xmpp): honour XEP-0280 per-resource carbons opt-in`

The `ConnectionActor` kept a local `bool` for carbons state that never propagated to the shared `ConnectionEntry` in the `ConnectionRegistry`, and the registry's resource lookup didn't consult the flag anyway. Result: the server shipped carbon-wrapped stanzas to every sibling resource regardless of whether it had sent `<enable xmlns='urn:xmpp:carbons:2'/>`, violating XEP-0280 §5.

- `ConnectionActor.carbons_enabled` is now the `Arc<AtomicBool>` returned from `ConnectionRegistry::register`, so enable/disable IQs flip the shared flag.
- New `get_other_carbon_resources_for_user` and `is_carbons_enabled` on the registry; all three carbon senders filter by per-resource opt-in.
- New integration suite `tests/xep0280_carbons.rs` covers the four opt-in states (no enable, enabled sibling, disable after enable, received-carbon path). Required by the project's XEP test-suite rule.

### Commit 2 — `feat(chat): catch up missed messages via MAM on reconnect`

Mobile Safari aggressively suspends WebSockets when a tab backgrounds or the phone locks. The server only routes live stanzas to connected sockets, so any message sent while the mobile client was suspended was silently lost once the socket resumed. This is the user-facing root cause even with carbons working correctly.

- `queryPersonalMam` / `queryMam` accept an optional `since` cursor; when set, they emit an XEP-0313 §4.1.5 `start` form field and drop `before` so MAM pages forward from the timestamp.
- New `ReconnectCatchup` tracker records a last-seen timestamp per DM peer / room (monotonic only — carbons can arrive out of order) and distinguishes the first `session:started` (initial login, nothing missed) from subsequent ones (resume, catch up everywhere).
- `BrowserXmppClient` wires the tracker into live `chat` / `groupchat` / `carbon:sent` dispatch, runs catch-up at the end of `session:started`, and resets on user-initiated disconnect.

## Test plan

- [x] `cargo test -p waddle-xmpp --test xep0280_carbons` — 4 new integration tests + smoke test, all GREEN
- [x] `cargo test -p waddle-xmpp --lib` — 1411 existing lib tests still pass
- [x] `cargo clippy -p waddle-xmpp --lib --test xep0280_carbons -- -D warnings` — clean
- [x] `cargo fmt --all`
- [x] `bun test tests/mam-history.test.ts tests/reconnect-catchup.test.ts` — 3 new MAM tests + 8 new ReconnectCatchup tests, all GREEN (TDD RED→GREEN)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx astro check` — 0 errors, 0 warnings
- [ ] Manual: open desktop Chrome + iPhone Safari signed in as the same user, send from desktop, confirm iPhone receives live
- [ ] Manual: on iPhone, disable network briefly, send from desktop, restore network, confirm message appears via MAM catch-up
- [ ] Manual: same checks for a MUC channel

## Notes

Pre-existing unrelated test failure (`chat/tests/groupchat-messaging.test.ts` imports a non-existent `sendCallInvite`) was left alone — not in scope.