### PR TITLE
fix(chat): restore rich message editing controls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "@grafana/faro-web-sdk": "^2.3.1",
         "@nanostores/vue": "^1.1.0",
         "@tailwindcss/vite": "^4.2.3",
-        "@tiptap/extension-bubble-menu": "^3.22.4",
         "@tiptap/extension-image": "^3.22.4",
         "@tiptap/extension-link": "^3.22.4",
         "@tiptap/extension-placeholder": "^3.22.4",

--- a/chat/package.json
+++ b/chat/package.json
@@ -26,7 +26,6 @@
     "@grafana/faro-web-sdk": "^2.3.1",
     "@nanostores/vue": "^1.1.0",
     "@tailwindcss/vite": "^4.2.3",
-    "@tiptap/extension-bubble-menu": "^3.22.4",
     "@tiptap/extension-image": "^3.22.4",
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",

--- a/chat/src/components/chat/ChatEditor.vue
+++ b/chat/src/components/chat/ChatEditor.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { watch, onBeforeUnmount, computed } from "vue";
+import { watch, onBeforeUnmount } from "vue";
 import { useEditor, EditorContent } from "@tiptap/vue-3";
 import StarterKit from "@tiptap/starter-kit";
 import Image from "@tiptap/extension-image";
 import Placeholder from "@tiptap/extension-placeholder";
+import { shouldSendOnEnter } from "@/lib/editor/chat-enter-key";
 import { ChatLink } from "@/lib/editor/chat-link";
 
 const props = withDefaults(
@@ -27,12 +28,13 @@ const emit = defineEmits<{
   update: [doc: Record<string, unknown>];
 }>();
 
-const extensions = computed(() => {
+function createExtensions() {
   const exts = [
     StarterKit.configure({
       heading: false,
       horizontalRule: false,
       link: false,
+      underline: false,
     }),
     ChatLink.configure({
       openOnClick: false,
@@ -42,7 +44,7 @@ const extensions = computed(() => {
       },
     }),
     Placeholder.configure({
-      placeholder: props.placeholder,
+      placeholder: () => props.placeholder,
     }),
   ];
 
@@ -56,7 +58,7 @@ const extensions = computed(() => {
   }
 
   return exts;
-});
+}
 
 function handleSend() {
   if (!editor.value || editor.value.isEmpty) return;
@@ -66,13 +68,13 @@ function handleSend() {
 }
 
 const editor = useEditor({
-  extensions: extensions.value,
+  extensions: createExtensions(),
   immediatelyRender: false,
   editable: !props.disabled,
   content: props.initialContent ?? "",
   editorProps: {
     handleKeyDown: (_view, event) => {
-      if (event.key === "Enter" && !event.shiftKey && !event.ctrlKey && !event.metaKey) {
+      if (editor.value && shouldSendOnEnter(editor.value, event)) {
         event.preventDefault();
         handleSend();
         return true;

--- a/chat/src/components/chat/EditorBubbleToolbar.vue
+++ b/chat/src/components/chat/EditorBubbleToolbar.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onBeforeUnmount } from "vue";
+import { computed } from "vue";
 import type { Editor } from "@tiptap/vue-3";
-import { BubbleMenuPlugin } from "@tiptap/extension-bubble-menu";
-import { Bold, Italic, Strikethrough, Code, Link } from "lucide-vue-next";
+import { BubbleMenu } from "@tiptap/vue-3/menus";
+import { Bold, Italic, Strikethrough, Code, Link, List, ListOrdered, TextQuote, SquareCode } from "lucide-vue-next";
 
 const props = defineProps<{
   editor: Editor;
 }>();
-
-const menuRef = ref<HTMLDivElement | null>(null);
 
 const items = computed(() => [
   {
@@ -40,6 +38,34 @@ const items = computed(() => [
     isActive: () => props.editor.isActive("code"),
   },
   {
+    name: "bullet-list",
+    icon: List,
+    title: "Bullet list",
+    action: () => props.editor.chain().focus().toggleBulletList().run(),
+    isActive: () => props.editor.isActive("bulletList"),
+  },
+  {
+    name: "ordered-list",
+    icon: ListOrdered,
+    title: "Numbered list",
+    action: () => props.editor.chain().focus().toggleOrderedList().run(),
+    isActive: () => props.editor.isActive("orderedList"),
+  },
+  {
+    name: "blockquote",
+    icon: TextQuote,
+    title: "Quote",
+    action: () => props.editor.chain().focus().toggleBlockquote().run(),
+    isActive: () => props.editor.isActive("blockquote"),
+  },
+  {
+    name: "code-block",
+    icon: SquareCode,
+    title: "Code block",
+    action: () => props.editor.chain().focus().toggleCodeBlock().run(),
+    isActive: () => props.editor.isActive("codeBlock"),
+  },
+  {
     name: "link",
     icon: Link,
     title: "Link (⌘K)",
@@ -56,50 +82,12 @@ const items = computed(() => [
     isActive: () => props.editor.isActive("link"),
   },
 ]);
-
-let pluginInstance: ReturnType<typeof BubbleMenuPlugin> | null = null;
-
-onMounted(() => {
-  if (!menuRef.value || !props.editor) return;
-
-  pluginInstance = BubbleMenuPlugin({
-    pluginKey: "waddleBubbleMenu",
-    editor: props.editor,
-    element: menuRef.value,
-    appendTo: () => document.body,
-    updateDelay: 150,
-    options: {
-      strategy: "fixed",
-      placement: "top",
-      offset: 8,
-      flip: true,
-      shift: { padding: 8 },
-    },
-    shouldShow: ({ editor, state }) => {
-      const { selection } = state;
-      const { empty } = selection;
-      return !empty && editor.isEditable;
-    },
-  });
-
-  props.editor.registerPlugin(pluginInstance);
-});
-
-onBeforeUnmount(() => {
-  if (pluginInstance && props.editor) {
-    props.editor.unregisterPlugin("waddleBubbleMenu");
-  }
-});
 </script>
 
 <template>
-  <div
-    ref="menuRef"
-    class="fixed left-0 top-0 z-50 w-max"
-    style="visibility: hidden"
-  >
+  <BubbleMenu :editor="editor">
     <div
-      class="flex items-center gap-0.5 px-1.5 py-1 glass-panel border border-border rounded-lg shadow-xl animate-fade-in"
+      class="z-50 flex items-center gap-0.5 px-1.5 py-1 glass-panel border border-border rounded-lg shadow-xl animate-fade-in"
     >
       <button
         v-for="item in items"
@@ -116,5 +104,5 @@ onBeforeUnmount(() => {
         <component :is="item.icon" class="w-3.5 h-3.5" />
       </button>
     </div>
-  </div>
+  </BubbleMenu>
 </template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onBeforeUnmount, watch } from "vue";
-import { MoreHorizontal, Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight, MessageSquare, Lock } from "lucide-vue-next";
+import { MoreHorizontal, Pencil, Reply, SmilePlus, Trash2, FileDown, CornerDownRight, MessageSquare, Lock, Send, X } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
+import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
 import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import { renderStyledBody, isImageUrl, type TimelineMessage, type MarkupSpan, type TimelineSharedFile } from "@/lib/chat-ui";
@@ -298,19 +299,38 @@ const forumThreadLabel = computed(() =>
 
 const isEditing = ref(false);
 const editInitialContent = ref<Record<string, unknown> | undefined>(undefined);
+const editDraftDoc = ref<Record<string, unknown> | undefined>(undefined);
 const editEditorRef = ref<InstanceType<typeof ChatEditor> | null>(null);
 const setEditEditorRef = (instance: InstanceType<typeof ChatEditor> | null) => {
   editEditorRef.value = instance;
 };
+const editTiptapEditor = computed(() => {
+  const e = editEditorRef.value as any;
+  return e?.editor?.value ?? e?.editor ?? null;
+});
+const editCanSubmit = computed(() => {
+  if (!editDraftDoc.value) return false;
+  const { body } = serializeTiptapToXep0393(editDraftDoc.value);
+  const trimmed = body.trim();
+  return !!trimmed && trimmed !== props.message.body;
+});
 
 function startEdit() {
-  editInitialContent.value = parseXep0393ToTiptap(props.message.body);
+  const content = parseXep0393ToTiptap(props.message.body);
+  editInitialContent.value = content;
+  editDraftDoc.value = content;
   isEditing.value = true;
+  void nextTick(() => editEditorRef.value?.focus());
 }
 
 function cancelEdit() {
   isEditing.value = false;
   editInitialContent.value = undefined;
+  editDraftDoc.value = undefined;
+}
+
+function updateEditDraft(doc: Record<string, unknown>) {
+  editDraftDoc.value = doc;
 }
 
 function submitEditFromEditor(doc: Record<string, unknown>) {
@@ -321,6 +341,12 @@ function submitEditFromEditor(doc: Record<string, unknown>) {
   }
   isEditing.value = false;
   editInitialContent.value = undefined;
+  editDraftDoc.value = undefined;
+}
+
+function submitCurrentEdit() {
+  const doc = editEditorRef.value?.getJSON?.();
+  if (doc) submitEditFromEditor(doc);
 }
 
 function emitAvatarClick() {
@@ -569,7 +595,7 @@ watch(
     </div>
 
     <!-- Edit mode -->
-    <div v-if="isEditing" class="flex gap-2 mt-1 items-end">
+    <div v-if="isEditing" class="mt-1 flex min-w-0 items-end gap-1.5">
       <ChatEditor
         :ref="setEditEditorRef"
         compact
@@ -577,12 +603,31 @@ watch(
         placeholder="Edit message..."
         @send="submitEditFromEditor"
         @cancel="cancelEdit"
+        @update="updateEditDraft"
         class="flex-1"
       />
-      <button
-        class="text-[12px] font-medium px-3 h-9 rounded-xl text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-200 shrink-0"
-        @click="cancelEdit"
-      >Cancel</button>
+      <div class="inline-flex h-9 shrink-0 items-center gap-0.5 rounded-lg border border-border bg-muted/50 p-0.5">
+        <button
+          type="button"
+          class="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground transition-all duration-200 hover:shadow-[0_0_14px_var(--glow-strong)] disabled:opacity-25 disabled:hover:shadow-none"
+          :disabled="!editCanSubmit"
+          title="Save edit"
+          aria-label="Save edit"
+          @click="submitCurrentEdit"
+        >
+          <Send class="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          class="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-muted hover:text-foreground"
+          title="Cancel edit"
+          aria-label="Cancel edit"
+          @click="cancelEdit"
+        >
+          <X class="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+      <EditorBubbleToolbar v-if="editTiptapEditor" :editor="editTiptapEditor" />
     </div>
 
     <!-- Sticker -->

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -306,6 +306,16 @@ function onKeydown(e: KeyboardEvent) {
       }
       return;
     }
+    if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (showMentions.value) {
+        insertMention(mentionResults.value[selectedIndex.value]);
+      } else if (showEmoji.value) {
+        insertEmoji(emojiResults.value[selectedIndex.value].emoji);
+      }
+      return;
+    }
   }
 }
 
@@ -334,7 +344,7 @@ watch(
 </script>
 
 <template>
-  <div class="relative px-4 py-3 flex-shrink-0" :class="isTopPinned ? 'border-b border-border' : ''" @keydown="onKeydown" @paste="onPaste">
+  <div class="relative px-4 py-3 flex-shrink-0" :class="isTopPinned ? 'border-b border-border' : ''" @keydown.capture="onKeydown" @paste="onPaste">
     <!-- Reply context chip -->
     <div
       v-if="replyingTo"

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -245,8 +245,6 @@ const md = new Marked({
     // Features not in XEP-0393 — de-style to plain text (preserve content, strip formatting)
     heading({ text }: { text: string }) { return text; },
     hr() { return ""; },
-    list(token) { return token.items.map((i) => i.text).join("\n"); },
-    listitem({ text }: { text: string }) { return `${text}\n`; },
     image() { return ""; },
     link({ href, text }: { href: string; text: string }) {
       try {

--- a/chat/src/lib/editor/chat-enter-key.ts
+++ b/chat/src/lib/editor/chat-enter-key.ts
@@ -1,0 +1,18 @@
+import type { Editor } from "@tiptap/vue-3";
+
+type EnterLikeEvent = Pick<
+  KeyboardEvent,
+  "key" | "shiftKey" | "ctrlKey" | "metaKey" | "altKey" | "isComposing"
+> & {
+  keyCode?: number;
+};
+
+const NATIVE_ENTER_NODES = ["blockquote", "codeBlock", "listItem"] as const;
+
+export function shouldSendOnEnter(editor: Editor, event: EnterLikeEvent): boolean {
+  if (event.key !== "Enter") return false;
+  if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey) return false;
+  if (event.isComposing || event.keyCode === 229) return false;
+  if (!editor.isEditable || editor.isEmpty) return false;
+  return !NATIVE_ENTER_NODES.some((nodeName) => editor.isActive(nodeName));
+}

--- a/chat/src/lib/editor/xep0393-parser.ts
+++ b/chat/src/lib/editor/xep0393-parser.ts
@@ -41,7 +41,23 @@ interface BlockquoteNode {
   content: ParagraphNode[];
 }
 
-type BlockNode = ParagraphNode | CodeBlockNode | BlockquoteNode;
+interface ListItemNode {
+  type: "listItem";
+  content: ParagraphNode[];
+}
+
+interface BulletListNode {
+  type: "bulletList";
+  content: ListItemNode[];
+}
+
+interface OrderedListNode {
+  type: "orderedList";
+  attrs?: { start: number };
+  content: ListItemNode[];
+}
+
+type BlockNode = ParagraphNode | CodeBlockNode | BlockquoteNode | BulletListNode | OrderedListNode;
 
 interface DocNode {
   type: "doc";
@@ -320,6 +336,13 @@ function makeParagraph(line: string): ParagraphNode {
   return { type: "paragraph", content };
 }
 
+const BULLET_LIST_RE = /^\s*[-*+]\s+(.*)$/;
+const ORDERED_LIST_RE = /^\s*(\d+)[.)]\s+(.*)$/;
+
+function makeListItem(line: string): ListItemNode {
+  return { type: "listItem", content: [makeParagraph(line)] };
+}
+
 /**
  * Top-level entry: parse an XEP-0393 body into a TipTap-compatible document.
  */
@@ -369,6 +392,37 @@ export function parseXep0393ToTiptap(body: string): Record<string, unknown> {
         i++;
       }
       blocks.push({ type: "blockquote", content: quoteParas });
+      continue;
+    }
+
+    const bulletMatch = line.match(BULLET_LIST_RE);
+    if (bulletMatch) {
+      const items: ListItemNode[] = [];
+      while (i < lines.length) {
+        const match = lines[i].match(BULLET_LIST_RE);
+        if (!match) break;
+        items.push(makeListItem(match[1]));
+        i++;
+      }
+      blocks.push({ type: "bulletList", content: items });
+      continue;
+    }
+
+    const orderedMatch = line.match(ORDERED_LIST_RE);
+    if (orderedMatch) {
+      const start = Number(orderedMatch[1]);
+      const items: ListItemNode[] = [];
+      while (i < lines.length) {
+        const match = lines[i].match(ORDERED_LIST_RE);
+        if (!match) break;
+        items.push(makeListItem(match[2]));
+        i++;
+      }
+      blocks.push({
+        type: "orderedList",
+        ...(start !== 1 ? { attrs: { start } } : {}),
+        content: items,
+      });
       continue;
     }
 

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -361,6 +361,23 @@
   margin: 0.5em 0;
   opacity: 0.75;
 }
+.styled-body ul,
+.styled-body ol {
+  margin: 0.35em 0;
+  padding-left: 1.4em;
+}
+.styled-body ul {
+  list-style-type: disc;
+}
+.styled-body ol {
+  list-style-type: decimal;
+}
+.styled-body li {
+  margin: 0.15em 0;
+}
+.styled-body li > p {
+  margin: 0;
+}
 .styled-body a {
   color: var(--primary);
   text-decoration: none;

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -31,6 +31,16 @@ describe("renderStyledBody", () => {
     expect(html).toContain("<p>line two</p>");
   });
 
+  test("renders bullet and ordered lists", () => {
+    const bulletHtml = renderStyledBody("- one\n- two");
+    const orderedHtml = renderStyledBody("3. one\n4. two");
+
+    expect(bulletHtml).toContain("<ul>");
+    expect(bulletHtml).toContain("<li>one</li>");
+    expect(orderedHtml).toContain('<ol start="3">');
+    expect(orderedHtml).toContain("<li>two</li>");
+  });
+
   test("synthesizes styling from markup-only payloads", () => {
     const body = "Hello world";
     const markup: MarkupSpan[] = [

--- a/chat/tests/editor-message-input.test.ts
+++ b/chat/tests/editor-message-input.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/vue-3";
+import StarterKit from "@tiptap/starter-kit";
+import { shouldSendOnEnter } from "../src/lib/editor/chat-enter-key";
+import { parseXep0393ToTiptap } from "../src/lib/editor/xep0393-parser";
+import { serializeTiptapToXep0393 } from "../src/lib/editor/xep0393-serializer";
+
+if (typeof globalThis.requestAnimationFrame !== "function") {
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(performance.now());
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+}
+
+const enter = {
+  key: "Enter",
+  shiftKey: false,
+  ctrlKey: false,
+  metaKey: false,
+  altKey: false,
+  isComposing: false,
+};
+
+function createEditor(content: Record<string, unknown>) {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({
+        heading: false,
+        horizontalRule: false,
+        link: false,
+        underline: false,
+      }),
+    ],
+    content,
+  });
+}
+
+describe("message input editor", () => {
+  test("uses Enter to send normal paragraphs", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "hello" }] }],
+    });
+
+    try {
+      expect(shouldSendOnEnter(editor, enter)).toBe(true);
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("leaves Enter available to list items and code blocks", () => {
+    const listEditor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            {
+              type: "listItem",
+              content: [{ type: "paragraph", content: [{ type: "text", text: "first" }] }],
+            },
+          ],
+        },
+      ],
+    });
+    const codeEditor = createEditor({
+      type: "doc",
+      content: [{ type: "codeBlock", content: [{ type: "text", text: "const x = 1" }] }],
+    });
+
+    try {
+      expect(shouldSendOnEnter(listEditor, enter)).toBe(false);
+      expect(shouldSendOnEnter(codeEditor, enter)).toBe(false);
+    } finally {
+      listEditor.destroy();
+      codeEditor.destroy();
+    }
+  });
+
+  test("round-trips bullet and ordered lists through edit content", () => {
+    const bulletDoc = parseXep0393ToTiptap("- one\n- *two*");
+    const orderedDoc = parseXep0393ToTiptap("3. one\n4. two");
+
+    expect(serializeTiptapToXep0393(bulletDoc as any).body).toBe("- one\n- *two*");
+    expect(serializeTiptapToXep0393(orderedDoc as any).body).toBe("3. one\n4. two");
+  });
+});


### PR DESCRIPTION
- let Tiptap handle list and code-block enter behavior while preserving enter-to-send for plain messages
- use the Vue BubbleMenu component with formatting actions in compose and inline edit flows
- render and round-trip list markup through message display and edit parsing