### PR TITLE
fix(chat): fetch avatars for archived room authors

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -34,7 +34,7 @@ import MemberManagement from "@/components/modals/MemberManagement.vue";
 import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
 import type { MemberSummary } from "@/lib/chat-types";
 import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
-import { mentionAutocompleteCandidates, mentionMatchesUsername, mergeMentionMembers } from "@/lib/mentions";
+import { avatarLookupCandidates, mentionAutocompleteCandidates, mentionMatchesUsername, mergeMentionMembers } from "@/lib/mentions";
 
 const props = defineProps<{
   tenorApiKey?: string;
@@ -212,6 +212,14 @@ const computedChannelUnreadMap = computed(() => channelUnread.channelUnreadMap()
 const notifications = useNotifications();
 const appUpdate = useAppUpdate();
 const version = useVersion(xmppClient);
+const avatarCandidates = computed(() =>
+  avatarLookupCandidates({
+    members: mergedMentionMembers.value.members,
+    messages: messaging.messages.value,
+    authorJidByNick: authorJidByNick.value,
+    selfDomain: selfDomain.value,
+  }),
+);
 const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
   const avatars: Record<string, string | null> = {};
 
@@ -235,6 +243,14 @@ const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
     }
   }
 
+  for (const candidate of avatarCandidates.value) {
+    const fetched = fetchedAvatarUrlByJid.value[candidate.jid];
+    const avatar = fetched ?? candidate.avatar_url;
+    if (!(candidate.nick in avatars) || avatar) {
+      avatars[candidate.nick] = avatar;
+    }
+  }
+
   return avatars;
 });
 const membersWithAvatars = computed<MemberSummary[]>(() =>
@@ -248,12 +264,12 @@ const authorHatsByNick = computed(() =>
 );
 
 watch(
-  () => [xmppClient.value, mergedMentionMembers.value.members.map((member) => member.jid).join("\n")] as const,
+  () => [xmppClient.value, avatarCandidates.value.map((candidate) => candidate.jid).join("\n")] as const,
   ([client]) => {
     if (!client) return;
-    for (const member of mergedMentionMembers.value.members) {
-      const jid = member.jid;
-      if (!jid || member.avatar_url || avatarFetchStateByJid.value[jid]) continue;
+    for (const candidate of avatarCandidates.value) {
+      const jid = candidate.jid;
+      if (!jid || candidate.avatar_url || avatarFetchStateByJid.value[jid]) continue;
       avatarFetchStateByJid.value = { ...avatarFetchStateByJid.value, [jid]: "pending" };
       void client.fetchUserAvatar(jid)
         .then((avatarUrl) => {

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -48,11 +48,12 @@ export function fromLiveMessage(
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
-    authorJid: `${msg.roomJid}/${msg.nick}`,
+    authorJid: msg.authorRealJid ?? `${msg.roomJid}/${msg.nick}`,
     body: msg.body,
     createdAt: msg.createdAt,
     isSelf: msg.nick === session.username,
   };
+  if (msg.authorRealJid) tm.authorRealJid = msg.authorRealJid;
   if (msg.wireIds && msg.wireIds.length > 0) {
     tm.wireIds = msg.wireIds;
   }

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -31,8 +31,10 @@ export interface TimelineMessage {
   /** Equivalent wire-level ids (XEP-0359 stanza/origin ids, echoed ids). */
   wireIds?: string[];
   author: string;
-  /** Actual JID / occupant JID for the author when known. */
+  /** Actual bare JID when known; otherwise the room occupant JID. */
   authorJid?: string;
+  /** XEP-0313 MUC archive real JID from muc#user item@jid, when present. */
+  authorRealJid?: string;
   body: string;
   createdAt: string;
   isSelf: boolean;

--- a/chat/src/lib/mentions.ts
+++ b/chat/src/lib/mentions.ts
@@ -1,4 +1,5 @@
 import type { MemberSummary } from "@/lib/chat-types";
+import type { TimelineMessage } from "@/lib/chat-ui";
 
 const BROADCAST_MENTION_SET = new Set(["everyone", "here"]);
 const MENTIONABLE_MEMBER_ROLES = new Set<MemberSummary["role"]>(["owner", "admin", "member"]);
@@ -13,8 +14,30 @@ export interface MentionCandidate {
   kind: "broadcast" | "member";
 }
 
+interface AvatarLookupCandidate {
+  nick: string;
+  jid: string;
+  avatar_url: string | null;
+}
+
 function canonicalMentionIdentifier(value: string): string {
   return value.trim().replace(/^xmpp:/i, "").replace(/^@+/, "").toLowerCase();
+}
+
+function bareJid(value?: string | null): string | null {
+  if (!value || !value.includes("@")) return null;
+  return value.split("/")[0] || null;
+}
+
+function isMucOccupantJid(jid: string): boolean {
+  const bare = bareJid(jid) ?? jid;
+  return jid.includes("/") && bare.split("@")[1]?.startsWith("muc.") === true;
+}
+
+function inferLocalUserJid(nick: string, selfDomain: string): string | null {
+  const canonical = canonicalMentionIdentifier(nick);
+  if (!canonical || canonical.includes("@") || !selfDomain) return null;
+  return `${canonical}@${selfDomain}`;
 }
 
 export function isBroadcastMention(value: string): boolean {
@@ -61,6 +84,79 @@ export function mentionAutocompleteCandidates(
       kind: "member",
     });
     seen.add(canonical);
+  }
+
+  return candidates;
+}
+
+export function avatarLookupCandidates({
+  members,
+  messages,
+  authorJidByNick,
+  selfDomain,
+}: {
+  members: readonly MemberSummary[];
+  messages: readonly Pick<TimelineMessage, "author" | "authorJid" | "authorRealJid">[];
+  authorJidByNick: Readonly<Record<string, string>>;
+  selfDomain: string;
+}): AvatarLookupCandidate[] {
+  const candidates: AvatarLookupCandidate[] = [];
+  const seenJids = new Set<string>();
+  const memberAvatarByJid = new Map<string, string | null>();
+  const mappedJidByNick = new Map<string, string>();
+
+  for (const member of members) {
+    const jid = bareJid(member.jid);
+    if (!jid) continue;
+    memberAvatarByJid.set(jid, member.avatar_url);
+    mappedJidByNick.set(canonicalMentionIdentifier(member.username), jid);
+  }
+  for (const [nick, jid] of Object.entries(authorJidByNick)) {
+    const bare = bareJid(jid);
+    if (bare) mappedJidByNick.set(canonicalMentionIdentifier(nick), bare);
+  }
+
+  function add(nick: string, jid: string, avatar_url: string | null): void {
+    const bare = bareJid(jid);
+    if (!bare || seenJids.has(bare)) return;
+    seenJids.add(bare);
+    candidates.push({ nick, jid: bare, avatar_url });
+  }
+
+  for (const member of members) {
+    const jid = bareJid(member.jid);
+    if (jid) add(member.username, jid, member.avatar_url);
+  }
+
+  const bestMessageCandidateByNick = new Map<string, { nick: string; jid: string; rank: number }>();
+  for (const message of messages) {
+    const nick = message.author;
+    const mappedJid = mappedJidByNick.get(canonicalMentionIdentifier(nick));
+    const realJid = bareJid(message.authorRealJid);
+    const messageJid = message.authorJid && !isMucOccupantJid(message.authorJid)
+      ? bareJid(message.authorJid)
+      : null;
+    const resolved = realJid
+      ? { jid: realJid, rank: 0 }
+      : mappedJid
+        ? { jid: mappedJid, rank: 1 }
+        : messageJid
+          ? { jid: messageJid, rank: 2 }
+          : (() => {
+              const inferred = inferLocalUserJid(nick, selfDomain);
+              return inferred ? { jid: inferred, rank: 3 } : null;
+            })();
+    if (!resolved) continue;
+    const key = canonicalMentionIdentifier(nick);
+    const previous = bestMessageCandidateByNick.get(key);
+    if (!previous || resolved.rank < previous.rank) {
+      bestMessageCandidateByNick.set(key, { nick, ...resolved });
+    }
+  }
+
+  for (const { nick, jid } of bestMessageCandidateByNick.values()) {
+    if (!jid) continue;
+    add(nick, jid, memberAvatarByJid.get(jid) ?? null);
   }
 
   return candidates;

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -30,6 +30,13 @@ type MessageExtensionsTarget = Pick<
   | "forumThreadTitle"
 >;
 
+type MucUserPayload = {
+  jid?: unknown;
+  item?: { jid?: unknown };
+  items?: Array<{ jid?: unknown }>;
+  users?: Array<{ jid?: unknown }>;
+};
+
 /** Access custom JXT extension fields that TypeScript doesn't know about. */
 export function ext(msg: unknown): Record<string, unknown> {
   return msg as Record<string, unknown>;
@@ -64,6 +71,19 @@ interface StanzaIdPayload {
 function asArray<T>(value: T | T[] | undefined): T[] {
   if (!value) return [];
   return Array.isArray(value) ? value : [value];
+}
+
+function bareJid(value: unknown): string | undefined {
+  if (typeof value !== "string" || !value.includes("@")) return undefined;
+  return value.split("/")[0] || undefined;
+}
+
+function extractMucUserRealJid(msg: ReceivedMessage): string | undefined {
+  const muc = (ext(msg).muc ?? ext(msg).mucUser) as MucUserPayload | undefined;
+  return bareJid(muc?.jid)
+    ?? bareJid(muc?.item?.jid)
+    ?? bareJid(muc?.items?.find((item) => item.jid)?.jid)
+    ?? bareJid(muc?.users?.find((item) => item.jid)?.jid);
 }
 
 export function resolveMessageIds(
@@ -324,6 +344,8 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
     createdAt: new Date().toISOString(),
     type: msg.body ? "message" : "subject",
   };
+  const authorRealJid = extractMucUserRealJid(msg);
+  if (authorRealJid) liveMsg.authorRealJid = authorRealJid;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;
   extractMessageExtensions(msg, liveMsg);
   h.onMessage?.(liveMsg);

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -92,6 +92,8 @@ export interface LiveRoomMessage {
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;
+  /** XEP-0313 MUC archive real JID from muc#user item@jid, when present. */
+  authorRealJid?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -96,6 +96,31 @@ describe("MAM history parsing", () => {
     expect(results[3].retractsId).toBe("msg-1");
   });
 
+  test("preserves real MUC author JID from archived muc#user item", async () => {
+    const xmpp = makeMamAgent([
+      {
+        id: "archive-msg-1",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+          message: {
+            id: "msg-1",
+            from: "room@muc.example.com/randax",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            body: "hello",
+            muc: { item: { jid: "randax@example.com/mobile" } },
+          },
+        },
+      },
+    ]);
+
+    const results = await queryMam(xmpp, "room@muc.example.com", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].nick).toBe("randax");
+    expect(results[0].authorRealJid).toBe("randax@example.com");
+  });
+
   test("parses archived direct-message reactions, corrections, and retractions with original stanza IDs", async () => {
     const xmpp = makeMamAgent([
       {

--- a/chat/tests/mentions.test.ts
+++ b/chat/tests/mentions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  avatarLookupCandidates,
   mentionAutocompleteCandidates,
   mentionAutocompleteNames,
   mentionMatchesUsername,
@@ -140,6 +141,66 @@ describe("mention helpers", () => {
     expect(merged.members).toEqual([]);
     expect(merged.diagnostics).toEqual([
       "Presence invariant violated: room appears anonymous or omitted bare occupant JIDs for alice, bob.",
+    ]);
+  });
+
+  test("avatar lookup candidates include visible MAM authors missing from members", () => {
+    const candidates = avatarLookupCandidates({
+      members: [{ jid: "rawkode@waddle.social", username: "rawkode", avatar_url: null, role: "owner", joined_at: "" }],
+      messages: [
+        {
+          author: "randax",
+          authorJid: "chat@muc.waddle.social/randax",
+          authorRealJid: "randax@waddle.social/laptop",
+        },
+        {
+          author: "icepuma",
+          authorJid: "chat@muc.waddle.social/icepuma",
+        },
+      ],
+      authorJidByNick: {},
+      selfDomain: "waddle.social",
+    });
+
+    expect(candidates.map((candidate) => candidate.jid)).toEqual([
+      "rawkode@waddle.social",
+      "randax@waddle.social",
+      "icepuma@waddle.social",
+    ]);
+  });
+
+  test("avatar lookup candidates prefer member and presence JIDs over inferred JIDs", () => {
+    const candidates = avatarLookupCandidates({
+      members: [],
+      messages: [
+        { author: "Randax", authorJid: "chat@muc.waddle.social/Randax" },
+        { author: "icepuma", authorJid: "chat@muc.waddle.social/icepuma" },
+      ],
+      authorJidByNick: {
+        randax: "randax@waddle.social",
+        Icepuma: "icepuma@elsewhere.example",
+      },
+      selfDomain: "waddle.social",
+    });
+
+    expect(candidates.map((candidate) => candidate.jid)).toEqual([
+      "randax@waddle.social",
+      "icepuma@elsewhere.example",
+    ]);
+  });
+
+  test("avatar lookup candidates do not use MUC occupant JIDs directly", () => {
+    const candidates = avatarLookupCandidates({
+      members: [],
+      messages: [
+        { author: "randax", authorJid: "chat@muc.waddle.social/randax" },
+      ],
+      authorJidByNick: {},
+      selfDomain: "waddle.social",
+    });
+
+    expect(candidates).toEqual([
+      { nick: "randax", jid: "randax@waddle.social", avatar_url: null },
     ]);
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -33,7 +33,7 @@ use waddle_xmpp::{
         build_pubsub_success, is_pubsub_iq, parse_pubsub_iq, PubSubError, PubSubItem,
         PubSubRequest,
     },
-    xep::xep0054::{build_vcard_element, VCard, VCardPhoto},
+    xep::xep0054::{VCard, VCardPhoto},
     xep::xep0357::{
         build_push_disable_result, build_push_enable_result, is_push_disable, is_push_enable,
         parse_push_disable, parse_push_enable,
@@ -60,7 +60,7 @@ use xmpp_parsers::minidom::Element;
 
 use super::super::{
     build_iq_error_xml, build_iq_error_xml_with_addresses, build_iq_result_xml, destroy_room_actor,
-    element_to_xml, get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml, WebSocketState,
+    get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml, WebSocketState,
 };
 use super::presence::get_managed_channel_for_room;
 use crate::auth::{NativeUserStore, Session};
@@ -2227,30 +2227,28 @@ async fn handle_vcard_iq(
                     )];
                 }
             },
-            Ok(None) => {
-                match materialize_avatar_vcard(Arc::clone(&db), &store, &target_jid).await {
-                    Ok(Some(vcard)) => waddle_xmpp::xep::xep0054::build_vcard_response(iq, &vcard),
-                    Ok(None) => {
-                        return vec![build_iq_error_xml_with_addresses(
-                            &iq.id,
-                            response_from,
-                            response_to,
-                            "cancel",
-                            "service-unavailable",
-                        )];
-                    }
-                    Err(error) => {
-                        warn!(target = %target_jid, error = %error, "Failed to materialize avatar vCard");
-                        return vec![build_iq_error_xml_with_addresses(
-                            &iq.id,
-                            response_from,
-                            response_to,
-                            "wait",
-                            "internal-server-error",
-                        )];
-                    }
+            Ok(None) => match avatar_vcard_from_user_profile(Arc::clone(&db), &target_jid).await {
+                Ok(Some(vcard)) => waddle_xmpp::xep::xep0054::build_vcard_response(iq, &vcard),
+                Ok(None) => {
+                    return vec![build_iq_error_xml_with_addresses(
+                        &iq.id,
+                        response_from,
+                        response_to,
+                        "cancel",
+                        "item-not-found",
+                    )];
                 }
-            }
+                Err(error) => {
+                    warn!(target = %target_jid, error = %error, "Failed to load avatar vCard fallback");
+                    return vec![build_iq_error_xml_with_addresses(
+                        &iq.id,
+                        response_from,
+                        response_to,
+                        "wait",
+                        "internal-server-error",
+                    )];
+                }
+            },
             Err(error) => {
                 warn!(target = %target_jid, error = %error, "Failed to load vCard");
                 return vec![build_iq_error_xml_with_addresses(
@@ -2468,9 +2466,8 @@ async fn handle_private_storage_iq(
     )]
 }
 
-async fn materialize_avatar_vcard(
+async fn avatar_vcard_from_user_profile(
     db: Arc<Database>,
-    store: &VCardStore,
     target_jid: &BareJid,
 ) -> Result<Option<VCard>, String> {
     let Some(localpart) = target_jid.node().map(|node| node.to_string()) else {
@@ -2497,13 +2494,95 @@ async fn materialize_avatar_vcard(
         photo: Some(VCardPhoto::External { url: avatar_url }),
         ..Default::default()
     };
-    let vcard_xml = element_to_xml(build_vcard_element(&vcard));
-    store
-        .set(target_jid, &vcard_xml)
-        .await
-        .map_err(|error| error.to_string())?;
 
     Ok(Some(vcard))
+}
+
+#[cfg(test)]
+mod vcard_fallback_tests {
+    use super::*;
+    use crate::db::MigrationRunner;
+    use waddle_xmpp::xep::xep0054::{VCardPhoto, NS_VCARD};
+
+    async fn test_db(name: &str) -> Arc<Database> {
+        let db = Arc::new(Database::in_memory(name).await.expect("database"));
+        MigrationRunner::global()
+            .run(&db)
+            .await
+            .expect("migrations");
+        db
+    }
+
+    #[tokio::test]
+    async fn vcard_get_fallback_returns_photo_extval_without_stored_vcard() {
+        let db = test_db("vcard-profile-fallback").await;
+        let conn = db.guard().await.expect("connection");
+        conn.execute(
+            "INSERT INTO users (id, username, xmpp_localpart, avatar_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            vec![
+                Value::from("user-rawkode"),
+                Value::from("rawkode"),
+                Value::from("rawkode"),
+                Value::from("https://cdn.example.com/rawkode.png"),
+                Value::from("2026-04-25T00:00:00Z"),
+                Value::from("2026-04-25T00:00:00Z"),
+            ],
+        )
+        .await
+        .expect("insert user");
+
+        let target_jid: BareJid = "rawkode@example.com".parse().expect("jid");
+        let vcard = avatar_vcard_from_user_profile(Arc::clone(&db), &target_jid)
+            .await
+            .expect("fallback")
+            .expect("profile avatar");
+        assert!(matches!(
+            vcard.photo,
+            Some(VCardPhoto::External { ref url }) if url == "https://cdn.example.com/rawkode.png"
+        ));
+
+        let stored = VCardStore::new(db)
+            .get(&target_jid)
+            .await
+            .expect("stored lookup");
+        assert_eq!(stored, None, "GET fallback must not persist a vCard");
+    }
+
+    #[tokio::test]
+    async fn vcard_get_fallback_builds_typed_result_not_internal_server_error() {
+        let db = test_db("vcard-profile-response").await;
+        let conn = db.guard().await.expect("connection");
+        conn.execute(
+            "INSERT INTO users (id, username, xmpp_localpart, avatar_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+            vec![
+                Value::from("user-icepuma"),
+                Value::from("icepuma"),
+                Value::from("icepuma"),
+                Value::from("https://cdn.example.com/icepuma.jpg"),
+                Value::from("2026-04-25T00:00:00Z"),
+                Value::from("2026-04-25T00:00:00Z"),
+            ],
+        )
+        .await
+        .expect("insert user");
+
+        let target_jid: BareJid = "icepuma@example.com".parse().expect("jid");
+        let vcard = avatar_vcard_from_user_profile(db, &target_jid)
+            .await
+            .expect("fallback")
+            .expect("profile avatar");
+        let iq = xmpp_parsers::iq::Iq {
+            from: Some("rawkode@example.com/web".parse::<Jid>().expect("from")),
+            to: Some("icepuma@example.com".parse::<Jid>().expect("to")),
+            id: "vcard-get".to_string(),
+            payload: xmpp_parsers::iq::IqType::Get(Element::builder("vCard", NS_VCARD).build()),
+        };
+        let response = iq_to_xml(waddle_xmpp::xep::xep0054::build_vcard_response(&iq, &vcard));
+
+        assert!(response.contains("type=\"result\"") || response.contains("type='result'"));
+        assert!(response.contains("<EXTVAL>https://cdn.example.com/icepuma.jpg</EXTVAL>"));
+        assert!(!response.contains("internal-server-error"));
+    }
 }
 
 async fn handle_blocking_iq(

--- a/server/crates/waddle-server/src/vcard.rs
+++ b/server/crates/waddle-server/src/vcard.rs
@@ -11,9 +11,10 @@
 
 use std::sync::Arc;
 
+use chrono::Utc;
 use tracing::debug;
 
-use crate::db::Database;
+use crate::db::{Database, Value};
 
 /// Error type for vCard operations.
 #[derive(Debug, thiserror::Error)]
@@ -84,16 +85,16 @@ impl VCardStore {
         debug!(jid = %jid_str, "Storing vCard");
 
         let conn = self.get_connection().await?;
+        let now = Utc::now().to_rfc3339();
 
         conn.execute(
-            r#"
-                INSERT INTO vcard_storage (jid, vcard_xml, created_at, updated_at)
-                VALUES (?, ?, datetime('now'), datetime('now'))
-                ON CONFLICT(jid) DO UPDATE SET
-                    vcard_xml = excluded.vcard_xml,
-                    updated_at = datetime('now')
-                "#,
-            (jid_str.as_str(), vcard_xml),
+            upsert_vcard_sql(),
+            vec![
+                Value::from(jid_str.as_str()),
+                Value::from(vcard_xml),
+                Value::from(now.as_str()),
+                Value::from(now.as_str()),
+            ],
         )
         .await
         .map_err(db_err)?;
@@ -128,6 +129,16 @@ impl VCardStore {
             Ok(false)
         }
     }
+}
+
+fn upsert_vcard_sql() -> &'static str {
+    r#"
+        INSERT INTO vcard_storage (jid, vcard_xml, created_at, updated_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(jid) DO UPDATE SET
+            vcard_xml = excluded.vcard_xml,
+            updated_at = excluded.updated_at
+        "#
 }
 
 /// Helper to convert database errors to VCardError.
@@ -207,6 +218,14 @@ mod tests {
         // Retrieve should return updated version
         let retrieved = store.get(&jid).await.expect("Failed to get vCard");
         assert_eq!(retrieved, Some(vcard_xml_v2.to_string()));
+    }
+
+    #[test]
+    fn test_vcard_store_set_sql_uses_bound_timestamps() {
+        let sql = upsert_vcard_sql();
+        assert!(!sql.contains("datetime("));
+        assert!(sql.contains("VALUES (?, ?, ?, ?)"));
+        assert!(sql.contains("updated_at = excluded.updated_at"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix XEP-0054 vCard avatar fallback so GET reads can return a typed vCard-temp PHOTO/EXTVAL from users.avatar_url without persisting during the read path.
- Make VCardStore::set portable across SQLite/Postgres by binding application-generated timestamps instead of using datetime('now').
- Carry real MUC author JIDs from XEP-0313 muc#user metadata and include visible MAM authors in avatar lookup candidates, while avoiding occupant JIDs for avatar IQs.
- Preserve existing XEP-0317 hats behavior; owner/admin moderator implication remains covered by existing hats tests.

## XEP notes

Reviewed local XEP-0045, XEP-0084, XEP-0153, XEP-0313, and XEP-0317 under ./xeps before editing. Avatar fetching stays XMPP-native: XEP-0084 first, XEP-0054 vCard fallback, no REST avatar API.

## Membership list finding

I did not find code that drops randax/icepuma affiliations from persistent MUC state. Managed MUC affiliations are currently populated into the room actor when users join or when explicit MUC admin changes are applied; if prod restarted and only rawkode rejoined, the owner/admin/member/outcast query can reflect that in-memory room state while older MAM entries still contain randax/icepuma messages. This looks like production room/affiliation state rather than a regression caused by this patch.

## Verification

- cargo fmt --all --check
- cargo check -p waddle-server -p waddle-xmpp
- cargo test -p waddle-server vcard
- cargo test -p waddle-xmpp xep0317
- chat: bun test tests/mentions.test.ts tests/mam-history.test.ts
- chat: bun run lint
- git diff --check