### PR TITLE
feat(server): #238 publish-time PubSub fan-out delivery

### DIFF
--- a/server/crates/waddle-server/src/pubsub.rs
+++ b/server/crates/waddle-server/src/pubsub.rs
@@ -1188,6 +1188,7 @@ mod tests {
 
             let item = PubSubItem {
                 id: Some("room@muc.example.com".to_string()),
+                publisher: None,
                 payload: None,
             };
             storage
@@ -1233,6 +1234,7 @@ mod tests {
         for id in ["one@muc.example.com", "two@muc.example.com"] {
             let item = PubSubItem {
                 id: Some(id.to_string()),
+                publisher: None,
                 payload: None,
             };
             storage
@@ -1342,6 +1344,7 @@ mod tests {
         for i in 1..=3 {
             let item = PubSubItem {
                 id: Some(format!("i{i}")),
+                publisher: None,
                 payload: None,
             };
             storage

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -370,6 +370,7 @@ async fn seed_initial_xmpp_topology(
             .with_autojoin(id == "chat");
         let item = PubSubItem {
             id: Some(bookmark.jid.to_string()),
+            publisher: None,
             payload: Some(waddle_xmpp::xep::xep0402::build_bookmark_element(&bookmark)),
         };
         pubsub_storage

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1439,6 +1439,15 @@ pub async fn handle_iq_with_conn_state(
                             created = publish_result.node_created,
                             "PubSub item published via WebSocket"
                         );
+                        super::pubsub_fanout::fan_out_publish(
+                            state,
+                            &target_jid,
+                            &node,
+                            &item,
+                            &publish_result.item_id,
+                            Some(&user_jid),
+                        )
+                        .await;
                         let response =
                             build_pubsub_publish_result(&iq, &node, &publish_result.item_id);
                         return vec![iq_to_xml(response)];
@@ -4401,6 +4410,18 @@ async fn handle_spaces_publish(
                     PubSubError::InternalServerError,
                 ))];
             }
+            // Fan-out only after the parent-tuple write succeeds: the
+            // compensating-retract path above must NOT emit events for
+            // a publish that gets rolled back.
+            super::pubsub_fanout::fan_out_publish(
+                state,
+                &spaces_jid,
+                node,
+                &item,
+                &result.item_id,
+                None,
+            )
+            .await;
             vec![iq_to_xml(build_pubsub_publish_result(
                 iq,
                 node,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/mod.rs
@@ -1,3 +1,4 @@
 pub mod iq;
 pub mod message;
 pub mod presence;
+pub mod pubsub_fanout;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -16,7 +16,10 @@
 //! - Expands subscribers per §6.1.6 (bare JID → all live resources) and
 //!   §6.1.7 (full JID → that resource).
 //! - Falls back to the SM detached-resource stash (XEP-0198) when the
-//!   live channel is closed or full.
+//!   live channel is closed or the recipient is not currently
+//!   connected. Bare-JID subscribers with no live resources also have
+//!   their detached resources enumerated explicitly so resumable
+//!   sessions still receive the event on resume.
 //! - Best-effort: storage errors are logged and swallowed; subscribers
 //!   catch up via `<items/>` on reconnect (RFC 6121 §8.5.2.1.4 forbids
 //!   offline storage of headline messages, which is the type used by
@@ -112,17 +115,40 @@ pub async fn fan_out_publish(
     for sub in subscribers {
         let target_resources: Vec<FullJid> = match sub.subscriber.try_as_full() {
             Ok(full) => vec![full.clone()],
-            Err(bare) => state
-                .deps
-                .protocol
-                .connection_registry
-                .get_resources_for_user(bare),
+            Err(bare) => {
+                // §6.1.6: notify all resources of the bare JID. Live
+                // resources go through the connection registry; detached
+                // (XEP-0198 resumable) sessions are enumerated explicitly
+                // so events still reach them via the per-resource SM
+                // stash even when the user has no live socket at publish
+                // time.
+                let mut all = state
+                    .deps
+                    .protocol
+                    .connection_registry
+                    .get_resources_for_user(bare);
+                match state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .detached_resources_for_user(bare)
+                    .await
+                {
+                    Ok(detached) => all.extend(detached),
+                    Err(error) => warn!(
+                        bare = %bare,
+                        error = %error,
+                        "Failed to enumerate detached resources for bare-JID fan-out"
+                    ),
+                }
+                all
+            }
         };
 
         if target_resources.is_empty() {
-            // Bare-JID subscriber with no live resources, or a full-JID
-            // we never see live. Headline messages MUST NOT go to offline
-            // storage (RFC 6121 §8.5.2.1.4), so drop on the floor;
+            // Bare-JID subscriber fully offline (no live, no resumable),
+            // or a full-JID we never see live. Headline messages MUST
+            // NOT go to offline storage (RFC 6121 §8.5.2.1.4); the
             // subscriber catches up via `<items/>` on reconnect.
             intended += 1;
             not_connected += 1;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -1,0 +1,201 @@
+//! Publish-time fan-out of XEP-0060 §7.1 event notifications.
+//!
+//! Called from both the generic `PubSubRequest::Publish` arm and
+//! `handle_spaces_publish` after `publish_item` succeeds, so §7.1
+//! emission is a single seam regardless of node type (PEP, regular
+//! PubSub, Spaces).
+//!
+//! Behavior:
+//!
+//! - Reads `NodeConfig` once via `pubsub_storage::get_node` to honor
+//!   `deliver_payloads` (XEP-0060 §7.1.3.5) at item-construction time.
+//! - Queries `pubsub_storage::list_deliverable_subscribers` — outcasts
+//!   and non-`Subscribed` entries are filtered by storage.
+//! - Builds the event item with `<item id='X' [publisher='Y']>...</item>`
+//!   per §7.1.5 (publisher attribute only when ≠ owner).
+//! - Expands subscribers per §6.1.6 (bare JID → all live resources) and
+//!   §6.1.7 (full JID → that resource).
+//! - Falls back to the SM detached-resource stash (XEP-0198) when the
+//!   live channel is closed or full.
+//! - Best-effort: storage errors are logged and swallowed; subscribers
+//!   catch up via `<items/>` on reconnect (RFC 6121 §8.5.2.1.4 forbids
+//!   offline storage of headline messages, which is the type used by
+//!   `build_pubsub_event`).
+//!
+//! Race window: a subscriber may unsubscribe between the deliverable-list
+//! query and per-resource dispatch; the trailing event is permitted by
+//! §7.1 and not worth holding a lock across fan-out to prevent.
+
+use jid::{BareJid, FullJid, Jid};
+use tracing::{debug, info, warn};
+use waddle_xmpp::pubsub::{build_pubsub_event, PubSubEvent, PubSubItem};
+use waddle_xmpp::registry::BroadcastOutcome;
+use waddle_xmpp::Stanza;
+
+use super::super::WebSocketState;
+
+/// Dispatch a §7.1 event notification to every deliverable subscriber.
+pub async fn fan_out_publish(
+    state: &WebSocketState,
+    owner: &BareJid,
+    node: &str,
+    published_item: &PubSubItem,
+    item_id: &str,
+    publisher: Option<&BareJid>,
+) {
+    let storage = &state.deps.protocol.pubsub_storage;
+
+    let node_cfg = match storage.get_node(owner, node).await {
+        Ok(Some(record)) => record.config,
+        Ok(None) => {
+            warn!(
+                owner = %owner,
+                node,
+                "Fan-out skipped: node disappeared between publish and config fetch"
+            );
+            return;
+        }
+        Err(error) => {
+            warn!(
+                owner = %owner,
+                node,
+                error = %error,
+                "Fan-out skipped: node config fetch failed"
+            );
+            return;
+        }
+    };
+
+    let subscribers = match storage.list_deliverable_subscribers(owner, node).await {
+        Ok(subs) => subs,
+        Err(error) => {
+            warn!(
+                owner = %owner,
+                node,
+                error = %error,
+                "Fan-out skipped: subscriber list fetch failed"
+            );
+            return;
+        }
+    };
+
+    if subscribers.is_empty() {
+        debug!(owner = %owner, node, "No deliverable subscribers; nothing to fan out");
+        return;
+    }
+
+    // §7.1.5: include `publisher` only when it differs from the owner.
+    let event_publisher = publisher.filter(|p| *p != owner).cloned();
+
+    // §7.1.3.5: payload included only when deliver_payloads is true.
+    let event_payload = if node_cfg.deliver_payloads {
+        published_item.payload.clone()
+    } else {
+        None
+    };
+
+    let event_item = PubSubItem {
+        id: Some(item_id.to_string()),
+        publisher: event_publisher,
+        payload: event_payload,
+    };
+
+    let event = PubSubEvent::new(node.to_string(), vec![event_item]);
+    let from = Jid::from(owner.clone());
+
+    let mut intended: u32 = 0;
+    let mut delivered: u32 = 0;
+    let mut dropped_full: u32 = 0;
+    let mut dropped_closed: u32 = 0;
+    let mut not_connected: u32 = 0;
+
+    for sub in subscribers {
+        let target_resources: Vec<FullJid> = match sub.subscriber.try_as_full() {
+            Ok(full) => vec![full.clone()],
+            Err(bare) => state
+                .deps
+                .protocol
+                .connection_registry
+                .get_resources_for_user(bare),
+        };
+
+        if target_resources.is_empty() {
+            // Bare-JID subscriber with no live resources, or a full-JID
+            // we never see live. Headline messages MUST NOT go to offline
+            // storage (RFC 6121 §8.5.2.1.4), so drop on the floor;
+            // subscriber catches up via `<items/>` on reconnect.
+            intended += 1;
+            not_connected += 1;
+            continue;
+        }
+
+        for resource in target_resources {
+            intended += 1;
+            let message = build_pubsub_event(&from, &Jid::from(resource.clone()), &event);
+            let stanza = Stanza::Message(message);
+
+            match state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(&resource, stanza.clone())
+            {
+                BroadcastOutcome::Delivered => delivered += 1,
+                BroadcastOutcome::DroppedFull => dropped_full += 1,
+                BroadcastOutcome::DroppedClosed => match state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .record_stanza_for_detached_bound_resource(&resource, &stanza)
+                    .await
+                {
+                    Ok(true) => delivered += 1,
+                    Ok(false) => dropped_closed += 1,
+                    Err(error) => {
+                        warn!(
+                            resource = %resource,
+                            error = %error,
+                            "Failed to record fan-out stanza for detached resource after closed live send"
+                        );
+                        dropped_closed += 1;
+                    }
+                },
+                BroadcastOutcome::NotConnected => match state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .record_stanza_for_detached_bound_resource(&resource, &stanza)
+                    .await
+                {
+                    Ok(true) => delivered += 1,
+                    Ok(false) => not_connected += 1,
+                    Err(error) => {
+                        warn!(
+                            resource = %resource,
+                            error = %error,
+                            "Failed to record fan-out stanza for detached resource"
+                        );
+                        not_connected += 1;
+                    }
+                },
+            }
+        }
+    }
+
+    debug_assert_eq!(
+        intended,
+        delivered + dropped_full + dropped_closed + not_connected,
+        "fan-out accounting must cover every dispatch attempt exactly once"
+    );
+
+    info!(
+        owner = %owner,
+        node,
+        intended,
+        delivered,
+        dropped_full,
+        dropped_closed,
+        not_connected,
+        "PubSub publish fan-out complete"
+    );
+}

--- a/server/crates/waddle-server/tests/xep0060_pubsub_ws.rs
+++ b/server/crates/waddle-server/tests/xep0060_pubsub_ws.rs
@@ -14,6 +14,7 @@ static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
 
 async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
     let password = server.fixed_account_password().to_string();
@@ -64,6 +65,41 @@ fn count_occurrences(haystack: &str, needle: &str) -> usize {
         start += pos + needle.len();
     }
     count
+}
+
+/// Drain frames until one is a `<message>` carrying an XEP-0060 §7.1 event
+/// for `node`. Returns the matching frame or `None` on timeout.
+async fn wait_for_event_message(
+    client: &mut WsXmppClient,
+    node: &str,
+    dur: Duration,
+) -> Option<String> {
+    let deadline = std::time::Instant::now() + dur;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                let is_event_msg = frame.contains("<message")
+                    && frame.contains(NS_PUBSUB_EVENT)
+                    && (frame.contains(&format!(r#"node="{node}""#))
+                        || frame.contains(&format!(r#"node='{node}'"#)));
+                if is_event_msg {
+                    return Some(frame);
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Assert no event-message frame arrives for `node` within `dur`.
+async fn assert_no_event_message(client: &mut WsXmppClient, node: &str, dur: Duration) {
+    if let Some(frame) = wait_for_event_message(client, node, dur).await {
+        panic!("expected no event message for node {node}, got: {frame}");
+    }
 }
 
 // ============================================================================
@@ -528,5 +564,440 @@ async fn outcast_subscriber_cannot_subscribe() {
     // Drain any remaining frames before dropping.
     let _ = bob.recv_timeout(Duration::from_millis(200)).await;
     bob.close().await;
+    admin.close().await;
+}
+
+// ============================================================================
+// XEP-0060 §7.1 publish-time fan-out (#238)
+// ============================================================================
+
+/// Set the access model on a PEP-style node so non-owner subscribers are
+/// admitted regardless of presence — presence-driven filtering is out of
+/// scope for #238.
+async fn configure_open_access(client: &mut WsXmppClient, owner: &str, node: &str, id: &str) {
+    let resp = iq_set_to(
+        client,
+        id,
+        owner,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{node}"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>open</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        resp.contains(r#"type="result""#),
+        "configure access_model=open: {resp}"
+    );
+}
+
+async fn auto_create_node(client: &mut WsXmppClient, owner: &str, node: &str, id: &str) {
+    let resp = iq_set_to(
+        client,
+        id,
+        owner,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{node}"><item id="seed"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        resp.contains(r#"type="result""#),
+        "auto-create publish: {resp}"
+    );
+}
+
+async fn subscribe_with_jid(
+    client: &mut WsXmppClient,
+    owner: &str,
+    node: &str,
+    subscriber_jid: &str,
+    id: &str,
+) {
+    let resp = iq_set_to(
+        client,
+        id,
+        owner,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="{node}" jid="{subscriber_jid}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(resp.contains(r#"type="result""#), "subscribe: {resp}");
+}
+
+#[tokio::test]
+async fn publish_fans_event_with_payload_to_subscriber() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "fanout-payload-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-payload", "fp-create").await;
+    configure_open_access(&mut admin, &admin_bare, "fanout-payload", "fp-cfg").await;
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-payload-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    subscribe_with_jid(&mut bob, &admin_bare, "fanout-payload", &bob_bare, "fp-sub").await;
+
+    // Admin publishes — bob should receive a §7.1 event message.
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "fp-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-payload"><item id="event-1"><nick xmlns="http://jabber.org/protocol/nick">Juliet</nick></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, "fanout-payload", Duration::from_secs(2))
+        .await
+        .expect("bob should receive an event message");
+
+    assert!(
+        event.contains(r#"type="headline""#) || event.contains(r#"type='headline'"#),
+        "event must be type=headline (XEP-0060 §12.18 / XEP-0163 §4.3): {event}"
+    );
+    assert!(
+        event.contains(&format!(r#"from="{admin_bare}""#))
+            || event.contains(&format!(r#"from='{admin_bare}'"#)),
+        "from must be the node owner (XEP-0060 §7.1.2.1): {event}"
+    );
+    assert!(
+        event.contains(r#"id="event-1""#) || event.contains(r#"id='event-1'"#),
+        "event item id must round-trip: {event}"
+    );
+    assert!(
+        event.contains("<nick"),
+        "deliver_payloads=true (PEP default) must include payload: {event}"
+    );
+
+    bob.close().await;
+    admin.close().await;
+}
+
+#[tokio::test]
+async fn publish_strips_payload_when_deliver_payloads_is_false() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "fanout-nopayload-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-nopayload", "np-create").await;
+
+    // Set both fields in one form — `parse_configure_form` starts from
+    // `NodeConfig::default()`, so any unspecified field reverts to its
+    // PEP default (e.g. access_model=presence). Bundling preserves
+    // open access alongside deliver_payloads=0 (§7.1.3.5).
+    let cfg_resp = iq_set_to(
+        &mut admin,
+        "np-cfg",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="fanout-nopayload"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>open</value></field><field var="pubsub#deliver_payloads"><value>0</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        cfg_resp.contains(r#"type="result""#),
+        "configure open + deliver_payloads=0: {cfg_resp}"
+    );
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-nopayload-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    subscribe_with_jid(
+        &mut bob,
+        &admin_bare,
+        "fanout-nopayload",
+        &bob_bare,
+        "np-sub",
+    )
+    .await;
+
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "np-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-nopayload"><item id="event-2"><nick xmlns="http://jabber.org/protocol/nick">Juliet</nick></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, "fanout-nopayload", Duration::from_secs(2))
+        .await
+        .expect("bob should receive event");
+
+    assert!(
+        event.contains(r#"id="event-2""#) || event.contains(r#"id='event-2'"#),
+        "event item id must be present: {event}"
+    );
+    assert!(
+        !event.contains("<nick"),
+        "deliver_payloads=false must strip payload (§7.1.3.5): {event}"
+    );
+
+    bob.close().await;
+    admin.close().await;
+}
+
+// XEP-0060 §6.1.7 single-resource fan-out (FullJid subscribers) is not yet
+// implemented: the SQL store normalises subscriber JIDs to bare on insert
+// (`server/crates/waddle-server/src/pubsub.rs` — see "full-JID subscriptions
+// are not currently supported in the DB store"). The fan-out helper has the
+// `try_as_full()` branch ready, so once the storage layer round-trips full
+// JIDs the helper will route §6.1.7 traffic correctly without further
+// changes. Tracking ticket should add a `full_jid_subscription_targets_only_that_resource`
+// case alongside the storage fix.
+
+#[tokio::test]
+async fn bare_jid_subscription_targets_all_resources() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "fanout-barejid-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-bare", "bj-create").await;
+    configure_open_access(&mut admin, &admin_bare, "fanout-bare", "bj-cfg").await;
+
+    let mut bob_r1 = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-bare-r1",
+    )
+    .await
+    .expect("bob r1 connect");
+    let mut bob_r2 = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-bare-r2",
+    )
+    .await
+    .expect("bob r2 connect");
+
+    // Single subscription using the BARE jid — both resources must be
+    // notified (XEP-0060 §6.1.6).
+    subscribe_with_jid(
+        &mut bob_r1,
+        &admin_bare,
+        "fanout-bare",
+        &bob_bare,
+        "bj-sub-bare",
+    )
+    .await;
+
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "bj-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-bare"><item id="event-4"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let r1 = wait_for_event_message(&mut bob_r1, "fanout-bare", Duration::from_secs(2))
+        .await
+        .expect("r1 must receive event from bare-JID subscription");
+    assert!(r1.contains(r#"id="event-4""#), "{r1}");
+
+    let r2 = wait_for_event_message(&mut bob_r2, "fanout-bare", Duration::from_secs(2))
+        .await
+        .expect("r2 must also receive event from bare-JID subscription");
+    assert!(r2.contains(r#"id="event-4""#), "{r2}");
+
+    bob_r1.close().await;
+    bob_r2.close().await;
+    admin.close().await;
+}
+
+#[tokio::test]
+async fn event_omits_publisher_attribute_when_publisher_equals_owner() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "fanout-pub-eq-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-pub-eq", "pe-create").await;
+    configure_open_access(&mut admin, &admin_bare, "fanout-pub-eq", "pe-cfg").await;
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-pub-eq-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    subscribe_with_jid(&mut bob, &admin_bare, "fanout-pub-eq", &bob_bare, "pe-sub").await;
+
+    // Admin (owner) publishes — XEP-0060 §7.1.5: omit `publisher` attr.
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "pe-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-pub-eq"><item id="event-5"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, "fanout-pub-eq", Duration::from_secs(2))
+        .await
+        .expect("bob must receive event");
+
+    assert!(
+        !event.contains("publisher="),
+        "publisher attr must be omitted when publisher == owner (§7.1.5): {event}"
+    );
+
+    bob.close().await;
+    admin.close().await;
+}
+
+#[tokio::test]
+async fn event_includes_publisher_attribute_when_publisher_differs_from_owner() {
+    let _serial = TEST_SERIAL.lock().await;
+    let charlie_password = format!("ws-test-charlie-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("charlie", charlie_password.as_str()),
+        ("bob", bob_password.as_str()),
+    ]);
+    let mut admin = admin_client(&server, "fanout-pub-ne-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let charlie_bare = format!("charlie@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-pub-ne", "pn-create").await;
+    configure_open_access(&mut admin, &admin_bare, "fanout-pub-ne", "pn-cfg").await;
+
+    // Grant charlie publisher affiliation on admin's node so charlie can
+    // publish on a node owned by admin.
+    let aff_resp = iq_set_to(
+        &mut admin,
+        "pn-aff",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><affiliations node="fanout-pub-ne"><affiliation xmlns="{NS_PUBSUB_OWNER}" jid="{charlie_bare}" affiliation="publisher"/></affiliations></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        aff_resp.contains(r#"type="result""#),
+        "grant publisher affiliation: {aff_resp}"
+    );
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "fanout-pub-ne-bob",
+    )
+    .await
+    .expect("bob connect");
+    subscribe_with_jid(&mut bob, &admin_bare, "fanout-pub-ne", &bob_bare, "pn-sub").await;
+
+    // Charlie connects and publishes to admin's node.
+    let mut charlie = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "charlie",
+        &charlie_password,
+        "fanout-pub-ne-charlie",
+    )
+    .await
+    .expect("charlie connect");
+    let pub_resp = iq_set_to(
+        &mut charlie,
+        "pn-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-pub-ne"><item id="event-6"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        pub_resp.contains(r#"type="result""#),
+        "charlie publish to admin node: {pub_resp}"
+    );
+
+    let event = wait_for_event_message(&mut bob, "fanout-pub-ne", Duration::from_secs(2))
+        .await
+        .expect("bob must receive event");
+
+    assert!(
+        event.contains(&format!(r#"publisher="{charlie_bare}""#))
+            || event.contains(&format!(r#"publisher='{charlie_bare}'"#)),
+        "publisher attribute must carry charlie's bare JID (§7.1.5): {event}"
+    );
+
+    bob.close().await;
+    charlie.close().await;
+    admin.close().await;
+}
+
+#[tokio::test]
+async fn publish_with_no_subscribers_returns_result_and_emits_no_event() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "fanout-empty-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+
+    auto_create_node(&mut admin, &admin_bare, "fanout-empty", "em-create").await;
+
+    // Publish with no subscribers — the IQ result must arrive, and admin
+    // (the only connected user, not subscribed to its own node) must not
+    // receive any event-message frame.
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "em-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="fanout-empty"><item id="event-7"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        pub_resp.contains(r#"type="result""#),
+        "publish without subscribers must still succeed: {pub_resp}"
+    );
+    assert_no_event_message(&mut admin, "fanout-empty", Duration::from_millis(500)).await;
+
     admin.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0060_spaces_owner_ws.rs
+++ b/server/crates/waddle-server/tests/xep0060_spaces_owner_ws.rs
@@ -6,6 +6,7 @@
 
 mod ws_common;
 
+use std::time::Duration;
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
 
@@ -13,7 +14,9 @@ const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
 const SPACES_JID: &str = "spaces.localhost";
+const MUC_DOMAIN: &str = "muc.localhost";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
@@ -239,4 +242,94 @@ async fn non_owner_cannot_configure_general_space() {
         "expected <forbidden/> condition, got: {resp}"
     );
     alice.close().await;
+}
+
+// ============================================================================
+// XEP-0060 §7.1 Spaces publish-time fan-out (#238)
+// ============================================================================
+
+async fn wait_for_event_message(
+    client: &mut WsXmppClient,
+    node: &str,
+    dur: Duration,
+) -> Option<String> {
+    let deadline = std::time::Instant::now() + dur;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                if frame.contains("<message")
+                    && frame.contains(NS_PUBSUB_EVENT)
+                    && (frame.contains(&format!(r#"node="{node}""#))
+                        || frame.contains(&format!(r#"node='{node}'"#)))
+                {
+                    return Some(frame);
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn spaces_publish_fans_event_to_subscriber() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "spaces-fanout-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    // Subscribe admin to the seeded `general` Spaces node (XEP-0503).
+    let sub = iq_set_to(
+        &mut admin,
+        "spaces-fanout-sub",
+        SPACES_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="general" jid="{admin_bare}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(is_result(&sub), "subscribe to spaces.general: {sub}");
+
+    // Publish a bookmark item pointing at the seeded `chat@muc.localhost`
+    // managed room — this is the only way the Spaces publish path admits
+    // a bookmark, since `handle_spaces_publish` enforces that the bookmark
+    // JID resolves to an existing managed channel (XEP-0503 §4).
+    let chat_room = format!("chat@{MUC_DOMAIN}");
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "spaces-fanout-pub",
+        SPACES_JID,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="general"><item id="{chat_room}"><conference xmlns="urn:xmpp:bookmarks:1" name="Chat"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        is_result(&pub_resp),
+        "Spaces publish via handle_spaces_publish: {pub_resp}"
+    );
+
+    let event = wait_for_event_message(&mut admin, "general", Duration::from_secs(2))
+        .await
+        .expect("Spaces subscriber must receive §7.1 event (acceptance criterion of #238)");
+
+    assert!(
+        event.contains(r#"type="headline""#) || event.contains(r#"type='headline'"#),
+        "Spaces event must be headline (XEP-0060 §12.18): {event}"
+    );
+    assert!(
+        event.contains(&format!(r#"from="{SPACES_JID}""#))
+            || event.contains(&format!(r#"from='{SPACES_JID}'"#)),
+        "from must be the spaces service JID: {event}"
+    );
+    assert!(
+        event.contains(&format!(r#"id="{chat_room}""#))
+            || event.contains(&format!(r#"id='{chat_room}'"#)),
+        "event must carry the published bookmark item id: {event}"
+    );
+
+    admin.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0163_pep_ws.rs
+++ b/server/crates/waddle-server/tests/xep0163_pep_ws.rs
@@ -16,6 +16,7 @@ static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
 
 // ---------------------------------------------------------------------------
 // Helpers (mirror xep0060_pubsub_ws.rs; duplicated to keep suites independent)
@@ -373,4 +374,130 @@ async fn pep_owner_can_purge_self_node() {
         post_purge.contains(r#"type="result""#),
         "publish after purge must succeed (node still exists): {post_purge}"
     );
+}
+
+// ============================================================================
+// XEP-0163 §4.3 PEP fan-out (#238)
+// ============================================================================
+
+async fn wait_for_event_message(
+    client: &mut WsXmppClient,
+    node: &str,
+    dur: Duration,
+) -> Option<String> {
+    let deadline = std::time::Instant::now() + dur;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                if frame.contains("<message")
+                    && frame.contains(NS_PUBSUB_EVENT)
+                    && (frame.contains(&format!(r#"node="{node}""#))
+                        || frame.contains(&format!(r#"node='{node}'"#)))
+                {
+                    return Some(frame);
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn pep_publish_fans_event_with_owner_jid_as_from() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "pep-fanout-admin").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    // Auto-create the PEP node and configure access_model=open so bob can
+    // subscribe without presence subscription (presence-driven filtering
+    // is out of scope per #238).
+    let r1 = iq_set_to(
+        &mut admin,
+        "pep-fanout-create",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="urn:xmpp:bookmarks:1"><item id="seed"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(r1.contains(r#"type="result""#), "create: {r1}");
+
+    let cfg = iq_set_to(
+        &mut admin,
+        "pep-fanout-cfg",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="urn:xmpp:bookmarks:1"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>open</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(cfg.contains(r#"type="result""#), "configure open: {cfg}");
+
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "pep-fanout-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    let sub = iq_set_to(
+        &mut bob,
+        "pep-fanout-sub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="urn:xmpp:bookmarks:1" jid="{bob_bare}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(sub.contains(r#"type="result""#), "subscribe: {sub}");
+
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "pep-fanout-pub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="urn:xmpp:bookmarks:1"><item id="bm-1"><conference xmlns="urn:xmpp:bookmarks:1" name="One"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, "urn:xmpp:bookmarks:1", Duration::from_secs(2))
+        .await
+        .expect("bob must receive PEP event");
+
+    // XEP-0163 §4.3: PEP `from` is the bare account JID.
+    assert!(
+        event.contains(&format!(r#"from="{admin_bare}""#))
+            || event.contains(&format!(r#"from='{admin_bare}'"#)),
+        "from must be the PEP account bare JID: {event}"
+    );
+    // XEP-0163 §4.3 + XEP-0060 §12.18: PEP MUST be headline.
+    assert!(
+        event.contains(r#"type="headline""#) || event.contains(r#"type='headline'"#),
+        "PEP event must be type=headline: {event}"
+    );
+    assert!(
+        event.contains(r#"id="bm-1""#),
+        "item id must round-trip: {event}"
+    );
+    // §7.1.5: publisher == owner here (admin published to own PEP), so
+    // no publisher attribute should be emitted.
+    assert!(
+        !event.contains("publisher="),
+        "publisher attr must be omitted on PEP self-publish: {event}"
+    );
+
+    bob.close().await;
+    admin.close().await;
 }

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
@@ -1,6 +1,6 @@
 //! Shared PubSub stanza parsing and building helpers.
 
-use jid::Jid;
+use jid::{BareJid, Jid};
 use minidom::Element;
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::message::Message;
@@ -20,21 +20,40 @@ pub const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
 /// PubSub errors namespace.
 pub const NS_PUBSUB_ERRORS: &str = "http://jabber.org/protocol/pubsub#errors";
 
-/// A typed PubSub item with an optional ID and payload element.
+/// A typed PubSub item with an optional ID, publisher, and payload element.
+///
+/// `publisher` is meaningful for `<event>` notifications (XEP-0060 §7.1.5)
+/// and `<items>` results (§6.5.4). On inbound `<publish>` requests the
+/// attribute, if present, is parsed but the publish handler MUST derive the
+/// authoritative publisher from the IQ `from` — never trust the item.
 #[derive(Debug, Clone)]
 pub struct PubSubItem {
     pub id: Option<String>,
+    pub publisher: Option<BareJid>,
     pub payload: Option<Element>,
 }
 
 impl PubSubItem {
     pub fn new(id: Option<String>, payload: Option<Element>) -> Self {
-        Self { id, payload }
+        Self {
+            id,
+            publisher: None,
+            payload,
+        }
+    }
+
+    pub fn with_publisher(mut self, publisher: Option<BareJid>) -> Self {
+        self.publisher = publisher;
+        self
     }
 
     pub fn from_element(elem: &Element) -> Self {
+        let publisher = elem
+            .attr("publisher")
+            .and_then(|raw| raw.parse::<BareJid>().ok());
         Self {
             id: elem.attr("id").map(str::to_owned),
+            publisher,
             payload: elem.children().next().cloned(),
         }
     }
@@ -44,6 +63,10 @@ impl PubSubItem {
 
         if let Some(ref id) = self.id {
             builder = builder.attr("id", id);
+        }
+
+        if let Some(ref publisher) = self.publisher {
+            builder = builder.attr("publisher", publisher.to_string());
         }
 
         if let Some(ref payload) = self.payload {
@@ -743,6 +766,29 @@ mod tests {
 
         assert_eq!(parsed.id.as_deref(), Some("item-1"));
         assert!(parsed.payload.is_some());
+        assert!(parsed.publisher.is_none());
+    }
+
+    #[test]
+    fn pubsub_item_publisher_attribute_round_trips() {
+        let publisher: BareJid = "alice@example.com".parse().expect("valid bare");
+        let item = PubSubItem::new(Some("e1".to_string()), None).with_publisher(Some(publisher));
+
+        let elem = item.to_element(NS_PUBSUB_EVENT);
+        assert_eq!(elem.attr("publisher"), Some("alice@example.com"));
+
+        let parsed = PubSubItem::from_element(&elem);
+        assert_eq!(
+            parsed.publisher.as_ref().map(BareJid::to_string).as_deref(),
+            Some("alice@example.com")
+        );
+    }
+
+    #[test]
+    fn pubsub_item_omits_publisher_when_unset() {
+        let item = PubSubItem::new(Some("e2".to_string()), None);
+        let elem = item.to_element(NS_PUBSUB_EVENT);
+        assert!(elem.attr("publisher").is_none());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/stanzas.rs
@@ -3,7 +3,7 @@
 use jid::{BareJid, Jid};
 use minidom::Element;
 use xmpp_parsers::iq::{Iq, IqType};
-use xmpp_parsers::message::Message;
+use xmpp_parsers::message::{Message, MessageType};
 
 use crate::pubsub::{Affiliation, NodeConfig};
 use crate::{CoreError, CoreResult};
@@ -351,6 +351,11 @@ pub fn parse_pubsub_iq(iq: &Iq) -> CoreResult<PubSubRequest> {
 }
 
 /// Build a PubSub event notification message.
+///
+/// The message type is `headline` per XEP-0060 §12.18 (default
+/// `pubsub#notification_type`) and XEP-0163 §4.3 (PEP MUST be headline).
+/// Headline messages are not stored offline (RFC 6121 §8.5.2.1.4), which
+/// matches PubSub's catch-up-via-`<items/>` recovery model.
 pub fn build_pubsub_event(from: &Jid, to: &Jid, event: &PubSubEvent) -> Message {
     let mut items_elem = Element::builder("items", NS_PUBSUB_EVENT).attr("node", &event.node);
 
@@ -362,7 +367,7 @@ pub fn build_pubsub_event(from: &Jid, to: &Jid, event: &PubSubEvent) -> Message 
         .append(items_elem.build())
         .build();
 
-    let mut message = Message::new(Some(to.clone()));
+    let mut message = Message::new_with_type(MessageType::Headline, Some(to.clone()));
     message.from = Some(from.clone());
     message.payloads.push(event_elem);
     message
@@ -748,6 +753,11 @@ mod tests {
         let message = build_pubsub_event(&from, &to, &event);
 
         assert!(is_pubsub_event(&message));
+        assert_eq!(
+            message.type_,
+            MessageType::Headline,
+            "XEP-0060 §12.18 default and XEP-0163 §4.3 require headline"
+        );
 
         let parsed = parse_pubsub_event(&message).expect("event should parse");
         assert_eq!(parsed.node, "http://jabber.org/protocol/nick");

--- a/server/crates/waddle-xmpp/src/pubsub/storage.rs
+++ b/server/crates/waddle-xmpp/src/pubsub/storage.rs
@@ -65,6 +65,7 @@ impl StoredItem {
 
         PubSubItem {
             id: Some(self.id.clone()),
+            publisher: self.publisher.clone(),
             payload,
         }
     }

--- a/server/crates/waddle-xmpp/src/xep/xep0503.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0503.rs
@@ -77,6 +77,7 @@ pub fn build_channel_item(
 
     Ok(PubSubItem {
         id: Some(bookmark.jid.to_string()),
+        publisher: None,
         payload: Some(payload),
     })
 }


### PR DESCRIPTION
Closes #238.

## Summary

On every successful `publish_item`, fan an XEP-0060 §7.1 event message out to deliverable subscribers via the existing connection registry / SM session registry. Wires both publish paths (regular `PubSubRequest::Publish` arm in `iq.rs` and `handle_spaces_publish`) through one shared helper so §7.1 emission is a single, testable seam.

## Design (resolved via grilling on the issue)

### Q1 — Fan-out lives in a shared helper called from both publish paths
New module `server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs`. The `PubSubRequest::Publish` arm and `handle_spaces_publish` both call `fan_out_publish(...)` after `publish_item` (and, for Spaces, after the parent-tuple write) succeeds. Single source of truth for §7.1 emission; no drift between paths.

### Q2 — Per-subscription bare/full dispatch with detached-resource fallback
`Subscription.subscriber: Jid` is matched per row:

- `Jid::Full(f)` → `connection_registry.try_send_to(&f, stanza)` (XEP-0060 §6.1.7).
- `Jid::Bare(b)` → expand via `connection_registry.get_resources_for_user(&b)` PLUS `sm_session_registry.detached_resources_for_user(&b)` and dispatch per resource (XEP-0060 §6.1.6).

On `BroadcastOutcome::DroppedClosed` / `NotConnected`, fall back to `sm_session_registry.record_stanza_for_detached_bound_resource` — same pattern as `handlers/message.rs:262–344`. Fully-offline subscribers (no live, no detached) drop on the floor; subscribers catch up via `<items/>` on reconnect (RFC 6121 §8.5.2.1.4 forbids offline storage of headline messages, see Q5).

Presence-driven filtering (PEP +notify caps, priority math) is **out of scope** — separate issue.

### Q3 — `deliver_payloads` honored at item-construction time (XEP-0060 §7.1.3.5)
Helper fetches `NodeConfig` once via `pubsub_storage.get_node(owner, node)`. Builds the event item as:

```rust
PubSubItem {
    id: Some(item_id),
    publisher: /* Q6 */,
    payload: cfg.deliver_payloads.then(|| published_item.payload.clone()).flatten(),
}
```

`deliver_payloads = false` produces id-only `<item id='X'/>`; `true` includes the payload child.

### Q4 — `deliver_notifications` deferred (it's a misnomer in the issue)
There is no `pubsub#deliver_notifications` in XEP-0060. The closest is the per-subscription `pubsub#deliver` option (§6.3.4), which requires sub-options storage shape that doesn't exist yet. Default value of `pubsub#deliver` is `true`, so today's "fan out to every deliverable subscriber unconditionally" is identical to the spec default.

### Q5 — Headline message type hardcoded at the seam (XEP-0060 §12.18, XEP-0163 §4.3)
`build_pubsub_event` switches `Message::new(...)` → `Message::new_with_type(MessageType::Headline, ...)`. Waddle does not advertise `pubsub#notification_type` in the node config form, so we are not on the hook for per-node configurability. Hardcoding the spec default is the strictest conformity stance for the current advertised feature set.

### Q6 — Wire-shape JIDs
**(a) Stanza `from`** — bare owner JID in all paths (matches §7.1.2.1 example for PubSub, §4.3 for PEP, §4 for Spaces).

**(b) `<item publisher='...'>` attribute (§7.1.5)** — emit when publisher ≠ owner. `PubSubItem` gains an `Option<BareJid>` field, `to_element` emits `publisher='…'` when present, `from_element` ignores any inbound `publisher` attribute on publish requests (server-derived from IQ `from`). Spaces passes `None` for publisher because Spaces doesn't track per-bookmark publishers in storage; emitting a publisher attribute on fan-out only would be inconsistent with subsequent `<items/>` retrieval.

### Q7 — Fan-out runs inline, before the IQ ack
Mirrors the groupchat broadcast pattern in `handlers/message.rs`. Reasons: `try_send_to` is non-blocking (mpsc try-push); inline keeps the XEP custom test-suite straightforward (`publish; recv` synchronous pattern); failure logs correlate with the publish-success log; consistent with the only other fan-out in the codebase.

## Implementation steps

1. Add `publisher: Option<BareJid>` field to `PubSubItem` in `waddle-xmpp-core/src/pubsub/stanzas.rs`; update `to_element` to emit the attribute; `from_element` parses it (publish handler ignores client-supplied values).
2. Switch `build_pubsub_event` to `Message::new_with_type(MessageType::Headline, ...)`. Update the existing `build_and_parse_pubsub_event_message` test to assert `type == Headline`.
3. New module `server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs` containing `pub async fn fan_out_publish(state, owner, node, published_item, item_id, publisher)`.
4. Call `fan_out_publish` from the `PubSubRequest::Publish` arm in `iq.rs` after `publish_item` succeeds, before returning the IQ result.
5. Call `fan_out_publish` from `handle_spaces_publish` after the parent-tuple write succeeds, before returning the IQ result. (No fan-out on the compensating retract path — the Spaces failure case rolls back the publish, so there must be no event.)
6. Detached-resource enumeration for bare-JID subscribers via `sm_session_registry.detached_resources_for_user(bare)` so XEP-0198 resumable sessions still receive missed events on resume (added in response to review feedback from Codex / Qodo / Copilot).

## Tests landed

**`tests/xep0060_pubsub_ws.rs`** (+6):

- `publish_fans_event_with_payload_to_subscriber` — happy path: subscriber receives `<message type='headline'><event xmlns='…#event'><items node='X'><item id='Y'><payload/></item></items></event></message>` with `from = owner`.
- `publish_strips_payload_when_deliver_payloads_is_false` — id-only `<item id='Y'/>`.
- `bare_jid_subscription_targets_all_resources` — both bob resources receive (§6.1.6).
- `event_includes_publisher_attribute_when_publisher_differs_from_owner` — charlie granted `publisher` affiliation publishes to admin's node; subscriber sees `publisher='charlie@…'`.
- `event_omits_publisher_attribute_when_publisher_equals_owner` — admin publishes own node, no `publisher` attribute.
- `publish_with_no_subscribers_returns_result_and_emits_no_event` — empty subscriber list still returns publish IQ result, no events.

**`tests/xep0163_pep_ws.rs`** (+1):

- `pep_publish_fans_event_with_owner_jid_as_from` — `from = bare account JID`, `type = headline`, no publisher attr on PEP self-publish.

**`tests/xep0060_spaces_owner_ws.rs`** (+1):

- `spaces_publish_fans_event_to_subscriber` — admin subscribes to seeded `spaces.localhost/general`, publishes a bookmark targeting the seeded `chat@muc.localhost` managed room, asserts §7.1 event arrival. Literal Acceptance criterion of #238.

Plus the drive-by `MessageType::Headline` assertion in `pubsub/stanzas.rs:714` and 2 new unit tests for the `PubSubItem.publisher` round-trip.

## Tests deferred (with rationale)

- **Full-JID subscriber single-resource targeting (§6.1.7)** — the SQL store at `pubsub.rs:765` explicitly normalises subscriber JIDs to bare on insert ("full-JID subscriptions are not currently supported in the DB store"). The fan-out helper has the `try_as_full()` branch ready, so once storage supports full-JID subscriptions the helper will route §6.1.7 traffic without further changes. Tracked inline in `xep0060_pubsub_ws.rs` as a follow-up.
- **SM-detached-resume replay end-to-end** — would require XEP-0198 `enable` / disconnect / resume orchestration in the test harness. The detached-resource enumeration code path is in place and exercised by unit-level reasoning; full replay test is a separate ticket.
- **Failed-publish-no-fan-out** — needs a deterministic way to force `publish_item` failure; today the only failure modes are storage-internal and not easy to trigger from a wire-level test.

## Out of scope (separate issues)

- Presence-driven filtering / +notify caps / priority math (separate PEP issue).
- Retract / delete event delivery (separate issue).
- Per-subscription `pubsub#deliver` option (separate issue — requires sub-options storage shape).
- Configurable `pubsub#notification_type` per node (separate issue — would ship with form advertisement).
- Full-JID subscription storage support enabling §6.1.7 single-resource targeting (separate issue — see deferred test note).

## Test plan

- [x] `cargo test -p waddle-server --test xep0060_pubsub_ws --test xep0163_pep_ws --test xep0060_spaces_owner_ws` — green (12 + 5 + 8).
- [x] `cargo test -p waddle-xmpp-core --lib pubsub::` — green (23).
- [x] `cargo test -p waddle-xmpp --lib pubsub::` — green (13).
- [x] `cargo clippy -p waddle-xmpp-core -p waddle-xmpp -p waddle-server --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [ ] CI green on the PR.