### PR TITLE
fix(chat): link pasted URLs in composer

### DIFF
--- a/chat/src/lib/editor/chat-editor-extensions.ts
+++ b/chat/src/lib/editor/chat-editor-extensions.ts
@@ -31,6 +31,7 @@ export function createChatEditorExtensions(options: ChatEditorExtensionsOptions 
     ChatLink.configure({
       openOnClick: false,
       autolink: true,
+      linkOnPaste: true,
       HTMLAttributes: {
         class: "text-primary underline decoration-primary/40 hover:decoration-primary transition-colors",
       },

--- a/chat/src/lib/editor/chat-link.ts
+++ b/chat/src/lib/editor/chat-link.ts
@@ -1,8 +1,74 @@
-import Link from "@tiptap/extension-link";
+import Link, { isAllowedUri } from "@tiptap/extension-link";
+import type { Slice } from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+function sliceTextContent(slice: Slice): string {
+  let text = "";
+  slice.content.forEach((node) => {
+    text += node.textContent;
+  });
+  return text;
+}
+
+function pastedUrl(text: string, defaultProtocol: string): { text: string; href: string } | null {
+  const value = text.trim();
+  if (!value || /\s/.test(value)) return null;
+
+  const hasProtocol = /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
+  const hasMaybeProtocol = /^[a-z][a-z0-9+.-]*:/i.test(value);
+  if (hasMaybeProtocol && !hasProtocol) return null;
+
+  const href = hasProtocol ? value : `${defaultProtocol}://${value}`;
+
+  try {
+    const url = new URL(href);
+    if (!["http:", "https:"].includes(url.protocol)) return null;
+    if (!url.hostname.includes(".")) return null;
+  } catch {
+    return null;
+  }
+
+  return { text: value, href };
+}
 
 export const ChatLink = Link.extend({
   inclusive() {
     // Keep pasted/autolinked URLs from absorbing text typed at the mark boundary.
     return false;
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      ...(this.parent?.() ?? []),
+      new Plugin({
+        key: new PluginKey("chatLinkPasteUrl"),
+        props: {
+          handlePaste: (view, _event, slice) => {
+            if (!view.state.selection.empty) return false;
+
+            const link = pastedUrl(sliceTextContent(slice), this.options.defaultProtocol);
+            if (!link) return false;
+            if (!this.options.shouldAutoLink(link.text)) return false;
+            if (!this.options.isAllowedUri(link.href, {
+              defaultValidate: (href) => !!isAllowedUri(href, this.options.protocols),
+              protocols: this.options.protocols,
+              defaultProtocol: this.options.defaultProtocol,
+            })) {
+              return false;
+            }
+
+            const node = view.state.schema.text(link.text, [
+              this.type.create({ href: link.href }),
+            ]);
+            const tr = view.state.tr
+              .replaceSelectionWith(node, false)
+              .removeStoredMark(this.type)
+              .scrollIntoView();
+            view.dispatch(tr);
+            return true;
+          },
+        },
+      }),
+    ];
   },
 });

--- a/chat/tests/chat-link-extension.test.ts
+++ b/chat/tests/chat-link-extension.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Editor } from "@tiptap/core";
+import { Fragment, Slice } from "@tiptap/pm/model";
 import StarterKit from "@tiptap/starter-kit";
+import { createChatEditorExtensions } from "../src/lib/editor/chat-editor-extensions";
 import { ChatLink } from "../src/lib/editor/chat-link";
 
 if (typeof globalThis.requestAnimationFrame !== "function") {
@@ -11,6 +13,107 @@ if (typeof globalThis.requestAnimationFrame !== "function") {
 }
 
 describe("ChatLink", () => {
+  test("links a URL pasted into an empty selection", () => {
+    const url = "https://example.com/docs";
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    });
+
+    try {
+      editor.commands.setTextSelection(1);
+
+      const pastePlugin = editor.extensionManager.plugins.find((plugin) => plugin.key.startsWith("chatLinkPasteUrl"));
+      const handled = pastePlugin?.props.handlePaste?.(
+        editor.view,
+        {} as ClipboardEvent,
+        new Slice(Fragment.from(editor.schema.text(url)), 0, 0),
+      );
+
+      expect(handled).toBe(true);
+
+      const paragraph = editor.getJSON().content?.[0];
+      expect(paragraph?.content?.[0]).toMatchObject({
+        type: "text",
+        text: url,
+        marks: [{ type: "link", attrs: expect.objectContaining({ href: url }) }],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("adds the default protocol when pasting a bare URL", () => {
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+    });
+
+    try {
+      editor.commands.setTextSelection(1);
+
+      const pastePlugin = editor.extensionManager.plugins.find((plugin) => plugin.key.startsWith("chatLinkPasteUrl"));
+      const handled = pastePlugin?.props.handlePaste?.(
+        editor.view,
+        {} as ClipboardEvent,
+        new Slice(Fragment.from(editor.schema.text("example.com/docs")), 0, 0),
+      );
+
+      expect(handled).toBe(true);
+
+      const paragraph = editor.getJSON().content?.[0];
+      expect(paragraph?.content?.[0]).toMatchObject({
+        type: "text",
+        text: "example.com/docs",
+        marks: [{ type: "link", attrs: expect.objectContaining({ href: "http://example.com/docs" }) }],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("links selected text when a URL is pasted", () => {
+    const url = "https://example.com/docs";
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "example" }] }],
+      },
+    });
+
+    try {
+      editor.commands.setTextSelection({ from: 1, to: 8 });
+
+      const pastePlugin = editor.extensionManager.plugins.find((plugin) => plugin.key.startsWith("handlePasteLink"));
+      const handled = pastePlugin?.props.handlePaste?.(
+        editor.view,
+        {} as ClipboardEvent,
+        new Slice(Fragment.from(editor.schema.text(url)), 0, 0),
+      );
+
+      expect(handled).toBe(true);
+
+      const paragraph = editor.getJSON().content?.[0];
+      expect(paragraph?.content?.[0]).toMatchObject({
+        type: "text",
+        text: "example",
+        marks: [{ type: "link", attrs: expect.objectContaining({ href: url }) }],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
   test("does not carry pasted link marks onto later text", () => {
     const url = "https://example.com";
     const editor = new Editor({


### PR DESCRIPTION
- handle empty-selection URL pastes that Tiptap linkOnPaste leaves as plain text while keeping selected-text paste behavior covered