### PR TITLE
fix(server): implement durable roster IQ and roster push fanout

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -3,6 +3,7 @@ use jid::{BareJid, FullJid, Jid};
 use std::sync::Arc;
 use tracing::{debug, warn};
 use url::{Host, Url};
+use uuid::Uuid;
 use waddle_xmpp::{
     carbons::CARBONS_NS,
     commands::{CommandContext, CommandResult},
@@ -32,6 +33,11 @@ use waddle_xmpp::{
         build_pubsub_error, build_pubsub_items_result, build_pubsub_publish_result,
         build_pubsub_success, is_pubsub_iq, parse_pubsub_iq, PubSubError, PubSubItem,
         PubSubRequest,
+    },
+    roster::{
+        build_roster_push, build_roster_result, build_roster_result_empty, is_roster_get,
+        is_roster_set, parse_roster_get, parse_roster_set, AskType, RosterItem, RosterSetResult,
+        Subscription,
     },
     xep::xep0054::{VCard, VCardPhoto},
     xep::xep0357::{
@@ -66,6 +72,7 @@ use super::presence::get_managed_channel_for_room;
 use crate::auth::{NativeUserStore, Session};
 use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};
 use crate::db::blocking::DatabaseBlockingStorage;
+use crate::db::roster::{DatabaseRosterStorage, RosterItemRow};
 use crate::db::{row_value, Database, Value, ValueExt};
 use crate::permissions::{
     CheckPermission, Object, ObjectType, Permission, PermissionError, Relation, Subject,
@@ -175,6 +182,10 @@ pub async fn handle_iq_with_conn_state(
         }
     }
 
+    if is_roster_get(&iq) || is_roster_set(&iq) {
+        return handle_roster_iq(&iq, state, phase.bound_jid(), response_from, response_to).await;
+    }
+
     // Sans-I/O dispatch: if the IQ namespace has a registered handler in
     // the protocol dispatcher, route through it and translate the emitted
     // OutboundEvents into outbound XML frames via `interpret()`.
@@ -277,9 +288,6 @@ pub async fn handle_iq_with_conn_state(
         }
         return outcome.frames;
     }
-
-    // jabber:iq:roster is now served by protocol::handlers::roster::RosterHandler
-    // through the sans-I/O dispatcher short-circuit above.
 
     if waddle_xmpp::xep::xep0054::is_vcard_get(&iq) || waddle_xmpp::xep::xep0054::is_vcard_set(&iq)
     {
@@ -1468,6 +1476,244 @@ pub async fn handle_iq_with_conn_state(
         "cancel",
         "feature-not-implemented",
     )]
+}
+
+async fn roster_storage(state: &WebSocketState) -> Option<DatabaseRosterStorage> {
+    match state
+        .deps
+        .app_state
+        .db_pool
+        .global_actor()
+        .clone()
+        .ask(GetDatabase)
+        .await
+    {
+        Ok(db) => Some(DatabaseRosterStorage::new(db)),
+        Err(error) => {
+            warn!(error = %error, "Failed to access roster database for IQ");
+            None
+        }
+    }
+}
+
+async fn handle_roster_iq(
+    iq: &xmpp_parsers::iq::Iq,
+    state: &WebSocketState,
+    bound_jid: Option<&FullJid>,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+) -> Vec<String> {
+    let Some(full_jid) = bound_jid else {
+        return vec![build_iq_error_xml_with_addresses(
+            &iq.id,
+            response_from,
+            response_to,
+            "auth",
+            "not-authorized",
+        )];
+    };
+    let Some(storage) = roster_storage(state).await else {
+        return vec![build_iq_error_xml_with_addresses(
+            &iq.id,
+            response_from,
+            response_to,
+            "wait",
+            "internal-server-error",
+        )];
+    };
+    let user_bare = full_jid.to_bare();
+
+    if is_roster_get(iq) {
+        if parse_roster_get(iq).is_err() {
+            return vec![build_iq_error_xml_with_addresses(
+                &iq.id,
+                response_from,
+                response_to,
+                "modify",
+                "bad-request",
+            )];
+        }
+        let items = match storage.get_roster(&user_bare).await {
+            Ok(rows) => rows.into_iter().map(roster_row_to_item).collect::<Vec<_>>(),
+            Err(error) => {
+                warn!(error = %error, user = %user_bare, "Failed to load roster");
+                return vec![build_iq_error_xml_with_addresses(
+                    &iq.id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )];
+            }
+        };
+        let version = storage.get_roster_version(&user_bare).await.ok().flatten();
+        let result = build_roster_result(iq, &items, version.as_deref());
+        return vec![stanza_to_xml(Stanza::Iq(result))];
+    }
+
+    let query = match parse_roster_set(iq) {
+        Ok(query) => query,
+        Err(_) => {
+            return vec![build_iq_error_xml_with_addresses(
+                &iq.id,
+                response_from,
+                response_to,
+                "modify",
+                "bad-request",
+            )];
+        }
+    };
+
+    // parse_roster_set guarantees at least one item per RFC 6121.
+    let requested_item = query.items[0].clone();
+    let set_result = if requested_item.subscription == Subscription::Remove {
+        match storage
+            .remove_roster_item(&user_bare, &requested_item.jid)
+            .await
+        {
+            Ok(true) => Some(RosterSetResult::Removed(requested_item.jid.clone())),
+            Ok(false) => None,
+            Err(error) => {
+                warn!(error = %error, user = %user_bare, contact = %requested_item.jid, "Failed to remove roster item");
+                return vec![build_iq_error_xml_with_addresses(
+                    &iq.id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )];
+            }
+        }
+    } else {
+        let existing = match storage
+            .get_roster_item(&user_bare, &requested_item.jid)
+            .await
+        {
+            Ok(existing) => existing.map(roster_row_to_item),
+            Err(error) => {
+                warn!(error = %error, user = %user_bare, contact = %requested_item.jid, "Failed to load roster item");
+                return vec![build_iq_error_xml_with_addresses(
+                    &iq.id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )];
+            }
+        };
+        let mut updated = existing
+            .clone()
+            .unwrap_or_else(|| RosterItem::new(requested_item.jid.clone()));
+        updated.name = requested_item.name.clone();
+        updated.groups = requested_item.groups.clone();
+        let row = roster_item_to_row(&updated);
+        match storage.set_roster_item(&user_bare, &row).await {
+            Ok(is_new) => {
+                if is_new {
+                    Some(RosterSetResult::Added(updated))
+                } else {
+                    Some(RosterSetResult::Updated(updated))
+                }
+            }
+            Err(error) => {
+                warn!(error = %error, user = %user_bare, contact = %requested_item.jid, "Failed to set roster item");
+                return vec![build_iq_error_xml_with_addresses(
+                    &iq.id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )];
+            }
+        }
+    };
+
+    if let Some(change) = set_result {
+        let version = storage.get_roster_version(&user_bare).await.ok().flatten();
+        let push_item = change.to_push_item();
+        for resource in state
+            .deps
+            .protocol
+            .connection_registry
+            .get_resources_for_user(&user_bare)
+        {
+            let push_id = format!("roster-push-{}", Uuid::new_v4());
+            match build_roster_push(
+                &push_id,
+                &resource.to_string(),
+                &push_item,
+                version.as_deref(),
+            ) {
+                Ok(push_iq) => {
+                    let _ = state
+                        .deps
+                        .protocol
+                        .connection_registry
+                        .send_to(&resource, Stanza::Iq(push_iq))
+                        .await;
+                }
+                Err(error) => {
+                    warn!(error = %error, user = %user_bare, resource = %resource, "Failed to build roster push IQ");
+                }
+            }
+        }
+    }
+
+    let result = build_roster_result_empty(iq);
+    vec![stanza_to_xml(Stanza::Iq(result))]
+}
+
+fn roster_row_to_item(row: RosterItemRow) -> RosterItem {
+    RosterItem {
+        jid: row.contact_jid.parse().expect("stored roster JID is valid"),
+        name: row.name,
+        subscription: parse_subscription_state(&row.subscription),
+        ask: row.ask.as_deref().and_then(parse_ask_state),
+        groups: row.groups,
+    }
+}
+
+fn roster_item_to_row(item: &RosterItem) -> RosterItemRow {
+    RosterItemRow {
+        contact_jid: item.jid.to_string(),
+        name: item.name.clone(),
+        subscription: subscription_state_str(item.subscription).to_string(),
+        ask: item.ask.map(ask_state_str).map(ToOwned::to_owned),
+        groups: item.groups.clone(),
+    }
+}
+
+fn parse_subscription_state(value: &str) -> Subscription {
+    match value {
+        "to" => Subscription::To,
+        "from" => Subscription::From,
+        "both" => Subscription::Both,
+        "remove" => Subscription::Remove,
+        _ => Subscription::None,
+    }
+}
+
+fn subscription_state_str(value: Subscription) -> &'static str {
+    match value {
+        Subscription::None => "none",
+        Subscription::To => "to",
+        Subscription::From => "from",
+        Subscription::Both => "both",
+        Subscription::Remove => "remove",
+    }
+}
+
+fn parse_ask_state(value: &str) -> Option<AskType> {
+    match value {
+        "subscribe" => Some(AskType::Subscribe),
+        _ => None,
+    }
+}
+
+fn ask_state_str(value: AskType) -> &'static str {
+    match value {
+        AskType::Subscribe => "subscribe",
+    }
 }
 
 async fn handle_muc_self_ping_iq(

--- a/server/crates/waddle-server/tests/rfc6121_roster_ws.rs
+++ b/server/crates/waddle-server/tests/rfc6121_roster_ws.rs
@@ -1,0 +1,233 @@
+//! RFC 6121 roster management behavior over the active WebSocket C2S transport.
+
+mod ws_common;
+
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+
+async fn connect_alice_bob() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+
+    let alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice connection");
+
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connection");
+
+    (server, alice, bob)
+}
+
+async fn roster_get(client: &mut WsXmppClient, id: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq xmlns='jabber:client' type='get' id='{id}'><query xmlns='jabber:iq:roster'/></iq>"#
+        ))
+        .await
+        .expect("send roster get");
+
+    client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id=\"{id}\"")) || frame.contains(&format!("id='{id}'"))
+        })
+        .await
+        .expect("roster get response")
+}
+
+async fn roster_set(client: &mut WsXmppClient, id: &str, item_xml: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq xmlns='jabber:client' type='set' id='{id}'><query xmlns='jabber:iq:roster'>{item_xml}</query></iq>"#
+        ))
+        .await
+        .expect("send roster set");
+
+    client
+        .recv_matching(|frame| {
+            frame.contains(&format!("id=\"{id}\"")) || frame.contains(&format!("id='{id}'"))
+        })
+        .await
+        .expect("roster set result")
+}
+
+#[tokio::test]
+async fn websocket_roster_get_add_update_remove_roundtrip() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    let add_result = roster_set(
+        &mut alice,
+        "roster-add-1",
+        "<item jid='bob@localhost' name='Bob Friend'><group>Buddies</group></item>",
+    )
+    .await;
+    assert!(add_result.contains("type=\"result\"") || add_result.contains("type='result'"));
+
+    let get_after_add = roster_get(&mut alice, "roster-get-after-add").await;
+    assert!(get_after_add.contains("<query") && get_after_add.contains("jabber:iq:roster"));
+    assert!(
+        get_after_add.contains("jid=\"bob@localhost\"")
+            || get_after_add.contains("jid='bob@localhost'")
+    );
+    assert!(
+        get_after_add.contains("name=\"Bob Friend\"")
+            || get_after_add.contains("name='Bob Friend'")
+    );
+    assert!(get_after_add.contains("<group>Buddies</group>"));
+
+    let update_result = roster_set(
+        &mut alice,
+        "roster-update-1",
+        "<item jid='bob@localhost' name='Bobby'><group>Colleagues</group></item>",
+    )
+    .await;
+    assert!(update_result.contains("type=\"result\"") || update_result.contains("type='result'"));
+
+    let get_after_update = roster_get(&mut alice, "roster-get-after-update").await;
+    assert!(
+        get_after_update.contains("name=\"Bobby\"") || get_after_update.contains("name='Bobby'")
+    );
+    assert!(get_after_update.contains("<group>Colleagues</group>"));
+    assert!(!get_after_update.contains("Bob Friend"));
+
+    let remove_result = roster_set(
+        &mut alice,
+        "roster-remove-1",
+        "<item jid='bob@localhost' subscription='remove' />",
+    )
+    .await;
+    assert!(remove_result.contains("type=\"result\"") || remove_result.contains("type='result'"));
+
+    let get_after_remove = roster_get(&mut alice, "roster-get-after-remove").await;
+    assert!(!get_after_remove.contains("bob@localhost"));
+
+    alice.close().await;
+    bob.close().await;
+}
+
+#[tokio::test]
+async fn websocket_roster_set_pushes_to_all_connected_resources() {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+
+    let mut alice_one = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-a-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice one connection");
+
+    let mut alice_two = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-b-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice two connection");
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connection");
+
+    let _result = roster_set(
+        &mut alice_one,
+        "roster-push-source",
+        "<item jid='bob@localhost' name='Bob Push'/>",
+    )
+    .await;
+
+    let push_one = alice_one
+        .recv_matching(|frame| {
+            frame.contains("type=\"set\"")
+                && frame.contains("jabber:iq:roster")
+                && frame.contains("bob@localhost")
+        })
+        .await
+        .expect("requesting resource receives roster push");
+    assert!(push_one.contains("jabber:iq:roster"));
+
+    let push_two = alice_two
+        .recv_matching(|frame| {
+            frame.contains("type=\"set\"")
+                && frame.contains("jabber:iq:roster")
+                && frame.contains("bob@localhost")
+        })
+        .await
+        .expect("second resource receives roster push");
+    assert!(push_two.contains("jabber:iq:roster"));
+
+    alice_one.close().await;
+    alice_two.close().await;
+    bob.close().await;
+}
+
+#[tokio::test]
+async fn websocket_roster_reflects_presence_subscription_state() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    bob.send(r#"<presence xmlns='jabber:client' type='subscribe' to='alice@localhost'/>"#)
+        .await
+        .expect("send subscribe");
+    let _subscribe_forward = alice
+        .recv_matching(|frame| {
+            frame.contains("type=\"subscribe\"") || frame.contains("type='subscribe'")
+        })
+        .await
+        .expect("alice receives subscribe");
+
+    alice
+        .send(r#"<presence xmlns='jabber:client' type='subscribed' to='bob@localhost'/>"#)
+        .await
+        .expect("send subscribed");
+    let _subscribed_forward = bob
+        .recv_matching(|frame| {
+            frame.contains("type=\"subscribed\"") || frame.contains("type='subscribed'")
+        })
+        .await
+        .expect("bob receives subscribed");
+
+    let alice_roster = roster_get(&mut alice, "roster-sub-state").await;
+    assert!(
+        alice_roster.contains("jid=\"bob@localhost\"")
+            || alice_roster.contains("jid='bob@localhost'")
+    );
+    assert!(
+        alice_roster.contains("subscription=\"to\"") || alice_roster.contains("subscription='to'")
+    );
+
+    bob.close().await;
+    alice.close().await;
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
@@ -10,7 +10,6 @@
 //! ✅ Migrated to this module:
 //! - XEP-0199 ping — [`ping::PingHandler`]
 //! - RFC 3921 session — [`session::SessionHandler`]
-//! - RFC 6121 roster — [`roster::RosterHandler`] (stateless empty-roster ack)
 //! - XEP-0280 carbons enable/disable — [`carbons::CarbonsHandler`]
 //!   (ack only; per-connection toggle still pending)
 //! - XEP-0092 software version — [`version::VersionHandler`]
@@ -44,7 +43,6 @@ use xmpp_parsers::iq::{Iq, IqType};
 pub fn register_default_handlers(dispatcher: &mut StanzaDispatcher) {
     dispatcher.register_iq(Arc::new(ping::PingHandler));
     dispatcher.register_iq(Arc::new(session::SessionHandler));
-    dispatcher.register_iq(Arc::new(roster::RosterHandler));
     dispatcher.register_iq(Arc::new(carbons::CarbonsHandler));
     dispatcher.register_iq(Arc::new(version::VersionHandler));
     dispatcher.register_iq(Arc::new(time::TimeHandler));


### PR DESCRIPTION
Closes #204

### Motivation

- Replace the legacy empty-roster compatibility stub with a durable, XMPP-native RFC 6121 implementation so clients can rely on persistent roster behaviour and subscription state.
- Ensure roster mutations are persisted and that roster pushes are fanned out to every connected resource for the user.

### Description

- Route `jabber:iq:roster` through the active WebSocket IQ path and implement `handle_roster_iq` to service roster `get` and `set` with authenticated user context and typed values (in `server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs`).
- Use `DatabaseRosterStorage` for durable reads/writes and roster-version support, and map DB rows ↔ typed `RosterItem` values via `roster_row_to_item` / `roster_item_to_row` helpers.
- Implement add/update/remove semantics per RFC 6121 and emit roster pushes to every connected resource after mutations using `build_roster_push` and the `ConnectionRegistry` for delivery; push IDs use `Uuid`.
- Remove the stateless empty-roster IQ handler from the synchronous dispatcher registration so the active path no longer returns the empty compatibility response (change in `server/crates/waddle-xmpp/src/protocol/handlers/mod.rs`).
- Add a WebSocket integration test suite covering roster get/add/update/remove, push fanout to multiple resources, and presence-driven subscription-state reflection in `server/crates/waddle-server/tests/rfc6121_roster_ws.rs`.

### Testing

- Ran formatter: `cargo fmt --all` (succeeded).
- Ran the unit tests for the migrated roster handler: `cargo test -p waddle-xmpp protocol::handlers::roster::tests` and the targeted tests passed (2 tests OK).
- Attempted to run the new WebSocket integration test `rfc6121_roster_ws` via `cargo test -p waddle-server --test rfc6121_roster_ws`, but the test run cannot complete in this environment because the `prescience` crate build script invokes `protoc` and fails due to missing `google/protobuf/*.proto` includes; this prevented executing the integration test here (build-time failure unrelated to the roster changes themselves).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbb871a6c8331825e6c001888afac)