### PR TITLE
fix(server,chat): preserve enriched stanza XML in MAM archive for faithful replay

### DIFF
--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -295,6 +295,14 @@ export function useDmMessaging(
       }
       if (githubEmbeds && githubEmbeds.length > 0) {
         updated.githubEmbeds = githubEmbeds;
+      } else if (m.githubEmbeds?.length) {
+        const newBodyText = newBody.trim();
+        const surviving = m.githubEmbeds.filter((e) => newBodyText.includes(e.url));
+        if (surviving.length > 0) {
+          updated.githubEmbeds = surviving;
+        } else {
+          delete updated.githubEmbeds;
+        }
       } else {
         delete updated.githubEmbeds;
       }
@@ -463,6 +471,13 @@ export function useDmMessaging(
         }
         if (update.githubEmbeds && update.githubEmbeds.length > 0) {
           target.githubEmbeds = update.githubEmbeds;
+        } else if (target.githubEmbeds?.length) {
+          const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
+          if (surviving.length > 0) {
+            target.githubEmbeds = surviving;
+          } else {
+            delete target.githubEmbeds;
+          }
         } else {
           delete target.githubEmbeds;
         }

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -587,6 +587,14 @@ export function useMessaging(
       }
       if (githubEmbeds && githubEmbeds.length > 0) {
         updated.githubEmbeds = githubEmbeds;
+      } else if (m.githubEmbeds?.length) {
+        const newBodyText = newBody.trim();
+        const surviving = m.githubEmbeds.filter((e) => newBodyText.includes(e.url));
+        if (surviving.length > 0) {
+          updated.githubEmbeds = surviving;
+        } else {
+          delete updated.githubEmbeds;
+        }
       } else {
         delete updated.githubEmbeds;
       }
@@ -818,6 +826,13 @@ export function useMessaging(
         }
         if (update.githubEmbeds && update.githubEmbeds.length > 0) {
           target.githubEmbeds = update.githubEmbeds;
+        } else if (target.githubEmbeds?.length) {
+          const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
+          if (surviving.length > 0) {
+            target.githubEmbeds = surviving;
+          } else {
+            delete target.githubEmbeds;
+          }
         } else {
           delete target.githubEmbeds;
         }

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -226,8 +226,8 @@ interface FallbackPayload {
  * body so the `> quoted` prefix doesn't double-render on top of the reply chip.
  */
 function stripReplyFallback(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
-  const fallbacks = ext(msg).fallbacks as FallbackPayload[] | undefined;
-  if (!fallbacks?.length || !base.body) return;
+  const fallbacks = asArray(ext(msg).fallbacks as FallbackPayload | FallbackPayload[] | undefined);
+  if (!fallbacks.length || !base.body) return;
   const range = fallbacks.find((f) => f.for === "urn:xmpp:reply:0")?.body;
   if (!range) return;
   const rawStart = range.start ?? 0;

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -368,4 +368,21 @@ describe("groupchat reply + thread parsing", () => {
       },
     ]);
   });
+
+  test("strips fallback when fallbacks is a singleton object instead of array", () => {
+    const h = makeHandlers();
+    const prefix = "> quoted\n\n";
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-singleton-fb",
+        body: `${prefix}reply text`,
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+        fallbacks: { for: "urn:xmpp:reply:0", body: { start: 0, end: prefix.length } },
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("reply text");
+    expect(h.messages[0].replyTo?.id).toBe("msg-1");
+  });
 });

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -531,4 +531,109 @@ describe("MAM history application", () => {
     expect(messaging.messages.value[0].id).toBe("stable-msg-1");
     expect(messaging.messages.value[0].reactions).toEqual({ "🔥": ["bob"] });
   });
+
+  test("preserves GitHub embeds when a correction omits them but URLs still in body", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "msg-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "check https://github.com/waddle-social/waddle",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message",
+          githubEmbeds: [
+            { kind: "repo", url: "https://github.com/waddle-social/waddle", owner: "waddle-social", name: "waddle" },
+          ],
+        },
+        {
+          id: "edit-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "check https://github.com/waddle-social/waddle out!",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          replacesId: "msg-1",
+        },
+      ]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0].id).toBe("msg-1");
+    expect(messaging.messages.value[0].isEdited).toBe(true);
+    expect(messaging.messages.value[0].body).toBe("check https://github.com/waddle-social/waddle out!");
+    expect(messaging.messages.value[0].githubEmbeds).toEqual([
+      { kind: "repo", url: "https://github.com/waddle-social/waddle", owner: "waddle-social", name: "waddle" },
+    ]);
+  });
+
+  test("drops GitHub embeds when a correction removes the URL from body", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "msg-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "check https://github.com/waddle-social/waddle",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message",
+          githubEmbeds: [
+            { kind: "repo", url: "https://github.com/waddle-social/waddle", owner: "waddle-social", name: "waddle" },
+          ],
+        },
+        {
+          id: "edit-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "never mind",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          replacesId: "msg-1",
+        },
+      ]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0].githubEmbeds).toBeUndefined();
+  });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -18,6 +18,7 @@ use waddle_xmpp::{
     muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
     parser::message_to_string,
     registry::{BroadcastOutcome, SendResult},
+    xep::xep0430::build_inbox_push,
     xep::{
         extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
         extract_references_from_message, extract_retraction_from_message, has_file_sharing,
@@ -990,9 +991,7 @@ fn should_archive_groupchat_message(msg: &xmpp_parsers::message::Message) -> boo
         || is_sticker_message(msg)
 }
 
-fn serialize_groupchat_stanza_xml(
-    message: &xmpp_parsers::message::Message,
-) -> Option<String> {
+fn serialize_groupchat_stanza_xml(message: &xmpp_parsers::message::Message) -> Option<String> {
     let mut msg = message.clone();
     msg.to = None;
     match message_to_string(&msg) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -16,8 +16,8 @@ use waddle_xmpp::{
         ArchivedRichPayload, RichMessageId, RichText, STANZA_ID_NS,
     },
     muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
+    parser::message_to_string,
     registry::{BroadcastOutcome, SendResult},
-    xep::xep0430::build_inbox_push,
     xep::{
         extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
         extract_references_from_message, extract_retraction_from_message, has_file_sharing,
@@ -990,6 +990,18 @@ fn should_archive_groupchat_message(msg: &xmpp_parsers::message::Message) -> boo
         || is_sticker_message(msg)
 }
 
+fn serialize_groupchat_stanza_xml(
+    message: &xmpp_parsers::message::Message,
+) -> Option<String> {
+    let mut msg = message.clone();
+    msg.to = None;
+    message_to_string(&msg).ok()
+}
+
+fn serialize_direct_stanza_xml(message: &xmpp_parsers::message::Message) -> Option<String> {
+    message_to_string(message).ok()
+}
+
 async fn archive_groupchat_message(
     state: &WebSocketState,
     room_jid: &BareJid,
@@ -1011,6 +1023,8 @@ async fn archive_groupchat_message(
     let origin_id = extract_origin_id(message);
     let rich = rich_archive_payload(message);
 
+    let stanza_xml = serialize_groupchat_stanza_xml(message);
+
     let archived = ArchivedMessage {
         id: archive_id,
         timestamp: Utc::now(),
@@ -1027,7 +1041,7 @@ async fn archive_groupchat_message(
         reply_to_jid,
         origin_id,
         message_type: mam_message_type(&message.type_),
-        stanza_xml: None,
+        stanza_xml,
         rich,
         nickname_generation: Some(sender_nickname_generation),
     };
@@ -1068,6 +1082,8 @@ async fn archive_direct_message(
         return;
     }
 
+    let stanza_xml = serialize_direct_stanza_xml(message);
+
     let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
     let origin_id = extract_origin_id(message);
 
@@ -1083,7 +1099,7 @@ async fn archive_direct_message(
         reply_to_jid,
         origin_id,
         message_type: mam_message_type(&message.type_),
-        stanza_xml: None,
+        stanza_xml,
         rich,
         nickname_generation: None,
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -995,11 +995,23 @@ fn serialize_groupchat_stanza_xml(
 ) -> Option<String> {
     let mut msg = message.clone();
     msg.to = None;
-    message_to_string(&msg).ok()
+    match message_to_string(&msg) {
+        Ok(xml) => Some(xml),
+        Err(error) => {
+            warn!(error = %error, "Failed to serialize groupchat stanza XML for MAM archive");
+            None
+        }
+    }
 }
 
 fn serialize_direct_stanza_xml(message: &xmpp_parsers::message::Message) -> Option<String> {
-    message_to_string(message).ok()
+    match message_to_string(message) {
+        Ok(xml) => Some(xml),
+        Err(error) => {
+            warn!(error = %error, "Failed to serialize direct message stanza XML for MAM archive");
+            None
+        }
+    }
 }
 
 async fn archive_groupchat_message(

--- a/server/crates/waddle-server/tests/xep0461_replies_ws.rs
+++ b/server/crates/waddle-server/tests/xep0461_replies_ws.rs
@@ -130,3 +130,74 @@ async fn reply_to_unknown_target_routes_without_error() {
 
     client.close().await;
 }
+
+#[tokio::test]
+async fn reply_with_fallback_replays_from_mam() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reply-fb-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="orig-1"><body>original message</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let target = stanza_id(
+        &client
+            .recv_matching(|frame| frame.contains("original message"))
+            .await
+            .expect("original echo"),
+    );
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reply-fb-1">
+                <body>&gt; original message\nmy reply</body>
+                <reply xmlns="urn:xmpp:reply:0" to="{room}/{USERNAME}" id="{target}"/>
+                <fallback xmlns="urn:xmpp:fallback:0" for="urn:xmpp:reply:0">
+                    <body start="0" end="20"/>
+                </fallback>
+            </message>"#
+        ))
+        .await
+        .expect("send reply with fallback");
+    let echo = client
+        .recv_matching(|frame| frame.contains("urn:xmpp:fallback:0"))
+        .await
+        .expect("reply fallback echo");
+    assert!(
+        echo.contains("urn:xmpp:reply:0"),
+        "reply echo missing reply element: {echo}"
+    );
+    assert!(
+        echo.contains("urn:xmpp:fallback:0"),
+        "reply echo missing fallback element: {echo}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-reply-fb" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-reply-fb") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    let reply_mam_frame = frames
+        .iter()
+        .find(|frame| frame.contains("urn:xmpp:reply:0"))
+        .expect("MAM should replay the reply message");
+    assert!(
+        reply_mam_frame.contains("urn:xmpp:fallback:0"),
+        "MAM replay should preserve fallback element: {reply_mam_frame}"
+    );
+    assert!(
+        reply_mam_frame.contains("for=\"urn:xmpp:reply:0\""),
+        "MAM replay should preserve fallback 'for' attribute: {reply_mam_frame}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -435,10 +435,6 @@ fn parse_message_jid(to_jid: &str) -> Jid {
 }
 
 fn archived_inner_message(archived: &ArchivedMessage) -> Element {
-    if let Some(rich) = archived.rich.as_ref() {
-        return build_typed_inner_message(archived, rich);
-    }
-
     if let Some(stanza_xml) = archived.stanza_xml.as_deref() {
         match stanza_xml.parse::<Element>() {
             Ok(element) => return normalize_archived_inner_message(element, archived),
@@ -446,10 +442,14 @@ fn archived_inner_message(archived: &ArchivedMessage) -> Element {
                 warn!(
                     archive_id = %archived.id,
                     error = %error,
-                    "Failed to parse archived stanza XML"
+                    "Failed to parse archived stanza XML, falling back to typed reconstruction"
                 );
             }
         }
+    }
+
+    if let Some(rich) = archived.rich.as_ref() {
+        return build_typed_inner_message(archived, rich);
     }
 
     build_legacy_inner_message(archived)
@@ -957,5 +957,149 @@ mod tests {
             .expect("stanza-id payload");
         assert_eq!(stanza_id.attr("id"), Some("archive-1"));
         assert_eq!(stanza_id.attr("by"), Some("room@example.com"));
+    }
+
+    #[test]
+    fn stanza_xml_preferred_over_rich_payload() {
+        let archived = ArchivedMessage {
+            id: "msg-priority".to_string(),
+            timestamp: Utc::now(),
+            from: "room@conference.example.com/alice".to_string(),
+            to: "room@conference.example.com".to_string(),
+            body: "typed body".to_string(),
+            message_type: "groupchat".to_string(),
+            stanza_xml: Some(
+                "<message xmlns='jabber:client' from='room@conference.example.com/alice' type='groupchat' id='live-1'><body>live body with embeds</body><github xmlns='urn:waddle:github:0'><repo url='https://github.com/example/project'><owner>example</owner><name>project</name></repo></github></message>".to_string(),
+            ),
+            rich: Some(ArchivedRichMessage {
+                payload: None,
+                reply: None,
+                references: vec![],
+                mentions: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let msg = build_result_messages("query-priority", "user@example.com", &[archived]);
+        let result = msg[0]
+            .payloads
+            .iter()
+            .find(|p| p.name() == "result" && p.ns() == MAM_NS)
+            .expect("result payload");
+        let forwarded = result
+            .children()
+            .find(|c| c.name() == "forwarded" && c.ns() == FORWARD_NS)
+            .expect("forwarded element");
+        let inner_msg = forwarded
+            .children()
+            .find(|c| c.name() == "message" && c.ns() == CLIENT_NS)
+            .expect("inner message");
+
+        let body = inner_msg
+            .get_child("body", CLIENT_NS)
+            .expect("body element");
+        assert_eq!(body.text(), "live body with embeds");
+
+        let github = inner_msg
+            .children()
+            .find(|c| c.name() == "github" && c.ns() == "urn:waddle:github:0")
+            .expect("github embed payload");
+        assert!(github.children().any(|c| c.name() == "repo"));
+    }
+
+    #[test]
+    fn stanza_xml_preserves_reply_fallback() {
+        let archived = ArchivedMessage {
+            id: "msg-fallback".to_string(),
+            timestamp: Utc::now(),
+            from: "room@conference.example.com/bob".to_string(),
+            to: "room@conference.example.com".to_string(),
+            body: "> Alice wrote:\n> Hello!\nI agree!".to_string(),
+            message_type: "groupchat".to_string(),
+            stanza_xml: Some(
+                "<message xmlns='jabber:client' from='room@conference.example.com/bob' type='groupchat' id='reply-1'><body>&gt; Alice wrote:\n&gt; Hello!\nI agree!</body><reply xmlns='urn:xmpp:reply:0' id='orig-1' to='room@conference.example.com/alice'/><fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'><body start='0' end='22'/></fallback></message>".to_string(),
+            ),
+            reply_to_id: Some("orig-1".to_string()),
+            reply_to_jid: Some("room@conference.example.com/alice".to_string()),
+            rich: Some(ArchivedRichMessage {
+                payload: None,
+                reply: Some(ArchivedReply {
+                    id: RichMessageId("orig-1".to_string()),
+                    to: Some("room@conference.example.com/alice".parse().unwrap()),
+                }),
+                references: vec![],
+                mentions: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let msg = build_result_messages("query-fallback", "user@example.com", &[archived]);
+        let result = msg[0]
+            .payloads
+            .iter()
+            .find(|p| p.name() == "result" && p.ns() == MAM_NS)
+            .expect("result payload");
+        let forwarded = result
+            .children()
+            .find(|c| c.name() == "forwarded" && c.ns() == FORWARD_NS)
+            .expect("forwarded element");
+        let inner_msg = forwarded
+            .children()
+            .find(|c| c.name() == "message" && c.ns() == CLIENT_NS)
+            .expect("inner message");
+
+        let reply = inner_msg
+            .children()
+            .find(|c| c.name() == "reply" && c.ns() == "urn:xmpp:reply:0")
+            .expect("reply element");
+        assert_eq!(reply.attr("id"), Some("orig-1"));
+
+        let fallback = inner_msg
+            .children()
+            .find(|c| c.name() == "fallback" && c.ns() == "urn:xmpp:fallback:0")
+            .expect("fallback element");
+        assert_eq!(fallback.attr("for"), Some("urn:xmpp:reply:0"));
+        let fallback_body = fallback
+            .get_child("body", "urn:xmpp:fallback:0")
+            .expect("fallback body element");
+        assert_eq!(fallback_body.attr("start"), Some("0"));
+        assert_eq!(fallback_body.attr("end"), Some("22"));
+    }
+
+    #[test]
+    fn stanza_xml_strips_to_for_groupchat() {
+        let archived = ArchivedMessage {
+            id: "msg-strip-to".to_string(),
+            timestamp: Utc::now(),
+            from: "room@conference.example.com/alice".to_string(),
+            to: "room@conference.example.com".to_string(),
+            body: "Hello!".to_string(),
+            message_type: "groupchat".to_string(),
+            stanza_xml: Some(
+                "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='msg-1'><body>Hello!</body></message>".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let msg = build_result_messages("query-strip-to", "user@example.com", &[archived]);
+        let result = msg[0]
+            .payloads
+            .iter()
+            .find(|p| p.name() == "result" && p.ns() == MAM_NS)
+            .expect("result payload");
+        let forwarded = result
+            .children()
+            .find(|c| c.name() == "forwarded" && c.ns() == FORWARD_NS)
+            .expect("forwarded element");
+        let inner_msg = forwarded
+            .children()
+            .find(|c| c.name() == "message" && c.ns() == CLIENT_NS)
+            .expect("inner message");
+
+        assert!(
+            inner_msg.attr("to").is_none(),
+            "groupchat MAM replay should not have a 'to' attribute, got: {:?}",
+            inner_msg.attr("to")
+        );
     }
 }

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -456,7 +456,7 @@ fn archived_inner_message(archived: &ArchivedMessage) -> Element {
 }
 
 fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage) -> Element {
-    if archived.message_type != "groupchat" || element.attr("to").is_none() {
+    if archived.message_type != "groupchat" {
         return element;
     }
 
@@ -465,7 +465,22 @@ fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage
         return Element::from(message);
     }
 
-    element
+    if element.attr("to").is_none() {
+        return element;
+    }
+
+    let ns = element.ns().to_string();
+    let name = element.name().to_string();
+    let mut builder = Element::builder(name, &ns);
+    for (key, value) in element.attrs() {
+        if key != "to" {
+            builder = builder.attr(key, value);
+        }
+    }
+    for child in element.children().cloned() {
+        builder = builder.append(child);
+    }
+    builder.build()
 }
 
 fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMessage) -> Element {
@@ -1099,6 +1114,42 @@ mod tests {
         assert!(
             inner_msg.attr("to").is_none(),
             "groupchat MAM replay should not have a 'to' attribute, got: {:?}",
+            inner_msg.attr("to")
+        );
+    }
+
+    #[test]
+    fn stanza_xml_strips_to_for_groupchat_on_raw_element_fallback() {
+        let stanza_xml = "<message xmlns='jabber:client' from='room@conf.example.com/alice' to='room@conf.example.com' type='groupchat' id='msg-x'><body>test</body><custom xmlns='urn:example:unknown'/></message>";
+        let archived = ArchivedMessage {
+            id: "msg-strip-raw".to_string(),
+            timestamp: Utc::now(),
+            from: "room@conf.example.com/alice".to_string(),
+            to: "room@conf.example.com".to_string(),
+            body: "test".to_string(),
+            message_type: "groupchat".to_string(),
+            stanza_xml: Some(stanza_xml.to_string()),
+            ..Default::default()
+        };
+
+        let msg = build_result_messages("query-strip-raw", "user@example.com", &[archived]);
+        let result = msg[0]
+            .payloads
+            .iter()
+            .find(|p| p.name() == "result" && p.ns() == MAM_NS)
+            .expect("result payload");
+        let forwarded = result
+            .children()
+            .find(|c| c.name() == "forwarded" && c.ns() == FORWARD_NS)
+            .expect("forwarded element");
+        let inner_msg = forwarded
+            .children()
+            .find(|c| c.name() == "message" && c.ns() == CLIENT_NS)
+            .expect("inner message");
+
+        assert!(
+            inner_msg.attr("to").is_none(),
+            "groupchat MAM replay via raw element fallback should not have a 'to' attribute, got: {:?}",
             inner_msg.attr("to")
         );
     }

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -391,11 +391,15 @@ impl SqlxMamStorage {
             MamDatabaseBackend::Sqlite(pool) => {
                 execute_sqlite_batch(pool, SQLITE_MAM_SCHEMA).await?;
                 ensure_sqlite_column(pool, "rich_payload", "TEXT").await?;
+                ensure_sqlite_column(pool, "stanza_xml", "TEXT").await?;
                 ensure_sqlite_column(pool, "nickname_generation", "INTEGER").await
             }
             MamDatabaseBackend::Postgres(pool) => {
                 execute_postgres_batch(pool, POSTGRES_MAM_SCHEMA).await?;
                 sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS rich_payload TEXT")
+                    .execute(pool)
+                    .await?;
+                sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS stanza_xml TEXT")
                     .execute(pool)
                     .await?;
                 sqlx::query(


### PR DESCRIPTION
## Summary

- **Root cause**: MAM archive stored only a reduced typed projection (`rich_payload`) of messages, discarding GitHub embeds (`urn:waddle:github:0`) and XEP-0428 fallback indications. On page refresh, MAM replay reconstructed stanzas from those lossy typed fields, causing GitHub enrichment cards to vanish and reply fallback quotes to double-render.

- **Server fix**: Populate `stanza_xml` in `archive_groupchat_message()` and `archive_direct_message()` with the full enriched stanza serialized to XML. Reverse replay priority in `archived_inner_message()` to prefer `stanza_xml` over typed reconstruction. The `normalize_archived_inner_message()` function already strips the `to` attribute for groupchat messages.

- **Client fix**: Harden `stripReplyFallback()` with `asArray()` to handle singleton fallback objects. Preserve GitHub embeds across corrections: when a correction lacks embeds but the embed URLs still appear in the new body, keep the surviving embeds instead of deleting them.

## Changes

### Server (`waddle-server`, `waddle-xmpp-core`)

- `message.rs`: Added `serialize_groupchat_stanza_xml()` and `serialize_direct_stanza_xml()` helpers; both archive functions now populate `stanza_xml` with the fully enriched message.
- `mam.rs`: Swapped priority in `archived_inner_message()` — `stanza_xml` is now tried first, with `rich` as fallback on parse errors. Added 3 unit tests: stanza_xml preferred over rich, reply+fallback preserved, groupchat `to` attribute stripped.
- `xep0461_replies_ws.rs`: Added integration test `reply_with_fallback_replays_from_mam`.

### Client (`chat`)

- `message-parsing.ts`: `stripReplyFallback()` now uses `asArray()` for `fallbacks` to handle singleton objects.
- `useMessaging.ts`, `useDmMessaging.ts`: `applyCorrection()` and inline correction path in `loadMessages()` now preserve embeds whose URLs still appear in the corrected body.
- Tests: singleton fallback stripping, embed preservation on correction, embed removal when URL gone.

## Test plan

- [x] Server unit tests pass (`cargo test -p waddle-xmpp-core -- mam::`)
- [x] Client tests pass (`bun test` — 381 tests)
- [x] Client lint passes (`bun run lint` — knip clean)
- [ ] Integration test (`xep0461_replies_ws`) blocked by pre-existing `build_inbox_push` compile error in `waddle-server`
- [ ] Manual verification: send a reply with fallback in a room, refresh page, verify fallback is stripped and GitHub cards persist