### PR TITLE
OCI extension puller, async loading, and GH Actions gitops + SHA tagging

### DIFF
--- a/.github/workflows/extension-github-enricher.yml
+++ b/.github/workflows/extension-github-enricher.yml
@@ -46,8 +46,8 @@ jobs:
         run: |
           WASM_FILE="target/wasm32-wasip2/release/github_enricher.wasm"
           echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-          SHORT_SHA="$(git rev-parse --short HEAD)"
-          oras push "${IMAGE}:sha-${SHORT_SHA}" \
+          FULL_SHA="$(git rev-parse HEAD)"
+          oras push "${IMAGE}:sha-${FULL_SHA}" \
             --artifact-type application/vnd.waddle.extension.wasm.v1+wasm \
             "${WASM_FILE}:application/wasm"
           TAG="${{ github.ref_name }}"
@@ -60,7 +60,14 @@ jobs:
 
       - name: Install Flux CLI
         if: github.event_name == 'push'
-        uses: fluxcd/flux2/action@main
+        uses: fluxcd/flux2/action@4e78a9d7e03d78d765549929af3094f55d74f6e6
+
+      - name: Install yq
+        if: github.event_name == 'push'
+        run: |
+          YQ_VERSION="v4.44.3"
+          sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo chmod +x /usr/local/bin/yq
 
       - name: Log in to GHCR
         if: github.event_name == 'push'
@@ -74,8 +81,9 @@ jobs:
         if: github.event_name == 'push'
         working-directory: infrastructure/waddle.cloud
         run: |
-          SHORT_SHA="$(git rev-parse --short HEAD)"
-          sed -i "/name: github-enricher/{n;n;s/tag: .*/tag: sha-${SHORT_SHA}/;}" ./gitops/waddle-server/helmrelease.yaml
+          FULL_SHA="$(git rev-parse HEAD)"
+          yq -i ".spec.values.extensions.modules[] |= (if .name == \"github-enricher\" then .tag = \"sha-${FULL_SHA}\" else . end)" ./gitops/waddle-server/helmrelease.yaml
+          yq -e ".spec.values.extensions.modules[] | select(.name == \"github-enricher\") | .tag == \"sha-${FULL_SHA}\"" ./gitops/waddle-server/helmrelease.yaml > /dev/null
 
       - name: Push gitops artifact
         if: github.event_name == 'push'

--- a/.github/workflows/extension-github-enricher.yml
+++ b/.github/workflows/extension-github-enricher.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           WASM_FILE="target/wasm32-wasip2/release/github_enricher.wasm"
           echo "${GITHUB_TOKEN}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          oras push "${IMAGE}:sha-${SHORT_SHA}" \
+            --artifact-type application/vnd.waddle.extension.wasm.v1+wasm \
+            "${WASM_FILE}:application/wasm"
           TAG="${{ github.ref_name }}"
           oras push "${IMAGE}:${TAG}" \
             --artifact-type application/vnd.waddle.extension.wasm.v1+wasm \
@@ -53,3 +57,32 @@ jobs:
           oras push "${IMAGE}:latest" \
             --artifact-type application/vnd.waddle.extension.wasm.v1+wasm \
             "${WASM_FILE}:application/wasm"
+
+      - name: Install Flux CLI
+        if: github.event_name == 'push'
+        uses: fluxcd/flux2/action@main
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pin extension tag to commit SHA
+        if: github.event_name == 'push'
+        working-directory: infrastructure/waddle.cloud
+        run: |
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          sed -i "/name: github-enricher/{n;n;s/tag: .*/tag: sha-${SHORT_SHA}/;}" ./gitops/waddle-server/helmrelease.yaml
+
+      - name: Push gitops artifact
+        if: github.event_name == 'push'
+        working-directory: infrastructure/waddle.cloud
+        run: |
+          flux push artifact \
+            oci://ghcr.io/waddle-social/waddle/gitops:latest \
+            --path=./gitops \
+            --source="${{ github.server_url }}/${{ github.repository }}" \
+            --revision="$(git rev-parse --short HEAD)"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -555,6 +555,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -847,12 +853,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,16 +971,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "compact_str"
@@ -3033,50 +3023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,17 +3071,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "10.3.0"
+name = "jwt"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "6204285f77fe7d9784db3fdc449ecce1a0114927a51d5a41c4c7a292011c015f"
 dependencies = [
- "base64 0.22.1",
- "getrandom 0.2.17",
- "js-sys",
+ "base64 0.13.1",
+ "crypto-common",
+ "digest",
+ "hmac",
  "serde",
  "serde_json",
- "signature",
+ "sha2",
 ]
 
 [[package]]
@@ -3734,7 +3681,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest",
  "ring",
  "serde",
  "serde_json",
@@ -3747,21 +3694,21 @@ dependencies = [
 
 [[package]]
 name = "oci-client"
-version = "0.16.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+checksum = "9b74df13319e08bc386d333d3dc289c774c88cc543cae31f5347db07b5ec2172"
 dependencies = [
  "bytes",
  "chrono",
  "futures-util",
  "http 1.4.0",
  "http-auth",
- "jsonwebtoken 10.3.0",
+ "jwt",
  "lazy_static",
  "oci-spec",
  "olpc-cjson",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -3773,9 +3720,9 @@ dependencies = [
 
 [[package]]
 name = "oci-spec"
-version = "0.9.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+checksum = "fc3da52b83ce3258fbf29f66ac784b279453c2ac3c22c5805371b921ede0d308"
 dependencies = [
  "const_format",
  "derive_builder",
@@ -3932,7 +3879,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
  "tracing",
 ]
 
@@ -3950,7 +3897,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",
@@ -4525,7 +4472,6 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4809,50 +4755,9 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.39",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-util",
- "tower 0.5.3",
- "tower-http 0.6.8",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
- "web-sys",
 ]
 
 [[package]]
@@ -5092,33 +4997,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls 0.23.39",
- "rustls-native-certs 0.8.3",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6969,7 +6847,7 @@ dependencies = [
  "minidom",
  "pulldown-cmark",
  "ratatui",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "syntect",
@@ -7039,7 +6917,7 @@ dependencies = [
  "html-escape",
  "http-body-util",
  "jid",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "kameo",
  "libsql",
  "lru",
@@ -7053,7 +6931,7 @@ dependencies = [
  "pbkdf2",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
  "rustls 0.23.39",
  "rustls-acme",
  "serde",
@@ -7103,7 +6981,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.9.4",
  "rcgen",
- "reqwest 0.12.28",
+ "reqwest",
  "rustls 0.23.39",
  "rustls-pemfile",
  "rxml 0.12.0",
@@ -7136,7 +7014,7 @@ dependencies = [
  "futures",
  "jid",
  "minidom",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -7344,19 +7222,6 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -7787,15 +7652,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8012,15 +7868,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8062,21 +7909,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8129,12 +7961,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8153,12 +7979,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8174,12 +7994,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8213,12 +8027,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8234,12 +8042,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8261,12 +8063,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8282,12 +8078,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8512,7 +8302,7 @@ dependencies = [
  "chrono",
  "futures",
  "log",
- "reqwest 0.12.28",
+ "reqwest",
  "tokio",
  "tokio-util",
  "tokio-xmpp",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -847,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1078,27 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1387,12 +1424,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
 ]
 
 [[package]]
@@ -1410,11 +1471,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn",
 ]
@@ -1498,6 +1570,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -2069,6 +2172,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2511,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2785,7 +2909,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2909,6 +3033,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3125,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+]
+
+[[package]]
 name = "kameo"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3176,21 @@ checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -3537,7 +3734,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.37.5",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "serde",
  "serde_json",
@@ -3549,12 +3746,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b7f8deaffcd3b0e3baf93dddcab3d18b91d46dc37d38a8b170089b234de5bb3"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "http 1.4.0",
+ "http-auth",
+ "jsonwebtoken 10.3.0",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
  "asn1-rs",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3681,7 +3932,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
  "tracing",
 ]
 
@@ -3699,7 +3950,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.13.5",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",
@@ -4111,6 +4362,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4252,6 +4525,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4385,7 +4659,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -4535,9 +4809,50 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.39",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -4777,6 +5092,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.39",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -5506,8 +5848,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -5519,6 +5867,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -6609,7 +6969,7 @@ dependencies = [
  "minidom",
  "pulldown-cmark",
  "ratatui",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "syntect",
@@ -6643,6 +7003,7 @@ dependencies = [
  "async-trait",
  "futures",
  "minidom",
+ "oci-client",
  "regex",
  "serde",
  "serde_json",
@@ -6678,7 +7039,7 @@ dependencies = [
  "html-escape",
  "http-body-util",
  "jid",
- "jsonwebtoken",
+ "jsonwebtoken 9.3.1",
  "kameo",
  "libsql",
  "lru",
@@ -6692,7 +7053,7 @@ dependencies = [
  "pbkdf2",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.39",
  "rustls-acme",
  "serde",
@@ -6742,7 +7103,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.9.4",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls 0.23.39",
  "rustls-pemfile",
  "rxml 0.12.0",
@@ -6775,7 +7136,7 @@ dependencies = [
  "futures",
  "jid",
  "minidom",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -6983,6 +7344,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -7413,6 +7787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7629,6 +8012,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7670,6 +8062,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7722,6 +8129,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7740,6 +8153,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7755,6 +8174,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7788,6 +8213,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7803,6 +8234,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7824,6 +8261,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7839,6 +8282,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8063,7 +8512,7 @@ dependencies = [
  "chrono",
  "futures",
  "log",
- "reqwest",
+ "reqwest 0.12.28",
  "tokio",
  "tokio-util",
  "tokio-xmpp",

--- a/server/crates/waddle-extensions/Cargo.toml
+++ b/server/crates/waddle-extensions/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 futures = { workspace = true }
 minidom = { workspace = true }
+oci-client = "0.16"
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/server/crates/waddle-extensions/Cargo.toml
+++ b/server/crates/waddle-extensions/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { workspace = true }
 async-trait = "0.1"
 futures = { workspace = true }
 minidom = { workspace = true }
-oci-client = "0.16"
+oci-client = { version = "0.15", default-features = false, features = ["rustls-tls"] }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/server/crates/waddle-extensions/src/manager.rs
+++ b/server/crates/waddle-extensions/src/manager.rs
@@ -80,7 +80,7 @@ impl ExtensionManager {
                 }
             };
 
-            let wasm_path = match puller.resolve_wasm_path(module) {
+            let wasm_path = match puller.resolve_wasm_path(module).await {
                 Ok(path) => path,
                 Err(error) => {
                     warn!(

--- a/server/crates/waddle-extensions/src/oci.rs
+++ b/server/crates/waddle-extensions/src/oci.rs
@@ -1,11 +1,13 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail, Context, Result};
 use oci_client::client::{Client, ClientConfig, ClientProtocol, ImageLayer};
 use oci_client::manifest::OciDescriptor;
 use oci_client::secrets::RegistryAuth;
 use oci_client::Reference;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::ExtensionModuleConfig;
 
@@ -20,6 +22,7 @@ pub struct OciExtensionPuller {
 
 const WASM_LAYER_MEDIA_TYPE: &str = "application/wasm";
 const EXTENSION_ARTIFACT_MEDIA_TYPE: &str = "application/vnd.waddle.extension.wasm.v1+wasm";
+const MAX_WASM_BYTES: usize = 50 * 1024 * 1024;
 
 impl OciExtensionPuller {
     pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
@@ -42,9 +45,25 @@ impl OciExtensionPuller {
             return Ok(path);
         }
 
-        let cached = self.cached_wasm_path(module);
+        let cached = self.cached_wasm_path(module)?;
         if cached.exists() {
-            return Ok(cached);
+            match validate_cached_wasm_file(&module.name, &cached) {
+                Ok(()) => return Ok(cached),
+                Err(error) => {
+                    warn!(
+                        extension = %module.name,
+                        cache_path = %cached.display(),
+                        %error,
+                        "cached extension wasm failed validation; re-pulling artifact"
+                    );
+                    std::fs::remove_file(&cached).with_context(|| {
+                        format!(
+                            "failed to remove invalid cached extension {}",
+                            cached.display()
+                        )
+                    })?;
+                }
+            }
         }
 
         self.pull_module(module)
@@ -52,15 +71,15 @@ impl OciExtensionPuller {
             .with_context(|| format!("failed to pull extension {}", module.name))
     }
 
-    fn cached_wasm_path(&self, module: &ExtensionModuleConfig) -> PathBuf {
-        self.cache_dir
-            .join(&module.name)
-            .join(format!("{}.wasm", module.tag))
+    fn cached_wasm_path(&self, module: &ExtensionModuleConfig) -> Result<PathBuf> {
+        let module_name = validate_cache_component("name", &module.name)?;
+        let tag = validate_cache_component("tag", &module.tag)?;
+        Ok(self.cache_dir.join(module_name).join(format!("{tag}.wasm")))
     }
 
     pub async fn pull_module(&self, module: &ExtensionModuleConfig) -> Result<PathBuf> {
         let reference = self.reference_for(module)?;
-        let cached = self.cached_wasm_path(module);
+        let cached = self.cached_wasm_path(module)?;
         if let Some(parent) = cached.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
                 format!("failed to create extension cache dir {}", parent.display())
@@ -85,20 +104,25 @@ impl OciExtensionPuller {
             .manifest
             .ok_or_else(|| anyhow!("OCI artifact {reference} returned no manifest"))?;
 
-        if let Some(artifact_type) = manifest.artifact_type.as_deref() {
-            if artifact_type != EXTENSION_ARTIFACT_MEDIA_TYPE {
-                bail!(
-                    "unexpected artifact type for {}: got {}, expected {}",
-                    module.name,
-                    artifact_type,
-                    EXTENSION_ARTIFACT_MEDIA_TYPE
-                );
-            }
+        let artifact_type = manifest.artifact_type.as_deref().ok_or_else(|| {
+            anyhow!(
+                "missing artifact type for {}: expected {}",
+                module.name,
+                EXTENSION_ARTIFACT_MEDIA_TYPE
+            )
+        })?;
+        if artifact_type != EXTENSION_ARTIFACT_MEDIA_TYPE {
+            bail!(
+                "unexpected artifact type for {}: got {}, expected {}",
+                module.name,
+                artifact_type,
+                EXTENSION_ARTIFACT_MEDIA_TYPE
+            );
         }
 
         let layer = select_wasm_layer(&module.name, &image.layers, &manifest.layers)?;
         validate_wasm_layer(&module.name, layer)?;
-        std::fs::write(&cached, &layer.data)
+        write_wasm_atomically(&cached, &layer.data)
             .with_context(|| format!("failed to write cached extension {}", cached.display()))?;
 
         info!(
@@ -147,13 +171,113 @@ fn select_wasm_layer<'a>(
 }
 
 fn validate_wasm_layer(module_name: &str, layer: &ImageLayer) -> Result<()> {
-    if layer.data.len() < 4 {
+    validate_wasm_bytes(module_name, layer.data.as_ref())
+}
+
+fn validate_wasm_bytes(module_name: &str, bytes: &[u8]) -> Result<()> {
+    if bytes.len() < 8 {
         bail!("extension {module_name} wasm payload is too small");
     }
-    if layer.data[..4] != [0x00, 0x61, 0x73, 0x6d] {
+    if bytes.len() > MAX_WASM_BYTES {
+        bail!("extension {module_name} wasm payload exceeds max size of {MAX_WASM_BYTES} bytes");
+    }
+    if bytes[..4] != [0x00, 0x61, 0x73, 0x6d] {
         bail!("extension {module_name} payload is not a wasm binary");
     }
+    if bytes[4..8] != [0x01, 0x00, 0x00, 0x00] {
+        bail!("extension {module_name} uses unsupported wasm binary version");
+    }
     Ok(())
+}
+
+fn validate_cached_wasm_file(module_name: &str, path: &Path) -> Result<()> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read cached extension {}", path.display()))?;
+    validate_wasm_bytes(module_name, &bytes)
+}
+
+fn validate_cache_component<'a>(field: &str, value: &'a str) -> Result<&'a str> {
+    if value.is_empty() {
+        bail!("extension {field} must not be empty");
+    }
+    if value == "." || value == ".." {
+        bail!("extension {field} must not be '.' or '..'");
+    }
+    if value.contains('/') || value.contains('\\') {
+        bail!("extension {field} must not include path separators");
+    }
+    if !value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' || ch == '.')
+    {
+        bail!("extension {field} contains unsupported characters");
+    }
+    Ok(value)
+}
+
+fn write_wasm_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        anyhow!(
+            "cached extension path has no parent directory: {}",
+            path.display()
+        )
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        anyhow!(
+            "cached extension path has no terminal filename: {}",
+            path.display()
+        )
+    })?;
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let temp_path = parent.join(format!(
+        ".{}.tmp-{}-{suffix}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+
+    let mut file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp_path)
+        .with_context(|| {
+            format!(
+                "failed to create temporary cache file {}",
+                temp_path.display()
+            )
+        })?;
+    file.write_all(bytes).with_context(|| {
+        format!(
+            "failed to write temporary cache file {}",
+            temp_path.display()
+        )
+    })?;
+    file.sync_all().with_context(|| {
+        format!(
+            "failed to sync temporary cache file {}",
+            temp_path.display()
+        )
+    })?;
+
+    match std::fs::rename(&temp_path, path) {
+        Ok(()) => Ok(()),
+        Err(_error) if path.exists() => {
+            let _ = std::fs::remove_file(&temp_path);
+            info!(
+                cache_path = %path.display(),
+                "cached extension was created concurrently; using existing file"
+            );
+            Ok(())
+        }
+        Err(error) => {
+            let _ = std::fs::remove_file(&temp_path);
+            Err(error).with_context(|| {
+                format!("failed to atomically move cache file to {}", path.display())
+            })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -165,7 +289,8 @@ mod tests {
 
     #[test]
     fn validates_reference_format() {
-        let puller = OciExtensionPuller::new("/tmp/waddle-test");
+        let cache_dir = std::env::temp_dir().join("waddle-test");
+        let puller = OciExtensionPuller::new(cache_dir);
         let module = ExtensionModuleConfig {
             name: "github-enricher".to_string(),
             registry: "ghcr.io/waddle-social/waddle/extensions/github-enricher".to_string(),
@@ -227,12 +352,33 @@ mod tests {
     #[test]
     fn rejects_invalid_wasm_payload() {
         let layer = ImageLayer {
-            data: vec![1, 2, 3, 4, 5].into(),
+            data: vec![1, 2, 3, 4, 0, 0, 0, 0].into(),
             media_type: "application/wasm".to_string(),
             annotations: None,
         };
         let error = validate_wasm_layer("github-enricher", &layer)
             .expect_err("invalid payload should fail");
         assert!(error.to_string().contains("payload is not a wasm binary"));
+    }
+
+    #[test]
+    fn rejects_invalid_cache_component() {
+        let puller = OciExtensionPuller::new(std::env::temp_dir().join("waddle-test"));
+        let module = ExtensionModuleConfig {
+            name: "../bad".to_string(),
+            registry: "ghcr.io/waddle-social/waddle/extensions/github-enricher".to_string(),
+            tag: "sha-abc123".to_string(),
+            namespace: "urn:waddle:github:0".to_string(),
+            config: serde_json::Value::Object(Default::default()),
+            config_secret_files: Default::default(),
+            local_path: None,
+        };
+
+        let error = puller
+            .cached_wasm_path(&module)
+            .expect_err("cache path should reject path traversal");
+        assert!(error
+            .to_string()
+            .contains("must not include path separators"));
     }
 }

--- a/server/crates/waddle-extensions/src/oci.rs
+++ b/server/crates/waddle-extensions/src/oci.rs
@@ -1,18 +1,25 @@
 use std::path::{Path, PathBuf};
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
+use oci_client::client::{Client, ClientConfig, ClientProtocol, ImageLayer};
+use oci_client::manifest::OciDescriptor;
+use oci_client::secrets::RegistryAuth;
+use oci_client::Reference;
+use tracing::info;
 
 use crate::config::ExtensionModuleConfig;
 
 /// Resolves an extension module configuration to a WASM component file on disk.
 ///
-/// Uses `local_path` when provided (dev/test mode). OCI pulling from a remote
-/// registry is not yet implemented; returns an error when neither a `local_path`
-/// nor a cached artifact under `cache_dir` is available.
+/// Uses `local_path` when provided (dev/test mode). Otherwise it resolves the
+/// configured OCI reference and writes the module payload into `cache_dir`.
 #[derive(Debug, Clone)]
 pub struct OciExtensionPuller {
     pub cache_dir: PathBuf,
 }
+
+const WASM_LAYER_MEDIA_TYPE: &str = "application/wasm";
+const EXTENSION_ARTIFACT_MEDIA_TYPE: &str = "application/vnd.waddle.extension.wasm.v1+wasm";
 
 impl OciExtensionPuller {
     pub fn new(cache_dir: impl Into<PathBuf>) -> Self {
@@ -22,7 +29,7 @@ impl OciExtensionPuller {
     }
 
     /// Resolve a module config to a concrete WASM file path on disk.
-    pub fn resolve_wasm_path(&self, module: &ExtensionModuleConfig) -> Result<PathBuf> {
+    pub async fn resolve_wasm_path(&self, module: &ExtensionModuleConfig) -> Result<PathBuf> {
         if let Some(local) = module.local_path.as_ref() {
             let path = PathBuf::from(local);
             if !path.exists() {
@@ -40,11 +47,9 @@ impl OciExtensionPuller {
             return Ok(cached);
         }
 
-        bail!(
-            "extension {}: no local_path set and no cached artifact at {} (OCI pulling not yet implemented)",
-            module.name,
-            cached.display()
-        )
+        self.pull_module(module)
+            .await
+            .with_context(|| format!("failed to pull extension {}", module.name))
     }
 
     fn cached_wasm_path(&self, module: &ExtensionModuleConfig) -> PathBuf {
@@ -53,13 +58,181 @@ impl OciExtensionPuller {
             .join(format!("{}.wasm", module.tag))
     }
 
-    /// Stub for future OCI artifact pulling from a registry like GHCR.
-    pub fn pull_module(&self, _module: &ExtensionModuleConfig) -> Result<Option<PathBuf>> {
-        // TODO: Implement OCI artifact pulling (oci-distribution or oras).
-        Ok(None)
+    pub async fn pull_module(&self, module: &ExtensionModuleConfig) -> Result<PathBuf> {
+        let reference = self.reference_for(module)?;
+        let cached = self.cached_wasm_path(module);
+        if let Some(parent) = cached.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create extension cache dir {}", parent.display())
+            })?;
+        }
+
+        let client = Client::new(ClientConfig {
+            protocol: ClientProtocol::Https,
+            ..Default::default()
+        });
+
+        let image = client
+            .pull(
+                &reference,
+                &RegistryAuth::Anonymous,
+                vec![WASM_LAYER_MEDIA_TYPE],
+            )
+            .await
+            .with_context(|| format!("failed to pull OCI artifact {reference}"))?;
+
+        let manifest = image
+            .manifest
+            .ok_or_else(|| anyhow!("OCI artifact {reference} returned no manifest"))?;
+
+        if let Some(artifact_type) = manifest.artifact_type.as_deref() {
+            if artifact_type != EXTENSION_ARTIFACT_MEDIA_TYPE {
+                bail!(
+                    "unexpected artifact type for {}: got {}, expected {}",
+                    module.name,
+                    artifact_type,
+                    EXTENSION_ARTIFACT_MEDIA_TYPE
+                );
+            }
+        }
+
+        let layer = select_wasm_layer(&module.name, &image.layers, &manifest.layers)?;
+        validate_wasm_layer(&module.name, layer)?;
+        std::fs::write(&cached, &layer.data)
+            .with_context(|| format!("failed to write cached extension {}", cached.display()))?;
+
+        info!(
+            extension = %module.name,
+            registry = %module.registry,
+            tag = %module.tag,
+            cache_path = %cached.display(),
+            "pulled extension OCI artifact"
+        );
+        Ok(cached)
     }
 
     pub fn cache_dir(&self) -> &Path {
         &self.cache_dir
+    }
+
+    fn reference_for(&self, module: &ExtensionModuleConfig) -> Result<Reference> {
+        let target = format!("{}:{}", module.registry, module.tag);
+        target
+            .parse()
+            .with_context(|| format!("invalid OCI reference {target}"))
+    }
+}
+
+fn select_wasm_layer<'a>(
+    module_name: &str,
+    layers: &'a [ImageLayer],
+    descriptors: &'a [OciDescriptor],
+) -> Result<&'a ImageLayer> {
+    let mut selected: Option<&ImageLayer> = None;
+    for (index, layer) in layers.iter().enumerate() {
+        let media_type = descriptors
+            .get(index)
+            .map(|descriptor| descriptor.media_type.as_str())
+            .unwrap_or(layer.media_type.as_str());
+        if media_type != WASM_LAYER_MEDIA_TYPE {
+            continue;
+        }
+        if selected.is_some() {
+            bail!("extension {module_name} OCI artifact has multiple wasm layers");
+        }
+        selected = Some(layer);
+    }
+
+    selected.ok_or_else(|| anyhow!("extension {module_name} OCI artifact has no wasm layer"))
+}
+
+fn validate_wasm_layer(module_name: &str, layer: &ImageLayer) -> Result<()> {
+    if layer.data.len() < 4 {
+        bail!("extension {module_name} wasm payload is too small");
+    }
+    if layer.data[..4] != [0x00, 0x61, 0x73, 0x6d] {
+        bail!("extension {module_name} payload is not a wasm binary");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use oci_client::manifest::OciDescriptor;
+    use oci_client::Reference;
+
+    use super::*;
+
+    #[test]
+    fn validates_reference_format() {
+        let puller = OciExtensionPuller::new("/tmp/waddle-test");
+        let module = ExtensionModuleConfig {
+            name: "github-enricher".to_string(),
+            registry: "ghcr.io/waddle-social/waddle/extensions/github-enricher".to_string(),
+            tag: "sha-abc123".to_string(),
+            namespace: "urn:waddle:github:0".to_string(),
+            config: serde_json::Value::Object(Default::default()),
+            config_secret_files: Default::default(),
+            local_path: None,
+        };
+
+        let reference = puller
+            .reference_for(&module)
+            .expect("reference should parse");
+        let expected: Reference =
+            "ghcr.io/waddle-social/waddle/extensions/github-enricher:sha-abc123"
+                .parse()
+                .expect("reference should parse");
+        assert_eq!(reference.registry(), expected.registry());
+        assert_eq!(reference.repository(), expected.repository());
+        assert_eq!(reference.tag(), expected.tag());
+    }
+
+    #[test]
+    fn selects_single_wasm_layer() {
+        let layers = vec![
+            ImageLayer {
+                data: vec![0u8; 8].into(),
+                media_type: "application/octet-stream".to_string(),
+                annotations: None,
+            },
+            ImageLayer {
+                data: vec![0, 97, 115, 109, 1, 0, 0, 0].into(),
+                media_type: "application/wasm".to_string(),
+                annotations: None,
+            },
+        ];
+        let descriptors = vec![
+            OciDescriptor {
+                media_type: "application/octet-stream".to_string(),
+                digest: String::new(),
+                size: 8,
+                urls: None,
+                annotations: None,
+            },
+            OciDescriptor {
+                media_type: "application/wasm".to_string(),
+                digest: String::new(),
+                size: 8,
+                urls: None,
+                annotations: None,
+            },
+        ];
+
+        let layer =
+            select_wasm_layer("github-enricher", &layers, &descriptors).expect("wasm selected");
+        assert_eq!(layer.data[..4], [0, 97, 115, 109]);
+    }
+
+    #[test]
+    fn rejects_invalid_wasm_payload() {
+        let layer = ImageLayer {
+            data: vec![1, 2, 3, 4, 5].into(),
+            media_type: "application/wasm".to_string(),
+            annotations: None,
+        };
+        let error = validate_wasm_layer("github-enricher", &layer)
+            .expect_err("invalid payload should fail");
+        assert!(error.to_string().contains("payload is not a wasm binary"));
     }
 }


### PR DESCRIPTION
### Motivation

- Enable automatic fetching of WASM extension artifacts from OCI registries (e.g. GHCR) and cache them for runtime loading. 
- Make runtime extension resolution asynchronous so pulling remote artifacts can be performed before loading. 
- Publish built extension artifacts with a commit-SHA tag and update GitOps artifacts in CI to pin deployments to the same SHA.

### Description

- Implement `OciExtensionPuller` in `server/crates/waddle-extensions/src/oci.rs` using the `oci-client` crate to pull images, select the wasm layer, validate it, and write a cached `.wasm` file. 
- Change `resolve_wasm_path` to be `async` and update `manager.rs` to `await` the puller so extensions can be pulled before compilation and initialization. 
- Add unit tests for reference parsing, layer selection, and wasm payload validation in `oci.rs`. 
- Add `oci-client = "0.16"` to `waddle-extensions` `Cargo.toml` and include the resulting dependency updates in `server/Cargo.lock`. 
- Update GitHub Actions workflow `.github/workflows/extension-github-enricher.yml` to push a SHA-tagged OCI artifact to GHCR, install Flux, log in to GHCR during pushes, pin the extension tag in the HelmRelease to the commit SHA, and `flux push` the gitops bundle.

### Testing

- Ran unit tests for the extensions crate with `cargo test -p waddle-extensions`, which executed the new `oci.rs` tests and succeeded. 
- Verified that the `waddle-extensions` crate builds locally with the added `oci-client` dependency using `cargo build -p waddle-extensions`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea72fa3c708331b9310d8b4f37b24a)