### PR TITLE
fix(server): require owner-created xmpp spaces

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -651,20 +651,20 @@ async function handleLogout() {
   await connectionStore.logout();
 }
 
-async function selectSpace(preferredChannelId?: string | null) {
+async function selectSpace(preferredId?: string | null) {
   ui.activePage.value = "chat";
   ui.sidebarMode.value = "channels";
   dmConversations.closeDm();
-  if (preferredChannelId && waddles.waddles.value.some((space) => space.id === preferredChannelId)) {
-    const channelId = waddles.selectDiscoveredSpace(preferredChannelId);
+  if (preferredId && waddles.waddles.value.some((space) => space.id === preferredId)) {
+    const channelId = waddles.selectDiscoveredSpace(preferredId);
     if (channelId) {
       messaging.clearMessages();
-      await messaging.loadMessages(preferredChannelId, channelId);
+      await messaging.loadMessages(preferredId, channelId);
     }
     ui.showMobileNav.value = false;
     return;
   }
-  const channelId = await waddles.loadStructure(preferredChannelId);
+  const channelId = await waddles.loadStructure(preferredId);
   if (channelId && waddles.activeSpaceId.value) {
     messaging.clearMessages();
     await messaging.loadMessages(waddles.activeSpaceId.value, channelId);

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -1232,7 +1232,7 @@ onUnmounted(() => {
       v-model:open="ui.showCreateChannel.value"
       :form="waddles.createChannelForm.value"
       :is-submitting="waddles.isSubmitting.value"
-      :spaces="waddles.sortedSpaces.value.map((space) => ({ jid: space.id, name: space.name }))"
+      :spaces="waddles.sortedSpaces.value.map((space) => ({ node: space.id, name: space.name }))"
       @update:form="waddles.createChannelForm.value = $event"
       @submit="handleCreateChannel"
     />

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -351,6 +351,7 @@ function showFirstRunSetupIfNeeded() {
     connectionStore.appState !== "ready" ||
     ui.sidebarMode.value !== "channels" ||
     ui.activePage.value !== "chat" ||
+    !waddles.canManageChannels.value ||
     !waddles.isEmptyDeployment.value ||
     waddles.isLoadingStructure.value
   ) {
@@ -654,6 +655,15 @@ async function selectSpace(preferredChannelId?: string | null) {
   ui.activePage.value = "chat";
   ui.sidebarMode.value = "channels";
   dmConversations.closeDm();
+  if (preferredChannelId && waddles.waddles.value.some((space) => space.id === preferredChannelId)) {
+    const channelId = waddles.selectDiscoveredSpace(preferredChannelId);
+    if (channelId) {
+      messaging.clearMessages();
+      await messaging.loadMessages(preferredChannelId, channelId);
+    }
+    ui.showMobileNav.value = false;
+    return;
+  }
   const channelId = await waddles.loadStructure(preferredChannelId);
   if (channelId && waddles.activeSpaceId.value) {
     messaging.clearMessages();
@@ -1222,6 +1232,7 @@ onUnmounted(() => {
       v-model:open="ui.showCreateChannel.value"
       :form="waddles.createChannelForm.value"
       :is-submitting="waddles.isSubmitting.value"
+      :spaces="waddles.sortedSpaces.value.map((space) => ({ jid: space.id, name: space.name }))"
       @update:form="waddles.createChannelForm.value = $event"
       @submit="handleCreateChannel"
     />

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -45,7 +45,7 @@ function waddleColor(waddle: SpaceSummary): string {
 }
 
 function waddleKey(waddle: SpaceSummary): string {
-  return waddle.name.toLowerCase() || "space";
+  return waddle.id;
 }
 
 function waddleGlow(waddle: SpaceSummary): string {
@@ -85,26 +85,26 @@ function waddleGlow(waddle: SpaceSummary): string {
         v-for="waddle in waddles"
         :key="waddleKey(waddle)"
         class="type-control relative w-10 h-10 rounded-lg flex items-center justify-center transition-all duration-200 group flex-shrink-0"
-        :class="activeSpaceId
+        :class="activeSpaceId === waddle.id
           ? 'text-primary-foreground shadow-lg'
           : 'text-rail-foreground hover:text-rail-active hover:scale-105'"
-        :style="activeSpaceId
+        :style="activeSpaceId === waddle.id
           ? { backgroundColor: waddleColor(waddle), boxShadow: waddleGlow(waddle) }
           : { backgroundColor: 'var(--rail-hover)' }"
         :title="waddle.name"
         :aria-label="`Open ${waddle.name}`"
-        :aria-current="activeSpaceId ? 'page' : undefined"
+        :aria-current="activeSpaceId === waddle.id ? 'page' : undefined"
         type="button"
-        @click="emit('selectSpace', activeSpaceId ?? 'space')"
+        @click="emit('selectSpace', waddle.id)"
       >
         <span class="type-rail-initial">{{ waddleInitial(waddle) }}</span>
         <span
-          v-if="activeSpaceId && !horizontal"
+          v-if="activeSpaceId === waddle.id && !horizontal"
           class="chat-rail-indicator-vertical absolute -left-2 top-1/2 -translate-y-1/2 rounded-r-full"
           :style="{ backgroundColor: waddleColor(waddle) }"
         />
         <span
-          v-if="activeSpaceId && horizontal"
+          v-if="activeSpaceId === waddle.id && horizontal"
           class="chat-rail-indicator-horizontal absolute bottom-0 left-1/2 -translate-x-1/2 rounded-t-full"
           :style="{ backgroundColor: waddleColor(waddle) }"
         />

--- a/chat/src/components/modals/CreateChannelDialog.vue
+++ b/chat/src/components/modals/CreateChannelDialog.vue
@@ -17,7 +17,7 @@ const open = defineModel<boolean>("open", { required: true });
 const props = defineProps<{
   form: CreateFormData;
   isSubmitting: boolean;
-  /** Available spaces for the "MUC in existing Space" intent (bare JID → display name). */
+  /** Available spaces for the "MUC in existing Space" intent (node id → display name). */
   spaces?: { jid: string; name: string }[];
 }>();
 
@@ -203,7 +203,7 @@ const dialogTitle = computed(() => {
       <!-- ── MUC in existing Space fields ── -->
       <template v-else-if="form.intent === 'space-muc'">
         <div class="chat-field-stack">
-          <label for="create-spacemuc-space" class="type-section-label text-muted-foreground">Target Space (JID)</label>
+          <label for="create-spacemuc-space" class="type-section-label text-muted-foreground">Target Space</label>
           <template v-if="spaces && spaces.length > 0">
             <select
               id="create-spacemuc-space"
@@ -220,10 +220,10 @@ const dialogTitle = computed(() => {
               id="create-spacemuc-space"
               :value="form.space_jid"
               class="chat-field-control type-field"
-              placeholder="space@conference.example.org"
+              placeholder="team-space"
               @input="$emit('update:form', { ...form, space_jid: ($event.target as HTMLInputElement).value })"
             />
-            <p class="type-caption text-muted-foreground">Enter the bare JID of the target space.</p>
+            <p class="type-caption text-muted-foreground">Enter an existing Spaces service node.</p>
           </template>
         </div>
         <div class="chat-field-stack">

--- a/chat/src/components/modals/CreateChannelDialog.vue
+++ b/chat/src/components/modals/CreateChannelDialog.vue
@@ -64,7 +64,7 @@ function selectIntent(intent: CreateIntent) {
       emit("update:form", { intent: "muc", name: "", description: "", muc_type: "text" } satisfies CreateMucFormData);
       break;
     case "space-muc":
-      emit("update:form", { intent: "space-muc", space_jid: "", name: "", description: "", muc_type: "text" } satisfies CreateSpaceMucFormData);
+      emit("update:form", { intent: "space-muc", space_node: "", name: "", description: "", muc_type: "text" } satisfies CreateSpaceMucFormData);
       break;
     case "space-with-muc":
       emit("update:form", { intent: "space-with-muc", space_name: "", space_description: "", muc_name: "", muc_description: "", muc_type: "text" } satisfies CreateSpaceWithMucFormData);
@@ -98,7 +98,7 @@ const isSubmitDisabled = computed(() => {
   const f = props.form;
   if (f.intent === "space") return !f.name.trim();
   if (f.intent === "muc") return !f.name.trim();
-  if (f.intent === "space-muc") return !f.space_jid.trim() || !f.name.trim();
+  if (f.intent === "space-muc") return !f.space_node.trim() || !f.name.trim();
   if (f.intent === "space-with-muc") return !f.space_name.trim() || !f.muc_name.trim();
   return true;
 });
@@ -207,9 +207,9 @@ const dialogTitle = computed(() => {
           <template v-if="spaces && spaces.length > 0">
             <select
               id="create-spacemuc-space"
-              :value="form.space_jid"
+              :value="form.space_node"
               class="chat-field-control type-field"
-              @change="$emit('update:form', { ...form, space_jid: ($event.target as HTMLSelectElement).value })"
+              @change="$emit('update:form', { ...form, space_node: ($event.target as HTMLSelectElement).value })"
             >
               <option value="" disabled>Select a space…</option>
               <option v-for="s in spaces" :key="s.node" :value="s.node">{{ s.name }}</option>
@@ -218,10 +218,10 @@ const dialogTitle = computed(() => {
           <template v-else>
             <input
               id="create-spacemuc-space"
-              :value="form.space_jid"
+              :value="form.space_node"
               class="chat-field-control type-field"
               placeholder="team-space"
-              @input="$emit('update:form', { ...form, space_jid: ($event.target as HTMLInputElement).value })"
+              @input="$emit('update:form', { ...form, space_node: ($event.target as HTMLInputElement).value })"
             />
             <p class="type-caption text-muted-foreground">Enter an existing Spaces service node.</p>
           </template>

--- a/chat/src/components/modals/CreateChannelDialog.vue
+++ b/chat/src/components/modals/CreateChannelDialog.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   form: CreateFormData;
   isSubmitting: boolean;
   /** Available spaces for the "MUC in existing Space" intent (node id → display name). */
-  spaces?: { jid: string; name: string }[];
+  spaces?: { node: string; name: string }[];
 }>();
 
 const emit = defineEmits<{
@@ -212,7 +212,7 @@ const dialogTitle = computed(() => {
               @change="$emit('update:form', { ...form, space_jid: ($event.target as HTMLSelectElement).value })"
             >
               <option value="" disabled>Select a space…</option>
-              <option v-for="s in spaces" :key="s.jid" :value="s.jid">{{ s.name }}</option>
+              <option v-for="s in spaces" :key="s.node" :value="s.node">{{ s.name }}</option>
             </select>
           </template>
           <template v-else>

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -333,9 +333,9 @@ export function useWaddles(
       }
 
       if (form.intent === "space-muc") {
-        if (!form.name.trim() || !form.space_jid.trim()) return undefined;
+        if (!form.name.trim() || !form.space_node.trim()) return undefined;
 
-        const spaceNode = form.space_jid;
+        const spaceNode = form.space_node;
         const { roomJid } = await createMucInSpace(xmppAgent, mucServiceJid, spacesServiceJid, {
           roomLocalpart: form.name.trim().toLowerCase().replace(/\s+/g, "-"),
           nick,

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -112,7 +112,8 @@ export function useWaddles(
   );
 
   const canManageChannels = computed(() =>
-    ["owner"].includes(serverRole.value ?? ""),
+    ["owner"].includes(serverRole.value ?? "") ||
+    ["owner"].includes(currentSpaceRole.value ?? currentRole.value ?? ""),
   );
 
   const canManageMembers = computed(() =>

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -32,6 +32,7 @@ export function useWaddles(
   const waddles = ref<SpaceSummary[]>([]);
   const channels = ref<ChannelSummary[]>([]);
   const members = ref<MemberSummary[]>([]);
+  const serverRole = ref<SpaceSummary["role"]>(null);
 
   const activeSpaceId: Ref<string | null> = ref(null);
   const activeChannelId: Ref<string | null> = ref(null);
@@ -57,7 +58,11 @@ export function useWaddles(
     position: 0,
   });
 
-  const currentSpace = computed(() => (activeSpaceId.value && waddles.value[0]) ? waddles.value[0] : null);
+  const currentSpace = computed(() =>
+    activeSpaceId.value
+      ? waddles.value.find((w) => w.id === activeSpaceId.value) ?? null
+      : null,
+  );
   const isEmptyDeployment = computed(() =>
     waddles.value.length === 0 && channels.value.length === 0 && !isLoadingStructure.value,
   );
@@ -83,7 +88,9 @@ export function useWaddles(
   );
 
   const sortedChannels = computed(() =>
-    [...channels.value].sort(
+    [...channels.value]
+      .filter((channel) => !activeSpaceId.value || channel.spaceId === activeSpaceId.value)
+      .sort(
       (a, b) =>
         (a.position ?? 0) - (b.position ?? 0) ||
         a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
@@ -100,11 +107,12 @@ export function useWaddles(
   });
 
   const canManageCommunity = computed(() =>
-    ["owner", "admin"].includes(currentSpaceRole.value ?? currentRole.value ?? ""),
+    ["owner"].includes(serverRole.value ?? "") ||
+    ["owner"].includes(currentSpaceRole.value ?? currentRole.value ?? ""),
   );
 
   const canManageChannels = computed(() =>
-    ["owner", "admin"].includes(currentSpaceRole.value ?? currentRole.value ?? ""),
+    ["owner"].includes(serverRole.value ?? ""),
   );
 
   const canManageMembers = computed(() =>
@@ -149,7 +157,9 @@ export function useWaddles(
         return null;
       }
 
+      serverRole.value = topology.serverRole ?? null;
       const discoveredSpaces = topology.spaces.map((space) => ({
+        id: space.id,
         name: space.name,
         role: space.role ?? null,
       }) satisfies SpaceSummary);
@@ -160,6 +170,7 @@ export function useWaddles(
         id: c.id,
         name: c.name,
         jid: c.jid,
+        spaceId: c.spaceId,
         channel_type: c.channelType,
         position: c.position,
       }));
@@ -182,6 +193,7 @@ export function useWaddles(
 
       activeChannelId.value = nextChannelId;
       const nextChannel = channelList.find((channel) => channel.id === nextChannelId);
+      activeSpaceId.value = nextChannel?.spaceId ?? activeSpaceId.value;
       if (nextChannelId && xmppClient.value) {
         const memberReqId = ++memberRequestId;
         try {
@@ -241,6 +253,15 @@ export function useWaddles(
         actionError.value = normalizeError(e);
       }
     }
+  }
+
+  function selectDiscoveredSpace(spaceId: string): string | null {
+    if (!waddles.value.some((space) => space.id === spaceId)) return null;
+    activeSpaceId.value = spaceId;
+    const nextChannelId = channels.value.find((channel) => channel.spaceId === spaceId)?.id ?? null;
+    activeChannelId.value = nextChannelId;
+    members.value = [];
+    return nextChannelId;
   }
 
   async function updateWaddle() {
@@ -313,7 +334,7 @@ export function useWaddles(
       if (form.intent === "space-muc") {
         if (!form.name.trim() || !form.space_jid.trim()) return undefined;
 
-        const spaceNode = form.space_jid.split("@")[0] ?? form.space_jid;
+        const spaceNode = form.space_jid;
         const { roomJid } = await createMucInSpace(xmppAgent, mucServiceJid, spacesServiceJid, {
           roomLocalpart: form.name.trim().toLowerCase().replace(/\s+/g, "-"),
           nick,
@@ -391,6 +412,7 @@ export function useWaddles(
     waddles.value = [];
     channels.value = [];
     members.value = [];
+    serverRole.value = null;
     activeSpaceId.value = null;
     activeChannelId.value = null;
   }
@@ -399,6 +421,7 @@ export function useWaddles(
     waddles,
     channels,
     members,
+    serverRole,
     activeSpaceId,
     activeChannelId,
     isLoadingStructure,
@@ -419,6 +442,7 @@ export function useWaddles(
     loadSpace,
     loadStructure,
     reloadChannelMembers,
+    selectDiscoveredSpace,
     updateWaddle,
     deleteWaddle,
     createChannel,

--- a/chat/src/lib/chat-types.ts
+++ b/chat/src/lib/chat-types.ts
@@ -1,4 +1,5 @@
 export interface SpaceSummary {
+  id: string;
   name: string;
   description?: string | null;
   icon_url?: string | null;
@@ -12,6 +13,7 @@ export interface ChannelSummary {
   id: string;
   name: string;
   jid?: string;
+  spaceId?: string;
   description?: string | null;
   channel_type?: string;
   position?: number;

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -103,8 +103,8 @@ export interface CreateMucFormData {
 /** Create a MUC inside an existing Space. */
 export interface CreateSpaceMucFormData {
   intent: "space-muc";
-  /** Bare JID of the target Space. */
-  space_jid: string;
+  /** PubSub node id of the target Space (not a bare JID). */
+  space_node: string;
   name: string;
   description: string;
   muc_type: MucSubtype;

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -233,5 +233,6 @@ export async function discoverTopology(
   return {
     spaces,
     rooms,
+    serverRole,
   };
 }

--- a/chat/src/lib/xmpp/protocol-helpers.ts
+++ b/chat/src/lib/xmpp/protocol-helpers.ts
@@ -103,6 +103,15 @@ function buildMucConfigFields(params: { name: string; description?: string; mucT
   return fields;
 }
 
+function slugifyNodeId(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    || "space";
+}
+
 /**
  * Returns a Promise that resolves when the agent emits a `muc:available`
  * presence matching the expected full JID (room + "/" + nick), or rejects
@@ -187,7 +196,7 @@ export async function createSpaceNode(
   spacesServiceJid: string,
   params: CreateSpaceNodeParams,
 ): Promise<CreateSpaceNodeResult> {
-  const nodeId = params.nodeId ?? "space";
+  const nodeId = params.nodeId ?? slugifyNodeId(params.name);
 
   const configFields: Array<{ name: string; value: string; type?: string }> = [
     { name: "FORM_TYPE", value: NS_PUBSUB_NODE_CONFIG, type: "hidden" },

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -222,6 +222,7 @@ export interface DiscoveredSpace {
 export interface DiscoveredTopology {
   spaces: DiscoveredSpace[];
   rooms: DiscoveredChannel[];
+  serverRole?: "owner" | "admin" | "moderator" | "member" | null;
 }
 
 /** Cross-room activity event with optional mention data for notifications. */

--- a/chat/tests/create-intent.test.ts
+++ b/chat/tests/create-intent.test.ts
@@ -43,14 +43,14 @@ describe("create intent form model", () => {
     it("narrows to CreateSpaceMucFormData when intent is space-muc", () => {
       const form: CreateFormData = {
         intent: "space-muc",
-        space_jid: "team@conference.example.org",
+        space_node: "team-space",
         name: "announcements",
         description: "",
         muc_type: "text",
       };
       if (form.intent === "space-muc") {
         const typed: CreateSpaceMucFormData = form;
-        expect(typed.space_jid).toBe("team@conference.example.org");
+        expect(typed.space_node).toBe("team-space");
         expect(typed.muc_type).toBe("text");
       } else {
         throw new Error("Expected space-muc intent");
@@ -87,9 +87,9 @@ describe("create intent form model", () => {
       expect(form.name.trim().length > 0).toBe(false);
     });
 
-    it("space-muc form requires both space_jid and name", () => {
-      const incomplete: CreateSpaceMucFormData = { intent: "space-muc", space_jid: "", name: "general", description: "", muc_type: "text" };
-      const isValid = incomplete.space_jid.trim().length > 0 && incomplete.name.trim().length > 0;
+    it("space-muc form requires both space_node and name", () => {
+      const incomplete: CreateSpaceMucFormData = { intent: "space-muc", space_node: "", name: "general", description: "", muc_type: "text" };
+      const isValid = incomplete.space_node.trim().length > 0 && incomplete.name.trim().length > 0;
       expect(isValid).toBe(false);
     });
 

--- a/chat/tests/discovery-topology.test.ts
+++ b/chat/tests/discovery-topology.test.ts
@@ -215,7 +215,7 @@ describe("topology discovery", () => {
       getDiscoInfo,
     } as unknown as Agent, "alice@example.com/desktop");
 
-    expect(topology).toEqual({ spaces: [], rooms: [] });
+    expect(topology).toEqual({ spaces: [], rooms: [], serverRole: null });
     expect(getDiscoItems.mock.calls).not.toContainEqual([
       "example.com",
       "http://jabber.org/protocol/commands",

--- a/server/crates/waddle-server/src/permissions/schema.rs
+++ b/server/crates/waddle-server/src/permissions/schema.rs
@@ -158,8 +158,8 @@ definition server {
   relation admin: user
   relation member: user
 
-  permission create_space = owner + admin
-  permission create_muc = owner + admin
+  permission create_space = owner
+  permission create_muc = owner
 }
 
 definition space {
@@ -172,7 +172,7 @@ definition space {
   permission manage_settings = owner + admin
   permission manage_roles = owner + admin
   permission manage_members = owner + admin + moderator
-  permission create_channel = owner + admin
+  permission create_channel = owner
   permission view = member
   permission update = owner + admin
 }
@@ -247,20 +247,8 @@ fn server_schema() -> ObjectTypeSchema {
                 ComputedPermission::direct("owner"),
             ]),
         )
-        .with_permission(
-            "create_space",
-            ComputedPermission::union(vec![
-                ComputedPermission::direct("admin"),
-                ComputedPermission::direct("owner"),
-            ]),
-        )
-        .with_permission(
-            "create_muc",
-            ComputedPermission::union(vec![
-                ComputedPermission::direct("admin"),
-                ComputedPermission::direct("owner"),
-            ]),
-        )
+        .with_permission("create_space", ComputedPermission::direct("owner"))
+        .with_permission("create_muc", ComputedPermission::direct("owner"))
 }
 
 /// Schema for Space objects
@@ -320,13 +308,7 @@ fn space_schema() -> ObjectTypeSchema {
                 ComputedPermission::direct("owner"),
             ]),
         )
-        .with_permission(
-            "create_channel",
-            ComputedPermission::union(vec![
-                ComputedPermission::direct("admin"),
-                ComputedPermission::direct("owner"),
-            ]),
-        )
+        .with_permission("create_channel", ComputedPermission::direct("owner"))
         .with_permission(
             "view",
             ComputedPermission::union(vec![

--- a/server/crates/waddle-server/src/permissions/tuple.rs
+++ b/server/crates/waddle-server/src/permissions/tuple.rs
@@ -211,10 +211,15 @@ impl Subject {
         id: impl Into<String>,
         relation: impl Into<String>,
     ) -> Self {
+        let relation = relation.into();
         Self {
             subject_type,
             id: id.into(),
-            relation: Some(relation.into()),
+            relation: if relation.is_empty() {
+                None
+            } else {
+                Some(relation)
+            },
         }
     }
 
@@ -771,6 +776,10 @@ mod tests {
 
         let subj = Subject::userset(SubjectType::Space, "penguin-club", "member");
         assert_eq!(subj.to_string(), "space:penguin-club#member");
+
+        let subj = Subject::userset(SubjectType::Space, "penguin-club", "");
+        assert_eq!(subj.to_string(), "space:penguin-club");
+        assert_eq!(subj.relation, None);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/bootstrap_membership.rs
+++ b/server/crates/waddle-server/src/server/bootstrap_membership.rs
@@ -10,13 +10,11 @@ use crate::permissions::{
 };
 
 pub const DEPLOYMENT_SERVER_ID: &str = "deployment";
-const DEFAULT_SPACE_ID: &str = "space";
 const OWNER_ENV: &str = "WADDLE_SERVER_OWNER_LOCALPARTS";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BootstrapMembershipConfig {
     pub server_id: String,
-    pub space_id: String,
     owner_localparts: Vec<String>,
 }
 
@@ -24,7 +22,6 @@ impl BootstrapMembershipConfig {
     pub fn from_env() -> Self {
         Self {
             server_id: DEPLOYMENT_SERVER_ID.to_string(),
-            space_id: DEFAULT_SPACE_ID.to_string(),
             owner_localparts: parse_owner_localparts(
                 std::env::var(OWNER_ENV).unwrap_or_default().as_str(),
             ),
@@ -35,7 +32,6 @@ impl BootstrapMembershipConfig {
     pub fn new(owner_localparts: Vec<String>) -> Self {
         Self {
             server_id: DEPLOYMENT_SERVER_ID.to_string(),
-            space_id: DEFAULT_SPACE_ID.to_string(),
             owner_localparts: owner_localparts
                 .into_iter()
                 .filter_map(|value| normalize_localpart(&value))
@@ -90,13 +86,9 @@ pub async fn provision_user_membership(
 ) -> Result<(), String> {
     let subject = Subject::user(user_id);
     if config.is_owner(xmpp_localpart) {
-        for object in [
-            Object::new(ObjectType::Server, config.server_id.as_str()),
-            Object::new(ObjectType::Space, config.space_id.as_str()),
-        ] {
-            let tuple = Tuple::new(object, Relation::new("owner"), subject.clone());
-            write_tuple_if_absent(permission_actor, tuple).await?;
-        }
+        let object = Object::new(ObjectType::Server, config.server_id.as_str());
+        let tuple = Tuple::new(object, Relation::new("owner"), subject);
+        write_tuple_if_absent(permission_actor, tuple).await?;
 
         debug!(
             user_id = %user_id,
@@ -241,7 +233,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn provisions_owner_and_default_member_through_permission_actor() {
+    async fn provisions_server_owner_and_default_member_through_permission_actor() {
         let db = Arc::new(
             Database::in_memory("bootstrap-membership")
                 .await
@@ -277,18 +269,8 @@ mod tests {
             })
             .await
             .expect("member check");
-        let space_owner = actor
-            .ask(CheckPermission {
-                subject: Subject::user("user-owner"),
-                permission: Permission::Owner,
-                object: Object::new(ObjectType::Space, DEFAULT_SPACE_ID),
-            })
-            .await
-            .expect("space owner check");
-
         assert!(owner.allowed);
         assert!(member.allowed);
-        assert!(space_owner.allowed);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -46,11 +46,12 @@ use waddle_xmpp::{
         parse_mark_read,
     },
     xep::{
-        build_channel_item, build_command_items, build_command_result,
-        build_last_activity_response, build_search_response, build_spaces_metadata_form,
-        is_last_activity_query, is_search_request, is_time_query, is_version_query,
-        parse_command_from_iq, parse_search_request, ChannelResult, Command, CommandStatus,
-        Searchable, NODE_COMMANDS, NS_CHANNEL_SEARCH,
+        build_command_items, build_command_result, build_last_activity_response,
+        build_search_response, build_server_role_form, build_spaces_metadata_form,
+        build_spaces_metadata_form_for_requester, is_last_activity_query, is_search_request,
+        is_time_query, is_version_query, parse_command_from_iq, parse_search_request,
+        ChannelResult, Command, CommandStatus, Searchable, SpaceAffiliation, NODE_COMMANDS,
+        NS_CHANNEL_SEARCH,
     },
     Affiliation, SpaceDetails, Stanza, StanzaErrorCondition, StanzaErrorType, XmppError,
 };
@@ -66,8 +67,8 @@ use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::{row_value, Database, Value, ValueExt};
 use crate::permissions::{
-    CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject,
-    SubjectType, Tuple, WriteTuple,
+    CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject, Tuple,
+    WriteTuple,
 };
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::xmpp_state::{list_xmpp_channels, XmppChannelRecord};
@@ -472,20 +473,28 @@ pub async fn handle_iq_with_conn_state(
         // Disco info on spaces service
         if to.as_deref() == Some(spaces_domain.as_str()) {
             if let Some(node) = query.node.as_deref() {
-                if node != "space" {
-                    return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
-                }
-
-                let space = SpaceDetails {
-                    id: "space".to_string(),
-                    name: domain.to_string(),
-                    description: None,
-                    owner_id: "server".to_string(),
-                    icon_url: None,
-                    is_public: true,
-                    created_at: "1970-01-01T00:00:00Z".to_string(),
+                let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
+                    return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                };
+                let space_node = match state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .get_node(&spaces_jid, node)
+                    .await
+                {
+                    Ok(Some(node)) => node,
+                    Ok(None) => return vec![build_iq_error_xml(&id, "cancel", "item-not-found")],
+                    Err(error) => {
+                        warn!(node, error = %error, "Failed to resolve Spaces node info");
+                        return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
+                    }
                 };
 
+                let space = space_details_from_node(&space_node);
+                let requester_affiliation =
+                    space_affiliation_for_requester(state, authenticated_session.as_ref(), node)
+                        .await;
                 let identities = vec![Identity::pubsub_leaf(Some(&space.name))];
                 let features = vec![
                     Feature::disco_info(),
@@ -493,7 +502,8 @@ pub async fn handle_iq_with_conn_state(
                     Feature::pubsub_retrieve_items(),
                     Feature::spaces(),
                 ];
-                let metadata = build_spaces_metadata_form(&space);
+                let metadata =
+                    build_spaces_metadata_form_for_requester(&space, requester_affiliation);
                 let response = build_disco_info_response_with_extensions(
                     request_iq,
                     &identities,
@@ -544,7 +554,17 @@ pub async fn handle_iq_with_conn_state(
                 .into_iter()
                 .map(|ns| Feature::new(&ns)),
         );
-        let response = build_disco_info_response(request_iq, &identities, &features, None);
+        let response =
+            match server_affiliation_for_requester(state, authenticated_session.as_ref()).await {
+                Some(role) => build_disco_info_response_with_extensions(
+                    request_iq,
+                    &identities,
+                    &features,
+                    None,
+                    &[build_server_role_form(role)],
+                ),
+                None => build_disco_info_response(request_iq, &identities, &features, None),
+            };
         return vec![iq_to_xml(response)];
     }
 
@@ -576,18 +596,29 @@ pub async fn handle_iq_with_conn_state(
 
         if to.as_deref() == Some(spaces_domain.as_str()) {
             let items: Vec<DiscoItem> = match query.node.as_deref() {
-                Some(node) => {
-                    if node != "space" {
-                        vec![]
-                    } else {
+                Some(_) => vec![],
+                None => match spaces_service_bare_jid(&spaces_domain) {
+                    Ok(spaces_jid) => match state
+                        .deps
+                        .protocol
+                        .pubsub_storage
+                        .list_nodes(&spaces_jid)
+                        .await
+                    {
+                        Ok(nodes) => nodes
+                            .into_iter()
+                            .map(|node| DiscoItem::spaces_node(&spaces_domain, &node, Some(&node)))
+                            .collect(),
+                        Err(error) => {
+                            warn!(error = %error, "Failed to list Spaces nodes");
+                            vec![]
+                        }
+                    },
+                    Err(error) => {
+                        warn!(error = %error, "Invalid Spaces service JID");
                         vec![]
                     }
-                }
-                None => vec![DiscoItem::spaces_node(
-                    &spaces_domain,
-                    "space",
-                    Some(domain),
-                )],
+                },
             };
 
             let response = build_disco_items_response(request_iq, &items, query.node.as_deref());
@@ -1053,11 +1084,13 @@ pub async fn handle_iq_with_conn_state(
 
         match request {
             PubSubRequest::Publish { node, item } => {
-                if target_jid.to_string() == spaces_domain && node == "space" {
+                if target_jid.to_string() == spaces_domain {
                     return handle_spaces_publish(
                         &iq,
                         state,
                         muc_domain,
+                        &spaces_domain,
+                        &node,
                         item,
                         authenticated_session.as_ref(),
                     )
@@ -1096,8 +1129,16 @@ pub async fn handle_iq_with_conn_state(
                 max_items,
                 item_ids,
             } => {
-                if target_jid.to_string() == spaces_domain && node == "space" {
-                    return handle_spaces_items(&iq, state, muc_domain, max_items, &item_ids).await;
+                if target_jid.to_string() == spaces_domain {
+                    return handle_spaces_items(
+                        &iq,
+                        state,
+                        &spaces_domain,
+                        &node,
+                        max_items,
+                        &item_ids,
+                    )
+                    .await;
                 }
 
                 let result = state
@@ -1132,11 +1173,13 @@ pub async fn handle_iq_with_conn_state(
                 item_id,
                 notify: _,
             } => {
-                if target_jid.to_string() == spaces_domain && node == "space" {
+                if target_jid.to_string() == spaces_domain {
                     return handle_spaces_retract(
                         &iq,
                         state,
                         muc_domain,
+                        &spaces_domain,
+                        &node,
                         &item_id,
                         authenticated_session.as_ref(),
                     )
@@ -1176,23 +1219,58 @@ pub async fn handle_iq_with_conn_state(
 
             PubSubRequest::CreateNode { node } => {
                 if target_jid.to_string() == spaces_domain {
-                    if node == "space" {
-                        if server_permission_allowed(
-                            state,
-                            authenticated_session.as_ref(),
-                            Permission::CreateSpace,
-                        )
-                        .await
-                        .unwrap_or(false)
+                    if server_permission_allowed(
+                        state,
+                        authenticated_session.as_ref(),
+                        Permission::CreateSpace,
+                    )
+                    .await
+                    .unwrap_or(false)
+                    {
+                        let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
+                            return vec![iq_to_xml(build_pubsub_error(
+                                &iq,
+                                PubSubError::InvalidJid,
+                            ))];
+                        };
+                        match state
+                            .deps
+                            .protocol
+                            .pubsub_storage
+                            .get_or_create_node(&spaces_jid, &node)
+                            .await
                         {
-                            let response = build_pubsub_success(&iq);
-                            return vec![iq_to_xml(response)];
+                            Ok((_, true)) => {
+                                if let Err(error) = write_space_owner_tuple(
+                                    state,
+                                    &node,
+                                    authenticated_session.as_ref(),
+                                )
+                                .await
+                                {
+                                    warn!(node = %node, error = %error, "Failed to persist Space owner tuple");
+                                    return vec![iq_to_xml(build_pubsub_error(
+                                        &iq,
+                                        PubSubError::Forbidden,
+                                    ))];
+                                }
+                                let response = build_pubsub_success(&iq);
+                                return vec![iq_to_xml(response)];
+                            }
+                            Ok((_, false)) => {
+                                let error = build_pubsub_error(&iq, PubSubError::NodeExists);
+                                return vec![iq_to_xml(error)];
+                            }
+                            Err(error) => {
+                                warn!(node = %node, error = %error, "Failed to create Spaces node");
+                                let error = build_pubsub_error(&iq, PubSubError::Forbidden);
+                                return vec![iq_to_xml(error)];
+                            }
                         }
+                    } else {
                         let error = build_pubsub_error(&iq, PubSubError::Forbidden);
                         return vec![iq_to_xml(error)];
                     }
-                    let error = build_pubsub_error(&iq, PubSubError::Forbidden);
-                    return vec![iq_to_xml(error)];
                 }
 
                 if target_jid != user_jid {
@@ -1226,15 +1304,39 @@ pub async fn handle_iq_with_conn_state(
             }
 
             PubSubRequest::ConfigureNode { node } => {
-                if target_jid.to_string() == spaces_domain && node == "space" {
-                    if server_permission_allowed(
-                        state,
-                        authenticated_session.as_ref(),
-                        Permission::CreateSpace,
-                    )
-                    .await
-                    .unwrap_or(false)
+                if target_jid.to_string() == spaces_domain {
+                    if spaces_node_mutation_allowed(state, authenticated_session.as_ref(), &node)
+                        .await
+                        .unwrap_or(false)
                     {
+                        let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
+                            return vec![iq_to_xml(build_pubsub_error(
+                                &iq,
+                                PubSubError::InvalidJid,
+                            ))];
+                        };
+                        match state
+                            .deps
+                            .protocol
+                            .pubsub_storage
+                            .get_node(&spaces_jid, &node)
+                            .await
+                        {
+                            Ok(Some(_)) => {}
+                            Ok(None) => {
+                                return vec![iq_to_xml(build_pubsub_error(
+                                    &iq,
+                                    PubSubError::NodeNotFound,
+                                ))];
+                            }
+                            Err(error) => {
+                                warn!(node = %node, error = %error, "Failed to configure Spaces node");
+                                return vec![iq_to_xml(build_pubsub_error(
+                                    &iq,
+                                    PubSubError::NodeNotFound,
+                                ))];
+                            }
+                        }
                         let response = build_pubsub_success(&iq);
                         return vec![iq_to_xml(response)];
                     }
@@ -1284,25 +1386,22 @@ pub async fn handle_iq_with_conn_state(
                     let error = build_pubsub_error(&iq, PubSubError::Forbidden);
                     return vec![iq_to_xml(error)];
                 }
-                let is_spaces_node = target_jid.to_string() == spaces_domain && node == "space";
-                if !is_spaces_node {
-                    match state
-                        .deps
-                        .protocol
-                        .pubsub_storage
-                        .get_node(&target_jid, &node)
-                        .await
-                    {
-                        Ok(Some(_)) => {}
-                        Ok(None) => {
-                            let error = build_pubsub_error(&iq, PubSubError::NodeNotFound);
-                            return vec![iq_to_xml(error)];
-                        }
-                        Err(e) => {
-                            warn!("PubSub subscribe node lookup failed: {}", e);
-                            let error = build_pubsub_error(&iq, PubSubError::NodeNotFound);
-                            return vec![iq_to_xml(error)];
-                        }
+                match state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .get_node(&target_jid, &node)
+                    .await
+                {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        let error = build_pubsub_error(&iq, PubSubError::NodeNotFound);
+                        return vec![iq_to_xml(error)];
+                    }
+                    Err(e) => {
+                        warn!("PubSub subscribe node lookup failed: {}", e);
+                        let error = build_pubsub_error(&iq, PubSubError::NodeNotFound);
+                        return vec![iq_to_xml(error)];
                     }
                 }
                 state.deps.protocol.pubsub_subscriptions.insert((
@@ -2648,28 +2747,76 @@ async fn server_permission_allowed(
     .await
 }
 
-async fn default_space_permission_allowed(
+async fn server_affiliation_for_requester(
     state: &WebSocketState,
     session: Option<&Session>,
-    permission: Permission,
-) -> Result<bool, String> {
-    permission_allowed(
-        state,
-        session,
-        Object::new(ObjectType::Space, "space"),
-        permission,
-    )
-    .await
+) -> Option<SpaceAffiliation> {
+    if server_permission_allowed(state, session, Permission::Owner)
+        .await
+        .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Owner);
+    }
+    if server_permission_allowed(state, session, Permission::Admin)
+        .await
+        .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Publisher);
+    }
+    if server_permission_allowed(state, session, Permission::Member)
+        .await
+        .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Member);
+    }
+    None
 }
 
-async fn channel_creation_allowed(
+async fn space_affiliation_for_requester(
     state: &WebSocketState,
     session: Option<&Session>,
-) -> Result<bool, String> {
-    if default_space_permission_allowed(state, session, Permission::CreateChannel).await? {
-        return Ok(true);
+    node: &str,
+) -> Option<SpaceAffiliation> {
+    if server_permission_allowed(state, session, Permission::Owner)
+        .await
+        .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Owner);
     }
-    server_permission_allowed(state, session, Permission::CreateMuc).await
+    if permission_allowed(
+        state,
+        session,
+        Object::new(ObjectType::Space, node),
+        Permission::Owner,
+    )
+    .await
+    .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Owner);
+    }
+    if permission_allowed(
+        state,
+        session,
+        Object::new(ObjectType::Space, node),
+        Permission::Admin,
+    )
+    .await
+    .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Publisher);
+    }
+    if permission_allowed(
+        state,
+        session,
+        Object::new(ObjectType::Space, node),
+        Permission::Member,
+    )
+    .await
+    .unwrap_or(false)
+    {
+        return Some(SpaceAffiliation::Member);
+    }
+    None
 }
 
 async fn write_tuple_if_absent(state: &WebSocketState, tuple: Tuple) -> Result<(), String> {
@@ -2686,28 +2833,35 @@ async fn write_tuple_if_absent(state: &WebSocketState, tuple: Tuple) -> Result<(
     }
 }
 
-async fn write_channel_membership_tuples(
+async fn spaces_node_mutation_allowed(
     state: &WebSocketState,
-    channel_id: &str,
+    session: Option<&Session>,
+    node: &str,
+) -> Result<bool, String> {
+    if server_permission_allowed(state, session, Permission::CreateSpace).await? {
+        return Ok(true);
+    }
+    permission_allowed(
+        state,
+        session,
+        Object::new(ObjectType::Space, node),
+        Permission::Owner,
+    )
+    .await
+}
+
+async fn write_space_owner_tuple(
+    state: &WebSocketState,
+    node: &str,
     session: Option<&Session>,
 ) -> Result<(), String> {
     let Some(session) = session else {
         return Ok(());
     };
-    let channel = Object::new(ObjectType::Channel, channel_id);
     write_tuple_if_absent(
         state,
         Tuple::new(
-            channel.clone(),
-            Relation::new("parent"),
-            Subject::userset(SubjectType::Space, "space", ""),
-        ),
-    )
-    .await?;
-    write_tuple_if_absent(
-        state,
-        Tuple::new(
-            channel,
+            Object::new(ObjectType::Space, node),
             Relation::new("owner"),
             Subject::user(&session.user_id),
         ),
@@ -2719,7 +2873,7 @@ async fn muc_owner_authorized(
     state: &WebSocketState,
     room_jid: &BareJid,
     sender_jid: &FullJid,
-    session: Option<&Session>,
+    _session: Option<&Session>,
 ) -> Result<bool, String> {
     let room_actor = get_room_actor(state, room_jid)
         .await
@@ -2735,7 +2889,7 @@ async fn muc_owner_authorized(
         return Ok(true);
     }
 
-    channel_creation_allowed(state, session).await
+    Ok(false)
 }
 
 async fn build_muc_owner_config_response(
@@ -2764,15 +2918,21 @@ async fn build_muc_owner_config_response(
     ))
 }
 
-fn canonical_space_details(domain: &str) -> SpaceDetails {
+fn spaces_service_bare_jid(spaces_domain: &str) -> Result<BareJid, String> {
+    spaces_domain
+        .parse::<BareJid>()
+        .map_err(|error| format!("invalid spaces service JID: {error}"))
+}
+
+fn space_details_from_node(node: &waddle_xmpp::pubsub::PubSubNode) -> SpaceDetails {
     SpaceDetails {
-        id: "space".to_string(),
-        name: domain.to_string(),
+        id: node.node_name.clone(),
+        name: node.node_name.clone(),
         description: None,
-        owner_id: "server".to_string(),
+        owner_id: node.owner.to_string(),
         icon_url: None,
         is_public: true,
-        created_at: "1970-01-01T00:00:00Z".to_string(),
+        created_at: node.created_at.to_rfc3339(),
     }
 }
 
@@ -2807,53 +2967,47 @@ async fn canonical_channel_disco_items(
     }
 }
 
-async fn canonical_space_pubsub_items(
-    state: &WebSocketState,
-    muc_domain: &str,
-    max_items: Option<u32>,
-    item_ids: &[String],
-) -> Result<Vec<PubSubItem>, String> {
-    let limit = max_items.unwrap_or(500).clamp(1, 500) as usize;
-    let channels = list_xmpp_channels(
-        state.deps.app_state.db_pool.global_actor().clone(),
-        limit,
-        0,
-    )
-    .await?;
-    let requested: std::collections::HashSet<&str> = item_ids.iter().map(String::as_str).collect();
-
-    channels
-        .into_iter()
-        .filter(|channel| {
-            if requested.is_empty() {
-                return true;
-            }
-            waddle_xmpp::managed_room_jid(&channel.id, muc_domain)
-                .map(|jid| requested.contains(jid.to_string().as_str()))
-                .unwrap_or(false)
-        })
-        .map(|channel| {
-            let channel = waddle_xmpp::ChannelInfo {
-                id: channel.id,
-                name: channel.name,
-                channel_type: channel.channel_type,
-            };
-            build_channel_item(&channel, muc_domain).map_err(|error| error.to_string())
-        })
-        .collect()
-}
-
 async fn handle_spaces_items(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
-    muc_domain: &str,
+    spaces_domain: &str,
+    node: &str,
     max_items: Option<u32>,
     item_ids: &[String],
 ) -> Vec<String> {
-    match canonical_space_pubsub_items(state, muc_domain, max_items, item_ids).await {
-        Ok(items) => vec![iq_to_xml(build_pubsub_items_result(iq, "space", &items))],
+    let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_node(&spaces_jid, node)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
         Err(error) => {
-            warn!(error = %error, "Failed to retrieve canonical Spaces items");
+            warn!(node, error = %error, "Failed to retrieve Spaces node");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+        }
+    }
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(&spaces_jid, node, max_items, item_ids)
+        .await
+    {
+        Ok(stored_items) => {
+            let items: Vec<_> = stored_items
+                .iter()
+                .map(|item| item.to_pubsub_item())
+                .collect();
+            vec![iq_to_xml(build_pubsub_items_result(iq, node, &items))]
+        }
+        Err(error) => {
+            warn!(node, error = %error, "Failed to retrieve Spaces items");
             vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))]
         }
     }
@@ -2863,15 +3017,34 @@ async fn handle_spaces_publish(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
     muc_domain: &str,
+    spaces_domain: &str,
+    node: &str,
     item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
-    match channel_creation_allowed(state, session).await {
+    match spaces_node_mutation_allowed(state, session, node).await {
         Ok(true) => {}
         Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
         Err(error) => {
-            warn!(error = %error, "Failed to authorize canonical Spaces publish");
+            warn!(node, error = %error, "Failed to authorize Spaces publish");
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+        }
+    }
+    let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_node(&spaces_jid, node)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
+        Err(error) => {
+            warn!(node, error = %error, "Failed to resolve Spaces node for publish");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
         }
     }
 
@@ -2891,40 +3064,24 @@ async fn handle_spaces_publish(
     if bookmark.jid.domain().as_str() != muc_domain {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     }
-    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&bookmark.jid) else {
-        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
-    };
-    let name = bookmark.name.unwrap_or_else(|| channel_id.clone());
-    let now = chrono::Utc::now().to_rfc3339();
-    let actor = state.deps.app_state.db_pool.global_actor().clone();
-    match actor
-        .ask(DbExecute {
-            sql: r#"
-                INSERT INTO channels (id, name, description, channel_type, position, is_default, created_at, updated_at)
-                VALUES (?, ?, NULL, 'text', 0, 0, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    name = excluded.name,
-                    updated_at = excluded.updated_at
-            "#
-            .to_string(),
-            params: vec![
-                channel_id.clone().into(),
-                name.into(),
-                now.clone().into(),
-                now.into(),
-            ],
-        })
+    if get_room_actor(state, &bookmark.jid).await.is_none() {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+    }
+
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(&spaces_jid, node, &item, None, false)
         .await
     {
-        Ok(_) => {
-            if let Err(error) = write_channel_membership_tuples(state, &channel_id, session).await {
-                warn!(item_id, error = %error, "Failed to persist channel permissions for canonical Spaces item");
-                return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
-            }
-            vec![iq_to_xml(build_pubsub_publish_result(iq, "space", item_id))]
-        }
+        Ok(result) => vec![iq_to_xml(build_pubsub_publish_result(
+            iq,
+            node,
+            &result.item_id,
+        ))],
         Err(error) => {
-            warn!(item_id, error = %error, "Failed to publish canonical Spaces item");
+            warn!(item_id, node, error = %error, "Failed to publish Spaces item");
             vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))]
         }
     }
@@ -2934,14 +3091,16 @@ async fn handle_spaces_retract(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
     muc_domain: &str,
+    spaces_domain: &str,
+    node: &str,
     item_id: &str,
     session: Option<&Session>,
 ) -> Vec<String> {
-    match channel_creation_allowed(state, session).await {
+    match spaces_node_mutation_allowed(state, session, node).await {
         Ok(true) => {}
         Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
         Err(error) => {
-            warn!(error = %error, "Failed to authorize canonical Spaces retract");
+            warn!(node, error = %error, "Failed to authorize Spaces retract");
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
         }
     }
@@ -2952,22 +3111,21 @@ async fn handle_spaces_retract(
     if room_jid.domain().as_str() != muc_domain {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     }
-    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&room_jid) else {
+    let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    let actor = state.deps.app_state.db_pool.global_actor().clone();
-    match actor
-        .ask(DbExecute {
-            sql: "DELETE FROM channels WHERE id = ?".to_string(),
-            params: vec![channel_id.into()],
-        })
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .retract_item(&spaces_jid, node, item_id)
         .await
     {
-        Ok(affected) if affected > 0 => vec![iq_to_xml(build_pubsub_success(iq))],
-        Ok(_) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
+        Ok(true) => vec![iq_to_xml(build_pubsub_success(iq))],
+        Ok(false) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
         Err(error) => {
-            warn!(item_id, error = %error, "Failed to retract canonical Spaces item");
-            vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))]
+            warn!(item_id, node, error = %error, "Failed to retract Spaces item");
+            vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))]
         }
     }
 }
@@ -2977,16 +3135,50 @@ async fn room_space_metadata_extensions(
     room_jid: &BareJid,
     domain: &str,
 ) -> Vec<Element> {
-    if get_managed_channel_for_room(state, room_jid)
+    let spaces_domain = format!("spaces.{domain}");
+    let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
+        return vec![];
+    };
+    let Ok(nodes) = state
+        .deps
+        .protocol
+        .pubsub_storage
+        .list_nodes(&spaces_jid)
         .await
-        .ok()
-        .flatten()
-        .is_some()
-    {
-        vec![build_spaces_metadata_form(&canonical_space_details(domain))]
-    } else {
-        vec![]
+    else {
+        return vec![];
+    };
+    let room_item_id = room_jid.to_string();
+    for node in nodes {
+        let Ok(items) = state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_items(
+                &spaces_jid,
+                &node,
+                None,
+                std::slice::from_ref(&room_item_id),
+            )
+            .await
+        else {
+            continue;
+        };
+        if items.iter().any(|item| item.id == room_item_id) {
+            if let Ok(Some(space_node)) = state
+                .deps
+                .protocol
+                .pubsub_storage
+                .get_node(&spaces_jid, &node)
+                .await
+            {
+                return vec![build_spaces_metadata_form(&space_details_from_node(
+                    &space_node,
+                ))];
+            }
+        }
     }
+    vec![]
 }
 
 fn data_form_value(form: &Element, var: &str) -> Option<String> {
@@ -3009,7 +3201,7 @@ async fn apply_muc_owner_config(
     state: &WebSocketState,
     room_jid: &BareJid,
     iq: &xmpp_parsers::iq::Iq,
-    session: Option<&Session>,
+    _session: Option<&Session>,
 ) -> Result<(), String> {
     let room_actor = get_room_actor(state, room_jid)
         .await
@@ -3085,7 +3277,7 @@ async fn apply_muc_owner_config(
         .await
         .map_err(|error| format!("channel upsert failed: {error}"))?;
 
-    write_channel_membership_tuples(state, &channel_id, session).await
+    Ok(())
 }
 
 async fn handle_command_iq(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -71,7 +71,7 @@ use crate::permissions::{
     WriteTuple,
 };
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
-use crate::server::xmpp_state::{list_xmpp_channels, XmppChannelRecord};
+use crate::server::xmpp_state::{get_xmpp_channel, list_xmpp_channels, XmppChannelRecord};
 use crate::vcard::VCardStore;
 
 /// Only called from test helpers — suppress dead_code lint for binary crate.
@@ -3064,8 +3064,17 @@ async fn handle_spaces_publish(
     if bookmark.jid.domain().as_str() != muc_domain {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     }
-    if get_room_actor(state, &bookmark.jid).await.is_none() {
-        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&bookmark.jid) else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    let db_actor = state.deps.app_state.db_pool.global_actor().clone();
+    match get_xmpp_channel(db_actor, &channel_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
+        Err(error) => {
+            warn!(channel_id, error = %error, "Failed to look up channel for Spaces bookmark");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+        }
     }
 
     match state
@@ -3139,46 +3148,25 @@ async fn room_space_metadata_extensions(
     let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
         return vec![];
     };
-    let Ok(nodes) = state
+    let room_item_id = room_jid.to_string();
+    match state
         .deps
         .protocol
         .pubsub_storage
-        .list_nodes(&spaces_jid)
+        .find_node_for_item(&spaces_jid, &room_item_id)
         .await
-    else {
-        return vec![];
-    };
-    let room_item_id = room_jid.to_string();
-    for node in nodes {
-        let Ok(items) = state
-            .deps
-            .protocol
-            .pubsub_storage
-            .get_items(
-                &spaces_jid,
-                &node,
-                None,
-                std::slice::from_ref(&room_item_id),
-            )
-            .await
-        else {
-            continue;
-        };
-        if items.iter().any(|item| item.id == room_item_id) {
-            if let Ok(Some(space_node)) = state
-                .deps
-                .protocol
-                .pubsub_storage
-                .get_node(&spaces_jid, &node)
-                .await
-            {
-                return vec![build_spaces_metadata_form(&space_details_from_node(
-                    &space_node,
-                ))];
-            }
+    {
+        Ok(Some(space_node)) => {
+            vec![build_spaces_metadata_form(&space_details_from_node(
+                &space_node,
+            ))]
+        }
+        Ok(None) => vec![],
+        Err(error) => {
+            warn!(room = %room_jid, error = %error, "Failed to find Space node for room");
+            vec![]
         }
     }
-    vec![]
 }
 
 fn data_form_value(form: &Element, var: &str) -> Option<String> {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -3115,8 +3115,28 @@ async fn handle_spaces_publish(
                     channel_id = %channel_id,
                     node,
                     error = %error,
-                    "Published Spaces item but failed to sync channel parent tuple"
+                    "Published Spaces item but failed to sync channel parent tuple; \
+                     retracting to keep PubSub and permission graph consistent"
                 );
+                // Compensating retract: remove the just-published bookmark so
+                // the server does not end up in a state where the item is
+                // advertised in PubSub but the channel is not accessible via
+                // Space membership (XEP-0503 §4).
+                if let Err(retract_err) = state
+                    .deps
+                    .protocol
+                    .pubsub_storage
+                    .retract_item(&spaces_jid, node, &result.item_id)
+                    .await
+                {
+                    warn!(
+                        channel_id = %channel_id,
+                        node,
+                        item_id = %result.item_id,
+                        error = %retract_err,
+                        "Compensating retract also failed; manual cleanup may be required"
+                    );
+                }
                 return vec![iq_to_xml(build_pubsub_error(
                     iq,
                     PubSubError::InternalServerError,
@@ -3312,17 +3332,28 @@ async fn apply_muc_owner_config(
 
     // Write channel#owner → session user so the creator can always rejoin the
     // managed room after a server restart (before a Space bookmark is published).
-    if let Some(session) = session {
-        write_tuple_if_absent(
-            state,
-            Tuple::new(
-                Object::new(ObjectType::Channel, &channel_id),
-                Relation::new("owner"),
-                Subject::user(&session.user_id),
-            ),
-        )
-        .await
-        .map_err(|error| format!("channel owner tuple failed: {error}"))?;
+    // XEP-0045 §10 requires the room creator to be an owner; without this tuple
+    // the channel becomes unjoinable after restart.
+    match session {
+        Some(session) => {
+            write_tuple_if_absent(
+                state,
+                Tuple::new(
+                    Object::new(ObjectType::Channel, &channel_id),
+                    Relation::new("owner"),
+                    Subject::user(&session.user_id),
+                ),
+            )
+            .await
+            .map_err(|error| format!("channel owner tuple failed: {error}"))?;
+        }
+        None => {
+            warn!(
+                channel_id = %channel_id,
+                "apply_muc_owner_config called without a session; \
+                 channel owner tuple not written — room may be inaccessible after server restart"
+            );
+        }
     }
 
     Ok(())

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -3108,9 +3108,7 @@ async fn handle_spaces_publish(
         .await
     {
         Ok(result) => {
-            if let Err(error) =
-                write_channel_parent_tuple(state, &channel_id, node).await
-            {
+            if let Err(error) = write_channel_parent_tuple(state, &channel_id, node).await {
                 warn!(
                     channel_id = %channel_id,
                     node,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -67,8 +67,8 @@ use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::{row_value, Database, Value, ValueExt};
 use crate::permissions::{
-    CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject, Tuple,
-    WriteTuple,
+    CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject,
+    SubjectType, Tuple, WriteTuple,
 };
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::xmpp_state::{get_xmpp_channel, list_xmpp_channels, XmppChannelRecord};
@@ -2869,6 +2869,26 @@ async fn write_space_owner_tuple(
     .await
 }
 
+/// Write `channel:<channel_id>#parent → space:<space_node>#` so that all members
+/// of the Space gain access to the channel via the permission arrow.
+/// Per XEP-0503 §4, a room bookmarked inside a Space node is considered part of
+/// that Space; this tuple propagates Space membership into channel access checks.
+async fn write_channel_parent_tuple(
+    state: &WebSocketState,
+    channel_id: &str,
+    space_node: &str,
+) -> Result<(), String> {
+    write_tuple_if_absent(
+        state,
+        Tuple::new(
+            Object::new(ObjectType::Channel, channel_id),
+            Relation::new("parent"),
+            Subject::userset(SubjectType::Space, space_node, ""),
+        ),
+    )
+    .await
+}
+
 async fn muc_owner_authorized(
     state: &WebSocketState,
     room_jid: &BareJid,
@@ -3073,7 +3093,10 @@ async fn handle_spaces_publish(
         Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
         Err(error) => {
             warn!(channel_id = %channel_id, error = %error, "Failed to look up channel for Spaces bookmark");
-            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
+            return vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))];
         }
     }
 
@@ -3084,14 +3107,33 @@ async fn handle_spaces_publish(
         .publish_item(&spaces_jid, node, &item, None, false)
         .await
     {
-        Ok(result) => vec![iq_to_xml(build_pubsub_publish_result(
-            iq,
-            node,
-            &result.item_id,
-        ))],
+        Ok(result) => {
+            if let Err(error) =
+                write_channel_parent_tuple(state, &channel_id, node).await
+            {
+                warn!(
+                    channel_id = %channel_id,
+                    node,
+                    error = %error,
+                    "Published Spaces item but failed to sync channel parent tuple"
+                );
+                return vec![iq_to_xml(build_pubsub_error(
+                    iq,
+                    PubSubError::InternalServerError,
+                ))];
+            }
+            vec![iq_to_xml(build_pubsub_publish_result(
+                iq,
+                node,
+                &result.item_id,
+            ))]
+        }
         Err(error) => {
             warn!(item_id, node, error = %error, "Failed to publish Spaces item");
-            vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))]
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
         }
     }
 }
@@ -3134,7 +3176,10 @@ async fn handle_spaces_retract(
         Ok(false) => vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
         Err(error) => {
             warn!(item_id, node, error = %error, "Failed to retract Spaces item");
-            vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))]
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
         }
     }
 }
@@ -3189,7 +3234,7 @@ async fn apply_muc_owner_config(
     state: &WebSocketState,
     room_jid: &BareJid,
     iq: &xmpp_parsers::iq::Iq,
-    _session: Option<&Session>,
+    session: Option<&Session>,
 ) -> Result<(), String> {
     let room_actor = get_room_actor(state, room_jid)
         .await
@@ -3264,6 +3309,21 @@ async fn apply_muc_owner_config(
         })
         .await
         .map_err(|error| format!("channel upsert failed: {error}"))?;
+
+    // Write channel#owner → session user so the creator can always rejoin the
+    // managed room after a server restart (before a Space bookmark is published).
+    if let Some(session) = session {
+        write_tuple_if_absent(
+            state,
+            Tuple::new(
+                Object::new(ObjectType::Channel, &channel_id),
+                Relation::new("owner"),
+                Subject::user(&session.user_id),
+            ),
+        )
+        .await
+        .map_err(|error| format!("channel owner tuple failed: {error}"))?;
+    }
 
     Ok(())
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -3072,7 +3072,7 @@ async fn handle_spaces_publish(
         Ok(Some(_)) => {}
         Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))],
         Err(error) => {
-            warn!(channel_id, error = %error, "Failed to look up channel for Spaces bookmark");
+            warn!(channel_id = %channel_id, error = %error, "Failed to look up channel for Spaces bookmark");
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::ItemNotFound))];
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -22,6 +22,7 @@ use crate::db::actor::GetDatabase;
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::roster::{DatabaseRosterStorage, RosterItemRow};
 use crate::permissions::{CheckPermission, Object, ObjectType, Permission, Subject};
+use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::xmpp_state::{get_xmpp_channel, XmppChannelRecord};
 use waddle_xmpp::protocol::ConnectionPhase;
 
@@ -609,6 +610,24 @@ pub async fn handle_muc_join(
     let (room_actor, created_instant_room) = match existing_room_actor {
         Some(actor) => (actor, false),
         None => {
+            if managed_channel.is_none()
+                && !server_permission_allowed(
+                    state,
+                    authenticated_session.as_ref(),
+                    Permission::CreateMuc,
+                )
+                .await
+                .unwrap_or(false)
+            {
+                return vec![build_muc_join_error_xml(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "cancel",
+                    "not-allowed",
+                )];
+            }
+
             let config = managed_channel
                 .as_ref()
                 .map(|channel| RoomConfig {
@@ -1000,6 +1019,30 @@ fn build_muc_self_unavailable_xml(room_jid: &BareJid, nick: &str, sender_jid: &F
         Some(sender_jid),
     );
     stanza_to_xml(&Stanza::Presence(presence))
+}
+
+async fn server_permission_allowed(
+    state: &WebSocketState,
+    session: Option<&Session>,
+    permission: Permission,
+) -> Result<bool, ()> {
+    let Some(session) = session else {
+        return Ok(false);
+    };
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: Subject::user(&session.user_id),
+            permission,
+            object: Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+        })
+        .await
+        .map(|response| response.allowed)
+        .map_err(|error| {
+            warn!(error = %error, "Failed to authorize MUC creation");
+        })
 }
 
 /// Create a presence stanza for MUC

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -1679,6 +1679,8 @@ mod tests {
     use super::*;
     use crate::config::ServerConfig;
     use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use crate::permissions::{Object, ObjectType, Relation, Subject, Tuple, WriteTuple};
+    use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
     use crate::server::AppState;
     use futures::Sink;
     use hmac::{Hmac, Mac};
@@ -1814,6 +1816,24 @@ mod tests {
             .create_session(&session)
             .await
             .expect("session");
+        session
+    }
+
+    async fn create_test_server_owner_session(state: &WebSocketState, username: &str) -> Session {
+        let session = create_test_session(state, username).await;
+        state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                    Relation::new("owner"),
+                    Subject::user(&session.user_id),
+                ),
+            })
+            .await
+            .expect("server owner tuple");
         session
     }
 
@@ -2018,7 +2038,7 @@ mod tests {
     #[tokio::test]
     async fn handle_xmpp_frame_auth_dispatches_via_typed_ingress() {
         let state = create_test_websocket_state().await;
-        let session = create_test_session(state.as_ref(), "alice").await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let payload = BASE64_STANDARD.encode(format!("n,,\x01auth=Bearer {}\x01\x01", session.id));
         let frame = element_to_xml(
             Element::builder("auth", waddle_xmpp::ns::SASL)
@@ -2186,7 +2206,7 @@ mod tests {
     #[tokio::test]
     async fn websocket_oauthbearer_authenticates_session_token() {
         let state = create_test_websocket_state().await;
-        let session = create_test_session(state.as_ref(), "alice").await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let payload = BASE64_STANDARD.encode(format!("n,,\x01auth=Bearer {}\x01\x01", session.id));
         let frame = element_to_xml(
             Element::builder("auth", waddle_xmpp::ns::SASL)
@@ -2602,6 +2622,7 @@ mod tests {
     #[tokio::test]
     async fn muc_stale_leave_does_not_remove_current_resource() {
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "channel@muc.example.com".parse().expect("room jid");
         let current_jid: FullJid = "alice@example.com/current".parse().expect("current jid");
         let stale_jid: FullJid = "alice@example.com/stale".parse().expect("stale jid");
@@ -2612,7 +2633,7 @@ mod tests {
             &room_jid,
             &current_jid,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
 
@@ -2632,6 +2653,7 @@ mod tests {
     #[tokio::test]
     async fn muc_join_responses_use_client_namespace() {
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "channel@muc.example.com".parse().expect("room jid");
         let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
 
@@ -2641,7 +2663,7 @@ mod tests {
             &room_jid,
             &sender_jid,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
 
@@ -3611,7 +3633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_iq_disco_items_spaces_lists_canonical_space() {
+    async fn handle_iq_disco_items_spaces_is_empty_without_owner_created_spaces() {
         let state = create_test_websocket_state().await;
         let session = create_test_session(state.as_ref(), "alice").await;
 
@@ -3640,33 +3662,38 @@ mod tests {
         let response = responses.first().expect("spaces disco items response");
 
         assert!(
-            response.contains("node=\"space\"") || response.contains("node='space'"),
-            "expected space node in spaces disco#items: {response}"
-        );
-        assert!(
-            response.contains("example.com"),
-            "expected space name in spaces disco#items: {response}"
+            !response.contains("node="),
+            "fresh deployments must not advertise a synthetic space node: {response}"
         );
     }
 
     #[tokio::test]
-    async fn handle_iq_pubsub_items_spaces_node_lists_bookmarked_channels() {
+    async fn handle_iq_pubsub_items_spaces_node_lists_published_bookmarks() {
         let state = create_test_websocket_state().await;
         let session = create_test_session(state.as_ref(), "alice").await;
 
-        let space_db = state.deps.app_state.db_pool.global();
-        MigrationRunner::waddle()
-            .run(space_db)
+        let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_or_create_node(&spaces_jid, "team")
             .await
-            .expect("space migrations");
-        let conn = space_db.guard().await.expect("persistent connection");
-        conn.execute(
-            "INSERT INTO channels (id, name, channel_type, position, is_default) VALUES (?, ?, 'text', 0, 0)",
-            crate::db_params!["general", "General"],
-        )
-        .await
-        .expect("insert channel");
-        drop(conn);
+            .expect("space node");
+        let channel = waddle_xmpp::ChannelInfo {
+            id: "general".to_string(),
+            name: "General".to_string(),
+            channel_type: "text".to_string(),
+        };
+        let item = waddle_xmpp::xep::build_channel_item(&channel, "muc.example.com")
+            .expect("bookmark item");
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(&spaces_jid, "team", &item, None, false)
+            .await
+            .expect("publish bookmark");
 
         let authenticated_session = Some(session);
         let authenticated_jid: FullJid = format!(
@@ -3679,7 +3706,7 @@ mod tests {
         .parse()
         .expect("authenticated jid");
         let authenticated_phase = ready_phase(&authenticated_jid);
-        let query = r#"<iq xmlns="jabber:client" id="space-node-items" type="get" to="spaces.example.com"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="space"/></pubsub></iq>"#;
+        let query = r#"<iq xmlns="jabber:client" id="space-node-items" type="get" to="spaces.example.com"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items node="team"/></pubsub></iq>"#;
 
         let responses = handle_iq(
             query,
@@ -3711,7 +3738,7 @@ mod tests {
     #[tokio::test]
     async fn standard_muc_owner_config_persists_room_and_enforces_nonanonymous_defaults() {
         let state = create_test_websocket_state().await;
-        let session = create_test_session(state.as_ref(), "alice").await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
 
         let room_jid: BareJid = "project@muc.example.com".parse().expect("room jid");
         let alice_jid: FullJid = format!("{}@example.com/web", session.xmpp_localpart)
@@ -3819,7 +3846,7 @@ mod tests {
     #[tokio::test]
     async fn standard_muc_owner_get_returns_config_without_persisting_room() {
         let state = create_test_websocket_state().await;
-        let session = create_test_session(state.as_ref(), "alice").await;
+        let session = create_test_server_owner_session(state.as_ref(), "alice").await;
 
         let room_jid: BareJid = "config-get@muc.example.com".parse().expect("room jid");
         let alice_jid: FullJid = format!("{}@example.com/web", session.xmpp_localpart)
@@ -3869,7 +3896,7 @@ mod tests {
     #[tokio::test]
     async fn standard_muc_owner_config_rejects_non_owner() {
         let state = create_test_websocket_state().await;
-        let alice_session = create_test_session(state.as_ref(), "alice").await;
+        let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let bob_session = create_test_session(state.as_ref(), "bob").await;
 
         let room_jid: BareJid = "locked@muc.example.com".parse().expect("room jid");
@@ -3980,6 +4007,28 @@ mod tests {
         .await
         .expect("insert channel");
         drop(conn);
+        let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_or_create_node(&spaces_jid, "team")
+            .await
+            .expect("space node");
+        let channel = waddle_xmpp::ChannelInfo {
+            id: "linked".to_string(),
+            name: "Linked".to_string(),
+            channel_type: "text".to_string(),
+        };
+        let item = waddle_xmpp::xep::build_channel_item(&channel, "muc.example.com")
+            .expect("bookmark item");
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .publish_item(&spaces_jid, "team", &item, None, false)
+            .await
+            .expect("publish bookmark");
 
         let query = disco_info_iq_frame("room-info", "linked@muc.example.com", None);
         let responses = handle_iq(
@@ -3993,16 +4042,24 @@ mod tests {
         .await;
         let response = responses.first().expect("room disco response");
         assert!(response.contains("muc_nonanonymous"));
-        assert!(response.contains("pubsub#title") && response.contains("example.com"));
+        assert!(response.contains("pubsub#title") && response.contains("team"));
     }
 
     #[tokio::test]
     async fn handle_iq_disco_info_spaces_node_reports_open_for_public_space() {
         let state = create_test_websocket_state().await;
         let viewer = create_test_session(state.as_ref(), "viewer").await;
+        let spaces_jid: BareJid = "spaces.example.com".parse().expect("spaces jid");
+        state
+            .deps
+            .protocol
+            .pubsub_storage
+            .get_or_create_node(&spaces_jid, "team")
+            .await
+            .expect("space node");
 
         let viewer_phase = authenticated_phase_for_session(&viewer, "example.com");
-        let query = disco_info_iq_frame("space-node-info", "spaces.example.com", Some("space"));
+        let query = disco_info_iq_frame("space-node-info", "spaces.example.com", Some("team"));
         let responses = handle_iq(
             &query,
             "example.com",
@@ -5007,6 +5064,7 @@ mod tests {
         // in the response (which used to be seen as a "ghost" occupant and
         // broke self-presence detection on the client).
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "rejoin-channel@muc.example.com".parse().expect("room");
         let first: FullJid = "alice@example.com/tab-1".parse().expect("first");
         let second: FullJid = "alice@example.com/tab-2".parse().expect("second");
@@ -5017,7 +5075,7 @@ mod tests {
             &room_jid,
             &first,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
         let responses = handle_muc_join(
@@ -5068,6 +5126,7 @@ mod tests {
     #[tokio::test]
     async fn muc_join_broadcast_includes_real_occupant_jid() {
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "public-channel@muc.example.com".parse().expect("room");
         let alice: FullJid = "alice@example.com/web".parse().expect("alice");
         let bob: FullJid = "bob@example.com/phone".parse().expect("bob");
@@ -5085,7 +5144,7 @@ mod tests {
             &room_jid,
             &alice,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
         let _ = handle_muc_join(state.as_ref(), "example.com", &room_jid, &bob, "bob", &None).await;
@@ -5121,6 +5180,7 @@ mod tests {
         // <presence type='error'/> with <conflict/>, and room state for
         // the incumbent is untouched.
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "conflict-channel@muc.example.com".parse().expect("room");
         let alice: FullJid = "alice@example.com/desktop".parse().expect("alice");
         let bob: FullJid = "bob@example.com/phone".parse().expect("bob");
@@ -5131,7 +5191,7 @@ mod tests {
             &room_jid,
             &alice,
             "dino",
-            &None,
+            &Some(owner_session),
         )
         .await;
         let responses = handle_muc_join(
@@ -5670,6 +5730,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_shutdown_detaches_resumable_session_on_transport_drop() {
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "detached-channel@muc.example.com".parse().expect("room");
         let jid: FullJid = "alice@example.com/web".parse().expect("jid");
 
@@ -5679,7 +5740,7 @@ mod tests {
             &room_jid,
             &jid,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
         let (tx, _rx) = mpsc::channel::<OutboundStanza>(4);
@@ -5718,6 +5779,7 @@ mod tests {
     #[tokio::test]
     async fn cleanup_shutdown_does_not_detach_explicit_close() {
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "closing-channel@muc.example.com".parse().expect("room");
         let jid: FullJid = "alice@example.com/web".parse().expect("jid");
 
@@ -5727,7 +5789,7 @@ mod tests {
             &room_jid,
             &jid,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
         let (tx, _rx) = mpsc::channel::<OutboundStanza>(4);
@@ -5770,6 +5832,7 @@ mod tests {
         // occupant that was held while the session was detached.
         use waddle_xmpp::stream_management::{DetachedSession, SmSessionRegistry};
         let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
         let room_jid: BareJid = "expired-channel@muc.example.com".parse().expect("room");
         let jid: FullJid = "alice@example.com/web".parse().expect("jid");
 
@@ -5780,7 +5843,7 @@ mod tests {
             &room_jid,
             &jid,
             "alice",
-            &None,
+            &Some(owner_session),
         )
         .await;
         assert!(snapshot_room(state.as_ref(), &room_jid)

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -69,6 +69,10 @@ impl TestServer {
                 &fixed_account_password,
             )
             .env("WADDLE_TEST_EXTRA_FIXED_ACCOUNTS", extra_accounts_env)
+            // The fixed test account ("admin") is always provisioned as a
+            // server owner so integration tests can exercise owner-gated
+            // operations (MUC creation, Space node creation, etc.)
+            .env("WADDLE_SERVER_OWNER_LOCALPARTS", "admin")
             .env("WADDLE_HTTP_ADDR", "127.0.0.1:0")
             .env("WADDLE_XMPP_DOMAIN", "localhost")
             .env("WADDLE_XMPP_MAM_DATABASE_URL", "sqlite::memory:")

--- a/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
+++ b/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
@@ -613,6 +613,22 @@ async fn websocket_normal_message_routes_as_direct_message() {
 async fn websocket_pubsub_subscribe_and_unsubscribe_acknowledge_spaces_node() {
     let (_server, mut client) = setup().await;
 
+    // Create the spaces node first (requires server owner; admin is owner in TestServer).
+    client
+        .send(
+            r#"<iq xmlns="jabber:client" type="set" id="ws-create-space" to="spaces.localhost"><pubsub xmlns="http://jabber.org/protocol/pubsub"><create node="space"/></pubsub></iq>"#,
+        )
+        .await
+        .expect("send pubsub create node");
+    let created = client
+        .recv_matching(|frame| frame.contains("ws-create-space"))
+        .await
+        .expect("pubsub create node response");
+    assert!(
+        created.contains("type=\"result\"") || created.contains("type='result'"),
+        "expected pubsub create-node result, got: {created}"
+    );
+
     client
         .send(
             r#"<iq xmlns="jabber:client" type="set" id="ws-pubsub-sub" to="spaces.localhost"><pubsub xmlns="http://jabber.org/protocol/pubsub"><subscribe node="space" jid="admin@localhost"/></pubsub></iq>"#,

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
@@ -116,6 +116,9 @@ pub enum PubSubError {
     InvalidJid,
     PreconditionNotMet,
     NotSubscribed,
+    /// An unexpected backend/storage failure unrelated to the requested resource.
+    /// Maps to XEP-0060 §8.1.3 `<internal-server-error/>` (error type: wait).
+    InternalServerError,
 }
 
 /// Check if an IQ is a PubSub request.
@@ -345,6 +348,9 @@ pub fn build_pubsub_error(original_iq: &Iq, error: PubSubError) -> Iq {
         }
         PubSubError::InvalidJid => (ErrorType::Modify, DefinedCondition::BadRequest),
         PubSubError::NotSubscribed => (ErrorType::Cancel, DefinedCondition::UnexpectedRequest),
+        PubSubError::InternalServerError => {
+            (ErrorType::Wait, DefinedCondition::InternalServerError)
+        }
     };
 
     let stanza_error = StanzaError::new(error_type, defined_condition, "en", "");

--- a/server/crates/waddle-xmpp/src/pubsub/storage.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/storage.rs
@@ -154,6 +154,11 @@ pub trait PubSubStorage: Send + Sync + 'static {
     /// given `item_id`, returning both the node name and the node metadata.
     ///
     /// Returns `Ok(None)` when no node contains the item.
+    ///
+    /// SQL-backed implementations should use an indexed join, e.g.:
+    /// `SELECT nodes.* FROM nodes JOIN items ON nodes.id = items.node_id
+    ///  WHERE nodes.owner = ? AND items.id = ?`
+    /// to avoid a full table scan.
     async fn find_node_for_item(
         &self,
         owner: &BareJid,

--- a/server/crates/waddle-xmpp/src/pubsub/storage.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/storage.rs
@@ -150,6 +150,16 @@ pub trait PubSubStorage: Send + Sync + 'static {
     /// List all nodes owned by a JID.
     async fn list_nodes(&self, owner: &BareJid) -> Result<Vec<String>, XmppError>;
 
+    /// Find the first node owned by `owner` that contains an item with the
+    /// given `item_id`, returning both the node name and the node metadata.
+    ///
+    /// Returns `Ok(None)` when no node contains the item.
+    async fn find_node_for_item(
+        &self,
+        owner: &BareJid,
+        item_id: &str,
+    ) -> Result<Option<PubSubNode>, XmppError>;
+
     /// Update node configuration.
     async fn update_node_config(
         &self,
@@ -366,6 +376,27 @@ impl PubSubStorage for InMemoryPubSubStorage {
             .collect();
 
         Ok(nodes)
+    }
+
+    async fn find_node_for_item(
+        &self,
+        owner: &BareJid,
+        item_id: &str,
+    ) -> Result<Option<PubSubNode>, XmppError> {
+        let owner_str = owner.to_string();
+        for entry in self.nodes.iter() {
+            if entry.key().0 != owner_str {
+                continue;
+            }
+            let key = entry.key().clone();
+            let node = entry.value().clone();
+            if let Some(items) = self.items.get(&key) {
+                if items.iter().any(|i| i.id == item_id) {
+                    return Ok(Some(node));
+                }
+            }
+        }
+        Ok(None)
     }
 
     async fn update_node_config(

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -615,7 +615,8 @@ pub use xep0508::{
 };
 
 pub use xep0503::{
-    build_channel_item, build_spaces_metadata_form, build_spaces_type_form, NS_SPACES,
+    build_channel_item, build_server_role_form, build_spaces_metadata_form,
+    build_spaces_metadata_form_for_requester, build_spaces_type_form, SpaceAffiliation, NS_SPACES,
 };
 
 // Re-export commonly used items at the xep module level


### PR DESCRIPTION
## Summary
- remove the synthetic canonical Space and list only explicitly created Spaces service PubSub nodes
- restrict arbitrary MUC creation to server owners and keep MUC owner config/destroy owner-only
- make Space publish/retract mutate PubSub membership only, with existing-MUC validation
- update chat discovery and creation UI to handle zero Spaces and use real Space node ids
- include the userset empty-relation fix for bare userset subjects

## Verification
- `bun run lint` in `chat/`
- `bun run build` in `chat/`
- `cuenv exec -- cargo test -p waddle-server --bin waddle-server` in `server/`

Note: `colony/app.db` and `ejabberd/` were intentionally left untracked and out of this PR.