### PR TITLE
refactor(server): #228 PR A — relocate XEP-0359 types to waddle-xmpp-core

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -952,7 +952,7 @@ pub async fn handle_iq_with_conn_state(
             request.reason.as_deref(),
         );
         let archive_id = uuid::Uuid::now_v7().to_string();
-        add_mam_stanza_id(&mut moderation, archive_id.as_str(), &room_jid.to_string());
+        add_mam_stanza_id(&mut moderation, archive_id.as_str(), &room_jid);
 
         if let (Some(target_id), Ok(moderator_jid)) = (
             RichMessageId::new(request.target_id.clone()),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -95,7 +95,7 @@ pub async fn handle_message(
             .clone()
             .or_else(|| Some(uuid::Uuid::new_v4().to_string()));
         prototype.type_ = XmppMessageType::Groupchat;
-        remove_stanza_ids_by(&mut prototype, &room_jid.to_string());
+        remove_stanza_ids_by(&mut prototype, &room_jid);
 
         // Enrich links with extension-provided XML elements (fail-open).
         let _embeds_added = state
@@ -278,7 +278,7 @@ pub async fn handle_message(
         let intended = local_messages.len();
         for mut outbound in local_messages.drain(..) {
             if let Some(ref archive_id) = archive_id {
-                add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid.to_string());
+                add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid);
             }
 
             if outbound.to == *sender_jid {
@@ -1300,7 +1300,7 @@ async fn archive_groupchat_message(
     }
 
     let archive_id = uuid::Uuid::now_v7().to_string();
-    add_mam_stanza_id(message, archive_id.as_str(), &room_jid.to_string());
+    add_mam_stanza_id(message, archive_id.as_str(), room_jid);
 
     let body = prototype_body(message)
         .map(|value| value.trim().to_string())

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -13,20 +13,20 @@ use waddle_xmpp::{
     mam::{
         add_stanza_id as add_mam_stanza_id, ArchivedMention, ArchivedMessage, ArchivedReactionSet,
         ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
-        ArchivedRichPayload, RichMessageId, RichText, STANZA_ID_NS,
+        ArchivedRichPayload, RichMessageId, RichText,
     },
     muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
     parser::message_to_string,
     registry::{BroadcastOutcome, SendResult},
     xep::xep0430::build_inbox_push,
     xep::{
-        extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
-        extract_references_from_message, extract_retraction_from_message, has_file_sharing,
-        is_moderation_request_message, is_moderation_result_message, is_reaction_message,
-        is_retraction_message, is_sticker_message, message_has_direct_invite,
-        parse_reply_from_message, remove_stanza_ids_by, should_skip_storage, RetractionKind,
-        NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE,
-        NS_REPLY,
+        extract_correction_from_message, extract_explicit_mentions, extract_origin_id_str,
+        extract_reactions_from_message, extract_references_from_message,
+        extract_retraction_from_message, has_file_sharing, is_moderation_request_message,
+        is_moderation_result_message, is_reaction_message, is_retraction_message,
+        is_sticker_message, message_has_direct_invite, parse_reply_from_message,
+        remove_stanza_ids_by, should_skip_storage, RetractionKind, NS_EXPLICIT_MENTIONS,
+        NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE, NS_REPLY,
     },
     Stanza,
 };
@@ -381,7 +381,7 @@ pub async fn handle_message(
             // Enrichment is fail-open: errors are logged but never block delivery.
             let mut prototype = incoming.clone();
             if prototype.id.is_none() {
-                prototype.id = extract_origin_id(&prototype)
+                prototype.id = extract_origin_id_str(&prototype)
                     .or_else(|| Some(uuid::Uuid::new_v4().to_string()));
             }
             prototype.from = Some(jid::Jid::from(sender_jid.clone()));
@@ -1307,7 +1307,7 @@ async fn archive_groupchat_message(
         .unwrap_or_default();
 
     let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
-    let origin_id = extract_origin_id(message);
+    let origin_id = extract_origin_id_str(message);
     let rich = rich_archive_payload(message);
 
     let stanza_xml = serialize_groupchat_stanza_xml(message);
@@ -1372,7 +1372,7 @@ async fn archive_direct_message(
     let stanza_xml = serialize_direct_stanza_xml(message);
 
     let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
-    let origin_id = extract_origin_id(message);
+    let origin_id = extract_origin_id_str(message);
 
     let archived = ArchivedMessage {
         id: String::new(),
@@ -1547,14 +1547,6 @@ fn rich_archive_payload(message: &xmpp_parsers::message::Message) -> Option<Arch
             mentions,
         })
     }
-}
-
-fn extract_origin_id(message: &xmpp_parsers::message::Message) -> Option<String> {
-    message
-        .payloads
-        .iter()
-        .find(|payload| payload.name() == "origin-id" && payload.ns() == STANZA_ID_NS)
-        .and_then(|origin| origin.attr("id").map(ToOwned::to_owned))
 }
 
 fn prototype_body(message: &xmpp_parsers::message::Message) -> Option<String> {

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod pubsub;
 pub mod roster;
 pub mod stanza;
 pub mod types;
+pub mod xep;
 
 pub use carbons::{
     build_carbons_result, build_received_carbon, build_sent_carbon, is_carbons_disable,
@@ -32,8 +33,8 @@ pub use domain::{
 };
 pub use error::{CoreError, CoreResult};
 pub use mam::{
-    add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,
-    ArchivedMessage, MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS, RSM_NS, STANZA_ID_NS,
+    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchivedMessage, MamQuery,
+    MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS, RSM_NS, STANZA_ID_NS,
 };
 pub use parser_utils::{ensure_thread_element, extract_thread_parent, reattach_thread_parent};
 pub use presence::{
@@ -50,3 +51,9 @@ pub use pubsub::{
 };
 pub use stanza::Stanza;
 pub use types::{Affiliation, ConnectionState, Role, StanzaType, Transport};
+pub use xep::xep0359::{
+    add_origin_id, add_stanza_id, build_origin_id_element, build_stanza_id_element,
+    extract_origin_id, extract_origin_id_str, extract_stanza_id_by, extract_stanza_ids,
+    has_origin_id, has_stanza_id, is_origin_id_element, is_stanza_id_element, remove_stanza_ids_by,
+    strip_all_ids, OriginId, StanzaId, StanzaIdCarrier, NS_SID,
+};

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -331,15 +331,6 @@ pub fn build_fin_iq(original_iq: &Iq, result: &MamResult) -> Iq {
     }
 }
 
-/// Add a stanza-id extension to a message for MAM compliance.
-pub fn add_stanza_id(message: &mut Message, archive_id: &str, by: &str) {
-    let stanza_id = Element::builder("stanza-id", STANZA_ID_NS)
-        .attr("id", archive_id)
-        .attr("by", by)
-        .build();
-    message.payloads.push(stanza_id);
-}
-
 fn parse_data_form(form: &Element, query: &mut MamQuery) -> CoreResult<()> {
     for field in form.children() {
         if field.name() != "field" {
@@ -961,9 +952,12 @@ mod tests {
 
     #[test]
     fn adds_stanza_id_payload() {
-        let mut message = Message::new(Some(parse_message_jid("juliet@example.com")));
+        use crate::xep::xep0359::add_stanza_id;
 
-        add_stanza_id(&mut message, "archive-1", "room@example.com");
+        let mut message = Message::new(Some(parse_message_jid("juliet@example.com")));
+        let by: BareJid = "room@example.com".parse().expect("valid bare jid");
+
+        add_stanza_id(&mut message, "archive-1", &by);
 
         let stanza_id = message
             .payloads

--- a/server/crates/waddle-xmpp-core/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-core/src/xep/mod.rs
@@ -1,0 +1,7 @@
+//! XMPP Extension Protocol (XEP) value objects shared by the core stack.
+//!
+//! These modules host typed protocol values that need to be visible to the
+//! storage layer (`mam`) and other low-level boundaries — they cannot live in
+//! the upper `waddle-xmpp` crate without inducing a dependency cycle.
+
+pub mod xep0359;

--- a/server/crates/waddle-xmpp-core/src/xep/xep0359.rs
+++ b/server/crates/waddle-xmpp-core/src/xep/xep0359.rs
@@ -1,8 +1,9 @@
 //! XEP-0359: Unique and Stable Stanza IDs
 //!
-//! Provides helpers for detecting, parsing, and building stanza ID elements.
-//! These ensure messages have stable, server-assigned identifiers for use
-//! in archives (MAM), corrections, reactions, and retractions.
+//! Provides typed value objects and helpers for detecting, parsing, and
+//! building stanza-id elements. These ensure messages have stable,
+//! server-assigned identifiers for use in archives (MAM), corrections,
+//! reactions, and retractions.
 //!
 //! ## Elements
 //!
@@ -28,42 +29,58 @@
 //! - Clients MUST NOT trust `<stanza-id/>` from other clients; only the
 //!   `by` entity that matches the server/MUC JID is authoritative.
 
+use jid::BareJid;
 use minidom::Element;
+use std::str::FromStr;
 use xmpp_parsers::message::Message;
 
 /// Namespace for XEP-0359 Unique and Stable Stanza IDs.
 pub const NS_SID: &str = "urn:xmpp:sid:0";
 
 /// A server-assigned stable stanza ID.
+///
+/// The `by` JID is always bare per XEP-0359 §4 — the assigning entity is a
+/// service (MUC, account, or domain), never a connected resource.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StanzaId {
-    /// The stable ID assigned by the server/service.
+    /// The stable ID assigned by the service referenced by `by`.
     pub id: String,
-    /// The JID of the entity that assigned this ID.
-    pub by: String,
+    /// The bare JID of the entity that assigned this ID.
+    pub by: BareJid,
 }
 
 impl StanzaId {
     /// Create a new stanza ID.
-    pub fn new(id: impl Into<String>, by: impl Into<String>) -> Self {
-        Self {
-            id: id.into(),
-            by: by.into(),
-        }
+    pub fn new(id: impl Into<String>, by: BareJid) -> Self {
+        Self { id: id.into(), by }
     }
 }
 
 /// A client-assigned origin ID.
+///
+/// Wraps a non-empty, non-whitespace string per XEP-0359 §3, which requires
+/// a unique, non-empty identifier.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OriginId {
-    /// The unique ID assigned by the originating client.
-    pub id: String,
+    id: String,
 }
 
 impl OriginId {
-    /// Create a new origin ID.
-    pub fn new(id: impl Into<String>) -> Self {
-        Self { id: id.into() }
+    /// Create a new origin ID. Returns `None` if the input is empty or only
+    /// whitespace.
+    pub fn new(id: impl Into<String>) -> Option<Self> {
+        let id = id.into();
+        (!id.trim().is_empty()).then_some(Self { id })
+    }
+
+    /// The unique ID assigned by the originating client.
+    pub fn as_str(&self) -> &str {
+        self.id.as_str()
+    }
+
+    /// Consume the origin ID and return the wrapped string.
+    pub fn into_string(self) -> String {
+        self.id
     }
 }
 
@@ -73,10 +90,10 @@ pub trait StanzaIdCarrier {
     fn stanza_ids(&self) -> Vec<StanzaId>;
 
     /// Extract the stanza ID assigned by a specific entity.
-    fn stanza_id_by(&self, by: &str) -> Option<String> {
+    fn stanza_id_by(&self, by: &BareJid) -> Option<String> {
         self.stanza_ids()
             .into_iter()
-            .find(|sid| sid.by == by)
+            .find(|sid| &sid.by == by)
             .map(|sid| sid.id)
     }
 
@@ -123,7 +140,11 @@ pub fn has_origin_id(msg: &Message) -> bool {
 
 // ── Extraction ───────────────────────────────────────────────────────
 
-/// Extract all stanza IDs from a message.
+/// Extract all well-formed stanza IDs from a message.
+///
+/// Elements with empty `id`, empty `by`, or unparseable `by` JIDs are
+/// silently skipped — they are malformed wire data that cannot be lifted
+/// into the typed shape.
 pub fn extract_stanza_ids(msg: &Message) -> Vec<StanzaId> {
     msg.payloads
         .iter()
@@ -131,16 +152,17 @@ pub fn extract_stanza_ids(msg: &Message) -> Vec<StanzaId> {
         .filter_map(|e| {
             let id = e.attr("id").filter(|s| !s.is_empty())?;
             let by = e.attr("by").filter(|s| !s.is_empty())?;
+            let by = BareJid::from_str(by).ok()?;
             Some(StanzaId::new(id, by))
         })
         .collect()
 }
 
 /// Extract the stanza ID assigned by a specific entity.
-pub fn extract_stanza_id_by(msg: &Message, by: &str) -> Option<String> {
+pub fn extract_stanza_id_by(msg: &Message, by: &BareJid) -> Option<String> {
     extract_stanza_ids(msg)
         .into_iter()
-        .find(|sid| sid.by == by)
+        .find(|sid| &sid.by == by)
         .map(|sid| sid.id)
 }
 
@@ -150,22 +172,21 @@ pub fn extract_origin_id(msg: &Message) -> Option<OriginId> {
         .iter()
         .find(|e| is_origin_id_element(e))
         .and_then(|e| e.attr("id"))
-        .filter(|id| !id.is_empty())
-        .map(OriginId::new)
+        .and_then(OriginId::new)
 }
 
 /// Extract the origin ID string from a message.
 pub fn extract_origin_id_str(msg: &Message) -> Option<String> {
-    extract_origin_id(msg).map(|o| o.id)
+    extract_origin_id(msg).map(OriginId::into_string)
 }
 
 // ── Building ─────────────────────────────────────────────────────────
 
 /// Build a `<stanza-id xmlns='urn:xmpp:sid:0' id='...' by='...'/>` element.
-pub fn build_stanza_id_element(id: &str, by: &str) -> Element {
+pub fn build_stanza_id_element(id: &str, by: &BareJid) -> Element {
     Element::builder("stanza-id", NS_SID)
         .attr("id", id)
-        .attr("by", by)
+        .attr("by", by.to_string())
         .build()
 }
 
@@ -180,7 +201,7 @@ pub fn build_origin_id_element(id: &str) -> Element {
 ///
 /// This is the primary function used by the server when archiving messages.
 /// Multiple stanza-ids from different entities may coexist.
-pub fn add_stanza_id(msg: &mut Message, id: &str, by: &str) {
+pub fn add_stanza_id(msg: &mut Message, id: &str, by: &BareJid) {
     msg.payloads.push(build_stanza_id_element(id, by));
 }
 
@@ -192,9 +213,10 @@ pub fn add_origin_id(msg: &mut Message, id: &str) {
 }
 
 /// Remove all stanza-id elements assigned by a specific entity.
-pub fn remove_stanza_ids_by(msg: &mut Message, by: &str) {
+pub fn remove_stanza_ids_by(msg: &mut Message, by: &BareJid) {
+    let by = by.to_string();
     msg.payloads
-        .retain(|e| !(is_stanza_id_element(e) && e.attr("by") == Some(by)));
+        .retain(|e| !(is_stanza_id_element(e) && e.attr("by") == Some(by.as_str())));
 }
 
 /// Strip all stanza-id and origin-id elements from a message.
@@ -206,13 +228,13 @@ pub fn strip_all_ids(msg: &mut Message) {
 
 impl From<xmpp_parsers::stanza_id::StanzaId> for StanzaId {
     fn from(sid: xmpp_parsers::stanza_id::StanzaId) -> Self {
-        Self::new(sid.id, sid.by.to_string())
+        Self::new(sid.id, sid.by.into_bare())
     }
 }
 
 impl From<xmpp_parsers::stanza_id::OriginId> for OriginId {
     fn from(oid: xmpp_parsers::stanza_id::OriginId) -> Self {
-        Self::new(oid.id)
+        Self { id: oid.id }
     }
 }
 
@@ -220,6 +242,10 @@ impl From<xmpp_parsers::stanza_id::OriginId> for OriginId {
 mod tests {
     use super::*;
     use xmpp_parsers::message::Message;
+
+    fn bare(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
 
     #[test]
     fn test_is_stanza_id_element() {
@@ -256,8 +282,11 @@ mod tests {
 
         let ids = extract_stanza_ids(&msg);
         assert_eq!(ids.len(), 2);
-        assert_eq!(ids[0], StanzaId::new("archive-1", "room@muc.example.com"));
-        assert_eq!(ids[1], StanzaId::new("archive-2", "example.com"));
+        assert_eq!(
+            ids[0],
+            StanzaId::new("archive-1", bare("room@muc.example.com"))
+        );
+        assert_eq!(ids[1], StanzaId::new("archive-2", bare("example.com")));
     }
 
     #[test]
@@ -270,10 +299,10 @@ mod tests {
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
         assert_eq!(
-            extract_stanza_id_by(&msg, "room@muc.example.com"),
+            extract_stanza_id_by(&msg, &bare("room@muc.example.com")),
             Some("arc-1".to_owned())
         );
-        assert_eq!(extract_stanza_id_by(&msg, "other@example.com"), None);
+        assert_eq!(extract_stanza_id_by(&msg, &bare("other@example.com")), None);
     }
 
     #[test]
@@ -286,7 +315,7 @@ mod tests {
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
         let oid = extract_origin_id(&msg).expect("has origin-id");
-        assert_eq!(oid.id, "client-uuid-1");
+        assert_eq!(oid.as_str(), "client-uuid-1");
         assert_eq!(
             extract_origin_id_str(&msg),
             Some("client-uuid-1".to_owned())
@@ -300,6 +329,24 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_origin_id_blank_rejected() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <origin-id xmlns='urn:xmpp:sid:0' id='   '/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(extract_origin_id(&msg).is_none());
+    }
+
+    #[test]
+    fn test_origin_id_new_rejects_blank() {
+        assert!(OriginId::new("").is_none());
+        assert!(OriginId::new("   ").is_none());
+        assert!(OriginId::new("\t\n").is_none());
+        assert!(OriginId::new("client-1").is_some());
+    }
+
+    #[test]
     fn test_extract_stanza_id_empty_attrs_ignored() {
         let xml = "<message xmlns='jabber:client' type='chat'>\
                     <stanza-id xmlns='urn:xmpp:sid:0' id='' by='example.com'/>\
@@ -310,8 +357,18 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_stanza_id_malformed_by_skipped() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <stanza-id xmlns='urn:xmpp:sid:0' id='abc' by='@'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(extract_stanza_ids(&msg).is_empty());
+    }
+
+    #[test]
     fn test_build_stanza_id_element() {
-        let elem = build_stanza_id_element("arc-99", "room@muc.example.com");
+        let elem = build_stanza_id_element("arc-99", &bare("room@muc.example.com"));
         assert_eq!(elem.name(), "stanza-id");
         assert_eq!(elem.ns(), NS_SID);
         assert_eq!(elem.attr("id"), Some("arc-99"));
@@ -329,8 +386,8 @@ mod tests {
     #[test]
     fn test_add_stanza_id() {
         let mut msg = Message::new(None::<jid::Jid>);
-        add_stanza_id(&mut msg, "arc-1", "room@muc.example.com");
-        add_stanza_id(&mut msg, "arc-2", "example.com");
+        add_stanza_id(&mut msg, "arc-1", &bare("room@muc.example.com"));
+        add_stanza_id(&mut msg, "arc-2", &bare("example.com"));
 
         let ids = extract_stanza_ids(&msg);
         assert_eq!(ids.len(), 2);
@@ -356,19 +413,19 @@ mod tests {
     #[test]
     fn test_remove_stanza_ids_by() {
         let mut msg = Message::new(None::<jid::Jid>);
-        add_stanza_id(&mut msg, "arc-1", "room@muc.example.com");
-        add_stanza_id(&mut msg, "arc-2", "example.com");
+        add_stanza_id(&mut msg, "arc-1", &bare("room@muc.example.com"));
+        add_stanza_id(&mut msg, "arc-2", &bare("example.com"));
 
-        remove_stanza_ids_by(&mut msg, "room@muc.example.com");
+        remove_stanza_ids_by(&mut msg, &bare("room@muc.example.com"));
         let ids = extract_stanza_ids(&msg);
         assert_eq!(ids.len(), 1);
-        assert_eq!(ids[0].by, "example.com");
+        assert_eq!(ids[0].by, bare("example.com"));
     }
 
     #[test]
     fn test_strip_all_ids() {
         let mut msg = Message::new(None::<jid::Jid>);
-        add_stanza_id(&mut msg, "arc-1", "example.com");
+        add_stanza_id(&mut msg, "arc-1", &bare("example.com"));
         add_origin_id(&mut msg, "client-1");
         msg.payloads
             .push(Element::builder("body", "jabber:client").build());
@@ -392,10 +449,13 @@ mod tests {
 
         assert!(msg.has_stanza_id());
         assert_eq!(
-            msg.stanza_id_by("room@muc.example.com"),
+            msg.stanza_id_by(&bare("room@muc.example.com")),
             Some("arc-1".to_owned())
         );
-        assert_eq!(msg.origin_id(), Some(OriginId::new("client-1")));
+        assert_eq!(
+            msg.origin_id().as_ref().map(OriginId::as_str),
+            Some("client-1")
+        );
     }
 
     #[test]
@@ -406,12 +466,12 @@ mod tests {
         }
         .into();
         assert_eq!(sid.id, "abc");
-        assert_eq!(sid.by, "room@muc.example.com");
+        assert_eq!(sid.by, bare("room@muc.example.com"));
 
         let oid: OriginId = xmpp_parsers::stanza_id::OriginId {
             id: "def".to_owned(),
         }
         .into();
-        assert_eq!(oid.id, "def");
+        assert_eq!(oid.as_str(), "def");
     }
 }

--- a/server/crates/waddle-xmpp-core/src/xep/xep0359.rs
+++ b/server/crates/waddle-xmpp-core/src/xep/xep0359.rs
@@ -32,6 +32,7 @@
 use jid::BareJid;
 use minidom::Element;
 use std::str::FromStr;
+use thiserror::Error;
 use xmpp_parsers::message::Message;
 
 /// Namespace for XEP-0359 Unique and Stable Stanza IDs.
@@ -226,15 +227,42 @@ pub fn strip_all_ids(msg: &mut Message) {
 
 // ── Conversion ───────────────────────────────────────────────────────
 
-impl From<xmpp_parsers::stanza_id::StanzaId> for StanzaId {
-    fn from(sid: xmpp_parsers::stanza_id::StanzaId) -> Self {
-        Self::new(sid.id, sid.by.into_bare())
+/// Reason a parsed `xmpp_parsers::stanza_id::StanzaId` cannot be lifted into
+/// the typed `StanzaId` shape.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum StanzaIdConversionError {
+    /// XEP-0359 §4 requires `by` to identify a service (account, MUC, or
+    /// domain), never a connected resource. A `by` carrying a resource is
+    /// malformed wire data and is rejected rather than silently truncated.
+    #[error("XEP-0359 §4 violation: stanza-id `by` must be a bare JID")]
+    NonBareBy,
+}
+
+/// Reason a parsed `xmpp_parsers::stanza_id::OriginId` cannot be lifted into
+/// the typed `OriginId` shape.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum OriginIdConversionError {
+    /// XEP-0359 §3 requires the origin-id to be a unique, non-empty value.
+    #[error("XEP-0359 §3 violation: origin-id must be non-empty")]
+    Empty,
+}
+
+impl TryFrom<xmpp_parsers::stanza_id::StanzaId> for StanzaId {
+    type Error = StanzaIdConversionError;
+
+    fn try_from(sid: xmpp_parsers::stanza_id::StanzaId) -> Result<Self, Self::Error> {
+        if sid.by.is_full() {
+            return Err(StanzaIdConversionError::NonBareBy);
+        }
+        Ok(Self::new(sid.id, sid.by.into_bare()))
     }
 }
 
-impl From<xmpp_parsers::stanza_id::OriginId> for OriginId {
-    fn from(oid: xmpp_parsers::stanza_id::OriginId) -> Self {
-        Self { id: oid.id }
+impl TryFrom<xmpp_parsers::stanza_id::OriginId> for OriginId {
+    type Error = OriginIdConversionError;
+
+    fn try_from(oid: xmpp_parsers::stanza_id::OriginId) -> Result<Self, Self::Error> {
+        OriginId::new(oid.id).ok_or(OriginIdConversionError::Empty)
     }
 }
 
@@ -459,19 +487,44 @@ mod tests {
     }
 
     #[test]
-    fn test_conversion_from_xmpp_parsers() {
+    fn test_conversion_from_xmpp_parsers_accepts_bare_by() {
         let sid: StanzaId = xmpp_parsers::stanza_id::StanzaId {
             id: "abc".to_owned(),
             by: "room@muc.example.com".parse().expect("valid jid"),
         }
-        .into();
+        .try_into()
+        .expect("bare by accepted");
         assert_eq!(sid.id, "abc");
         assert_eq!(sid.by, bare("room@muc.example.com"));
 
         let oid: OriginId = xmpp_parsers::stanza_id::OriginId {
             id: "def".to_owned(),
         }
-        .into();
+        .try_into()
+        .expect("non-empty origin id accepted");
         assert_eq!(oid.as_str(), "def");
+    }
+
+    #[test]
+    fn test_conversion_from_xmpp_parsers_rejects_full_by() {
+        let result: Result<StanzaId, _> = xmpp_parsers::stanza_id::StanzaId {
+            id: "abc".to_owned(),
+            by: "room@muc.example.com/nick".parse().expect("valid jid"),
+        }
+        .try_into();
+        assert_eq!(result, Err(StanzaIdConversionError::NonBareBy));
+    }
+
+    #[test]
+    fn test_conversion_from_xmpp_parsers_rejects_empty_origin() {
+        let result: Result<OriginId, _> =
+            xmpp_parsers::stanza_id::OriginId { id: String::new() }.try_into();
+        assert_eq!(result, Err(OriginIdConversionError::Empty));
+
+        let result: Result<OriginId, _> = xmpp_parsers::stanza_id::OriginId {
+            id: "   ".to_owned(),
+        }
+        .try_into();
+        assert_eq!(result, Err(OriginIdConversionError::Empty));
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -17,8 +17,9 @@ pub mod storage;
 
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
 pub use waddle_xmpp_core::mam::{
-    add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,
-    ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference,
-    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
-    MamQuery, MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
+    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchivedMention,
+    ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference, ArchivedReply,
+    ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone, MamQuery,
+    MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
 };
+pub use waddle_xmpp_core::xep::xep0359::add_stanza_id;

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -161,7 +161,6 @@ pub mod xep0333;
 pub mod xep0334;
 pub mod xep0352;
 pub mod xep0357;
-pub mod xep0359;
 pub mod xep0363;
 pub mod xep0372;
 pub mod xep0377;
@@ -388,7 +387,7 @@ pub use xep0393::{
     Block, Span, StyledBody,
 };
 
-pub use xep0359::{
+pub use waddle_xmpp_core::xep::xep0359::{
     add_origin_id, add_stanza_id as add_stanza_id_xep0359, build_origin_id_element,
     build_stanza_id_element, extract_origin_id as extract_origin_id_xep0359, extract_origin_id_str,
     extract_stanza_id_by, extract_stanza_ids, has_origin_id, has_stanza_id, is_origin_id_element,


### PR DESCRIPTION
## Summary

PR A of the two-PR plan for #228 (Refactor `ArchivedMessage` to typed Message + typed JIDs). This is the **prerequisite move** with **no wire-format change** but several internal API tightenings (see below).

`waddle-xmpp-core::mam::ArchivedMessage` will need typed `xep0359::StanzaId` / `OriginId` values (PR B). Today those types live in `waddle-xmpp::xep::xep0359`, the *upper* crate — `waddle-xmpp-core` cannot depend on it. This PR moves them down so PR B can land cleanly.

## What changed

**Relocated:** `xep0359::{StanzaId, OriginId, NS_SID, StanzaIdCarrier}` and the public parse/build/mutate helpers from `server/crates/waddle-xmpp/src/xep/xep0359.rs` into a new module at `server/crates/waddle-xmpp-core/src/xep/xep0359.rs`. The custom test suite moves with the module (18 tests).

**Tightenings on the move (intentional, behavioural):**

- `StanzaId.by: BareJid` (was `String`). Per XEP-0359 §4 the assigning entity is always a service (account/MUC/domain), never a connected resource — bare JID is the wire-faithful shape.
- `OriginId::new(...) -> Option<Self>` rejects empty/whitespace ids, matching XEP-0359 §3 ("unique, non-empty"). `OriginId.id` becomes private; readers go through `as_str()` / `into_string()`.
- `extract_stanza_ids` silently skips `<stanza-id>` elements with empty `id`, empty `by`, or `by` values that fail to parse as `BareJid` — malformed wire data cannot be lifted into the typed shape.
- `add_stanza_id`, `build_stanza_id_element`, `remove_stanza_ids_by`, `extract_stanza_id_by`, `StanzaIdCarrier::stanza_id_by` all take `&BareJid` instead of `&str`. Callers in `waddle-server` drop their `&room_jid.to_string()` round-trips.

**Deleted:** the duplicate `add_stanza_id` previously in `waddle-xmpp-core::mam::add_stanza_id` (it built the same `<stanza-id/>` element directly without using the typed type). There is now a single canonical definition in `xep::xep0359`.

**Replaced:** the local private `extract_origin_id` in `websocket/handlers/message.rs` (which duplicated the parse logic but bypassed the new non-empty/whitespace invariant). All three call sites now use the canonical `extract_origin_id_str` from core. This closes the loophole where a whitespace-only client `<origin-id id='   '/>` could leak into `prototype.id` and the archived `origin_id` field.

Per CLAUDE.md "breaking changes by default" no compatibility shims remain; upstream callers in `waddle-xmpp` and `waddle-server` are updated to import from the new location.

## Out of scope (PR B follows)

- Any change to `ArchivedMessage` shape, MAM storage trait, SQL schema, FFI projection, or bench crate.
- XEP-0490 `DisplayedSync` carries the same string-typed `stanza_id_by` pattern this PR fixes for XEP-0359 — filed as #253.

## Plan reference

Decisions in #228 grilling thread: Q1 (relocation), Q4 (StanzaId.by: BareJid), Q5 (OriginId non-empty invariant).

## Related

- #228 — parent issue
- #250 — XEP-0201 thread parent loss (filed during grilling)
- #251 — client-side `waddle-xmpp-client::ArchivedMessage` typing (filed during grilling)
- #253 — XEP-0490 `DisplayedSync` typing (filed during code review)

## Test plan

- [x] `cargo build -p waddle-xmpp-core -p waddle-xmpp -p waddle-server`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p waddle-xmpp-core` — 102 passed (incl. new XEP-0359 tests for non-empty/malformed-by behaviour)
- [x] `cargo test -p waddle-xmpp` — passes
- [x] `cargo test -p waddle-server` — 318 + integration suites all pass
- [ ] CI green before flipping to ready-for-review