### PR TITLE
feat(server): promote rich-message XEP behavior

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -14,7 +14,11 @@ use waddle_xmpp::{
     },
     inbox::runtime::filter_query,
     isr::{build_isr_token_error, build_isr_token_result, is_isr_token_request, IsrToken, ISR_NS},
-    mam::{build_fin_iq, build_result_messages, is_mam_query, parse_mam_query},
+    mam::{
+        add_stanza_id as add_mam_stanza_id, build_fin_iq, build_result_messages, is_mam_query,
+        parse_mam_query, ArchivedMessage, ArchivedModeration, ArchivedRichMessage,
+        ArchivedRichPayload, RichMessageId, RichText,
+    },
     muc::{
         admin::{
             build_admin_result, build_admin_set_result, build_role_result, is_muc_admin_iq,
@@ -48,11 +52,11 @@ use waddle_xmpp::{
     },
     xep::{
         build_command_items, build_command_result, build_last_activity_response,
-        build_search_response, build_server_role_form, build_spaces_metadata_form,
-        build_spaces_metadata_form_for_requester, is_last_activity_query, is_search_request,
-        is_time_query, is_version_query, parse_command_from_iq, parse_search_request,
-        ChannelResult, Command, CommandStatus, Searchable, SpaceAffiliation, NODE_COMMANDS,
-        NS_CHANNEL_SEARCH,
+        build_moderation_result_message, build_search_response, build_server_role_form,
+        build_spaces_metadata_form, build_spaces_metadata_form_for_requester,
+        is_last_activity_query, is_search_request, is_time_query, is_version_query,
+        parse_command_from_iq, parse_moderation_iq, parse_search_request, ChannelResult, Command,
+        CommandStatus, Searchable, SpaceAffiliation, NODE_COMMANDS, NS_CHANNEL_SEARCH,
     },
     Affiliation, SpaceDetails, Stanza, StanzaErrorCondition, StanzaErrorType, XmppError,
 };
@@ -799,6 +803,179 @@ pub async fn handle_iq_with_conn_state(
             response_to,
             None,
         )];
+    }
+
+    if let Some(request) = parse_moderation_iq(&iq) {
+        let Some(sender_jid) = phase.bound_jid() else {
+            return vec![build_iq_error_xml_with_addresses(
+                &id,
+                response_from,
+                response_to,
+                "auth",
+                "not-authorized",
+            )];
+        };
+        let Some(room_jid) = iq.to.as_ref().map(|jid| jid.to_bare()) else {
+            return vec![build_iq_error_xml_with_addresses(
+                &id,
+                response_from,
+                response_to,
+                "modify",
+                "bad-request",
+            )];
+        };
+        let Some(room_actor) = get_room_actor(state, &room_jid).await else {
+            return vec![build_iq_error_xml_with_addresses(
+                &id,
+                response_from,
+                response_to,
+                "cancel",
+                "item-not-found",
+            )];
+        };
+        let context = match room_actor
+            .ask(GetAdminContext {
+                sender_jid: sender_jid.clone(),
+            })
+            .await
+        {
+            Ok(context) => context,
+            Err(_) => {
+                return vec![build_iq_error_xml_with_addresses(
+                    &id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )]
+            }
+        };
+        let is_moderator = matches!(context.affiliation, Affiliation::Owner | Affiliation::Admin)
+            || matches!(context.role, waddle_xmpp::Role::Moderator);
+        if !is_moderator {
+            return vec![build_iq_error_xml_with_addresses(
+                &id,
+                response_from,
+                response_to,
+                "auth",
+                "forbidden",
+            )];
+        }
+        match state
+            .deps
+            .protocol
+            .mam_storage
+            .get_message(&request.target_id)
+            .await
+        {
+            Ok(Some(message)) if message.to == room_jid.to_string() => {}
+            Ok(Some(_)) => {
+                return vec![build_iq_error_xml_with_addresses(
+                    &id,
+                    response_from,
+                    response_to,
+                    "cancel",
+                    "item-not-found",
+                )]
+            }
+            Ok(None) => {
+                return vec![build_iq_error_xml_with_addresses(
+                    &id,
+                    response_from,
+                    response_to,
+                    "cancel",
+                    "item-not-found",
+                )]
+            }
+            Err(error) => {
+                warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to look up moderation target");
+                return vec![build_iq_error_xml_with_addresses(
+                    &id,
+                    response_from,
+                    response_to,
+                    "wait",
+                    "internal-server-error",
+                )];
+            }
+        }
+
+        let moderator_nick = context
+            .nick
+            .unwrap_or_else(|| sender_jid.resource().to_string());
+        let moderated_by = format!("{room_jid}/{moderator_nick}");
+        let stamp_time = chrono::Utc::now();
+        let stamp = stamp_time.to_rfc3339();
+        let mut moderation = build_moderation_result_message(
+            Some(jid::Jid::from(room_jid.clone())),
+            &request.target_id,
+            &moderated_by,
+            &stamp,
+            request.reason.as_deref(),
+        );
+        let archive_id = uuid::Uuid::now_v7().to_string();
+        add_mam_stanza_id(&mut moderation, archive_id.as_str(), &room_jid.to_string());
+
+        if let (Some(target_id), Ok(moderator_jid)) = (
+            RichMessageId::new(request.target_id.clone()),
+            moderated_by.parse::<Jid>(),
+        ) {
+            let archived = ArchivedMessage {
+                id: archive_id,
+                timestamp: chrono::Utc::now(),
+                from: room_jid.to_string(),
+                to: room_jid.to_string(),
+                body: String::new(),
+                stanza_id: moderation.id.clone(),
+                thread_id: None,
+                reply_to_id: None,
+                reply_to_jid: None,
+                origin_id: None,
+                message_type: "groupchat".to_string(),
+                stanza_xml: None,
+                rich: Some(ArchivedRichMessage {
+                    payload: Some(ArchivedRichPayload::Moderation(ArchivedModeration {
+                        target_id,
+                        moderated_by: moderator_jid,
+                        stamp: Some(stamp_time),
+                        reason: request.reason.as_deref().and_then(RichText::new),
+                    })),
+                    reply: None,
+                    references: Vec::new(),
+                    mentions: Vec::new(),
+                }),
+            };
+            if let Err(error) = state
+                .deps
+                .protocol
+                .mam_storage
+                .store_message(&room_jid.to_string(), &archived)
+                .await
+            {
+                warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to archive moderation event");
+            }
+        }
+
+        let mut frames = Vec::new();
+        if let Ok(snapshot) = room_actor.ask(GetSnapshot).await {
+            for occupant in snapshot.room.occupants.values() {
+                for occupant_jid in snapshot.room.get_occupant_sessions(&occupant.nick) {
+                    let mut outbound = moderation.clone();
+                    outbound.to = Some(jid::Jid::from(occupant_jid.clone()));
+                    if occupant_jid == *sender_jid {
+                        frames.push(stanza_to_xml(&Stanza::Message(outbound)));
+                        continue;
+                    }
+                    let _ = state
+                        .deps
+                        .protocol
+                        .connection_registry
+                        .try_send_to(&occupant_jid, Stanza::Message(outbound));
+                }
+            }
+        }
+
+        frames.push(build_iq_result_xml(&id, response_from, response_to, None));
+        return frames;
     }
 
     // MAM (Message Archive Management) query

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -11,14 +11,21 @@ use waddle_xmpp::{
         },
         InboxEntry,
     },
-    mam::{add_stanza_id as add_mam_stanza_id, ArchivedMessage, STANZA_ID_NS},
+    mam::{
+        add_stanza_id as add_mam_stanza_id, ArchivedMention, ArchivedMessage, ArchivedReactionSet,
+        ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
+        ArchivedRichPayload, RichMessageId, RichText, STANZA_ID_NS,
+    },
     muc::room_actor::BuildGroupchatBroadcast,
     registry::{BroadcastOutcome, SendResult},
     xep::xep0430::build_inbox_push,
     xep::{
-        has_file_sharing, is_moderation_request_message, is_moderation_result_message,
-        is_reaction_message, is_retraction_message, is_sticker_message, message_has_direct_invite,
-        should_skip_storage, NS_REPLY,
+        extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
+        extract_references_from_message, extract_retraction_from_message, has_file_sharing,
+        is_moderation_request_message, is_moderation_result_message, is_reaction_message,
+        is_retraction_message, is_sticker_message, message_has_direct_invite,
+        parse_reply_from_message, remove_stanza_ids_by, should_skip_storage, RetractionKind,
+        NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REPLY,
     },
     Stanza,
 };
@@ -31,10 +38,6 @@ use crate::db::blocking::DatabaseBlockingStorage;
 use crate::permissions::{CheckPermission, Object, ObjectType, Permission, Subject};
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use waddle_xmpp::protocol::ConnectionPhase;
-
-fn archived_stanza_xml(message: &xmpp_parsers::message::Message) -> String {
-    stanza_to_xml(&Stanza::Message(message.clone()))
-}
 
 pub async fn handle_message(
     mut incoming: xmpp_parsers::message::Message,
@@ -89,6 +92,7 @@ pub async fn handle_message(
             .clone()
             .or_else(|| Some(uuid::Uuid::new_v4().to_string()));
         prototype.type_ = XmppMessageType::Groupchat;
+        remove_stanza_ids_by(&mut prototype, &room_jid.to_string());
 
         // Enrich: detect GitHub links and append embed XML elements (fail-open)
         let _embeds_added = state
@@ -128,11 +132,20 @@ pub async fn handle_message(
         }
         prototype.to = None;
 
-        // Archive body-bearing room messages in XMPP MAM storage.
-        let archive_id = archive_groupchat_message(state, &room_jid, &prototype).await;
-        if let Some(ref archive_id) = archive_id {
-            add_mam_stanza_id(&mut prototype, archive_id.as_str(), &room_jid.to_string());
+        if let Some(error) =
+            validate_rich_message_targets(state, &room_jid.to_string(), &prototype, true).await
+        {
+            return vec![stanza_to_xml(&Stanza::Message(error_message(
+                &incoming,
+                &jid::Jid::from(room_jid.clone()),
+                &jid::Jid::from(sender_jid.clone()),
+                "modify",
+                error,
+            )))];
         }
+
+        // Archive body-bearing and rich protocol room messages in XMPP MAM storage.
+        let archive_id = archive_groupchat_message(state, &room_jid, &mut prototype).await;
 
         if should_project_message(&prototype) {
             let timestamp = Utc::now().timestamp();
@@ -344,6 +357,23 @@ pub async fn handle_message(
                 state.deps.protocol.extension_manager.feature_namespaces(),
             );
 
+            if let Some(error) = validate_rich_message_targets(
+                state,
+                &sender_jid.to_bare().to_string(),
+                &prototype,
+                false,
+            )
+            .await
+            {
+                return vec![stanza_to_xml(&Stanza::Message(error_message(
+                    &incoming,
+                    to_jid,
+                    &jid::Jid::from(sender_jid.clone()),
+                    "modify",
+                    error,
+                )))];
+            }
+
             // Archive body-bearing DMs to both sender's and recipient's personal MAM.
             archive_direct_message(state, sender_jid, to_jid, &prototype).await;
 
@@ -470,16 +500,181 @@ fn forbidden_message_error(
     room_jid: &BareJid,
     sender_jid: &FullJid,
 ) -> xmpp_parsers::message::Message {
+    error_message(
+        incoming,
+        &jid::Jid::from(room_jid.clone()),
+        &jid::Jid::from(sender_jid.clone()),
+        "auth",
+        "forbidden",
+    )
+}
+
+fn error_message(
+    incoming: &xmpp_parsers::message::Message,
+    from: &jid::Jid,
+    to: &jid::Jid,
+    error_type: &str,
+    condition: &str,
+) -> xmpp_parsers::message::Message {
     let mut error = incoming.clone();
     error.type_ = XmppMessageType::Error;
-    error.from = Some(jid::Jid::from(room_jid.clone()));
-    error.to = Some(jid::Jid::from(sender_jid.clone()));
+    error.from = Some(from.clone());
+    error.to = Some(to.clone());
     let stanza_error = Element::builder("error", "jabber:client")
-        .attr("type", "auth")
-        .append(Element::builder("forbidden", "urn:ietf:params:xml:ns:xmpp-stanzas").build())
+        .attr("type", error_type)
+        .append(Element::builder(condition, "urn:ietf:params:xml:ns:xmpp-stanzas").build())
         .build();
     error.payloads.push(stanza_error);
     error
+}
+
+async fn validate_rich_message_targets(
+    state: &WebSocketState,
+    archive_jid: &str,
+    message: &xmpp_parsers::message::Message,
+    groupchat: bool,
+) -> Option<&'static str> {
+    let sender = message.from.as_ref()?;
+    if has_malformed_rich_payload(message) {
+        return Some("bad-request");
+    }
+
+    if let Some(correction) = extract_correction_from_message(message) {
+        let original = match lookup_correction_target_message(
+            state,
+            archive_jid,
+            &correction.replaces_id,
+            groupchat,
+        )
+        .await
+        {
+            Ok(Some(original)) => original,
+            Ok(None) => return Some("item-not-found"),
+            Err(_) => return Some("internal-server-error"),
+        };
+        if !same_rich_sender(sender, &original.from, groupchat) {
+            return Some("forbidden");
+        }
+    }
+
+    if let Some(RetractionKind::Request(retraction)) = extract_retraction_from_message(message) {
+        let original = match lookup_retraction_target_message(
+            state,
+            archive_jid,
+            &retraction.retracts_id,
+            groupchat,
+        )
+        .await
+        {
+            Ok(Some(original)) => original,
+            Ok(None) => return Some("item-not-found"),
+            Err(_) => return Some("internal-server-error"),
+        };
+        if !same_rich_sender(sender, &original.from, groupchat) {
+            return Some("forbidden");
+        }
+    }
+
+    if let Some(reactions) = extract_reactions_from_message(message) {
+        match lookup_rich_target_message(state, archive_jid, &reactions.message_id, groupchat).await
+        {
+            Ok(Some(_)) => {}
+            Ok(None) => return Some("item-not-found"),
+            Err(_) => return Some("internal-server-error"),
+        }
+    }
+
+    if let Some(reply) = parse_reply_from_message(message) {
+        match lookup_rich_target_message(state, archive_jid, &reply.id, groupchat).await {
+            Ok(Some(_)) => {}
+            Ok(None) => return Some("item-not-found"),
+            Err(_) => return Some("internal-server-error"),
+        }
+    }
+
+    None
+}
+
+async fn lookup_correction_target_message(
+    state: &WebSocketState,
+    archive_jid: &str,
+    target_id: &str,
+    _groupchat: bool,
+) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .get_message_by_message_id(archive_jid, target_id)
+        .await
+}
+
+async fn lookup_retraction_target_message(
+    state: &WebSocketState,
+    archive_jid: &str,
+    target_id: &str,
+    groupchat: bool,
+) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
+    if groupchat {
+        return lookup_rich_target_message(state, archive_jid, target_id, true).await;
+    }
+
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .get_message_by_message_id(archive_jid, target_id)
+        .await
+}
+
+async fn lookup_rich_target_message(
+    state: &WebSocketState,
+    archive_jid: &str,
+    target_id: &str,
+    groupchat: bool,
+) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
+    if groupchat {
+        return state
+            .deps
+            .protocol
+            .mam_storage
+            .get_message(target_id)
+            .await
+            .map(|message| message.filter(|message| message.to == archive_jid));
+    }
+
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .get_message_by_stanza_id(archive_jid, target_id)
+        .await
+}
+
+fn same_rich_sender(sender: &jid::Jid, original_from: &str, groupchat: bool) -> bool {
+    if groupchat {
+        return sender.to_string() == original_from;
+    }
+    original_from
+        .parse::<jid::Jid>()
+        .is_ok_and(|original| original.to_bare() == sender.to_bare())
+}
+
+fn has_malformed_rich_payload(message: &xmpp_parsers::message::Message) -> bool {
+    message.payloads.iter().any(|payload| {
+        (payload.ns() == NS_MESSAGE_CORRECT
+            && payload.name() == "replace"
+            && payload.attr("id").is_none_or(str::is_empty))
+            || (payload.ns() == NS_MESSAGE_RETRACT
+                && payload.name() == "retract"
+                && payload.attr("id").is_none_or(str::is_empty))
+            || (payload.ns() == NS_REACTIONS
+                && payload.name() == "reactions"
+                && payload.attr("id").is_none_or(str::is_empty))
+            || (payload.ns() == NS_REPLY
+                && payload.name() == "reply"
+                && payload.attr("id").is_none_or(str::is_empty))
+    })
 }
 
 async fn send_sent_carbons_to_websocket_resources(
@@ -589,11 +784,14 @@ fn should_archive_groupchat_message(msg: &xmpp_parsers::message::Message) -> boo
 async fn archive_groupchat_message(
     state: &WebSocketState,
     room_jid: &BareJid,
-    message: &xmpp_parsers::message::Message,
+    message: &mut xmpp_parsers::message::Message,
 ) -> Option<String> {
     if !should_archive_groupchat_message(message) {
         return None;
     }
+
+    let archive_id = uuid::Uuid::now_v7().to_string();
+    add_mam_stanza_id(message, archive_id.as_str(), &room_jid.to_string());
 
     let body = prototype_body(message)
         .map(|value| value.trim().to_string())
@@ -601,9 +799,10 @@ async fn archive_groupchat_message(
 
     let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
     let origin_id = extract_origin_id(message);
+    let rich = rich_archive_payload(message);
 
     let archived = ArchivedMessage {
-        id: String::new(),
+        id: archive_id,
         timestamp: Utc::now(),
         from: message
             .from
@@ -618,7 +817,8 @@ async fn archive_groupchat_message(
         reply_to_jid,
         origin_id,
         message_type: mam_message_type(&message.type_),
-        stanza_xml: Some(archived_stanza_xml(message)),
+        stanza_xml: None,
+        rich,
     };
 
     let archive_jid = room_jid.to_string();
@@ -649,12 +849,13 @@ async fn archive_direct_message(
     to_jid: &jid::Jid,
     message: &xmpp_parsers::message::Message,
 ) {
-    let Some(body) = prototype_body(message)
+    let body = prototype_body(message)
         .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-    else {
+        .unwrap_or_default();
+    let rich = rich_archive_payload(message);
+    if body.is_empty() && rich.is_none() {
         return;
-    };
+    }
 
     let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
     let origin_id = extract_origin_id(message);
@@ -671,7 +872,8 @@ async fn archive_direct_message(
         reply_to_jid,
         origin_id,
         message_type: mam_message_type(&message.type_),
-        stanza_xml: Some(archived_stanza_xml(message)),
+        stanza_xml: None,
+        rich,
     };
 
     // Store in sender's personal archive
@@ -734,6 +936,102 @@ fn extract_reply_reference(
         reply.attr("id").map(ToOwned::to_owned),
         reply.attr("to").map(ToOwned::to_owned),
     )
+}
+
+fn rich_archive_payload(message: &xmpp_parsers::message::Message) -> Option<ArchivedRichMessage> {
+    let payload = extract_correction_from_message(message)
+        .and_then(|correction| {
+            RichMessageId::new(correction.replaces_id)
+                .map(|replaces_id| ArchivedRichPayload::Correction { replaces_id })
+        })
+        .or_else(|| {
+            extract_retraction_from_message(message).and_then(|kind| match kind {
+                RetractionKind::Request(retraction) => RichMessageId::new(retraction.retracts_id)
+                    .map(|target_id| {
+                        ArchivedRichPayload::Retraction(ArchivedRetraction {
+                            target_id,
+                            stamp: None,
+                            retraction_id: message.id.clone().and_then(RichMessageId::new),
+                        })
+                    }),
+                RetractionKind::Tombstone(retracted) => message.id.clone().and_then(|id| {
+                    RichMessageId::new(id).map(|target_id| {
+                        ArchivedRichPayload::Retraction(ArchivedRetraction {
+                            target_id,
+                            stamp: chrono::DateTime::parse_from_rfc3339(&retracted.stamp)
+                                .ok()
+                                .map(|stamp| stamp.with_timezone(&Utc)),
+                            retraction_id: None,
+                        })
+                    })
+                }),
+            })
+        })
+        .or_else(|| {
+            extract_reactions_from_message(message).and_then(|reactions| {
+                RichMessageId::new(reactions.message_id).map(|target_id| {
+                    ArchivedRichPayload::Reactions(ArchivedReactionSet {
+                        target_id,
+                        emojis: reactions
+                            .emojis
+                            .into_iter()
+                            .filter_map(RichText::new)
+                            .collect(),
+                    })
+                })
+            })
+        });
+
+    let reply = parse_reply_from_message(message).and_then(|reply| {
+        RichMessageId::new(reply.id).map(|id| ArchivedReply {
+            id,
+            to: reply.to.and_then(|to| to.parse().ok()),
+        })
+    });
+
+    let references = extract_references_from_message(message)
+        .into_iter()
+        .filter_map(|reference| {
+            let ref_type = RichText::new(reference.ref_type.as_str())?;
+            Some(ArchivedReference {
+                ref_type,
+                begin: reference.begin.and_then(|value| value.try_into().ok()),
+                end: reference.end.and_then(|value| value.try_into().ok()),
+                uri: reference.uri.and_then(RichText::new),
+                anchor: reference.anchor.and_then(RichText::new),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mentions = extract_explicit_mentions(message)
+        .map(|mentions| {
+            mentions
+                .mentions
+                .into_iter()
+                .map(|mention| ArchivedMention {
+                    begin: mention.begin,
+                    end: mention.end,
+                    jid: mention.jid,
+                    occupant_id: mention.occupant_id.and_then(RichText::new),
+                    mentions: mention.mentions.and_then(RichText::new),
+                    uri: mention.uri.and_then(RichText::new),
+                    active: mention.active,
+                    noping: mention.noping,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if payload.is_none() && reply.is_none() && references.is_empty() && mentions.is_empty() {
+        None
+    } else {
+        Some(ArchivedRichMessage {
+            payload,
+            reply,
+            references,
+            mentions,
+        })
+    }
 }
 
 fn extract_origin_id(message: &xmpp_parsers::message::Message) -> Option<String> {

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -457,3 +457,20 @@ pub fn extract_element_text(xml: &str, tag: &str) -> Option<String> {
     let end_idx = content.find(&close)?;
     Some(content[..end_idx].trim().to_string())
 }
+
+#[allow(dead_code)]
+pub fn extract_attr_after(xml: &str, marker: &str, attr: &str) -> Option<String> {
+    let start = xml.find(marker)?;
+    let tail = &xml[start..];
+    let double = format!("{attr}=\"");
+    if let Some(attr_start) = tail.find(&double).map(|idx| idx + double.len()) {
+        let rest = &tail[attr_start..];
+        return rest.find('"').map(|end| rest[..end].to_string());
+    }
+    let single = format!("{attr}='");
+    if let Some(attr_start) = tail.find(&single).map(|idx| idx + single.len()) {
+        let rest = &tail[attr_start..];
+        return rest.find('\'').map(|end| rest[..end].to_string());
+    }
+    None
+}

--- a/server/crates/waddle-server/tests/xep0308_message_corrections_ws.rs
+++ b/server/crates/waddle-server/tests/xep0308_message_corrections_ws.rs
@@ -1,0 +1,235 @@
+//! XEP-0308 message correction integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0308-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn setup_with_bob() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let bob_password = format!("ws-test-bob-password-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let admin_resource = format!("xep0308-admin-{}", uuid::Uuid::new_v4());
+    let admin_password = server.fixed_account_password().to_string();
+    let admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_password,
+        &admin_resource,
+    )
+    .await
+    .expect("connect admin");
+    let bob_resource = format!("xep0308-bob-{}", uuid::Uuid::new_v4());
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &bob_resource,
+    )
+    .await
+    .expect("connect bob");
+    (server, admin, bob)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    join_room_as(client, room, USERNAME).await;
+}
+
+async fn join_room_as(client: &mut WsXmppClient, room: &str, nick: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{nick}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+#[tokio::test]
+async fn correction_routes_and_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("correct-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>typo</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    client
+        .recv_matching(|frame| frame.contains("typo"))
+        .await
+        .expect("original echo");
+    let target = "orig-1";
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="fix-1">
+                <body>fixed</body>
+                <replace xmlns="urn:xmpp:message-correct:0" id="{target}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send correction");
+    let echo = client
+        .recv_matching(|frame| frame.contains("fixed"))
+        .await
+        .expect("correction echo");
+    assert!(
+        echo.contains("urn:xmpp:message-correct:0"),
+        "missing replace: {echo}"
+    );
+    assert!(echo.contains(&target), "missing correction target: {echo}");
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-correct" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-correct") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:message-correct:0") && frame.contains(&target)),
+        "MAM did not replay correction: {frames:?}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn correction_can_target_original_message_id() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("correct-id-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-client-id"><body>typo by id</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    client
+        .recv_matching(|frame| frame.contains("typo by id"))
+        .await
+        .expect("original echo");
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="fix-client-id">
+                <body>fixed by id</body>
+                <replace xmlns="urn:xmpp:message-correct:0" id="orig-client-id"/>
+            </message>"#
+        ))
+        .await
+        .expect("send correction");
+    let echo = client
+        .recv_matching(|frame| frame.contains("fixed by id"))
+        .await
+        .expect("correction echo");
+    assert!(
+        echo.contains("urn:xmpp:message-correct:0"),
+        "missing replace: {echo}"
+    );
+    assert!(
+        echo.contains("orig-client-id"),
+        "missing correction target: {echo}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn correction_without_target_id_returns_bad_request() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("correct-invalid-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="bad-correction">
+                <body>fixed</body>
+                <replace xmlns="urn:xmpp:message-correct:0"/>
+            </message>"#
+        ))
+        .await
+        .expect("send malformed correction");
+    let error = client
+        .recv_matching(|frame| frame.contains("<bad-request"))
+        .await
+        .expect("bad request error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn correction_from_different_occupant_returns_forbidden() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut admin, mut bob) = setup_with_bob().await;
+    let room = format!("correct-forbidden-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room_as(&mut admin, &room, USERNAME).await;
+    join_room_as(&mut bob, &room, "bob").await;
+
+    admin
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-forbid"><body>owned by admin</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    admin
+        .recv_matching(|frame| frame.contains("owned by admin"))
+        .await
+        .expect("original echo");
+    let target = "orig-forbid";
+
+    bob.send(&format!(
+        r#"<message type="groupchat" to="{room}" id="bad-owner">
+                <body>not mine</body>
+                <replace xmlns="urn:xmpp:message-correct:0" id="{target}"/>
+            </message>"#
+    ))
+    .await
+    .expect("send unauthorized correction");
+    let error = bob
+        .recv_matching(|frame| frame.contains("<forbidden"))
+        .await
+        .expect("forbidden error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    admin.close().await;
+    bob.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -1,0 +1,67 @@
+//! XEP-0359 stanza-id integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0359-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+#[tokio::test]
+async fn room_replaces_spoofed_room_stanza_id_and_preserves_origin_id() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("sid-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="client-msg-1">
+                <body>sid body</body>
+                <stanza-id xmlns="urn:xmpp:sid:0" id="spoofed" by="{room}"/>
+                <origin-id xmlns="urn:xmpp:sid:0" id="origin-1"/>
+            </message>"#
+        ))
+        .await
+        .expect("send message");
+
+    let echo = client
+        .recv_matching(|frame| frame.contains("sid body"))
+        .await
+        .expect("echo");
+    assert!(echo.contains("urn:xmpp:sid:0"), "echo missing sid: {echo}");
+    assert!(echo.contains("origin-1"), "origin-id not preserved: {echo}");
+    assert!(
+        !echo.contains("spoofed"),
+        "spoofed room stanza-id leaked: {echo}"
+    );
+    assert!(echo.contains(&format!("by=\"{room}\"")) || echo.contains(&format!("by='{room}'")));
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0372_references_ws.rs
+++ b/server/crates/waddle-server/tests/xep0372_references_ws.rs
@@ -1,0 +1,80 @@
+//! XEP-0372 reference integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0372-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+#[tokio::test]
+async fn references_route_and_replay_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reference-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reference-1">
+                <body>Hello @admin</body>
+                <reference xmlns="urn:xmpp:reference:0" type="mention" begin="6" end="12" uri="xmpp:admin@localhost"/>
+            </message>"#
+        ))
+        .await
+        .expect("send reference");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:reference:0"))
+        .await
+        .expect("reference echo");
+    assert!(
+        echo.contains("xmpp:admin@localhost"),
+        "missing reference uri: {echo}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-reference" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-reference") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:reference:0")
+                && frame.contains("xmpp:admin@localhost")),
+        "MAM did not replay reference: {frames:?}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
+++ b/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
@@ -1,0 +1,93 @@
+//! XEP-0424 message retraction integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0424-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn stanza_id(frame: &str) -> String {
+    extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
+}
+
+#[tokio::test]
+async fn retraction_routes_and_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("retract-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>remove me</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let target = stanza_id(
+        &client
+            .recv_matching(|frame| frame.contains("remove me"))
+            .await
+            .expect("original echo"),
+    );
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="retract-1">
+                <retract xmlns="urn:xmpp:message-retract:1" id="{target}"/>
+                <body>/me retracted a previous message</body>
+            </message>"#
+        ))
+        .await
+        .expect("send retraction");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:message-retract:1"))
+        .await
+        .expect("retraction echo");
+    assert!(echo.contains(&target), "missing retraction target: {echo}");
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-retract" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-retract") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:message-retract:1") && frame.contains(&target)),
+        "MAM did not replay retraction: {frames:?}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
+++ b/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
@@ -1,0 +1,161 @@
+//! XEP-0425 moderated retraction integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0425-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn stanza_id(frame: &str) -> String {
+    extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
+}
+
+fn find_descendant<'a>(element: &'a Element, name: &str, ns: &str) -> Option<&'a Element> {
+    for child in element.children() {
+        if child.name() == name && child.ns() == ns {
+            return Some(child);
+        }
+        if let Some(found) = find_descendant(child, name, ns) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+fn find_moderation_message(element: &Element) -> Option<&Element> {
+    if element.name() == "message"
+        && element.ns() == "jabber:client"
+        && element
+            .get_child("retract", "urn:xmpp:message-retract:1")
+            .is_some()
+    {
+        return Some(element);
+    }
+    for child in element.children() {
+        if let Some(message) = find_moderation_message(child) {
+            return Some(message);
+        }
+    }
+    None
+}
+
+fn assert_moderation_shape(frame: &str, target: &str) {
+    let element = frame.parse::<Element>().expect("valid XML frame");
+    let message = find_moderation_message(&element)
+        .unwrap_or_else(|| panic!("missing message carrying moderation payload: {frame}"));
+    assert!(
+        message.attr("from").is_some_and(|from| !from.contains("/")),
+        "moderation broadcast must be from bare room jid: {frame}"
+    );
+    assert!(
+        find_descendant(message, "apply-to", "urn:xmpp:fasten:0").is_none(),
+        "old fastening moderation shape leaked: {frame}"
+    );
+    assert!(
+        find_descendant(message, "retracted", "urn:xmpp:message-retract:1").is_none(),
+        "tombstone-only retracted element leaked into live moderation: {frame}"
+    );
+
+    let retract = find_descendant(message, "retract", "urn:xmpp:message-retract:1")
+        .unwrap_or_else(|| panic!("missing retract payload: {frame}"));
+    assert_eq!(retract.attr("id"), Some(target), "wrong retract target");
+    let moderated = retract
+        .get_child("moderated", "urn:xmpp:message-moderate:1")
+        .unwrap_or_else(|| panic!("missing moderated child: {frame}"));
+    assert!(
+        moderated.attr("by").is_some_and(|by| by.contains("/admin")),
+        "missing moderator occupant jid: {frame}"
+    );
+    let reason = retract
+        .get_child("reason", "urn:xmpp:message-retract:1")
+        .unwrap_or_else(|| panic!("missing retract reason: {frame}"));
+    assert_eq!(reason.text(), "cleanup");
+}
+
+#[tokio::test]
+async fn moderation_broadcasts_and_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("moderate-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>moderate me</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let target = stanza_id(
+        &client
+            .recv_matching(|frame| frame.contains("moderate me"))
+            .await
+            .expect("original echo"),
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="moderate-1" to="{room}">
+                <moderate xmlns="urn:xmpp:message-moderate:1" id="{target}">
+                    <retract xmlns="urn:xmpp:message-retract:1"/>
+                    <reason>cleanup</reason>
+                </moderate>
+            </iq>"#
+        ))
+        .await
+        .expect("send moderation");
+    let frames = client
+        .recv_until(|frame| frame.contains("moderate-1") && frame.contains("type=\"result\""))
+        .await
+        .expect("moderation frames");
+    let broadcast = frames
+        .iter()
+        .find(|frame| frame.contains("urn:xmpp:message-moderate:1"))
+        .unwrap_or_else(|| panic!("missing moderation broadcast: {frames:?}"));
+    assert_moderation_shape(broadcast, &target);
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-moderate" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-moderate") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    let replay = frames
+        .iter()
+        .find(|frame| frame.contains("urn:xmpp:message-moderate:1"))
+        .unwrap_or_else(|| panic!("MAM did not replay moderation: {frames:?}"));
+    assert_moderation_shape(replay, &target);
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0444_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0444_reactions_ws.rs
@@ -1,0 +1,94 @@
+//! XEP-0444 reaction integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0444-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn stanza_id(frame: &str) -> String {
+    extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
+}
+
+#[tokio::test]
+async fn reaction_routes_and_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("react-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>react here</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let target = stanza_id(
+        &client
+            .recv_matching(|frame| frame.contains("react here"))
+            .await
+            .expect("original echo"),
+    );
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reaction-1">
+                <reactions xmlns="urn:xmpp:reactions:0" id="{target}">
+                    <reaction>👍</reaction>
+                </reactions>
+            </message>"#
+        ))
+        .await
+        .expect("send reaction");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:reactions:0"))
+        .await
+        .expect("reaction echo");
+    assert!(echo.contains(&target), "missing reaction target: {echo}");
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-react" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-react") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:reactions:0") && frame.contains(&target)),
+        "MAM did not replay reaction: {frames:?}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0461_replies_ws.rs
+++ b/server/crates/waddle-server/tests/xep0461_replies_ws.rs
@@ -1,0 +1,93 @@
+//! XEP-0461 reply integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0461-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn stanza_id(frame: &str) -> String {
+    extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
+}
+
+#[tokio::test]
+async fn reply_routes_and_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reply-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>question</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let target = stanza_id(
+        &client
+            .recv_matching(|frame| frame.contains("question"))
+            .await
+            .expect("original echo"),
+    );
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reply-1">
+                <body>answer</body>
+                <reply xmlns="urn:xmpp:reply:0" to="{room}/{USERNAME}" id="{target}"/>
+            </message>"#
+        ))
+        .await
+        .expect("send reply");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:reply:0"))
+        .await
+        .expect("reply echo");
+    assert!(echo.contains(&target), "missing reply target: {echo}");
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-reply" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-reply") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:reply:0") && frame.contains(&target)),
+        "MAM did not replay reply: {frames:?}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -1,0 +1,80 @@
+//! XEP-0513 explicit mention integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0513-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+#[tokio::test]
+async fn explicit_mentions_route_and_replay_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("mentions-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="mention-1">
+                <body>@admin please check this</body>
+                <mention xmlns="urn:xmpp:mentions:0" begin="0" end="6" jid="admin@localhost"/>
+            </message>"#
+        ))
+        .await
+        .expect("send mention");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:mentions:0"))
+        .await
+        .expect("mention echo");
+    assert!(
+        echo.contains("admin@localhost"),
+        "missing mentioned jid: {echo}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-mention" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-mention") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames
+            .iter()
+            .any(|frame| frame.contains("urn:xmpp:mentions:0")
+                && frame.contains("admin@localhost")),
+        "MAM did not replay mention: {frames:?}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -100,6 +100,30 @@ impl Feature {
         Self::new("urn:xmpp:reply:0")
     }
 
+    pub fn stanza_ids() -> Self {
+        Self::new("urn:xmpp:sid:0")
+    }
+
+    pub fn message_correction() -> Self {
+        Self::new("urn:xmpp:message-correct:0")
+    }
+
+    pub fn message_retraction() -> Self {
+        Self::new("urn:xmpp:message-retract:1")
+    }
+
+    pub fn message_moderation() -> Self {
+        Self::new("urn:xmpp:message-moderate:1")
+    }
+
+    pub fn reactions() -> Self {
+        Self::new("urn:xmpp:reactions:0")
+    }
+
+    pub fn references() -> Self {
+        Self::new("urn:xmpp:reference:0")
+    }
+
     pub fn fallback_indication() -> Self {
         Self::new("urn:xmpp:fallback:0")
     }
@@ -441,7 +465,12 @@ pub fn server_features() -> Vec<Feature> {
         Feature::caps(),
         Feature::roster_versioning(),
         Feature::mam(),
+        Feature::stanza_ids(),
         Feature::replies(),
+        Feature::message_correction(),
+        Feature::message_retraction(),
+        Feature::reactions(),
+        Feature::references(),
         Feature::fallback_indication(),
         Feature::threads(),
         Feature::stream_management(),
@@ -535,7 +564,13 @@ pub fn muc_room_features(
         Feature::disco_info(),
         Feature::muc(),
         Feature::mam(),
+        Feature::stanza_ids(),
         Feature::replies(),
+        Feature::message_correction(),
+        Feature::message_retraction(),
+        Feature::message_moderation(),
+        Feature::reactions(),
+        Feature::references(),
         Feature::fallback_indication(),
         Feature::threads(),
         Feature::vcard(),

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -33,6 +33,104 @@ pub const DELAY_NS: &str = "urn:xmpp:delay";
 
 const CLIENT_NS: &str = "jabber:client";
 const REPLY_NS: &str = "urn:xmpp:reply:0";
+const MESSAGE_CORRECT_NS: &str = "urn:xmpp:message-correct:0";
+const MESSAGE_RETRACT_NS: &str = "urn:xmpp:message-retract:1";
+const MESSAGE_MODERATE_NS: &str = "urn:xmpp:message-moderate:1";
+const REACTIONS_NS: &str = "urn:xmpp:reactions:0";
+const REFERENCE_NS: &str = "urn:xmpp:reference:0";
+const MENTIONS_NS: &str = "urn:xmpp:mentions:0";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RichMessageId(pub String);
+
+impl RichMessageId {
+    pub fn new(value: impl Into<String>) -> Option<Self> {
+        let value = value.into();
+        (!value.trim().is_empty()).then_some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RichText(pub String);
+
+impl RichText {
+    pub fn new(value: impl Into<String>) -> Option<Self> {
+        let value = value.into();
+        (!value.trim().is_empty()).then_some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedReply {
+    pub id: RichMessageId,
+    pub to: Option<Jid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedReference {
+    pub ref_type: RichText,
+    pub begin: Option<u32>,
+    pub end: Option<u32>,
+    pub uri: Option<RichText>,
+    pub anchor: Option<RichText>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedMention {
+    pub begin: Option<u32>,
+    pub end: Option<u32>,
+    pub jid: Option<BareJid>,
+    pub occupant_id: Option<RichText>,
+    pub mentions: Option<RichText>,
+    pub uri: Option<RichText>,
+    pub active: bool,
+    pub noping: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedReactionSet {
+    pub target_id: RichMessageId,
+    pub emojis: Vec<RichText>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedRetraction {
+    pub target_id: RichMessageId,
+    pub stamp: Option<DateTime<Utc>>,
+    pub retraction_id: Option<RichMessageId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedModeration {
+    pub target_id: RichMessageId,
+    pub moderated_by: Jid,
+    pub stamp: Option<DateTime<Utc>>,
+    pub reason: Option<RichText>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ArchivedRichPayload {
+    Correction { replaces_id: RichMessageId },
+    Retraction(ArchivedRetraction),
+    Moderation(ArchivedModeration),
+    Reactions(ArchivedReactionSet),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ArchivedRichMessage {
+    pub payload: Option<ArchivedRichPayload>,
+    pub reply: Option<ArchivedReply>,
+    pub references: Vec<ArchivedReference>,
+    pub mentions: Vec<ArchivedMention>,
+}
 
 /// Archived message metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,6 +160,8 @@ pub struct ArchivedMessage {
     pub message_type: String,
     /// Preserved full stanza XML for faithful replay of archived timeline events.
     pub stanza_xml: Option<String>,
+    /// Typed rich-message payload and annotations used to reconstruct XMPP payloads.
+    pub rich: Option<ArchivedRichMessage>,
 }
 
 fn default_message_type() -> String {
@@ -83,6 +183,7 @@ impl Default for ArchivedMessage {
             origin_id: None,
             message_type: default_message_type(),
             stanza_xml: None,
+            rich: None,
         }
     }
 }
@@ -297,9 +398,13 @@ fn parse_message_jid(to_jid: &str) -> Jid {
 }
 
 fn archived_inner_message(archived: &ArchivedMessage) -> Element {
+    if let Some(rich) = archived.rich.as_ref() {
+        return build_typed_inner_message(archived, rich);
+    }
+
     if let Some(stanza_xml) = archived.stanza_xml.as_deref() {
         match stanza_xml.parse::<Element>() {
-            Ok(element) => return element,
+            Ok(element) => return normalize_archived_inner_message(element, archived),
             Err(error) => {
                 warn!(
                     archive_id = %archived.id,
@@ -313,6 +418,166 @@ fn archived_inner_message(archived: &ArchivedMessage) -> Element {
     build_legacy_inner_message(archived)
 }
 
+fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage) -> Element {
+    if archived.message_type != "groupchat" || element.attr("to").is_none() {
+        return element;
+    }
+
+    if let Ok(mut message) = Message::try_from(element.clone()) {
+        message.to = None;
+        return Element::from(message);
+    }
+
+    element
+}
+
+fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMessage) -> Element {
+    let msg_type = if archived.message_type.is_empty() {
+        "chat"
+    } else {
+        archived.message_type.as_str()
+    };
+
+    let mut builder = Element::builder("message", CLIENT_NS)
+        .attr("from", &archived.from)
+        .attr("type", msg_type);
+    if msg_type != "groupchat" {
+        builder = builder.attr("to", &archived.to);
+    }
+
+    if let Some(stanza_id) = archived.stanza_id.as_deref() {
+        builder = builder.attr("id", stanza_id);
+    }
+    if !archived.body.is_empty() {
+        builder = builder.append(
+            Element::builder("body", CLIENT_NS)
+                .append(archived.body.clone())
+                .build(),
+        );
+    }
+    if let Some(thread_id) = archived.thread_id.as_deref() {
+        builder = builder.append(
+            Element::builder("thread", CLIENT_NS)
+                .append(thread_id)
+                .build(),
+        );
+    }
+    if let Some(origin_id) = archived.origin_id.as_deref() {
+        builder = builder.append(
+            Element::builder("origin-id", STANZA_ID_NS)
+                .attr("id", origin_id)
+                .build(),
+        );
+    }
+    if msg_type == "groupchat" && !archived.id.is_empty() && !archived.to.is_empty() {
+        builder = builder.append(
+            Element::builder("stanza-id", STANZA_ID_NS)
+                .attr("id", &archived.id)
+                .attr("by", &archived.to)
+                .build(),
+        );
+    }
+    if let Some(reply) = rich.reply.as_ref() {
+        let mut reply_builder = Element::builder("reply", REPLY_NS).attr("id", reply.id.as_str());
+        if let Some(to) = reply.to.as_ref() {
+            reply_builder = reply_builder.attr("to", to.to_string());
+        }
+        builder = builder.append(reply_builder.build());
+    }
+    for reference in &rich.references {
+        let mut reference_builder =
+            Element::builder("reference", REFERENCE_NS).attr("type", reference.ref_type.as_str());
+        if let Some(begin) = reference.begin {
+            reference_builder = reference_builder.attr("begin", begin.to_string());
+        }
+        if let Some(end) = reference.end {
+            reference_builder = reference_builder.attr("end", end.to_string());
+        }
+        if let Some(uri) = reference.uri.as_ref() {
+            reference_builder = reference_builder.attr("uri", uri.as_str());
+        }
+        if let Some(anchor) = reference.anchor.as_ref() {
+            reference_builder = reference_builder.attr("anchor", anchor.as_str());
+        }
+        builder = builder.append(reference_builder.build());
+    }
+    for mention in &rich.mentions {
+        let mut mention_elem = Element::builder("mention", MENTIONS_NS).build();
+        if let Some(begin) = mention.begin {
+            mention_elem.set_attr("begin", begin.to_string());
+        }
+        if let Some(end) = mention.end {
+            mention_elem.set_attr("end", end.to_string());
+        }
+        if let Some(jid) = mention.jid.as_ref() {
+            mention_elem.set_attr("jid", jid.to_string());
+        }
+        if let Some(occupant_id) = mention.occupant_id.as_ref() {
+            mention_elem.set_attr("occupantid", occupant_id.as_str());
+        }
+        if let Some(mentions) = mention.mentions.as_ref() {
+            mention_elem.set_attr("mentions", mentions.as_str());
+        }
+        if let Some(uri) = mention.uri.as_ref() {
+            mention_elem.set_attr("uri", uri.as_str());
+        }
+        if mention.active {
+            mention_elem.append_child(Element::builder("active", MENTIONS_NS).build());
+        }
+        if mention.noping {
+            mention_elem.append_child(Element::builder("noping", MENTIONS_NS).build());
+        }
+        builder = builder.append(mention_elem);
+    }
+
+    match rich.payload.as_ref() {
+        Some(ArchivedRichPayload::Correction { replaces_id }) => {
+            builder = builder.append(
+                Element::builder("replace", MESSAGE_CORRECT_NS)
+                    .attr("id", replaces_id.as_str())
+                    .build(),
+            );
+        }
+        Some(ArchivedRichPayload::Retraction(retraction)) => {
+            let retract_builder = Element::builder("retract", MESSAGE_RETRACT_NS)
+                .attr("id", retraction.target_id.as_str());
+            builder = builder.append(retract_builder.build());
+        }
+        Some(ArchivedRichPayload::Moderation(moderation)) => {
+            let moderated = Element::builder("moderated", MESSAGE_MODERATE_NS)
+                .attr("by", moderation.moderated_by.to_string())
+                .build();
+            let mut retract = Element::builder("retract", MESSAGE_RETRACT_NS)
+                .attr("id", moderation.target_id.as_str())
+                .append(moderated);
+            if let Some(reason) = moderation.reason.as_ref() {
+                retract = retract.append(
+                    Element::builder("reason", MESSAGE_RETRACT_NS)
+                        .append(reason.as_str())
+                        .build(),
+                );
+            }
+            builder = builder.append(retract.build());
+        }
+        Some(ArchivedRichPayload::Reactions(reactions)) => {
+            let mut reactions_elem = Element::builder("reactions", REACTIONS_NS)
+                .attr("id", reactions.target_id.as_str())
+                .build();
+            for emoji in &reactions.emojis {
+                reactions_elem.append_child(
+                    Element::builder("reaction", REACTIONS_NS)
+                        .append(emoji.as_str())
+                        .build(),
+                );
+            }
+            builder = builder.append(reactions_elem);
+        }
+        None => {}
+    }
+
+    builder.build()
+}
+
 fn build_legacy_inner_message(archived: &ArchivedMessage) -> Element {
     let msg_type = if archived.message_type.is_empty() {
         "chat"
@@ -322,8 +587,10 @@ fn build_legacy_inner_message(archived: &ArchivedMessage) -> Element {
 
     let mut builder = Element::builder("message", CLIENT_NS)
         .attr("from", &archived.from)
-        .attr("to", &archived.to)
         .attr("type", msg_type);
+    if msg_type != "groupchat" {
+        builder = builder.attr("to", &archived.to);
+    }
 
     if let Some(stanza_id) = archived.stanza_id.as_deref() {
         builder = builder.attr("id", stanza_id);
@@ -353,6 +620,14 @@ fn build_legacy_inner_message(archived: &ArchivedMessage) -> Element {
         builder = builder.append(
             Element::builder("origin-id", STANZA_ID_NS)
                 .attr("id", origin_id)
+                .build(),
+        );
+    }
+    if msg_type == "groupchat" && !archived.id.is_empty() && !archived.to.is_empty() {
+        builder = builder.append(
+            Element::builder("stanza-id", STANZA_ID_NS)
+                .attr("id", &archived.id)
+                .attr("by", &archived.to)
                 .build(),
         );
     }

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -18,5 +18,7 @@ pub mod storage;
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
 pub use waddle_xmpp_core::mam::{
     add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,
-    ArchivedMessage, MamQuery, MamResult, MAM_NS, RSM_NS, STANZA_ID_NS,
+    ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference,
+    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, MamQuery,
+    MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
 };

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -80,6 +80,27 @@ pub trait MamStorage: Send + Sync {
         archive_id: &str,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
+    /// Get a single message by its original message/stanza id inside an archive.
+    async fn get_message_by_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError>;
+
+    /// Get a message by its wire message id inside an archive.
+    async fn get_message_by_message_id(
+        &self,
+        archive_jid: &str,
+        message_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError>;
+
+    /// Get a message by server archive id or stanza id, excluding client origin-id.
+    async fn get_message_by_archive_or_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError>;
+
     /// Get the total count of messages in an archive (for RSM).
     async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError>;
 
@@ -197,6 +218,51 @@ impl MamStorage for InMemoryMamStorage {
             .map(|(_, message)| message.clone()))
     }
 
+    async fn get_message_by_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .find(|(jid, message)| {
+                jid == archive_jid
+                    && (message.stanza_id.as_deref() == Some(stanza_id)
+                        || message.origin_id.as_deref() == Some(stanza_id))
+            })
+            .map(|(_, message)| message.clone()))
+    }
+
+    async fn get_message_by_message_id(
+        &self,
+        archive_jid: &str,
+        message_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .find(|(jid, message)| {
+                jid == archive_jid && message.stanza_id.as_deref() == Some(message_id)
+            })
+            .map(|(_, message)| message.clone()))
+    }
+
+    async fn get_message_by_archive_or_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .find(|(jid, message)| {
+                jid == archive_jid
+                    && (message.id == stanza_id || message.stanza_id.as_deref() == Some(stanza_id))
+            })
+            .map(|(_, message)| message.clone()))
+    }
+
     async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError> {
         let entries = self.entries.read().await;
         Ok(entries.iter().filter(|(jid, _)| jid == room_jid).count() as u32)
@@ -275,9 +341,16 @@ impl SqlxMamStorage {
 
     async fn initialize(&self) -> Result<(), MamStorageError> {
         match &self.backend {
-            MamDatabaseBackend::Sqlite(pool) => execute_sqlite_batch(pool, SQLITE_MAM_SCHEMA).await,
+            MamDatabaseBackend::Sqlite(pool) => {
+                execute_sqlite_batch(pool, SQLITE_MAM_SCHEMA).await?;
+                ensure_sqlite_rich_payload_column(pool).await
+            }
             MamDatabaseBackend::Postgres(pool) => {
-                execute_postgres_batch(pool, POSTGRES_MAM_SCHEMA).await
+                execute_postgres_batch(pool, POSTGRES_MAM_SCHEMA).await?;
+                sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS rich_payload TEXT")
+                    .execute(pool)
+                    .await?;
+                Ok(())
             }
         }
     }
@@ -288,7 +361,7 @@ impl SqlxMamStorage {
 }
 
 const SELECT_COLUMNS: &str =
-    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml";
+    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload";
 
 const SQLITE_MAM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS mam_messages (
@@ -305,6 +378,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
+    rich_payload TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -334,6 +408,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
+    rich_payload TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -421,6 +496,22 @@ async fn execute_postgres_batch(pool: &PgPool, sql: &str) -> Result<(), MamStora
     Ok(())
 }
 
+async fn ensure_sqlite_rich_payload_column(pool: &SqlitePool) -> Result<(), MamStorageError> {
+    let columns = sqlx::query("PRAGMA table_info(mam_messages)")
+        .fetch_all(pool)
+        .await?;
+    let exists = columns.iter().any(|row| {
+        row.try_get::<String, _>("name")
+            .is_ok_and(|name| name == "rich_payload")
+    });
+    if !exists {
+        sqlx::query("ALTER TABLE mam_messages ADD COLUMN rich_payload TEXT")
+            .execute(pool)
+            .await?;
+    }
+    Ok(())
+}
+
 fn uses_backward_pagination(query: &MamQuery) -> bool {
     query
         .before_id
@@ -457,6 +548,7 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         .map_err(|error| MamStorageError::Serialization(format!("Invalid timestamp: {error}")))?
         .with_timezone(&Utc);
 
+    let rich_payload: Option<String> = row.try_get(13)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp,
@@ -470,10 +562,12 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         origin_id: row.try_get(10)?,
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
+        rich: decode_rich_payload(rich_payload.as_deref())?,
     })
 }
 
 fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorageError> {
+    let rich_payload: Option<String> = row.try_get(13)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp: row.try_get(2)?,
@@ -487,7 +581,27 @@ fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorag
         origin_id: row.try_get(10)?,
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
+        rich: decode_rich_payload(rich_payload.as_deref())?,
     })
+}
+
+fn encode_rich_payload(message: &ArchivedMessage) -> Result<Option<String>, MamStorageError> {
+    message
+        .rich
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|error| MamStorageError::Serialization(error.to_string()))
+}
+
+fn decode_rich_payload(
+    value: Option<&str>,
+) -> Result<Option<waddle_xmpp_core::mam::ArchivedRichMessage>, MamStorageError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .map(serde_json::from_str)
+        .transpose()
+        .map_err(|error| MamStorageError::Serialization(error.to_string()))
 }
 
 #[async_trait]
@@ -508,11 +622,12 @@ impl MamStorage for SqlxMamStorage {
         } else {
             message.message_type.as_str()
         };
+        let rich_payload = encode_rich_payload(message)?;
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut query = QueryBuilder::<Sqlite>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -528,13 +643,14 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(message.reply_to_jid.as_deref())
                         .push_bind(message.origin_id.as_deref())
                         .push_bind(message_type)
-                        .push_bind(message.stanza_xml.as_deref());
+                        .push_bind(message.stanza_xml.as_deref())
+                        .push_bind(rich_payload.as_deref());
                 });
                 query.build().execute(pool).await?;
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut query = QueryBuilder::<Postgres>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -550,7 +666,8 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(message.reply_to_jid.as_deref())
                         .push_bind(message.origin_id.as_deref())
                         .push_bind(message_type)
-                        .push_bind(message.stanza_xml.as_deref());
+                        .push_bind(message.stanza_xml.as_deref())
+                        .push_bind(rich_payload.as_deref());
                 });
                 query.build().execute(pool).await?;
             }
@@ -680,6 +797,95 @@ impl MamStorage for SqlxMamStorage {
         }
     }
 
+    async fn get_message_by_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        match &self.backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (stanza_id = ? OR origin_id = ?) ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(stanza_id)
+                .bind(stanza_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_sqlite_message_row).transpose()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (stanza_id = $2 OR origin_id = $2) ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(stanza_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_postgres_message_row).transpose()
+            }
+        }
+    }
+
+    async fn get_message_by_message_id(
+        &self,
+        archive_jid: &str,
+        message_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        match &self.backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND stanza_id = ? ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(message_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_sqlite_message_row).transpose()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND stanza_id = $2 ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(message_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_postgres_message_row).transpose()
+            }
+        }
+    }
+
+    async fn get_message_by_archive_or_stanza_id(
+        &self,
+        archive_jid: &str,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        match &self.backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (id = ? OR stanza_id = ?) ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(stanza_id)
+                .bind(stanza_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_sqlite_message_row).transpose()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let row = sqlx::query(&format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (id = $2 OR stanza_id = $2) ORDER BY timestamp DESC LIMIT 1"
+                ))
+                .bind(archive_jid)
+                .bind(stanza_id)
+                .fetch_optional(pool)
+                .await?;
+                row.as_ref().map(decode_postgres_message_row).transpose()
+            }
+        }
+    }
+
     #[instrument(skip(self))]
     async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError> {
         let count = match &self.backend {
@@ -791,6 +997,7 @@ mod tests {
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='archive-stanza-1'><body>Reply body</body></message>".to_string(),
             ),
+            rich: None,
         };
 
         let archive_id = storage

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -88,6 +88,7 @@ pub struct PresenceUpdateOutcome {
 pub struct AdminContext {
     pub affiliation: Affiliation,
     pub role: Role,
+    pub nick: Option<String>,
 }
 
 #[derive(Debug, Clone, Error)]
@@ -693,6 +694,7 @@ impl kameo::message::Message<GetAdminContext> for RoomActor {
         Ok(AdminContext {
             affiliation: sender_affiliation,
             role: sender_role,
+            nick: sender_occupant.map(|occupant| occupant.nick.clone()),
         })
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -430,10 +430,10 @@ pub use xep0424::{
 };
 
 pub use xep0425::{
-    build_moderation_request, build_moderation_request_element, build_moderation_result_element,
-    build_moderation_result_message, extract_moderation_request, extract_moderation_result,
-    is_moderation_request_message, is_moderation_result_message, ModerationCarrier,
-    ModerationRequest, ModerationResult, NS_FASTEN, NS_MESSAGE_MODERATE,
+    build_moderated_retract_element, build_moderation_result_message, extract_moderation_request,
+    extract_moderation_result, is_moderation_request_message, is_moderation_result_message,
+    parse_moderation_iq, ModerationCarrier, ModerationRequest, ModerationResult,
+    NS_MESSAGE_MODERATE,
 };
 
 pub use xep0444::{

--- a/server/crates/waddle-xmpp/src/xep/xep0425.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0425.rs
@@ -39,6 +39,7 @@
 //! - Broadcast to all occupants
 
 use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::message::Message;
 
 /// Namespace for XEP-0425 Message Moderation.
@@ -57,6 +58,29 @@ pub struct ModerationRequest {
     pub target_id: String,
     /// Optional reason for the moderation action.
     pub reason: Option<String>,
+}
+
+/// Parse a current XEP-0425 IQ moderation request:
+/// `<iq type='set'><moderate id='stanza-id'><retract/><reason/></moderate></iq>`.
+pub fn parse_moderation_iq(iq: &Iq) -> Option<ModerationRequest> {
+    let moderate = match &iq.payload {
+        IqType::Set(elem) if elem.name() == "moderate" && elem.ns() == NS_MESSAGE_MODERATE => elem,
+        _ => return None,
+    };
+    let target_id = moderate.attr("id").filter(|value| !value.is_empty())?;
+    moderate
+        .children()
+        .find(|child| child.name() == "retract" && child.ns() == NS_RETRACT)?;
+    let reason = moderate
+        .children()
+        .find(|child| child.name() == "reason" && child.ns() == NS_MESSAGE_MODERATE)
+        .map(|child| child.text())
+        .filter(|value| !value.trim().is_empty());
+
+    Some(ModerationRequest {
+        target_id: target_id.to_owned(),
+        reason,
+    })
 }
 
 impl ModerationRequest {
@@ -137,120 +161,40 @@ pub fn is_moderation_result_message(msg: &Message) -> bool {
 // ── Extraction ───────────────────────────────────────────────────────
 
 /// Extract a moderation request from a message.
-pub fn extract_moderation_request(msg: &Message) -> Option<ModerationRequest> {
-    let apply_to = msg
-        .payloads
-        .iter()
-        .find(|e| e.name() == "apply-to" && e.ns() == NS_FASTEN)?;
-
-    let target_id = apply_to.attr("id").filter(|s| !s.is_empty())?.to_owned();
-
-    let moderate = apply_to
-        .children()
-        .find(|c| c.name() == "moderate" && c.ns() == NS_MESSAGE_MODERATE)?;
-
-    let reason = moderate
-        .children()
-        .find(|c| c.name() == "reason")
-        .map(|c| c.text())
-        .filter(|t| !t.is_empty());
-
-    Some(ModerationRequest { target_id, reason })
+pub fn extract_moderation_request(_msg: &Message) -> Option<ModerationRequest> {
+    None
 }
 
 /// Extract a moderation result from a message.
 pub fn extract_moderation_result(msg: &Message) -> Option<ModerationResult> {
-    let apply_to = msg
+    if let Some(retract) = msg
         .payloads
         .iter()
-        .find(|e| e.name() == "apply-to" && e.ns() == NS_FASTEN)?;
+        .find(|e| e.name() == "retract" && e.ns() == NS_RETRACT)
+    {
+        let target_id = retract.attr("id").filter(|s| !s.is_empty())?.to_owned();
+        let moderated = retract
+            .children()
+            .find(|c| c.name() == "moderated" && c.ns() == NS_MESSAGE_MODERATE)?;
+        let moderated_by = moderated.attr("by").filter(|s| !s.is_empty())?.to_owned();
+        let reason = retract
+            .children()
+            .find(|c| c.name() == "reason" && c.ns() == NS_RETRACT)
+            .map(|c| c.text())
+            .filter(|t| !t.is_empty());
 
-    let target_id = apply_to.attr("id").filter(|s| !s.is_empty())?.to_owned();
+        return Some(ModerationResult {
+            target_id,
+            moderated_by,
+            stamp: String::new(),
+            reason,
+        });
+    }
 
-    let moderated = apply_to
-        .children()
-        .find(|c| c.name() == "moderated" && c.ns() == NS_MESSAGE_MODERATE)?;
-
-    let moderated_by = moderated.attr("by").filter(|s| !s.is_empty())?.to_owned();
-
-    let stamp = moderated
-        .children()
-        .find(|c| c.name() == "retracted" && c.ns() == NS_RETRACT)
-        .and_then(|c| c.attr("stamp"))
-        .unwrap_or("")
-        .to_owned();
-
-    let reason = moderated
-        .children()
-        .find(|c| c.name() == "reason")
-        .map(|c| c.text())
-        .filter(|t| !t.is_empty());
-
-    Some(ModerationResult {
-        target_id,
-        moderated_by,
-        stamp,
-        reason,
-    })
+    None
 }
 
 // ── Building ─────────────────────────────────────────────────────────
-
-/// Build a moderation request message.
-pub fn build_moderation_request(
-    to: impl Into<Option<jid::Jid>>,
-    request: &ModerationRequest,
-) -> Message {
-    let mut msg = Message::new(to.into());
-    msg.type_ = xmpp_parsers::message::MessageType::Groupchat;
-    msg.id = Some(uuid::Uuid::new_v4().to_string());
-    msg.payloads.push(build_moderation_request_element(request));
-    msg
-}
-
-/// Build the `<apply-to>/<moderate>` element for a moderation request.
-pub fn build_moderation_request_element(request: &ModerationRequest) -> Element {
-    let mut moderate = Element::builder("moderate", NS_MESSAGE_MODERATE).build();
-    moderate.append_child(Element::builder("retract", NS_RETRACT).build());
-    if let Some(ref reason) = request.reason {
-        let mut reason_elem = Element::builder("reason", NS_MESSAGE_MODERATE).build();
-        reason_elem.append_text_node(reason);
-        moderate.append_child(reason_elem);
-    }
-
-    Element::builder("apply-to", NS_FASTEN)
-        .attr("id", request.target_id.as_str())
-        .append(moderate)
-        .build()
-}
-
-/// Build the `<apply-to>/<moderated>` element for a moderation result (server broadcast).
-pub fn build_moderation_result_element(
-    target_id: &str,
-    moderated_by: &str,
-    stamp: &str,
-    reason: Option<&str>,
-) -> Element {
-    let retracted = Element::builder("retracted", NS_RETRACT)
-        .attr("stamp", stamp)
-        .build();
-
-    let mut moderated = Element::builder("moderated", NS_MESSAGE_MODERATE)
-        .attr("by", moderated_by)
-        .build();
-    moderated.append_child(retracted);
-
-    if let Some(reason_text) = reason {
-        let mut reason_elem = Element::builder("reason", NS_MESSAGE_MODERATE).build();
-        reason_elem.append_text_node(reason_text);
-        moderated.append_child(reason_elem);
-    }
-
-    Element::builder("apply-to", NS_FASTEN)
-        .attr("id", target_id)
-        .append(moderated)
-        .build()
-}
 
 /// Build a complete moderation result message for broadcasting.
 pub fn build_moderation_result_message(
@@ -264,7 +208,7 @@ pub fn build_moderation_result_message(
     msg.from = from_room.into();
     msg.type_ = xmpp_parsers::message::MessageType::Groupchat;
     msg.id = Some(uuid::Uuid::new_v4().to_string());
-    msg.payloads.push(build_moderation_result_element(
+    msg.payloads.push(build_moderated_retract_element(
         target_id,
         moderated_by,
         stamp,
@@ -273,42 +217,63 @@ pub fn build_moderation_result_message(
     msg
 }
 
+/// Build the current XEP-0425 broadcast payload:
+/// `<retract id='target'><moderated by='moderator'/><reason>...</reason></retract>`.
+pub fn build_moderated_retract_element(
+    target_id: &str,
+    moderated_by: &str,
+    stamp: &str,
+    reason: Option<&str>,
+) -> Element {
+    let moderated = Element::builder("moderated", NS_MESSAGE_MODERATE)
+        .attr("by", moderated_by)
+        .build();
+    let mut retract = Element::builder("retract", NS_RETRACT)
+        .attr("id", target_id)
+        .append(moderated);
+    if let Some(reason_text) = reason {
+        retract = retract.append(
+            Element::builder("reason", NS_RETRACT)
+                .append(reason_text)
+                .build(),
+        );
+    }
+
+    let _ = stamp;
+    retract.build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use xmpp_parsers::iq::Iq;
     use xmpp_parsers::message::{Message, MessageType};
 
     #[test]
     fn test_parse_moderation_request() {
-        let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <apply-to xmlns='urn:xmpp:fasten:0' id='target-1'>\
-                      <moderate xmlns='urn:xmpp:message-moderate:1'>\
-                        <retract xmlns='urn:xmpp:message-retract:1'/>\
-                        <reason>Spam</reason>\
-                      </moderate>\
-                    </apply-to>\
-                    </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        let xml = "<iq xmlns='jabber:client' type='set' id='mod-1'>\
+                    <moderate xmlns='urn:xmpp:message-moderate:1' id='target-1'>\
+                      <retract xmlns='urn:xmpp:message-retract:1'/>\
+                      <reason>Spam</reason>\
+                    </moderate>\
+                   </iq>";
+        let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid iq");
 
-        let req = extract_moderation_request(&msg).expect("has request");
+        let req = parse_moderation_iq(&iq).expect("has request");
         assert_eq!(req.target_id, "target-1");
         assert_eq!(req.reason.as_deref(), Some("Spam"));
     }
 
     #[test]
     fn test_parse_moderation_request_no_reason() {
-        let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <apply-to xmlns='urn:xmpp:fasten:0' id='target-2'>\
-                      <moderate xmlns='urn:xmpp:message-moderate:1'>\
-                        <retract xmlns='urn:xmpp:message-retract:1'/>\
-                      </moderate>\
-                    </apply-to>\
-                    </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        let xml = "<iq xmlns='jabber:client' type='set' id='mod-2'>\
+                    <moderate xmlns='urn:xmpp:message-moderate:1' id='target-2'>\
+                      <retract xmlns='urn:xmpp:message-retract:1'/>\
+                    </moderate>\
+                   </iq>";
+        let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid iq");
 
-        let req = extract_moderation_request(&msg).expect("has request");
+        let req = parse_moderation_iq(&iq).expect("has request");
         assert_eq!(req.target_id, "target-2");
         assert_eq!(req.reason, None);
     }
@@ -316,12 +281,10 @@ mod tests {
     #[test]
     fn test_parse_moderation_result() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <apply-to xmlns='urn:xmpp:fasten:0' id='target-1'>\
-                      <moderated xmlns='urn:xmpp:message-moderate:1' by='room@muc.example.com/modnick'>\
-                        <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-06-01T12:00:00Z'/>\
-                        <reason>Spam</reason>\
-                      </moderated>\
-                    </apply-to>\
+                    <retract xmlns='urn:xmpp:message-retract:1' id='target-1'>\
+                      <moderated xmlns='urn:xmpp:message-moderate:1' by='room@muc.example.com/modnick'/>\
+                      <reason>Spam</reason>\
+                    </retract>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -329,7 +292,7 @@ mod tests {
         let result = extract_moderation_result(&msg).expect("has result");
         assert_eq!(result.target_id, "target-1");
         assert_eq!(result.moderated_by, "room@muc.example.com/modnick");
-        assert_eq!(result.stamp, "2024-06-01T12:00:00Z");
+        assert_eq!(result.stamp, "");
         assert_eq!(result.reason.as_deref(), Some("Spam"));
     }
 
@@ -341,19 +304,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_moderation_request() {
-        let req = ModerationRequest::new("msg-42").with_reason("Off-topic");
-        let msg = build_moderation_request("room@muc.example.com".parse::<jid::Jid>().ok(), &req);
-
-        assert_eq!(msg.type_, MessageType::Groupchat);
-        let parsed = extract_moderation_request(&msg).expect("parseable");
-        assert_eq!(parsed.target_id, "msg-42");
-        assert_eq!(parsed.reason.as_deref(), Some("Off-topic"));
-    }
-
-    #[test]
     fn test_build_moderation_result() {
-        let elem = build_moderation_result_element(
+        let elem = build_moderated_retract_element(
             "msg-42",
             "room@muc.example.com/admin",
             "2024-06-01T12:00:00Z",
@@ -398,19 +350,17 @@ mod tests {
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
-        assert!(msg.is_moderation_request());
+        assert!(!msg.is_moderation_request());
         assert!(!msg.is_moderation_result());
-        assert!(msg.has_moderation());
+        assert!(!msg.has_moderation());
     }
 
     #[test]
     fn test_moderation_carrier_trait_result() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <apply-to xmlns='urn:xmpp:fasten:0' id='t-1'>\
-                      <moderated xmlns='urn:xmpp:message-moderate:1' by='mod@room'>\
-                        <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-01-01T00:00:00Z'/>\
-                      </moderated>\
-                    </apply-to>\
+                    <retract xmlns='urn:xmpp:message-retract:1' id='t-1'>\
+                      <moderated xmlns='urn:xmpp:message-moderate:1' by='mod@room'/>\
+                    </retract>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");


### PR DESCRIPTION
## Summary

Implements #211 by promoting rich-message XEP helpers into active server behavior for routing, authorization, persistence, and MAM reconstruction.

## Implementation

- Adds active handling for XEP-0308 corrections, XEP-0359 stanza IDs, XEP-0372 references, XEP-0424 retractions, XEP-0425 moderation, XEP-0444 reactions, XEP-0461 replies, and XEP-0513 explicit mentions.
- Generates authoritative room stanza IDs, strips spoofed room `stanza-id` values, preserves `origin-id`, and uses XEP-specific target semantics.
- Validates correction/retraction ownership, moderation privileges, and rich-message target existence with typed stanza errors.
- Stores rich-message archive state as typed MAM payload data with an idempotent `rich_payload` schema migration.
- Reconstructs MAM replay from typed rich payloads, including conformant XEP-0425 moderation broadcasts from the bare room JID.
- Removes stale public XEP-0425 builders for the old Fastening message shape.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p waddle-xmpp -p waddle-server`
- `cargo test -p waddle-xmpp xep0425`
- `cargo test -p waddle-server --test xep0359_stanza_ids_ws --test xep0308_message_corrections_ws --test xep0424_message_retraction_ws --test xep0425_message_moderation_ws --test xep0444_reactions_ws --test xep0461_replies_ws --test xep0372_references_ws --test xep0513_mentions_ws`

## Review

Ran repeated adversarial sub-agent review passes for protocol/XEP conformance, MAM/storage correctness, and CI/test risk until the final pass reported no actionable findings.
