### PR TITLE
refactor(infra): route alloy scrape via OTLP gateway, drop direct Mimir creds

### DIFF
--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/external-secret.yaml
@@ -27,18 +27,3 @@ spec:
       remoteRef:
         key: grafana-cloud-credentials
         property: otlp-password
-    # Grafana Cloud Mimir remote_write URL + basic-auth. Used by
-    # `prometheus.remote_write "grafana_cloud"` for metrics scraped
-    # from waddle-server's /metrics endpoint.
-    - secretKey: MIMIR_URL
-      remoteRef:
-        key: grafana-cloud-credentials
-        property: mimir-url
-    - secretKey: MIMIR_USERNAME
-      remoteRef:
-        key: grafana-cloud-credentials
-        property: mimir-username
-    - secretKey: MIMIR_PASSWORD
-      remoteRef:
-        key: grafana-cloud-credentials
-        property: mimir-password

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -104,24 +104,23 @@ spec:
 
           prometheus.scrape "waddle_server" {
             targets         = discovery.relabel.waddle_server.output
-            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to      = [otelcol.receiver.prometheus.waddle_server.receiver]
             metrics_path    = "/metrics"
             scrape_interval = "30s"
           }
 
-          prometheus.remote_write "grafana_cloud" {
-            endpoint {
-              url = sys.env("MIMIR_URL")
-              basic_auth {
-                username = sys.env("MIMIR_USERNAME")
-                password = sys.env("MIMIR_PASSWORD")
-              }
+          // Bridge Prometheus scrape samples into the OTLP pipeline so
+          // they ship through the Grafana Cloud OTLP gateway alongside
+          // traces and logs — one credential, one egress path.
+          otelcol.receiver.prometheus "waddle_server" {
+            output {
+              metrics = [otelcol.processor.batch.default.input]
             }
           }
-      # Inject Grafana Cloud creds from the ExternalSecret.
-      # Chart key is `envFrom` (not `extraEnvFrom`); helm silently drops
-      # unknown values, so the typo left the alloy container with no
-      # OTLP_/MIMIR_ env vars and the config failed to evaluate.
+      # Inject Grafana Cloud creds from the ExternalSecret. The chart key
+      # is `envFrom` (not `extraEnvFrom`); helm silently drops unknown
+      # values, so the typo would leave the alloy container with no
+      # OTLP_* env vars.
       envFrom:
         - secretRef:
             name: grafana-cloud-credentials


### PR DESCRIPTION
## Summary

- Replace `prometheus.remote_write.grafana_cloud` with an `otelcol.receiver.prometheus.waddle_server` bridge so scraped `waddle-server /metrics` flow through the existing OTLP batch processor and out via the Grafana Cloud OTLP gateway, alongside traces and logs.
- Drop `MIMIR_URL` / `MIMIR_USERNAME` / `MIMIR_PASSWORD` entries from the ExternalSecret — only `OTLP_*` creds are still referenced.

## Why

After #168 and #171 the alloy pod is running, but every Prometheus scrape gets **`401 "authentication error: invalid token"`** from `prometheus-prod-68-prod-eu-west-6.grafana.net/api/prom/push`. The `mimir-password` field in the `grafana-cloud-credentials` 1Password item contains the auto-generated **OTLP-scoped** access-policy token (internal name `stack-1602000-otlp-write-oltp-password`), which has no `metrics:write` authority against the Mimir API. Rather than mint a second access-policy token for direct Mimir, collapse everything onto the single working OTLP egress — one credential, one code path, fewer things to rotate.

## Follow-up (out of this PR)

The `mimir-url` / `mimir-username` / `mimir-password` fields in the 1Password `grafana-cloud-credentials` item become unused after this change. Leave them in place for one rotation cycle, then prune.

## Test plan

- [ ] Flux reconciles the HelmRelease and `kubectl -n grafana-alloy rollout status deploy/grafana-alloy` reaches Ready.
- [ ] `kubectl -n grafana-alloy logs deploy/grafana-alloy -c alloy --tail=200 | grep -iE "error|401"` shows zero 401s and no `prometheus.remote_write` entries.
- [ ] `kubectl -n grafana-alloy get secret grafana-cloud-credentials -o jsonpath='{.data}'` has only three keys: `OTLP_ENDPOINT`, `OTLP_USERNAME`, `OTLP_PASSWORD`.
- [ ] Grafana Cloud → Explore (Mimir datasource) → `up{job="waddle-server"}` and representative `waddle_*` counters return fresh data points (note: OTLP ingestion may normalize `_total` suffixes; flag any dashboard queries that need updating as a follow-up, don't block on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)