### PR TITLE
fix(server): #211 conformance follow-ups (typed errors, authz, disco)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -958,6 +958,61 @@ pub async fn handle_iq_with_conn_state(
             {
                 warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to archive moderation event");
             }
+
+            // XEP-0425 §"the archiving service MAY replace the
+            // retracted message with a tombstone": replace the
+            // original room archive row with a moderation tombstone
+            // whose `<retracted/>` carries `<moderated by/>` and the
+            // optional reason.
+            let original_lookup = state
+                .deps
+                .protocol
+                .mam_storage
+                .get_message(&request.target_id)
+                .await;
+            match original_lookup {
+                Ok(Some(original)) if original.to == room_jid.to_string() => {
+                    let tombstone = waddle_xmpp::mam::ArchivedTombstone {
+                        retraction_id: moderation
+                            .id
+                            .clone()
+                            .and_then(waddle_xmpp::mam::RichMessageId::new),
+                        stamp: stamp_time,
+                        moderation: Some(ArchivedModeration {
+                            target_id: waddle_xmpp::mam::RichMessageId::new(
+                                request.target_id.clone(),
+                            )
+                            .expect("target id is non-empty here"),
+                            moderated_by: moderated_by
+                                .parse::<Jid>()
+                                .expect("moderated_by parsed earlier"),
+                            stamp: Some(stamp_time),
+                            reason: request.reason.as_deref().and_then(RichText::new),
+                        }),
+                    };
+                    if let Err(error) = state
+                        .deps
+                        .protocol
+                        .mam_storage
+                        .replace_with_tombstone(&original.id, tombstone)
+                        .await
+                    {
+                        warn!(
+                            room = %room_jid,
+                            target = %request.target_id,
+                            error = %error,
+                            "Failed to replace original with moderation tombstone"
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => warn!(
+                    room = %room_jid,
+                    target = %request.target_id,
+                    error = %error,
+                    "Failed to look up moderation target for tombstone"
+                ),
+            }
         }
 
         let mut frames = Vec::new();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -538,22 +538,20 @@ pub async fn handle_iq_with_conn_state(
             return vec![iq_to_xml(response)];
         }
 
-        // Disco info on server
+        // Disco info on server. Source the canonical feature catalogue
+        // from `waddle-xmpp-core::disco::info::server_features()` so the
+        // rich-message XEPs (corrections, retractions, reactions,
+        // references, stanza-ids, etc.) declared there stay discoverable
+        // here without drift between the two lists. Server-instance
+        // additions (Spaces, jabber:iq:search, ISR) are appended below,
+        // and dynamic extension namespaces extend further still.
         let identities = vec![Identity::server(Some("Waddle"))];
-        let mut features = vec![
-            Feature::ping(),
-            Feature::replies(),
-            Feature::disco_info(),
-            Feature::disco_items(),
-            Feature::commands(),
+        let mut features = waddle_xmpp::disco::info::server_features();
+        features.extend([
             Feature::spaces(),
-            Feature::last_activity(),
-            Feature::software_version(),
-            Feature::entity_time(),
-            Feature::blocking(),
             Feature::new("jabber:iq:search"),
             Feature::new(ISR_NS),
-        ];
+        ]);
         features.extend(
             state
                 .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -850,9 +850,13 @@ pub async fn handle_iq_with_conn_state(
                 )]
             }
         };
-        let is_moderator = matches!(context.affiliation, Affiliation::Owner | Affiliation::Admin)
-            || matches!(context.role, waddle_xmpp::Role::Moderator);
-        if !is_moderator {
+        // XEP-0425 §"only moderators are allowed to moderate" combined with
+        // XEP-0045 §5.1.2: runtime moderation privilege is role-bound, not
+        // affiliation-bound. Owner/Admin affiliations only matter to the
+        // extent that they cause the room to grant the Moderator *role* on
+        // entry; if an owner has explicitly taken a non-moderator role
+        // (e.g. visitor), that signal is intentional and must be honoured.
+        if !matches!(context.role, waddle_xmpp::Role::Moderator) {
             return vec![build_iq_error_xml_with_addresses(
                 &id,
                 response_from,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -943,6 +943,7 @@ pub async fn handle_iq_with_conn_state(
                     references: Vec::new(),
                     mentions: Vec::new(),
                 }),
+                nickname_generation: None,
             };
             if let Err(error) = state
                 .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -922,7 +922,7 @@ pub async fn handle_iq_with_conn_state(
             moderated_by.parse::<Jid>(),
         ) {
             let archived = ArchivedMessage {
-                id: archive_id,
+                id: archive_id.clone(),
                 timestamp: chrono::Utc::now(),
                 from: room_jid.to_string(),
                 to: room_jid.to_string(),
@@ -970,11 +970,16 @@ pub async fn handle_iq_with_conn_state(
                 .await;
             match original_lookup {
                 Ok(Some(original)) if original.to == room_jid.to_string() => {
+                    // Use the moderation message's server-assigned
+                    // archive id (XEP-0359 stanza-id stamped via
+                    // `add_mam_stanza_id` above). That's the id
+                    // clients see on the live moderation broadcast
+                    // and need to correlate against the tombstone —
+                    // `moderation.id` is the client message-id
+                    // attribute, which would not match the archive
+                    // entry clients can resolve.
                     let tombstone = waddle_xmpp::mam::ArchivedTombstone {
-                        retraction_id: moderation
-                            .id
-                            .clone()
-                            .and_then(waddle_xmpp::mam::RichMessageId::new),
+                        retraction_id: waddle_xmpp::mam::RichMessageId::new(archive_id.clone()),
                         stamp: stamp_time,
                         moderation: Some(ArchivedModeration {
                             target_id: waddle_xmpp::mam::RichMessageId::new(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -156,7 +156,7 @@ pub async fn handle_message(
         {
             apply_retraction_tombstones(
                 state,
-                &[room_jid.to_string()],
+                std::slice::from_ref(&room_jid),
                 &prototype,
                 &retraction.retracts_id,
                 Utc::now(),
@@ -399,10 +399,7 @@ pub async fn handle_message(
             if let Some(RetractionKind::Request(retraction)) =
                 extract_retraction_from_message(&prototype)
             {
-                let archives = [
-                    sender_jid.to_bare().to_string(),
-                    to_jid.to_bare().to_string(),
-                ];
+                let archives = [sender_jid.to_bare(), to_jid.to_bare()];
                 apply_retraction_tombstones(
                     state,
                     &archives,
@@ -583,12 +580,10 @@ async fn validate_rich_message_targets(
         ));
     }
 
-    let archive_jid_str = archive_jid.to_string();
-
     if let Some(correction) = extract_correction_from_message(message) {
         let original = match lookup_correction_target_message(
             state,
-            archive_jid_str.as_str(),
+            archive_jid,
             &correction.replaces_id,
             groupchat,
         )
@@ -611,7 +606,7 @@ async fn validate_rich_message_targets(
     if let Some(RetractionKind::Request(retraction)) = extract_retraction_from_message(message) {
         let original = match lookup_retraction_target_message(
             state,
-            archive_jid_str.as_str(),
+            archive_jid,
             &retraction.retracts_id,
             groupchat,
         )
@@ -650,7 +645,7 @@ async fn validate_rich_message_targets(
 /// is on archive distribution, not on the retraction itself).
 async fn apply_retraction_tombstones(
     state: &WebSocketState,
-    archive_jids: &[String],
+    archive_jids: &[BareJid],
     retraction_message: &xmpp_parsers::message::Message,
     target_id: &str,
     stamp: chrono::DateTime<chrono::Utc>,
@@ -664,7 +659,7 @@ async fn apply_retraction_tombstones(
     for archive_jid in archive_jids {
         let original = match lookup_retraction_target_message(
             state,
-            archive_jid.as_str(),
+            archive_jid,
             target_id,
             groupchat,
         )
@@ -804,7 +799,7 @@ fn internal_server_error_for_lookup() -> StanzaError {
 
 async fn lookup_correction_target_message(
     state: &WebSocketState,
-    archive_jid: &str,
+    archive_jid: &BareJid,
     target_id: &str,
     _groupchat: bool,
 ) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
@@ -812,13 +807,13 @@ async fn lookup_correction_target_message(
         .deps
         .protocol
         .mam_storage
-        .get_message_by_message_id(archive_jid, target_id)
+        .get_message_by_message_id(&archive_jid.to_string(), target_id)
         .await
 }
 
 async fn lookup_retraction_target_message(
     state: &WebSocketState,
-    archive_jid: &str,
+    archive_jid: &BareJid,
     target_id: &str,
     groupchat: bool,
 ) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
@@ -830,31 +825,32 @@ async fn lookup_retraction_target_message(
         .deps
         .protocol
         .mam_storage
-        .get_message_by_message_id(archive_jid, target_id)
+        .get_message_by_message_id(&archive_jid.to_string(), target_id)
         .await
 }
 
 async fn lookup_rich_target_message(
     state: &WebSocketState,
-    archive_jid: &str,
+    archive_jid: &BareJid,
     target_id: &str,
     groupchat: bool,
 ) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
     if groupchat {
+        let archive_str = archive_jid.to_string();
         return state
             .deps
             .protocol
             .mam_storage
             .get_message(target_id)
             .await
-            .map(|message| message.filter(|message| message.to == archive_jid));
+            .map(|message| message.filter(|message| message.to == archive_str));
     }
 
     state
         .deps
         .protocol
         .mam_storage
-        .get_message_by_stanza_id(archive_jid, target_id)
+        .get_message_by_stanza_id(&archive_jid.to_string(), target_id)
         .await
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -16,7 +16,7 @@ use waddle_xmpp::{
         ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
         ArchivedRichPayload, RichMessageId, RichText, STANZA_ID_NS,
     },
-    muc::room_actor::BuildGroupchatBroadcast,
+    muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
     registry::{BroadcastOutcome, SendResult},
     xep::xep0430::build_inbox_push,
     xep::{
@@ -38,6 +38,7 @@ use crate::auth::Session;
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::permissions::{CheckPermission, Object, ObjectType, Permission, Subject};
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
+use kameo::actor::ActorRef;
 use waddle_xmpp::protocol::ConnectionPhase;
 
 pub async fn handle_message(
@@ -124,6 +125,7 @@ pub async fn handle_message(
         let sender_nick = broadcast.sender_nick;
         let mut local_messages = broadcast.messages;
         let occupant_bare_jids = broadcast.occupant_bare_jids;
+        let sender_nickname_generation = broadcast.sender_nickname_generation;
 
         let from_room_jid = format!("{}/{}", room_jid, sender_nick);
         if let Ok(from_jid) = from_room_jid.parse::<FullJid>() {
@@ -134,7 +136,8 @@ pub async fn handle_message(
         prototype.to = None;
 
         if let Err(error) =
-            validate_rich_message_targets(state, &room_jid.to_string(), &prototype, true).await
+            validate_rich_message_targets(state, &room_jid, &prototype, true, Some(&room_actor))
+                .await
         {
             return vec![stanza_to_xml(&Stanza::Message(error_message(
                 &incoming,
@@ -145,7 +148,9 @@ pub async fn handle_message(
         }
 
         // Archive body-bearing and rich protocol room messages in XMPP MAM storage.
-        let archive_id = archive_groupchat_message(state, &room_jid, &mut prototype).await;
+        let archive_id =
+            archive_groupchat_message(state, &room_jid, &mut prototype, sender_nickname_generation)
+                .await;
 
         if should_project_message(&prototype) {
             let timestamp = Utc::now().timestamp();
@@ -357,13 +362,9 @@ pub async fn handle_message(
                 state.deps.protocol.extension_manager.feature_namespaces(),
             );
 
-            if let Err(error) = validate_rich_message_targets(
-                state,
-                &sender_jid.to_bare().to_string(),
-                &prototype,
-                false,
-            )
-            .await
+            if let Err(error) =
+                validate_rich_message_targets(state, &sender_jid.to_bare(), &prototype, false, None)
+                    .await
             {
                 return vec![stanza_to_xml(&Stanza::Message(error_message(
                     &incoming,
@@ -528,9 +529,10 @@ fn error_message(
 
 async fn validate_rich_message_targets(
     state: &WebSocketState,
-    archive_jid: &str,
+    archive_jid: &BareJid,
     message: &xmpp_parsers::message::Message,
     groupchat: bool,
+    room_actor: Option<&ActorRef<RoomActor>>,
 ) -> Result<(), StanzaError> {
     let Some(sender) = message.from.as_ref() else {
         return Ok(());
@@ -541,10 +543,12 @@ async fn validate_rich_message_targets(
         ));
     }
 
+    let archive_jid_str = archive_jid.to_string();
+
     if let Some(correction) = extract_correction_from_message(message) {
         let original = match lookup_correction_target_message(
             state,
-            archive_jid,
+            archive_jid_str.as_str(),
             &correction.replaces_id,
             groupchat,
         )
@@ -559,12 +563,15 @@ async fn validate_rich_message_targets(
                 "Only the original sender may correct a message.",
             ));
         }
+        if groupchat {
+            verify_muc_occupancy_generation(sender, &original, room_actor).await?;
+        }
     }
 
     if let Some(RetractionKind::Request(retraction)) = extract_retraction_from_message(message) {
         let original = match lookup_retraction_target_message(
             state,
-            archive_jid,
+            archive_jid_str.as_str(),
             &retraction.retracts_id,
             groupchat,
         )
@@ -582,7 +589,13 @@ async fn validate_rich_message_targets(
     }
 
     if let Some(reactions) = extract_reactions_from_message(message) {
-        match lookup_rich_target_message(state, archive_jid, &reactions.message_id, groupchat).await
+        match lookup_rich_target_message(
+            state,
+            archive_jid_str.as_str(),
+            &reactions.message_id,
+            groupchat,
+        )
+        .await
         {
             Ok(Some(_)) => {}
             Ok(None) => return Err(item_not_found_error("Reaction target not found.")),
@@ -591,11 +604,68 @@ async fn validate_rich_message_targets(
     }
 
     if let Some(reply) = parse_reply_from_message(message) {
-        match lookup_rich_target_message(state, archive_jid, &reply.id, groupchat).await {
+        match lookup_rich_target_message(state, archive_jid_str.as_str(), &reply.id, groupchat)
+            .await
+        {
             Ok(Some(_)) => {}
             Ok(None) => return Err(item_not_found_error("Reply target not found.")),
             Err(_) => return Err(internal_server_error_for_lookup()),
         }
+    }
+
+    Ok(())
+}
+
+/// Enforce XEP-0308 §3 SHOULD #2: a full-JID that left the room and
+/// rejoined under the same nickname MUST NOT be allowed to correct
+/// messages from the previous occupancy. Implemented by comparing the
+/// per-nickname occupancy generation captured in the archived row
+/// (set at archive-write time from
+/// [`super::super::super::super::muc::room_actor::GroupchatBroadcastResult::sender_nickname_generation`])
+/// against the room's current generation for the same nickname.
+async fn verify_muc_occupancy_generation(
+    sender: &jid::Jid,
+    original: &waddle_xmpp::mam::ArchivedMessage,
+    room_actor: Option<&ActorRef<RoomActor>>,
+) -> Result<(), StanzaError> {
+    let Some(actor) = room_actor else {
+        // No room actor available — the correction handler caller did
+        // not supply one. This is a wiring bug; refuse rather than
+        // silently allow.
+        return Err(forbidden_error(
+            "Room state unavailable for occupancy continuity check.",
+        ));
+    };
+
+    let Some(nick) = sender.resource().map(|r| r.to_string()) else {
+        // Sender JID has no nickname (resource) — should not happen for
+        // a server-stamped MUC reflection, but bail safely.
+        return Err(forbidden_error(
+            "Correction sender has no MUC nickname for occupancy check.",
+        ));
+    };
+
+    let Some(archived_generation) = original.nickname_generation else {
+        // The original archive row predates occupancy-generation
+        // tracking (or was written by a non-MUC path). Per XEP-0308
+        // §3, we cannot prove continuity, so refuse.
+        return Err(forbidden_error(
+            "Original message predates occupancy tracking; correction window has closed.",
+        ));
+    };
+
+    let current_generation = match actor
+        .ask(GetNicknameGeneration { nick: nick.clone() })
+        .await
+    {
+        Ok(value) => value,
+        Err(_) => return Err(internal_server_error_for_lookup()),
+    };
+
+    if current_generation != archived_generation {
+        return Err(forbidden_error(
+            "Occupancy generation has advanced; correction is no longer permitted across the leave/rejoin boundary.",
+        ));
     }
 
     Ok(())
@@ -817,6 +887,7 @@ async fn archive_groupchat_message(
     state: &WebSocketState,
     room_jid: &BareJid,
     message: &mut xmpp_parsers::message::Message,
+    sender_nickname_generation: u64,
 ) -> Option<String> {
     if !should_archive_groupchat_message(message) {
         return None;
@@ -851,6 +922,7 @@ async fn archive_groupchat_message(
         message_type: mam_message_type(&message.type_),
         stanza_xml: None,
         rich,
+        nickname_generation: Some(sender_nickname_generation),
     };
 
     let archive_jid = room_jid.to_string();
@@ -906,6 +978,7 @@ async fn archive_direct_message(
         message_type: mam_message_type(&message.type_),
         stanza_xml: None,
         rich,
+        nickname_generation: None,
     };
 
     // Store in sender's personal archive

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -31,6 +31,7 @@ use waddle_xmpp::{
 };
 use xmpp_parsers::message::MessageType as XmppMessageType;
 use xmpp_parsers::minidom::Element;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 use super::super::{get_room_actor, stanza_to_xml, WebSocketState};
 use crate::auth::Session;
@@ -132,14 +133,13 @@ pub async fn handle_message(
         }
         prototype.to = None;
 
-        if let Some(error) =
+        if let Err(error) =
             validate_rich_message_targets(state, &room_jid.to_string(), &prototype, true).await
         {
             return vec![stanza_to_xml(&Stanza::Message(error_message(
                 &incoming,
                 &jid::Jid::from(room_jid.clone()),
                 &jid::Jid::from(sender_jid.clone()),
-                "modify",
                 error,
             )))];
         }
@@ -357,7 +357,7 @@ pub async fn handle_message(
                 state.deps.protocol.extension_manager.feature_namespaces(),
             );
 
-            if let Some(error) = validate_rich_message_targets(
+            if let Err(error) = validate_rich_message_targets(
                 state,
                 &sender_jid.to_bare().to_string(),
                 &prototype,
@@ -369,7 +369,6 @@ pub async fn handle_message(
                     &incoming,
                     to_jid,
                     &jid::Jid::from(sender_jid.clone()),
-                    "modify",
                     error,
                 )))];
             }
@@ -504,8 +503,12 @@ fn forbidden_message_error(
         incoming,
         &jid::Jid::from(room_jid.clone()),
         &jid::Jid::from(sender_jid.clone()),
-        "auth",
-        "forbidden",
+        StanzaError::new(
+            ErrorType::Auth,
+            DefinedCondition::Forbidden,
+            "en",
+            "Sender is not permitted to address this resource.",
+        ),
     )
 }
 
@@ -513,19 +516,14 @@ fn error_message(
     incoming: &xmpp_parsers::message::Message,
     from: &jid::Jid,
     to: &jid::Jid,
-    error_type: &str,
-    condition: &str,
+    error: StanzaError,
 ) -> xmpp_parsers::message::Message {
-    let mut error = incoming.clone();
-    error.type_ = XmppMessageType::Error;
-    error.from = Some(from.clone());
-    error.to = Some(to.clone());
-    let stanza_error = Element::builder("error", "jabber:client")
-        .attr("type", error_type)
-        .append(Element::builder(condition, "urn:ietf:params:xml:ns:xmpp-stanzas").build())
-        .build();
-    error.payloads.push(stanza_error);
-    error
+    let mut reply = incoming.clone();
+    reply.type_ = XmppMessageType::Error;
+    reply.from = Some(from.clone());
+    reply.to = Some(to.clone());
+    reply.payloads.push(Element::from(error));
+    reply
 }
 
 async fn validate_rich_message_targets(
@@ -533,10 +531,14 @@ async fn validate_rich_message_targets(
     archive_jid: &str,
     message: &xmpp_parsers::message::Message,
     groupchat: bool,
-) -> Option<&'static str> {
-    let sender = message.from.as_ref()?;
+) -> Result<(), StanzaError> {
+    let Some(sender) = message.from.as_ref() else {
+        return Ok(());
+    };
     if has_malformed_rich_payload(message) {
-        return Some("bad-request");
+        return Err(bad_request_error(
+            "Rich-message payload is missing required identifier.",
+        ));
     }
 
     if let Some(correction) = extract_correction_from_message(message) {
@@ -549,11 +551,13 @@ async fn validate_rich_message_targets(
         .await
         {
             Ok(Some(original)) => original,
-            Ok(None) => return Some("item-not-found"),
-            Err(_) => return Some("internal-server-error"),
+            Ok(None) => return Err(item_not_found_error("Correction target not found.")),
+            Err(_) => return Err(internal_server_error_for_lookup()),
         };
         if !same_rich_sender(sender, &original.from, groupchat) {
-            return Some("forbidden");
+            return Err(forbidden_error(
+                "Only the original sender may correct a message.",
+            ));
         }
     }
 
@@ -567,11 +571,13 @@ async fn validate_rich_message_targets(
         .await
         {
             Ok(Some(original)) => original,
-            Ok(None) => return Some("item-not-found"),
-            Err(_) => return Some("internal-server-error"),
+            Ok(None) => return Err(item_not_found_error("Retraction target not found.")),
+            Err(_) => return Err(internal_server_error_for_lookup()),
         };
         if !same_rich_sender(sender, &original.from, groupchat) {
-            return Some("forbidden");
+            return Err(forbidden_error(
+                "Only the original sender may retract a message.",
+            ));
         }
     }
 
@@ -579,20 +585,46 @@ async fn validate_rich_message_targets(
         match lookup_rich_target_message(state, archive_jid, &reactions.message_id, groupchat).await
         {
             Ok(Some(_)) => {}
-            Ok(None) => return Some("item-not-found"),
-            Err(_) => return Some("internal-server-error"),
+            Ok(None) => return Err(item_not_found_error("Reaction target not found.")),
+            Err(_) => return Err(internal_server_error_for_lookup()),
         }
     }
 
     if let Some(reply) = parse_reply_from_message(message) {
         match lookup_rich_target_message(state, archive_jid, &reply.id, groupchat).await {
             Ok(Some(_)) => {}
-            Ok(None) => return Some("item-not-found"),
-            Err(_) => return Some("internal-server-error"),
+            Ok(None) => return Err(item_not_found_error("Reply target not found.")),
+            Err(_) => return Err(internal_server_error_for_lookup()),
         }
     }
 
-    None
+    Ok(())
+}
+
+fn bad_request_error(text: &str) -> StanzaError {
+    StanzaError::new(ErrorType::Modify, DefinedCondition::BadRequest, "en", text)
+}
+
+fn item_not_found_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ItemNotFound,
+        "en",
+        text,
+    )
+}
+
+fn forbidden_error(text: &str) -> StanzaError {
+    StanzaError::new(ErrorType::Auth, DefinedCondition::Forbidden, "en", text)
+}
+
+fn internal_server_error_for_lookup() -> StanzaError {
+    StanzaError::new(
+        ErrorType::Wait,
+        DefinedCondition::InternalServerError,
+        "en",
+        "Archive lookup failed while validating rich-message target.",
+    )
 }
 
 async fn lookup_correction_target_message(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -627,30 +627,16 @@ async fn validate_rich_message_targets(
         }
     }
 
-    if let Some(reactions) = extract_reactions_from_message(message) {
-        match lookup_rich_target_message(
-            state,
-            archive_jid_str.as_str(),
-            &reactions.message_id,
-            groupchat,
-        )
-        .await
-        {
-            Ok(Some(_)) => {}
-            Ok(None) => return Err(item_not_found_error("Reaction target not found.")),
-            Err(_) => return Err(internal_server_error_for_lookup()),
-        }
-    }
-
-    if let Some(reply) = parse_reply_from_message(message) {
-        match lookup_rich_target_message(state, archive_jid_str.as_str(), &reply.id, groupchat)
-            .await
-        {
-            Ok(Some(_)) => {}
-            Ok(None) => return Err(item_not_found_error("Reply target not found.")),
-            Err(_) => return Err(internal_server_error_for_lookup()),
-        }
-    }
+    // Reactions (XEP-0444) and replies (XEP-0461) intentionally skip
+    // target-existence validation. Both specs are silent on
+    // server-side target verification — XEP-0444 §"It is up to
+    // receiving entities" and XEP-0461 placing no obligation on the
+    // server — and rejecting on missing target would break legitimate
+    // cases the server cannot disambiguate: cross-server messages
+    // (s2s), replies to messages before archive retention, reactions
+    // to messages cached by the client but not by the server. The
+    // well-formedness check above (`has_malformed_rich_payload`)
+    // already rejects malformed payloads with `<bad-request/>`.
 
     Ok(())
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -147,6 +147,23 @@ pub async fn handle_message(
             )))];
         }
 
+        // XEP-0424 §"prevent further distribution… by replacing the
+        // original message with a tombstone": after authorization
+        // passes, mutate the room archive's original row in place.
+        if let Some(RetractionKind::Request(retraction)) =
+            extract_retraction_from_message(&prototype)
+        {
+            apply_retraction_tombstones(
+                state,
+                &[room_jid.to_string()],
+                &prototype,
+                &retraction.retracts_id,
+                Utc::now(),
+                true,
+            )
+            .await;
+        }
+
         // Archive body-bearing and rich protocol room messages in XMPP MAM storage.
         let archive_id =
             archive_groupchat_message(state, &room_jid, &mut prototype, sender_nickname_generation)
@@ -372,6 +389,28 @@ pub async fn handle_message(
                     &jid::Jid::from(sender_jid.clone()),
                     error,
                 )))];
+            }
+
+            // XEP-0424 §"prevent further distribution": when a DM is a
+            // retraction request, tombstone the original in BOTH
+            // archives that hold it (sender's and recipient's
+            // personal MAM).
+            if let Some(RetractionKind::Request(retraction)) =
+                extract_retraction_from_message(&prototype)
+            {
+                let archives = [
+                    sender_jid.to_bare().to_string(),
+                    to_jid.to_bare().to_string(),
+                ];
+                apply_retraction_tombstones(
+                    state,
+                    &archives,
+                    &prototype,
+                    &retraction.retracts_id,
+                    Utc::now(),
+                    false,
+                )
+                .await;
             }
 
             // Archive body-bearing DMs to both sender's and recipient's personal MAM.
@@ -614,6 +653,85 @@ async fn validate_rich_message_targets(
     }
 
     Ok(())
+}
+
+/// Replace the retraction-target row in each given archive with a
+/// XEP-0424 tombstone. Called after `validate_rich_message_targets`
+/// has confirmed sender authorization. Failures are logged but do not
+/// propagate — the retraction message is still archived and broadcast,
+/// matching the spec's "best effort" framing for tombstones (the SHOULD
+/// is on archive distribution, not on the retraction itself).
+async fn apply_retraction_tombstones(
+    state: &WebSocketState,
+    archive_jids: &[String],
+    retraction_message: &xmpp_parsers::message::Message,
+    target_id: &str,
+    stamp: chrono::DateTime<chrono::Utc>,
+    groupchat: bool,
+) {
+    let retraction_id = retraction_message
+        .id
+        .clone()
+        .and_then(waddle_xmpp::mam::RichMessageId::new);
+
+    for archive_jid in archive_jids {
+        let original = match lookup_retraction_target_message(
+            state,
+            archive_jid.as_str(),
+            target_id,
+            groupchat,
+        )
+        .await
+        {
+            Ok(Some(original)) => original,
+            Ok(None) => {
+                debug!(
+                    archive = %archive_jid,
+                    target = %target_id,
+                    "Retraction target not found in this archive; tombstone skipped"
+                );
+                continue;
+            }
+            Err(error) => {
+                warn!(
+                    archive = %archive_jid,
+                    target = %target_id,
+                    error = %error,
+                    "Failed to look up retraction target for tombstone"
+                );
+                continue;
+            }
+        };
+
+        let tombstone = waddle_xmpp::mam::ArchivedTombstone {
+            retraction_id: retraction_id.clone(),
+            stamp,
+            moderation: None,
+        };
+
+        match state
+            .deps
+            .protocol
+            .mam_storage
+            .replace_with_tombstone(&original.id, tombstone)
+            .await
+        {
+            Ok(true) => {
+                debug!(archive = %archive_jid, original_id = %original.id, "Replaced with tombstone")
+            }
+            Ok(false) => warn!(
+                archive = %archive_jid,
+                original_id = %original.id,
+                "Tombstone replacement found no row to update"
+            ),
+            Err(error) => warn!(
+                archive = %archive_jid,
+                original_id = %original.id,
+                error = %error,
+                "Tombstone replacement failed"
+            ),
+        }
+    }
 }
 
 /// Enforce XEP-0308 §3 SHOULD #2: a full-JID that left the room and

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -25,7 +25,8 @@ use waddle_xmpp::{
         is_moderation_request_message, is_moderation_result_message, is_reaction_message,
         is_retraction_message, is_sticker_message, message_has_direct_invite,
         parse_reply_from_message, remove_stanza_ids_by, should_skip_storage, RetractionKind,
-        NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REPLY,
+        NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE,
+        NS_REPLY,
     },
     Stanza,
 };
@@ -868,6 +869,8 @@ fn same_rich_sender(sender: &jid::Jid, original_from: &str, groupchat: bool) -> 
 
 fn has_malformed_rich_payload(message: &xmpp_parsers::message::Message) -> bool {
     message.payloads.iter().any(|payload| {
+        // XEP-0308 / 0424 / 0444 / 0461: each requires a non-empty 'id'
+        // attribute on its top-level element.
         (payload.ns() == NS_MESSAGE_CORRECT
             && payload.name() == "replace"
             && payload.attr("id").is_none_or(str::is_empty))
@@ -880,6 +883,20 @@ fn has_malformed_rich_payload(message: &xmpp_parsers::message::Message) -> bool 
             || (payload.ns() == NS_REPLY
                 && payload.name() == "reply"
                 && payload.attr("id").is_none_or(str::is_empty))
+            // XEP-0372: '<reference/>' MUST contain 'type' and 'uri'.
+            || (payload.ns() == NS_REFERENCE
+                && payload.name() == "reference"
+                && (payload.attr("type").is_none_or(str::is_empty)
+                    || payload.attr("uri").is_none_or(str::is_empty)))
+            // XEP-0513: a '<mention/>' MUST carry at least one of
+            // 'jid', 'occupantid', or 'mentions' so the receiver can
+            // identify the target. Pure decorative mentions are not
+            // useful and are likely client bugs.
+            || (payload.ns() == NS_EXPLICIT_MENTIONS
+                && payload.name() == "mention"
+                && payload.attr("jid").is_none_or(str::is_empty)
+                && payload.attr("occupantid").is_none_or(str::is_empty)
+                && payload.attr("mentions").is_none_or(str::is_empty))
     })
 }
 

--- a/server/crates/waddle-server/tests/xep0308_message_corrections_ws.rs
+++ b/server/crates/waddle-server/tests/xep0308_message_corrections_ws.rs
@@ -194,6 +194,63 @@ async fn correction_without_target_id_returns_bad_request() {
 }
 
 #[tokio::test]
+async fn correction_after_leave_and_rejoin_under_same_nickname_is_forbidden() {
+    // XEP-0308 §3 SHOULD #2: a full-JID leaving the room and rejoining
+    // under the same nickname must not be allowed to correct messages
+    // from the previous occupancy. We enforce via per-nickname
+    // occupancy generations stored on the archived row.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("correct-rejoin-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-before-rejoin"><body>before rejoin</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    client
+        .recv_matching(|frame| frame.contains("before rejoin"))
+        .await
+        .expect("original echo");
+
+    client
+        .send(&format!(
+            r#"<presence type="unavailable" to="{room}/{USERNAME}"/>"#
+        ))
+        .await
+        .expect("send leave");
+    client
+        .recv_matching(|frame| frame.contains("type=\"unavailable\""))
+        .await
+        .expect("self-unavailable echo");
+
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="rejoin-correct">
+                <body>fixed after rejoin</body>
+                <replace xmlns="urn:xmpp:message-correct:0" id="orig-before-rejoin"/>
+            </message>"#
+        ))
+        .await
+        .expect("send correction after rejoin");
+    let error = client
+        .recv_matching(|frame| frame.contains("<forbidden"))
+        .await
+        .expect("forbidden error after rejoin");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
 async fn correction_from_different_occupant_returns_forbidden() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut admin, mut bob) = setup_with_bob().await;

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -3,7 +3,7 @@
 mod ws_common;
 
 use tokio::sync::Mutex;
-use ws_common::{TestServer, WsXmppClient};
+use ws_common::{disco_info_query, TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
@@ -62,6 +62,39 @@ async fn room_replaces_spoofed_room_stanza_id_and_preserves_origin_id() {
         "spoofed room stanza-id leaked: {echo}"
     );
     assert!(echo.contains(&format!("by=\"{room}\"")) || echo.contains(&format!("by='{room}'")));
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn server_disco_advertises_rich_message_features() {
+    // The shared `server_features()` catalogue from `waddle-xmpp-core`
+    // must be reflected by the live server-disco IQ path so clients
+    // can discover XEP support. Without this, advertised behaviour
+    // is invisible to clients (the inverse of the project's
+    // "no advertise without behaviour" rule — equally bad).
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    let response = disco_info_query(&mut client, DOMAIN, "rich-disco-1")
+        .await
+        .expect("disco#info response");
+
+    for ns in [
+        "urn:xmpp:sid:0",
+        "urn:xmpp:reply:0",
+        "urn:xmpp:message-correct:0",
+        "urn:xmpp:message-retract:1",
+        "urn:xmpp:reactions:0",
+        "urn:xmpp:reference:0",
+        "urn:xmpp:fallback:0",
+        "urn:xmpp:threads:0",
+    ] {
+        assert!(
+            response.contains(ns),
+            "server disco#info missing feature {ns}: {response}"
+        );
+    }
 
     client.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0372_references_ws.rs
+++ b/server/crates/waddle-server/tests/xep0372_references_ws.rs
@@ -78,3 +78,34 @@ async fn references_route_and_replay_from_mam() {
 
     client.close().await;
 }
+
+#[tokio::test]
+async fn reference_without_required_attributes_returns_bad_request() {
+    // XEP-0372: '<reference/>' MUST contain a 'type' and a 'uri'.
+    // Server should reject malformed references with bad-request so
+    // misbehaving clients don't poison archives with junk payloads.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reference-bad-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="bad-reference">
+                <body>broken reference</body>
+                <reference xmlns="urn:xmpp:reference:0" begin="0" end="6"/>
+            </message>"#
+        ))
+        .await
+        .expect("send malformed reference");
+    let error = client
+        .recv_matching(|frame| frame.contains("<bad-request"))
+        .await
+        .expect("bad-request error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
+++ b/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
@@ -82,12 +82,139 @@ async fn retraction_routes_and_replays_from_mam() {
         .recv_until(|frame| frame.contains("mam-retract") && frame.contains("<fin"))
         .await
         .expect("MAM frames");
+
+    // The retraction message itself is archived as its own row with a
+    // live `<retract>` payload — that's the "I retracted X" timeline
+    // entry clients render.
     assert!(
         frames
             .iter()
-            .any(|frame| frame.contains("urn:xmpp:message-retract:1") && frame.contains(&target)),
-        "MAM did not replay retraction: {frames:?}"
+            .any(|frame| frame.contains("<retract ") && frame.contains(&target)),
+        "MAM did not replay retraction event: {frames:?}"
+    );
+
+    // XEP-0424 §"prevent further distribution… by replacing the
+    // original message with a tombstone": the original row's body
+    // must not appear in MAM, and a `<retracted/>` tombstone must
+    // take its place.
+    let tombstone = frames
+        .iter()
+        .find(|frame| frame.contains("<retracted "))
+        .unwrap_or_else(|| panic!("MAM missing tombstone for retracted message: {frames:?}"));
+    assert!(
+        !tombstone.contains("<body>remove me</body>"),
+        "tombstone leaked original body: {tombstone}"
+    );
+    assert!(
+        frames
+            .iter()
+            .all(|frame| !frame.contains("<body>remove me</body>")),
+        "original body must not appear in any MAM result after retraction: {frames:?}"
     );
 
     client.close().await;
+}
+
+#[tokio::test]
+async fn dm_retraction_tombstones_both_archives() {
+    // XEP-0424 §"prevent further distribution" applies to both
+    // archives that hold a 1:1 message — the sender's and the
+    // recipient's. The retraction is sent via the sender's path; the
+    // recipient's archive must independently observe the tombstone.
+    let _guard = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-password-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let admin_resource = format!("xep0424-admin-{}", uuid::Uuid::new_v4());
+    let admin_password = server.fixed_account_password().to_string();
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_password,
+        &admin_resource,
+    )
+    .await
+    .expect("connect admin");
+    let bob_resource = format!("xep0424-bob-{}", uuid::Uuid::new_v4());
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &bob_resource,
+    )
+    .await
+    .expect("connect bob");
+
+    let original_id = format!("dm-{}", uuid::Uuid::new_v4());
+    admin
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@{DOMAIN}" id="{original_id}"><body>retract this dm</body></message>"#
+        ))
+        .await
+        .expect("send DM");
+    bob.recv_matching(|frame| frame.contains("retract this dm"))
+        .await
+        .expect("bob receives DM");
+
+    admin
+        .send(&format!(
+            r#"<message xmlns="jabber:client" type="chat" to="bob@{DOMAIN}" id="dm-retract-1">
+                <retract xmlns="urn:xmpp:message-retract:1" id="{original_id}"/>
+                <body>/me retracted a previous message</body>
+            </message>"#
+        ))
+        .await
+        .expect("send retraction");
+    bob.recv_matching(|frame| frame.contains("urn:xmpp:message-retract:1"))
+        .await
+        .expect("bob receives retraction");
+
+    // Bob queries his own MAM and must not see the original body.
+    bob.send(
+        r#"<iq type="set" id="bob-mam" to="bob@localhost"><query xmlns="urn:xmpp:mam:2"/></iq>"#,
+    )
+    .await
+    .expect("bob MAM query");
+    let bob_frames = bob
+        .recv_until(|frame| frame.contains("bob-mam") && frame.contains("<fin"))
+        .await
+        .expect("bob MAM frames");
+    assert!(
+        bob_frames
+            .iter()
+            .all(|frame| !frame.contains("<body>retract this dm</body>")),
+        "recipient archive leaked original body after retraction: {bob_frames:?}"
+    );
+    assert!(
+        bob_frames.iter().any(|frame| frame.contains("<retracted ")),
+        "recipient archive missing tombstone for retracted DM: {bob_frames:?}"
+    );
+
+    // Admin's MAM also tombstones.
+    admin
+        .send(
+            r#"<iq type="set" id="admin-mam" to="admin@localhost"><query xmlns="urn:xmpp:mam:2"/></iq>"#,
+        )
+        .await
+        .expect("admin MAM query");
+    let admin_frames = admin
+        .recv_until(|frame| frame.contains("admin-mam") && frame.contains("<fin"))
+        .await
+        .expect("admin MAM frames");
+    assert!(
+        admin_frames
+            .iter()
+            .all(|frame| !frame.contains("<body>retract this dm</body>")),
+        "sender archive leaked original body after retraction: {admin_frames:?}"
+    );
+    assert!(
+        admin_frames
+            .iter()
+            .any(|frame| frame.contains("<retracted ")),
+        "sender archive missing tombstone for retracted DM: {admin_frames:?}"
+    );
+
+    bob.close().await;
+    admin.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
+++ b/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
@@ -159,3 +159,83 @@ async fn moderation_broadcasts_and_replays_from_mam() {
 
     client.close().await;
 }
+
+#[tokio::test]
+async fn moderation_from_non_moderator_returns_forbidden() {
+    // XEP-0425 §"only moderators are allowed to moderate" plus
+    // XEP-0045 §5.1.2: runtime moderation privilege is role-bound.
+    // bob joins with no affiliation → role=visitor or participant; he
+    // attempts to moderate admin's message and must be refused with
+    // <forbidden/>.
+    let _guard = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-password-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let admin_resource = format!("xep0425-admin-{}", uuid::Uuid::new_v4());
+    let admin_password = server.fixed_account_password().to_string();
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_password,
+        &admin_resource,
+    )
+    .await
+    .expect("connect admin");
+    let bob_resource = format!("xep0425-bob-{}", uuid::Uuid::new_v4());
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &bob_resource,
+    )
+    .await
+    .expect("connect bob");
+
+    let room = format!("moderate-forbidden-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut admin, &room).await;
+
+    bob.send(&format!(
+        r#"<presence to="{room}/bob"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+    ))
+    .await
+    .expect("send bob join");
+    bob.recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("bob join responses");
+
+    admin
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-mod"><body>moderate me</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let echo = admin
+        .recv_matching(|frame| frame.contains("moderate me") && frame.contains("stanza-id"))
+        .await
+        .expect("original echo");
+    let target = stanza_id(&echo);
+
+    bob.send(&format!(
+        r#"<iq type="set" id="bob-mod" to="{room}">
+            <moderate id="{target}" xmlns="urn:xmpp:message-moderate:1">
+                <retract xmlns="urn:xmpp:message-retract:1"/>
+                <reason>nope</reason>
+            </moderate>
+        </iq>"#
+    ))
+    .await
+    .expect("send unauthorized moderation");
+
+    let error = bob
+        .recv_matching(|frame| frame.contains("bob-mod") && frame.contains("<forbidden"))
+        .await
+        .expect("forbidden error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    bob.close().await;
+    admin.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
+++ b/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
@@ -151,11 +151,51 @@ async fn moderation_broadcasts_and_replays_from_mam() {
         .recv_until(|frame| frame.contains("mam-moderate") && frame.contains("<fin"))
         .await
         .expect("MAM frames");
-    let replay = frames
+
+    // The room archive now contains TWO rows for this moderation:
+    // 1. the original message replaced in place with a `<retracted>`
+    //    tombstone wrapping the moderator annotation, and
+    // 2. the moderation result message itself with a live `<retract>`
+    //    payload — which clients can use as the "moderation event"
+    //    timeline entry.
+    let live = frames
         .iter()
-        .find(|frame| frame.contains("urn:xmpp:message-moderate:1"))
-        .unwrap_or_else(|| panic!("MAM did not replay moderation: {frames:?}"));
-    assert_moderation_shape(replay, &target);
+        .find(|frame| {
+            frame.contains("<retract ")
+                && !frame.contains("<retracted ")
+                && frame.contains("urn:xmpp:message-moderate:1")
+        })
+        .unwrap_or_else(|| panic!("MAM did not replay live moderation event: {frames:?}"));
+    assert_moderation_shape(live, &target);
+
+    let tombstone = frames
+        .iter()
+        .find(|frame| {
+            frame.contains("<retracted ") && frame.contains("urn:xmpp:message-moderate:1")
+        })
+        .unwrap_or_else(|| panic!("MAM did not replay moderation tombstone: {frames:?}"));
+    let tombstone_element = tombstone.parse::<Element>().expect("valid tombstone XML");
+    let retracted = find_descendant(
+        &tombstone_element,
+        "retracted",
+        "urn:xmpp:message-retract:1",
+    )
+    .expect("retracted element");
+    let moderated = retracted
+        .get_child("moderated", "urn:xmpp:message-moderate:1")
+        .expect("moderated child on tombstone");
+    assert!(
+        moderated.attr("by").is_some_and(|by| by.contains("/admin")),
+        "tombstone moderated by missing admin nick: {tombstone}"
+    );
+    assert!(
+        retracted.attr("stamp").is_some(),
+        "tombstone must include stamp: {tombstone}"
+    );
+    assert!(
+        !tombstone.contains("<body>moderate me</body>"),
+        "tombstoned row must not leak the original body: {tombstone}"
+    );
 
     client.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0461_replies_ws.rs
+++ b/server/crates/waddle-server/tests/xep0461_replies_ws.rs
@@ -91,3 +91,42 @@ async fn reply_routes_and_replays_from_mam() {
 
     client.close().await;
 }
+
+#[tokio::test]
+async fn reply_to_unknown_target_routes_without_error() {
+    // XEP-0461 imposes no server-side target-existence requirement
+    // ("It is up to receiving entities…"). The previous implementation
+    // returned `<item-not-found/>` when the server hadn't archived the
+    // referenced message, which would reject legitimate cross-server
+    // replies, replies to messages before retention, or replies to
+    // client-cached history we never saw. Verify that a well-formed
+    // reply to an unknown id is routed normally.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reply-unknown-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reply-orphan">
+                <body>orphan reply</body>
+                <reply xmlns="urn:xmpp:reply:0" to="{room}/{USERNAME}" id="never-archived-id"/>
+            </message>"#
+        ))
+        .await
+        .expect("send reply to unknown target");
+    let echo = client
+        .recv_matching(|frame| frame.contains("orphan reply"))
+        .await
+        .expect("reply echo");
+    assert!(
+        echo.contains("urn:xmpp:reply:0"),
+        "reply payload missing: {echo}"
+    );
+    assert!(
+        !echo.contains("<item-not-found"),
+        "spec-non-conformant rejection: {echo}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -78,3 +78,35 @@ async fn explicit_mentions_route_and_replay_from_mam() {
 
     client.close().await;
 }
+
+#[tokio::test]
+async fn mention_without_target_attribute_returns_bad_request() {
+    // XEP-0513: a '<mention/>' must identify its target via 'jid',
+    // 'occupantid', or 'mentions' (group). Decorative mentions with
+    // none of these are not interpretable by receivers and are
+    // rejected with bad-request.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("mention-bad-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="bad-mention">
+                <body>broken mention</body>
+                <mention xmlns="urn:xmpp:mentions:0" begin="0" end="6"/>
+            </message>"#
+        ))
+        .await
+        .expect("send malformed mention");
+    let error = client
+        .recv_matching(|frame| frame.contains("<bad-request"))
+        .await
+        .expect("bad-request error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -162,6 +162,13 @@ pub struct ArchivedMessage {
     pub stanza_xml: Option<String>,
     /// Typed rich-message payload and annotations used to reconstruct XMPP payloads.
     pub rich: Option<ArchivedRichMessage>,
+    /// Per-XEP-0308 §3 occupancy generation for the sender's MUC nickname
+    /// at archive-write time. Only set for `groupchat` rows; `None`
+    /// otherwise. Used to disallow corrections across leave/rejoin
+    /// cycles — the correction handler refuses if the room's current
+    /// generation for the same nickname has advanced.
+    #[serde(default)]
+    pub nickname_generation: Option<u64>,
 }
 
 fn default_message_type() -> String {
@@ -184,6 +191,7 @@ impl Default for ArchivedMessage {
             message_type: default_message_type(),
             stanza_xml: None,
             rich: None,
+            nickname_generation: None,
         }
     }
 }

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -116,12 +116,41 @@ pub struct ArchivedModeration {
     pub reason: Option<RichText>,
 }
 
+/// A XEP-0424 tombstone replacing a retracted message in the archive.
+///
+/// When the optional `moderation` is `Some`, this is a XEP-0425
+/// moderation tombstone whose `<retracted/>` element wraps a
+/// `<moderated by/>` annotation; otherwise it is a plain XEP-0424
+/// sender-initiated retraction tombstone.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedTombstone {
+    /// Stanza-id of the retraction message that produced the
+    /// tombstone (for clients to correlate the tombstone to the
+    /// retraction event that caused it). May be `None` for
+    /// IQ-driven moderation tombstones whose request is not itself
+    /// archived as a separate row.
+    pub retraction_id: Option<RichMessageId>,
+    /// XEP-0424 §"`<retracted/>` SHOULD include a 'stamp' attribute
+    /// indicating the time at which the retraction took place."
+    pub stamp: DateTime<Utc>,
+    /// When set, this tombstone is the result of XEP-0425 moderation
+    /// rather than a sender-initiated XEP-0424 retraction.
+    pub moderation: Option<ArchivedModeration>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ArchivedRichPayload {
-    Correction { replaces_id: RichMessageId },
+    Correction {
+        replaces_id: RichMessageId,
+    },
     Retraction(ArchivedRetraction),
     Moderation(ArchivedModeration),
     Reactions(ArchivedReactionSet),
+    /// In-place tombstone produced by XEP-0424 retraction or
+    /// XEP-0425 moderation. The original row's `body` and
+    /// leak-prone fields (`thread_id`, `reply_to_id`, mentions, ...)
+    /// are cleared when this variant is set.
+    Tombstone(ArchivedTombstone),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -579,6 +608,27 @@ fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMess
                 );
             }
             builder = builder.append(reactions_elem);
+        }
+        Some(ArchivedRichPayload::Tombstone(tombstone)) => {
+            let mut retracted = Element::builder("retracted", MESSAGE_RETRACT_NS)
+                .attr("stamp", tombstone.stamp.to_rfc3339());
+            if let Some(retraction_id) = tombstone.retraction_id.as_ref() {
+                retracted = retracted.attr("id", retraction_id.as_str());
+            }
+            if let Some(moderation) = tombstone.moderation.as_ref() {
+                let moderated = Element::builder("moderated", MESSAGE_MODERATE_NS)
+                    .attr("by", moderation.moderated_by.to_string())
+                    .build();
+                retracted = retracted.append(moderated);
+                if let Some(reason) = moderation.reason.as_ref() {
+                    retracted = retracted.append(
+                        Element::builder("reason", MESSAGE_RETRACT_NS)
+                            .append(reason.as_str())
+                            .build(),
+                    );
+                }
+            }
+            builder = builder.append(retracted.build());
         }
         None => {}
     }

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -19,6 +19,6 @@ pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorag
 pub use waddle_xmpp_core::mam::{
     add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,
     ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference,
-    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, MamQuery,
-    MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
+    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
+    MamQuery, MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
 };

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -607,7 +607,7 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         .with_timezone(&Utc);
 
     let rich_payload: Option<String> = row.try_get(13)?;
-    let nickname_generation: Option<i64> = row.try_get(14)?;
+    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(14)?)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp,
@@ -622,13 +622,13 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
-        nickname_generation: nickname_generation.map(|v| v as u64),
+        nickname_generation,
     })
 }
 
 fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorageError> {
     let rich_payload: Option<String> = row.try_get(13)?;
-    let nickname_generation: Option<i64> = row.try_get(14)?;
+    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(14)?)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp: row.try_get(2)?,
@@ -643,7 +643,7 @@ fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorag
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
-        nickname_generation: nickname_generation.map(|v| v as u64),
+        nickname_generation,
     })
 }
 
@@ -666,6 +666,29 @@ fn decode_rich_payload(
         .map_err(|error| MamStorageError::Serialization(error.to_string()))
 }
 
+/// Convert the database's signed `nickname_generation` column to the
+/// typed `u64`. Negative values would only appear from corruption,
+/// manual edits, or a write that bypassed `encode_nickname_generation`
+/// — refuse them rather than wrap silently with `as u64`.
+fn decode_nickname_generation(value: Option<i64>) -> Result<Option<u64>, MamStorageError> {
+    value.map(u64::try_from).transpose().map_err(|error| {
+        MamStorageError::Serialization(format!(
+            "negative nickname_generation column value rejected: {error}"
+        ))
+    })
+}
+
+/// Convert a typed `u64` generation to the SQL backend's signed `i64`,
+/// rejecting values outside `i64` range so the column never stores a
+/// negative wrapped value that would later round-trip incorrectly.
+fn encode_nickname_generation(value: Option<u64>) -> Result<Option<i64>, MamStorageError> {
+    value.map(i64::try_from).transpose().map_err(|error| {
+        MamStorageError::Serialization(format!(
+            "nickname_generation overflow on store ({error}) — exceeds i64::MAX"
+        ))
+    })
+}
+
 #[async_trait]
 impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self, message), fields(archive = %archive_jid))]
@@ -685,7 +708,7 @@ impl MamStorage for SqlxMamStorage {
             message.message_type.as_str()
         };
         let rich_payload = encode_rich_payload(message)?;
-        let nickname_generation = message.nickname_generation.map(|v| v as i64);
+        let nickname_generation = encode_nickname_generation(message.nickname_generation)?;
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -343,13 +343,19 @@ impl SqlxMamStorage {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 execute_sqlite_batch(pool, SQLITE_MAM_SCHEMA).await?;
-                ensure_sqlite_rich_payload_column(pool).await
+                ensure_sqlite_column(pool, "rich_payload", "TEXT").await?;
+                ensure_sqlite_column(pool, "nickname_generation", "INTEGER").await
             }
             MamDatabaseBackend::Postgres(pool) => {
                 execute_postgres_batch(pool, POSTGRES_MAM_SCHEMA).await?;
                 sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS rich_payload TEXT")
                     .execute(pool)
                     .await?;
+                sqlx::query(
+                    "ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS nickname_generation BIGINT",
+                )
+                .execute(pool)
+                .await?;
                 Ok(())
             }
         }
@@ -361,7 +367,7 @@ impl SqlxMamStorage {
 }
 
 const SELECT_COLUMNS: &str =
-    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload";
+    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation";
 
 const SQLITE_MAM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS mam_messages (
@@ -379,6 +385,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
     rich_payload TEXT,
+    nickname_generation INTEGER,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -409,6 +416,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
     rich_payload TEXT,
+    nickname_generation BIGINT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -496,18 +504,21 @@ async fn execute_postgres_batch(pool: &PgPool, sql: &str) -> Result<(), MamStora
     Ok(())
 }
 
-async fn ensure_sqlite_rich_payload_column(pool: &SqlitePool) -> Result<(), MamStorageError> {
+async fn ensure_sqlite_column(
+    pool: &SqlitePool,
+    column: &str,
+    column_type: &str,
+) -> Result<(), MamStorageError> {
     let columns = sqlx::query("PRAGMA table_info(mam_messages)")
         .fetch_all(pool)
         .await?;
     let exists = columns.iter().any(|row| {
         row.try_get::<String, _>("name")
-            .is_ok_and(|name| name == "rich_payload")
+            .is_ok_and(|name| name == column)
     });
     if !exists {
-        sqlx::query("ALTER TABLE mam_messages ADD COLUMN rich_payload TEXT")
-            .execute(pool)
-            .await?;
+        let sql = format!("ALTER TABLE mam_messages ADD COLUMN {column} {column_type}");
+        sqlx::query(&sql).execute(pool).await?;
     }
     Ok(())
 }
@@ -549,6 +560,7 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         .with_timezone(&Utc);
 
     let rich_payload: Option<String> = row.try_get(13)?;
+    let nickname_generation: Option<i64> = row.try_get(14)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp,
@@ -563,11 +575,13 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
+        nickname_generation: nickname_generation.map(|v| v as u64),
     })
 }
 
 fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorageError> {
     let rich_payload: Option<String> = row.try_get(13)?;
+    let nickname_generation: Option<i64> = row.try_get(14)?;
     Ok(ArchivedMessage {
         id: row.try_get(0)?,
         timestamp: row.try_get(2)?,
@@ -582,6 +596,7 @@ fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorag
         message_type: row.try_get(11)?,
         stanza_xml: row.try_get(12)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
+        nickname_generation: nickname_generation.map(|v| v as u64),
     })
 }
 
@@ -623,11 +638,12 @@ impl MamStorage for SqlxMamStorage {
             message.message_type.as_str()
         };
         let rich_payload = encode_rich_payload(message)?;
+        let nickname_generation = message.nickname_generation.map(|v| v as i64);
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut query = QueryBuilder::<Sqlite>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -644,13 +660,14 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(message.origin_id.as_deref())
                         .push_bind(message_type)
                         .push_bind(message.stanza_xml.as_deref())
-                        .push_bind(rich_payload.as_deref());
+                        .push_bind(rich_payload.as_deref())
+                        .push_bind(nickname_generation);
                 });
                 query.build().execute(pool).await?;
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut query = QueryBuilder::<Postgres>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -667,7 +684,8 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(message.origin_id.as_deref())
                         .push_bind(message_type)
                         .push_bind(message.stanza_xml.as_deref())
-                        .push_bind(rich_payload.as_deref());
+                        .push_bind(rich_payload.as_deref())
+                        .push_bind(nickname_generation);
                 });
                 query.build().execute(pool).await?;
             }
@@ -998,6 +1016,7 @@ mod tests {
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='archive-stanza-1'><body>Reply body</body></message>".to_string(),
             ),
             rich: None,
+            nickname_generation: None,
         };
 
         let archive_id = storage

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -80,6 +80,20 @@ pub trait MamStorage: Send + Sync {
         archive_id: &str,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
+    /// Replace an archived message with a XEP-0424 / XEP-0425 tombstone in
+    /// place. Clears `body`, `stanza_xml`, `thread_id`, `reply_to_id`,
+    /// `reply_to_jid`, and overwrites `rich_payload` with the typed
+    /// `ArchivedRichPayload::Tombstone(...)` value.
+    ///
+    /// Looks up the row by `archive_id` (the storage primary key). Returns
+    /// `Ok(true)` when a row was found and updated, `Ok(false)` when no row
+    /// matched, and `Err` on storage failure.
+    async fn replace_with_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<bool, MamStorageError>;
+
     /// Get a single message by its original message/stanza id inside an archive.
     async fn get_message_by_stanza_id(
         &self,
@@ -278,6 +292,39 @@ impl MamStorage for InMemoryMamStorage {
         entries.retain(|(jid, message)| !(jid == room_jid && message.timestamp < before));
         Ok((previous_len - entries.len()) as u64)
     }
+
+    async fn replace_with_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<bool, MamStorageError> {
+        let mut entries = self.entries.write().await;
+        for (_jid, message) in entries.iter_mut() {
+            if message.id == archive_id {
+                apply_tombstone(message, tombstone);
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+fn apply_tombstone(
+    message: &mut ArchivedMessage,
+    tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+) {
+    use waddle_xmpp_core::mam::{ArchivedRichMessage, ArchivedRichPayload};
+    message.body.clear();
+    message.stanza_xml = None;
+    message.thread_id = None;
+    message.reply_to_id = None;
+    message.reply_to_jid = None;
+    message.rich = Some(ArchivedRichMessage {
+        payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
+        reply: None,
+        references: Vec::new(),
+        mentions: Vec::new(),
+    });
 }
 
 #[derive(Clone)]
@@ -955,6 +1002,53 @@ impl MamStorage for SqlxMamStorage {
 
         debug!(archive = %room_jid, deleted, "Deleted old messages from MAM archive");
         Ok(deleted)
+    }
+
+    #[instrument(skip(self, tombstone))]
+    async fn replace_with_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<bool, MamStorageError> {
+        use waddle_xmpp_core::mam::{ArchivedRichMessage, ArchivedRichPayload};
+        let payload = ArchivedRichMessage {
+            payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
+            reply: None,
+            references: Vec::new(),
+            mentions: Vec::new(),
+        };
+        let encoded = serde_json::to_string(&payload)
+            .map_err(|error| MamStorageError::Serialization(error.to_string()))?;
+
+        let rows = match &self.backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let mut builder = QueryBuilder::<Sqlite>::new(
+                    "UPDATE mam_messages SET body = '', stanza_xml = NULL, thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                );
+                builder
+                    .push_bind(encoded.as_str())
+                    .push(" WHERE id = ")
+                    .push_bind(archive_id);
+                builder.build().execute(pool).await?.rows_affected()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let mut builder = QueryBuilder::<Postgres>::new(
+                    "UPDATE mam_messages SET body = '', stanza_xml = NULL, thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                );
+                builder
+                    .push_bind(encoded.as_str())
+                    .push(" WHERE id = ")
+                    .push_bind(archive_id);
+                builder.build().execute(pool).await?.rows_affected()
+            }
+        };
+
+        debug!(
+            archive_id = %archive_id,
+            rows_affected = rows,
+            "Replaced archived message with tombstone"
+        );
+        Ok(rows > 0)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -165,6 +165,14 @@ pub struct MucRoom {
     occupant_sessions: HashMap<String, Vec<FullJid>>,
     /// Persistent affiliation list (synced with Zanzibar)
     affiliation_list: AffiliationList,
+    /// Per-nickname occupancy generation, bumped each time a nickname
+    /// transitions from absent to present (XEP-0308 §3 SHOULD #2: a
+    /// full-JID leaving and rejoining should not be allowed to correct
+    /// messages from the previous occupancy). Generation is in-memory
+    /// only — server restart effectively closes the correction window
+    /// for all prior messages, which is consistent with §3 since a
+    /// restart is observationally identical to every occupant leaving.
+    nickname_generation: HashMap<String, u64>,
 }
 
 impl MucRoom {
@@ -183,14 +191,32 @@ impl MucRoom {
             occupants: HashMap::new(),
             occupant_sessions: HashMap::new(),
             affiliation_list: AffiliationList::new(),
+            nickname_generation: HashMap::new(),
         }
     }
 
     /// Add an occupant to the room.
+    ///
+    /// When this is a fresh join (nickname not currently present), the
+    /// per-nickname occupancy generation is bumped — used by XEP-0308
+    /// to disallow corrections across leave/rejoin cycles.
     pub fn add_occupant(&mut self, occupant: Occupant) {
+        if !self.occupants.contains_key(&occupant.nick) {
+            let gen = self
+                .nickname_generation
+                .entry(occupant.nick.clone())
+                .or_insert(0);
+            *gen += 1;
+        }
         self.occupant_sessions
             .insert(occupant.nick.clone(), vec![occupant.real_jid.clone()]);
         self.occupants.insert(occupant.nick.clone(), occupant);
+    }
+
+    /// Current occupancy generation for `nick`, or `None` if the
+    /// nickname has never been observed since this actor was created.
+    pub fn current_nickname_generation(&self, nick: &str) -> Option<u64> {
+        self.nickname_generation.get(nick).copied()
     }
 
     /// Remove an occupant from the room.
@@ -421,6 +447,9 @@ impl MucRoom {
             is_remote,
             home_server,
         };
+
+        let gen = self.nickname_generation.entry(nick.clone()).or_insert(0);
+        *gen += 1;
 
         self.occupant_sessions.insert(nick.clone(), vec![real_jid]);
         self.occupants.insert(nick.clone(), occupant);

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -168,11 +168,21 @@ pub struct MucRoom {
     /// Per-nickname occupancy generation, bumped each time a nickname
     /// transitions from absent to present (XEP-0308 §3 SHOULD #2: a
     /// full-JID leaving and rejoining should not be allowed to correct
-    /// messages from the previous occupancy). Generation is in-memory
-    /// only — server restart effectively closes the correction window
-    /// for all prior messages, which is consistent with §3 since a
-    /// restart is observationally identical to every occupant leaving.
+    /// messages from the previous occupancy). Each fresh nickname is
+    /// seeded from [`Self::generation_floor`] before the first bump so
+    /// post-restart generation values cannot collide with pre-restart
+    /// archived rows.
     nickname_generation: HashMap<String, u64>,
+    /// Lower bound for fresh nickname generations in this room actor's
+    /// lifetime. Initialised at room creation from the wall clock so
+    /// that every restart of the server (or recreation of the actor)
+    /// uses a higher floor than any prior archive row's generation,
+    /// which closes the §3 SHOULD #2 correction window across server
+    /// boundaries. Pre-restart rows recorded with generation N have
+    /// N < floor; post-restart fresh joins start at floor+1, so the
+    /// equality check in `verify_muc_occupancy_generation` cannot
+    /// match.
+    generation_floor: u64,
 }
 
 impl MucRoom {
@@ -192,6 +202,14 @@ impl MucRoom {
             occupant_sessions: HashMap::new(),
             affiliation_list: AffiliationList::new(),
             nickname_generation: HashMap::new(),
+            // Seed the floor from the wall clock in milliseconds. Any
+            // future restart will produce a higher floor than any
+            // generation values archived under the previous floor,
+            // since each fresh-nick generation is at most floor + (#
+            // distinct same-nickname rejoins observed in this actor's
+            // lifetime), which is bounded well below the millisecond
+            // tick rate.
+            generation_floor: u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0),
         }
     }
 
@@ -202,10 +220,11 @@ impl MucRoom {
     /// to disallow corrections across leave/rejoin cycles.
     pub fn add_occupant(&mut self, occupant: Occupant) {
         if !self.occupants.contains_key(&occupant.nick) {
+            let floor = self.generation_floor;
             let gen = self
                 .nickname_generation
                 .entry(occupant.nick.clone())
-                .or_insert(0);
+                .or_insert(floor);
             *gen += 1;
         }
         self.occupant_sessions
@@ -448,7 +467,11 @@ impl MucRoom {
             home_server,
         };
 
-        let gen = self.nickname_generation.entry(nick.clone()).or_insert(0);
+        let floor = self.generation_floor;
+        let gen = self
+            .nickname_generation
+            .entry(nick.clone())
+            .or_insert(floor);
         *gen += 1;
 
         self.occupant_sessions.insert(nick.clone(), vec![real_jid]);

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -44,6 +44,12 @@ pub struct GroupchatBroadcastResult {
     pub sender_nick: String,
     pub messages: Vec<OutboundMucMessage>,
     pub occupant_bare_jids: Vec<String>,
+    /// Per-XEP-0308 §3 occupancy generation for the sender's nickname
+    /// at the moment this broadcast was built. Stored alongside the
+    /// archive row so that later corrections can verify the sender is
+    /// still in the same occupancy session (i.e. the nickname has not
+    /// been left and re-claimed in the meantime).
+    pub sender_nickname_generation: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -443,11 +449,39 @@ impl kameo::message::Message<BuildGroupchatBroadcast> for RoomActor {
             .map(|jid| jid.to_bare().to_string())
             .collect();
 
+        let sender_nickname_generation = self
+            .room
+            .current_nickname_generation(&sender_nick)
+            .unwrap_or(0);
+
         Ok(GroupchatBroadcastResult {
             sender_nick,
             messages,
             occupant_bare_jids,
+            sender_nickname_generation,
         })
+    }
+}
+
+/// Query the current per-nickname occupancy generation. Returns 0 when
+/// the nickname has never been observed by this actor (e.g. after
+/// server restart, which closes the correction window for prior
+/// archive entries per XEP-0308 §3).
+pub struct GetNicknameGeneration {
+    pub nick: String,
+}
+
+impl kameo::message::Message<GetNicknameGeneration> for RoomActor {
+    type Reply = u64;
+
+    async fn handle(
+        &mut self,
+        msg: GetNicknameGeneration,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room
+            .current_nickname_generation(&msg.nick)
+            .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
Follow-up conformance fixes for #211, building on #225 which already shipped per-archive stanza-id stamping, the strip rule, type filtering, target validation for corrections/retractions, and the rich-message disco entries.

This PR closes the gaps a structured audit against #211's acceptance criteria and the relevant XEPs surfaced. Each commit addresses one gap with its own targeted integration test using the existing `ws_common` WebSocket harness.

## Resolved gaps

| # | AC | Before | Fix |
|---|---|---|---|
| Q2 | AC5 typed stanza errors | `&'static str` flag → `minidom::Element` builder | `xmpp_parsers::stanza_error::StanzaError` with typed `DefinedCondition` flowing through `validate_rich_message_targets` and `error_message`. |
| Q12 | AC2 authz strictness | MUC correction allowed across leave/rejoin (XEP-0308 §3 SHOULD #2 ignored) | In-memory `nickname_generation` counter on `MucRoom`; archive row stores it; correction handler refuses when generations differ. New SQL column with idempotent migration on both backends. |
| Q15 | AC3/AC4 reconstruction | `<retract>` archived; original row left intact (effectively (δ) "no tombstone") | New `ArchivedRichPayload::Tombstone(ArchivedTombstone)` variant + `MamStorage::replace_with_tombstone`. SQL UPDATE clears body/leak-prone fields. Hooked into MUC retraction, DM retraction (both archives), and XEP-0425 moderation. |
| Q16 | AC2 authz | XEP-0421 occupant-id branch missing | Verified non-issue — Waddle exposes only non-anonymous rooms; `same_rich_sender`'s full-JID match is the right rule for every room. Forward-looking work tracked in **#231**. |
| Q17 | AC2 authz | `role >= Moderator OR affiliation in {Owner, Admin}` | Tightened to `role == Moderator` per XEP-0045 §5.1.2's role-bound runtime privilege model. |
| Q18 | AC4 MAM | Tombstone replay on history-on-join | Verified non-issue for #211 — Waddle does not implement XEP-0045 §7.2.16 history-on-join; clients catch up via MAM, which post-Q15 returns tombstones naturally. History-on-join itself is a separate completeness gap tracked in **#232** (the Q15 tombstone shape will be inherited by that work for free). |
| Q14 + Q20 | AC1 typed | `<item-not-found/>` for missing reply/reaction targets (stricter than XEP-0461/0444 spec) | Removed target-existence check for these two XEPs (kept for corrections/retractions where it backs up authz). |
| Q21 | AC1 typed | XEP-0372 references and XEP-0513 mentions accepted without attribute validation | `has_malformed_rich_payload` extended: `<reference/>` requires `type` + `uri`; `<mention/>` requires `jid`/`occupantid`/`mentions`. |
| Q9 | XEP-conformance hard rule | Live server `disco#info` IQ path was building its feature list inline, omitting the rich-message namespaces declared in `server_features()` | Live IQ path now sources `waddle_xmpp_core::disco::info::server_features()` and appends only Waddle-specific extras (Spaces, jabber:iq:search, ISR). |

## New tests

- `correction_after_leave_and_rejoin_under_same_nickname_is_forbidden` (xep0308)
- `dm_retraction_tombstones_both_archives` (xep0424)
- `moderation_from_non_moderator_returns_forbidden` (xep0425)
- `reply_to_unknown_target_routes_without_error` (xep0461)
- `reference_without_required_attributes_returns_bad_request` (xep0372)
- `mention_without_target_attribute_returns_bad_request` (xep0513)
- `server_disco_advertises_rich_message_features` (xep0359)
- Existing `retraction_routes_and_replays_from_mam` and `moderation_broadcasts_and_replays_from_mam` updated to assert tombstone-shape semantics.

All eight pre-existing rich-message integration tests continue to pass. The full waddle-server test suite is green.

## Out of scope

- The `iq.rs` IQ-error builders (`build_iq_error_xml_with_addresses`) still use stringly-typed condition flags. Refactoring those mirrors Q2 and is broader than the rich-message scope; tracked as a separate follow-up.
- The MAM result-builder shape for moderation tombstones uses XEP-0425's `<retracted>...<moderated by/>...` nesting; if the reference implementation in the wild settles on a different shape, we may need to revisit.

Refs #211, #225. Follow-ups: #231 (semi-anon occupant-id authz), #232 (history-on-join), #228 (typed `ArchivedMessage`), #229 (sans-I/O migration of `message.rs`).
