### PR TITLE
Make XMPP storage and namespaces XEP-compliant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # waddle Development Guidelines
 
 - use jj when .jj exists, git otherwise
+- Before implementation work begins, create a branch and open a draft PR whose
+  title summarizes the intended work and whose description contains the plan.
+  Make this the first action for all non-trivial tasks unless explicitly told
+  not to.
 - XMPP Native, Never use out of band/XMPP APIs.
 - Always review your plan against the XEPS in ./xeps
     - If ./xeps doesn't exist, clone xsf/xeps into ./xeps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,13 @@
 - XMPP Native, Never use out of band/XMPP APIs.
 - Always review your plan against the XEPS in ./xeps
     - If ./xeps doesn't exist, clone xsf/xeps into ./xeps
+- XEP conformance hard rule:
+  - Prefer conformant XEP/XMPP shapes at all times. Use custom `urn:waddle:*`
+    namespaces only when no suitable XEP-defined shape exists.
+  - If Waddle advertises an official XEP feature or uses an official
+    `urn:xmpp:*`, `jabber:*`, or `http://jabber.org/*` namespace, the wire
+    shape and behavior MUST conform to that XEP exactly.
+  - Do not use official XEP namespaces for Waddle-specific semantics.
 
 ## Active Technologies
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -65,7 +65,7 @@ export interface TimelineMessage {
   /** RFC 6121 / XEP-0201: Thread identifier + optional parent thread. */
   threadId?: string;
   parentThreadId?: string;
-  /** XEP-0508: Forum topic/reply metadata when present. */
+  /** Waddle thread metadata when present. */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1122,7 +1122,7 @@ export class BrowserXmppClient {
     }
   }
 
-  // -- Inbox (XEP-0430) --
+  // -- Waddle inbox --
 
   async fetchInbox(opts: inboxApi.FetchInboxOptions = {}): Promise<inboxApi.InboxResult> {
     await this.connect();

--- a/chat/src/lib/xmpp/extensions/forums.ts
+++ b/chat/src/lib/xmpp/extensions/forums.ts
@@ -1,8 +1,8 @@
-/** XEP-0508: MUC Forums. */
+/** Private Waddle MUC thread metadata. */
 import type { DefinitionOptions } from "stanza/jxt";
 import { attribute } from "stanza/jxt";
 
-const NS_FORUMS_0 = "urn:xmpp:forums:0";
+const NS_WADDLE_FORUMS_0 = "urn:waddle:forums:0";
 
 export interface WaddleThreadCreate {
   title: string;
@@ -19,7 +19,7 @@ const definitions: DefinitionOptions[] = [
     fields: {
       title: attribute("title"),
     },
-    namespace: NS_FORUMS_0,
+    namespace: NS_WADDLE_FORUMS_0,
   },
   {
     aliases: [{ path: "message.threadReply", multiple: false }],
@@ -27,7 +27,7 @@ const definitions: DefinitionOptions[] = [
     fields: {
       threadId: attribute("thread-id"),
     },
-    namespace: NS_FORUMS_0,
+    namespace: NS_WADDLE_FORUMS_0,
   },
 ];
 

--- a/chat/src/lib/xmpp/extensions/inbox.ts
+++ b/chat/src/lib/xmpp/extensions/inbox.ts
@@ -1,5 +1,5 @@
 /**
- * XEP-0430 (urn:xmpp:inbox:0) — Unified inbox.
+ * Private Waddle inbox.
  *
  * Mirrors the Rust types in `server/crates/waddle-xmpp/src/inbox/mod.rs`
  * and the protocol wrapper in `server/crates/waddle-xmpp/src/xep/xep0430.rs`.
@@ -8,12 +8,12 @@
  *
  * Request:
  *   <iq type='get'>
- *     <query xmlns='urn:xmpp:inbox:0' since='1700000' only-unread='true'/>
+ *     <query xmlns='urn:waddle:inbox:0' since='1700000' only-unread='true'/>
  *   </iq>
  *
  * Result:
  *   <iq type='result'>
- *     <query xmlns='urn:xmpp:inbox:0' total-unread='3'>
+ *     <query xmlns='urn:waddle:inbox:0' total-unread='3'>
  *       <conversation partner='alice@example.com' kind='direct'
  *                     last-stanza-id='sid' last-updated='1700000' unread='2'>
  *         <preview>hi there</preview>
@@ -23,13 +23,13 @@
  *
  * Mark read:
  *   <iq type='set'>
- *     <mark-read xmlns='urn:xmpp:inbox:0' partner='alice@example.com'/>
+ *     <mark-read xmlns='urn:waddle:inbox:0' partner='alice@example.com'/>
  *   </iq>
  */
 import type { DefinitionOptions } from "stanza/jxt";
 import { attribute, booleanAttribute, childText, integerAttribute } from "stanza/jxt";
 
-export const NS_INBOX_0 = "urn:xmpp:inbox:0";
+export const NS_WADDLE_INBOX_0 = "urn:waddle:inbox:0";
 
 export type InboxConversationKind = "direct" | "muc";
 
@@ -57,7 +57,7 @@ const definitions: DefinitionOptions[] = [
       threads: booleanAttribute("threads"),
       totalUnread: integerAttribute("total-unread"),
     },
-    namespace: NS_INBOX_0,
+    namespace: NS_WADDLE_INBOX_0,
   },
   {
     aliases: [
@@ -71,13 +71,13 @@ const definitions: DefinitionOptions[] = [
       lastStanzaId: attribute("last-stanza-id"),
       lastUpdated: integerAttribute("last-updated"),
       unread: integerAttribute("unread"),
-      preview: childText(NS_INBOX_0, "preview"),
+      preview: childText(NS_WADDLE_INBOX_0, "preview"),
       thread: attribute("thread"),
       threadTitle: attribute("thread-title"),
       replyCount: integerAttribute("reply-count"),
       author: attribute("author"),
     },
-    namespace: NS_INBOX_0,
+    namespace: NS_WADDLE_INBOX_0,
   },
   {
     aliases: [{ path: "iq.inboxMarkRead", multiple: false }],
@@ -86,7 +86,7 @@ const definitions: DefinitionOptions[] = [
       partner: attribute("partner"),
       thread: attribute("thread"),
     },
-    namespace: NS_INBOX_0,
+    namespace: NS_WADDLE_INBOX_0,
   },
 ];
 

--- a/chat/src/lib/xmpp/extensions/inbox.ts
+++ b/chat/src/lib/xmpp/extensions/inbox.ts
@@ -29,7 +29,7 @@
 import type { DefinitionOptions } from "stanza/jxt";
 import { attribute, booleanAttribute, childText, integerAttribute } from "stanza/jxt";
 
-export const NS_WADDLE_INBOX_0 = "urn:waddle:inbox:0";
+const NS_WADDLE_INBOX_0 = "urn:waddle:inbox:0";
 
 export type InboxConversationKind = "direct" | "muc";
 

--- a/chat/src/lib/xmpp/inbox.ts
+++ b/chat/src/lib/xmpp/inbox.ts
@@ -1,4 +1,4 @@
-/** XEP-0430 Inbox: high-level client helpers. */
+/** Waddle inbox: high-level client helpers. */
 import type { Agent } from "stanza";
 import type { InboxConversationKind, WaddleInboxConversation } from "./extensions/inbox";
 

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -88,7 +88,7 @@ export interface LiveRoomMessage {
   /** RFC 6121 / XEP-0201 */
   threadId?: string;
   parentThreadId?: string;
-  /** XEP-0508 */
+  /** Waddle thread metadata */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;
@@ -120,7 +120,7 @@ export interface LiveDmMessage {
   /** RFC 6121 / XEP-0201 */
   threadId?: string;
   parentThreadId?: string;
-  /** XEP-0508 */
+  /** Waddle thread metadata */
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -1,4 +1,4 @@
-//! Database-backed storage for XEP-0430 inbox projections.
+//! Database-backed storage for Waddle inbox projections.
 
 use std::path::Path;
 use std::sync::Arc;

--- a/server/crates/waddle-server/src/main.rs
+++ b/server/crates/waddle-server/src/main.rs
@@ -9,6 +9,7 @@ mod db;
 mod inbox;
 mod messages;
 mod permissions;
+mod pubsub;
 mod server;
 pub(crate) mod storage;
 mod telemetry;

--- a/server/crates/waddle-server/src/pubsub.rs
+++ b/server/crates/waddle-server/src/pubsub.rs
@@ -1,0 +1,675 @@
+//! Database-backed storage for XEP-0060 PubSub and XEP-0163 PEP data.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jid::BareJid;
+use tracing::info;
+use waddle_xmpp::pubsub::{NodeConfig, PubSubItem, PubSubNode, PubSubStorage, StoredItem};
+use waddle_xmpp::XmppError;
+
+use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+
+#[derive(Clone)]
+pub struct DatabasePubSubStorage {
+    db: Database,
+}
+
+impl DatabasePubSubStorage {
+    pub async fn open(database_url: Option<&str>) -> Result<Self, XmppError> {
+        let db = match database_url {
+            Some(database_url) => open_database(database_url).await?,
+            None => Database::in_memory("pubsub")
+                .await
+                .map_err(|error| XmppError::internal(error.to_string()))?,
+        };
+        let storage = Self { db };
+        storage.initialize().await?;
+        info!(driver = ?storage.db.driver(), "PubSub storage initialized");
+        Ok(storage)
+    }
+
+    async fn initialize(&self) -> Result<(), XmppError> {
+        self.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS pubsub_nodes (
+                owner_jid TEXT NOT NULL,
+                node_name TEXT NOT NULL,
+                access_model TEXT NOT NULL,
+                publish_model TEXT NOT NULL,
+                max_items INTEGER NOT NULL,
+                persist_items INTEGER NOT NULL,
+                deliver_payloads INTEGER NOT NULL,
+                notify_retract INTEGER NOT NULL,
+                notify_delete INTEGER NOT NULL,
+                send_last_published_item TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (owner_jid, node_name)
+            )
+            "#,
+            (),
+        )
+        .await?;
+        self.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS pubsub_items (
+                owner_jid TEXT NOT NULL,
+                node_name TEXT NOT NULL,
+                item_id TEXT NOT NULL,
+                payload_xml TEXT,
+                publisher_jid TEXT,
+                published_at TEXT NOT NULL,
+                PRIMARY KEY (owner_jid, node_name, item_id),
+                FOREIGN KEY (owner_jid, node_name)
+                    REFERENCES pubsub_nodes(owner_jid, node_name)
+                    ON DELETE CASCADE
+            )
+            "#,
+            (),
+        )
+        .await?;
+        self.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pubsub_items_node_time ON pubsub_items (owner_jid, node_name, published_at)",
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, XmppError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))
+    }
+
+    async fn execute(&self, sql: &str, params: impl IntoParams) -> Result<u64, XmppError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))
+    }
+
+    async fn insert_node(&self, node: &PubSubNode) -> Result<(), XmppError> {
+        let config = &node.config;
+        self.execute(
+            r#"
+            INSERT INTO pubsub_nodes (
+                owner_jid, node_name, access_model, publish_model, max_items,
+                persist_items, deliver_payloads, notify_retract, notify_delete,
+                send_last_published_item, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(owner_jid, node_name) DO NOTHING
+            "#,
+            crate::db_params![
+                node.owner.to_string(),
+                node.node_name.clone(),
+                config.access_model.to_string(),
+                config.publish_model.to_string(),
+                config.max_items,
+                config.persist_items,
+                config.deliver_payloads,
+                config.notify_retract,
+                config.notify_delete,
+                config.send_last_published_item.to_string(),
+                node.created_at.to_rfc3339(),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    fn decode_node(row: &crate::db::Row) -> Result<PubSubNode, XmppError> {
+        let owner_raw: String = row
+            .get(0)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let owner = owner_raw
+            .parse::<BareJid>()
+            .map_err(|error| XmppError::internal(format!("invalid PubSub owner JID: {error}")))?;
+        let node_name: String = row
+            .get(1)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let access_model_raw: String = row
+            .get(2)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let publish_model_raw: String = row
+            .get(3)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let max_items: i64 = row
+            .get(4)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let persist_items: bool = row
+            .get(5)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let deliver_payloads: bool = row
+            .get(6)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let notify_retract: bool = row
+            .get(7)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let notify_delete: bool = row
+            .get(8)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let send_last_raw: String = row
+            .get(9)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let created_raw: String = row
+            .get(10)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let created_at = chrono::DateTime::parse_from_rfc3339(&created_raw)
+            .map_err(|error| XmppError::internal(format!("invalid PubSub created_at: {error}")))?
+            .with_timezone(&chrono::Utc);
+
+        Ok(PubSubNode {
+            node_name,
+            owner,
+            config: NodeConfig {
+                access_model: access_model_raw.parse().unwrap_or_default(),
+                publish_model: publish_model_raw.parse().unwrap_or_default(),
+                max_items: u32::try_from(max_items)
+                    .map_err(|error| XmppError::internal(error.to_string()))?,
+                persist_items,
+                deliver_payloads,
+                notify_retract,
+                notify_delete,
+                send_last_published_item: send_last_raw.parse().unwrap_or_default(),
+            },
+            created_at,
+        })
+    }
+
+    fn decode_item(row: &crate::db::Row) -> Result<StoredItem, XmppError> {
+        let id: String = row
+            .get(0)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let payload_xml: Option<String> = row
+            .get(1)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let publisher_raw: Option<String> = row
+            .get(2)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let published_raw: String = row
+            .get(3)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let publisher = publisher_raw
+            .map(|raw| {
+                raw.parse::<BareJid>().map_err(|error| {
+                    XmppError::internal(format!("invalid PubSub publisher JID: {error}"))
+                })
+            })
+            .transpose()?;
+        let published_at = chrono::DateTime::parse_from_rfc3339(&published_raw)
+            .map_err(|error| XmppError::internal(format!("invalid PubSub published_at: {error}")))?
+            .with_timezone(&chrono::Utc);
+        Ok(StoredItem {
+            id,
+            payload_xml,
+            publisher,
+            published_at,
+        })
+    }
+
+    async fn enforce_max_items(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        max_items: u32,
+    ) -> Result<(), XmppError> {
+        if max_items == 0 || max_items == u32::MAX {
+            return Ok(());
+        }
+
+        let mut rows = self
+            .query(
+                r#"
+                SELECT item_id FROM pubsub_items
+                WHERE owner_jid = ? AND node_name = ?
+                ORDER BY published_at DESC, item_id DESC
+                "#,
+                crate::db_params![owner.to_string(), node_name],
+            )
+            .await?;
+        let mut seen = 0_u32;
+        let mut excess = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        {
+            let item_id: String = row
+                .get(0)
+                .map_err(|error| XmppError::internal(error.to_string()))?;
+            seen += 1;
+            if seen > max_items {
+                excess.push(item_id);
+            }
+        }
+
+        for item_id in excess {
+            self.retract_item(owner, node_name, &item_id).await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl PubSubStorage for DatabasePubSubStorage {
+    async fn get_or_create_node(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+    ) -> Result<(PubSubNode, bool), XmppError> {
+        if let Some(node) = self.get_node(owner, node_name).await? {
+            return Ok((node, false));
+        }
+
+        let node = PubSubNode::new_pep(owner.clone(), node_name.to_string());
+        self.insert_node(&node).await?;
+        Ok((node, true))
+    }
+
+    async fn get_node(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+    ) -> Result<Option<PubSubNode>, XmppError> {
+        let mut rows = self
+            .query(
+                r#"
+                SELECT owner_jid, node_name, access_model, publish_model, max_items,
+                       persist_items, deliver_payloads, notify_retract, notify_delete,
+                       send_last_published_item, created_at
+                FROM pubsub_nodes
+                WHERE owner_jid = ? AND node_name = ?
+                "#,
+                crate::db_params![owner.to_string(), node_name],
+            )
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Self::decode_node(&row)?))
+    }
+
+    async fn delete_node(&self, owner: &BareJid, node_name: &str) -> Result<bool, XmppError> {
+        let affected = self
+            .execute(
+                "DELETE FROM pubsub_nodes WHERE owner_jid = ? AND node_name = ?",
+                crate::db_params![owner.to_string(), node_name],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
+    async fn publish_item(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item: &PubSubItem,
+        publisher: Option<&BareJid>,
+        auto_create: bool,
+    ) -> Result<waddle_xmpp::pubsub::PublishResult, XmppError> {
+        let (node, node_created) = match self.get_node(owner, node_name).await? {
+            Some(node) => (node, false),
+            None if auto_create => {
+                let node = PubSubNode::new_pep(owner.clone(), node_name.to_string());
+                self.insert_node(&node).await?;
+                (node, true)
+            }
+            None => {
+                return Err(XmppError::item_not_found(Some(format!(
+                    "Node '{node_name}' does not exist"
+                ))));
+            }
+        };
+
+        let item_id = item
+            .id
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let payload_xml = item.payload.as_ref().map(String::from);
+        let publisher_jid = publisher.map(ToString::to_string);
+        let published_at = chrono::Utc::now().to_rfc3339();
+
+        self.execute(
+            r#"
+            INSERT INTO pubsub_items (
+                owner_jid, node_name, item_id, payload_xml, publisher_jid, published_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(owner_jid, node_name, item_id) DO UPDATE SET
+                payload_xml = excluded.payload_xml,
+                publisher_jid = excluded.publisher_jid,
+                published_at = excluded.published_at
+            "#,
+            crate::db_params![
+                owner.to_string(),
+                node_name,
+                item_id.clone(),
+                payload_xml,
+                publisher_jid,
+                published_at,
+            ],
+        )
+        .await?;
+        self.enforce_max_items(owner, node_name, node.config.max_items)
+            .await?;
+
+        Ok(waddle_xmpp::pubsub::PublishResult {
+            item_id,
+            node_created,
+        })
+    }
+
+    async fn get_items(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        max_items: Option<u32>,
+        item_ids: &[String],
+    ) -> Result<Vec<StoredItem>, XmppError> {
+        let mut rows = self
+            .query(
+                r#"
+                SELECT item_id, payload_xml, publisher_jid, published_at
+                FROM pubsub_items
+                WHERE owner_jid = ? AND node_name = ?
+                ORDER BY published_at ASC, item_id ASC
+                "#,
+                crate::db_params![owner.to_string(), node_name],
+            )
+            .await?;
+        let mut items = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        {
+            let item = Self::decode_item(&row)?;
+            if item_ids.is_empty() || item_ids.contains(&item.id) {
+                items.push(item);
+            }
+        }
+        if let Some(max_items) = max_items {
+            let max_items = max_items as usize;
+            if max_items > 0 && items.len() > max_items {
+                items = items[items.len() - max_items..].to_vec();
+            }
+        }
+        Ok(items)
+    }
+
+    async fn retract_item(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        item_id: &str,
+    ) -> Result<bool, XmppError> {
+        let affected = self
+            .execute(
+                "DELETE FROM pubsub_items WHERE owner_jid = ? AND node_name = ? AND item_id = ?",
+                crate::db_params![owner.to_string(), node_name, item_id],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
+    async fn list_nodes(&self, owner: &BareJid) -> Result<Vec<String>, XmppError> {
+        let mut rows = self
+            .query(
+                "SELECT node_name FROM pubsub_nodes WHERE owner_jid = ? ORDER BY node_name ASC",
+                crate::db_params![owner.to_string()],
+            )
+            .await?;
+        let mut nodes = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        {
+            nodes.push(
+                row.get(0)
+                    .map_err(|error| XmppError::internal(error.to_string()))?,
+            );
+        }
+        Ok(nodes)
+    }
+
+    async fn find_node_for_item(
+        &self,
+        owner: &BareJid,
+        item_id: &str,
+    ) -> Result<Option<PubSubNode>, XmppError> {
+        let mut rows = self
+            .query(
+                r#"
+                SELECT n.owner_jid, n.node_name, n.access_model, n.publish_model, n.max_items,
+                       n.persist_items, n.deliver_payloads, n.notify_retract, n.notify_delete,
+                       n.send_last_published_item, n.created_at
+                FROM pubsub_nodes n
+                JOIN pubsub_items i
+                  ON i.owner_jid = n.owner_jid AND i.node_name = n.node_name
+                WHERE n.owner_jid = ? AND i.item_id = ?
+                ORDER BY n.node_name ASC
+                "#,
+                crate::db_params![owner.to_string(), item_id],
+            )
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(Self::decode_node(&row)?))
+    }
+
+    async fn update_node_config(
+        &self,
+        owner: &BareJid,
+        node_name: &str,
+        config: &NodeConfig,
+    ) -> Result<(), XmppError> {
+        let affected = self
+            .execute(
+                r#"
+                UPDATE pubsub_nodes
+                SET access_model = ?,
+                    publish_model = ?,
+                    max_items = ?,
+                    persist_items = ?,
+                    deliver_payloads = ?,
+                    notify_retract = ?,
+                    notify_delete = ?,
+                    send_last_published_item = ?
+                WHERE owner_jid = ? AND node_name = ?
+                "#,
+                crate::db_params![
+                    config.access_model.to_string(),
+                    config.publish_model.to_string(),
+                    config.max_items,
+                    config.persist_items,
+                    config.deliver_payloads,
+                    config.notify_retract,
+                    config.notify_delete,
+                    config.send_last_published_item.to_string(),
+                    owner.to_string(),
+                    node_name,
+                ],
+            )
+            .await?;
+        if affected == 0 {
+            return Err(XmppError::item_not_found(Some(format!(
+                "Node '{node_name}' does not exist"
+            ))));
+        }
+        Ok(())
+    }
+}
+
+pub async fn build_pubsub_storage(
+    database_url: Option<String>,
+) -> Result<Arc<dyn PubSubStorage>, XmppError> {
+    Ok(Arc::new(
+        DatabasePubSubStorage::open(database_url.as_deref()).await?,
+    ))
+}
+
+async fn open_database(database_url: &str) -> Result<Database, XmppError> {
+    ensure_sqlite_parent_dir(database_url)?;
+    let driver = infer_database_driver(database_url)?;
+    Database::from_config(
+        "pubsub",
+        &DatabaseConfig::new(driver, database_url.to_string()),
+    )
+    .await
+    .map_err(|error| XmppError::internal(error.to_string()))
+}
+
+fn infer_database_driver(database_url: &str) -> Result<DatabaseDriver, XmppError> {
+    let lower = database_url.to_ascii_lowercase();
+    if lower.starts_with("postgres://") || lower.starts_with("postgresql://") {
+        return Ok(DatabaseDriver::Postgres);
+    }
+    if lower.starts_with("sqlite:") {
+        return Ok(DatabaseDriver::Sqlite);
+    }
+
+    Err(XmppError::config(format!(
+        "unsupported PubSub database URL '{database_url}': expected sqlite: or postgres://"
+    )))
+}
+
+fn ensure_sqlite_parent_dir(database_url: &str) -> Result<(), XmppError> {
+    let Some(path) = sqlite_database_path(database_url) else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent).map_err(|error| XmppError::internal(error.to_string()))?;
+    }
+
+    Ok(())
+}
+
+fn sqlite_database_path(database_url: &str) -> Option<&Path> {
+    let path = database_url
+        .strip_prefix("sqlite://")
+        .or_else(|| database_url.strip_prefix("sqlite:"))?;
+    if path.is_empty() || path.starts_with(":memory:") || path.starts_with("file:") {
+        return None;
+    }
+    Some(Path::new(path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn jid(value: &str) -> BareJid {
+        value.parse().expect("valid JID")
+    }
+
+    #[tokio::test]
+    async fn database_pubsub_storage_persists_file_backing() {
+        let artifacts = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-artifacts");
+        std::fs::create_dir_all(&artifacts).expect("artifacts dir");
+        let path = artifacts.join(format!("pubsub-{}.db", uuid::Uuid::new_v4()));
+        let url = format!("sqlite://{}", path.display());
+        let owner = jid("alice@example.com");
+
+        {
+            let storage = DatabasePubSubStorage::open(Some(&url))
+                .await
+                .expect("storage");
+            let (_, created) = storage
+                .get_or_create_node(&owner, "urn:xmpp:bookmarks:1")
+                .await
+                .expect("node");
+            assert!(created);
+
+            let item = PubSubItem {
+                id: Some("room@muc.example.com".to_string()),
+                payload: None,
+            };
+            storage
+                .publish_item(&owner, "urn:xmpp:bookmarks:1", &item, Some(&owner), false)
+                .await
+                .expect("publish");
+        }
+
+        let reopened = DatabasePubSubStorage::open(Some(&url))
+            .await
+            .expect("reopened storage");
+        let items = reopened
+            .get_items(&owner, "urn:xmpp:bookmarks:1", None, &[])
+            .await
+            .expect("items");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "room@muc.example.com");
+
+        for cleanup in [
+            path.clone(),
+            PathBuf::from(format!("{}-shm", path.display())),
+            PathBuf::from(format!("{}-wal", path.display())),
+        ] {
+            let _ = std::fs::remove_file(cleanup);
+        }
+    }
+
+    #[tokio::test]
+    async fn spaces_config_keeps_multiple_items() {
+        let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+            .await
+            .expect("storage");
+        let owner = jid("spaces.example.com");
+        storage
+            .get_or_create_node(&owner, "general")
+            .await
+            .expect("node");
+        storage
+            .update_node_config(&owner, "general", &NodeConfig::spaces_public())
+            .await
+            .expect("config");
+
+        for id in ["one@muc.example.com", "two@muc.example.com"] {
+            let item = PubSubItem {
+                id: Some(id.to_string()),
+                payload: None,
+            };
+            storage
+                .publish_item(&owner, "general", &item, Some(&owner), false)
+                .await
+                .expect("publish");
+        }
+
+        let items = storage
+            .get_items(&owner, "general", None, &[])
+            .await
+            .expect("items");
+        assert_eq!(items.len(), 2);
+    }
+}

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -66,7 +66,7 @@ pub struct AppState {
     pub db_pool: Arc<DatabasePool>,
     /// Blob storage backend for file uploads (XEP-0363).
     pub blob_storage: Arc<dyn crate::storage::BlobStorage>,
-    /// Shared XEP-0430 inbox projection storage.
+    /// Shared Waddle inbox projection storage.
     pub inbox_storage: Arc<dyn InboxStorage>,
     /// Shared permission actor handle.
     pub permission_actor: ActorRef<PermissionActor>,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -4,6 +4,7 @@ use crate::db::actor::{DbExecute, DbQueryOne};
 use crate::db::{DatabasePool, PoolHealth};
 use crate::inbox::build_inbox_storage;
 use crate::permissions::PermissionActor;
+use crate::pubsub::build_pubsub_storage;
 use anyhow::Result;
 use axum::{
     extract::State,
@@ -119,6 +120,8 @@ pub struct XmppConfig {
     pub mam_database_url: Option<String>,
     /// Inbox database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
     pub inbox_database_url: Option<String>,
+    /// PubSub/PEP database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
+    pub pubsub_database_url: Option<String>,
     /// Whether native JID authentication is enabled (default: true)
     /// When enabled, users can authenticate with SCRAM-SHA-256 using native credentials.
     pub native_auth_enabled: bool,
@@ -134,6 +137,7 @@ impl Default for XmppConfig {
             component_domain: "localhost".to_string(),
             mam_database_url: None,
             inbox_database_url: None,
+            pubsub_database_url: None,
             native_auth_enabled: true,
             acme: XmppAcmeConfig {
                 enabled: false,
@@ -159,6 +163,7 @@ impl XmppConfig {
 
         let mam_database_url = resolve_xmpp_database_url("WADDLE_XMPP_MAM_DATABASE_URL");
         let inbox_database_url = resolve_xmpp_database_url("WADDLE_XMPP_INBOX_DATABASE_URL");
+        let pubsub_database_url = resolve_xmpp_database_url("WADDLE_XMPP_PUBSUB_DATABASE_URL");
 
         let native_auth_enabled = std::env::var("WADDLE_NATIVE_AUTH_ENABLED")
             .map(|v| v.to_lowercase() != "false" && v != "0")
@@ -184,6 +189,7 @@ impl XmppConfig {
             component_domain,
             mam_database_url,
             inbox_database_url,
+            pubsub_database_url,
             native_auth_enabled,
             acme: XmppAcmeConfig {
                 enabled: acme_enabled,
@@ -299,7 +305,7 @@ async fn bootstrap_fresh_xmpp_topology(
         .await
         .map_err(|error| anyhow::anyhow!("failed to create General space node: {error}"))?;
     pubsub_storage
-        .update_node_config(&spaces_jid, "general", &NodeConfig::public())
+        .update_node_config(&spaces_jid, "general", &NodeConfig::spaces_public())
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure General space node: {error}"))?;
 
@@ -852,9 +858,10 @@ async fn create_router(
     waddle_xmpp::protocol::handlers::register_default_handlers(&mut stanza_dispatcher);
     let stanza_dispatcher = Arc::new(stanza_dispatcher);
 
-    // Shared PubSub/PEP storage for the WebSocket transport (XEP-0060/0163).
-    let pubsub_storage: Arc<dyn waddle_xmpp::pubsub::PubSubStorage> =
-        Arc::new(waddle_xmpp::pubsub::InMemoryPubSubStorage::new());
+    // Shared durable PubSub/PEP storage for the WebSocket transport (XEP-0060/0163).
+    let pubsub_storage = build_pubsub_storage(xmpp_config.pubsub_database_url.clone())
+        .await
+        .unwrap_or_else(|error| panic!("Failed to initialize PubSub storage: {error}"));
     if let Err(error) =
         bootstrap_fresh_xmpp_topology(&state, Arc::clone(&pubsub_storage), &service_domains).await
     {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1248,6 +1248,23 @@ pub async fn handle_iq_with_conn_state(
                             .await
                         {
                             Ok((_, true)) => {
+                                if let Err(error) = state
+                                    .deps
+                                    .protocol
+                                    .pubsub_storage
+                                    .update_node_config(
+                                        &spaces_jid,
+                                        &node,
+                                        &waddle_xmpp::pubsub::NodeConfig::spaces_public(),
+                                    )
+                                    .await
+                                {
+                                    warn!(node = %node, error = %error, "Failed to configure Spaces node");
+                                    return vec![iq_to_xml(build_pubsub_error(
+                                        &iq,
+                                        PubSubError::Forbidden,
+                                    ))];
+                                }
                                 if let Err(error) = write_space_owner_tuple(
                                     state,
                                     &node,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -152,7 +152,7 @@ pub async fn handle_message(
             // Thread-level inbox projection: if the message carries a <thread/>,
             // upsert a thread-scoped entry alongside the channel-level one.
             let thread_entry = prototype.thread.as_ref().map(|thread| {
-                // Resolve thread title: XEP-0508 thread-create title, or first message preview
+                // Resolve thread title from Waddle thread metadata or first message preview.
                 let forum_title = waddle_xmpp::xep::xep0508::extract_forum_action(&prototype)
                     .and_then(|action| match action {
                         waddle_xmpp::xep::xep0508::ForumAction::CreateThread(tc) => Some(tc.title),

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -101,7 +101,7 @@ pub struct ProtocolServices {
     pub room_registry: ActorRef<RoomRegistryActor>,
     /// Shared XMPP MAM storage for archived message history.
     pub mam_storage: Arc<dyn MamStorage>,
-    /// Shared XEP-0430 inbox projection storage.
+    /// Shared Waddle inbox projection storage.
     pub inbox_storage: Arc<dyn InboxStorage>,
     /// Registry for ad-hoc commands exposed over the WebSocket transport.
     pub command_registry: Arc<CommandRegistry>,
@@ -4421,7 +4421,7 @@ mod tests {
 
         let inbox_query = format!(
             "<iq xmlns='jabber:client' type='get' to='{}' id='inbox-1'>\
-                <query xmlns='urn:xmpp:inbox:0'/>\
+                <query xmlns='urn:waddle:inbox:0'/>\
              </iq>",
             bob_jid.to_bare()
         );
@@ -4450,7 +4450,7 @@ mod tests {
 
         let mark_read = format!(
             "<iq xmlns='jabber:client' type='set' to='{}' id='inbox-2'>\
-                <mark-read xmlns='urn:xmpp:inbox:0' partner='alice@example.com'/>\
+                <mark-read xmlns='urn:waddle:inbox:0' partner='alice@example.com'/>\
              </iq>",
             bob_jid.to_bare()
         );
@@ -4471,7 +4471,7 @@ mod tests {
 
         let unread_only_query = format!(
             "<iq xmlns='jabber:client' type='get' to='{}' id='inbox-3'>\
-                <query xmlns='urn:xmpp:inbox:0' only-unread='true'/>\
+                <query xmlns='urn:waddle:inbox:0' only-unread='true'/>\
              </iq>",
             bob_jid.to_bare()
         );
@@ -4501,7 +4501,7 @@ mod tests {
         let session = create_test_session(state.as_ref(), "bob").await;
         let pending_jid: FullJid = "bob@example.com/pending".parse().expect("pending jid");
         let mut carbons_enabled = false;
-        let frame = r#"<iq xmlns='jabber:client' type='get' to='bob@example.com' id='inbox-prebind-1'><query xmlns='urn:xmpp:inbox:0'/></iq>"#;
+        let frame = r#"<iq xmlns='jabber:client' type='get' to='bob@example.com' id='inbox-prebind-1'><query xmlns='urn:waddle:inbox:0'/></iq>"#;
         let responses = handle_iq_with_conn_state(
             parse_iq_for_test(frame),
             "example.com",
@@ -4560,7 +4560,7 @@ mod tests {
 
         let inbox_query = format!(
             "<iq xmlns='jabber:client' type='get' to='{}' id='inbox-esfs-1'>\
-                <query xmlns='urn:xmpp:inbox:0'/>\
+                <query xmlns='urn:waddle:inbox:0'/>\
              </iq>",
             bob_jid.to_bare()
         );

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -163,7 +163,7 @@ pub struct XmppAppState {
     global_db_actor: ActorRef<DbActor>,
     /// Database service for canonical space data.
     space_db_service: Option<SpaceDbService>,
-    /// Shared XEP-0430 inbox projection storage.
+    /// Shared Waddle inbox projection storage.
     inbox_storage: Option<Arc<dyn InboxStorage>>,
 }
 
@@ -1304,7 +1304,7 @@ impl waddle_xmpp::AppState for XmppAppState {
     }
 
     // =========================================================================
-    // XEP-0430 Inbox Projection Methods
+    // Waddle Inbox Projection Methods
     // =========================================================================
 
     async fn list_inbox(&self, user_jid: &jid::BareJid) -> Result<Vec<InboxEntry>, XmppError> {

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -546,9 +546,7 @@ pub fn muc_room_features(
         Feature::muc_nonanonymous(),
     ];
 
-    if forum {
-        features.push(Feature::forums());
-    }
+    let _ = forum;
 
     if persistent {
         features.push(Feature::muc_persistent());
@@ -659,7 +657,7 @@ mod tests {
     #[test]
     fn test_muc_room_features_forum_room() {
         let features = muc_room_features(true, true, false, true);
-        assert!(features.contains(&Feature::forums()));
+        assert!(!features.contains(&Feature::forums()));
         assert!(features.contains(&Feature::muc_persistent()));
         assert!(features.contains(&Feature::muc_membersonly()));
         assert!(features.contains(&Feature::muc_unmoderated()));

--- a/server/crates/waddle-xmpp-core/src/domain.rs
+++ b/server/crates/waddle-xmpp-core/src/domain.rs
@@ -34,7 +34,7 @@ pub struct ChannelRoomInfo {
 pub enum ChannelType {
     /// Standard text chat channel.
     Text,
-    /// XEP-0508 forum channel.
+    /// Waddle thread-oriented channel.
     Forum,
 }
 

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -140,6 +140,34 @@ impl Default for NodeConfig {
 }
 
 impl NodeConfig {
+    /// XEP-0503 configuration for a public Space node.
+    pub fn spaces_public() -> Self {
+        Self {
+            access_model: AccessModel::Open,
+            publish_model: PublishModel::Publishers,
+            max_items: u32::MAX,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: true,
+            notify_delete: true,
+            send_last_published_item: SendLastPublishedItem::OnSub,
+        }
+    }
+
+    /// XEP-0503 configuration for a private Space node.
+    pub fn spaces_private() -> Self {
+        Self {
+            access_model: AccessModel::Whitelist,
+            publish_model: PublishModel::Publishers,
+            max_items: u32::MAX,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: true,
+            notify_delete: true,
+            send_last_published_item: SendLastPublishedItem::OnSub,
+        }
+    }
+
     /// Default configuration for PEP nodes.
     pub fn pep_default() -> Self {
         Self {
@@ -209,5 +237,20 @@ mod tests {
         assert_eq!(config, NodeConfig::pep_default());
         assert_eq!(config.max_items, 1);
         assert!(config.persist_items);
+    }
+
+    #[test]
+    fn spaces_configs_do_not_inherit_pep_single_item_retention() {
+        let public = NodeConfig::spaces_public();
+        assert_eq!(public.access_model, AccessModel::Open);
+        assert_eq!(public.max_items, u32::MAX);
+        assert!(public.persist_items);
+        assert!(public.notify_retract);
+
+        let private = NodeConfig::spaces_private();
+        assert_eq!(private.access_model, AccessModel::Whitelist);
+        assert_eq!(private.max_items, u32::MAX);
+        assert!(private.persist_items);
+        assert!(private.notify_retract);
     }
 }

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -15,9 +15,7 @@ pub fn parse_disco_info_query(iq: &Iq) -> Result<DiscoInfoQuery, XmppError> {
     waddle_xmpp_core::disco::info::parse_disco_info_query(iq).map_err(Into::into)
 }
 
-/// Server-level disco features, extended with XEP-0430 Inbox advertisement
-/// (which lives in the `waddle-xmpp` crate's xep module and therefore cannot
-/// be declared in `waddle-xmpp-core`).
+/// Server-level disco features, extended with Waddle inbox advertisement.
 pub fn server_features() -> Vec<Feature> {
     let mut features = waddle_xmpp_core::disco::info::server_features();
     features.push(Feature::new(crate::xep::xep0430::NS_INBOX));

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -103,7 +103,7 @@ pub struct InboxEntry {
     pub preview: Option<String>,
     /// RFC 6121 thread identifier — `None` for channel-level entries.
     pub thread_id: Option<String>,
-    /// Thread title (XEP-0508 `thread-create` title or first-message preview).
+    /// Thread title (Waddle thread metadata title or first-message preview).
     pub thread_title: Option<String>,
     /// Total replies in this thread.
     pub reply_count: u32,

--- a/server/crates/waddle-xmpp/src/inbox/runtime.rs
+++ b/server/crates/waddle-xmpp/src/inbox/runtime.rs
@@ -1,4 +1,4 @@
-//! Shared runtime helpers for projecting live message traffic into XEP-0430 inbox rows.
+//! Shared runtime helpers for projecting live message traffic into Waddle inbox rows.
 
 use jid::BareJid;
 use xmpp_parsers::message::Message;

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -436,7 +436,7 @@ pub trait AppState: Send + Sync + 'static {
     ) -> impl std::future::Future<Output = Result<(), XmppError>> + Send;
 
     // =========================================================================
-    // XEP-0430 Inbox Projection Methods
+    // Waddle Inbox Projection Methods
     // =========================================================================
 
     /// List inbox entries for a user, newest first.

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -101,7 +101,7 @@ pub struct RoomConfig {
     pub max_occupants: u32,
     /// Whether to log messages (for MAM)
     pub enable_logging: bool,
-    /// Whether the room is in forum mode (XEP-0508)
+    /// Whether the room uses Waddle thread-oriented metadata.
     #[serde(default)]
     pub forum: bool,
     /// Federation permission policy retained for serialized room configs.

--- a/server/crates/waddle-xmpp/src/pubsub/pep.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/pep.rs
@@ -6,8 +6,7 @@ pub use waddle_xmpp_core::pubsub::{
 
 use waddle_xmpp_core::disco::info::Feature;
 
-/// Extended PEP features: core PEP features plus waddle-specific extensions
-/// (currently: XEP-0430 Inbox advertisement).
+/// Extended PEP features: core PEP features plus Waddle-specific extensions.
 pub fn pep_features() -> Vec<Feature> {
     let mut features = waddle_xmpp_core::pubsub::pep_features();
     features.push(Feature::new(crate::xep::xep0430::NS_INBOX));

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -120,8 +120,8 @@
 //! - **XEP-0461**: Message Replies - Reply references and thread metadata.
 //! - **XEP-0513**: Explicit Mentions - @everyone, @here, @role, @user
 //!   mentions with notification decision logic.
-//! - **XEP-0508**: Forums - Forum-style threaded discussions with
-//!   thread-create and thread-reply elements for topic-based MUC.
+//! - Private Waddle MUC thread metadata, used until XEP-0508 is implemented
+//!   through PubSub/XEP-0472 forum nodes.
 //! - **XEP-0503**: Server-side Spaces - Community discovery via pubsub.
 
 pub mod xep0004;

--- a/server/crates/waddle-xmpp/src/xep/xep0430.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0430.rs
@@ -1,13 +1,13 @@
-//! Inbox — unified conversation list with unread counters.
+//! Waddle inbox — unified conversation list with unread counters.
 //!
 //! This module carries the IQ-level protocol for the "inbox" feature:
 //! a single query that returns an ordered list of conversations for the
 //! requesting user, each with its last message and unread counter.
 //!
 //! The contract maps to the in-process types defined in [`crate::inbox`]:
-//! `list → Vec<InboxEntry>`, `mark-read`, `total-unread`. We use the
-//! `urn:xmpp:inbox:0` namespace while the XSF consolidates the spec; the
-//! on-wire shape is stable and already consumed by MongooseIM / Movim.
+//! `list → Vec<InboxEntry>`, `mark-read`, `total-unread`. This is Waddle's
+//! private IQ shape; exact XEP-0430 support uses `urn:xmpp:inbox:1`,
+//! `<inbox/>`, streamed `<entry/>` messages, and final `<fin/>`.
 //!
 //! Thread-level entries extend the `<conversation>` element with optional
 //! `thread`, `thread-title`, `reply-count`, and `author` attributes.
@@ -22,8 +22,8 @@ use xmpp_parsers::message::{Message, MessageType};
 
 use crate::inbox::{ConversationKind, InboxEntry};
 
-/// Inbox protocol namespace.
-pub const NS_INBOX: &str = "urn:xmpp:inbox:0";
+/// Private Waddle inbox protocol namespace.
+pub const NS_INBOX: &str = "urn:waddle:inbox:0";
 
 /// Errors returned by inbox stanza parsing.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -42,7 +42,7 @@ pub enum InboxError {
     WrongIqType,
 }
 
-/// A `<query xmlns='urn:xmpp:inbox:0'/>` request for the user's inbox.
+/// A `<query xmlns='urn:waddle:inbox:0'/>` request for the user's inbox.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct InboxQuery {
     /// Optional lower bound on `last_updated` (inclusive).
@@ -260,7 +260,7 @@ pub fn build_mark_read_result(original: &Iq) -> Iq {
 ///
 /// The stanza carries a single `<conversation>` child in the inbox namespace,
 /// identical to what `build_inbox_query_result` emits for each entry.  Clients
-/// that understand `urn:xmpp:inbox:0` can parse this the same way they parse
+/// that understand `urn:waddle:inbox:0` can parse this the same way they parse
 /// query results and update their local unread state in real time.
 pub fn build_inbox_push(to: jid::Jid, entry: &InboxEntry) -> Message {
     let mut msg = Message::new(Some(to));

--- a/server/crates/waddle-xmpp/src/xep/xep0508.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0508.rs
@@ -1,8 +1,7 @@
-//! XEP-0508: MUC Forums
+//! Waddle MUC thread metadata.
 //!
-//! Extends MUC rooms with forum-style threaded discussions. Unlike
-//! real-time chat, forums organize messages into topic threads with
-//! structured replies.
+//! This is a private Waddle message payload used by the chat UI while real
+//! XEP-0508 support is implemented through PubSub/XEP-0472.
 //!
 //! ## XML Format
 //!
@@ -10,7 +9,7 @@
 //! ```xml
 //! <message type='groupchat' to='forum@muc.example.com'>
 //!   <body>Welcome to the discussion!</body>
-//!   <thread-create xmlns='urn:xmpp:forums:0'
+//!   <thread-create xmlns='urn:waddle:forums:0'
 //!                  title='Getting Started Guide'/>
 //! </message>
 //! ```
@@ -19,7 +18,7 @@
 //! ```xml
 //! <message type='groupchat' to='forum@muc.example.com'>
 //!   <body>Great guide, thanks!</body>
-//!   <thread-reply xmlns='urn:xmpp:forums:0' thread-id='thread-123'/>
+//!   <thread-reply xmlns='urn:waddle:forums:0' thread-id='thread-123'/>
 //! </message>
 //! ```
 //!
@@ -31,8 +30,8 @@
 use minidom::Element;
 use xmpp_parsers::message::Message;
 
-/// Namespace for XEP-0508 Forums.
-pub const NS_FORUMS: &str = "urn:xmpp:forums:0";
+/// Private Waddle namespace for MUC thread metadata.
+pub const NS_FORUMS: &str = "urn:waddle:forums:0";
 
 /// Room config field for enabling forum mode.
 pub const FIELD_FORUM_MODE: &str = "muc#roomconfig_forum";
@@ -237,7 +236,7 @@ mod tests {
     fn test_extract_thread_create() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
                     <body>Welcome!</body>\
-                    <thread-create xmlns='urn:xmpp:forums:0' title='Getting Started'/>\
+                    <thread-create xmlns='urn:waddle:forums:0' title='Getting Started'/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -252,7 +251,7 @@ mod tests {
     fn test_extract_thread_reply() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
                     <body>Great guide!</body>\
-                    <thread-reply xmlns='urn:xmpp:forums:0' thread-id='thread-42'/>\
+                    <thread-reply xmlns='urn:waddle:forums:0' thread-id='thread-42'/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -315,7 +314,7 @@ mod tests {
     #[test]
     fn test_forum_carrier_trait() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <thread-create xmlns='urn:xmpp:forums:0' title='Test'/>\
+                    <thread-create xmlns='urn:waddle:forums:0' title='Test'/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");


### PR DESCRIPTION
## Summary

This draft PR tracks the planned work to make Waddle XMPP-native and XEP-conformant by default. Official `urn:xmpp:*`, `jabber:*`, and `http://jabber.org/*` namespaces must match their XEP wire shape exactly; private `urn:waddle:*` payloads are allowed only when no conformant XEP shape exists.

The first commits update `AGENTS.md` so future non-trivial tasks begin by creating a branch and opening a draft PR with the plan, and so future protocol work explicitly requires exact XEP conformance.

## Plan

### AGENTS and Process

- Add an explicit XEP conformance hard rule to `AGENTS.md`.
- Keep this PR in draft while implementation and dedicated XEP suites land.

### Storage and Disco

- Replace process-local PubSub/PEP/Spaces storage with DB-backed nodes, items, subscriptions, affiliations, and node config.
- Keep only transient runtime state in memory: connections, presence, active MUC occupants, stream resumption sessions, ISR tokens, command sessions, and pending auth flows.
- Require persistent DB storage when advertising durable features such as PEP, persistent PubSub items, Spaces, MAM, Inbox, Push, private XML, and persistent MUC rooms.
- Build disco/caps from actual enabled capability state so unsupported XEP features are not advertised.

### PubSub, PEP, and Spaces

- Add durable PubSub tables for nodes, items, subscriptions, and affiliations.
- Use typed XML payloads internally and serialize only at the DB boundary.
- Add dedicated Spaces node configs instead of PEP defaults: `pubsub#type=urn:xmpp:spaces:0`, `pubsub#persist_items=true`, `pubsub#notify_retract=true`, `pubsub#purge_offline=false`, `pubsub#max_items=max`, and correct access model.
- Implement the full XEP-0503 required feature set before advertising Spaces.
- Keep Space item publish/retract/delete synchronized with permission tuples.

### Inbox and Read State

- Implement XEP-0430 exactly: `urn:xmpp:inbox:1`, IQ `<inbox/>`, message `<entry/>` results carrying MAM `<result/>`, and final `<fin/>`.
- Remove current custom `urn:xmpp:inbox:0` `<query/>`, `<conversation/>`, and `<mark-read/>` wire shape.
- Implement read state through conformant mechanisms, primarily XEP-0333 displayed/acknowledged markers, instead of custom mark-read IQs.

### Forums

- Implement XEP-0508 exactly via PubSub/XEP-0472: root/category/forum PubSub nodes, Atom topic payloads, comments nodes for replies, and required `pubsub#type` profiles.
- Remove MUC `<thread-create/>` and `<thread-reply/>` usage under `urn:xmpp:forums:0`.
- Stop advertising `urn:xmpp:forums:0` until the PubSub/XEP-0472 forum model exists.

### MUC, Push, and Extensions

- Persist XEP-0045 long-lived room state: room config, persistent flag, subject, owners/admins/members/outcasts, and destroy state.
- Rehydrate persistent rooms from DB on first query/join after restart; active occupants and roles remain memory-only.
- Persist XEP-0357 push enablement in DB because an enabled push service remains enabled until disabled or invalidated.
- Keep private payloads such as `urn:waddle:github:0` only for app-specific extensions without XEP equivalents.
- Audit Channel Search and ISR against their local XEPs before further advertisement; fix exact wire shape if mismatched.

## Progress

- Added the default draft-PR workflow rule to `AGENTS.md`.
- Added the explicit XEP conformance hard rule to `AGENTS.md`.
- Added DB-backed PubSub/PEP storage for nodes, items, and node config, wired through `WADDLE_XMPP_PUBSUB_DATABASE_URL` with fallback to `WADDLE_DATABASE_URL`.
- Added dedicated Spaces node configs so Spaces no longer inherit PEP single-item retention.
- Stopped advertising `urn:xmpp:forums:0` for MUC thread metadata and moved that custom payload to `urn:waddle:forums:0`.
- Moved the custom Waddle inbox IQ shape from `urn:xmpp:inbox:0` to `urn:waddle:inbox:0`; exact XEP-0430 remains planned.

## Test Plan

- Add or update dedicated Rust suites for XEP-0045, XEP-0060, XEP-0163, XEP-0223, XEP-0333, XEP-0357, XEP-0402, XEP-0430, XEP-0472, XEP-0503, and XEP-0508.
- Add reboot-survival tests for PubSub, PEP bookmarks, Spaces, MUC persistent rooms, and Push.
- Add negative disco tests proving official features disappear when exact backing behavior is unavailable.
- Add protocol-shape tests proving Inbox and Forums match local XEP XML examples.
- Update chat tests to consume conformant Inbox and Forum flows.

## Assumptions

- Use the global Waddle DB for durable XMPP state.
- No migration shim for existing in-memory PubSub/Spaces data.
- Breaking changes are acceptable for non-conformant custom wire shapes.
- Private Waddle namespaces are acceptable only for app-specific extensions with no XEP equivalent.

## Validation

- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp-core spaces_configs_do_not_inherit_pep_single_item_retention`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server pubsub`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp xep0508`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp-core test_muc_room_features_forum_room`
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp xep0430`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server inbox`
- `bun run build` in `chat/`


## Related issues

Partially addresses:
- #207, by adding DB-backed PubSub/PEP storage for nodes, items, and node config.
  Remaining: subscriptions, affiliations, last-published metadata, restart-persistence tests, subscribe/unsubscribe tests, permission failures, and production fallback policy.

Related but not closed:
- #97, because XEP-0357 push enablement must become durable and conformant, but this PR does not yet replace the bespoke push relay or implement durable push subscriptions.
- #194, because APNS push depends on conformant durable XEP-0357 enablement, but APNS/client/iOS work is not implemented here.
- #214, because this PR adds XEP conformance rules and starts correcting namespace/storage behavior, but does not implement the listed ejabberd parity XEPs.
- #99, because this PR establishes the private-namespace policy, but does not fix private XML key collisions or XEP-0106 Unicode slicing.