### PR TITLE
feat(server): export tracing events as OTLP log records

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2989,6 +2989,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5584,6 +5596,7 @@ dependencies = [
  "lru",
  "object_store",
  "opentelemetry",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "p256",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -74,9 +74,10 @@ dirs = "5.0"
 # Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
-opentelemetry = "0.28"
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics"] }
+opentelemetry = { version = "0.28", features = ["logs"] }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "logs"] }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic", "metrics", "logs"] }
+opentelemetry-appender-tracing = "0.28"
 tracing-opentelemetry = "0.29"
 
 # Security/Crypto

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -67,6 +67,7 @@ tracing-subscriber = { workspace = true }
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
+opentelemetry-appender-tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 
 # Security/Crypto

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -7,19 +7,24 @@
 
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry::KeyValue;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
+    logs::SdkLoggerProvider,
     metrics::{PeriodicReader, SdkMeterProvider},
     trace::SdkTracerProvider,
     Resource,
 };
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
 /// The global tracer provider, stored for shutdown.
 static TRACER_PROVIDER: std::sync::OnceLock<SdkTracerProvider> = std::sync::OnceLock::new();
 
 /// The global meter provider, stored for shutdown.
 static METER_PROVIDER: std::sync::OnceLock<SdkMeterProvider> = std::sync::OnceLock::new();
+
+/// The global logger provider, stored for shutdown.
+static LOGGER_PROVIDER: std::sync::OnceLock<SdkLoggerProvider> = std::sync::OnceLock::new();
 
 /// Build the OpenTelemetry resource with service information.
 fn build_resource() -> Resource {
@@ -39,6 +44,42 @@ fn build_resource() -> Resource {
 fn default_filter() -> EnvFilter {
     // Keep historical defaults to avoid changing verbosity unexpectedly.
     EnvFilter::new("info,waddle_server=debug,waddle_xmpp=debug")
+}
+
+/// Filter for the OTLP log bridge.
+///
+/// The exporter itself uses `tonic` / `hyper` / `h2` / `reqwest`, and
+/// those crates emit `tracing` events internally. Without this filter
+/// the bridge would feed their output right back into the exporter,
+/// which would emit more events — a feedback loop that blows up the
+/// pipeline. Silencing those targets at the bridge layer keeps them
+/// visible on stdout (through the `fmt` layer) but out of OTLP.
+fn log_bridge_filter() -> EnvFilter {
+    EnvFilter::new("info,waddle_server=debug,waddle_xmpp=debug")
+        .add_directive("hyper=off".parse().expect("static directive must be valid"))
+        .add_directive(
+            "hyper_util=off"
+                .parse()
+                .expect("static directive must be valid"),
+        )
+        .add_directive("tonic=off".parse().expect("static directive must be valid"))
+        .add_directive("h2=off".parse().expect("static directive must be valid"))
+        .add_directive(
+            "reqwest=off"
+                .parse()
+                .expect("static directive must be valid"),
+        )
+        .add_directive("tower=off".parse().expect("static directive must be valid"))
+        .add_directive(
+            "opentelemetry=off"
+                .parse()
+                .expect("static directive must be valid"),
+        )
+        .add_directive(
+            "opentelemetry_sdk=off"
+                .parse()
+                .expect("static directive must be valid"),
+        )
 }
 
 fn build_log_filter() -> EnvFilter {
@@ -69,6 +110,7 @@ fn build_log_filter() -> EnvFilter {
 /// This sets up:
 /// - OTLP exporter for traces (to Jaeger, Grafana Tempo, etc.)
 /// - OTLP exporter for metrics
+/// - OTLP exporter for logs (bridged from `tracing` events)
 /// - tracing-subscriber with OpenTelemetry integration
 /// - Console output for local development
 ///
@@ -129,7 +171,7 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Build meter provider
     let meter_provider = SdkMeterProvider::builder()
         .with_reader(PeriodicReader::builder(metrics_exporter).build())
-        .with_resource(resource)
+        .with_resource(resource.clone())
         .build();
 
     // Store the meter provider for shutdown
@@ -137,6 +179,21 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Set global meter provider
     opentelemetry::global::set_meter_provider(meter_provider);
+
+    // Build OTLP logs exporter + provider. The tracing bridge below
+    // feeds every `tracing::{info,warn,error,debug,trace}!` event into
+    // this provider as an OTLP log record, in addition to stdout.
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_endpoint(&otlp_endpoint)
+        .build()?;
+
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_batch_exporter(log_exporter)
+        .with_resource(resource)
+        .build();
+
+    let _ = LOGGER_PROVIDER.set(logger_provider.clone());
 
     let filter = build_log_filter();
 
@@ -153,11 +210,18 @@ pub fn init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Build the OpenTelemetry tracing layer
     let telemetry_layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
+    // Bridge `tracing` events into the OTLP log pipeline. Scope its
+    // own filter so the HTTP/gRPC transports used by the OTLP exporter
+    // can't feed their logs back into themselves and loop.
+    let otel_log_layer =
+        OpenTelemetryTracingBridge::new(&logger_provider).with_filter(log_bridge_filter());
+
     // Combine layers and set as global subscriber
     tracing_subscriber::registry()
         .with(filter)
         .with(fmt_layer)
         .with(telemetry_layer)
+        .with(otel_log_layer)
         .init();
 
     tracing::info!(
@@ -211,6 +275,13 @@ pub fn shutdown() {
     if let Some(provider) = METER_PROVIDER.get() {
         if let Err(e) = provider.shutdown() {
             tracing::error!(error = %e, "Error shutting down meter provider");
+        }
+    }
+
+    // Shutdown logger provider (flushes any buffered OTLP log records).
+    if let Some(provider) = LOGGER_PROVIDER.get() {
+        if let Err(e) = provider.shutdown() {
+            tracing::error!(error = %e, "Error shutting down logger provider");
         }
     }
 

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -54,32 +54,34 @@ fn default_filter() -> EnvFilter {
 /// which would emit more events — a feedback loop that blows up the
 /// pipeline. Silencing those targets at the bridge layer keeps them
 /// visible on stdout (through the `fmt` layer) but out of OTLP.
+///
+/// Built on top of `default_filter()` so the base verbosity stays in
+/// lockstep with the primary subscriber filter.
 fn log_bridge_filter() -> EnvFilter {
-    EnvFilter::new("info,waddle_server=debug,waddle_xmpp=debug")
-        .add_directive("hyper=off".parse().expect("static directive must be valid"))
-        .add_directive(
-            "hyper_util=off"
-                .parse()
-                .expect("static directive must be valid"),
-        )
-        .add_directive("tonic=off".parse().expect("static directive must be valid"))
-        .add_directive("h2=off".parse().expect("static directive must be valid"))
-        .add_directive(
-            "reqwest=off"
-                .parse()
-                .expect("static directive must be valid"),
-        )
-        .add_directive("tower=off".parse().expect("static directive must be valid"))
-        .add_directive(
-            "opentelemetry=off"
-                .parse()
-                .expect("static directive must be valid"),
-        )
-        .add_directive(
-            "opentelemetry_sdk=off"
-                .parse()
-                .expect("static directive must be valid"),
-        )
+    // Every crate in the OTLP export path. If any of these starts
+    // emitting `tracing` events that land back in the exporter, the
+    // pipeline loops. Keep this list exhaustive.
+    const OFF_TARGETS: &[&str] = &[
+        "hyper",
+        "hyper_util",
+        "tonic",
+        "h2",
+        "reqwest",
+        "tower",
+        "opentelemetry",
+        "opentelemetry_sdk",
+        "opentelemetry_otlp",
+        "opentelemetry_http",
+        "opentelemetry_proto",
+        "opentelemetry_appender_tracing",
+    ];
+
+    OFF_TARGETS.iter().fold(default_filter(), |filter, target| {
+        let directive = format!("{target}=off")
+            .parse()
+            .expect("static `<target>=off` directive must be valid");
+        filter.add_directive(directive)
+    })
 }
 
 fn build_log_filter() -> EnvFilter {
@@ -401,5 +403,14 @@ mod tests {
         // Note: Can only initialize once per process
         // This test just verifies the function compiles
         // let _ = super::init_local();
+    }
+
+    #[test]
+    fn test_log_bridge_filter_directives_parse() {
+        // Constructing the filter parses every `<target>=off` directive
+        // via `.expect(...)`. If any entry in OFF_TARGETS drifts into an
+        // invalid form, this test panics here instead of at process init
+        // in production.
+        let _filter = super::log_bridge_filter();
     }
 }

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -17,7 +17,12 @@ use tokio_tungstenite::{connect_async, tungstenite};
 type HmacSha256 = Hmac<Sha256>;
 
 const RECV_TIMEOUT: Duration = Duration::from_secs(10);
-const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+// Each test spawns a fresh waddle-server binary; startup includes
+// ephemeral cert generation (CPU-bound ring keygen) before listeners
+// bind. Under `cargo test --test-threads=N` several servers race for
+// CPU and one can miss a tight budget on slower CI runners. 60s is
+// generous enough to absorb that without masking a real hang.
+const SERVER_STARTUP_TIMEOUT: Duration = Duration::from_secs(60);
 
 // ---------------------------------------------------------------------------
 // Test server harness


### PR DESCRIPTION
## Summary

- Bridge every `tracing::{info,warn,error,debug,trace}!` emitted by `waddle-server` into the existing OTLP pipeline via `opentelemetry-appender-tracing`.
- New `SdkLoggerProvider` with a batch OTLP exporter targets the same `OTEL_EXPORTER_OTLP_ENDPOINT` as traces and metrics (in-cluster Grafana Alloy), and is flushed in `telemetry::shutdown()` alongside the tracer and meter providers.
- Scoped `EnvFilter` on the bridge silences the exporter's own transport stack (`hyper`, `hyper_util`, `tonic`, `h2`, `reqwest`, `tower`, `opentelemetry*`) so the exporter's internal tracing can't feed back into itself. Those events remain visible on stdout via the existing fmt layer.

## Why

Alloy was never receiving a single log record (`otelcol_exporter_sent_log_records_total` was absent on the `grafana_cloud` exporter; `otelcol_receiver_accepted_log_records_total` likewise). Traces and metrics were flowing, logs weren't — because nothing was producing them. This closes the gap without changing how container stdout looks for `kubectl logs`.

## Notes

- Deps: enable `logs` feature on `opentelemetry`, `opentelemetry_sdk`, and `opentelemetry-otlp`; add `opentelemetry-appender-tracing = "0.28"` (version pinned to match the 0.28 SDK line; 0.29 pulls a second copy of `opentelemetry` and breaks the trait bounds).
- `RUST_LOG` / `WADDLE_LOG_LEVEL` still drive the main subscriber filter; the bridge uses its own fixed filter so its feedback-loop guards can't be accidentally disabled by an env change.

## Test plan

- [ ] CI build succeeds; container image is pushed and gitops OCI artifact reconciled by Flux.
- [ ] After rollout, on the alloy pod: `otelcol_receiver_accepted_log_records_total` becomes non-zero, `otelcol_exporter_sent_log_records_total{exporter=".../grafana_cloud"}` climbs, `otelcol_exporter_send_failed_log_records_total{...} = 0`.
- [ ] In Grafana Cloud Explore → Loki datasource → `{service_name="waddle-server"}` returns recent log lines.
- [ ] Container stdout via `kubectl logs` is unchanged — human-readable JSON, same volume, same fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)