### PR TITLE
feat(infra): add LiveKit SFU deployment

### DIFF
--- a/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: livekit-sfu
+description: Minimal LiveKit SFU chart for Waddle infrastructure.
+type: application
+version: 0.1.1
+appVersion: v1.11.0
+
+sources:
+  - https://github.com/livekit/livekit
+  - https://github.com/livekit/livekit-helm

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/_helpers.tpl
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "livekit-sfu.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "livekit-sfu.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "livekit-sfu.labels" -}}
+helm.sh/chart: {{ include "livekit-sfu.chart" . }}
+{{ include "livekit-sfu.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "livekit-sfu.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "livekit-sfu.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Chart label.
+*/}}
+{{- define "livekit-sfu.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Service account name.
+*/}}
+{{- define "livekit-sfu.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "livekit-sfu.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+API keys secret name.
+*/}}
+{{- define "livekit-sfu.apiKeysSecretName" -}}
+{{- if .Values.apiKeys.existingSecret -}}
+{{- .Values.apiKeys.existingSecret -}}
+{{- else -}}
+{{- printf "%s-api-keys" (include "livekit-sfu.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/configmap.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- $config := deepCopy .Values.livekit -}}
+{{- if or .Values.apiKeys.existingSecret (gt (len .Values.apiKeys.values) 0) -}}
+{{- $_ := set $config "key_file" .Values.apiKeys.mountPath -}}
+{{- end -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "livekit-sfu.fullname" . }}
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+{{ toYaml $config | indent 4 }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/deployment.yaml
@@ -1,0 +1,161 @@
+{{- $apiKeysEnabled := or .Values.apiKeys.existingSecret (gt (len .Values.apiKeys.values) 0) -}}
+{{- $turnTLS := and .Values.livekit.turn.enabled (gt (int (.Values.livekit.turn.tls_port | default 0)) 0) -}}
+{{- $turnTLSSecret := and $turnTLS (not .Values.livekit.turn.external_tls) -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "livekit-sfu.fullname" . }}
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      {{- include "livekit-sfu.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if and (not .Values.apiKeys.existingSecret) (gt (len .Values.apiKeys.values) 0) }}
+        checksum/api-keys: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "livekit-sfu.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "livekit-sfu.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podHostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: livekit
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --disable-strict-config
+          env:
+            - name: LIVEKIT_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "livekit-sfu.fullname" . }}
+                  key: config.yaml
+            {{- if $turnTLSSecret }}
+            - name: LIVEKIT_TURN_CERT
+              value: {{ printf "%s/%s" .Values.turn.mountPath .Values.turn.certKey | quote }}
+            - name: LIVEKIT_TURN_KEY
+              value: {{ printf "%s/%s" .Values.turn.mountPath .Values.turn.keyKey | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.livekit.port }}
+              protocol: TCP
+            {{- if .Values.livekit.rtc.tcp_port }}
+            - name: rtc-tcp
+              containerPort: {{ .Values.livekit.rtc.tcp_port }}
+              hostPort: {{ .Values.livekit.rtc.tcp_port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.livekit.rtc.udp_port }}
+            - name: rtc-udp
+              containerPort: {{ .Values.livekit.rtc.udp_port }}
+              hostPort: {{ .Values.livekit.rtc.udp_port }}
+              protocol: UDP
+            {{- end }}
+            {{- if $turnTLS }}
+            - name: turn-tls
+              containerPort: {{ .Values.livekit.turn.tls_port }}
+              hostPort: {{ .Values.livekit.turn.tls_port }}
+              protocol: TCP
+            {{- end }}
+            {{- if and .Values.livekit.turn.enabled .Values.livekit.turn.udp_port }}
+            - name: turn-udp
+              containerPort: {{ .Values.livekit.turn.udp_port }}
+              hostPort: {{ .Values.livekit.turn.udp_port }}
+              protocol: UDP
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or $apiKeysEnabled $turnTLSSecret .Values.tmpDir.enabled }}
+          volumeMounts:
+            {{- if $apiKeysEnabled }}
+            - name: api-keys
+              mountPath: {{ dir .Values.apiKeys.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if $turnTLSSecret }}
+            - name: turn-cert
+              mountPath: {{ .Values.turn.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.tmpDir.enabled }}
+            - name: tmp
+              mountPath: {{ .Values.tmpDir.mountPath }}
+            {{- end }}
+          {{- end }}
+      {{- if or $apiKeysEnabled $turnTLSSecret .Values.tmpDir.enabled }}
+      volumes:
+        {{- if $apiKeysEnabled }}
+        - name: api-keys
+          secret:
+            secretName: {{ include "livekit-sfu.apiKeysSecretName" . }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.apiKeys.secretKey }}
+                path: {{ base .Values.apiKeys.mountPath }}
+        {{- end }}
+        {{- if $turnTLSSecret }}
+        - name: turn-cert
+          secret:
+            secretName: {{ .Values.turn.secretName }}
+            defaultMode: 0440
+            items:
+              - key: {{ .Values.turn.certKey }}
+                path: {{ .Values.turn.certKey }}
+              - key: {{ .Values.turn.keyKey }}
+                path: {{ .Values.turn.keyKey }}
+        {{- end }}
+        {{- if .Values.tmpDir.enabled }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: {{ .Values.tmpDir.sizeLimit }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/secret.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (not .Values.apiKeys.existingSecret) (gt (len .Values.apiKeys.values) 0) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "livekit-sfu.apiKeysSecretName" . }}
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.apiKeys.secretKey }}: |
+{{ toYaml .Values.apiKeys.values | indent 4 }}
+{{- end }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/service.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "livekit-sfu.fullname" . }}
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "livekit-sfu.selectorLabels" . | nindent 4 }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/serviceaccount.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "livekit-sfu.serviceAccountName" . }}
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/turn-service.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/turn-service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "livekit-sfu.fullname" . }}-turn
+  labels:
+    {{- include "livekit-sfu.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: turn-tls
+      port: {{ .Values.livekit.turn.tls_port }}
+      targetPort: turn-tls
+      protocol: TCP
+  selector:
+    {{- include "livekit-sfu.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/templates/validations.yaml
@@ -1,0 +1,41 @@
+{{- if and (not .Values.apiKeys.existingSecret) (eq (len .Values.apiKeys.values) 0) -}}
+{{- fail "livekit-sfu requires apiKeys.existingSecret or apiKeys.values to be set" -}}
+{{- end -}}
+{{- range $apiKey, $apiSecret := .Values.apiKeys.values -}}
+{{- if lt (len (printf "%v" $apiSecret)) 32 -}}
+{{- fail (printf "apiKeys.values.%s must be at least 32 characters" $apiKey) -}}
+{{- end -}}
+{{- end -}}
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "livekit-sfu is intentionally single-node for now; replicaCount must be 1" -}}
+{{- end -}}
+{{- if not .Values.podHostNetwork -}}
+{{- fail "livekit-sfu requires podHostNetwork=true so LiveKit can advertise node-reachable RTC ports" -}}
+{{- end -}}
+{{- if and .Values.livekit.port (lt (int .Values.livekit.port) 1024) -}}
+{{- fail "livekit.port must be >= 1024 with the hardened non-root container securityContext" -}}
+{{- end -}}
+{{- if and .Values.livekit.rtc.tcp_port (lt (int .Values.livekit.rtc.tcp_port) 1024) -}}
+{{- fail "livekit.rtc.tcp_port must be >= 1024 with the hardened non-root container securityContext" -}}
+{{- end -}}
+{{- if and .Values.livekit.rtc.udp_port (lt (int .Values.livekit.rtc.udp_port) 1024) -}}
+{{- fail "livekit.rtc.udp_port must be >= 1024 with the hardened non-root container securityContext" -}}
+{{- end -}}
+{{- if and .Values.livekit.turn.tls_port (lt (int .Values.livekit.turn.tls_port) 1024) -}}
+{{- fail "livekit.turn.tls_port must be >= 1024 with the hardened non-root container securityContext; expose 443 through the Gateway/LB instead" -}}
+{{- end -}}
+{{- if and .Values.livekit.turn.udp_port (lt (int .Values.livekit.turn.udp_port) 1024) -}}
+{{- fail "livekit.turn.udp_port must be >= 1024 with the hardened non-root container securityContext" -}}
+{{- end -}}
+{{- if and (not .Values.livekit.rtc.udp_port) (not (and .Values.livekit.rtc.port_range_start .Values.livekit.rtc.port_range_end)) -}}
+{{- fail "livekit-sfu requires either livekit.rtc.udp_port or livekit.rtc.port_range_start/livekit.rtc.port_range_end" -}}
+{{- end -}}
+{{- if and .Values.livekit.turn.enabled (not .Values.livekit.turn.domain) -}}
+{{- fail "livekit.turn.domain is required when turn.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.livekit.turn.enabled (not (or .Values.livekit.turn.tls_port .Values.livekit.turn.udp_port)) -}}
+{{- fail "livekit.turn requires at least one of tls_port or udp_port when enabled" -}}
+{{- end -}}
+{{- if and .Values.livekit.turn.enabled .Values.livekit.turn.tls_port (not .Values.livekit.turn.external_tls) (not .Values.turn.secretName) -}}
+{{- fail "turn.secretName is required when livekit.turn.tls_port is set and livekit.turn.external_tls=false" -}}
+{{- end -}}

--- a/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
+++ b/infrastructure/waddle.cloud/charts/livekit-sfu/values.yaml
@@ -1,0 +1,90 @@
+replicaCount: 1
+revisionHistoryLimit: 3
+
+image:
+  repository: livekit/livekit-server
+  tag: v1.11.0
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+automountServiceAccountToken: false
+
+service:
+  type: ClusterIP
+  annotations: {}
+  port: 7880
+
+terminationGracePeriodSeconds: 18000
+
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 0
+
+apiKeys:
+  existingSecret: ""
+  secretKey: keys.yaml
+  mountPath: /etc/livekit/keys/keys.yaml
+  values: {}
+
+livekit:
+  port: 7880
+  log_level: info
+  rtc:
+    use_external_ip: true
+    tcp_port: 7881
+    udp_port: 7882
+  turn:
+    enabled: false
+    domain: ""
+    udp_port: 3478
+    tls_port: 5349
+    external_tls: false
+    relay_range_start: 30000
+    relay_range_end: 40000
+
+turn:
+  secretName: ""
+  mountPath: /etc/livekit/turn
+  certKey: tls.crt
+  keyKey: tls.key
+
+podHostNetwork: true
+podAnnotations:
+  sidecar.istio.io/inject: "false"
+  linkerd.io/inject: disabled
+podLabels: {}
+podSecurityContext:
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+
+tmpDir:
+  enabled: true
+  mountPath: /tmp
+  sizeLimit: 64Mi
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/infrastructure/waddle.cloud/env.cue
+++ b/infrastructure/waddle.cloud/env.cue
@@ -13,7 +13,7 @@ schema.#Project & {
 	tasks: {
 		"helm-push": schema.#Task & {
 			command: "bash"
-			args: ["-c", "helm package ../../server/charts/waddle-server && helm push waddle-server-*.tgz oci://ghcr.io/waddle-social/waddle/charts && rm -f waddle-server-*.tgz"]
+			args: ["-c", "helm package ../../server/charts/waddle-server && helm package ./charts/livekit-sfu && helm push waddle-server-*.tgz oci://ghcr.io/waddle-social/waddle/charts && helm push livekit-sfu-*.tgz oci://ghcr.io/waddle-social/waddle/charts && rm -f waddle-server-*.tgz livekit-sfu-*.tgz"]
 		}
 		"gitops-push": schema.#Task & {
 			command: "bash"

--- a/infrastructure/waddle.cloud/gitops/cilium-gateway/gateway.yaml
+++ b/infrastructure/waddle.cloud/gitops/cilium-gateway/gateway.yaml
@@ -42,6 +42,33 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - name: https-sfu
+      protocol: HTTPS
+      port: 443
+      hostname: sfu.waddle.social
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: sfu-waddle-social-tls
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: http-sfu
+      protocol: HTTP
+      port: 80
+      hostname: sfu.waddle.social
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: turn-passthrough
+      protocol: TLS
+      port: 443
+      hostname: turn.waddle.social
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: All
     - name: teleport-passthrough
       protocol: TLS
       port: 443

--- a/infrastructure/waddle.cloud/gitops/cilium-gateway/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/cilium-gateway/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - gateway.yaml
   - wildcard-certificate.yaml
   - api-certificate.yaml
+  - sfu-certificate.yaml

--- a/infrastructure/waddle.cloud/gitops/cilium-gateway/sfu-certificate.yaml
+++ b/infrastructure/waddle.cloud/gitops/cilium-gateway/sfu-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sfu-waddle-social-tls
+  namespace: default
+spec:
+  secretName: sfu-waddle-social-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - sfu.waddle.social

--- a/infrastructure/waddle.cloud/gitops/kustomization-infra-livekit-sfu.yaml
+++ b/infrastructure/waddle.cloud/gitops/kustomization-infra-livekit-sfu.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infra-livekit-sfu
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-onepassword-connect
+    - name: infra-external-secrets
+    - name: infra-cilium-gateway
+    - name: infra-external-dns
+  interval: 10m
+  retryInterval: 1m
+  timeout: 15m
+  path: ./livekit-sfu
+  prune: true
+  wait: true
+  sourceRef:
+    kind: OCIRepository
+    name: bootstrap
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: livekit-sfu
+      namespace: livekit

--- a/infrastructure/waddle.cloud/gitops/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - kustomization-infra-spicedb-operator.yaml
   - kustomization-infra-cert-manager-issuer.yaml
   - kustomization-infra-cilium-gateway.yaml
+  - kustomization-infra-livekit-sfu.yaml
   - kustomization-infra-teleport-core.yaml
   - kustomization-infra-teleport-postinstall.yaml
   - kustomization-infra-waddle-server.yaml

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/external-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: livekit-sfu-api-keys
+  namespace: livekit
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: livekit-sfu-api-keys
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        keys.yaml: |
+          {{ .apiKey }}: {{ .apiSecret | quote }}
+  data:
+    - secretKey: apiKey
+      remoteRef:
+        key: livekit-sfu
+        property: api-key
+    - secretKey: apiSecret
+      remoteRef:
+        key: livekit-sfu
+        property: api-secret

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrelease.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: livekit-sfu
+  namespace: livekit
+spec:
+  driftDetection:
+    mode: enabled
+  interval: 30m
+  chart:
+    spec:
+      chart: livekit-sfu
+      version: 0.1.x
+      sourceRef:
+        kind: HelmRepository
+        name: livekit-sfu
+        namespace: livekit
+      interval: 12h
+  values:
+    image:
+      repository: livekit/livekit-server
+      tag: v1.11.0
+    apiKeys:
+      existingSecret: livekit-sfu-api-keys
+    livekit:
+      log_level: info
+      rtc:
+        use_external_ip: true
+        tcp_port: 7881
+        udp_port: 7882
+      turn:
+        enabled: true
+        domain: turn.waddle.social
+        udp_port: 3478
+        tls_port: 5349
+        relay_range_start: 30000
+        relay_range_end: 40000
+    turn:
+      secretName: turn-waddle-social-tls
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrepository.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/helmrepository.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: livekit-sfu
+  namespace: livekit
+spec:
+  type: oci
+  interval: 12h
+  url: oci://ghcr.io/waddle-social/waddle/charts

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/httproute-http-redirect.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/httproute-http-redirect.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: livekit-sfu-http-redirect
+  namespace: livekit
+spec:
+  parentRefs:
+    - name: waddle-gateway
+      namespace: default
+      sectionName: http-sfu
+  hostnames:
+    - sfu.waddle.social
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/httproute.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/httproute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: livekit-sfu
+  namespace: livekit
+spec:
+  parentRefs:
+    - name: waddle-gateway
+      namespace: default
+      sectionName: https-sfu
+  hostnames:
+    - sfu.waddle.social
+  rules:
+    - backendRefs:
+        - name: livekit-sfu
+          port: 7880

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - turn-certificate.yaml
+  - external-secret.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - httproute.yaml
+  - httproute-http-redirect.yaml
+  - tlsroute.yaml
+  - reference-grant.yaml

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/namespace.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: livekit

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/reference-grant.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/reference-grant.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-to-livekit-sfu
+  namespace: livekit
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: livekit
+    - group: gateway.networking.k8s.io
+      kind: TLSRoute
+      namespace: livekit
+  to:
+    - group: ""
+      kind: Service

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/tlsroute.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/tlsroute.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: livekit-sfu-turn
+  namespace: livekit
+spec:
+  hostnames:
+    - turn.waddle.social
+  parentRefs:
+    - name: waddle-gateway
+      namespace: default
+      sectionName: turn-passthrough
+  rules:
+    - backendRefs:
+        - name: livekit-sfu-turn
+          port: 5349

--- a/infrastructure/waddle.cloud/gitops/livekit-sfu/turn-certificate.yaml
+++ b/infrastructure/waddle.cloud/gitops/livekit-sfu/turn-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: turn-waddle-social-tls
+  namespace: livekit
+spec:
+  secretName: turn-waddle-social-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  dnsNames:
+    - turn.waddle.social


### PR DESCRIPTION
- add a hardened single-node LiveKit Helm chart with host-networked RTC/TURN ports
- wire Flux, Gateway routes, cert-manager certificates, and OnePassword-backed API keys
- package the SFU chart from the infrastructure helm-push task