### PR TITLE
feat(server): wire sans-I/O message pipeline + XEP-0359 stanza-id (#211 PR1)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -118,19 +118,17 @@ pub async fn interpret(
                 let _entry = registry.unregister(&jid);
                 debug!(jid = %jid, "UnregisterConnection: removed from registry");
             }
-            OutboundEvent::ArchiveGroupchat { room, sender, .. } => {
+            OutboundEvent::ArchiveRoomMessage { room, .. } => {
                 warn!(
-                    variant = "ArchiveGroupchat",
+                    variant = "ArchiveRoomMessage",
                     room = %room,
-                    sender = %sender,
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }
-            OutboundEvent::ArchiveDirect { from, to, .. } => {
+            OutboundEvent::ArchivePersonalMessage { archive_owner, .. } => {
                 warn!(
-                    variant = "ArchiveDirect",
-                    from = %from,
-                    to = %to,
+                    variant = "ArchivePersonalMessage",
+                    archive_owner = %archive_owner,
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -16,14 +16,17 @@
 //!
 //! # Current coverage
 //!
-//! Only a subset of variants have their interpreter wiring in place — the
-//! ones needed by handlers that have been migrated so far (ping, session).
-//! The remaining variants (`SendDirect`, `BroadcastToRoom`, `QueryMam`,
-//! `AskSfu`, `RequestEnrichment`, etc.) are defined in the event enum so
-//! future handlers can emit them, but land in the interpreter as later
-//! migration steps pull their XEP into the sans-I/O world.
+//! `SendStanza`, `SendDirect`, `Log`, `CloseTransport`,
+//! `UnregisterConnection`, `ArchivePersonalMessage`, and
+//! `ArchiveRoomMessage` are wired against the registry and MAM storage. The
+//! remaining variants (`BroadcastToRoom`, `RegisterConnection`, `QueryMam`,
+//! `AskSfu`, `RequestEnrichment`, the timer variants) are defined in the
+//! event enum so future handlers can emit them, but land here as warnings
+//! until later migration steps pull their XEP into the sans-I/O world.
 
+use std::sync::Arc;
 use tracing::{debug, error, info, warn};
+use waddle_xmpp::mam::{message_to_archived, MamStorage};
 use waddle_xmpp::parser::stanza_to_string;
 use waddle_xmpp::protocol::OutboundEvent;
 use waddle_xmpp::registry::ConnectionRegistry;
@@ -42,13 +45,15 @@ pub struct InterpretOutcome {
 
 /// Execute the side effects described by `events`.
 ///
-/// The function is `async` because future migration steps add variants
-/// that genuinely require `.await` (registry lookups, actor calls, MAM
-/// storage). The currently-supported variants are all synchronous, so this
-/// function will return immediately for the ping/session flow.
+/// The function is `async` because variants like `ArchivePersonalMessage`,
+/// `ArchiveRoomMessage`, and `SendDirect` perform real async work against
+/// MAM storage and the connection registry. Variants whose interpretation
+/// is still stubbed (`BroadcastToRoom`, the request/response callback
+/// pairs) return immediately.
 pub async fn interpret(
     events: Vec<OutboundEvent>,
     registry: &ConnectionRegistry,
+    mam_storage: &Arc<dyn MamStorage>,
 ) -> InterpretOutcome {
     let mut outcome = InterpretOutcome::default();
 
@@ -118,19 +123,61 @@ pub async fn interpret(
                 let _entry = registry.unregister(&jid);
                 debug!(jid = %jid, "UnregisterConnection: removed from registry");
             }
-            OutboundEvent::ArchiveRoomMessage { room, .. } => {
-                warn!(
-                    variant = "ArchiveRoomMessage",
-                    room = %room,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::ArchiveRoomMessage {
+                room,
+                archive_id,
+                message,
+            } => {
+                let archived =
+                    message_to_archived(&message, &room, &archive_id, chrono::Utc::now());
+                match mam_storage
+                    .store_message(&room.to_string(), &archived)
+                    .await
+                {
+                    Ok(_) => {
+                        debug!(
+                            archive = %room,
+                            archive_id = %archive_id,
+                            "ArchiveRoomMessage persisted"
+                        );
+                    }
+                    Err(err) => {
+                        error!(
+                            archive = %room,
+                            archive_id = %archive_id,
+                            error = %err,
+                            "ArchiveRoomMessage failed to persist"
+                        );
+                    }
+                }
             }
-            OutboundEvent::ArchivePersonalMessage { archive_owner, .. } => {
-                warn!(
-                    variant = "ArchivePersonalMessage",
-                    archive_owner = %archive_owner,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::ArchivePersonalMessage {
+                archive_owner,
+                archive_id,
+                message,
+            } => {
+                let archived =
+                    message_to_archived(&message, &archive_owner, &archive_id, chrono::Utc::now());
+                match mam_storage
+                    .store_message(&archive_owner.to_string(), &archived)
+                    .await
+                {
+                    Ok(_) => {
+                        debug!(
+                            archive = %archive_owner,
+                            archive_id = %archive_id,
+                            "ArchivePersonalMessage persisted"
+                        );
+                    }
+                    Err(err) => {
+                        error!(
+                            archive = %archive_owner,
+                            archive_id = %archive_id,
+                            error = %err,
+                            "ArchivePersonalMessage failed to persist"
+                        );
+                    }
+                }
             }
             OutboundEvent::RequestEnrichment { id, .. } => {
                 warn!(
@@ -210,12 +257,17 @@ impl ToElementString for waddle_xmpp::Stanza {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use waddle_xmpp::mam::InMemoryMamStorage;
     use waddle_xmpp::Stanza;
     use xmpp_parsers::iq::{Iq, IqType};
     use xmpp_parsers::minidom::Element;
 
     fn test_registry() -> ConnectionRegistry {
         ConnectionRegistry::new()
+    }
+
+    fn test_mam() -> Arc<dyn MamStorage> {
+        Arc::new(InMemoryMamStorage::new())
     }
 
     fn result_iq(id: &str) -> Iq {
@@ -232,7 +284,7 @@ mod tests {
         let events = vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(result_iq(
             "x",
         ))))];
-        let outcome = interpret(events, &test_registry()).await;
+        let outcome = interpret(events, &test_registry(), &test_mam()).await;
         assert_eq!(outcome.frames.len(), 1);
         assert!(outcome.frames[0].contains("type=\"result\""));
         assert!(outcome.frames[0].contains("id=\"x\""));
@@ -242,7 +294,7 @@ mod tests {
     #[tokio::test]
     async fn interprets_close_transport() {
         let events = vec![OutboundEvent::CloseTransport];
-        let outcome = interpret(events, &test_registry()).await;
+        let outcome = interpret(events, &test_registry(), &test_mam()).await;
         assert!(outcome.close);
         assert!(outcome.frames.is_empty());
     }
@@ -253,7 +305,7 @@ mod tests {
             level: tracing::Level::INFO,
             message: "hello".to_string(),
         }];
-        let outcome = interpret(events, &test_registry()).await;
+        let outcome = interpret(events, &test_registry(), &test_mam()).await;
         assert!(outcome.frames.is_empty());
         assert!(!outcome.close);
     }
@@ -268,9 +320,43 @@ mod tests {
             },
             OutboundEvent::SendStanza(Box::new(Stanza::Iq(result_iq("b")))),
         ];
-        let outcome = interpret(events, &test_registry()).await;
+        let outcome = interpret(events, &test_registry(), &test_mam()).await;
         assert_eq!(outcome.frames.len(), 2);
         assert!(outcome.frames[0].contains("id=\"a\""));
         assert!(outcome.frames[1].contains("id=\"b\""));
+    }
+
+    #[tokio::test]
+    async fn archive_personal_message_persists_to_mam() {
+        use chrono::Utc;
+        use jid::BareJid;
+        use waddle_xmpp::mam::MamQuery;
+        use xmpp_parsers::message::{Body, Message, MessageType};
+
+        let alice: BareJid = "alice@waddle.test".parse().unwrap();
+        let mam = test_mam();
+
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(String::new(), Body("hello".into()));
+        waddle_xmpp::xep::xep0359::add_stanza_id(&mut msg, "uuid-1", &alice.to_string());
+
+        let events = vec![OutboundEvent::ArchivePersonalMessage {
+            archive_owner: alice.clone(),
+            archive_id: "uuid-1".to_string(),
+            message: Box::new(msg),
+        }];
+
+        let _ = interpret(events, &test_registry(), &mam).await;
+
+        let result = mam
+            .query_messages(&alice.to_string(), &MamQuery::default())
+            .await
+            .expect("query");
+        assert_eq!(result.messages.len(), 1);
+        assert_eq!(result.messages[0].id, "uuid-1");
+        let body = &result.messages[0].body;
+        assert_eq!(body, "hello");
+        let _ = Utc::now();
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -540,6 +540,7 @@ pub async fn handle_iq_with_conn_state(
         let mut features = vec![
             Feature::ping(),
             Feature::replies(),
+            Feature::stanza_id(),
             Feature::disco_info(),
             Feature::disco_items(),
             Feature::commands(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -266,6 +266,7 @@ pub async fn handle_iq_with_conn_state(
         let outcome = crate::server::routes::interpret::interpret(
             events,
             &state.deps.protocol.connection_registry,
+            &state.deps.protocol.mam_storage,
         )
         .await;
         if outcome.close {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -11,8 +11,9 @@ use waddle_xmpp::{
         },
         InboxEntry,
     },
-    mam::{add_stanza_id as add_mam_stanza_id, ArchivedMessage, STANZA_ID_NS},
+    mam::{add_stanza_id as add_mam_stanza_id, message_to_archived, ArchivedMessage, STANZA_ID_NS},
     muc::room_actor::BuildGroupchatBroadcast,
+    protocol::canonicalize::{canonicalize, Canonicalized},
     registry::{BroadcastOutcome, SendResult},
     xep::xep0430::build_inbox_push,
     xep::{
@@ -344,8 +345,22 @@ pub async fn handle_message(
                 state.deps.protocol.extension_manager.feature_namespaces(),
             );
 
-            // Archive body-bearing DMs to both sender's and recipient's personal MAM.
-            archive_direct_message(state, sender_jid, to_jid, &prototype).await;
+            // Archive body-bearing DMs to both sender's and recipient's
+            // personal MAM. Each archive write stamps a per-archive
+            // `<stanza-id by=$archive_owner/>` (XEP-0359 §"the assigning
+            // entity is the account") and the same canonicalized message
+            // — sender-stamped or recipient-stamped — is what we deliver
+            // on the wire and over carbons.
+            let archive_outcome =
+                archive_direct_message(state, sender_jid, to_jid, &prototype).await;
+            let prototype_for_recipient = archive_outcome
+                .as_ref()
+                .map(|o| o.recipient_canonical.clone())
+                .unwrap_or_else(|| prototype.clone());
+            let prototype_for_sender_carbons = archive_outcome
+                .as_ref()
+                .map(|o| o.sender_canonical.clone())
+                .unwrap_or_else(|| prototype.clone());
 
             if should_project_message(&prototype) {
                 let timestamp = Utc::now().timestamp();
@@ -386,9 +401,9 @@ pub async fn handle_message(
                 }
             }
 
-            // Route the enriched message
+            // Route the enriched, recipient-stamped message
             let delivered_full_jid = if let Ok(to_full_jid) = to_jid.clone().try_into_full() {
-                let mut msg = prototype.clone();
+                let mut msg = prototype_for_recipient.clone();
                 msg.to = Some(jid::Jid::from(to_full_jid.clone()));
                 let stanza = Stanza::Message(msg);
                 match state
@@ -409,7 +424,7 @@ pub async fn handle_message(
                     .connection_registry
                     .get_resources_for_user(&to_bare_jid);
                 for resource_jid in resources {
-                    let mut msg = prototype.clone();
+                    let mut msg = prototype_for_recipient.clone();
                     msg.to = Some(jid::Jid::from(resource_jid.clone()));
                     let stanza = Stanza::Message(msg);
                     let _ = state
@@ -427,15 +442,20 @@ pub async fn handle_message(
                     send_received_carbons_to_websocket_resources(
                         state,
                         recipient_full_jid,
-                        &prototype,
+                        &prototype_for_recipient,
                     )
                     .await;
                 }
-                send_sent_carbons_to_websocket_resources(state, sender_jid, &prototype).await;
+                send_sent_carbons_to_websocket_resources(
+                    state,
+                    sender_jid,
+                    &prototype_for_sender_carbons,
+                )
+                .await;
             }
 
             if has_github_embed {
-                let echo = prototype.clone();
+                let echo = prototype_for_sender_carbons.clone();
                 return vec![stanza_to_xml(&Stanza::Message(echo))];
             }
         } else {
@@ -641,46 +661,87 @@ async fn archive_groupchat_message(
     }
 }
 
-/// Archive a direct (type="chat") message to both the sender's and recipient's
-/// personal MAM archives.  Only messages with a `<body>` are stored.
+/// Outcome of archiving a direct message to both archives.
+///
+/// The two `Message` values are the same logical stanza canonicalized
+/// twice — once with `<stanza-id by=$sender_bare/>` for the sender's MAM
+/// (and any sent-carbons reaching the sender's other devices), and once
+/// with `<stanza-id by=$recipient_bare/>` for the recipient's MAM (the
+/// outbound wire stanza and any received-carbons).
+#[derive(Debug, Clone)]
+struct DirectArchiveOutcome {
+    sender_canonical: xmpp_parsers::message::Message,
+    recipient_canonical: xmpp_parsers::message::Message,
+}
+
+/// Archive a direct (type="chat") message to both the sender's and
+/// recipient's personal MAM archives, stamping each archive's row with a
+/// `<stanza-id>` whose `by` is the archive owner's bare JID per
+/// XEP-0359 §"the assigning entity is the account". Returns the two
+/// canonicalized messages so the caller can use them on the wire and on
+/// carbons; the same stanza-id is what clients see on delivery and what
+/// they can target for retraction/correction/reactions.
+///
+/// Only messages with a non-empty `<body>` are stored. When skipped,
+/// returns `None` and the caller falls back to delivering the un-stamped
+/// prototype.
 async fn archive_direct_message(
     state: &WebSocketState,
     sender_jid: &FullJid,
     to_jid: &jid::Jid,
     message: &xmpp_parsers::message::Message,
-) {
-    let Some(body) = prototype_body(message)
+) -> Option<DirectArchiveOutcome> {
+    let _ = prototype_body(message)
         .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
+        .filter(|value| !value.is_empty())?;
+
+    let sender_bare = sender_jid.to_bare();
+    let recipient_bare = to_jid.to_bare();
+
+    let Canonicalized {
+        message: sender_canonical,
+        stanza_id: sender_archive_id,
+    } = canonicalize(message.clone(), &sender_bare);
+    let Canonicalized {
+        message: recipient_canonical,
+        stanza_id: recipient_archive_id,
+    } = canonicalize(message.clone(), &recipient_bare);
+
+    // The canonicalizer produced a stanza-id iff the message is of an
+    // archivable type; chat messages always pass that check, so for the
+    // body-having direct-chat case both ids are present. Anything else
+    // is a logic bug.
+    let (Some(sender_archive_id), Some(recipient_archive_id)) =
+        (sender_archive_id, recipient_archive_id)
     else {
-        return;
+        warn!(
+            from = %sender_jid,
+            to = %to_jid,
+            "DM canonicalization unexpectedly skipped stamping; archive aborted"
+        );
+        return None;
     };
 
-    let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
-    let origin_id = extract_origin_id(message);
+    let timestamp = Utc::now();
+    let sender_archived = message_to_archived(
+        &sender_canonical,
+        &sender_bare,
+        &sender_archive_id,
+        timestamp,
+    );
+    let recipient_archived = message_to_archived(
+        &recipient_canonical,
+        &recipient_bare,
+        &recipient_archive_id,
+        timestamp,
+    );
 
-    let archived = ArchivedMessage {
-        id: String::new(),
-        timestamp: Utc::now(),
-        from: sender_jid.to_bare().to_string(),
-        to: to_jid.to_bare().to_string(),
-        body,
-        stanza_id: message.id.clone(),
-        thread_id: message.thread.as_ref().map(|thread| thread.0.clone()),
-        reply_to_id,
-        reply_to_jid,
-        origin_id,
-        message_type: mam_message_type(&message.type_),
-        stanza_xml: Some(archived_stanza_xml(message)),
-    };
-
-    // Store in sender's personal archive
-    let sender_bare = sender_jid.to_bare().to_string();
+    let sender_archive_jid = sender_bare.to_string();
     if let Err(err) = state
         .deps
         .protocol
         .mam_storage
-        .store_message(sender_bare.as_str(), &archived)
+        .store_message(sender_archive_jid.as_str(), &sender_archived)
         .await
     {
         warn!(
@@ -691,13 +752,12 @@ async fn archive_direct_message(
         );
     }
 
-    // Store in recipient's personal archive
-    let recipient_bare = to_jid.to_bare().to_string();
+    let recipient_archive_jid = recipient_bare.to_string();
     if let Err(err) = state
         .deps
         .protocol
         .mam_storage
-        .store_message(recipient_bare.as_str(), &archived)
+        .store_message(recipient_archive_jid.as_str(), &recipient_archived)
         .await
     {
         warn!(
@@ -707,6 +767,11 @@ async fn archive_direct_message(
             "Failed to archive DM to recipient's personal MAM"
         );
     }
+
+    Some(DirectArchiveOutcome {
+        sender_canonical,
+        recipient_canonical,
+    })
 }
 
 fn mam_message_type(message_type: &XmppMessageType) -> String {

--- a/server/crates/waddle-server/tests/xep0359_stanza_id_integration.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_id_integration.rs
@@ -1,0 +1,201 @@
+//! XEP-0359 (Unique and Stable Stanza IDs) integration tests over WebSocket.
+//!
+//! These exercise the wire-stamping behaviour of the message canonicalizer:
+//! 1:1 messages get per-archive `<stanza-id>` elements with `by=$archive_owner`,
+//! the strip rule removes any inbound `<stanza-id by=$us/>` forged by the
+//! sender, and `<origin-id/>` from the client is preserved.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{disco_info_query, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect_alice_bob() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+
+    let alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice connection");
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connection");
+
+    (server, alice, bob)
+}
+
+/// Pull the value of a `<stanza-id>` element whose `by` attribute equals
+/// `expected_by`. Returns `None` when no matching element is present.
+fn extract_stanza_id_by(frame: &str, expected_by: &str) -> Option<String> {
+    // The XML attribute order we generate is `xmlns="..."`, then `id`, then
+    // `by`. Be tolerant of single vs double quotes and arbitrary attribute
+    // order — we look for "stanza-id" with both id and by attributes.
+    for tag_start in frame
+        .match_indices("<stanza-id")
+        .map(|(idx, _)| idx)
+        .chain(frame.match_indices("<stanza-id ").map(|(idx, _)| idx))
+    {
+        let after_open = &frame[tag_start..];
+        let Some(tag_end) = after_open.find("/>").or_else(|| after_open.find('>')) else {
+            continue;
+        };
+        let tag_text = &after_open[..tag_end];
+        let by = attr_value(tag_text, "by")?;
+        if by == expected_by {
+            return attr_value(tag_text, "id");
+        }
+    }
+    None
+}
+
+fn attr_value(text: &str, name: &str) -> Option<String> {
+    for delim in ['"', '\''] {
+        let needle = format!(r#"{name}={delim}"#);
+        if let Some(start) = text.find(&needle) {
+            let value_start = start + needle.len();
+            if let Some(rel_end) = text[value_start..].find(delim) {
+                return Some(text[value_start..value_start + rel_end].to_string());
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn dm_carries_recipient_archive_stanza_id() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    let body_marker = format!("dm-{}", uuid::Uuid::new_v4());
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@{DOMAIN}" id="msg-1"><body>{body_marker}</body></message>"#
+        ))
+        .await
+        .expect("send dm");
+
+    let delivered = bob
+        .recv_matching(|frame| {
+            frame.contains(&body_marker)
+                && frame.contains("type=\"chat\"")
+                && frame.contains("<body>")
+        })
+        .await
+        .expect("dm delivery");
+
+    let stanza_id = extract_stanza_id_by(&delivered, &format!("bob@{DOMAIN}"))
+        .unwrap_or_else(|| {
+            panic!("recipient-archive <stanza-id by='bob@localhost'/> on delivery; delivered frame was: {delivered}")
+        });
+    assert!(
+        !stanza_id.is_empty(),
+        "stanza-id value must be non-empty: {delivered}"
+    );
+
+    bob.close().await;
+    alice.close().await;
+}
+
+#[tokio::test]
+async fn dm_strip_rule_removes_forged_recipient_stamp() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    // Alice forges a `<stanza-id>` with `by=bob@localhost` — the spec MUST
+    // says we strip this before re-stamping.
+    let body_marker = format!("forge-{}", uuid::Uuid::new_v4());
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@{DOMAIN}" id="msg-2"><body>{body_marker}</body><stanza-id xmlns="urn:xmpp:sid:0" id="forged-by-alice" by="bob@{DOMAIN}"/></message>"#
+        ))
+        .await
+        .expect("send forged");
+
+    let delivered = bob
+        .recv_matching(|frame| {
+            frame.contains(&body_marker)
+                && frame.contains("type=\"chat\"")
+                && frame.contains("<body>")
+        })
+        .await
+        .expect("forged dm delivery");
+
+    let stamped =
+        extract_stanza_id_by(&delivered, &format!("bob@{DOMAIN}")).expect("our recipient stamp");
+    assert_ne!(
+        stamped, "forged-by-alice",
+        "forged stanza-id must be replaced; saw {delivered}"
+    );
+
+    bob.close().await;
+    alice.close().await;
+}
+
+#[tokio::test]
+async fn dm_origin_id_preserved() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    let origin = format!("origin-{}", uuid::Uuid::new_v4());
+    let body_marker = format!("origin-test-{}", uuid::Uuid::new_v4());
+    alice
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@{DOMAIN}" id="msg-3"><body>{body_marker}</body><origin-id xmlns="urn:xmpp:sid:0" id="{origin}"/></message>"#
+        ))
+        .await
+        .expect("send with origin-id");
+
+    let delivered = bob
+        .recv_matching(|frame| {
+            frame.contains(&body_marker)
+                && frame.contains("type=\"chat\"")
+                && frame.contains("<body>")
+        })
+        .await
+        .expect("dm delivery");
+
+    assert!(
+        delivered.contains(&format!(r#"id="{origin}""#))
+            || delivered.contains(&format!("id='{origin}'")),
+        "origin-id must be preserved: {delivered}"
+    );
+
+    bob.close().await;
+    alice.close().await;
+}
+
+#[tokio::test]
+async fn disco_advertises_stanza_id_feature() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, _bob) = connect_alice_bob().await;
+
+    let response = disco_info_query(&mut alice, DOMAIN, "disco-sid-1")
+        .await
+        .expect("disco#info response");
+
+    assert!(
+        response.contains("urn:xmpp:sid:0"),
+        "server disco#info must list urn:xmpp:sid:0: {response}"
+    );
+
+    alice.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -96,6 +96,10 @@ impl Feature {
         Self::new("urn:xmpp:mam:2")
     }
 
+    pub fn stanza_id() -> Self {
+        Self::new("urn:xmpp:sid:0")
+    }
+
     pub fn replies() -> Self {
         Self::new("urn:xmpp:reply:0")
     }
@@ -441,6 +445,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::caps(),
         Feature::roster_versioning(),
         Feature::mam(),
+        Feature::stanza_id(),
         Feature::replies(),
         Feature::fallback_indication(),
         Feature::threads(),
@@ -535,6 +540,7 @@ pub fn muc_room_features(
         Feature::disco_info(),
         Feature::muc(),
         Feature::mam(),
+        Feature::stanza_id(),
         Feature::replies(),
         Feature::fallback_indication(),
         Feature::threads(),

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -13,8 +13,10 @@
 //! `waddle-xmpp-core` so server and client crates can share typed history
 //! primitives without runtime coupling.
 
+pub mod sink;
 pub mod storage;
 
+pub use sink::message_to_archived;
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
 pub use waddle_xmpp_core::mam::{
     add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,

--- a/server/crates/waddle-xmpp/src/mam/sink.rs
+++ b/server/crates/waddle-xmpp/src/mam/sink.rs
@@ -1,0 +1,144 @@
+//! Storage-boundary conversion from typed [`Message`] to [`ArchivedMessage`].
+//!
+//! Per the project's typed-payloads rule, protocol values flow through the
+//! sans-I/O state machine and handlers as typed Rust values. This module is
+//! the *single* serialization seam where a typed `Message` is decomposed
+//! into [`ArchivedMessage`]'s string-shaped storage form (the SQL row
+//! schema). Anywhere else that constructs an `ArchivedMessage` literal is a
+//! historical artefact tracked under #228; new archive writes go through
+//! [`message_to_archived`].
+
+use chrono::{DateTime, Utc};
+use jid::BareJid;
+use xmpp_parsers::message::{Message, MessageType};
+
+use crate::mam::ArchivedMessage;
+use crate::parser::message_to_string;
+use crate::xep::{xep0359, xep0461};
+
+/// Convert a fully-canonicalized message into its archive row.
+///
+/// `archive_id` MUST equal the `<stanza-id by=$archive_owner/>` value the
+/// canonicalizer stamped — both fields end up populated to that same value
+/// for cross-row lookup symmetry.
+pub fn message_to_archived(
+    message: &Message,
+    archive_owner: &BareJid,
+    archive_id: &str,
+    timestamp: DateTime<Utc>,
+) -> ArchivedMessage {
+    let from = message
+        .from
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+
+    let to = message
+        .to
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| archive_owner.to_string());
+
+    let body = message
+        .bodies
+        .get("")
+        .or_else(|| message.bodies.values().next())
+        .map(|b| b.0.clone())
+        .unwrap_or_default();
+
+    let reply = xep0461::parse_reply_from_message(message);
+
+    ArchivedMessage {
+        id: archive_id.to_owned(),
+        timestamp,
+        from,
+        to,
+        body,
+        stanza_id: Some(archive_id.to_owned()),
+        thread_id: xep0461::thread_id_from_message(message),
+        reply_to_id: reply.as_ref().map(|r| r.id.clone()),
+        reply_to_jid: reply.and_then(|r| r.to),
+        origin_id: xep0359::extract_origin_id_str(message),
+        message_type: message_type_to_str(&message.type_).to_owned(),
+        stanza_xml: message_to_string(message).ok(),
+    }
+}
+
+fn message_type_to_str(t: &MessageType) -> &'static str {
+    match t {
+        MessageType::Chat => "chat",
+        MessageType::Groupchat => "groupchat",
+        MessageType::Normal => "normal",
+        MessageType::Headline => "headline",
+        MessageType::Error => "error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use xmpp_parsers::jid::Jid;
+    use xmpp_parsers::message::Body;
+
+    fn alice_bare() -> BareJid {
+        "alice@waddle.test".parse().expect("valid bare jid")
+    }
+
+    fn bob_bare() -> BareJid {
+        "bob@waddle.test".parse().expect("valid bare jid")
+    }
+
+    fn ts() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 4, 26, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn maps_typed_chat_to_archive_row() {
+        let mut msg = Message::new(Some(Jid::from(bob_bare())));
+        msg.from = Some(Jid::from(alice_bare()));
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(String::new(), Body("hi bob".into()));
+        xep0359::add_origin_id(&mut msg, "client-origin-1");
+
+        let row = message_to_archived(&msg, &bob_bare(), "archive-uuid-1", ts());
+
+        assert_eq!(row.id, "archive-uuid-1");
+        assert_eq!(row.stanza_id.as_deref(), Some("archive-uuid-1"));
+        assert_eq!(row.from, "alice@waddle.test");
+        assert_eq!(row.to, "bob@waddle.test");
+        assert_eq!(row.body, "hi bob");
+        assert_eq!(row.origin_id.as_deref(), Some("client-origin-1"));
+        assert_eq!(row.message_type, "chat");
+        assert!(row.stanza_xml.is_some());
+    }
+
+    #[test]
+    fn falls_back_to_archive_owner_when_to_is_missing() {
+        let mut msg = Message::new(None);
+        msg.from = Some(Jid::from(alice_bare()));
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(String::new(), Body("self note".into()));
+
+        let row = message_to_archived(&msg, &alice_bare(), "id", ts());
+
+        assert_eq!(row.to, "alice@waddle.test");
+    }
+
+    #[test]
+    fn extracts_reply_reference() {
+        let mut msg = Message::new(Some(Jid::from(bob_bare())));
+        msg.from = Some(Jid::from(alice_bare()));
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(String::new(), Body("ack".into()));
+        xep0461::set_reply_payload(
+            &mut msg,
+            &xep0461::ReplyReference::new("orig-1").with_to("bob@waddle.test"),
+        );
+
+        let row = message_to_archived(&msg, &bob_bare(), "id", ts());
+
+        assert_eq!(row.reply_to_id.as_deref(), Some("orig-1"));
+        assert_eq!(row.reply_to_jid.as_deref(), Some("bob@waddle.test"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/canonicalize.rs
@@ -1,0 +1,264 @@
+//! XEP-0359 inbound canonicalization.
+//!
+//! A single point that prepares an inbound message for archiving and
+//! broadcast. It always enforces the XEP-0359 strip rule (a generating entity
+//! MUST delete any `<stanza-id/>` whose `by` matches its own scope) and, when
+//! the message is of an archivable type, stamps a fresh `<stanza-id/>` whose
+//! `by` is the archive owner — `account@server` for personal archives,
+//! `room@muc.server` for MUC archives — per XEP-0359 § "the assigning entity
+//! is the account / room".
+//!
+//! The same canonicalized message is what gets persisted to MAM *and* what
+//! gets broadcast on the wire, so clients see one stable identifier across
+//! both surfaces. Origin-ids are preserved untouched (XEP-0359 MUST).
+
+use crate::xep::xep0359;
+use jid::BareJid;
+use uuid::Uuid;
+use xmpp_parsers::message::{Message, MessageType};
+
+/// Output of [`canonicalize`].
+#[derive(Debug, Clone)]
+pub struct Canonicalized {
+    /// The canonicalized message — strip rule applied, plus a server-assigned
+    /// `<stanza-id/>` when the message is of an archivable type.
+    pub message: Message,
+    /// `Some(uuid)` when the message was stamped (i.e. it is archivable),
+    /// `None` for `headline` / `error` / bodyless `normal`.
+    pub stanza_id: Option<String>,
+}
+
+/// Whether this message type carries content the server should archive.
+///
+/// Per the project decision aligned with XEP-0313 §4.1.1: archive `chat`,
+/// `groupchat`, and `normal` messages that have a body. Skip `headline` and
+/// `error` entirely.
+pub fn should_archive(msg: &Message) -> bool {
+    match msg.type_ {
+        MessageType::Chat | MessageType::Groupchat => true,
+        MessageType::Normal => has_non_empty_body(msg),
+        MessageType::Headline | MessageType::Error => false,
+    }
+}
+
+/// Canonicalize `msg` for the archive owned by `archive_owner`, generating a
+/// fresh v7 UUID when stamping is needed.
+pub fn canonicalize(msg: Message, archive_owner: &BareJid) -> Canonicalized {
+    canonicalize_with_id(msg, archive_owner, || Uuid::now_v7().to_string())
+}
+
+/// Variant of [`canonicalize`] that lets callers inject the stanza-id value —
+/// used by tests to make outputs deterministic.
+pub fn canonicalize_with_id<F>(
+    mut msg: Message,
+    archive_owner: &BareJid,
+    fresh_id: F,
+) -> Canonicalized
+where
+    F: FnOnce() -> String,
+{
+    let by = archive_owner.to_string();
+    xep0359::remove_stanza_ids_by(&mut msg, &by);
+
+    let stanza_id = if should_archive(&msg) {
+        let id = fresh_id();
+        xep0359::add_stanza_id(&mut msg, &id, &by);
+        Some(id)
+    } else {
+        None
+    };
+
+    Canonicalized {
+        message: msg,
+        stanza_id,
+    }
+}
+
+fn has_non_empty_body(msg: &Message) -> bool {
+    msg.bodies.values().any(|b| !b.0.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minidom::Element;
+    use xmpp_parsers::message::{Body, MessageType};
+
+    const SERVER: &str = "waddle.test";
+
+    fn alice() -> BareJid {
+        format!("alice@{SERVER}").parse().expect("valid bare jid")
+    }
+
+    fn bob() -> BareJid {
+        format!("bob@{SERVER}").parse().expect("valid bare jid")
+    }
+
+    fn room() -> BareJid {
+        format!("room@conference.{SERVER}")
+            .parse()
+            .expect("valid bare jid")
+    }
+
+    fn chat_with_body(text: &str) -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(String::new(), Body(text.to_owned()));
+        msg
+    }
+
+    fn groupchat_with_body(text: &str) -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Groupchat;
+        msg.bodies.insert(String::new(), Body(text.to_owned()));
+        msg
+    }
+
+    fn normal_without_body() -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Normal;
+        msg
+    }
+
+    fn normal_with_body(text: &str) -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Normal;
+        msg.bodies.insert(String::new(), Body(text.to_owned()));
+        msg
+    }
+
+    fn headline_with_body(text: &str) -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Headline;
+        msg.bodies.insert(String::new(), Body(text.to_owned()));
+        msg
+    }
+
+    fn error_with_body(text: &str) -> Message {
+        let mut msg = Message::new(None);
+        msg.type_ = MessageType::Error;
+        msg.bodies.insert(String::new(), Body(text.to_owned()));
+        msg
+    }
+
+    fn forged_stanza_id_for(by: &BareJid) -> Element {
+        Element::builder("stanza-id", xep0359::NS_SID)
+            .attr("id", "forged-by-client")
+            .attr("by", by.to_string())
+            .build()
+    }
+
+    #[test]
+    fn stamps_chat_with_archive_owner_by() {
+        let result = canonicalize_with_id(chat_with_body("hi"), &alice(), || "uuid-1".into());
+
+        assert_eq!(result.stanza_id.as_deref(), Some("uuid-1"));
+        let ids = xep0359::extract_stanza_ids(&result.message);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].id, "uuid-1");
+        assert_eq!(ids[0].by, alice().to_string());
+    }
+
+    #[test]
+    fn stamps_groupchat_with_room_by() {
+        let result =
+            canonicalize_with_id(groupchat_with_body("hello"), &room(), || "room-uuid".into());
+
+        assert_eq!(result.stanza_id.as_deref(), Some("room-uuid"));
+        let ids = xep0359::extract_stanza_ids(&result.message);
+        assert_eq!(ids[0].by, room().to_string());
+    }
+
+    #[test]
+    fn strips_forged_stanza_id_matching_owner_then_stamps_fresh() {
+        let mut msg = chat_with_body("hi");
+        msg.payloads.push(forged_stanza_id_for(&alice()));
+
+        let result = canonicalize_with_id(msg, &alice(), || "fresh".into());
+
+        let ids = xep0359::extract_stanza_ids(&result.message);
+        assert_eq!(ids.len(), 1, "exactly one stanza-id remains");
+        assert_eq!(ids[0].id, "fresh");
+        assert_eq!(ids[0].by, alice().to_string());
+    }
+
+    #[test]
+    fn preserves_stanza_ids_from_other_entities() {
+        let mut msg = chat_with_body("hi");
+        msg.payloads.push(forged_stanza_id_for(&bob()));
+
+        let result = canonicalize_with_id(msg, &alice(), || "alice-id".into());
+
+        let ids = xep0359::extract_stanza_ids(&result.message);
+        assert_eq!(ids.len(), 2, "bob's stanza-id stays, alice's gets added");
+        assert!(ids.iter().any(|s| s.by == bob().to_string()));
+        assert!(ids.iter().any(|s| s.by == alice().to_string()));
+    }
+
+    #[test]
+    fn preserves_origin_id() {
+        let mut msg = chat_with_body("hi");
+        xep0359::add_origin_id(&mut msg, "client-origin");
+
+        let result = canonicalize_with_id(msg, &alice(), || "uuid".into());
+
+        assert_eq!(
+            xep0359::extract_origin_id_str(&result.message).as_deref(),
+            Some("client-origin")
+        );
+    }
+
+    #[test]
+    fn skips_stamp_for_headline_but_still_strips() {
+        let mut msg = headline_with_body("notification");
+        msg.payloads.push(forged_stanza_id_for(&alice()));
+
+        let result = canonicalize_with_id(msg, &alice(), || {
+            panic!("should not be called for headline")
+        });
+
+        assert!(result.stanza_id.is_none());
+        assert!(
+            xep0359::extract_stanza_ids(&result.message).is_empty(),
+            "forged stanza-id was stripped even though we did not re-stamp"
+        );
+    }
+
+    #[test]
+    fn skips_stamp_for_error_but_still_strips() {
+        let mut msg = error_with_body("err");
+        msg.payloads.push(forged_stanza_id_for(&alice()));
+
+        let result = canonicalize_with_id(msg, &alice(), || panic!("should not stamp"));
+
+        assert!(result.stanza_id.is_none());
+        assert!(xep0359::extract_stanza_ids(&result.message).is_empty());
+    }
+
+    #[test]
+    fn skips_normal_without_body() {
+        let result = canonicalize_with_id(normal_without_body(), &alice(), || {
+            panic!("should not stamp")
+        });
+
+        assert!(result.stanza_id.is_none());
+    }
+
+    #[test]
+    fn stamps_normal_with_body() {
+        let result =
+            canonicalize_with_id(normal_with_body("system"), &alice(), || "norm-id".into());
+
+        assert_eq!(result.stanza_id.as_deref(), Some("norm-id"));
+    }
+
+    #[test]
+    fn should_archive_classification() {
+        assert!(should_archive(&chat_with_body("x")));
+        assert!(should_archive(&groupchat_with_body("x")));
+        assert!(should_archive(&normal_with_body("x")));
+        assert!(!should_archive(&normal_without_body()));
+        assert!(!should_archive(&headline_with_body("x")));
+        assert!(!should_archive(&error_with_body("x")));
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -165,18 +165,24 @@ pub enum OutboundEvent {
     // -------------------------------------------------------------------
     // Storage
     // -------------------------------------------------------------------
-    /// Persist a groupchat message to the MAM archive.
+    /// Persist a message to a personal MAM archive owned by `archive_owner`.
     ///
-    /// The interpreter's MAM storage layer owns ID generation and indexing.
-    ArchiveGroupchat {
-        room: BareJid,
-        sender: FullJid,
+    /// One archive flow per archive owner. For 1:1 messages this event is
+    /// emitted twice — once for the sender's archive and once for the
+    /// recipient's — each carrying a `message` that has already been
+    /// canonicalized for that archive's `by` (see
+    /// [`super::canonicalize::canonicalize`]). The interpreter trusts the
+    /// stamp and persists the typed `Message` as-is.
+    ArchivePersonalMessage {
+        archive_owner: BareJid,
         message: Box<Message>,
     },
-    /// Persist a one-to-one direct message to the MAM archive.
-    ArchiveDirect {
-        from: BareJid,
-        to: BareJid,
+    /// Persist a groupchat message to a room's MAM archive.
+    ///
+    /// The `message` MUST already be canonicalized with `by=$room` by the
+    /// emitter. The interpreter persists and does not re-stamp.
+    ArchiveRoomMessage {
+        room: BareJid,
         message: Box<Message>,
     },
 

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -169,20 +169,22 @@ pub enum OutboundEvent {
     ///
     /// One archive flow per archive owner. For 1:1 messages this event is
     /// emitted twice — once for the sender's archive and once for the
-    /// recipient's — each carrying a `message` that has already been
-    /// canonicalized for that archive's `by` (see
-    /// [`super::canonicalize::canonicalize`]). The interpreter trusts the
-    /// stamp and persists the typed `Message` as-is.
+    /// recipient's — each carrying a `message` already canonicalized for
+    /// that archive's `by` (see [`super::canonicalize::canonicalize`]) and
+    /// the matching `archive_id` (the stanza-id UUID that the canonicalizer
+    /// stamped). The interpreter trusts the stamp and persists as-is.
     ArchivePersonalMessage {
         archive_owner: BareJid,
+        archive_id: String,
         message: Box<Message>,
     },
     /// Persist a groupchat message to a room's MAM archive.
     ///
     /// The `message` MUST already be canonicalized with `by=$room` by the
-    /// emitter. The interpreter persists and does not re-stamp.
+    /// emitter, and `archive_id` is the matching stanza-id UUID.
     ArchiveRoomMessage {
         room: BareJid,
+        archive_id: String,
         message: Box<Message>,
     },
 

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -23,6 +23,7 @@
 //! Only the middle layer — the state machine — lives here. The WebSocket C2S
 //! adapter and its async interpreter remain the caller's responsibility.
 
+pub mod canonicalize;
 pub mod dispatch;
 pub mod event;
 pub mod frame;
@@ -31,6 +32,7 @@ pub mod machine;
 pub mod phase;
 pub mod traits;
 
+pub use canonicalize::{canonicalize, canonicalize_with_id, should_archive, Canonicalized};
 pub use dispatch::StanzaDispatcher;
 pub use event::{CallbackId, InboundEvent, OutboundEvent, StanzaContext, TimerId};
 pub use frame::InboundFrame;


### PR DESCRIPTION
Implements **PR1 of 4** for #211 — XEP-0359 stanza-id wire stamping for direct messages.

After codebase exploration, the live message handler at `routes/websocket/handlers/message.rs` turned out to be mature and active (already archives both groupchat and DM, already stamps groupchat with `by=$room`). The original plan to absorb a full sans-I/O migration of message routing was descoped to **option (III) — surgical conformance fix here, full migration deferred to #229**.

## Conformance fix in this PR

- **DM wire stamping (the original gap).** `archive_direct_message` now runs the new `protocol::canonicalize` module twice — once per archive owner — and returns the two canonicalized messages. Recipient gets a stanza carrying `<stanza-id by='$recipient_bare'/>`; sender's other devices get sent-carbons carrying `<stanza-id by='$sender_bare'/>`. Two distinct UUIDs, account-scoped `by`, per XEP-0359 §"the assigning entity is the account."
- **Strip rule (XEP-0359 MUST)**: forged inbound `<stanza-id by=$us/>` is stripped before our stamp.
- **Origin-id preservation (XEP-0359 MUST)**: client's `<origin-id/>` is preserved untouched.
- **Disco**: `urn:xmpp:sid:0` advertised in both `server_features()` and `muc_room_features()`, plus the hard-coded server-disco list in `iq.rs`.
- **MUC**: already conformant (`archive_groupchat_message` + `add_mam_stanza_id`). No MUC change.

## Foundation for the deferred migration

Even though the live DM path uses the surgical fix, the sans-I/O scaffolding the migration will need is committed and tested:
- `MessageCanonicalizer` module — pure function, 10 unit tests.
- Per-archive event variants `ArchivePersonalMessage` / `ArchiveRoomMessage` carrying explicit `archive_id`.
- `mam::sink::message_to_archived` converter — typed `Message` → `ArchivedMessage` at the storage boundary.
- Interpreter wiring against `MamStorage` for both archive variants — round-trip test passing.

These are consumed by #229 (sans-I/O migration of `message.rs`) and complement the rich-message handlers in PR2-PR4. The surgical fix path uses the canonicalizer directly; the event/interpreter path stands ready for the migration.

## Tests

`server/crates/waddle-server/tests/xep0359_stanza_id_integration.rs` (4 cases) using the existing `ws_common` WebSocket harness:

- DM delivery carries a recipient-archive `<stanza-id by='bob@localhost'/>`.
- Strip rule replaces a sender-forged `<stanza-id by=$recipient/>`.
- Client-supplied `<origin-id/>` survives the round-trip.
- Disco lists `urn:xmpp:sid:0`.

Plus `mam::sink` converter tests (3 cases) and `protocol::canonicalize` tests (10 cases) at the unit level. All existing integration tests (XEP-0313 MAM, XEP-0280 carbons, etc.) continue to pass.

## Out of scope

- **Sans-I/O migration of `message.rs`** — tracked in **#229**.
- **`ArchivedMessage` typed-payload refactor** — string fields preserved at the storage boundary; tracked in **#228**.
- **Carbon fan-out implementation** — XEP-0280's enable/disable IQ remains stubbed-ack; out of scope per #211.
- **s2s federation** — `route_message_remote` already returns `RemoteUnsupported`; unchanged.

## Subsequent PRs

- **PR2** — XEP-0308 corrections + XEP-0461 replies. Will hook into `message.rs`'s archive sink to inspect/route correction and reply payloads.
- **PR3** — XEP-0424 retraction + XEP-0425 moderation.
- **PR4** — XEP-0444 reactions + XEP-0372/0513 mentions/references.

Refs #211, #228, #229.