### PR TITLE
feat: ship waddle-server + chat signals to Grafana Cloud

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/outfit": "^5.2.8",
         "@fontsource-variable/syne": "^5.2.7",
+        "@grafana/faro-web-sdk": "^2.3.1",
         "@nanostores/vue": "^1.1.0",
         "@tailwindcss/vite": "^4.2.2",
         "@tiptap/extension-bubble-menu": "^3.22.3",
@@ -281,6 +282,10 @@
 
     "@fontsource-variable/syne": ["@fontsource-variable/syne@5.2.7", "", {}, "sha512-B2z7P0mGdNSAgz6SmtK7HXReZL22WJ8Z8sk5Z1ZuKiCSRM7DwWLjWXLwhbQ+CvmtNS/+p95jGvVEfQT9bm+UKw=="],
 
+    "@grafana/faro-core": ["@grafana/faro-core@2.3.1", "", { "dependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/otlp-transformer": "^0.213.0" } }, "sha512-htDKO0YFKr0tfntrPoM151vOPSZzmP6oE0+0MDvbI1WDaBW4erXmYi3feGJLWDXt5/vZBg9iQRmZoRzTLTTcOA=="],
+
+    "@grafana/faro-web-sdk": ["@grafana/faro-web-sdk@2.3.1", "", { "dependencies": { "@grafana/faro-core": "^2.3.1", "ua-parser-js": "1.0.41", "web-vitals": "^5.1.0" } }, "sha512-WMfErl2YSP+CcfcobMpCdK6apX86hc8bymMXsvYLQpBBkQ0KJjIilEQS/YXd+g/cg6F1kwbeweisBKluNNy5sA=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -357,6 +362,20 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.6.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/sdk-logs": "0.213.0", "@opentelemetry/sdk-metrics": "2.6.0", "@opentelemetry/sdk-trace-base": "2.6.0", "protobufjs": "^7.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-RSuAlxFFPjeK4d5Y6ps8L2WhaQI6CXWllIjvo5nkAlBpmq2XdYWEBGiAbOF4nDs8CX4QblJDv5BbMUft3sEfDw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.213.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.213.0", "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.0", "", { "dependencies": { "@opentelemetry/core": "2.6.0", "@opentelemetry/resources": "2.6.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ=="],
+
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
@@ -408,6 +427,26 @@
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.4", "", {}, "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.0", "", {}, "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.0", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1", "@protobufjs/inquire": "^1.1.0" } }, "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/inquire": ["@protobufjs/inquire@1.1.0", "", {}, "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.0", "", {}, "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="],
 
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 
@@ -991,6 +1030,8 @@
 
     "linkifyjs": ["linkifyjs@4.3.2", "", {}, "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
@@ -1221,6 +1262,8 @@
 
     "prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
 
+    "protobufjs": ["protobufjs@7.5.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
@@ -1369,6 +1412,8 @@
 
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
+    "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": { "ua-parser-js": "script/cli.js" } }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
+
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
@@ -1474,6 +1519,8 @@
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "web-vitals": ["web-vitals@5.2.0", "", {}, "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -23,6 +23,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/outfit": "^5.2.8",
     "@fontsource-variable/syne": "^5.2.7",
+    "@grafana/faro-web-sdk": "^2.3.1",
     "@nanostores/vue": "^1.1.0",
     "@tailwindcss/vite": "^4.2.2",
     "@tiptap/extension-bubble-menu": "^3.22.3",

--- a/chat/src/components/XmppProvider.vue
+++ b/chat/src/components/XmppProvider.vue
@@ -5,6 +5,7 @@ import { BrowserXmppClient } from "@/lib/xmpp-client";
 import { connectionStore } from "@/lib/connection-store";
 import { createServerAuth } from "@/lib/server-auth";
 import { $xmppStatus, OFFLINE_SNAPSHOT } from "@/stores/xmpp-status";
+import { installInstrumentation } from "@/lib/xmpp/xmpp-instrumentation";
 
 const props = defineProps<{
   serverBaseUrl: string;
@@ -27,6 +28,11 @@ async function bootstrap() {
 
   if (auth.appState.value === "ready" && auth.session.value) {
     const client = new BrowserXmppClient(auth.session.value);
+    // Wire Faro telemetry hooks before any handlers are set — the
+    // primary setStatusHandler below is unaffected, but the telemetry
+    // `onStatus` hook fires alongside it. Safe to install even when
+    // Faro isn't initialized; `@/lib/telemetry` no-ops until bootstrap.
+    installInstrumentation(client);
     const serverUrl = auth.activeServerUrl.value;
     client.setRefreshSession(async () => {
       const serverAuth = createServerAuth(serverUrl);

--- a/chat/src/env.d.ts
+++ b/chat/src/env.d.ts
@@ -3,6 +3,8 @@
 
 interface ImportMetaEnv {
   readonly PUBLIC_COMMIT_SHA: string;
+  readonly PUBLIC_FARO_URL: string;
+  readonly PUBLIC_FARO_APP_NAME: string;
 }
 
 interface ImportMeta {

--- a/chat/src/layouts/AppLayout.astro
+++ b/chat/src/layouts/AppLayout.astro
@@ -35,6 +35,18 @@ const serverBaseUrl = env.SERVER_BASE_URL;
       })();
     </script>
     <title>Waddle</title>
+    <script>
+      // Faro RUM bootstrap. `initTelemetry` is a no-op unless
+      // `PUBLIC_FARO_URL` is set, so this ships on every build but
+      // stays silent locally and in tests. Vite inlines
+      // `import.meta.env.PUBLIC_*` at build time.
+      import { initTelemetry } from "@/lib/telemetry";
+      initTelemetry({
+        url: import.meta.env.PUBLIC_FARO_URL,
+        appName: import.meta.env.PUBLIC_FARO_APP_NAME,
+        release: import.meta.env.PUBLIC_COMMIT_SHA,
+      });
+    </script>
     <ClientRouter />
   </head>
   <body class="bg-background text-foreground font-sans antialiased">

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -1,0 +1,141 @@
+/**
+ * Grafana Faro RUM wrapper.
+ *
+ * All reporting functions are no-ops when Faro isn't initialized, which
+ * is the default in local dev and in tests. Initialization is gated on
+ * the runtime presence of `PUBLIC_FARO_URL` — there is no "disabled"
+ * mode in the SDK itself; we just skip `initializeFaro()` entirely so
+ * no beacons leave the page.
+ *
+ * Drop-detection signals emitted here all live under the
+ * `chat.xmpp.*` event namespace so they're easy to filter in Grafana.
+ * The server side ships the same information via the
+ * `waddle_broadcast_*_total` and `waddle_sm_unacked_evicted_total`
+ * counters scraped by the in-cluster Alloy collector, so Grafana
+ * dashboards can cross-reference both sides of every drop.
+ */
+import { initializeFaro, type Faro } from "@grafana/faro-web-sdk";
+
+type MessageKind = "room" | "dm";
+
+interface InitTelemetryOptions {
+  /** Faro collector URL (from Grafana Cloud Faro app config). */
+  url: string;
+  /** App name, typically the env-specific identifier e.g. `waddle-chat`. */
+  appName: string;
+  /** Commit SHA used as the app version, for Faro release correlation. */
+  release?: string;
+}
+
+let faro: Faro | null = null;
+
+/**
+ * Initialize Faro exactly once per page lifetime. Re-invocation is a
+ * no-op — the module guards on `faro` being non-null.
+ *
+ * Missing `url` silently skips init. That's the shape callers rely on:
+ * `initTelemetry({ url: import.meta.env.PUBLIC_FARO_URL, ... })` can be
+ * fired unconditionally and does nothing when env vars are unset.
+ */
+export function initTelemetry(options: InitTelemetryOptions): void {
+  if (faro) return;
+  if (!options.url) return;
+
+  try {
+    faro = initializeFaro({
+      url: options.url,
+      app: {
+        name: options.appName || "waddle-chat",
+        version: options.release,
+      },
+      instrumentations: [],
+    });
+  } catch (err) {
+    // Faro itself throwing here is already a telemetry bug; log to the
+    // console so it surfaces in devtools but never propagate — chat
+    // must continue to work with or without telemetry.
+    console.error("Faro initialization failed", err);
+    faro = null;
+  }
+}
+
+/** For tests only — inject a stub or clear state between test cases. */
+export function __setFaroForTesting(instance: Faro | null): void {
+  faro = instance;
+}
+
+export function reportMessageFailed(payload: {
+  id: string;
+  kind: MessageKind;
+}): void {
+  faro?.api.pushEvent("chat.xmpp.message.failed", {
+    id: payload.id,
+    kind: payload.kind,
+  });
+}
+
+export function reportMessageAcked(payload: {
+  id: string;
+  kind: MessageKind;
+  latencyMs: number;
+}): void {
+  if (!faro) return;
+  faro.api.pushEvent("chat.xmpp.message.acked", {
+    id: payload.id,
+    kind: payload.kind,
+    latency_ms: String(Math.round(payload.latencyMs)),
+  });
+  faro.api.pushMeasurement({
+    type: "chat.xmpp.message.acked.latency_ms",
+    values: { latency_ms: payload.latencyMs },
+    context: { kind: payload.kind },
+  });
+}
+
+export function reportSendEnqueued(payload: {
+  kind: MessageKind;
+  reason: string;
+}): void {
+  faro?.api.pushEvent("chat.xmpp.send.enqueued", {
+    kind: payload.kind,
+    reason: payload.reason,
+  });
+}
+
+export function reportQueueDepthChange(payload: {
+  persisted: number;
+  inflight: number;
+}): void {
+  if (!faro) return;
+  faro.api.pushMeasurement({
+    type: "chat.xmpp.queue.depth",
+    values: {
+      persisted: payload.persisted,
+      inflight: payload.inflight,
+    },
+  });
+}
+
+export function reportSessionLifecycle(payload: {
+  type: "fresh" | "resumed";
+}): void {
+  faro?.api.pushEvent("chat.xmpp.session.lifecycle", { type: payload.type });
+}
+
+export function reportStatusChange(payload: {
+  state: string;
+  detail?: string;
+  reconnectDurationMs?: number;
+}): void {
+  if (!faro) return;
+  faro.api.pushEvent("chat.xmpp.status", {
+    state: payload.state,
+    detail: payload.detail ?? "",
+  });
+  if (typeof payload.reconnectDurationMs === "number") {
+    faro.api.pushMeasurement({
+      type: "chat.xmpp.reconnect.duration_ms",
+      values: { duration_ms: payload.reconnectDurationMs },
+    });
+  }
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -273,14 +273,13 @@ export class BrowserXmppClient {
     }
   }
 
-  private emitQueueDepth(kind: "room" | "dm") {
+  private emitQueueDepth() {
     if (this.queueDepthHooks.length === 0) return;
     const depth = {
       persisted: countQueuedMessages(this.queueScope),
       inflight: this.inflightQueuedIds.size,
     };
     this.fireHook(this.queueDepthHooks, depth);
-    void kind;
   }
 
   private recordPendingSend(id: string | null, kind: "room" | "dm") {
@@ -301,8 +300,10 @@ export class BrowserXmppClient {
   /**
    * Track `reconnecting → online` transitions for telemetry latency.
    * Called from `emitStatus` so every status transition is observed.
-   * Returns `{ reconnectDurationMs }` when the snap is the first
-   * non-reconnecting snap after a reconnecting one; empty otherwise.
+   * Only returns `{ reconnectDurationMs }` on a successful resumption
+   * (reconnecting → online). Transitions to `offline` / `error` just
+   * reset the timer without emitting, so failed reconnect attempts
+   * don't skew `chat.xmpp.reconnect.duration_ms`.
    */
   private updateReconnectTimer(snap: XmppStatusSnapshot): { reconnectDurationMs?: number } {
     if (snap.state === "reconnecting") {
@@ -311,11 +312,13 @@ export class BrowserXmppClient {
       }
       return {};
     }
-    if (this.reconnectStartedAt !== null) {
+    if (this.reconnectStartedAt === null) return {};
+    if (snap.state === "online") {
       const durationMs = performance.now() - this.reconnectStartedAt;
       this.reconnectStartedAt = null;
       return { reconnectDurationMs: durationMs };
     }
+    this.reconnectStartedAt = null;
     return {};
   }
 
@@ -667,7 +670,7 @@ export class BrowserXmppClient {
     this.queuedMessageStatusHandler?.(queuedId, "queued");
     this.noteQueuedMessage();
     this.fireHook(this.sendEnqueuedHooks, { kind: "room", reason: this.enqueueReason() });
-    this.emitQueueDepth("room");
+    this.emitQueueDepth();
     return { id: queuedId, state: "queued" };
   }
 
@@ -691,7 +694,7 @@ export class BrowserXmppClient {
     this.queuedMessageStatusHandler?.(queuedId, "queued");
     this.noteQueuedMessage();
     this.fireHook(this.sendEnqueuedHooks, { kind: "dm", reason: this.enqueueReason() });
-    this.emitQueueDepth("dm");
+    this.emitQueueDepth();
     return { id: queuedId, state: "queued" };
   }
 
@@ -1279,7 +1282,7 @@ export class BrowserXmppClient {
         const latencyMs = performance.now() - pending.at;
         this.fireHook(this.messageAckHooks, msg.id, { kind: pending.kind, latencyMs });
       }
-      if (wasQueued) this.emitQueueDepth("room");
+      if (wasQueued) this.emitQueueDepth();
     });
 
     // XEP-0198: stanza.js emits message:failed when SM resume fails (server
@@ -1293,12 +1296,14 @@ export class BrowserXmppClient {
     xmpp.on("message:failed", (msg) => {
       if (this.xmpp !== xmpp) return;
       if (!msg?.id) return;
-      this.inflightQueuedIds.delete(msg.id);
+      const wasQueued = this.inflightQueuedIds.delete(msg.id);
       this.messageDeliveryFailureHandler?.(msg.id);
       const pending = this.pendingSendAt.get(msg.id);
-      const kind = pending?.kind ?? "room";
-      this.pendingSendAt.delete(msg.id);
-      this.fireHook(this.messageFailHooks, msg.id, { kind });
+      if (pending) {
+        this.pendingSendAt.delete(msg.id);
+        this.fireHook(this.messageFailHooks, msg.id, { kind: pending.kind });
+      }
+      if (wasQueued) this.emitQueueDepth();
     });
 
     xmpp.on("disconnected", (err) => {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -191,6 +191,26 @@ export class BrowserXmppClient {
   // session (session:started) because stanza.js drops its SM buffer
   // there, so those stanzas need to be re-flushed from scratch.
   private readonly inflightQueuedIds = new Set<string>();
+  // Send-latency bookkeeping keyed by stanza id. Populated on every
+  // outbound message (live-send or queue flush); cleared on ack / fail.
+  // Values are `performance.now()` at send time; the `message:acked`
+  // handler subtracts to compute latency for telemetry. Independent of
+  // `inflightQueuedIds` because it covers both persistent-queue and
+  // live-send ids.
+  private readonly pendingSendAt = new Map<string, { at: number; kind: "room" | "dm" }>();
+  // Timestamp of the last transition INTO `reconnecting` state, used to
+  // compute reconnect duration when we transition back to `online`.
+  private reconnectStartedAt: number | null = null;
+  // Telemetry hook arrays. These fire ALONGSIDE the primary `*Handler`
+  // methods set by the app — never replacing them — so UI state and
+  // telemetry evolve independently. Any exception thrown by a hook is
+  // swallowed per-call to keep instrumentation from breaking chat.
+  private readonly messageAckHooks: Array<(id: string, meta: { kind: "room" | "dm"; latencyMs: number }) => void> = [];
+  private readonly messageFailHooks: Array<(id: string, meta: { kind: "room" | "dm" }) => void> = [];
+  private readonly sessionLifecycleHooks: Array<(event: SessionLifecycleEvent) => void> = [];
+  private readonly statusHooks: Array<(status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }) => void> = [];
+  private readonly sendEnqueuedHooks: Array<(info: { kind: "room" | "dm"; reason: string }) => void> = [];
+  private readonly queueDepthHooks: Array<(depth: { persisted: number; inflight: number }) => void> = [];
 
   constructor(session: WaddleSession) { this.session = session; }
 
@@ -220,6 +240,89 @@ export class BrowserXmppClient {
   }
   setSessionLifecycleHandler(h: (event: SessionLifecycleEvent) => void) { this.sessionLifecycleHandler = h; }
   setRefreshSession(fn: () => Promise<WaddleSession | null>) { this.refreshSession = fn; }
+
+  // -- Telemetry hooks --
+  //
+  // Hooks fire in addition to (never replacing) the primary `set*Handler`
+  // callbacks. They exist so external telemetry code (Faro / any future
+  // backend) can observe message-drop events without fighting the UI for
+  // ownership of the single primary handler slot.
+  onMessageAcked(hook: (id: string, meta: { kind: "room" | "dm"; latencyMs: number }) => void) {
+    this.messageAckHooks.push(hook);
+  }
+  onMessageDeliveryFailed(hook: (id: string, meta: { kind: "room" | "dm" }) => void) {
+    this.messageFailHooks.push(hook);
+  }
+  onSessionLifecycle(hook: (event: SessionLifecycleEvent) => void) {
+    this.sessionLifecycleHooks.push(hook);
+  }
+  onStatus(hook: (status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }) => void) {
+    this.statusHooks.push(hook);
+  }
+  onSendEnqueued(hook: (info: { kind: "room" | "dm"; reason: string }) => void) {
+    this.sendEnqueuedHooks.push(hook);
+  }
+  onQueueDepthChange(hook: (depth: { persisted: number; inflight: number }) => void) {
+    this.queueDepthHooks.push(hook);
+  }
+
+  private fireHook<Args extends unknown[]>(hooks: Array<(...args: Args) => void>, ...args: Args) {
+    for (const hook of hooks) {
+      try { hook(...args); }
+      catch (err) { console.error("xmpp telemetry hook threw", err); }
+    }
+  }
+
+  private emitQueueDepth(kind: "room" | "dm") {
+    if (this.queueDepthHooks.length === 0) return;
+    const depth = {
+      persisted: countQueuedMessages(this.queueScope),
+      inflight: this.inflightQueuedIds.size,
+    };
+    this.fireHook(this.queueDepthHooks, depth);
+    void kind;
+  }
+
+  private recordPendingSend(id: string | null, kind: "room" | "dm") {
+    if (!id) return;
+    this.pendingSendAt.set(id, { at: performance.now(), kind });
+  }
+
+  private emitStatus(snap: XmppStatusSnapshot) {
+    this.statusHandler?.(snap);
+    if (this.statusHooks.length === 0) {
+      this.updateReconnectTimer(snap);
+      return;
+    }
+    const meta = this.updateReconnectTimer(snap);
+    this.fireHook(this.statusHooks, snap, meta);
+  }
+
+  /**
+   * Track `reconnecting → online` transitions for telemetry latency.
+   * Called from `emitStatus` so every status transition is observed.
+   * Returns `{ reconnectDurationMs }` when the snap is the first
+   * non-reconnecting snap after a reconnecting one; empty otherwise.
+   */
+  private updateReconnectTimer(snap: XmppStatusSnapshot): { reconnectDurationMs?: number } {
+    if (snap.state === "reconnecting") {
+      if (this.reconnectStartedAt === null) {
+        this.reconnectStartedAt = performance.now();
+      }
+      return {};
+    }
+    if (this.reconnectStartedAt !== null) {
+      const durationMs = performance.now() - this.reconnectStartedAt;
+      this.reconnectStartedAt = null;
+      return { reconnectDurationMs: durationMs };
+    }
+    return {};
+  }
+
+  private emitSessionLifecycle(event: SessionLifecycleEvent) {
+    this.sessionLifecycleHandler?.(event);
+    this.fireHook(this.sessionLifecycleHooks, event);
+  }
 
   private updateSession(session: WaddleSession, xmpp: Agent | null = this.xmpp) {
     this.session = session;
@@ -530,16 +633,12 @@ export class BrowserXmppClient {
     return this.canUseConnectedSession() && this.currentRoom === roomJid;
   }
 
-  private shouldQueueImmediately(): boolean {
-    return this.browserOffline() || this.destroying || (!!this.xmpp && !this.connected);
-  }
-
   private noteQueuedMessage() {
     const queueCount = countQueuedMessages(this.queueScope);
     const detail = queueCount === 1
       ? "Message queued until the connection returns"
       : `${queueCount} messages queued until the connection returns`;
-    this.statusHandler?.({
+    this.emitStatus({
       state: this.browserOffline() ? "offline" : "reconnecting",
       detail,
     });
@@ -567,6 +666,8 @@ export class BrowserXmppClient {
     });
     this.queuedMessageStatusHandler?.(queuedId, "queued");
     this.noteQueuedMessage();
+    this.fireHook(this.sendEnqueuedHooks, { kind: "room", reason: this.enqueueReason() });
+    this.emitQueueDepth("room");
     return { id: queuedId, state: "queued" };
   }
 
@@ -589,7 +690,17 @@ export class BrowserXmppClient {
     });
     this.queuedMessageStatusHandler?.(queuedId, "queued");
     this.noteQueuedMessage();
+    this.fireHook(this.sendEnqueuedHooks, { kind: "dm", reason: this.enqueueReason() });
+    this.emitQueueDepth("dm");
     return { id: queuedId, state: "queued" };
+  }
+
+  private enqueueReason(): string {
+    if (this.browserOffline()) return "offline";
+    if (this.destroying) return "destroying";
+    if (!this.xmpp) return "no-client";
+    if (!this.connected) return "reconnecting";
+    return "not-ready";
   }
 
   private nudgeReconnect() {
@@ -623,7 +734,10 @@ export class BrowserXmppClient {
             id: entry.id,
           },
         );
-        if (messageId) this.inflightQueuedIds.add(entry.id);
+        if (messageId) {
+          this.inflightQueuedIds.add(entry.id);
+          this.recordPendingSend(entry.id, "dm");
+        }
       }
     })();
     const trackedPromise = flushPromise.finally(() => {
@@ -656,7 +770,10 @@ export class BrowserXmppClient {
           ...(entry.threadReply ? { threadReply: entry.threadReply } : {}),
           id: entry.id,
         });
-        if (messageId) this.inflightQueuedIds.add(entry.id);
+        if (messageId) {
+          this.inflightQueuedIds.add(entry.id);
+          this.recordPendingSend(entry.id, "room");
+        }
       }
     })();
 
@@ -713,10 +830,9 @@ export class BrowserXmppClient {
     // button from hanging on connect(15s) + switchRoom(10s→4s) while
     // the user is staring at a spinner.
     if (this.roomIsReady(roomJid) && this.xmpp) {
-      return {
-        id: messaging.sendGroupMessage(this.xmpp, roomJid, body, opts),
-        state: "sending",
-      };
+      const id = messaging.sendGroupMessage(this.xmpp, roomJid, body, opts);
+      this.recordPendingSend(id, "room");
+      return { id, state: "sending" };
     }
 
     const queued = this.queueRoomMessage(roomJid, body, opts);
@@ -792,10 +908,9 @@ export class BrowserXmppClient {
     // the 15s `Reconnection timed out` path used to block the Send
     // button under a bad network.
     if (this.canUseConnectedSession() && this.xmpp) {
-      return {
-        id: dmMessaging.sendDirectMessage(this.xmpp, normalizedPeerJid, body, opts),
-        state: "sending",
-      };
+      const id = dmMessaging.sendDirectMessage(this.xmpp, normalizedPeerJid, body, opts);
+      this.recordPendingSend(id, "dm");
+      return { id, state: "sending" };
     }
 
     const queued = this.queueDirectMessage(normalizedPeerJid, body, opts);
@@ -1072,7 +1187,7 @@ export class BrowserXmppClient {
       if (this.xmpp !== xmpp) return;
       this.connected = true;
       this.startKeepAlive(xmpp);
-      this.statusHandler?.({
+      this.emitStatus({
         state: "online",
         detail: countQueuedMessages(this.queueScope) > 0 ? "Reconnected — replaying queued messages" : "Connection ready",
       });
@@ -1084,7 +1199,7 @@ export class BrowserXmppClient {
       // buffer; anything we thought was in flight is gone. Clear the
       // inflight set so the next flush re-sends all persisted entries.
       this.inflightQueuedIds.clear();
-      this.sessionLifecycleHandler?.({ type: "fresh" });
+      this.emitSessionLifecycle({ type: "fresh" });
       void this.flushQueuedDirectMessages();
       try {
         await xmpp.enableCarbons();
@@ -1123,11 +1238,11 @@ export class BrowserXmppClient {
       if (this.xmpp !== xmpp) return;
       this.connected = true;
       this.startKeepAlive(xmpp);
-      this.statusHandler?.({
+      this.emitStatus({
         state: "online",
         detail: countQueuedMessages(this.queueScope) > 0 ? "Connection resumed — replaying queued messages" : "Connection resumed",
       });
-      this.sessionLifecycleHandler?.({ type: "resumed" });
+      this.emitSessionLifecycle({ type: "resumed" });
       void this.flushQueuedDirectMessages();
       if (this.currentRoom) {
         void this.flushQueuedRoomMessages(this.currentRoom);
@@ -1146,18 +1261,25 @@ export class BrowserXmppClient {
     // wiping messages out of localStorage before they were durable.
     xmpp.on("message:acked", (msg) => {
       if (this.xmpp !== xmpp) return;
-      if (msg?.id) {
-        // Only touch localStorage for ids that originated from the
-        // persisted queue. `inflightQueuedIds` is the authoritative
-        // set of handed-off-from-localStorage ids; anything else is a
-        // live-send ack and doesn't belong in the persistence layer.
-        // `Set.prototype.delete` returns true iff the id was present,
-        // so this gate is also the inflight-removal step.
-        if (this.inflightQueuedIds.delete(msg.id)) {
-          removeQueuedMessage(this.queueScope, msg.id);
-        }
-        this.messageAckHandler?.(msg.id);
+      if (!msg?.id) return;
+      // Only touch localStorage for ids that originated from the
+      // persisted queue. `inflightQueuedIds` is the authoritative
+      // set of handed-off-from-localStorage ids; anything else is a
+      // live-send ack and doesn't belong in the persistence layer.
+      // `Set.prototype.delete` returns true iff the id was present,
+      // so this gate is also the inflight-removal step.
+      const wasQueued = this.inflightQueuedIds.delete(msg.id);
+      if (wasQueued) {
+        removeQueuedMessage(this.queueScope, msg.id);
       }
+      this.messageAckHandler?.(msg.id);
+      const pending = this.pendingSendAt.get(msg.id);
+      if (pending) {
+        this.pendingSendAt.delete(msg.id);
+        const latencyMs = performance.now() - pending.at;
+        this.fireHook(this.messageAckHooks, msg.id, { kind: pending.kind, latencyMs });
+      }
+      if (wasQueued) this.emitQueueDepth("room");
     });
 
     // XEP-0198: stanza.js emits message:failed when SM resume fails (server
@@ -1170,10 +1292,13 @@ export class BrowserXmppClient {
     // get re-sent.
     xmpp.on("message:failed", (msg) => {
       if (this.xmpp !== xmpp) return;
-      if (msg?.id) {
-        this.inflightQueuedIds.delete(msg.id);
-        this.messageDeliveryFailureHandler?.(msg.id);
-      }
+      if (!msg?.id) return;
+      this.inflightQueuedIds.delete(msg.id);
+      this.messageDeliveryFailureHandler?.(msg.id);
+      const pending = this.pendingSendAt.get(msg.id);
+      const kind = pending?.kind ?? "room";
+      this.pendingSendAt.delete(msg.id);
+      this.fireHook(this.messageFailHooks, msg.id, { kind });
     });
 
     xmpp.on("disconnected", (err) => {
@@ -1194,10 +1319,10 @@ export class BrowserXmppClient {
         this.hatsHandler?.({});
         this.roomPresence = {};
         this.presenceHandler?.({});
-        this.statusHandler?.({ state: "offline", detail: err?.message ?? "Disconnected" });
+        this.emitStatus({ state: "offline", detail: err?.message ?? "Disconnected" });
       } else {
         // Unexpected drop — keep xmpp + currentRoom alive for auto-reconnect.
-        this.statusHandler?.({
+        this.emitStatus({
           state: "reconnecting",
           detail: countQueuedMessages(this.queueScope) > 0
             ? "Connection lost — queued messages will send when reconnected"
@@ -1213,14 +1338,14 @@ export class BrowserXmppClient {
         this.destroying = true;
       }
       const detail = err?.message ?? condition ?? "Stream error";
-      this.statusHandler?.({ state: fatal ? "error" : "reconnecting", detail });
+      this.emitStatus({ state: fatal ? "error" : "reconnecting", detail });
       console.error("XMPP stream error", detail);
     });
     xmpp.on("auth:failed" as any, async () => {
       if (this.xmpp !== xmpp) return;
       if (!this.refreshSession) {
         this.destroying = true;
-        this.statusHandler?.({ state: "error", detail: "Session expired. Please log in again." });
+        this.emitStatus({ state: "error", detail: "Session expired. Please log in again." });
         return;
       }
       try {
@@ -1229,11 +1354,11 @@ export class BrowserXmppClient {
           this.updateSession(refreshed, xmpp);
         } else {
           this.destroying = true;
-          this.statusHandler?.({ state: "error", detail: "Session expired. Please log in again." });
+          this.emitStatus({ state: "error", detail: "Session expired. Please log in again." });
         }
       } catch {
         this.destroying = true;
-        this.statusHandler?.({ state: "error", detail: "Session expired. Please log in again." });
+        this.emitStatus({ state: "error", detail: "Session expired. Please log in again." });
       }
     });
 

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -1,0 +1,42 @@
+/**
+ * Glue between `BrowserXmppClient`'s telemetry hook API and Grafana Faro.
+ *
+ * Every function this installs is a no-op when Faro isn't initialized —
+ * the SDK wrapper in `@/lib/telemetry` handles that at the report-site,
+ * so tests and non-prod builds can `installInstrumentation()` freely
+ * without any beacon traffic.
+ */
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import {
+  reportMessageAcked,
+  reportMessageFailed,
+  reportQueueDepthChange,
+  reportSendEnqueued,
+  reportSessionLifecycle,
+  reportStatusChange,
+} from "@/lib/telemetry";
+
+export function installInstrumentation(client: BrowserXmppClient): void {
+  client.onMessageAcked((id, meta) => {
+    reportMessageAcked({ id, kind: meta.kind, latencyMs: meta.latencyMs });
+  });
+  client.onMessageDeliveryFailed((id, meta) => {
+    reportMessageFailed({ id, kind: meta.kind });
+  });
+  client.onSessionLifecycle((event) => {
+    reportSessionLifecycle({ type: event.type });
+  });
+  client.onStatus((status, meta) => {
+    reportStatusChange({
+      state: status.state,
+      detail: status.detail,
+      reconnectDurationMs: meta.reconnectDurationMs,
+    });
+  });
+  client.onSendEnqueued((info) => {
+    reportSendEnqueued({ kind: info.kind, reason: info.reason });
+  });
+  client.onQueueDepthChange((depth) => {
+    reportQueueDepthChange(depth);
+  });
+}

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import {
+  __setFaroForTesting,
+  initTelemetry,
+  reportMessageAcked,
+  reportMessageFailed,
+  reportQueueDepthChange,
+  reportSendEnqueued,
+  reportSessionLifecycle,
+  reportStatusChange,
+} from "../src/lib/telemetry";
+import { installInstrumentation } from "../src/lib/xmpp/xmpp-instrumentation";
+
+function session(partial: Partial<WaddleSession> = {}): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/xmpp",
+    ...partial,
+  } as WaddleSession;
+}
+
+function createStorageMock() {
+  const values = new Map<string, string>();
+  return {
+    getItem(key: string) {
+      return values.has(key) ? values.get(key)! : null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    clear() {
+      values.clear();
+    },
+  };
+}
+
+/**
+ * Minimal Faro API stub that records every pushEvent / pushMeasurement
+ * call. The telemetry module never reaches into the full Faro instance
+ * beyond `faro.api.*`, so mirroring the `api` surface is enough.
+ */
+function createFaroStub() {
+  const events: Array<{ name: string; attributes?: Record<string, string> }> = [];
+  const measurements: Array<{
+    type: string;
+    values: Record<string, number>;
+    context?: Record<string, string>;
+  }> = [];
+  return {
+    events,
+    measurements,
+    api: {
+      pushEvent: (name: string, attributes?: Record<string, string>) => {
+        events.push({ name, attributes });
+      },
+      pushMeasurement: (payload: {
+        type: string;
+        values: Record<string, number>;
+        context?: Record<string, string>;
+      }) => {
+        measurements.push(payload);
+      },
+    },
+  };
+}
+
+const originalWindow = globalThis.window;
+const originalLocalStorage = globalThis.localStorage;
+
+beforeEach(() => {
+  const storage = createStorageMock();
+  (globalThis as typeof globalThis & { localStorage: typeof storage }).localStorage = storage;
+  (globalThis as typeof globalThis & { window: Window & { localStorage: typeof storage } }).window = {
+    ...(originalWindow ?? {}),
+    localStorage: storage,
+  } as Window & { localStorage: typeof storage };
+  localStorage.clear();
+  __setFaroForTesting(null);
+});
+
+afterEach(() => {
+  localStorage.clear();
+  __setFaroForTesting(null);
+  if (originalLocalStorage === undefined) {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  } else {
+    (globalThis as typeof globalThis & { localStorage: Storage }).localStorage = originalLocalStorage;
+  }
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+  } else {
+    (globalThis as typeof globalThis & { window: Window & typeof globalThis }).window = originalWindow;
+  }
+});
+
+describe("telemetry module no-op behaviour", () => {
+  test("initTelemetry without a URL is a no-op and never throws", () => {
+    expect(() =>
+      initTelemetry({ url: "", appName: "test" }),
+    ).not.toThrow();
+  });
+
+  test("report functions are no-ops when Faro has not been initialized", () => {
+    // Nothing to assert beyond 'must not throw' — if these hit undefined
+    // faro refs the chat would blow up on every send in local dev.
+    expect(() => {
+      reportMessageAcked({ id: "x", kind: "room", latencyMs: 5 });
+      reportMessageFailed({ id: "x", kind: "dm" });
+      reportSendEnqueued({ kind: "room", reason: "offline" });
+      reportQueueDepthChange({ persisted: 0, inflight: 0 });
+      reportSessionLifecycle({ type: "fresh" });
+      reportStatusChange({ state: "online" });
+    }).not.toThrow();
+  });
+
+  test("report functions forward to Faro api when initialized", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    reportMessageAcked({ id: "m-1", kind: "room", latencyMs: 123.4 });
+    reportMessageFailed({ id: "m-2", kind: "dm" });
+    reportSendEnqueued({ kind: "dm", reason: "offline" });
+    reportQueueDepthChange({ persisted: 2, inflight: 1 });
+    reportSessionLifecycle({ type: "resumed" });
+    reportStatusChange({ state: "reconnecting", detail: "lost" });
+    reportStatusChange({ state: "online", reconnectDurationMs: 4_321 });
+
+    const eventNames = stub.events.map((e) => e.name);
+    expect(eventNames).toEqual([
+      "chat.xmpp.message.acked",
+      "chat.xmpp.message.failed",
+      "chat.xmpp.send.enqueued",
+      "chat.xmpp.session.lifecycle",
+      "chat.xmpp.status",
+      "chat.xmpp.status",
+    ]);
+
+    const measurementTypes = stub.measurements.map((m) => m.type);
+    expect(measurementTypes).toEqual([
+      "chat.xmpp.message.acked.latency_ms",
+      "chat.xmpp.queue.depth",
+      "chat.xmpp.reconnect.duration_ms",
+    ]);
+
+    const ackMeasurement = stub.measurements[0];
+    expect(ackMeasurement.values.latency_ms).toBe(123.4);
+    expect(ackMeasurement.context).toEqual({ kind: "room" });
+
+    const depthMeasurement = stub.measurements[1];
+    expect(depthMeasurement.values).toEqual({ persisted: 2, inflight: 1 });
+
+    const reconnectMeasurement = stub.measurements[2];
+    expect(reconnectMeasurement.values.duration_ms).toBe(4_321);
+  });
+});
+
+describe("BrowserXmppClient telemetry hooks", () => {
+  test("hooks fire in addition to primary handlers", () => {
+    const client = new BrowserXmppClient(session());
+
+    const primaryAcks: string[] = [];
+    const hookAcks: Array<{ id: string; kind: "room" | "dm"; latencyMs: number }> = [];
+    client.setMessageAckHandler((id) => primaryAcks.push(id));
+    client.onMessageAcked((id, meta) => hookAcks.push({ id, kind: meta.kind, latencyMs: meta.latencyMs }));
+
+    // Stub the pending-send bookkeeping by simulating a flush that
+    // added an inflight entry plus a pending timestamp, then emit ack.
+    const internal = client as unknown as {
+      inflightQueuedIds: Set<string>;
+      pendingSendAt: Map<string, { at: number; kind: "room" | "dm" }>;
+      xmpp: { on: (name: string, fn: (msg: unknown) => void) => void; emit: (name: string, msg: unknown) => void };
+      wireEvents: (xmpp: unknown) => void;
+    };
+    const handlers = new Map<string, Array<(msg: unknown) => void>>();
+    const stubXmpp = {
+      on(event: string, handler: (msg: unknown) => void) {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      emit(event: string, msg: unknown) {
+        for (const h of handlers.get(event) ?? []) h(msg);
+      },
+    };
+    internal.xmpp = stubXmpp as never;
+    internal.wireEvents(stubXmpp);
+    internal.inflightQueuedIds.add("room-1");
+    internal.pendingSendAt.set("room-1", { at: performance.now() - 42, kind: "room" });
+
+    stubXmpp.emit("message:acked", { id: "room-1" });
+
+    expect(primaryAcks).toEqual(["room-1"]);
+    expect(hookAcks).toHaveLength(1);
+    expect(hookAcks[0].id).toBe("room-1");
+    expect(hookAcks[0].kind).toBe("room");
+    expect(hookAcks[0].latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("installInstrumentation forwards client hooks to Faro api", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    const internal = client as unknown as {
+      inflightQueuedIds: Set<string>;
+      pendingSendAt: Map<string, { at: number; kind: "room" | "dm" }>;
+      xmpp: unknown;
+      wireEvents: (xmpp: unknown) => void;
+      emitStatus: (snap: { state: string; detail?: string }) => void;
+      emitSessionLifecycle: (evt: { type: "fresh" | "resumed" }) => void;
+    };
+    const handlers = new Map<string, Array<(msg: unknown) => void>>();
+    const stubXmpp = {
+      on(event: string, handler: (msg: unknown) => void) {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      emit(event: string, msg: unknown) {
+        for (const h of handlers.get(event) ?? []) h(msg);
+      },
+    };
+    internal.xmpp = stubXmpp;
+    internal.wireEvents(stubXmpp);
+    internal.inflightQueuedIds.add("dm-9");
+    internal.pendingSendAt.set("dm-9", { at: performance.now() - 10, kind: "dm" });
+
+    // Ack → Faro event + measurement
+    (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "dm-9" });
+    // Fail → Faro event
+    (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:failed", { id: "live-1" });
+    // Session lifecycle + status
+    internal.emitSessionLifecycle({ type: "resumed" });
+    internal.emitStatus({ state: "reconnecting", detail: "ws dropped" });
+    internal.emitStatus({ state: "online", detail: "back" });
+
+    const eventNames = stub.events.map((e) => e.name);
+    expect(eventNames).toContain("chat.xmpp.message.acked");
+    expect(eventNames).toContain("chat.xmpp.message.failed");
+    expect(eventNames).toContain("chat.xmpp.session.lifecycle");
+    expect(eventNames.filter((n) => n === "chat.xmpp.status")).toHaveLength(2);
+
+    const reconnectMeasurement = stub.measurements.find(
+      (m) => m.type === "chat.xmpp.reconnect.duration_ms",
+    );
+    expect(reconnectMeasurement).toBeDefined();
+    expect(reconnectMeasurement?.values.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test("enqueuing a send fires onSendEnqueued + onQueueDepthChange", async () => {
+    const client = new BrowserXmppClient(session());
+    // Force the slow path: make connect throw so we stay in "no-client" reason.
+    (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => {
+      throw new Error("Reconnection timed out");
+    });
+    (client as unknown as { switchRoom: ReturnType<typeof mock> }).switchRoom = mock(async () => {
+      throw new Error("Reconnection timed out");
+    });
+
+    const enqueued: Array<{ kind: string; reason: string }> = [];
+    const depths: Array<{ persisted: number; inflight: number }> = [];
+    client.onSendEnqueued((info) => enqueued.push(info));
+    client.onQueueDepthChange((d) => depths.push(d));
+
+    await client.sendDirectMessage("bob@example.com", "hi", { id: "dm-queued-1" });
+
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0].kind).toBe("dm");
+    expect(depths).toHaveLength(1);
+    expect(depths[0].persisted).toBe(1);
+  });
+
+  test("hook exceptions are swallowed and do not break chat", () => {
+    const client = new BrowserXmppClient(session());
+    client.onMessageAcked(() => {
+      throw new Error("hook failure");
+    });
+
+    const internal = client as unknown as {
+      inflightQueuedIds: Set<string>;
+      pendingSendAt: Map<string, { at: number; kind: "room" | "dm" }>;
+      xmpp: unknown;
+      wireEvents: (xmpp: unknown) => void;
+    };
+    const handlers = new Map<string, Array<(msg: unknown) => void>>();
+    const stubXmpp = {
+      on(event: string, handler: (msg: unknown) => void) {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      emit(event: string, msg: unknown) {
+        for (const h of handlers.get(event) ?? []) h(msg);
+      },
+    };
+    internal.xmpp = stubXmpp;
+    internal.wireEvents(stubXmpp);
+    internal.pendingSendAt.set("m-bad", { at: performance.now(), kind: "dm" });
+
+    expect(() => {
+      (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "m-bad" });
+    }).not.toThrow();
+  });
+});

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -233,6 +233,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
     internal.wireEvents(stubXmpp);
     internal.inflightQueuedIds.add("dm-9");
     internal.pendingSendAt.set("dm-9", { at: performance.now() - 10, kind: "dm" });
+    // Record the pending kind so the failure hook reports it truthfully.
+    internal.pendingSendAt.set("live-1", { at: performance.now() - 5, kind: "dm" });
 
     // Ack → Faro event + measurement
     (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "dm-9" });
@@ -309,5 +311,104 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(() => {
       (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "m-bad" });
     }).not.toThrow();
+  });
+
+  test("message:failed emits queue depth and preserves recorded DM kind", () => {
+    const client = new BrowserXmppClient(session());
+
+    const fails: Array<{ id: string; kind: "room" | "dm" }> = [];
+    const depths: Array<{ persisted: number; inflight: number }> = [];
+    client.onMessageDeliveryFailed((id, meta) => fails.push({ id, kind: meta.kind }));
+    client.onQueueDepthChange((d) => depths.push(d));
+
+    const internal = client as unknown as {
+      inflightQueuedIds: Set<string>;
+      pendingSendAt: Map<string, { at: number; kind: "room" | "dm" }>;
+      xmpp: unknown;
+      wireEvents: (xmpp: unknown) => void;
+    };
+    const handlers = new Map<string, Array<(msg: unknown) => void>>();
+    const stubXmpp = {
+      on(event: string, handler: (msg: unknown) => void) {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      emit(event: string, msg: unknown) {
+        for (const h of handlers.get(event) ?? []) h(msg);
+      },
+    };
+    internal.xmpp = stubXmpp;
+    internal.wireEvents(stubXmpp);
+    internal.inflightQueuedIds.add("dm-fail-1");
+    internal.pendingSendAt.set("dm-fail-1", { at: performance.now(), kind: "dm" });
+
+    stubXmpp.emit("message:failed", { id: "dm-fail-1" });
+
+    expect(fails).toEqual([{ id: "dm-fail-1", kind: "dm" }]);
+    expect(depths).toHaveLength(1);
+    expect(depths[0].inflight).toBe(0);
+  });
+
+  test("message:failed without a recorded pending entry does not fire the failure hook", () => {
+    const client = new BrowserXmppClient(session());
+
+    const fails: string[] = [];
+    client.onMessageDeliveryFailed((id) => fails.push(id));
+
+    const internal = client as unknown as {
+      xmpp: unknown;
+      wireEvents: (xmpp: unknown) => void;
+    };
+    const handlers = new Map<string, Array<(msg: unknown) => void>>();
+    const stubXmpp = {
+      on(event: string, handler: (msg: unknown) => void) {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      },
+      emit(event: string, msg: unknown) {
+        for (const h of handlers.get(event) ?? []) h(msg);
+      },
+    };
+    internal.xmpp = stubXmpp;
+    internal.wireEvents(stubXmpp);
+
+    stubXmpp.emit("message:failed", { id: "orphan" });
+
+    expect(fails).toEqual([]);
+  });
+
+  test("reconnect duration is only reported on reconnecting → online", () => {
+    const client = new BrowserXmppClient(session());
+
+    const reconnectDurations: number[] = [];
+    client.onStatus((_snap, meta) => {
+      if (meta.reconnectDurationMs !== undefined) {
+        reconnectDurations.push(meta.reconnectDurationMs);
+      }
+    });
+
+    const internal = client as unknown as {
+      emitStatus: (snap: { state: string; detail?: string }) => void;
+    };
+
+    // reconnecting → offline: should NOT emit a duration.
+    internal.emitStatus({ state: "reconnecting" });
+    internal.emitStatus({ state: "offline" });
+    expect(reconnectDurations).toEqual([]);
+
+    // reconnecting → online: SHOULD emit a duration.
+    internal.emitStatus({ state: "reconnecting" });
+    internal.emitStatus({ state: "online" });
+    expect(reconnectDurations).toHaveLength(1);
+    expect(reconnectDurations[0]).toBeGreaterThanOrEqual(0);
+
+    // reconnecting → error: should NOT emit, and should reset the timer
+    // so a subsequent bare `online` doesn't retroactively emit.
+    internal.emitStatus({ state: "reconnecting" });
+    internal.emitStatus({ state: "error", detail: "fatal" });
+    internal.emitStatus({ state: "online" });
+    expect(reconnectDurations).toHaveLength(1);
   });
 });

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/external-secret.yaml
@@ -1,0 +1,44 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: grafana-cloud-credentials
+  namespace: grafana-alloy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: grafana-cloud-credentials
+    creationPolicy: Owner
+  data:
+    # Grafana Cloud OTLP HTTP endpoint and basic-auth instance id / API
+    # token. Used by `otelcol.exporter.otlphttp "grafana_cloud"` for
+    # traces and OTLP-native metrics from waddle-server.
+    - secretKey: OTLP_ENDPOINT
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: otlp-endpoint
+    - secretKey: OTLP_USERNAME
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: otlp-username
+    - secretKey: OTLP_PASSWORD
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: otlp-password
+    # Grafana Cloud Mimir remote_write URL + basic-auth. Used by
+    # `prometheus.remote_write "grafana_cloud"` for metrics scraped
+    # from waddle-server's /metrics endpoint.
+    - secretKey: MIMIR_URL
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: mimir-url
+    - secretKey: MIMIR_USERNAME
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: mimir-username
+    - secretKey: MIMIR_PASSWORD
+      remoteRef:
+        key: grafana-cloud-credentials
+        property: mimir-password

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -1,0 +1,142 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana-alloy
+  namespace: grafana-alloy
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: alloy
+      version: 1.0.x
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: grafana-alloy
+      interval: 12h
+  values:
+    # Stateless collector — one replica is enough for a single-pod
+    # waddle-server deployment; scale up when that changes.
+    controller:
+      type: deployment
+      replicas: 1
+    # Default service (ClusterIP) exposes 12345 for Alloy's own UI and
+    # 4317/4318 via otelcol.receiver.otlp below.
+    alloy:
+      # The Alloy config below is what actually does the work. Env vars
+      # referenced via env("…") come from `envFrom` on the container.
+      configMap:
+        create: true
+        content: |
+          logging {
+            level  = "info"
+            format = "json"
+          }
+
+          // ---------- OTLP receive from waddle-server ----------
+          otelcol.receiver.otlp "default" {
+            grpc {
+              endpoint = "0.0.0.0:4317"
+            }
+            http {
+              endpoint = "0.0.0.0:4318"
+            }
+            output {
+              metrics = [otelcol.processor.batch.default.input]
+              traces  = [otelcol.processor.batch.default.input]
+              logs    = [otelcol.processor.batch.default.input]
+            }
+          }
+
+          otelcol.processor.batch "default" {
+            output {
+              metrics = [otelcol.exporter.otlphttp.grafana_cloud.input]
+              traces  = [otelcol.exporter.otlphttp.grafana_cloud.input]
+              logs    = [otelcol.exporter.otlphttp.grafana_cloud.input]
+            }
+          }
+
+          // ---------- OTLP export to Grafana Cloud ----------
+          otelcol.auth.basic "grafana_cloud" {
+            username = sys.env("OTLP_USERNAME")
+            password = sys.env("OTLP_PASSWORD")
+          }
+
+          otelcol.exporter.otlphttp "grafana_cloud" {
+            client {
+              endpoint = sys.env("OTLP_ENDPOINT")
+              auth     = otelcol.auth.basic.grafana_cloud.handler
+            }
+          }
+
+          // ---------- Prometheus scrape of waddle-server /metrics ----------
+          // waddle-server's Service exposes port `http` (3000) which the
+          // Rust server binds for both the HTTP API and the Prometheus
+          // text /metrics endpoint rendered from waddle-xmpp::prometheus.
+          discovery.kubernetes "waddle_server" {
+            role = "endpoints"
+            namespaces {
+              names = ["waddle"]
+            }
+          }
+
+          discovery.relabel "waddle_server" {
+            targets = discovery.kubernetes.waddle_server.targets
+            rule {
+              source_labels = ["__meta_kubernetes_service_name"]
+              action        = "keep"
+              regex         = "waddle-server"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_endpoint_port_name"]
+              action        = "keep"
+              regex         = "http"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "instance"
+            }
+            rule {
+              target_label = "job"
+              replacement  = "waddle-server"
+            }
+          }
+
+          prometheus.scrape "waddle_server" {
+            targets         = discovery.relabel.waddle_server.output
+            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            metrics_path    = "/metrics"
+            scrape_interval = "30s"
+          }
+
+          prometheus.remote_write "grafana_cloud" {
+            endpoint {
+              url = sys.env("MIMIR_URL")
+              basic_auth {
+                username = sys.env("MIMIR_USERNAME")
+                password = sys.env("MIMIR_PASSWORD")
+              }
+            }
+          }
+      # Inject Grafana Cloud creds from the ExternalSecret.
+      extraEnvFrom:
+        - secretRef:
+            name: grafana-cloud-credentials
+      # Expose OTLP receivers so waddle-server (cluster-internal) can
+      # reach them via the default alloy Service at alloy.grafana-alloy.svc.
+      extraPorts:
+        - name: otlp-grpc
+          port: 4317
+          targetPort: 4317
+          protocol: TCP
+        - name: otlp-http
+          port: 4318
+          targetPort: 4318
+          protocol: TCP
+    # Alloy needs read access to Service / Endpoint objects across the
+    # cluster for the discovery.kubernetes target above. The chart's
+    # default RBAC already grants this when `rbac.create=true`.
+    rbac:
+      create: true
+    serviceAccount:
+      create: true

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
     # 4317/4318 via otelcol.receiver.otlp below.
     alloy:
       # The Alloy config below is what actually does the work. Env vars
-      # referenced via env("…") come from `envFrom` on the container.
+      # referenced via sys.env("…") come from `envFrom` on the container.
       configMap:
         create: true
         content: |
@@ -123,7 +123,8 @@ spec:
         - secretRef:
             name: grafana-cloud-credentials
       # Expose OTLP receivers so waddle-server (cluster-internal) can
-      # reach them via the default alloy Service at alloy.grafana-alloy.svc.
+      # reach them via the default alloy Service at
+      # grafana-alloy.grafana-alloy.svc.cluster.local.
       extraPorts:
         - name: otlp-grpc
           port: 4317

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrepository.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: grafana-alloy
+spec:
+  interval: 12h
+  url: https://grafana.github.io/helm-charts

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - external-secret.yaml

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/namespace.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana-alloy

--- a/infrastructure/waddle.cloud/gitops/kustomization-infra-grafana-alloy.yaml
+++ b/infrastructure/waddle.cloud/gitops/kustomization-infra-grafana-alloy.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-grafana-alloy
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-onepassword-connect
+  interval: 10m
+  retryInterval: 1m
+  timeout: 15m
+  path: ./grafana-alloy
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: bootstrap
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: grafana-alloy
+      namespace: grafana-alloy

--- a/infrastructure/waddle.cloud/gitops/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - kustomization-infra-onepassword-connect.yaml
   - kustomization-infra-cert-manager.yaml
   - kustomization-infra-external-dns.yaml
+  - kustomization-infra-grafana-alloy.yaml
   - kustomization-infra-cloudnative-pg.yaml
   - kustomization-infra-spicedb-operator-source.yaml
   - kustomization-infra-spicedb-operator.yaml

--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -27,6 +27,17 @@ spec:
       s3Bucket: "waddle-social-files"
     extraSecretRefs:
       - waddle-r2-credentials
+    # Ship traces + OTel-native metrics to Grafana Cloud via the
+    # in-cluster Alloy collector. `telemetry.rs` reads these env vars
+    # (default endpoint was `localhost:4317`, which silently dropped
+    # everything before this was wired up).
+    containerExtraEnv:
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: "http://grafana-alloy.grafana-alloy.svc.cluster.local:4317"
+      - name: OTEL_EXPORTER_OTLP_PROTOCOL
+        value: "grpc"
+      - name: OTEL_SERVICE_NAME
+        value: "waddle-server"
     xmpp:
       domain: waddle.social
       mamDbPath: /data/mam.db

--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -30,14 +30,15 @@ spec:
     # Ship traces + OTel-native metrics to Grafana Cloud via the
     # in-cluster Alloy collector. `telemetry.rs` reads these env vars
     # (default endpoint was `localhost:4317`, which silently dropped
-    # everything before this was wired up).
+    # everything before this was wired up). Chart-modelled keys go in
+    # `telemetry`; `containerExtraEnv` is reserved for settings the
+    # chart doesn't model (currently just the OTLP protocol).
+    telemetry:
+      otlpEndpoint: "http://grafana-alloy.grafana-alloy.svc.cluster.local:4317"
+      serviceName: "waddle-server"
     containerExtraEnv:
-      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-        value: "http://grafana-alloy.grafana-alloy.svc.cluster.local:4317"
       - name: OTEL_EXPORTER_OTLP_PROTOCOL
         value: "grpc"
-      - name: OTEL_SERVICE_NAME
-        value: "waddle-server"
     xmpp:
       domain: waddle.social
       mamDbPath: /data/mam.db


### PR DESCRIPTION
## Summary

Follow-up to #166. The silent-drop counters shipped there, plus the existing OpenTelemetry wiring in `server/crates/waddle-server/src/telemetry.rs`, all dropped on the floor in prod — no `OTEL_*` env vars on the pod, no in-cluster collector, and no Prometheus scraper. This PR wires both ends into an existing Grafana Cloud stack:

- **Server-side**: deploy Grafana Alloy in-cluster; Alloy receives OTLP from `waddle-server` on `:4317` and scrapes its `/metrics` endpoint, then forwards everything to Grafana Cloud via `otelcol.exporter.otlphttp` + `prometheus.remote_write`.
- **Frontend**: instrument the browser chat with `@grafana/faro-web-sdk` so every message-drop symptom identified in the #166 audit becomes a Grafana-queryable signal from the user side.

### Infra (commit `d9b59e5`)

- New `infrastructure/waddle.cloud/gitops/grafana-alloy/` directory cloning the `external-dns` layout exactly: namespace + HelmRepository (`https://grafana.github.io/helm-charts`) + HelmRelease + ExternalSecret + kustomization.
- Inline Alloy HCL config does: OTLP receive on 4317/4318, `discovery.kubernetes` + `prometheus.scrape` against the waddle-server Service's `http` port, `otelcol.processor.batch`, and two Grafana Cloud exporters (OTLP HTTP + Mimir `remote_write`).
- `kustomization-infra-grafana-alloy.yaml` + index in root `kustomization.yaml` — same Flux pattern as `infra-external-dns`.
- `waddle-server/helmrelease.yaml`: `containerExtraEnv` adds `OTEL_EXPORTER_OTLP_ENDPOINT=http://grafana-alloy.grafana-alloy.svc.cluster.local:4317`, `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`, `OTEL_SERVICE_NAME=waddle-server`. No Rust code change — `telemetry.rs` already reads these.

### Frontend (commit `…`)

- `chat/src/lib/telemetry.ts` — thin Faro wrapper. `initTelemetry` gated on `import.meta.env.PUBLIC_FARO_URL`; no-op until it's set in Cloudflare Pages.
- `chat/src/lib/xmpp/client.ts` — parallel hook arrays + helpers. Primary `set*Handler` callbacks are untouched; hooks fire alongside. New `pendingSendAt` Map keyed by stanza id computes end-to-end send latency on `message:acked`. New `reconnectStartedAt` timestamp computes `reconnecting → online` duration. Hook exceptions are swallowed so telemetry bugs never break chat.
- `chat/src/lib/xmpp/xmpp-instrumentation.ts` — glue between the hooks and Faro's `pushEvent` / `pushMeasurement`.
- `chat/src/components/XmppProvider.vue` — `installInstrumentation(client)` right after construction.
- `chat/src/layouts/AppLayout.astro` — client-side `<script>` calls `initTelemetry` from `PUBLIC_FARO_URL` / `PUBLIC_FARO_APP_NAME` / `PUBLIC_COMMIT_SHA`.
- `chat/src/env.d.ts` — declares the new `PUBLIC_*` env keys.
- Removes the dead `shouldQueueImmediately` helper left over from #166.

### Tests (commit `8f98ca2`)

New `chat/tests/xmpp-telemetry.test.ts` covers:
- `initTelemetry("")` is a no-op and never throws.
- All six `report*` functions are no-ops before init.
- Injecting a Faro stub via `__setFaroForTesting` and asserting the exact event name set + measurement shapes pins the public signal contract.
- `BrowserXmppClient` hooks fire in addition to primary handlers on `message:acked`.
- `installInstrumentation` routes the five lifecycle hooks into Faro correctly.
- Enqueuing a send on the slow path emits `onSendEnqueued` + `onQueueDepthChange`.
- A throwing hook is swallowed and does not propagate out of the xmpp event.

## Drop-detection signal table

| Signal | Source | Faro | Drop indicator |
|---|---|---|---|
| `chat.xmpp.message.failed` | `xmpp.on("message:failed")` | event | stanza.js gave up after resume failure |
| `chat.xmpp.message.acked.latency_ms` | ack timestamp − send timestamp | measurement | P95 blowing up = send path degraded |
| `chat.xmpp.queue.depth` | `countQueuedMessages` + inflight set | measurement | sustained non-zero = flush stuck |
| `chat.xmpp.session.lifecycle` | fresh / resumed events | event | ratio ~1:0 = SM resume broken (what #164 fixed) |
| `chat.xmpp.reconnect.duration_ms` | time in `reconnecting` | measurement | P50 seconds = chronic reconnect churn |
| `chat.xmpp.send.enqueued` | slow-path in `sendGroupMessage` / `sendDirectMessage` | event | spike = users sending faster than we stay ready |

Together with the server-side counters (`waddle_broadcast_dropped_full_total`, `waddle_sm_unacked_evicted_total`, `waddle_broadcast_not_connected_total`), this covers both ends of every drop pattern the #166 audit surfaced.

## Before this merges — user action required

1. **1Password item `grafana-cloud-credentials`**: make sure these property names exist, or rename in `grafana-alloy/external-secret.yaml`:
   - `otlp-endpoint`, `otlp-username`, `otlp-password` (Grafana Cloud OTLP HTTP)
   - `mimir-url`, `mimir-username`, `mimir-password` (Grafana Cloud Mimir `remote_write`)
2. **Cloudflare Pages env** for the chat app:
   - `PUBLIC_FARO_URL` — Faro collector URL from Grafana Cloud Faro
   - `PUBLIC_FARO_APP_NAME` — e.g. `waddle-chat`

Missing any of the above makes the relevant half go silent (graceful degradation — nothing breaks).

## Test plan

- [x] `cargo test -p waddle-xmpp -p waddle-server` — still green after HelmRelease change (no Rust code touched).
- [x] `cargo build -p waddle-server` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bun test` in `chat/` — 243 pass (+7 new telemetry tests).
- [x] `bun run lint` (knip) in `chat/` — clean.
- [x] `bunx astro check` in `chat/` — 0 errors, 0 warnings, 0 hints.
- [ ] Post-merge: Flux reconciles `infra-grafana-alloy`, then the waddle-server pod restart picks up the new OTEL env vars.
- [ ] Grafana Cloud Explore:
  - PromQL `rate(waddle_broadcast_dropped_full_total[5m])` — reports.
  - Tempo finds traces under `service.name=waddle-server`.
  - Faro shows `chat.xmpp.*` events after opening the chat app.
- [ ] Devtools repro for drop detection: throttle WS to Offline, send a message, go back Online — confirm `chat.xmpp.send.enqueued` → `chat.xmpp.message.acked` lands with a representative `latency_ms` and a non-zero `chat.xmpp.reconnect.duration_ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)