### PR TITLE
fix(chat): render GitHub enrichment embeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,12 @@
   title summarizes the intended work and whose description contains the plan.
   Make this the first action for all non-trivial tasks unless explicitly told
   not to.
-- XMPP Native, Never use out of band/XMPP APIs.
 - Always review your plan against the XEPS in ./xeps
     - If ./xeps doesn't exist, clone xsf/xeps into ./xeps
+- Divide work up, use sub-agents and role specific agents to achieve our task.
+- After you are finished, use multiple adverserial personas subagents to review our changes; repeat until they find no real and actionable issues.
+- Our job doesn't stop after we push, we always monitor CI and fix it until all checks are green
+- XMPP Native, Never use out of band non-XMPP APIs.
 - XEP conformance hard rule:
   - Prefer conformant XEP/XMPP shapes at all times. Use custom `urn:waddle:*`
     namespaces only when no suitable XEP-defined shape exists.
@@ -77,8 +80,7 @@ TypeScript 5.8.x; Bun 1.3.x: Follow standard conventions
   - Any PR that adds or expands XEP behavior MUST add or update that XEP’s dedicated Rust tests in the same PR.
   - If a feature is advertised but lacks testable behavior, either implement behavior with tests or remove the advertisement.
 
-<!-- MANUAL ADDITIONS START -->
 - Breaking changes by default: do not add backwards compatibility layers, migration shims, or legacy aliases unless explicitly requested.
 - Assume no production servers/users/data for this project; prioritize clean design over compatibility.
 - Keep the codebase clean: remove dead compatibility code immediately instead of preserving legacy paths.
-<!-- MANUAL ADDITIONS END -->
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@
   title summarizes the intended work and whose description contains the plan.
   Make this the first action for all non-trivial tasks unless explicitly told
   not to.
+- When creating or editing PR descriptions with `gh`, pass multiline Markdown
+  with real newlines, never escaped `\n` sequences, and verify the rendered body
+  with `gh pr view` before moving on.
 - Always review your plan against the XEPS in ./xeps
     - If ./xeps doesn't exist, clone xsf/xeps into ./xeps
 - Divide work up, use sub-agents and role specific agents to achieve our task.
@@ -83,4 +86,3 @@ TypeScript 5.8.x; Bun 1.3.x: Follow standard conventions
 - Breaking changes by default: do not add backwards compatibility layers, migration shims, or legacy aliases unless explicitly requested.
 - Assume no production servers/users/data for this project; prioritize clean design over compatibility.
 - Keep the codebase clean: remove dead compatibility code immediately instead of preserving legacy paths.
-

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -11,6 +11,9 @@ import {
   CornerDownRight,
   MessageSquare,
   Lock,
+  Github,
+  GitPullRequest,
+  CircleDot,
 } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
@@ -20,6 +23,9 @@ import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import {
   renderStyledBody,
+  githubEmbedDisplayTitle,
+  githubEmbedKindLabel,
+  githubEmbedNumber,
   isAudioFile,
   isImageUrl,
   isImageFile,
@@ -112,6 +118,7 @@ const setStyledBodyRef = (el: HTMLDivElement | null) => {
   styledBodyRef.value = el;
 };
 const sharedFiles = computed(() => props.message.sharedFiles ?? []);
+const githubEmbeds = computed(() => props.message.githubEmbeds ?? []);
 const isGif = computed(() => sharedFiles.value.length === 0 && isImageUrl(props.message.body));
 
 const imageAttachments = computed(() =>
@@ -801,6 +808,33 @@ watch(
           class="chat-attachment-image rounded-lg border border-border object-contain"
           loading="lazy"
         />
+      </div>
+
+      <!-- GitHub enrichment cards -->
+      <div v-if="githubEmbeds.length > 0" class="flex flex-col gap-2">
+        <a
+          v-for="embed in githubEmbeds"
+          :key="`${embed.kind}:${embed.url}`"
+          :href="embed.url"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="chat-github-card group/github flex min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 p-3 text-left transition-colors hover:bg-muted/55 focus-visible:outline-2 focus-visible:outline-primary"
+          :title="embed.url"
+        >
+          <span class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-background text-foreground ring-1 ring-border">
+            <Github v-if="embed.kind === 'repo'" class="h-4 w-4" aria-hidden="true" />
+            <CircleDot v-else-if="embed.kind === 'issue'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
+            <GitPullRequest v-else class="h-4 w-4 text-success" aria-hidden="true" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="type-section-label block text-muted-foreground">
+              GitHub {{ githubEmbedKindLabel(embed.kind) }}<template v-if="githubEmbedNumber(embed)"> #{{ githubEmbedNumber(embed) }}</template>
+            </span>
+            <span class="type-control block truncate text-foreground">
+              {{ githubEmbedDisplayTitle(embed) }}
+            </span>
+          </span>
+        </a>
       </div>
 
       <!-- Image attachments gallery -->

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -813,8 +813,8 @@ watch(
       <!-- GitHub enrichment cards -->
       <div v-if="githubEmbeds.length > 0" class="flex flex-col gap-2">
         <a
-          v-for="embed in githubEmbeds"
-          :key="`${embed.kind}:${embed.url}`"
+          v-for="(embed, index) in githubEmbeds"
+          :key="`${embed.kind}:${embed.url}:${index}`"
           :href="embed.url"
           target="_blank"
           rel="noopener noreferrer"

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -52,6 +52,7 @@ function fromLiveDmMessage(
   if (msg.markup?.length) tm.markup = msg.markup;
   if (msg.references?.length) tm.references = msg.references;
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;
+  if (msg.githubEmbeds && msg.githubEmbeds.length > 0) tm.githubEmbeds = msg.githubEmbeds;
   if (msg.isSticker) tm.isSticker = true;
   if (msg.replyTo) {
     const parent = parentLookup?.(msg.replyTo.id);
@@ -277,6 +278,7 @@ export function useDmMessaging(
     newBody: string,
     markup?: LiveDmMessage["markup"],
     references?: LiveDmMessage["references"],
+    githubEmbeds?: LiveDmMessage["githubEmbeds"],
   ) {
     messages.value = messages.value.map((m) => {
       if (!matchMessageId(m, replacesId)) return m;
@@ -290,6 +292,11 @@ export function useDmMessaging(
         updated.references = references;
       } else {
         delete updated.references;
+      }
+      if (githubEmbeds && githubEmbeds.length > 0) {
+        updated.githubEmbeds = githubEmbeds;
+      } else {
+        delete updated.githubEmbeds;
       }
       return updated;
     });
@@ -316,16 +323,18 @@ export function useDmMessaging(
     const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
     if (existing) {
       const wasPending = existing.id !== msg.id;
-      if (wasPending || (existing.deliveryStatus && existing.deliveryStatus !== "delivered")) {
-        messages.value = messages.value.map((m) =>
-          m.id !== existing.id
-            ? m
-            : {
-                ...mergeMessageIds(m, msg.id, msg.wireIds),
-                deliveryStatus: "delivered" as DeliveryStatus,
-              },
-        );
-      }
+      messages.value = messages.value.map((m) => {
+        if (m.id !== existing.id) return m;
+        const updated: TimelineMessage = {
+          ...m,
+          ...msg,
+          ...mergeMessageIds(m, msg.id, msg.wireIds),
+        };
+        if (m.isSelf && msg.isSelf) {
+          updated.deliveryStatus = "delivered" as DeliveryStatus;
+        }
+        return updated;
+      });
       if (wasPending) pendingEchoClientIds.delete(existing.id);
       return;
     }
@@ -403,7 +412,13 @@ export function useDmMessaging(
       const regular: LiveDmMessage[] = [];
       const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
       const retractionUpdates: string[] = [];
-      const correctionUpdates: { targetId: string; body: string; markup?: LiveDmMessage["markup"]; references?: LiveDmMessage["references"] }[] = [];
+      const correctionUpdates: {
+        targetId: string;
+        body: string;
+        markup?: LiveDmMessage["markup"];
+        references?: LiveDmMessage["references"];
+        githubEmbeds?: LiveDmMessage["githubEmbeds"];
+      }[] = [];
       for (const msg of mamResults) {
         if (msg._reactionTarget && msg._reactionEmojis) {
           reactionUpdates.push({
@@ -419,8 +434,9 @@ export function useDmMessaging(
             body: msg.body,
             markup: msg.markup,
             references: msg.references,
+            githubEmbeds: msg.githubEmbeds,
           });
-        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker) {
+        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
           regular.push(msg);
         }
       }
@@ -444,6 +460,11 @@ export function useDmMessaging(
           target.references = update.references;
         } else {
           delete target.references;
+        }
+        if (update.githubEmbeds && update.githubEmbeds.length > 0) {
+          target.githubEmbeds = update.githubEmbeds;
+        } else {
+          delete target.githubEmbeds;
         }
       }
       for (const retractsId of retractionUpdates) {
@@ -730,7 +751,7 @@ export function useDmMessaging(
       return;
     }
     if (msg.replacesId) {
-      applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references);
+      applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references, msg.githubEmbeds);
       return;
     }
     mergeLiveMessage(

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -63,6 +63,9 @@ export function fromLiveMessage(
   if (msg.sharedFiles && msg.sharedFiles.length > 0) {
     tm.sharedFiles = msg.sharedFiles;
   }
+  if (msg.githubEmbeds && msg.githubEmbeds.length > 0) {
+    tm.githubEmbeds = msg.githubEmbeds;
+  }
   if (msg.isSticker) {
     tm.isSticker = true;
   }
@@ -309,7 +312,7 @@ export function useMessaging(
 
         // XEP-0308: Handle message corrections
         if (msg.replacesId) {
-          applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references);
+          applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references, msg.githubEmbeds);
           return;
         }
 
@@ -560,7 +563,13 @@ export function useMessaging(
     );
   }
 
-  function applyCorrection(replacesId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {
+  function applyCorrection(
+    replacesId: string,
+    newBody: string,
+    markup?: MarkupSpan[],
+    references?: MessageReference[],
+    githubEmbeds?: LiveRoomMessage["githubEmbeds"],
+  ) {
     const idx = messages.value.findIndex((m) => matchMessageId(m, replacesId));
     if (idx === -1) return;
     messages.value = messages.value.map((m) => {
@@ -575,6 +584,11 @@ export function useMessaging(
         updated.references = references;
       } else {
         delete updated.references;
+      }
+      if (githubEmbeds && githubEmbeds.length > 0) {
+        updated.githubEmbeds = githubEmbeds;
+      } else {
+        delete updated.githubEmbeds;
       }
       return updated;
     });
@@ -604,21 +618,24 @@ export function useMessaging(
     const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
     if (existing) {
       const wasPending = existing.id !== msg.id;
-      if (wasPending || (existing.deliveryStatus && existing.deliveryStatus !== "delivered")) {
-        // Reconcile the ID to the server-assigned one and mark delivered.
-        // A self-echo is authoritative evidence that the server accepted
-        // the stanza, so it supersedes any prior "sending" or "failed"
-        // optimistic state.
-        messages.value = messages.value.map((m) =>
-          m.id !== existing.id
-            ? m
-            : {
-                ...mergeMessageIds(m, msg.id, msg.wireIds),
-                deliveryStatus: "delivered" as DeliveryStatus,
-              },
-        );
-        messages.value = applyForumContext(messages.value);
-      }
+      // Reconcile the ID to the server-assigned one and merge authoritative
+      // server-side enrichment while preserving local-only UI state.
+      messages.value = messages.value.map((m) => {
+        if (m.id !== existing.id) return m;
+        const updated: TimelineMessage = {
+          ...m,
+          ...msg,
+          ...mergeMessageIds(m, msg.id, msg.wireIds),
+        };
+        if (m.isSelf && msg.isSelf) {
+          // A self-echo is authoritative evidence that the server accepted
+          // the stanza, so it supersedes any prior "sending" or "failed"
+          // optimistic state.
+          updated.deliveryStatus = "delivered" as DeliveryStatus;
+        }
+        return updated;
+      });
+      messages.value = applyForumContext(messages.value);
       if (wasPending) pendingEchoClientIds.delete(existing.id);
       return;
     }
@@ -745,7 +762,13 @@ export function useMessaging(
       const regularMessages: LiveRoomMessage[] = [];
       const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
       const retractionUpdates: string[] = [];
-      const correctionUpdates: { targetId: string; body: string; markup?: MarkupSpan[]; references?: MessageReference[] }[] = [];
+      const correctionUpdates: {
+        targetId: string;
+        body: string;
+        markup?: MarkupSpan[];
+        references?: MessageReference[];
+        githubEmbeds?: LiveRoomMessage["githubEmbeds"];
+      }[] = [];
 
       for (const msg of mamResults) {
         if (msg._reactionTarget && msg._reactionEmojis) {
@@ -762,8 +785,9 @@ export function useMessaging(
             body: msg.body,
             markup: msg.markup,
             references: msg.references,
+            githubEmbeds: msg.githubEmbeds,
           });
-        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker) {
+        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
           regularMessages.push(msg);
         }
       }
@@ -791,6 +815,11 @@ export function useMessaging(
           target.references = update.references;
         } else {
           delete target.references;
+        }
+        if (update.githubEmbeds && update.githubEmbeds.length > 0) {
+          target.githubEmbeds = update.githubEmbeds;
+        } else {
+          delete target.githubEmbeds;
         }
       }
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -26,6 +26,15 @@ export interface TimelineSharedFile {
   encrypted?: WaddleEncryptedFile;
 }
 
+export type GitHubEmbedKind = "repo" | "issue" | "pr";
+
+export interface GitHubEmbed {
+  kind: GitHubEmbedKind;
+  url: string;
+  owner: string;
+  name: string;
+}
+
 export interface TimelineMessage {
   id: string;
   /** Equivalent wire-level ids (XEP-0359 stanza/origin ids, echoed ids). */
@@ -56,6 +65,8 @@ export interface TimelineMessage {
   isSticker?: boolean;
   /** XEP-0446/0447: Shared files (zero or more attachments). */
   sharedFiles?: TimelineSharedFile[];
+  /** Waddle GitHub enrichment embeds. */
+  githubEmbeds?: GitHubEmbed[];
   /** XEP-0513: Broadcast mention (everyone/here). */
   broadcastMention?: "everyone" | "here";
   /** XEP-0394: Message Markup offset-based annotations. */
@@ -249,4 +260,34 @@ export function inferredFileDisposition(
     || isPdfFile(mediaType, url)
     ? "inline"
     : "attachment";
+}
+
+export function githubEmbedKindLabel(kind: GitHubEmbedKind): string {
+  switch (kind) {
+    case "issue":
+      return "Issue";
+    case "pr":
+      return "Pull request";
+    default:
+      return "Repository";
+  }
+}
+
+export function githubEmbedNumber(embed: GitHubEmbed): string | null {
+  const marker = embed.kind === "issue" ? "/issues/" : embed.kind === "pr" ? "/pull/" : "";
+  if (!marker) return null;
+  try {
+    const url = new URL(embed.url);
+    const value = url.pathname.split(marker)[1]?.split("/")[0];
+    return value && /^\d+$/.test(value) ? value : null;
+  } catch {
+    const value = embed.url.split(marker)[1]?.split(/[/?#]/)[0];
+    return value && /^\d+$/.test(value) ? value : null;
+  }
+}
+
+export function githubEmbedDisplayTitle(embed: GitHubEmbed): string {
+  const repo = `${embed.owner}/${embed.name}`;
+  const number = githubEmbedNumber(embed);
+  return number ? `${repo} #${number}` : repo;
 }

--- a/chat/src/lib/xmpp/extensions/github.ts
+++ b/chat/src/lib/xmpp/extensions/github.ts
@@ -1,0 +1,34 @@
+/** Waddle GitHub enrichment embeds. */
+import type { DefinitionOptions } from "stanza/jxt";
+import { attribute } from "stanza/jxt";
+
+const NS_WADDLE_GITHUB_0 = "urn:waddle:github:0";
+
+const fields = {
+  url: attribute("url"),
+  owner: attribute("owner"),
+  name: attribute("name"),
+};
+
+const definitions: DefinitionOptions[] = [
+  {
+    aliases: [{ path: "message.githubRepos", multiple: true }],
+    element: "repo",
+    fields,
+    namespace: NS_WADDLE_GITHUB_0,
+  },
+  {
+    aliases: [{ path: "message.githubIssues", multiple: true }],
+    element: "issue",
+    fields,
+    namespace: NS_WADDLE_GITHUB_0,
+  },
+  {
+    aliases: [{ path: "message.githubPullRequests", multiple: true }],
+    element: "pr",
+    fields,
+    namespace: NS_WADDLE_GITHUB_0,
+  },
+];
+
+export default definitions;

--- a/chat/src/lib/xmpp/extensions/inbox.ts
+++ b/chat/src/lib/xmpp/extensions/inbox.ts
@@ -29,7 +29,7 @@
 import type { DefinitionOptions } from "stanza/jxt";
 import { attribute, booleanAttribute, childText, integerAttribute } from "stanza/jxt";
 
-const NS_WADDLE_INBOX_0 = "urn:waddle:inbox:0";
+export const NS_INBOX_0 = "urn:waddle:inbox:0";
 
 export type InboxConversationKind = "direct" | "muc";
 
@@ -57,7 +57,7 @@ const definitions: DefinitionOptions[] = [
       threads: booleanAttribute("threads"),
       totalUnread: integerAttribute("total-unread"),
     },
-    namespace: NS_WADDLE_INBOX_0,
+    namespace: NS_INBOX_0,
   },
   {
     aliases: [
@@ -71,13 +71,13 @@ const definitions: DefinitionOptions[] = [
       lastStanzaId: attribute("last-stanza-id"),
       lastUpdated: integerAttribute("last-updated"),
       unread: integerAttribute("unread"),
-      preview: childText(NS_WADDLE_INBOX_0, "preview"),
+      preview: childText(NS_INBOX_0, "preview"),
       thread: attribute("thread"),
       threadTitle: attribute("thread-title"),
       replyCount: integerAttribute("reply-count"),
       author: attribute("author"),
     },
-    namespace: NS_WADDLE_INBOX_0,
+    namespace: NS_INBOX_0,
   },
   {
     aliases: [{ path: "iq.inboxMarkRead", multiple: false }],
@@ -86,7 +86,7 @@ const definitions: DefinitionOptions[] = [
       partner: attribute("partner"),
       thread: attribute("thread"),
     },
-    namespace: NS_WADDLE_INBOX_0,
+    namespace: NS_INBOX_0,
   },
 ];
 

--- a/chat/src/lib/xmpp/extensions/index.ts
+++ b/chat/src/lib/xmpp/extensions/index.ts
@@ -15,6 +15,7 @@ import forums from "./forums";
 import inbox from "./inbox";
 import encryptedFile from "./encrypted-file";
 import stanzaIds from "./stanza-ids";
+import github from "./github";
 
 const allDefinitions = [
   ...hats,
@@ -32,6 +33,7 @@ const allDefinitions = [
   ...inbox,
   ...encryptedFile,
   ...stanzaIds,
+  ...github,
 ];
 
 export function registerWaddleExtensions(client: Agent): void {

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -57,7 +57,7 @@ export function hasRenderableMessagePayload(msg: ReceivedMessage): boolean {
   const fileSharing = stanza.fileSharing;
   if (Array.isArray(fileSharing)) return fileSharing.length > 0;
   if (fileSharing) return true;
-  return !!stanza.sticker || hasGithubEmbeds(stanza);
+  return !!stanza.sticker || githubEmbedsFromStanza(stanza).length > 0;
 }
 
 interface OriginIdPayload {
@@ -132,14 +132,9 @@ interface GithubPayload {
   name?: string;
 }
 
-function hasGithubEmbeds(stanza: Record<string, unknown>): boolean {
-  return asArray(stanza.githubRepos as GithubPayload | GithubPayload[] | undefined).length > 0
-    || asArray(stanza.githubIssues as GithubPayload | GithubPayload[] | undefined).length > 0
-    || asArray(stanza.githubPullRequests as GithubPayload | GithubPayload[] | undefined).length > 0;
-}
-
 function parseGithubEmbed(kind: GitHubEmbedKind, payload: GithubPayload): GitHubEmbed | null {
   if (!payload.url || !payload.owner || !payload.name) return null;
+  if (!isValidGithubEmbedUrl(kind, payload.url, payload.owner, payload.name)) return null;
   return {
     kind,
     url: payload.url,
@@ -148,9 +143,33 @@ function parseGithubEmbed(kind: GitHubEmbedKind, payload: GithubPayload): GitHub
   };
 }
 
-function extractGithubEmbeds(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
-  const stanza = ext(msg);
-  const embeds = [
+function isValidGithubEmbedUrl(
+  kind: GitHubEmbedKind,
+  rawUrl: string,
+  owner: string,
+  name: string,
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts[0] !== owner || parts[1] !== name) return false;
+
+  if (kind === "repo") {
+    return parts.length === 2;
+  }
+
+  const expectedSegment = kind === "issue" ? "issues" : "pull";
+  return parts[2] === expectedSegment && !!parts[3] && /^\d+$/.test(parts[3]) && parts.length === 4;
+}
+
+function githubEmbedsFromStanza(stanza: Record<string, unknown>): GitHubEmbed[] {
+  return [
     ...asArray(stanza.githubRepos as GithubPayload | GithubPayload[] | undefined)
       .flatMap((payload) => parseGithubEmbed("repo", payload) ?? []),
     ...asArray(stanza.githubIssues as GithubPayload | GithubPayload[] | undefined)
@@ -158,6 +177,18 @@ function extractGithubEmbeds(msg: ReceivedMessage, base: MessageExtensionsTarget
     ...asArray(stanza.githubPullRequests as GithubPayload | GithubPayload[] | undefined)
       .flatMap((payload) => parseGithubEmbed("pr", payload) ?? []),
   ];
+}
+
+function hasNonBodyMessagePayload(msg: ReceivedMessage): boolean {
+  const stanza = ext(msg);
+  const fileSharing = stanza.fileSharing;
+  return (Array.isArray(fileSharing) ? fileSharing.length > 0 : !!fileSharing)
+    || !!stanza.sticker
+    || githubEmbedsFromStanza(stanza).length > 0;
+}
+
+function extractGithubEmbeds(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
+  const embeds = githubEmbedsFromStanza(ext(msg));
   if (embeds.length > 0) base.githubEmbeds = embeds;
 }
 
@@ -379,7 +410,7 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
     id: messageIds.id, roomJid, nick,
     body: msg.body ?? msg.subject ?? "",
     createdAt: new Date().toISOString(),
-    type: msg.body ? "message" : "subject",
+    type: msg.body || hasNonBodyMessagePayload(msg) ? "message" : "subject",
   };
   const authorRealJid = extractMucUserRealJid(msg);
   if (authorRealJid) liveMsg.authorRealJid = authorRealJid;

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -4,7 +4,7 @@ import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 import { splitMessageIds } from "@/lib/message-ids";
 import { stripMarkupRange } from "./extensions/markup";
 import { codePointLength, codePointToCodeUnitIndex } from "@/lib/text-offsets";
-import type { MessageReference } from "@/lib/chat-ui";
+import type { GitHubEmbed, GitHubEmbedKind, MessageReference } from "@/lib/chat-ui";
 import type {
   ChatStateEvent, ChatStateType, DisplayedEvent,
   LiveDmMessage, LiveRoomMessage, ReactionEvent, RoomActivityEvent, SharedFileInfo,
@@ -19,6 +19,7 @@ type MessageExtensionsTarget = Pick<
   | "references"
   | "broadcastMention"
   | "sharedFiles"
+  | "githubEmbeds"
   | "isSticker"
   | "replacesId"
   | "markup"
@@ -56,7 +57,7 @@ export function hasRenderableMessagePayload(msg: ReceivedMessage): boolean {
   const fileSharing = stanza.fileSharing;
   if (Array.isArray(fileSharing)) return fileSharing.length > 0;
   if (fileSharing) return true;
-  return !!stanza.sticker;
+  return !!stanza.sticker || hasGithubEmbeds(stanza);
 }
 
 interface OriginIdPayload {
@@ -115,6 +116,7 @@ export function extractMessageExtensions(
   extractReferences(msg, base);
   extractExplicitMentions(msg, base);
   extractFileSharing(msg, base);
+  extractGithubEmbeds(msg, base);
   extractMarkup(msg, base);
   extractReplyAndThread(msg, base);
   stripReplyFallback(msg, base);
@@ -122,6 +124,41 @@ export function extractMessageExtensions(
   if (ext(msg).sticker) {
     base.isSticker = true;
   }
+}
+
+interface GithubPayload {
+  url?: string;
+  owner?: string;
+  name?: string;
+}
+
+function hasGithubEmbeds(stanza: Record<string, unknown>): boolean {
+  return asArray(stanza.githubRepos as GithubPayload | GithubPayload[] | undefined).length > 0
+    || asArray(stanza.githubIssues as GithubPayload | GithubPayload[] | undefined).length > 0
+    || asArray(stanza.githubPullRequests as GithubPayload | GithubPayload[] | undefined).length > 0;
+}
+
+function parseGithubEmbed(kind: GitHubEmbedKind, payload: GithubPayload): GitHubEmbed | null {
+  if (!payload.url || !payload.owner || !payload.name) return null;
+  return {
+    kind,
+    url: payload.url,
+    owner: payload.owner,
+    name: payload.name,
+  };
+}
+
+function extractGithubEmbeds(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
+  const stanza = ext(msg);
+  const embeds = [
+    ...asArray(stanza.githubRepos as GithubPayload | GithubPayload[] | undefined)
+      .flatMap((payload) => parseGithubEmbed("repo", payload) ?? []),
+    ...asArray(stanza.githubIssues as GithubPayload | GithubPayload[] | undefined)
+      .flatMap((payload) => parseGithubEmbed("issue", payload) ?? []),
+    ...asArray(stanza.githubPullRequests as GithubPayload | GithubPayload[] | undefined)
+      .flatMap((payload) => parseGithubEmbed("pr", payload) ?? []),
+  ];
+  if (embeds.length > 0) base.githubEmbeds = embeds;
 }
 
 /** XEP-0461 reply pointer + RFC 6121 / XEP-0201 thread id + parent. */

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -1,4 +1,5 @@
 import type { WaddleChannelType } from "@/lib/channel-types";
+import type { GitHubEmbed } from "@/lib/chat-ui";
 import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 
 /** Shared types for the XMPP client layer. */
@@ -79,6 +80,8 @@ export interface LiveRoomMessage {
   references?: import("@/lib/chat-ui").MessageReference[];
   /** XEP-0446/0447 — zero or more attachments. */
   sharedFiles?: SharedFileInfo[];
+  /** Waddle GitHub enrichment embeds. */
+  githubEmbeds?: GitHubEmbed[];
   /** XEP-0449 */
   isSticker?: boolean;
   /** XEP-0513 */
@@ -116,6 +119,7 @@ export interface LiveDmMessage {
   /** XEP-0372 */
   references?: import("@/lib/chat-ui").MessageReference[];
   sharedFiles?: SharedFileInfo[];
+  githubEmbeds?: GitHubEmbed[];
   isSticker?: boolean;
   /** XEP-0461 */
   replyTo?: ReplyPreview;

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -1189,6 +1189,11 @@
   width: var(--chat-attachment-card-width);
 }
 
+.chat-github-card {
+  width: var(--chat-attachment-card-width);
+  max-width: 100%;
+}
+
 .chat-attachment-card,
 .chat-file-card {
   max-width: 100%;

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   inferredFileDisposition,
+  githubEmbedDisplayTitle,
+  githubEmbedKindLabel,
+  githubEmbedNumber,
   isAudioFile,
   isImageFile,
   isPdfFile,
@@ -92,5 +95,27 @@ describe("renderStyledBody", () => {
     expect(isPdfFile(undefined, "notes.pdf")).toBe(true);
     expect(inferredFileDisposition("text/plain", "notes.txt")).toBe("attachment");
     expect(inferredFileDisposition("video/mp4", "clip.mp4")).toBe("inline");
+  });
+
+  test("formats GitHub embed card metadata", () => {
+    const issue = {
+      kind: "issue" as const,
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    };
+    const repo = {
+      kind: "repo" as const,
+      url: "https://github.com/waddle-social/waddle",
+      owner: "waddle-social",
+      name: "waddle",
+    };
+
+    expect(githubEmbedKindLabel(issue.kind)).toBe("Issue");
+    expect(githubEmbedNumber(issue)).toBe("42");
+    expect(githubEmbedDisplayTitle(issue)).toBe("waddle-social/waddle #42");
+    expect(githubEmbedKindLabel(repo.kind)).toBe("Repository");
+    expect(githubEmbedNumber(repo)).toBeNull();
+    expect(githubEmbedDisplayTitle(repo)).toBe("waddle-social/waddle");
   });
 });

--- a/chat/tests/dm-parsing.test.ts
+++ b/chat/tests/dm-parsing.test.ts
@@ -222,6 +222,32 @@ describe("dispatchChat", () => {
     ]);
   });
 
+  test("dispatches body-less GitHub enrichment messages", () => {
+    const h = makeHandlers();
+    dispatchChat(
+      makeMsg({
+        id: "dm-github-only",
+        githubIssues: {
+          url: "https://github.com/waddle-social/waddle/issues/42",
+          owner: "waddle-social",
+          name: "waddle",
+        },
+      } as Partial<ReceivedMessage>),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("");
+    expect(h.messages[0].githubEmbeds).toEqual([
+      {
+        kind: "issue",
+        url: "https://github.com/waddle-social/waddle/issues/42",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+    ]);
+  });
+
   test("ignores messages with no body/subject/replace", () => {
     const h = makeHandlers();
     dispatchChat(makeMsg({}), h);

--- a/chat/tests/dm-parsing.test.ts
+++ b/chat/tests/dm-parsing.test.ts
@@ -248,6 +248,38 @@ describe("dispatchChat", () => {
     ]);
   });
 
+  test("ignores malformed body-less GitHub enrichment payloads", () => {
+    const h = makeHandlers();
+    dispatchChat(
+      makeMsg({
+        id: "dm-github-malformed",
+        githubRepos: {
+          url: "https://github.com/waddle-social/waddle",
+        },
+      } as Partial<ReceivedMessage>),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(0);
+  });
+
+  test("ignores GitHub enrichment payloads with unsafe URLs", () => {
+    const h = makeHandlers();
+    dispatchChat(
+      makeMsg({
+        id: "dm-github-unsafe",
+        githubRepos: {
+          url: "javascript:alert(1)",
+          owner: "waddle-social",
+          name: "waddle",
+        },
+      } as Partial<ReceivedMessage>),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(0);
+  });
+
   test("ignores messages with no body/subject/replace", () => {
     const h = makeHandlers();
     dispatchChat(makeMsg({}), h);

--- a/chat/tests/github-extension.test.ts
+++ b/chat/tests/github-extension.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { Registry, XMLElement } from "stanza/jxt";
+import githubDefinitions from "../src/lib/xmpp/extensions/github";
+
+const NS_WADDLE_GITHUB_0 = "urn:waddle:github:0";
+
+function newRegistry(): Registry {
+  const registry = new Registry();
+  registry.define(githubDefinitions);
+  return registry;
+}
+
+describe("GitHub enrichment jxt extension", () => {
+  test("imports repo, issue, and pull request XML payloads", () => {
+    const registry = newRegistry();
+    const repo = new XMLElement("repo", {
+      xmlns: NS_WADDLE_GITHUB_0,
+      url: "https://github.com/waddle-social/waddle",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+    const issue = new XMLElement("issue", {
+      xmlns: NS_WADDLE_GITHUB_0,
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+    const pr = new XMLElement("pr", {
+      xmlns: NS_WADDLE_GITHUB_0,
+      url: "https://github.com/waddle-social/waddle/pull/48",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+
+    expect(registry.import(repo)).toEqual({
+      url: "https://github.com/waddle-social/waddle",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+    expect(registry.import(issue)).toEqual({
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+    expect(registry.import(pr)).toEqual({
+      url: "https://github.com/waddle-social/waddle/pull/48",
+      owner: "waddle-social",
+      name: "waddle",
+    });
+  });
+
+  test("exports repo, issue, and pull request XML payloads", () => {
+    const registry = newRegistry();
+    const repo = registry.export("message.githubRepos", {
+      url: "https://github.com/waddle-social/waddle",
+      owner: "waddle-social",
+      name: "waddle",
+    } as unknown as Parameters<Registry["export"]>[1]);
+    const issue = registry.export("message.githubIssues", {
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    } as unknown as Parameters<Registry["export"]>[1]);
+    const pr = registry.export("message.githubPullRequests", {
+      url: "https://github.com/waddle-social/waddle/pull/48",
+      owner: "waddle-social",
+      name: "waddle",
+    } as unknown as Parameters<Registry["export"]>[1]);
+
+    expect(repo?.name).toBe("repo");
+    expect(repo?.getNamespace()).toBe(NS_WADDLE_GITHUB_0);
+    expect(repo?.getAttribute("url")).toBe("https://github.com/waddle-social/waddle");
+    expect(issue?.name).toBe("issue");
+    expect(issue?.getAttribute("url")).toBe("https://github.com/waddle-social/waddle/issues/42");
+    expect(pr?.name).toBe("pr");
+    expect(pr?.getAttribute("url")).toBe("https://github.com/waddle-social/waddle/pull/48");
+  });
+});

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -106,6 +106,69 @@ describe("groupchat reply + thread parsing", () => {
     ]);
   });
 
+  test("keeps body-less GitHub enrichment messages in the timeline", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-github-only",
+        githubRepos: {
+          url: "https://github.com/waddle-social/waddle",
+          owner: "waddle-social",
+          name: "waddle",
+        },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("");
+    expect(h.messages[0].githubEmbeds).toEqual([
+      {
+        kind: "repo",
+        url: "https://github.com/waddle-social/waddle",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+    ]);
+  });
+
+  test("extracts GitHub issue and pull request enrichment payloads", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-github",
+        body: "links",
+        githubIssues: [{
+          url: "https://github.com/waddle-social/waddle/issues/42",
+          owner: "waddle-social",
+          name: "waddle",
+        }],
+        githubPullRequests: [{
+          url: "https://github.com/waddle-social/waddle/pull/48",
+          owner: "waddle-social",
+          name: "waddle",
+        }],
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].githubEmbeds).toEqual([
+      {
+        kind: "issue",
+        url: "https://github.com/waddle-social/waddle/issues/42",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+      {
+        kind: "pr",
+        url: "https://github.com/waddle-social/waddle/pull/48",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+    ]);
+  });
+
   test("extracts thread id and parent thread id", () => {
     const h = makeHandlers();
     dispatchGroupchat(

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -122,6 +122,7 @@ describe("groupchat reply + thread parsing", () => {
 
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].body).toBe("");
+    expect(h.messages[0].type).toBe("message");
     expect(h.messages[0].githubEmbeds).toEqual([
       {
         kind: "repo",
@@ -130,6 +131,38 @@ describe("groupchat reply + thread parsing", () => {
         name: "waddle",
       },
     ]);
+  });
+
+  test("ignores malformed body-less GitHub enrichment payloads", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-github-malformed",
+        githubRepos: {
+          url: "https://github.com/waddle-social/waddle",
+        },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(0);
+  });
+
+  test("ignores GitHub enrichment payloads with non-GitHub URLs", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-github-spoof",
+        githubRepos: {
+          url: "https://evil.example/waddle-social/waddle",
+          owner: "waddle-social",
+          name: "waddle",
+        },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(0);
   });
 
   test("extracts GitHub issue and pull request enrichment payloads", () => {

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -558,6 +558,71 @@ describe("XEP-0198 self-echo reconciliation (group chat)", () => {
       },
     ]);
   });
+
+  test("body-less room GitHub enrichment messages reach the timeline", async () => {
+    const currentSession = session();
+    const roomJid = roomBareJidFor(currentSession, "c1");
+    const queryMam = mock(async () => []);
+    let onMessage: ((msg: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const xmppClient = ref(null as never);
+    const messaging = useMessaging(
+      ref(currentSession),
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    xmppClient.value = {
+      queryMam,
+      setMessageHandler(handler: (msg: LiveRoomMessage) => void) {
+        onMessage = handler;
+      },
+      setStatusHandler() {},
+      setChatStateHandler() {},
+      setReactionHandler() {},
+      setDisplayedHandler() {},
+      setHatsHandler() {},
+      setPresenceHandler() {},
+      setLastSeenHandler() {},
+      setActivityHandler() {},
+      setRoomAvatarHandler() {},
+      setSlowModeHandler() {},
+    } as never;
+    await nextTick();
+
+    onMessage?.({
+      id: "server-github-only",
+      roomJid,
+      nick: "bob",
+      body: "",
+      createdAt: "2024-01-01T00:00:05Z",
+      type: "message",
+      githubEmbeds: [{
+        kind: "repo",
+        url: "https://github.com/waddle-social/waddle",
+        owner: "waddle-social",
+        name: "waddle",
+      }],
+    });
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0].githubEmbeds).toEqual([
+      {
+        kind: "repo",
+        url: "https://github.com/waddle-social/waddle",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+    ]);
+  });
 });
 
 test("fresh DM session self-echo reconciles preserved sending entries", async () => {

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -483,6 +483,81 @@ describe("XEP-0198 self-echo reconciliation (group chat)", () => {
     expect(messaging.messages.value[0].id).toBe("server-room");
     expect(messaging.messages.value[0].deliveryStatus).toBe("delivered");
   });
+
+  test("room self-echo merges GitHub enrichment after the SM ack marked delivered", async () => {
+    const currentSession = session();
+    const roomJid = roomBareJidFor(currentSession, "c1");
+    const queryMam = mock(async () => []);
+    const sendGroupMessage = mock(async () => ({ id: "client-room", state: "sending" as const }));
+    const sendChatState = mock(async () => undefined);
+    let onMessage: ((msg: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const xmppClient = ref(null as never);
+    const messaging = useMessaging(
+      ref(currentSession),
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    xmppClient.value = {
+      queryMam,
+      sendGroupMessage,
+      sendChatState,
+      setMessageHandler(handler: (msg: LiveRoomMessage) => void) {
+        onMessage = handler;
+      },
+      setStatusHandler() {},
+      setChatStateHandler() {},
+      setReactionHandler() {},
+      setDisplayedHandler() {},
+      setHatsHandler() {},
+      setPresenceHandler() {},
+      setLastSeenHandler() {},
+      setActivityHandler() {},
+      setRoomAvatarHandler() {},
+      setSlowModeHandler() {},
+    } as never;
+    await nextTick();
+
+    await messaging.sendMessage("https://github.com/waddle-social/waddle");
+    messaging.onMessageAck("client-room");
+    expect(messaging.messages.value[0].deliveryStatus).toBe("delivered");
+    expect(messaging.messages.value[0].githubEmbeds).toBeUndefined();
+
+    onMessage?.({
+      id: "client-room",
+      roomJid,
+      nick: "alice",
+      body: "https://github.com/waddle-social/waddle",
+      createdAt: "2024-01-01T00:00:03Z",
+      type: "message",
+      githubEmbeds: [{
+        kind: "repo",
+        url: "https://github.com/waddle-social/waddle",
+        owner: "waddle-social",
+        name: "waddle",
+      }],
+    });
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0].deliveryStatus).toBe("delivered");
+    expect(messaging.messages.value[0].githubEmbeds).toEqual([
+      {
+        kind: "repo",
+        url: "https://github.com/waddle-social/waddle",
+        owner: "waddle-social",
+        name: "waddle",
+      },
+    ]);
+  });
 });
 
 test("fresh DM session self-echo reconciles preserved sending entries", async () => {
@@ -521,4 +596,52 @@ test("fresh DM session self-echo reconciles preserved sending entries", async ()
   expect(dm.messages.value).toHaveLength(1);
   expect(dm.messages.value[0].id).toBe("server-dm");
   expect(dm.messages.value[0].deliveryStatus).toBe("delivered");
+});
+
+test("DM self-echo merges GitHub enrichment after the SM ack marked delivered", async () => {
+  const client = makeDmClient([]);
+  const { dm } = makeDmMessaging(client);
+
+  const sendDirectMessage = mock(async (_peer: string, _body: string) => ({
+    id: "client-dm",
+    state: "sending" as const,
+  }));
+  const sendDmChatState = mock(async () => undefined);
+  (client as unknown as { value: Record<string, unknown> }).value = {
+    ...(client as unknown as { value: Record<string, unknown> }).value,
+    sendDirectMessage,
+    sendDmChatState,
+  };
+
+  await dm.sendMessage("https://github.com/waddle-social/waddle/issues/42");
+  dm.onMessageAck("client-dm");
+  expect(dm.messages.value[0].deliveryStatus).toBe("delivered");
+  expect(dm.messages.value[0].githubEmbeds).toBeUndefined();
+
+  dm.onIncomingMessage({
+    id: "client-dm",
+    peerJid: "bob@example.com",
+    fromJid: "alice@example.com/desktop",
+    nick: "alice",
+    body: "https://github.com/waddle-social/waddle/issues/42",
+    createdAt: "2024-01-01T00:00:04Z",
+    type: "message",
+    githubEmbeds: [{
+      kind: "issue",
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    }],
+  });
+
+  expect(dm.messages.value).toHaveLength(1);
+  expect(dm.messages.value[0].deliveryStatus).toBe("delivered");
+  expect(dm.messages.value[0].githubEmbeds).toEqual([
+    {
+      kind: "issue",
+      url: "https://github.com/waddle-social/waddle/issues/42",
+      owner: "waddle-social",
+      name: "waddle",
+    },
+  ]);
 });

--- a/server/extensions/github-enricher/src/detect.rs
+++ b/server/extensions/github-enricher/src/detect.rs
@@ -7,16 +7,53 @@ pub fn github_links(body: &str) -> Vec<String> {
             .expect("valid regex")
     });
 
-    re.find_iter(body).map(|m| m.as_str().to_string()).collect()
+    re.find_iter(body)
+        .filter_map(|m| normalize_github_url(m.as_str()))
+        .collect()
+}
+
+pub fn normalize_github_url(url: &str) -> Option<String> {
+    static RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"^https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/(issues|pull)/\d+)?$")
+            .expect("valid regex")
+    });
+
+    if !re.is_match(url) {
+        return None;
+    }
+
+    Some(match url.strip_prefix("http://") {
+        Some(rest) => format!("https://{rest}"),
+        None => url.to_string(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::github_links;
+    use super::{github_links, normalize_github_url};
 
     #[test]
     fn detects_repo_and_issue_links() {
         let links = github_links("repo https://github.com/rust-lang/rust and issue https://github.com/rust-lang/rust/issues/1");
         assert_eq!(links.len(), 2);
+    }
+
+    #[test]
+    fn normalizes_http_links_to_https() {
+        let links = github_links("repo http://github.com/waddle-social/waddle");
+        assert_eq!(links, vec!["https://github.com/waddle-social/waddle"]);
+    }
+
+    #[test]
+    fn rejects_non_github_urls() {
+        assert_eq!(
+            normalize_github_url("https://evil.example/waddle-social/waddle"),
+            None
+        );
+        assert_eq!(
+            normalize_github_url("https://github.com.evil.example/waddle-social/waddle"),
+            None
+        );
     }
 }

--- a/server/extensions/github-enricher/src/lib.rs
+++ b/server/extensions/github-enricher/src/lib.rs
@@ -49,7 +49,7 @@ impl EnrichGuest for Extension {
             links
                 .into_iter()
                 .map(|link| link.url)
-                .filter(|url| url.contains("github.com/"))
+                .filter_map(|url| detect::normalize_github_url(&url))
                 .collect()
         };
 
@@ -66,12 +66,44 @@ export!(Extension);
 
 #[cfg(test)]
 mod tests {
-    use super::{Extension, LifecycleGuest};
+    use super::{EnrichGuest, Extension, LifecycleGuest, WitDetectedLink};
 
     #[test]
     fn init_accepts_empty_json() {
         let info = Extension::init("{}".to_string()).expect("init should succeed");
         assert_eq!(info.name, "github-enricher");
         assert_eq!(info.namespace, "urn:waddle:github:0");
+    }
+
+    #[test]
+    fn enrich_message_normalizes_detected_http_github_links() {
+        let result = Extension::enrich_message(
+            String::new(),
+            vec![WitDetectedLink {
+                url: "http://github.com/waddle-social/waddle".to_string(),
+                start_offset: 0,
+                end_offset: 37,
+            }],
+        );
+
+        assert_eq!(result.embeds.len(), 1);
+        assert_eq!(
+            result.embeds[0].attributes[0].1,
+            "https://github.com/waddle-social/waddle"
+        );
+    }
+
+    #[test]
+    fn enrich_message_rejects_non_github_detected_links() {
+        let result = Extension::enrich_message(
+            String::new(),
+            vec![WitDetectedLink {
+                url: "https://evil.example/github.com/waddle-social/waddle".to_string(),
+                start_offset: 0,
+                end_offset: 51,
+            }],
+        );
+
+        assert!(result.embeds.is_empty());
     }
 }


### PR DESCRIPTION
## Plan

### Summary
Production is wired to append GitHub embed XML, but chat cannot consume it: registered stanza extensions omit urn:waddle:github:0, parsing ignores it, message types have no embed field, and MessageCard has no render path. Server-side enrichment is called for MUC and DM sends, and prod config advertises urn:waddle:github:0; however, the extension manager can advertise the namespace even if the actor fails to load, so ops still need logs to confirm embeds are actually injected.

### Key Changes
- Add a chat stanza extension for existing wire payloads: <repo/>, <issue/>, and <pr/> in urn:waddle:github:0, with url, owner, and name attributes. No server wire-shape change.
- Add typed GitHubEmbed data and githubEmbeds?: GitHubEmbed[] to LiveRoomMessage, LiveDmMessage, and TimelineMessage; parse repo/issue/PR embeds for groupchat, DM, corrections, MAM history, and bodyless embed payloads.
- Update live and DM timeline mapping so server echoes and history preserve GitHub embeds. Fix optimistic self-echo reconciliation so the enriched fields from the authoritative server echo are merged into the existing local message, not just the ID/delivery state.
- Render GitHub cards in MessageCard.vue inside the existing media stack, using existing visual tokens and lucide icons. Cards link to GitHub, show repo owner/name, type, and issue/PR number derived from the URL when present.

### Tests
- Add parser tests for groupchat and DM repo/issue/PR payloads.
- Add propagation tests for live-to-timeline mapping, correction updates, and self-echo enrichment merge.
- Add UI/helper coverage for GitHub card labels/URLs, plus build coverage for the Vue render path.
- Run from chat/: bun test, bun run lint, and bun run build.

### Assumptions
- No client-side GitHub API calls and no client-side synthetic embeds from plain URLs; chat renders only XMPP-carried enrichment.
- urn:waddle:github:0 remains a Waddle custom namespace. XEP review found no official GitHub embed XEP, so this does not misuse an official XMPP namespace.
- If production actor initialization fails, this frontend fix will not create embeds; it will make injected embeds visible once present on the stanza.