### PR TITLE
fix(infra): use envFrom (not extraEnvFrom) in grafana-alloy HelmRelease

### DIFF
--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -119,7 +119,10 @@ spec:
             }
           }
       # Inject Grafana Cloud creds from the ExternalSecret.
-      extraEnvFrom:
+      # Chart key is `envFrom` (not `extraEnvFrom`); helm silently drops
+      # unknown values, so the typo left the alloy container with no
+      # OTLP_/MIMIR_ env vars and the config failed to evaluate.
+      envFrom:
         - secretRef:
             name: grafana-cloud-credentials
       # Expose OTLP receivers so waddle-server (cluster-internal) can


### PR DESCRIPTION
## Summary

- Rename `alloy.extraEnvFrom` → `alloy.envFrom` in `infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml`.
- Unblocks the `infra-grafana-alloy` Kustomization applied by #168, which is currently failing its Helm health gate in production.

## Why this is broken on main

The grafana/alloy chart (1.0.x) values schema defines `alloy.envFrom: []`; there is no `extraEnvFrom` key. Helm silently drops unknown values, so the `secretRef: grafana-cloud-credentials` added in #168 never made it onto the `alloy` container. The container came up with only `ALLOY_DEPLOY_MODE` and `HOSTNAME`, and the config evaluation failed:

```
Error: /etc/alloy/config.alloy:35:1: Failed to build component:
  decoding configuration: at least one endpoint must be specified
otelcol.exporter.otlphttp "grafana_cloud" {
  client {
    endpoint = sys.env("OTLP_ENDPOINT")   // ← empty string at runtime
    ...
```

Observed in cluster after #168 merged:

- `ExternalSecret grafana-cloud-credentials` — `SecretSynced` with keys `OTLP_ENDPOINT`, `OTLP_USERNAME`, `OTLP_PASSWORD`, `MIMIR_URL`, `MIMIR_USERNAME`, `MIMIR_PASSWORD` (all non-empty).
- `Pod grafana-alloy-...` — `CrashLoopBackOff`, `envFrom: []` on the alloy container.
- `Kustomization infra-grafana-alloy` — not Ready: `HelmRelease/grafana-alloy status: 'Failed'`.

Waddle-server (deployed by the same PR) is already rolled to `sha-e381a02` and is emitting OTLP to a receiver that isn't accepting traffic, so the "ship signals to Grafana Cloud" half of #168 is effectively a no-op in prod until this lands.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: `Container Image` workflow pushes new gitops OCI artifact.
- [ ] Flux `bootstrap` OCIRepository digest updates; `infra-grafana-alloy` Kustomization goes Ready.
- [ ] `kubectl -n grafana-alloy get pods` → `grafana-alloy-*` is `2/2 Running`, no restarts.
- [ ] `kubectl -n grafana-alloy exec ... -c alloy -- env | grep -E 'OTLP_|MIMIR_'` shows the 6 keys.
- [ ] Grafana Cloud receives `waddle-server` traces/metrics for service `waddle-server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)