### PR TITLE
refactor(server): #228 PR B — typed ArchivedMessage and MAM trait surface

### DIFF
--- a/bench-storage-backends/crates/bench-clickhouse/src/lib.rs
+++ b/bench-storage-backends/crates/bench-clickhouse/src/lib.rs
@@ -30,11 +30,9 @@ struct ClickHouseMessageRow {
     timestamp_ms: i64,
     from_jid: String,
     to_jid: String,
-    body: String,
+    body: Option<String>,
     stanza_id: Option<String>,
     thread_id: Option<String>,
-    reply_to_id: Option<String>,
-    reply_to_jid: Option<String>,
     origin_id: Option<String>,
     message_type: String,
     stanza_xml: Option<String>,
@@ -64,8 +62,6 @@ impl From<ClickHouseMessageRow> for ArchivedMessage {
             body: value.body,
             stanza_id: value.stanza_id,
             thread_id: value.thread_id,
-            reply_to_id: value.reply_to_id,
-            reply_to_jid: value.reply_to_jid,
             origin_id: value.origin_id,
             message_type: value.message_type,
             stanza_xml: value.stanza_xml,
@@ -84,11 +80,9 @@ impl StanzaStore for ClickHouseStore {
                     timestamp_ms Int64,
                     from_jid String,
                     to_jid String,
-                    body String,
+                    body Nullable(String),
                     stanza_id Nullable(String),
                     thread_id Nullable(String),
-                    reply_to_id Nullable(String),
-                    reply_to_jid Nullable(String),
                     origin_id Nullable(String),
                     message_type String,
                     stanza_xml Nullable(String),
@@ -107,8 +101,8 @@ impl StanzaStore for ClickHouseStore {
             .query(
                 "INSERT INTO mam_messages
                 (id, room_jid, timestamp_ms, from_jid, to_jid, body, stanza_id, thread_id,
-                 reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 origin_id, message_type, stanza_xml)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
             .bind(&m.id)
             .bind(&m.room_jid)
@@ -118,8 +112,6 @@ impl StanzaStore for ClickHouseStore {
             .bind(&m.body)
             .bind(&m.stanza_id)
             .bind(&m.thread_id)
-            .bind(&m.reply_to_id)
-            .bind(&m.reply_to_jid)
             .bind(&m.origin_id)
             .bind(&m.message_type)
             .bind(&m.stanza_xml)
@@ -132,7 +124,7 @@ impl StanzaStore for ClickHouseStore {
     async fn query_messages(&self, q: &MamQuery) -> Result<Vec<ArchivedMessage>, StoreError> {
         let mut sql = String::from(
             "SELECT id, room_jid, timestamp_ms, from_jid, to_jid, body, stanza_id, thread_id, \
-             reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml \
+             origin_id, message_type, stanza_xml \
              FROM mam_messages WHERE room_jid = ?",
         );
         if q.start.is_some() {

--- a/bench-storage-backends/crates/bench-clickhouse/src/lib.rs
+++ b/bench-storage-backends/crates/bench-clickhouse/src/lib.rs
@@ -31,7 +31,7 @@ struct ClickHouseMessageRow {
     from_jid: String,
     to_jid: String,
     body: Option<String>,
-    stanza_id: Option<String>,
+    message_id: Option<String>,
     thread_id: Option<String>,
     origin_id: Option<String>,
     message_type: String,
@@ -60,7 +60,7 @@ impl From<ClickHouseMessageRow> for ArchivedMessage {
             from: value.from_jid,
             to: value.to_jid,
             body: value.body,
-            stanza_id: value.stanza_id,
+            message_id: value.message_id,
             thread_id: value.thread_id,
             origin_id: value.origin_id,
             message_type: value.message_type,
@@ -81,7 +81,7 @@ impl StanzaStore for ClickHouseStore {
                     from_jid String,
                     to_jid String,
                     body Nullable(String),
-                    stanza_id Nullable(String),
+                    message_id Nullable(String),
                     thread_id Nullable(String),
                     origin_id Nullable(String),
                     message_type String,
@@ -100,7 +100,7 @@ impl StanzaStore for ClickHouseStore {
         self.client
             .query(
                 "INSERT INTO mam_messages
-                (id, room_jid, timestamp_ms, from_jid, to_jid, body, stanza_id, thread_id,
+                (id, room_jid, timestamp_ms, from_jid, to_jid, body, message_id, thread_id,
                  origin_id, message_type, stanza_xml)
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             )
@@ -110,7 +110,7 @@ impl StanzaStore for ClickHouseStore {
             .bind(&m.from)
             .bind(&m.to)
             .bind(&m.body)
-            .bind(&m.stanza_id)
+            .bind(&m.message_id)
             .bind(&m.thread_id)
             .bind(&m.origin_id)
             .bind(&m.message_type)
@@ -123,7 +123,7 @@ impl StanzaStore for ClickHouseStore {
 
     async fn query_messages(&self, q: &MamQuery) -> Result<Vec<ArchivedMessage>, StoreError> {
         let mut sql = String::from(
-            "SELECT id, room_jid, timestamp_ms, from_jid, to_jid, body, stanza_id, thread_id, \
+            "SELECT id, room_jid, timestamp_ms, from_jid, to_jid, body, message_id, thread_id, \
              origin_id, message_type, stanza_xml \
              FROM mam_messages WHERE room_jid = ?",
         );

--- a/bench-storage-backends/crates/bench-core/src/message.rs
+++ b/bench-storage-backends/crates/bench-core/src/message.rs
@@ -20,8 +20,8 @@ pub struct ArchivedMessage {
     pub to: String,
     /// `<body/>` is optional per RFC 6121 §5.2.2 — `None` when absent.
     pub body: Option<String>,
-    /// XEP-0359 stanza id (if supplied by client).
-    pub stanza_id: Option<String>,
+    /// RFC 6121 `<message id='...'>` attribute (wire stanza identifier).
+    pub message_id: Option<String>,
     /// RFC 6121 thread identifier.
     pub thread_id: Option<String>,
     /// XEP-0359 origin id.
@@ -42,7 +42,7 @@ impl ArchivedMessage {
             from: from.to_string(),
             to: to.to_string(),
             body: Some(body.to_string()),
-            stanza_id: None,
+            message_id: None,
             thread_id: None,
             origin_id: None,
             message_type: MessageType::Chat.as_str().to_string(),

--- a/bench-storage-backends/crates/bench-core/src/message.rs
+++ b/bench-storage-backends/crates/bench-core/src/message.rs
@@ -18,15 +18,12 @@ pub struct ArchivedMessage {
     pub from: String,
     /// Recipient JID (room JID for MUC).
     pub to: String,
-    pub body: String,
+    /// `<body/>` is optional per RFC 6121 §5.2.2 — `None` when absent.
+    pub body: Option<String>,
     /// XEP-0359 stanza id (if supplied by client).
     pub stanza_id: Option<String>,
     /// RFC 6121 thread identifier.
     pub thread_id: Option<String>,
-    /// XEP-0461 reply target message id.
-    pub reply_to_id: Option<String>,
-    /// XEP-0461 optional original sender JID.
-    pub reply_to_jid: Option<String>,
     /// XEP-0359 origin id.
     pub origin_id: Option<String>,
     /// "chat" | "groupchat" | ...
@@ -44,11 +41,9 @@ impl ArchivedMessage {
             timestamp: Utc::now(),
             from: from.to_string(),
             to: to.to_string(),
-            body: body.to_string(),
+            body: Some(body.to_string()),
             stanza_id: None,
             thread_id: None,
-            reply_to_id: None,
-            reply_to_jid: None,
             origin_id: None,
             message_type: MessageType::Chat.as_str().to_string(),
             stanza_xml: None,

--- a/bench-storage-backends/crates/bench-core/src/workload.rs
+++ b/bench-storage-backends/crates/bench-core/src/workload.rs
@@ -377,7 +377,7 @@ fn build_message(room: u64, user: u64, tag: &str) -> ArchivedMessage {
         &format!("hello from user {user} in {tag}"),
     );
     m.thread_id = Some(format!("thr-{}", room));
-    m.stanza_id = Some(m.id.clone());
+    m.message_id = Some(m.id.clone());
     m.origin_id = Some(m.id.clone());
     m.message_type = "groupchat".to_string();
     m

--- a/bench-storage-backends/crates/bench-postgres/src/lib.rs
+++ b/bench-storage-backends/crates/bench-postgres/src/lib.rs
@@ -15,11 +15,9 @@ const MAM_SCHEMA_STATEMENTS: &[&str] = &[
         timestamp TIMESTAMPTZ NOT NULL,
         from_jid TEXT NOT NULL,
         to_jid TEXT NOT NULL,
-        body TEXT NOT NULL,
+        body TEXT,
         stanza_id TEXT,
         thread_id TEXT,
-        reply_to_id TEXT,
-        reply_to_jid TEXT,
         origin_id TEXT,
         message_type TEXT NOT NULL DEFAULT 'chat',
         stanza_xml TEXT,
@@ -55,11 +53,9 @@ struct PgArchivedMessageRow {
     timestamp: chrono::DateTime<chrono::Utc>,
     from_jid: String,
     to_jid: String,
-    body: String,
+    body: Option<String>,
     stanza_id: Option<String>,
     thread_id: Option<String>,
-    reply_to_id: Option<String>,
-    reply_to_jid: Option<String>,
     origin_id: Option<String>,
     message_type: String,
     stanza_xml: Option<String>,
@@ -76,8 +72,6 @@ impl From<PgArchivedMessageRow> for ArchivedMessage {
             body: value.body,
             stanza_id: value.stanza_id,
             thread_id: value.thread_id,
-            reply_to_id: value.reply_to_id,
-            reply_to_jid: value.reply_to_jid,
             origin_id: value.origin_id,
             message_type: value.message_type,
             stanza_xml: value.stanza_xml,
@@ -101,8 +95,8 @@ impl StanzaStore for PostgresStore {
         sqlx::query(
             r#"INSERT INTO mam_messages
                (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id,
-                thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)"#,
+                thread_id, origin_id, message_type, stanza_xml)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
         )
         .bind(&m.id)
         .bind(&m.room_jid)
@@ -112,8 +106,6 @@ impl StanzaStore for PostgresStore {
         .bind(&m.body)
         .bind(&m.stanza_id)
         .bind(&m.thread_id)
-        .bind(&m.reply_to_id)
-        .bind(&m.reply_to_jid)
         .bind(&m.origin_id)
         .bind(&m.message_type)
         .bind(&m.stanza_xml)
@@ -126,7 +118,7 @@ impl StanzaStore for PostgresStore {
     async fn query_messages(&self, q: &MamQuery) -> Result<Vec<ArchivedMessage>, StoreError> {
         let mut qb = QueryBuilder::new(
             "SELECT id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, \
-             reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml \
+             origin_id, message_type, stanza_xml \
              FROM mam_messages WHERE room_jid = ",
         );
         qb.push_bind(&q.room_jid);

--- a/bench-storage-backends/crates/bench-postgres/src/lib.rs
+++ b/bench-storage-backends/crates/bench-postgres/src/lib.rs
@@ -16,7 +16,7 @@ const MAM_SCHEMA_STATEMENTS: &[&str] = &[
         from_jid TEXT NOT NULL,
         to_jid TEXT NOT NULL,
         body TEXT,
-        stanza_id TEXT,
+        message_id TEXT,
         thread_id TEXT,
         origin_id TEXT,
         message_type TEXT NOT NULL DEFAULT 'chat',
@@ -54,7 +54,7 @@ struct PgArchivedMessageRow {
     from_jid: String,
     to_jid: String,
     body: Option<String>,
-    stanza_id: Option<String>,
+    message_id: Option<String>,
     thread_id: Option<String>,
     origin_id: Option<String>,
     message_type: String,
@@ -70,7 +70,7 @@ impl From<PgArchivedMessageRow> for ArchivedMessage {
             from: value.from_jid,
             to: value.to_jid,
             body: value.body,
-            stanza_id: value.stanza_id,
+            message_id: value.message_id,
             thread_id: value.thread_id,
             origin_id: value.origin_id,
             message_type: value.message_type,
@@ -104,7 +104,7 @@ impl StanzaStore for PostgresStore {
         .bind(&m.from)
         .bind(&m.to)
         .bind(&m.body)
-        .bind(&m.stanza_id)
+        .bind(&m.message_id)
         .bind(&m.thread_id)
         .bind(&m.origin_id)
         .bind(&m.message_type)
@@ -117,7 +117,7 @@ impl StanzaStore for PostgresStore {
 
     async fn query_messages(&self, q: &MamQuery) -> Result<Vec<ArchivedMessage>, StoreError> {
         let mut qb = QueryBuilder::new(
-            "SELECT id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, \
+            "SELECT id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, \
              origin_id, message_type, stanza_xml \
              FROM mam_messages WHERE room_jid = ",
         );

--- a/bench-storage-backends/crates/bench-sqlite/src/lib.rs
+++ b/bench-storage-backends/crates/bench-sqlite/src/lib.rs
@@ -42,11 +42,9 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     timestamp TEXT NOT NULL,
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
-    body TEXT NOT NULL,
+    body TEXT,
     stanza_id TEXT,
     thread_id TEXT,
-    reply_to_id TEXT,
-    reply_to_jid TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
@@ -357,8 +355,8 @@ fn writer_loop(
 
     const INSERT_SQL: &str = r#"INSERT INTO mam_messages
             (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id,
-             thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml)
-           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)"#;
+             thread_id, origin_id, message_type, stanza_xml)
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"#;
 
     while let Ok(job) = rx.recv() {
         let qw = job.enqueued_at.elapsed();
@@ -381,8 +379,6 @@ fn writer_loop(
                     m.body,
                     m.stanza_id,
                     m.thread_id,
-                    m.reply_to_id,
-                    m.reply_to_jid,
                     m.origin_id,
                     m.message_type,
                     m.stanza_xml,
@@ -577,7 +573,7 @@ fn run_query(pool: &Pool<UriManager>, q: &MamQuery) -> Result<Vec<ArchivedMessag
     let conn = pool.get().map_err(StoreError::backend)?;
     let mut sql = String::from(
         "SELECT id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, \
-         reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml \
+         origin_id, message_type, stanza_xml \
          FROM mam_messages WHERE room_jid = ?1",
     );
     let mut params_dyn: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(q.room_jid.clone())];
@@ -640,11 +636,9 @@ fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArchivedMessage> 
         body: row.get(5)?,
         stanza_id: row.get(6)?,
         thread_id: row.get(7)?,
-        reply_to_id: row.get(8)?,
-        reply_to_jid: row.get(9)?,
-        origin_id: row.get(10)?,
-        message_type: row.get(11)?,
-        stanza_xml: row.get(12)?,
+        origin_id: row.get(8)?,
+        message_type: row.get(9)?,
+        stanza_xml: row.get(10)?,
     })
 }
 

--- a/bench-storage-backends/crates/bench-sqlite/src/lib.rs
+++ b/bench-storage-backends/crates/bench-sqlite/src/lib.rs
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
     body TEXT,
-    stanza_id TEXT,
+    message_id TEXT,
     thread_id TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
@@ -377,7 +377,7 @@ fn writer_loop(
                     m.from,
                     m.to,
                     m.body,
-                    m.stanza_id,
+                    m.message_id,
                     m.thread_id,
                     m.origin_id,
                     m.message_type,
@@ -572,7 +572,7 @@ impl StanzaStore for SqliteStore {
 fn run_query(pool: &Pool<UriManager>, q: &MamQuery) -> Result<Vec<ArchivedMessage>, StoreError> {
     let conn = pool.get().map_err(StoreError::backend)?;
     let mut sql = String::from(
-        "SELECT id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, \
+        "SELECT id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, \
          origin_id, message_type, stanza_xml \
          FROM mam_messages WHERE room_jid = ?1",
     );
@@ -634,7 +634,7 @@ fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<ArchivedMessage> 
         from: row.get(3)?,
         to: row.get(4)?,
         body: row.get(5)?,
-        stanza_id: row.get(6)?,
+        message_id: row.get(6)?,
         thread_id: row.get(7)?,
         origin_id: row.get(8)?,
         message_type: row.get(9)?,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -63,8 +63,7 @@ use waddle_xmpp::{
         build_server_role_form, build_spaces_metadata_form_for_requester, is_last_activity_query,
         is_search_request, is_time_query, is_version_query, parse_command_from_iq,
         parse_moderation_iq, parse_search_request, ChannelResult, Command, CommandStatus,
-        Searchable, SpaceAffiliation, Xep0359StanzaId as StanzaId, NODE_COMMANDS,
-        NS_CHANNEL_SEARCH,
+        Searchable, SpaceAffiliation, NODE_COMMANDS, NS_CHANNEL_SEARCH,
     },
     Affiliation, SpaceDetails, Stanza, StanzaErrorCondition, StanzaErrorType, XmppError,
 };
@@ -973,17 +972,14 @@ pub async fn handle_iq_with_conn_state(
             RichMessageId::new(request.target_id.clone()),
             moderated_by.parse::<Jid>(),
         ) {
-            let stanza_id = moderation
-                .id
-                .clone()
-                .map(|id| StanzaId::new(id, room_jid.clone()));
+            let message_id = moderation.id.clone().and_then(RichMessageId::new);
             let archived = ArchivedMessage {
                 id: archive_id.clone(),
                 timestamp: chrono::Utc::now(),
                 from: jid::Jid::from(room_jid.clone()),
                 to: room_jid.clone(),
                 body: None,
-                stanza_id,
+                message_id,
                 thread: None,
                 origin_id: None,
                 message_type: xmpp_parsers::message::MessageType::Groupchat,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1,5 +1,6 @@
 use chrono;
 use jid::{BareJid, FullJid, Jid};
+use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, warn};
 use url::{Host, Url};
@@ -16,7 +17,7 @@ use waddle_xmpp::{
     isr::{build_isr_token_error, build_isr_token_result, is_isr_token_request, IsrToken, ISR_NS},
     mam::{
         add_stanza_id as add_mam_stanza_id, build_fin_iq, build_result_messages, is_mam_query,
-        parse_mam_query, ArchivedMessage, ArchivedModeration, ArchivedRichMessage,
+        parse_mam_query, ArchiveId, ArchivedMessage, ArchivedModeration, ArchivedRichMessage,
         ArchivedRichPayload, RichMessageId, RichText,
     },
     muc::{
@@ -62,7 +63,8 @@ use waddle_xmpp::{
         build_server_role_form, build_spaces_metadata_form_for_requester, is_last_activity_query,
         is_search_request, is_time_query, is_version_query, parse_command_from_iq,
         parse_moderation_iq, parse_search_request, ChannelResult, Command, CommandStatus,
-        Searchable, SpaceAffiliation, NODE_COMMANDS, NS_CHANNEL_SEARCH,
+        Searchable, SpaceAffiliation, Xep0359StanzaId as StanzaId, NODE_COMMANDS,
+        NS_CHANNEL_SEARCH,
     },
     Affiliation, SpaceDetails, Stanza, StanzaErrorCondition, StanzaErrorType, XmppError,
 };
@@ -900,14 +902,26 @@ pub async fn handle_iq_with_conn_state(
                 "forbidden",
             )];
         }
+        let target_archive_id = match ArchiveId::new(request.target_id.clone()) {
+            Some(id) => id,
+            None => {
+                return vec![build_iq_error_xml_with_addresses(
+                    &id,
+                    response_from,
+                    response_to,
+                    "modify",
+                    "bad-request",
+                )];
+            }
+        };
         match state
             .deps
             .protocol
             .mam_storage
-            .get_message(&request.target_id)
+            .get_message(&target_archive_id)
             .await
         {
-            Ok(Some(message)) if message.to == room_jid.to_string() => {}
+            Ok(Some(message)) if message.to == room_jid => {}
             Ok(Some(_)) => {
                 return vec![build_iq_error_xml_with_addresses(
                     &id,
@@ -951,25 +965,28 @@ pub async fn handle_iq_with_conn_state(
             &stamp,
             request.reason.as_deref(),
         );
-        let archive_id = uuid::Uuid::now_v7().to_string();
+        let archive_id =
+            ArchiveId::new(uuid::Uuid::now_v7().to_string()).expect("UUID is non-empty");
         add_mam_stanza_id(&mut moderation, archive_id.as_str(), &room_jid);
 
         if let (Some(target_id), Ok(moderator_jid)) = (
             RichMessageId::new(request.target_id.clone()),
             moderated_by.parse::<Jid>(),
         ) {
+            let stanza_id = moderation
+                .id
+                .clone()
+                .map(|id| StanzaId::new(id, room_jid.clone()));
             let archived = ArchivedMessage {
                 id: archive_id.clone(),
                 timestamp: chrono::Utc::now(),
-                from: room_jid.to_string(),
-                to: room_jid.to_string(),
-                body: String::new(),
-                stanza_id: moderation.id.clone(),
-                thread_id: None,
-                reply_to_id: None,
-                reply_to_jid: None,
+                from: jid::Jid::from(room_jid.clone()),
+                to: room_jid.clone(),
+                body: None,
+                stanza_id,
+                thread: None,
                 origin_id: None,
-                message_type: "groupchat".to_string(),
+                message_type: xmpp_parsers::message::MessageType::Groupchat,
                 stanza_xml: None,
                 rich: Some(ArchivedRichMessage {
                     payload: Some(ArchivedRichPayload::Moderation(ArchivedModeration {
@@ -988,7 +1005,7 @@ pub async fn handle_iq_with_conn_state(
                 .deps
                 .protocol
                 .mam_storage
-                .store_message(&room_jid.to_string(), &archived)
+                .store_message(&room_jid, &archived)
                 .await
             {
                 warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to archive moderation event");
@@ -1003,10 +1020,10 @@ pub async fn handle_iq_with_conn_state(
                 .deps
                 .protocol
                 .mam_storage
-                .get_message(&request.target_id)
+                .get_message(&target_archive_id)
                 .await;
             match original_lookup {
-                Ok(Some(original)) if original.to == room_jid.to_string() => {
+                Ok(Some(original)) if original.to == room_jid => {
                     // Use the moderation message's server-assigned
                     // archive id (XEP-0359 stanza-id stamped via
                     // `add_mam_stanza_id` above). That's the id
@@ -1016,7 +1033,9 @@ pub async fn handle_iq_with_conn_state(
                     // attribute, which would not match the archive
                     // entry clients can resolve.
                     let tombstone = waddle_xmpp::mam::ArchivedTombstone {
-                        retraction_id: waddle_xmpp::mam::RichMessageId::new(archive_id.clone()),
+                        retraction_id: waddle_xmpp::mam::RichMessageId::new(
+                            archive_id.as_str().to_owned(),
+                        ),
                         stamp: stamp_time,
                         moderation: Some(ArchivedModeration {
                             target_id: waddle_xmpp::mam::RichMessageId::new(
@@ -1111,12 +1130,11 @@ pub async fn handle_iq_with_conn_state(
             }
         };
 
-        let archive_jid = target_bare.to_string();
         let mut result = match state
             .deps
             .protocol
             .mam_storage
-            .query_messages(archive_jid.as_str(), &query)
+            .query_messages(&target_bare, &query)
             .await
         {
             Ok(result) => result,
@@ -1130,19 +1148,20 @@ pub async fn handle_iq_with_conn_state(
             .deps
             .protocol
             .mam_storage
-            .count_messages(archive_jid.as_str())
+            .count_messages(&target_bare)
             .await
             .ok();
 
         let recipient_jid = request_iq
             .from
-            .as_ref()
-            .map(|jid| jid.to_string())
-            .or_else(|| phase.bound_jid().map(ToString::to_string))
-            .unwrap_or_else(|| "unknown@localhost".to_string());
+            .clone()
+            .or_else(|| phase.bound_jid().cloned().map(jid::Jid::from))
+            .unwrap_or_else(|| {
+                jid::Jid::from(BareJid::from_str("unknown@localhost").expect("static valid jid"))
+            });
 
         let mut responses: Vec<String> =
-            build_result_messages(&query_id, recipient_jid.as_str(), &result.messages)
+            build_result_messages(&query_id, &recipient_jid, &result.messages)
                 .into_iter()
                 .map(|message| stanza_to_xml(&Stanza::Message(message)))
                 .collect();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -11,9 +11,9 @@ use waddle_xmpp::{
         InboxEntry,
     },
     mam::{
-        add_stanza_id as add_mam_stanza_id, ArchivedMention, ArchivedMessage, ArchivedReactionSet,
-        ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
-        ArchivedRichPayload, RichMessageId, RichText,
+        add_stanza_id as add_mam_stanza_id, ArchiveId, ArchivedMention, ArchivedMessage,
+        ArchivedReactionSet, ArchivedReference, ArchivedReply, ArchivedRetraction,
+        ArchivedRichMessage, ArchivedRichPayload, RichMessageId, RichText,
     },
     muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
     parser::message_to_string,
@@ -25,8 +25,9 @@ use waddle_xmpp::{
         extract_retraction_from_message, has_file_sharing, is_moderation_request_message,
         is_moderation_result_message, is_reaction_message, is_retraction_message,
         is_sticker_message, message_has_direct_invite, parse_reply_from_message,
-        remove_stanza_ids_by, should_skip_storage, RetractionKind, NS_EXPLICIT_MENTIONS,
-        NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE, NS_REPLY,
+        remove_stanza_ids_by, should_skip_storage, RetractionKind, Xep0359OriginId as OriginId,
+        Xep0359StanzaId as StanzaId, NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT,
+        NS_REACTIONS, NS_REFERENCE, NS_REPLY,
     },
     Stanza,
 };
@@ -278,7 +279,7 @@ pub async fn handle_message(
         let intended = local_messages.len();
         for mut outbound in local_messages.drain(..) {
             if let Some(ref archive_id) = archive_id {
-                add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid);
+                add_mam_stanza_id(&mut outbound.message, archive_id.as_str(), &room_jid);
             }
 
             if outbound.to == *sender_jid {
@@ -944,11 +945,14 @@ async fn lookup_correction_target_message(
     target_id: &str,
     _groupchat: bool,
 ) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
+    let Some(target) = RichMessageId::new(target_id.to_owned()) else {
+        return Ok(None);
+    };
     state
         .deps
         .protocol
         .mam_storage
-        .get_message_by_message_id(&archive_jid.to_string(), target_id)
+        .get_message_by_message_id(archive_jid, &target)
         .await
 }
 
@@ -962,11 +966,14 @@ async fn lookup_retraction_target_message(
         return lookup_rich_target_message(state, archive_jid, target_id, true).await;
     }
 
+    let Some(target) = RichMessageId::new(target_id.to_owned()) else {
+        return Ok(None);
+    };
     state
         .deps
         .protocol
         .mam_storage
-        .get_message_by_message_id(&archive_jid.to_string(), target_id)
+        .get_message_by_message_id(archive_jid, &target)
         .await
 }
 
@@ -977,31 +984,35 @@ async fn lookup_rich_target_message(
     groupchat: bool,
 ) -> Result<Option<ArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
     if groupchat {
-        let archive_str = archive_jid.to_string();
+        let Some(archive_id) = ArchiveId::new(target_id.to_owned()) else {
+            return Ok(None);
+        };
+        let archive_owner = archive_jid.clone();
         return state
             .deps
             .protocol
             .mam_storage
-            .get_message(target_id)
+            .get_message(&archive_id)
             .await
-            .map(|message| message.filter(|message| message.to == archive_str));
+            .map(|message| message.filter(|message| message.to == archive_owner));
     }
 
+    let Some(target) = RichMessageId::new(target_id.to_owned()) else {
+        return Ok(None);
+    };
     state
         .deps
         .protocol
         .mam_storage
-        .get_message_by_stanza_id(&archive_jid.to_string(), target_id)
+        .get_message_by_stanza_id(archive_jid, &target)
         .await
 }
 
-fn same_rich_sender(sender: &jid::Jid, original_from: &str, groupchat: bool) -> bool {
+fn same_rich_sender(sender: &jid::Jid, original_from: &jid::Jid, groupchat: bool) -> bool {
     if groupchat {
-        return sender.to_string() == original_from;
+        return sender == original_from;
     }
-    original_from
-        .parse::<jid::Jid>()
-        .is_ok_and(|original| original.to_bare() == sender.to_bare())
+    original_from.to_bare() == sender.to_bare()
 }
 
 fn has_malformed_rich_payload(message: &xmpp_parsers::message::Message) -> bool {
@@ -1294,51 +1305,53 @@ async fn archive_groupchat_message(
     room_jid: &BareJid,
     message: &mut xmpp_parsers::message::Message,
     sender_nickname_generation: u64,
-) -> Option<String> {
+) -> Option<ArchiveId> {
     if !should_archive_groupchat_message(message) {
         return None;
     }
 
-    let archive_id = uuid::Uuid::now_v7().to_string();
+    let archive_id = ArchiveId::new(uuid::Uuid::now_v7().to_string()).expect("UUID is non-empty");
     add_mam_stanza_id(message, archive_id.as_str(), room_jid);
 
     let body = prototype_body(message)
         .map(|value| value.trim().to_string())
-        .unwrap_or_default();
+        .and_then(RichText::new);
 
-    let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
-    let origin_id = extract_origin_id_str(message);
+    let origin_id = extract_origin_id_str(message).and_then(OriginId::new);
     let rich = rich_archive_payload(message);
 
     let stanza_xml = serialize_groupchat_stanza_xml(message);
 
+    let from_jid = match message.from.as_ref() {
+        Some(jid) => jid.clone(),
+        None => return None,
+    };
+
+    let stanza_id = message
+        .id
+        .clone()
+        .map(|id| StanzaId::new(id, room_jid.clone()));
+
     let archived = ArchivedMessage {
         id: archive_id,
         timestamp: Utc::now(),
-        from: message
-            .from
-            .as_ref()
-            .map(|jid| jid.to_string())
-            .unwrap_or_default(),
-        to: room_jid.to_string(),
+        from: from_jid,
+        to: room_jid.clone(),
         body,
-        stanza_id: message.id.clone(),
-        thread_id: message.thread.as_ref().map(|thread| thread.0.clone()),
-        reply_to_id,
-        reply_to_jid,
+        stanza_id,
+        thread: message.thread.clone(),
         origin_id,
-        message_type: mam_message_type(&message.type_),
+        message_type: message.type_.clone(),
         stanza_xml,
         rich,
         nickname_generation: Some(sender_nickname_generation),
     };
 
-    let archive_jid = room_jid.to_string();
     match state
         .deps
         .protocol
         .mam_storage
-        .store_message(archive_jid.as_str(), &archived)
+        .store_message(room_jid, &archived)
         .await
     {
         Ok(archive_id) => Some(archive_id),
@@ -1363,41 +1376,44 @@ async fn archive_direct_message(
 ) {
     let body = prototype_body(message)
         .map(|value| value.trim().to_string())
-        .unwrap_or_default();
+        .and_then(RichText::new);
     let rich = rich_archive_payload(message);
-    if body.is_empty() && rich.is_none() {
+    if body.is_none() && rich.is_none() {
         return;
     }
 
     let stanza_xml = serialize_direct_stanza_xml(message);
+    let origin_id = extract_origin_id_str(message).and_then(OriginId::new);
 
-    let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
-    let origin_id = extract_origin_id_str(message);
+    let sender_bare = sender_jid.to_bare();
+    let recipient_bare = to_jid.to_bare();
 
-    let archived = ArchivedMessage {
-        id: String::new(),
+    // The personal archive stamps the row's `<stanza-id by/>` with the
+    // archive owner's JID; we re-stamp per archive below.
+    let make_archived = |archive_owner: &BareJid| ArchivedMessage {
+        id: ArchiveId::new(uuid::Uuid::now_v7().to_string()).expect("UUID is non-empty"),
         timestamp: Utc::now(),
-        from: sender_jid.to_bare().to_string(),
-        to: to_jid.to_bare().to_string(),
-        body,
-        stanza_id: message.id.clone(),
-        thread_id: message.thread.as_ref().map(|thread| thread.0.clone()),
-        reply_to_id,
-        reply_to_jid,
-        origin_id,
-        message_type: mam_message_type(&message.type_),
-        stanza_xml,
-        rich,
+        from: jid::Jid::from(sender_bare.clone()),
+        to: archive_owner.clone(),
+        body: body.clone(),
+        stanza_id: message
+            .id
+            .clone()
+            .map(|id| StanzaId::new(id, archive_owner.clone())),
+        thread: message.thread.clone(),
+        origin_id: origin_id.clone(),
+        message_type: message.type_.clone(),
+        stanza_xml: stanza_xml.clone(),
+        rich: rich.clone(),
         nickname_generation: None,
     };
 
-    // Store in sender's personal archive
-    let sender_bare = sender_jid.to_bare().to_string();
+    let sender_archived = make_archived(&sender_bare);
     if let Err(err) = state
         .deps
         .protocol
         .mam_storage
-        .store_message(sender_bare.as_str(), &archived)
+        .store_message(&sender_bare, &sender_archived)
         .await
     {
         warn!(
@@ -1408,13 +1424,12 @@ async fn archive_direct_message(
         );
     }
 
-    // Store in recipient's personal archive
-    let recipient_bare = to_jid.to_bare().to_string();
+    let recipient_archived = make_archived(&recipient_bare);
     if let Err(err) = state
         .deps
         .protocol
         .mam_storage
-        .store_message(recipient_bare.as_str(), &archived)
+        .store_message(&recipient_bare, &recipient_archived)
         .await
     {
         warn!(
@@ -1424,33 +1439,6 @@ async fn archive_direct_message(
             "Failed to archive DM to recipient's personal MAM"
         );
     }
-}
-
-fn mam_message_type(message_type: &XmppMessageType) -> String {
-    match message_type {
-        XmppMessageType::Chat => "chat".to_string(),
-        XmppMessageType::Error => "error".to_string(),
-        XmppMessageType::Groupchat => "groupchat".to_string(),
-        XmppMessageType::Headline => "headline".to_string(),
-        XmppMessageType::Normal => "normal".to_string(),
-    }
-}
-
-fn extract_reply_reference(
-    message: &xmpp_parsers::message::Message,
-) -> (Option<String>, Option<String>) {
-    let Some(reply) = message
-        .payloads
-        .iter()
-        .find(|payload| payload.name() == "reply" && payload.ns() == NS_REPLY)
-    else {
-        return (None, None);
-    };
-
-    (
-        reply.attr("id").map(ToOwned::to_owned),
-        reply.attr("to").map(ToOwned::to_owned),
-    )
 }
 
 fn rich_archive_payload(message: &xmpp_parsers::message::Message) -> Option<ArchivedRichMessage> {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -1310,6 +1310,16 @@ async fn archive_groupchat_message(
         return None;
     }
 
+    // Refuse to archive (and stamp a stanza-id on) a message that is missing
+    // its sender JID — the previous flat-fields path silently stored
+    // `from = ""`, but a typed `Jid` cannot be empty. Bailing out here also
+    // avoids leaving a dangling `<stanza-id by/>` on the broadcast prototype
+    // that would never resolve to a stored row.
+    let from_jid = match message.from.as_ref() {
+        Some(jid) => jid.clone(),
+        None => return None,
+    };
+
     let archive_id = ArchiveId::new(uuid::Uuid::now_v7().to_string()).expect("UUID is non-empty");
     add_mam_stanza_id(message, archive_id.as_str(), room_jid);
 
@@ -1321,11 +1331,6 @@ async fn archive_groupchat_message(
     let rich = rich_archive_payload(message);
 
     let stanza_xml = serialize_groupchat_stanza_xml(message);
-
-    let from_jid = match message.from.as_ref() {
-        Some(jid) => jid.clone(),
-        None => return None,
-    };
 
     let stanza_id = message
         .id

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -26,8 +26,8 @@ use waddle_xmpp::{
         is_moderation_result_message, is_reaction_message, is_retraction_message,
         is_sticker_message, message_has_direct_invite, parse_reply_from_message,
         remove_stanza_ids_by, should_skip_storage, RetractionKind, Xep0359OriginId as OriginId,
-        Xep0359StanzaId as StanzaId, NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT,
-        NS_REACTIONS, NS_REFERENCE, NS_REPLY,
+        NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE,
+        NS_REPLY,
     },
     Stanza,
 };
@@ -1332,10 +1332,7 @@ async fn archive_groupchat_message(
 
     let stanza_xml = serialize_groupchat_stanza_xml(message);
 
-    let stanza_id = message
-        .id
-        .clone()
-        .map(|id| StanzaId::new(id, room_jid.clone()));
+    let message_id = message.id.clone().and_then(RichMessageId::new);
 
     let archived = ArchivedMessage {
         id: archive_id,
@@ -1343,7 +1340,7 @@ async fn archive_groupchat_message(
         from: from_jid,
         to: room_jid.clone(),
         body,
-        stanza_id,
+        message_id,
         thread: message.thread.clone(),
         origin_id,
         message_type: message.type_.clone(),
@@ -1392,19 +1389,20 @@ async fn archive_direct_message(
 
     let sender_bare = sender_jid.to_bare();
     let recipient_bare = to_jid.to_bare();
+    let message_id = message.id.clone().and_then(RichMessageId::new);
 
-    // The personal archive stamps the row's `<stanza-id by/>` with the
-    // archive owner's JID; we re-stamp per archive below.
-    let make_archived = |archive_owner: &BareJid| ArchivedMessage {
+    // Wire `from`/`to` are preserved across both archive copies — the
+    // archive owner is the row's `room_jid` (passed to `store_message`),
+    // not the `to` field. Archiving with `to = archive_owner` would
+    // collapse `from == to == self` in the sender's archive and break
+    // both `<with/>` peer filtering and replay-fallback `to=` rendering.
+    let make_archived = || ArchivedMessage {
         id: ArchiveId::new(uuid::Uuid::now_v7().to_string()).expect("UUID is non-empty"),
         timestamp: Utc::now(),
         from: jid::Jid::from(sender_bare.clone()),
-        to: archive_owner.clone(),
+        to: recipient_bare.clone(),
         body: body.clone(),
-        stanza_id: message
-            .id
-            .clone()
-            .map(|id| StanzaId::new(id, archive_owner.clone())),
+        message_id: message_id.clone(),
         thread: message.thread.clone(),
         origin_id: origin_id.clone(),
         message_type: message.type_.clone(),
@@ -1413,7 +1411,7 @@ async fn archive_direct_message(
         nickname_generation: None,
     };
 
-    let sender_archived = make_archived(&sender_bare);
+    let sender_archived = make_archived();
     if let Err(err) = state
         .deps
         .protocol
@@ -1429,7 +1427,7 @@ async fn archive_direct_message(
         );
     }
 
-    let recipient_archived = make_archived(&recipient_bare);
+    let recipient_archived = make_archived();
     if let Err(err) = state
         .deps
         .protocol

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -33,8 +33,8 @@ pub use domain::{
 };
 pub use error::{CoreError, CoreResult};
 pub use mam::{
-    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchivedMessage, MamQuery,
-    MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS, RSM_NS, STANZA_ID_NS,
+    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchiveId, ArchivedMessage,
+    MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS, RSM_NS, STANZA_ID_NS,
 };
 pub use parser_utils::{ensure_thread_element, extract_thread_parent, reattach_thread_parent};
 pub use presence::{

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -2,6 +2,8 @@
 //!
 //! These types and builders are safe to share across server and client code.
 
+use std::str::FromStr;
+
 use chrono::{DateTime, Utc};
 use jid::{BareJid, Jid};
 use minidom::Element;
@@ -9,8 +11,9 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use uuid::Uuid;
 use xmpp_parsers::iq::{Iq, IqType};
-use xmpp_parsers::message::{Message, MessageType};
+use xmpp_parsers::message::{Message, MessageType, Thread};
 
+use crate::xep::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId, StanzaId};
 use crate::{CoreError, CoreResult};
 
 /// MAM XML namespace (XEP-0313 v2).
@@ -161,68 +164,81 @@ pub struct ArchivedRichMessage {
     pub mentions: Vec<ArchivedMention>,
 }
 
-/// Archived message metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Archive-assigned unique identifier for a stored message row.
+///
+/// Per XEP-0313 §5.1.1 the archive emits this as the `id=` attribute of a
+/// `<stanza-id by='archive-jid' id='archive-id'/>` element. Per
+/// XEP-0359 §4 the value is an opaque non-empty string — Waddle's storage
+/// generator emits UUID-v7 today, but the type only encodes the
+/// XEP-required non-emptiness.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ArchiveId(String);
+
+impl ArchiveId {
+    /// Wrap a raw archive id, rejecting empty/whitespace strings.
+    pub fn new(value: impl Into<String>) -> Option<Self> {
+        let value = value.into();
+        (!value.trim().is_empty()).then_some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for ArchiveId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Archived message row at the storage boundary.
+///
+/// Protocol fields are typed per the project's typed-payloads rule. The two
+/// serialization-boundary fields — `stanza_xml` and `rich` — retain string /
+/// JSON shapes since they are themselves serialized blobs at the SQL layer.
+#[derive(Debug, Clone)]
 pub struct ArchivedMessage {
-    /// Unique message ID.
-    pub id: String,
-    /// Timestamp when the message was received.
+    /// Archive-assigned unique identifier.
+    pub id: ArchiveId,
+    /// Timestamp when the message was archived.
     pub timestamp: DateTime<Utc>,
-    /// Sender JID.
-    pub from: String,
-    /// Recipient JID (room JID for MUC, or contact bare JID for 1:1).
-    pub to: String,
-    /// Message body.
-    pub body: String,
-    /// Original stanza ID (if present).
-    pub stanza_id: Option<String>,
-    /// RFC 6121 thread identifier for this message.
-    pub thread_id: Option<String>,
-    /// XEP-0461 reply target message ID.
-    pub reply_to_id: Option<String>,
-    /// XEP-0461 optional original sender JID.
-    pub reply_to_jid: Option<String>,
-    /// XEP-0359 origin-id supplied by client.
-    pub origin_id: Option<String>,
-    /// Message type ("chat", "groupchat", "normal", etc.).
-    #[serde(default = "default_message_type")]
-    pub message_type: String,
-    /// Preserved full stanza XML for faithful replay of archived timeline events.
+    /// Sender JID. Bare for direct, full (room+nick) for groupchat.
+    pub from: Jid,
+    /// Recipient/archive JID — always bare (room JID for MUC, contact bare
+    /// for 1:1 personal archive).
+    pub to: BareJid,
+    /// Message body. `None` when absent on the wire (RFC 6121 §5.2.2 makes
+    /// `<body/>` optional); always non-empty when present.
+    pub body: Option<RichText>,
+    /// XEP-0359 stanza-id stamped on the incoming message (if any). The
+    /// `by` half is reconstructed from the archive owner's JID at read
+    /// time — the archive is the assigning entity per XEP-0359 §4.
+    pub stanza_id: Option<StanzaId>,
+    /// RFC 6121 / XEP-0201 thread identifier. The optional `parent`
+    /// attribute on `<thread/>` is currently dropped (tracked in #250).
+    pub thread: Option<Thread>,
+    /// XEP-0359 origin-id supplied by the originating client.
+    pub origin_id: Option<OriginId>,
+    /// XMPP message type (Chat / Groupchat / Normal / etc).
+    pub message_type: MessageType,
+    /// Preserved full stanza XML for faithful replay of archived timeline
+    /// events. SQL byte-blob equivalent to wire bytes.
     pub stanza_xml: Option<String>,
-    /// Typed rich-message payload and annotations used to reconstruct XMPP payloads.
+    /// Typed rich-message payload and annotations used to reconstruct
+    /// XMPP payloads. Reply target lives here (canonical), not in flat
+    /// fields. Persisted as JSON in a single SQL column.
     pub rich: Option<ArchivedRichMessage>,
     /// Per-XEP-0308 §3 occupancy generation for the sender's MUC nickname
     /// at archive-write time. Only set for `groupchat` rows; `None`
     /// otherwise. Used to disallow corrections across leave/rejoin
     /// cycles — the correction handler refuses if the room's current
     /// generation for the same nickname has advanced.
-    #[serde(default)]
     pub nickname_generation: Option<u64>,
-}
-
-fn default_message_type() -> String {
-    "chat".to_string()
-}
-
-impl Default for ArchivedMessage {
-    fn default() -> Self {
-        Self {
-            id: String::new(),
-            timestamp: Utc::now(),
-            from: String::new(),
-            to: String::new(),
-            body: String::new(),
-            stanza_id: None,
-            thread_id: None,
-            reply_to_id: None,
-            reply_to_jid: None,
-            origin_id: None,
-            message_type: default_message_type(),
-            stanza_xml: None,
-            rich: None,
-            nickname_generation: None,
-        }
-    }
 }
 
 /// MAM query parameters.
@@ -232,14 +248,18 @@ pub struct MamQuery {
     pub start: Option<DateTime<Utc>>,
     /// End time filter.
     pub end: Option<DateTime<Utc>>,
-    /// Filter by sender.
-    pub with: Option<String>,
+    /// XEP-0313 `<with/>` filter — JID (bare or full) of the counterpart.
+    pub with: Option<Jid>,
     /// Maximum results to return.
     pub max: Option<u32>,
-    /// Pagination: before this ID.
-    pub before_id: Option<String>,
-    /// Pagination: after this ID.
-    pub after_id: Option<String>,
+    /// RSM pagination: return rows whose archive id < this id, newest first.
+    pub before_id: Option<ArchiveId>,
+    /// RSM pagination: return rows whose archive id > this id.
+    pub after_id: Option<ArchiveId>,
+    /// XEP-0059 §2.5: empty `<before/>` element requests the last page of
+    /// results. Set when the wire query contains a `<before/>` element with
+    /// no text content; mutually informative with `before_id`.
+    pub last_page: bool,
 }
 
 /// MAM query result.
@@ -249,10 +269,10 @@ pub struct MamResult {
     pub messages: Vec<ArchivedMessage>,
     /// Whether there are more messages available.
     pub complete: bool,
-    /// First message ID in the result set.
-    pub first_id: Option<String>,
-    /// Last message ID in the result set.
-    pub last_id: Option<String>,
+    /// First archive id in the result set.
+    pub first_id: Option<ArchiveId>,
+    /// Last archive id in the result set.
+    pub last_id: Option<ArchiveId>,
     /// Total count (if available).
     pub count: Option<u32>,
 }
@@ -307,7 +327,7 @@ pub fn is_mam_query(iq: &Iq) -> bool {
 /// Build MAM result messages for each archived message.
 pub fn build_result_messages(
     query_id: &str,
-    to_jid: &str,
+    to_jid: &Jid,
     messages: &[ArchivedMessage],
 ) -> Vec<Message> {
     messages
@@ -355,7 +375,11 @@ fn parse_data_form(form: &Element, query: &mut MamQuery) -> CoreResult<()> {
                 }
             }
             "with" => {
-                query.with = value.filter(|value| !value.is_empty());
+                if let Some(value) = value.filter(|value| !value.is_empty()) {
+                    query.with = Some(Jid::from_str(&value).map_err(|error| {
+                        CoreError::bad_request(Some(format!("Invalid <with/> JID: {error}")))
+                    })?);
+                }
             }
             _ => {}
         }
@@ -377,12 +401,19 @@ fn parse_rsm(rsm: &Element, query: &mut MamQuery) -> CoreResult<()> {
             }
             "after" => {
                 let value = child.text();
-                if !value.is_empty() {
-                    query.after_id = Some(value);
+                if let Some(id) = ArchiveId::new(value) {
+                    query.after_id = Some(id);
                 }
             }
             "before" => {
-                query.before_id = Some(child.text());
+                // XEP-0059 §2.5: a `<before/>` element with no text requests
+                // the last page; with text it's a backward-from-cursor page.
+                let value = child.text();
+                if let Some(id) = ArchiveId::new(value) {
+                    query.before_id = Some(id);
+                } else {
+                    query.last_page = true;
+                }
             }
             _ => {}
         }
@@ -397,7 +428,7 @@ fn parse_datetime(value: &str) -> CoreResult<DateTime<Utc>> {
         .map_err(|error| CoreError::bad_request(Some(format!("Invalid datetime: {}", error))))
 }
 
-fn build_result_message(query_id: &str, to_jid: &str, archived: &ArchivedMessage) -> Message {
+fn build_result_message(query_id: &str, to_jid: &Jid, archived: &ArchivedMessage) -> Message {
     let inner_msg = archived_inner_message(archived);
     let delay = Element::builder("delay", DELAY_NS)
         .attr("stamp", archived.timestamp.to_rfc3339())
@@ -408,21 +439,15 @@ fn build_result_message(query_id: &str, to_jid: &str, archived: &ArchivedMessage
         .build();
     let result = Element::builder("result", MAM_NS)
         .attr("queryid", query_id)
-        .attr("id", &archived.id)
+        .attr("id", archived.id.as_str())
         .append(forwarded)
         .build();
 
-    let mut msg = Message::new(Some(parse_message_jid(to_jid)));
+    let mut msg = Message::new(Some(to_jid.clone()));
     msg.id = Some(Uuid::now_v7().to_string());
     msg.type_ = MessageType::Normal;
     msg.payloads.push(result);
     msg
-}
-
-fn parse_message_jid(to_jid: &str) -> Jid {
-    to_jid
-        .parse()
-        .unwrap_or_else(|_| Jid::from(BareJid::new("unknown").expect("valid fallback JID")))
 }
 
 fn archived_inner_message(archived: &ArchivedMessage) -> Element {
@@ -439,15 +464,19 @@ fn archived_inner_message(archived: &ArchivedMessage) -> Element {
         }
     }
 
-    if let Some(rich) = archived.rich.as_ref() {
-        return build_typed_inner_message(archived, rich);
-    }
-
-    build_legacy_inner_message(archived)
+    let rich_default;
+    let rich = match archived.rich.as_ref() {
+        Some(rich) => rich,
+        None => {
+            rich_default = ArchivedRichMessage::default();
+            &rich_default
+        }
+    };
+    build_typed_inner_message(archived, rich)
 }
 
 fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage) -> Element {
-    if archived.message_type != "groupchat" {
+    if archived.message_type != MessageType::Groupchat {
         return element;
     }
 
@@ -474,51 +503,48 @@ fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage
     builder.build()
 }
 
+fn message_type_attr(message_type: &MessageType) -> &'static str {
+    match message_type {
+        MessageType::Chat => "chat",
+        MessageType::Error => "error",
+        MessageType::Groupchat => "groupchat",
+        MessageType::Headline => "headline",
+        MessageType::Normal => "normal",
+    }
+}
+
 fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMessage) -> Element {
-    let msg_type = if archived.message_type.is_empty() {
-        "chat"
-    } else {
-        archived.message_type.as_str()
-    };
+    let msg_type = message_type_attr(&archived.message_type);
 
     let mut builder = Element::builder("message", CLIENT_NS)
-        .attr("from", &archived.from)
+        .attr("from", archived.from.to_string())
         .attr("type", msg_type);
-    if msg_type != "groupchat" {
-        builder = builder.attr("to", &archived.to);
+    if archived.message_type != MessageType::Groupchat {
+        builder = builder.attr("to", archived.to.to_string());
     }
 
-    if let Some(stanza_id) = archived.stanza_id.as_deref() {
-        builder = builder.attr("id", stanza_id);
+    if let Some(stanza_id) = archived.stanza_id.as_ref() {
+        builder = builder.attr("id", stanza_id.id.as_str());
     }
-    if !archived.body.is_empty() {
+    if let Some(body) = archived.body.as_ref() {
         builder = builder.append(
             Element::builder("body", CLIENT_NS)
-                .append(archived.body.clone())
+                .append(body.as_str())
                 .build(),
         );
     }
-    if let Some(thread_id) = archived.thread_id.as_deref() {
+    if let Some(thread) = archived.thread.as_ref() {
         builder = builder.append(
             Element::builder("thread", CLIENT_NS)
-                .append(thread_id)
+                .append(thread.0.as_str())
                 .build(),
         );
     }
-    if let Some(origin_id) = archived.origin_id.as_deref() {
-        builder = builder.append(
-            Element::builder("origin-id", STANZA_ID_NS)
-                .attr("id", origin_id)
-                .build(),
-        );
+    if let Some(origin_id) = archived.origin_id.as_ref() {
+        builder = builder.append(build_origin_id_element(origin_id.as_str()));
     }
-    if msg_type == "groupchat" && !archived.id.is_empty() && !archived.to.is_empty() {
-        builder = builder.append(
-            Element::builder("stanza-id", STANZA_ID_NS)
-                .attr("id", &archived.id)
-                .attr("by", &archived.to)
-                .build(),
-        );
+    if archived.message_type == MessageType::Groupchat {
+        builder = builder.append(build_stanza_id_element(archived.id.as_str(), &archived.to));
     }
     if let Some(reply) = rich.reply.as_ref() {
         let mut reply_builder = Element::builder("reply", REPLY_NS).attr("id", reply.id.as_str());
@@ -642,71 +668,22 @@ fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMess
     builder.build()
 }
 
-fn build_legacy_inner_message(archived: &ArchivedMessage) -> Element {
-    let msg_type = if archived.message_type.is_empty() {
-        "chat"
-    } else {
-        archived.message_type.as_str()
-    };
-
-    let mut builder = Element::builder("message", CLIENT_NS)
-        .attr("from", &archived.from)
-        .attr("type", msg_type);
-    if msg_type != "groupchat" {
-        builder = builder.attr("to", &archived.to);
-    }
-
-    if let Some(stanza_id) = archived.stanza_id.as_deref() {
-        builder = builder.attr("id", stanza_id);
-    }
-    if !archived.body.is_empty() {
-        builder = builder.append(
-            Element::builder("body", CLIENT_NS)
-                .append(archived.body.clone())
-                .build(),
-        );
-    }
-    if let Some(thread_id) = archived.thread_id.as_deref() {
-        builder = builder.append(
-            Element::builder("thread", CLIENT_NS)
-                .append(thread_id)
-                .build(),
-        );
-    }
-    if let Some(reply_to_id) = archived.reply_to_id.as_deref() {
-        let mut reply = Element::builder("reply", REPLY_NS).attr("id", reply_to_id);
-        if let Some(reply_to_jid) = archived.reply_to_jid.as_deref() {
-            reply = reply.attr("to", reply_to_jid);
-        }
-        builder = builder.append(reply.build());
-    }
-    if let Some(origin_id) = archived.origin_id.as_deref() {
-        builder = builder.append(
-            Element::builder("origin-id", STANZA_ID_NS)
-                .attr("id", origin_id)
-                .build(),
-        );
-    }
-    if msg_type == "groupchat" && !archived.id.is_empty() && !archived.to.is_empty() {
-        builder = builder.append(
-            Element::builder("stanza-id", STANZA_ID_NS)
-                .attr("id", &archived.id)
-                .attr("by", &archived.to)
-                .build(),
-        );
-    }
-
-    builder.build()
-}
-
 fn build_rsm_response_element(result: &MamResult) -> Element {
     let mut builder = Element::builder("set", RSM_NS);
 
-    if let Some(first) = result.first_id.as_deref() {
-        builder = builder.append(Element::builder("first", RSM_NS).append(first).build());
+    if let Some(first) = result.first_id.as_ref() {
+        builder = builder.append(
+            Element::builder("first", RSM_NS)
+                .append(first.as_str())
+                .build(),
+        );
     }
-    if let Some(last) = result.last_id.as_deref() {
-        builder = builder.append(Element::builder("last", RSM_NS).append(last).build());
+    if let Some(last) = result.last_id.as_ref() {
+        builder = builder.append(
+            Element::builder("last", RSM_NS)
+                .append(last.as_str())
+                .build(),
+        );
     }
     if let Some(count) = result.count {
         builder = builder.append(
@@ -723,6 +700,22 @@ fn build_rsm_response_element(result: &MamResult) -> Element {
 mod tests {
     use super::*;
     use chrono::Datelike;
+
+    fn archive_id(s: &str) -> ArchiveId {
+        ArchiveId::new(s).expect("non-empty archive id")
+    }
+
+    fn rich_text(s: &str) -> RichText {
+        RichText::new(s).expect("non-empty rich text")
+    }
+
+    fn jid(s: &str) -> Jid {
+        Jid::from_str(s).expect("valid jid")
+    }
+
+    fn bare_jid(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
 
     #[test]
     fn parses_mam_query_with_form_and_rsm() {
@@ -772,8 +765,14 @@ mod tests {
 
         assert_eq!(query_id, "query-1");
         assert_eq!(query.max, Some(10));
-        assert_eq!(query.after_id.as_deref(), Some("msg-9"));
-        assert_eq!(query.with.as_deref(), Some("juliet@example.com"));
+        assert_eq!(
+            query.after_id.as_ref().map(ArchiveId::as_str),
+            Some("msg-9"),
+        );
+        assert_eq!(
+            query.with.as_ref().map(Jid::to_string).as_deref(),
+            Some("juliet@example.com"),
+        );
         let start = query.start.expect("start filter");
         assert_eq!(start.year(), 2024);
         assert_eq!(start.month(), 1);
@@ -799,7 +798,8 @@ mod tests {
 
         let (_, query) = parse_mam_query(&iq).expect("valid MAM query");
 
-        assert_eq!(query.before_id, Some(String::new()));
+        assert_eq!(query.before_id, None);
+        assert!(query.last_page);
     }
 
     #[test]
@@ -833,21 +833,32 @@ mod tests {
     }
 
     #[test]
-    fn builds_result_message_from_legacy_fields() {
+    fn builds_result_message_from_typed_fields() {
         let archived = ArchivedMessage {
-            id: "msg-123".to_string(),
+            id: archive_id("msg-123"),
             timestamp: Utc::now(),
-            from: "user@example.com/nick".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "Hello, world!".to_string(),
-            thread_id: Some("thread-1".to_string()),
-            reply_to_id: Some("parent-1".to_string()),
-            reply_to_jid: Some("alice@example.com".to_string()),
-            origin_id: Some("origin-1".to_string()),
-            ..Default::default()
+            from: jid("user@example.com/nick"),
+            to: bare_jid("room@conference.example.com"),
+            body: Some(rich_text("Hello, world!")),
+            stanza_id: None,
+            thread: Some(Thread("thread-1".to_owned())),
+            origin_id: OriginId::new("origin-1"),
+            message_type: MessageType::Chat,
+            stanza_xml: None,
+            rich: Some(ArchivedRichMessage {
+                payload: None,
+                reply: Some(ArchivedReply {
+                    id: RichMessageId("parent-1".to_string()),
+                    to: Some(jid("alice@example.com")),
+                }),
+                references: vec![],
+                mentions: vec![],
+            }),
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-1", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-1", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()
@@ -874,19 +885,24 @@ mod tests {
     #[test]
     fn preserves_archived_stanza_payload() {
         let archived = ArchivedMessage {
-            id: "msg-124".to_string(),
+            id: archive_id("msg-124"),
             timestamp: Utc::now(),
-            from: "room@conference.example.com/alice".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: String::new(),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conference.example.com/alice"),
+            to: bare_jid("room@conference.example.com"),
+            body: None,
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='reaction-1'><reactions xmlns='urn:xmpp:reactions:0' id='msg-1'><reaction>👍</reaction></reactions></message>".to_string(),
             ),
-            ..Default::default()
+            rich: None,
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-2", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-2", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()
@@ -912,16 +928,16 @@ mod tests {
     #[test]
     fn builds_fin_iq_with_rsm_metadata() {
         let original = Iq {
-            from: Some(parse_message_jid("romeo@example.com/orchard")),
-            to: Some(parse_message_jid("juliet@example.com/balcony")),
+            from: Some(jid("romeo@example.com/orchard")),
+            to: Some(jid("juliet@example.com/balcony")),
             id: "iq-1".to_string(),
             payload: IqType::Get(Element::builder("query", MAM_NS).build()),
         };
         let result = MamResult {
             messages: Vec::new(),
             complete: true,
-            first_id: Some("msg-1".to_string()),
-            last_id: Some("msg-2".to_string()),
+            first_id: Some(archive_id("msg-1")),
+            last_id: Some(archive_id("msg-2")),
             count: Some(2),
         };
 
@@ -954,8 +970,8 @@ mod tests {
     fn adds_stanza_id_payload() {
         use crate::xep::xep0359::add_stanza_id;
 
-        let mut message = Message::new(Some(parse_message_jid("juliet@example.com")));
-        let by: BareJid = "room@example.com".parse().expect("valid bare jid");
+        let mut message = Message::new(Some(jid("juliet@example.com")));
+        let by = bare_jid("room@example.com");
 
         add_stanza_id(&mut message, "archive-1", &by);
 
@@ -971,12 +987,15 @@ mod tests {
     #[test]
     fn stanza_xml_preferred_over_rich_payload() {
         let archived = ArchivedMessage {
-            id: "msg-priority".to_string(),
+            id: archive_id("msg-priority"),
             timestamp: Utc::now(),
-            from: "room@conference.example.com/alice".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "typed body".to_string(),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conference.example.com/alice"),
+            to: bare_jid("room@conference.example.com"),
+            body: Some(rich_text("typed body")),
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' type='groupchat' id='live-1'><body>live body with embeds</body><github xmlns='urn:waddle:github:0'><repo url='https://github.com/example/project'><owner>example</owner><name>project</name></repo></github></message>".to_string(),
             ),
@@ -986,10 +1005,11 @@ mod tests {
                 references: vec![],
                 mentions: vec![],
             }),
-            ..Default::default()
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-priority", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-priority", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()
@@ -1019,30 +1039,32 @@ mod tests {
     #[test]
     fn stanza_xml_preserves_reply_fallback() {
         let archived = ArchivedMessage {
-            id: "msg-fallback".to_string(),
+            id: archive_id("msg-fallback"),
             timestamp: Utc::now(),
-            from: "room@conference.example.com/bob".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "> Alice wrote:\n> Hello!\nI agree!".to_string(),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conference.example.com/bob"),
+            to: bare_jid("room@conference.example.com"),
+            body: Some(rich_text("> Alice wrote:\n> Hello!\nI agree!")),
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/bob' type='groupchat' id='reply-1'><body>&gt; Alice wrote:\n&gt; Hello!\nI agree!</body><reply xmlns='urn:xmpp:reply:0' id='orig-1' to='room@conference.example.com/alice'/><fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'><body start='0' end='22'/></fallback></message>".to_string(),
             ),
-            reply_to_id: Some("orig-1".to_string()),
-            reply_to_jid: Some("room@conference.example.com/alice".to_string()),
             rich: Some(ArchivedRichMessage {
                 payload: None,
                 reply: Some(ArchivedReply {
                     id: RichMessageId("orig-1".to_string()),
-                    to: Some("room@conference.example.com/alice".parse().unwrap()),
+                    to: Some(jid("room@conference.example.com/alice")),
                 }),
                 references: vec![],
                 mentions: vec![],
             }),
-            ..Default::default()
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-fallback", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-fallback", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()
@@ -1078,19 +1100,24 @@ mod tests {
     #[test]
     fn stanza_xml_strips_to_for_groupchat() {
         let archived = ArchivedMessage {
-            id: "msg-strip-to".to_string(),
+            id: archive_id("msg-strip-to"),
             timestamp: Utc::now(),
-            from: "room@conference.example.com/alice".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "Hello!".to_string(),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conference.example.com/alice"),
+            to: bare_jid("room@conference.example.com"),
+            body: Some(rich_text("Hello!")),
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='msg-1'><body>Hello!</body></message>".to_string(),
             ),
-            ..Default::default()
+            rich: None,
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-strip-to", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-strip-to", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()
@@ -1116,17 +1143,22 @@ mod tests {
     fn stanza_xml_strips_to_for_groupchat_on_raw_element_fallback() {
         let stanza_xml = "<message xmlns='jabber:client' from='room@conf.example.com/alice' to='room@conf.example.com' type='groupchat' id='msg-x'><body>test</body><custom xmlns='urn:example:unknown'/></message>";
         let archived = ArchivedMessage {
-            id: "msg-strip-raw".to_string(),
+            id: archive_id("msg-strip-raw"),
             timestamp: Utc::now(),
-            from: "room@conf.example.com/alice".to_string(),
-            to: "room@conf.example.com".to_string(),
-            body: "test".to_string(),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conf.example.com/alice"),
+            to: bare_jid("room@conf.example.com"),
+            body: Some(rich_text("test")),
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(stanza_xml.to_string()),
-            ..Default::default()
+            rich: None,
+            nickname_generation: None,
         };
 
-        let msg = build_result_messages("query-strip-raw", "user@example.com", &[archived]);
+        let to_jid = jid("user@example.com");
+        let msg = build_result_messages("query-strip-raw", &to_jid, &[archived]);
         let result = msg[0]
             .payloads
             .iter()

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::message::{Message, MessageType, Thread};
 
-use crate::xep::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId, StanzaId};
+use crate::xep::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId};
 use crate::{CoreError, CoreResult};
 
 /// MAM XML namespace (XEP-0313 v2).
@@ -215,10 +215,12 @@ pub struct ArchivedMessage {
     /// Message body. `None` when absent on the wire (RFC 6121 §5.2.2 makes
     /// `<body/>` optional); always non-empty when present.
     pub body: Option<RichText>,
-    /// XEP-0359 stanza-id stamped on the incoming message (if any). The
-    /// `by` half is reconstructed from the archive owner's JID at read
-    /// time — the archive is the assigning entity per XEP-0359 §4.
-    pub stanza_id: Option<StanzaId>,
+    /// RFC 6121 `<message id='...'>` attribute as supplied by the
+    /// originating client (the wire stanza identifier). Distinct from
+    /// XEP-0359 stanza-ids: the latter are server-assigned values that
+    /// flow through the archive primary key (`id`) and are reconstructed
+    /// in replay via `build_stanza_id_element(archived.id, archived.to)`.
+    pub message_id: Option<RichMessageId>,
     /// RFC 6121 / XEP-0201 thread identifier. The optional `parent`
     /// attribute on `<thread/>` is currently dropped (tracked in #250).
     pub thread: Option<Thread>,
@@ -523,8 +525,8 @@ fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMess
         builder = builder.attr("to", archived.to.to_string());
     }
 
-    if let Some(stanza_id) = archived.stanza_id.as_ref() {
-        builder = builder.attr("id", stanza_id.id.as_str());
+    if let Some(message_id) = archived.message_id.as_ref() {
+        builder = builder.attr("id", message_id.as_str());
     }
     if let Some(body) = archived.body.as_ref() {
         builder = builder.append(
@@ -840,7 +842,7 @@ mod tests {
             from: jid("user@example.com/nick"),
             to: bare_jid("room@conference.example.com"),
             body: Some(rich_text("Hello, world!")),
-            stanza_id: None,
+            message_id: None,
             thread: Some(Thread("thread-1".to_owned())),
             origin_id: OriginId::new("origin-1"),
             message_type: MessageType::Chat,
@@ -890,7 +892,7 @@ mod tests {
             from: jid("room@conference.example.com/alice"),
             to: bare_jid("room@conference.example.com"),
             body: None,
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,
@@ -992,7 +994,7 @@ mod tests {
             from: jid("room@conference.example.com/alice"),
             to: bare_jid("room@conference.example.com"),
             body: Some(rich_text("typed body")),
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,
@@ -1044,7 +1046,7 @@ mod tests {
             from: jid("room@conference.example.com/bob"),
             to: bare_jid("room@conference.example.com"),
             body: Some(rich_text("> Alice wrote:\n> Hello!\nI agree!")),
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,
@@ -1105,7 +1107,7 @@ mod tests {
             from: jid("room@conference.example.com/alice"),
             to: bare_jid("room@conference.example.com"),
             body: Some(rich_text("Hello!")),
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,
@@ -1148,7 +1150,7 @@ mod tests {
             from: jid("room@conf.example.com/alice"),
             to: bare_jid("room@conf.example.com"),
             body: Some(rich_text("test")),
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -17,7 +17,7 @@ pub mod storage;
 
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
 pub use waddle_xmpp_core::mam::{
-    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchivedMention,
+    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchiveId, ArchivedMention,
     ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference, ArchivedReply,
     ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone, MamQuery,
     MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -24,7 +24,7 @@ use xmpp_parsers::message::{MessageType, Thread};
 
 use super::{ArchivedMessage, MamQuery, MamResult, RichMessageId, RichText};
 use waddle_xmpp_core::mam::{ArchiveId, ArchivedRichMessage, ArchivedTombstone};
-use waddle_xmpp_core::xep::xep0359::{OriginId, StanzaId};
+use waddle_xmpp_core::xep::xep0359::OriginId;
 
 /// Errors that can occur during MAM storage operations.
 #[derive(Error, Debug)]
@@ -176,10 +176,18 @@ impl MamStorage for InMemoryMamStorage {
             messages.retain(|message| message.timestamp <= end);
         }
         if let Some(with) = query.with.as_ref() {
-            let with_str = with.to_string();
+            // XEP-0313 §4.1.2: equality match, plus full-JID-of-bare match
+            // when the filter itself is bare. See `WithMatch` for rationale.
+            let exact = with.to_string();
+            let bare_resource_prefix = with.is_bare().then(|| format!("{exact}/"));
             messages.retain(|message| {
-                message.from.to_string().starts_with(&with_str)
-                    || message.to.to_string().starts_with(&with_str)
+                let from = message.from.to_string();
+                let to = message.to.to_string();
+                let exact_match = from == exact || to == exact;
+                let resource_match = bare_resource_prefix
+                    .as_deref()
+                    .is_some_and(|prefix| from.starts_with(prefix) || to.starts_with(prefix));
+                exact_match || resource_match
             });
         }
         if let Some(before_id) = query.before_id.as_ref() {
@@ -238,7 +246,7 @@ impl MamStorage for InMemoryMamStorage {
             .iter()
             .find(|(jid, message)| {
                 jid == archive_jid
-                    && (message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                    && (message.message_id.as_ref().map(RichMessageId::as_str)
                         == Some(stanza_id.as_str())
                         || message.origin_id.as_ref().map(OriginId::as_str)
                             == Some(stanza_id.as_str()))
@@ -256,7 +264,7 @@ impl MamStorage for InMemoryMamStorage {
             .iter()
             .find(|(jid, message)| {
                 jid == archive_jid
-                    && message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                    && message.message_id.as_ref().map(RichMessageId::as_str)
                         == Some(message_id.as_str())
             })
             .map(|(_, message)| message.clone()))
@@ -273,7 +281,7 @@ impl MamStorage for InMemoryMamStorage {
             .find(|(jid, message)| {
                 jid == archive_jid
                     && (message.id.as_str() == stanza_id.as_str()
-                        || message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                        || message.message_id.as_ref().map(RichMessageId::as_str)
                             == Some(stanza_id.as_str()))
             })
             .map(|(_, message)| message.clone()))
@@ -411,8 +419,18 @@ impl SqlxMamStorage {
 }
 
 const SELECT_COLUMNS: &str =
-    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation";
+    "id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation";
 
+// `body` is nullable per RFC 6121 §5.2.2 (`<body/>` is optional).
+// `message_id` stores the wire `<message id='...'>` attribute (RFC 6121 §8.1.3),
+// distinct from XEP-0359 stanza-ids — the archive's own stanza-id is the row's
+// primary key column `id`, and `<stanza-id by/>` is reconstructed at read time.
+//
+// Existing dev databases created against pre-#228 PR B schemas (`body NOT NULL`,
+// column named `stanza_id`) will not be silently rewritten — `CREATE TABLE IF
+// NOT EXISTS` is a no-op when the table is present. Per CLAUDE.md "no production
+// data; breaking changes by default", operators carrying old dev databases must
+// drop them before reopening with this build. We do not add migration tooling.
 const SQLITE_MAM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS mam_messages (
     id TEXT PRIMARY KEY,
@@ -421,7 +439,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
     body TEXT,
-    stanza_id TEXT,
+    message_id TEXT,
     thread_id TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
@@ -448,7 +466,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
     body TEXT,
-    stanza_id TEXT,
+    message_id TEXT,
     thread_id TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
@@ -559,6 +577,54 @@ async fn ensure_sqlite_column(
     Ok(())
 }
 
+/// XEP-0313 §4.1.2 `<with/>` filter.
+///
+/// A bare JID matches the bare itself (1:1 archive owner ↔ peer bare) or any
+/// full JID resource of that bare (room@/nick form in MUC). A full JID matches
+/// only itself. Built with explicit equality predicates so a `juliet@host`
+/// filter cannot accidentally match `juliet@host.evil` — the previous prefix
+/// `LIKE 'juliet@host%'` shape was XEP-non-conformant.
+struct WithMatch {
+    exact: String,
+    /// `Some(prefix)` when the filter is bare and we should also match
+    /// stored full JIDs whose bare equals this filter, via
+    /// `from_jid LIKE prefix || '%'` where `prefix = "{bare}/"`.
+    bare_resource_prefix: Option<String>,
+}
+
+impl WithMatch {
+    fn from_jid(jid: &Jid) -> Self {
+        let exact = jid.to_string();
+        // `Jid::is_bare()` is true when no resource is present.
+        let bare_resource_prefix = jid.is_bare().then(|| format!("{exact}/"));
+        Self {
+            exact,
+            bare_resource_prefix,
+        }
+    }
+}
+
+fn push_with_filter<'a, DB>(builder: &mut QueryBuilder<'a, DB>, with: &'a WithMatch)
+where
+    DB: sqlx::Database,
+    String: sqlx::Encode<'a, DB> + sqlx::Type<DB>,
+{
+    builder
+        .push(" AND (from_jid = ")
+        .push_bind(with.exact.clone())
+        .push(" OR to_jid = ")
+        .push_bind(with.exact.clone());
+    if let Some(prefix) = with.bare_resource_prefix.as_ref() {
+        let pattern = format!("{prefix}%");
+        builder
+            .push(" OR from_jid LIKE ")
+            .push_bind(pattern.clone())
+            .push(" OR to_jid LIKE ")
+            .push_bind(pattern);
+    }
+    builder.push(")");
+}
+
 fn uses_backward_pagination(query: &MamQuery) -> bool {
     // XEP-0059 §2.5: an empty <before/> element requests the last page of
     // results, signalled by `last_page = true`. A `<before/>` with a cursor
@@ -594,30 +660,28 @@ fn finalize_result(mut messages: Vec<ArchivedMessage>, query: &MamQuery) -> MamR
 }
 
 /// Column indices match `SELECT_COLUMNS`:
-/// `id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation`.
+/// `id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation`.
 fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStorageError> {
     let timestamp = DateTime::parse_from_rfc3339(&row.try_get::<String, _>(2)?)
         .map_err(|error| MamStorageError::Serialization(format!("Invalid timestamp: {error}")))?
         .with_timezone(&Utc);
 
-    let room_jid: String = row.try_get(1)?;
-    let stanza_id: Option<String> = row.try_get(6)?;
+    let message_id: Option<String> = row.try_get(6)?;
     let thread_id: Option<String> = row.try_get(7)?;
     let origin_id: Option<String> = row.try_get(8)?;
     let message_type_str: String = row.try_get(9)?;
     let rich_payload: Option<String> = row.try_get(11)?;
     let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(12)?)?;
 
-    let archive_owner = decode_archive_jid(&room_jid)?;
     Ok(ArchivedMessage {
         id: decode_archive_id(row.try_get(0)?, "id")?,
         timestamp,
         from: decode_jid(row.try_get(3)?, "from_jid")?,
-        to: decode_archive_jid(&row.try_get::<String, _>(4)?)?,
+        to: decode_bare_jid(&row.try_get::<String, _>(4)?, "to_jid")?,
         body: decode_body(row.try_get(5)?),
-        stanza_id: decode_stanza_id(stanza_id, &archive_owner),
+        message_id: decode_message_id(message_id)?,
         thread: thread_id.map(Thread),
-        origin_id: origin_id.and_then(OriginId::new),
+        origin_id: decode_origin_id(origin_id)?,
         message_type: decode_message_type(&message_type_str)?,
         stanza_xml: row.try_get(10)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
@@ -626,24 +690,22 @@ fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStor
 }
 
 fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorageError> {
-    let room_jid: String = row.try_get(1)?;
-    let stanza_id: Option<String> = row.try_get(6)?;
+    let message_id: Option<String> = row.try_get(6)?;
     let thread_id: Option<String> = row.try_get(7)?;
     let origin_id: Option<String> = row.try_get(8)?;
     let message_type_str: String = row.try_get(9)?;
     let rich_payload: Option<String> = row.try_get(11)?;
     let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(12)?)?;
 
-    let archive_owner = decode_archive_jid(&room_jid)?;
     Ok(ArchivedMessage {
         id: decode_archive_id(row.try_get(0)?, "id")?,
         timestamp: row.try_get(2)?,
         from: decode_jid(row.try_get(3)?, "from_jid")?,
-        to: decode_archive_jid(&row.try_get::<String, _>(4)?)?,
+        to: decode_bare_jid(&row.try_get::<String, _>(4)?, "to_jid")?,
         body: decode_body(row.try_get(5)?),
-        stanza_id: decode_stanza_id(stanza_id, &archive_owner),
+        message_id: decode_message_id(message_id)?,
         thread: thread_id.map(Thread),
-        origin_id: origin_id.and_then(OriginId::new),
+        origin_id: decode_origin_id(origin_id)?,
         message_type: decode_message_type(&message_type_str)?,
         stanza_xml: row.try_get(10)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
@@ -665,9 +727,9 @@ fn decode_jid(raw: String, column: &str) -> Result<Jid, MamStorageError> {
     })
 }
 
-fn decode_archive_jid(raw: &str) -> Result<BareJid, MamStorageError> {
+fn decode_bare_jid(raw: &str, column: &str) -> Result<BareJid, MamStorageError> {
     BareJid::from_str(raw).map_err(|error| {
-        MamStorageError::Serialization(format!("Invalid `room_jid` column JID: {error}"))
+        MamStorageError::Serialization(format!("Invalid `{column}` column JID: {error}"))
     })
 }
 
@@ -675,11 +737,32 @@ fn decode_body(raw: Option<String>) -> Option<RichText> {
     raw.and_then(RichText::new)
 }
 
-/// Per Q4 of #228 the `<stanza-id by='...'>` is reconstructed from the row's
-/// archive owner — the archive IS the assigning entity per XEP-0359 §4.
-fn decode_stanza_id(raw: Option<String>, archive_owner: &BareJid) -> Option<StanzaId> {
-    raw.filter(|value| !value.is_empty())
-        .map(|id| StanzaId::new(id, archive_owner.clone()))
+/// Decode the wire `<message id='...'>` attribute from storage. Whitespace-only
+/// or empty present values are rejected as malformed rather than silently
+/// mapped to `None` — a stored present-but-blank id is corruption per the
+/// fail-loud invariant in #228 Q11.
+fn decode_message_id(raw: Option<String>) -> Result<Option<RichMessageId>, MamStorageError> {
+    match raw {
+        None => Ok(None),
+        Some(value) => RichMessageId::new(value).map(Some).ok_or_else(|| {
+            MamStorageError::Serialization(
+                "empty or whitespace-only `message_id` column value rejected".to_string(),
+            )
+        }),
+    }
+}
+
+/// Decode the XEP-0359 `<origin-id id='...'>` value from storage. Whitespace-
+/// only or empty present values are rejected as malformed.
+fn decode_origin_id(raw: Option<String>) -> Result<Option<OriginId>, MamStorageError> {
+    match raw {
+        None => Ok(None),
+        Some(value) => OriginId::new(value).map(Some).ok_or_else(|| {
+            MamStorageError::Serialization(
+                "empty or whitespace-only `origin_id` column value rejected (XEP-0359 §3 requires non-empty)".to_string(),
+            )
+        }),
+    }
 }
 
 fn decode_message_type(raw: &str) -> Result<MessageType, MamStorageError> {
@@ -762,7 +845,7 @@ impl MamStorage for SqlxMamStorage {
         let archive_jid_str = archive_jid.to_string();
         let from_jid_str = message.from.to_string();
         let to_jid_str = message.to.to_string();
-        let stanza_id_str = message.stanza_id.as_ref().map(|sid| sid.id.clone());
+        let message_id_str = message.message_id.as_ref().map(|m| m.as_str().to_owned());
         let thread_id_str = message.thread.as_ref().map(|t| t.0.clone());
         let origin_id_str = message
             .origin_id
@@ -773,7 +856,7 @@ impl MamStorage for SqlxMamStorage {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut query = QueryBuilder::<Sqlite>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -783,7 +866,7 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(&from_jid_str)
                         .push_bind(&to_jid_str)
                         .push_bind(body_str.as_deref())
-                        .push_bind(stanza_id_str.as_deref())
+                        .push_bind(message_id_str.as_deref())
                         .push_bind(thread_id_str.as_deref())
                         .push_bind(origin_id_str.as_deref())
                         .push_bind(message_type)
@@ -795,7 +878,7 @@ impl MamStorage for SqlxMamStorage {
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut query = QueryBuilder::<Postgres>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, message_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
@@ -805,7 +888,7 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(&from_jid_str)
                         .push_bind(&to_jid_str)
                         .push_bind(body_str.as_deref())
-                        .push_bind(stanza_id_str.as_deref())
+                        .push_bind(message_id_str.as_deref())
                         .push_bind(thread_id_str.as_deref())
                         .push_bind(origin_id_str.as_deref())
                         .push_bind(message_type)
@@ -828,8 +911,12 @@ impl MamStorage for SqlxMamStorage {
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
         let limit = i64::from(query.max.unwrap_or(100).min(500)) + 1;
-        let with_filter = query.with.as_ref().map(|with| format!("{with}%"));
         let archive_jid_str = archive_jid.to_string();
+        // XEP-0313 §4.1.2: `<with/>` matches messages where the counterpart
+        // JID equals (full match) or, for bare-JID filters, equals OR is a
+        // resource of the bare JID. Prefix `LIKE` was vulnerable to spoofing
+        // (e.g. `juliet@example.com` matching `juliet@example.com.evil`).
+        let with_match: Option<WithMatch> = query.with.as_ref().map(WithMatch::from_jid);
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
@@ -847,13 +934,8 @@ impl MamStorage for SqlxMamStorage {
                         .push(" AND timestamp <= ")
                         .push_bind(end.to_rfc3339());
                 }
-                if let Some(with) = with_filter.as_deref() {
-                    builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
+                if let Some(with) = with_match.as_ref() {
+                    push_with_filter::<Sqlite>(&mut builder, with);
                 }
                 if let Some(before_id) = query.before_id.as_ref() {
                     builder.push(" AND id < ").push_bind(before_id.as_str());
@@ -886,13 +968,8 @@ impl MamStorage for SqlxMamStorage {
                 if let Some(end) = query.end {
                     builder.push(" AND timestamp <= ").push_bind(end);
                 }
-                if let Some(with) = with_filter.as_deref() {
-                    builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
+                if let Some(with) = with_match.as_ref() {
+                    push_with_filter::<Postgres>(&mut builder, with);
                 }
                 if let Some(before_id) = query.before_id.as_ref() {
                     builder.push(" AND id < ").push_bind(before_id.as_str());
@@ -951,7 +1028,7 @@ impl MamStorage for SqlxMamStorage {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (stanza_id = ? OR origin_id = ?) ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (message_id = ? OR origin_id = ?) ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(stanza_id.as_str())
@@ -962,7 +1039,7 @@ impl MamStorage for SqlxMamStorage {
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (stanza_id = $2 OR origin_id = $2) ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (message_id = $2 OR origin_id = $2) ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(stanza_id.as_str())
@@ -982,7 +1059,7 @@ impl MamStorage for SqlxMamStorage {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND stanza_id = ? ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND message_id = ? ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(message_id.as_str())
@@ -992,7 +1069,7 @@ impl MamStorage for SqlxMamStorage {
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND stanza_id = $2 ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND message_id = $2 ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(message_id.as_str())
@@ -1012,7 +1089,7 @@ impl MamStorage for SqlxMamStorage {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (id = ? OR stanza_id = ?) ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (id = ? OR message_id = ?) ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(stanza_id.as_str())
@@ -1023,7 +1100,7 @@ impl MamStorage for SqlxMamStorage {
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let row = sqlx::query(&format!(
-                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (id = $2 OR stanza_id = $2) ORDER BY timestamp DESC LIMIT 1"
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (id = $2 OR message_id = $2) ORDER BY timestamp DESC LIMIT 1"
                 ))
                 .bind(&archive_jid_str)
                 .bind(stanza_id.as_str())
@@ -1166,7 +1243,7 @@ mod tests {
             from: jid(from),
             to: archive.clone(),
             body: RichText::new(body),
-            stanza_id: None,
+            message_id: None,
             thread: None,
             origin_id: None,
             message_type: MessageType::Groupchat,
@@ -1182,7 +1259,7 @@ mod tests {
         let archive = bare("room@conference.example.com");
 
         let mut msg = fixture_message(&archive, "user@example.com/nick", "Hello, world!");
-        msg.stanza_id = Some(StanzaId::new("abc123", archive.clone()));
+        msg.message_id = RichMessageId::new("abc123");
 
         let archive_id = storage.store_message(&archive, &msg).await.unwrap();
         assert!(!archive_id.as_str().is_empty());
@@ -1198,7 +1275,7 @@ mod tests {
             Some("Hello, world!")
         );
         assert_eq!(
-            retrieved.stanza_id.as_ref().map(|sid| sid.id.as_str()),
+            retrieved.message_id.as_ref().map(RichMessageId::as_str),
             Some("abc123")
         );
     }
@@ -1214,7 +1291,7 @@ mod tests {
             from: jid("room@conference.example.com/alice"),
             to: archive.clone(),
             body: RichText::new("Reply body"),
-            stanza_id: Some(StanzaId::new("archive-stanza-1", archive.clone())),
+            message_id: RichMessageId::new("archive-stanza-1"),
             thread: Some(Thread("thread-root-1".to_owned())),
             origin_id: OriginId::new("origin-abc"),
             message_type: MessageType::Groupchat,

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -8,6 +8,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use jid::{BareJid, Jid};
 use sqlx::postgres::{PgPool, PgPoolOptions, PgRow};
 use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
@@ -19,9 +20,11 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{debug, info, instrument};
-use uuid::Uuid;
+use xmpp_parsers::message::{MessageType, Thread};
 
-use super::{ArchivedMessage, MamQuery, MamResult};
+use super::{ArchivedMessage, MamQuery, MamResult, RichMessageId, RichText};
+use waddle_xmpp_core::mam::{ArchiveId, ArchivedRichMessage, ArchivedTombstone};
+use waddle_xmpp_core::xep::xep0359::{OriginId, StanzaId};
 
 /// Errors that can occur during MAM storage operations.
 #[derive(Error, Debug)]
@@ -57,9 +60,9 @@ pub trait MamStorage: Send + Sync {
     /// Returns the unique archive ID assigned to the message.
     async fn store_message(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError>;
+    ) -> Result<ArchiveId, MamStorageError>;
 
     /// Query messages from the archive.
     ///
@@ -70,76 +73,73 @@ pub trait MamStorage: Send + Sync {
     /// Supports filtering by time range, sender, and RSM pagination.
     async fn query_messages(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError>;
 
     /// Get a single message by its archive ID.
     async fn get_message(
         &self,
-        archive_id: &str,
+        archive_id: &ArchiveId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
     /// Replace an archived message with a XEP-0424 / XEP-0425 tombstone in
-    /// place. Clears `body`, `stanza_xml`, `thread_id`, `reply_to_id`,
-    /// `reply_to_jid`, and overwrites `rich_payload` with the typed
-    /// `ArchivedRichPayload::Tombstone(...)` value.
+    /// place. Clears `body`, `stanza_xml`, `thread`, and overwrites
+    /// `rich_payload` with the typed `ArchivedRichPayload::Tombstone(...)`
+    /// value (the canonical reply target also lives in `rich.reply` and
+    /// is cleared here).
     ///
     /// Looks up the row by `archive_id` (the storage primary key). Returns
     /// `Ok(true)` when a row was found and updated, `Ok(false)` when no row
     /// matched, and `Err` on storage failure.
     async fn replace_with_tombstone(
         &self,
-        archive_id: &str,
-        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+        archive_id: &ArchiveId,
+        tombstone: ArchivedTombstone,
     ) -> Result<bool, MamStorageError>;
 
     /// Get a single message by its original message/stanza id inside an archive.
     async fn get_message_by_stanza_id(
         &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
     /// Get a message by its wire message id inside an archive.
     async fn get_message_by_message_id(
         &self,
-        archive_jid: &str,
-        message_id: &str,
+        archive_jid: &BareJid,
+        message_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
     /// Get a message by server archive id or stanza id, excluding client origin-id.
     async fn get_message_by_archive_or_stanza_id(
         &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
     /// Get the total count of messages in an archive (for RSM).
-    async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError>;
+    async fn count_messages(&self, room_jid: &BareJid) -> Result<u32, MamStorageError>;
 
     /// Delete messages older than a given timestamp.
     ///
     /// Used for archive maintenance/cleanup.
     async fn delete_before(
         &self,
-        room_jid: &str,
+        room_jid: &BareJid,
         before: DateTime<Utc>,
     ) -> Result<u64, MamStorageError>;
 }
 
 #[derive(Clone, Default)]
 pub struct InMemoryMamStorage {
-    entries: Arc<RwLock<Vec<(String, ArchivedMessage)>>>,
+    entries: Arc<RwLock<Vec<(BareJid, ArchivedMessage)>>>,
 }
 
 impl InMemoryMamStorage {
     pub fn new() -> Self {
         Self::default()
-    }
-
-    fn generate_archive_id() -> String {
-        Uuid::now_v7().to_string()
     }
 }
 
@@ -147,26 +147,19 @@ impl InMemoryMamStorage {
 impl MamStorage for InMemoryMamStorage {
     async fn store_message(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError> {
-        let archive_id = if message.id.is_empty() {
-            Self::generate_archive_id()
-        } else {
-            message.id.clone()
-        };
-
-        let mut stored = message.clone();
-        stored.id = archive_id.clone();
-
+    ) -> Result<ArchiveId, MamStorageError> {
+        let archive_id = message.id.clone();
+        let stored = message.clone();
         let mut entries = self.entries.write().await;
-        entries.push((archive_jid.to_string(), stored));
+        entries.push((archive_jid.clone(), stored));
         Ok(archive_id)
     }
 
     async fn query_messages(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
         let entries = self.entries.read().await;
@@ -182,21 +175,24 @@ impl MamStorage for InMemoryMamStorage {
         if let Some(end) = query.end {
             messages.retain(|message| message.timestamp <= end);
         }
-        if let Some(with) = query.with.as_deref() {
-            messages
-                .retain(|message| message.from.starts_with(with) || message.to.starts_with(with));
+        if let Some(with) = query.with.as_ref() {
+            let with_str = with.to_string();
+            messages.retain(|message| {
+                message.from.to_string().starts_with(&with_str)
+                    || message.to.to_string().starts_with(&with_str)
+            });
         }
-        if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-            messages.retain(|message| message.id.as_str() < before_id);
+        if let Some(before_id) = query.before_id.as_ref() {
+            messages.retain(|message| message.id.as_str() < before_id.as_str());
         }
-        if let Some(after_id) = query.after_id.as_deref() {
-            messages.retain(|message| message.id.as_str() > after_id);
+        if let Some(after_id) = query.after_id.as_ref() {
+            messages.retain(|message| message.id.as_str() > after_id.as_str());
         }
 
         if uses_backward_pagination(query) {
-            messages.sort_by(|a, b| b.id.cmp(&a.id));
+            messages.sort_by(|a, b| b.id.as_str().cmp(a.id.as_str()));
         } else {
-            messages.sort_by(|a, b| a.id.cmp(&b.id));
+            messages.sort_by(|a, b| a.id.as_str().cmp(b.id.as_str()));
         }
 
         let actual_limit = query.max.unwrap_or(100).min(500) as usize;
@@ -223,68 +219,74 @@ impl MamStorage for InMemoryMamStorage {
 
     async fn get_message(
         &self,
-        archive_id: &str,
+        archive_id: &ArchiveId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
-            .find(|(_, message)| message.id == archive_id)
+            .find(|(_, message)| &message.id == archive_id)
             .map(|(_, message)| message.clone()))
     }
 
     async fn get_message_by_stanza_id(
         &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
             .find(|(jid, message)| {
                 jid == archive_jid
-                    && (message.stanza_id.as_deref() == Some(stanza_id)
-                        || message.origin_id.as_deref() == Some(stanza_id))
+                    && (message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                        == Some(stanza_id.as_str())
+                        || message.origin_id.as_ref().map(OriginId::as_str)
+                            == Some(stanza_id.as_str()))
             })
             .map(|(_, message)| message.clone()))
     }
 
     async fn get_message_by_message_id(
         &self,
-        archive_jid: &str,
-        message_id: &str,
-    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
-        let entries = self.entries.read().await;
-        Ok(entries
-            .iter()
-            .find(|(jid, message)| {
-                jid == archive_jid && message.stanza_id.as_deref() == Some(message_id)
-            })
-            .map(|(_, message)| message.clone()))
-    }
-
-    async fn get_message_by_archive_or_stanza_id(
-        &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        message_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
             .find(|(jid, message)| {
                 jid == archive_jid
-                    && (message.id == stanza_id || message.stanza_id.as_deref() == Some(stanza_id))
+                    && message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                        == Some(message_id.as_str())
             })
             .map(|(_, message)| message.clone()))
     }
 
-    async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError> {
+    async fn get_message_by_archive_or_stanza_id(
+        &self,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .find(|(jid, message)| {
+                jid == archive_jid
+                    && (message.id.as_str() == stanza_id.as_str()
+                        || message.stanza_id.as_ref().map(|sid| sid.id.as_str())
+                            == Some(stanza_id.as_str()))
+            })
+            .map(|(_, message)| message.clone()))
+    }
+
+    async fn count_messages(&self, room_jid: &BareJid) -> Result<u32, MamStorageError> {
         let entries = self.entries.read().await;
         Ok(entries.iter().filter(|(jid, _)| jid == room_jid).count() as u32)
     }
 
     async fn delete_before(
         &self,
-        room_jid: &str,
+        room_jid: &BareJid,
         before: DateTime<Utc>,
     ) -> Result<u64, MamStorageError> {
         let mut entries = self.entries.write().await;
@@ -295,12 +297,12 @@ impl MamStorage for InMemoryMamStorage {
 
     async fn replace_with_tombstone(
         &self,
-        archive_id: &str,
-        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+        archive_id: &ArchiveId,
+        tombstone: ArchivedTombstone,
     ) -> Result<bool, MamStorageError> {
         let mut entries = self.entries.write().await;
         for (_jid, message) in entries.iter_mut() {
-            if message.id == archive_id {
+            if &message.id == archive_id {
                 apply_tombstone(message, tombstone);
                 return Ok(true);
             }
@@ -309,16 +311,11 @@ impl MamStorage for InMemoryMamStorage {
     }
 }
 
-fn apply_tombstone(
-    message: &mut ArchivedMessage,
-    tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
-) {
-    use waddle_xmpp_core::mam::{ArchivedRichMessage, ArchivedRichPayload};
-    message.body.clear();
+fn apply_tombstone(message: &mut ArchivedMessage, tombstone: ArchivedTombstone) {
+    use waddle_xmpp_core::mam::ArchivedRichPayload;
+    message.body = None;
     message.stanza_xml = None;
-    message.thread_id = None;
-    message.reply_to_id = None;
-    message.reply_to_jid = None;
+    message.thread = None;
     message.rich = Some(ArchivedRichMessage {
         payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
         reply: None,
@@ -411,14 +408,10 @@ impl SqlxMamStorage {
             }
         }
     }
-
-    fn generate_archive_id() -> String {
-        Uuid::now_v7().to_string()
-    }
 }
 
 const SELECT_COLUMNS: &str =
-    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation";
+    "id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation";
 
 const SQLITE_MAM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS mam_messages (
@@ -427,11 +420,9 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     timestamp TEXT NOT NULL,
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
-    body TEXT NOT NULL,
+    body TEXT,
     stanza_id TEXT,
     thread_id TEXT,
-    reply_to_id TEXT,
-    reply_to_jid TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
@@ -447,8 +438,6 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_id
     ON mam_messages(room_jid, id);
 CREATE INDEX IF NOT EXISTS idx_mam_room_thread
     ON mam_messages(room_jid, thread_id, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
-    ON mam_messages(room_jid, reply_to_id, timestamp DESC);
 "#;
 
 const POSTGRES_MAM_SCHEMA: &str = r#"
@@ -458,11 +447,9 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     timestamp TIMESTAMPTZ NOT NULL,
     from_jid TEXT NOT NULL,
     to_jid TEXT NOT NULL,
-    body TEXT NOT NULL,
+    body TEXT,
     stanza_id TEXT,
     thread_id TEXT,
-    reply_to_id TEXT,
-    reply_to_jid TEXT,
     origin_id TEXT,
     message_type TEXT NOT NULL DEFAULT 'chat',
     stanza_xml TEXT,
@@ -478,8 +465,6 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_id
     ON mam_messages(room_jid, id);
 CREATE INDEX IF NOT EXISTS idx_mam_room_thread
     ON mam_messages(room_jid, thread_id, timestamp DESC);
-CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
-    ON mam_messages(room_jid, reply_to_id, timestamp DESC);
 "#;
 
 fn infer_driver(database_url: &str) -> Result<MamDatabaseDriver, MamStorageError> {
@@ -576,12 +561,12 @@ async fn ensure_sqlite_column(
 
 fn uses_backward_pagination(query: &MamQuery) -> bool {
     // XEP-0059 §2.5: an empty <before/> element requests the last page of
-    // results. We treat any present `before_id` — including `Some("")` — as a
-    // backward-pagination signal so the SQL emits ORDER BY id DESC and
-    // `finalize_result` reverses back to chronological order. The downstream
-    // `id < ?` predicate is still skipped for the empty case, so no rows are
-    // filtered out.
-    query.before_id.is_some()
+    // results, signalled by `last_page = true`. A `<before/>` with a cursor
+    // is also backward-pagination. Either signal flips the SQL to
+    // ORDER BY id DESC and `finalize_result` reverses back to chronological
+    // order. With `last_page` and no cursor, no `id < ?` predicate is
+    // emitted, so no rows are filtered out.
+    query.before_id.is_some() || query.last_page
 }
 
 fn finalize_result(mut messages: Vec<ArchivedMessage>, query: &MamQuery) -> MamResult {
@@ -608,50 +593,116 @@ fn finalize_result(mut messages: Vec<ArchivedMessage>, query: &MamQuery) -> MamR
     }
 }
 
+/// Column indices match `SELECT_COLUMNS`:
+/// `id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation`.
 fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStorageError> {
     let timestamp = DateTime::parse_from_rfc3339(&row.try_get::<String, _>(2)?)
         .map_err(|error| MamStorageError::Serialization(format!("Invalid timestamp: {error}")))?
         .with_timezone(&Utc);
 
-    let rich_payload: Option<String> = row.try_get(13)?;
-    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(14)?)?;
+    let room_jid: String = row.try_get(1)?;
+    let stanza_id: Option<String> = row.try_get(6)?;
+    let thread_id: Option<String> = row.try_get(7)?;
+    let origin_id: Option<String> = row.try_get(8)?;
+    let message_type_str: String = row.try_get(9)?;
+    let rich_payload: Option<String> = row.try_get(11)?;
+    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(12)?)?;
+
+    let archive_owner = decode_archive_jid(&room_jid)?;
     Ok(ArchivedMessage {
-        id: row.try_get(0)?,
+        id: decode_archive_id(row.try_get(0)?, "id")?,
         timestamp,
-        from: row.try_get(3)?,
-        to: row.try_get(4)?,
-        body: row.try_get(5)?,
-        stanza_id: row.try_get(6)?,
-        thread_id: row.try_get(7)?,
-        reply_to_id: row.try_get(8)?,
-        reply_to_jid: row.try_get(9)?,
-        origin_id: row.try_get(10)?,
-        message_type: row.try_get(11)?,
-        stanza_xml: row.try_get(12)?,
+        from: decode_jid(row.try_get(3)?, "from_jid")?,
+        to: decode_archive_jid(&row.try_get::<String, _>(4)?)?,
+        body: decode_body(row.try_get(5)?),
+        stanza_id: decode_stanza_id(stanza_id, &archive_owner),
+        thread: thread_id.map(Thread),
+        origin_id: origin_id.and_then(OriginId::new),
+        message_type: decode_message_type(&message_type_str)?,
+        stanza_xml: row.try_get(10)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
         nickname_generation,
     })
 }
 
 fn decode_postgres_message_row(row: &PgRow) -> Result<ArchivedMessage, MamStorageError> {
-    let rich_payload: Option<String> = row.try_get(13)?;
-    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(14)?)?;
+    let room_jid: String = row.try_get(1)?;
+    let stanza_id: Option<String> = row.try_get(6)?;
+    let thread_id: Option<String> = row.try_get(7)?;
+    let origin_id: Option<String> = row.try_get(8)?;
+    let message_type_str: String = row.try_get(9)?;
+    let rich_payload: Option<String> = row.try_get(11)?;
+    let nickname_generation = decode_nickname_generation(row.try_get::<Option<i64>, _>(12)?)?;
+
+    let archive_owner = decode_archive_jid(&room_jid)?;
     Ok(ArchivedMessage {
-        id: row.try_get(0)?,
+        id: decode_archive_id(row.try_get(0)?, "id")?,
         timestamp: row.try_get(2)?,
-        from: row.try_get(3)?,
-        to: row.try_get(4)?,
-        body: row.try_get(5)?,
-        stanza_id: row.try_get(6)?,
-        thread_id: row.try_get(7)?,
-        reply_to_id: row.try_get(8)?,
-        reply_to_jid: row.try_get(9)?,
-        origin_id: row.try_get(10)?,
-        message_type: row.try_get(11)?,
-        stanza_xml: row.try_get(12)?,
+        from: decode_jid(row.try_get(3)?, "from_jid")?,
+        to: decode_archive_jid(&row.try_get::<String, _>(4)?)?,
+        body: decode_body(row.try_get(5)?),
+        stanza_id: decode_stanza_id(stanza_id, &archive_owner),
+        thread: thread_id.map(Thread),
+        origin_id: origin_id.and_then(OriginId::new),
+        message_type: decode_message_type(&message_type_str)?,
+        stanza_xml: row.try_get(10)?,
         rich: decode_rich_payload(rich_payload.as_deref())?,
         nickname_generation,
     })
+}
+
+fn decode_archive_id(raw: String, column: &str) -> Result<ArchiveId, MamStorageError> {
+    ArchiveId::new(raw).ok_or_else(|| {
+        MamStorageError::Serialization(format!(
+            "empty `{column}` column value rejected (XEP-0359 §4 requires non-empty)"
+        ))
+    })
+}
+
+fn decode_jid(raw: String, column: &str) -> Result<Jid, MamStorageError> {
+    Jid::from_str(&raw).map_err(|error| {
+        MamStorageError::Serialization(format!("Invalid `{column}` column JID: {error}"))
+    })
+}
+
+fn decode_archive_jid(raw: &str) -> Result<BareJid, MamStorageError> {
+    BareJid::from_str(raw).map_err(|error| {
+        MamStorageError::Serialization(format!("Invalid `room_jid` column JID: {error}"))
+    })
+}
+
+fn decode_body(raw: Option<String>) -> Option<RichText> {
+    raw.and_then(RichText::new)
+}
+
+/// Per Q4 of #228 the `<stanza-id by='...'>` is reconstructed from the row's
+/// archive owner — the archive IS the assigning entity per XEP-0359 §4.
+fn decode_stanza_id(raw: Option<String>, archive_owner: &BareJid) -> Option<StanzaId> {
+    raw.filter(|value| !value.is_empty())
+        .map(|id| StanzaId::new(id, archive_owner.clone()))
+}
+
+fn decode_message_type(raw: &str) -> Result<MessageType, MamStorageError> {
+    match raw {
+        "chat" => Ok(MessageType::Chat),
+        "error" => Ok(MessageType::Error),
+        "groupchat" => Ok(MessageType::Groupchat),
+        "headline" => Ok(MessageType::Headline),
+        "normal" => Ok(MessageType::Normal),
+        other => Err(MamStorageError::Serialization(format!(
+            "Invalid `message_type` column value: {other}"
+        ))),
+    }
+}
+
+fn encode_message_type(message_type: &MessageType) -> &'static str {
+    match message_type {
+        MessageType::Chat => "chat",
+        MessageType::Error => "error",
+        MessageType::Groupchat => "groupchat",
+        MessageType::Headline => "headline",
+        MessageType::Normal => "normal",
+    }
 }
 
 fn encode_rich_payload(message: &ArchivedMessage) -> Result<Option<String>, MamStorageError> {
@@ -701,40 +752,40 @@ impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self, message), fields(archive = %archive_jid))]
     async fn store_message(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError> {
-        let archive_id = if message.id.is_empty() {
-            Self::generate_archive_id()
-        } else {
-            message.id.clone()
-        };
-        let message_type = if message.message_type.is_empty() {
-            "chat"
-        } else {
-            message.message_type.as_str()
-        };
+    ) -> Result<ArchiveId, MamStorageError> {
+        let archive_id = message.id.clone();
+        let message_type = encode_message_type(&message.message_type);
         let rich_payload = encode_rich_payload(message)?;
         let nickname_generation = encode_nickname_generation(message.nickname_generation)?;
+        let archive_jid_str = archive_jid.to_string();
+        let from_jid_str = message.from.to_string();
+        let to_jid_str = message.to.to_string();
+        let stanza_id_str = message.stanza_id.as_ref().map(|sid| sid.id.clone());
+        let thread_id_str = message.thread.as_ref().map(|t| t.0.clone());
+        let origin_id_str = message
+            .origin_id
+            .as_ref()
+            .map(|oid| oid.as_str().to_owned());
+        let body_str = message.body.as_ref().map(|b| b.as_str().to_owned());
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut query = QueryBuilder::<Sqlite>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
-                        .push_bind(&archive_id)
-                        .push_bind(archive_jid)
+                        .push_bind(archive_id.as_str())
+                        .push_bind(&archive_jid_str)
                         .push_bind(message.timestamp.to_rfc3339())
-                        .push_bind(message.from.as_str())
-                        .push_bind(message.to.as_str())
-                        .push_bind(message.body.as_str())
-                        .push_bind(message.stanza_id.as_deref())
-                        .push_bind(message.thread_id.as_deref())
-                        .push_bind(message.reply_to_id.as_deref())
-                        .push_bind(message.reply_to_jid.as_deref())
-                        .push_bind(message.origin_id.as_deref())
+                        .push_bind(&from_jid_str)
+                        .push_bind(&to_jid_str)
+                        .push_bind(body_str.as_deref())
+                        .push_bind(stanza_id_str.as_deref())
+                        .push_bind(thread_id_str.as_deref())
+                        .push_bind(origin_id_str.as_deref())
                         .push_bind(message_type)
                         .push_bind(message.stanza_xml.as_deref())
                         .push_bind(rich_payload.as_deref())
@@ -744,21 +795,19 @@ impl MamStorage for SqlxMamStorage {
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut query = QueryBuilder::<Postgres>::new(
-                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
+                    "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, origin_id, message_type, stanza_xml, rich_payload, nickname_generation) ",
                 );
                 query.push_values(std::iter::once(()), |mut builder, _| {
                     builder
-                        .push_bind(&archive_id)
-                        .push_bind(archive_jid)
+                        .push_bind(archive_id.as_str())
+                        .push_bind(&archive_jid_str)
                         .push_bind(message.timestamp)
-                        .push_bind(message.from.as_str())
-                        .push_bind(message.to.as_str())
-                        .push_bind(message.body.as_str())
-                        .push_bind(message.stanza_id.as_deref())
-                        .push_bind(message.thread_id.as_deref())
-                        .push_bind(message.reply_to_id.as_deref())
-                        .push_bind(message.reply_to_jid.as_deref())
-                        .push_bind(message.origin_id.as_deref())
+                        .push_bind(&from_jid_str)
+                        .push_bind(&to_jid_str)
+                        .push_bind(body_str.as_deref())
+                        .push_bind(stanza_id_str.as_deref())
+                        .push_bind(thread_id_str.as_deref())
+                        .push_bind(origin_id_str.as_deref())
                         .push_bind(message_type)
                         .push_bind(message.stanza_xml.as_deref())
                         .push_bind(rich_payload.as_deref())
@@ -775,18 +824,19 @@ impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self), fields(archive = %archive_jid))]
     async fn query_messages(
         &self,
-        archive_jid: &str,
+        archive_jid: &BareJid,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
         let limit = i64::from(query.max.unwrap_or(100).min(500)) + 1;
-        let with_filter = query.with.as_deref().map(|with| format!("{with}%"));
+        let with_filter = query.with.as_ref().map(|with| format!("{with}%"));
+        let archive_jid_str = archive_jid.to_string();
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut builder = QueryBuilder::<Sqlite>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                builder.push_bind(archive_jid);
+                builder.push_bind(&archive_jid_str);
                 if let Some(start) = query.start {
                     builder
                         .push(" AND timestamp >= ")
@@ -805,11 +855,11 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(with)
                         .push(")");
                 }
-                if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-                    builder.push(" AND id < ").push_bind(before_id);
+                if let Some(before_id) = query.before_id.as_ref() {
+                    builder.push(" AND id < ").push_bind(before_id.as_str());
                 }
-                if let Some(after_id) = query.after_id.as_deref() {
-                    builder.push(" AND id > ").push_bind(after_id);
+                if let Some(after_id) = query.after_id.as_ref() {
+                    builder.push(" AND id > ").push_bind(after_id.as_str());
                 }
                 builder.push(if uses_backward_pagination(query) {
                     " ORDER BY id DESC"
@@ -829,7 +879,7 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Postgres>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                builder.push_bind(archive_jid);
+                builder.push_bind(&archive_jid_str);
                 if let Some(start) = query.start {
                     builder.push(" AND timestamp >= ").push_bind(start);
                 }
@@ -844,11 +894,11 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(with)
                         .push(")");
                 }
-                if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-                    builder.push(" AND id < ").push_bind(before_id);
+                if let Some(before_id) = query.before_id.as_ref() {
+                    builder.push(" AND id < ").push_bind(before_id.as_str());
                 }
-                if let Some(after_id) = query.after_id.as_deref() {
-                    builder.push(" AND id > ").push_bind(after_id);
+                if let Some(after_id) = query.after_id.as_ref() {
+                    builder.push(" AND id > ").push_bind(after_id.as_str());
                 }
                 builder.push(if uses_backward_pagination(query) {
                     " ORDER BY id DESC"
@@ -870,14 +920,14 @@ impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self))]
     async fn get_message(
         &self,
-        archive_id: &str,
+        archive_id: &ArchiveId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut builder = QueryBuilder::<Sqlite>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE id = "
                 ));
-                builder.push_bind(archive_id);
+                builder.push_bind(archive_id.as_str());
                 let row = builder.build().fetch_optional(pool).await?;
                 row.as_ref().map(decode_sqlite_message_row).transpose()
             }
@@ -885,7 +935,7 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Postgres>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE id = "
                 ));
-                builder.push_bind(archive_id);
+                builder.push_bind(archive_id.as_str());
                 let row = builder.build().fetch_optional(pool).await?;
                 row.as_ref().map(decode_postgres_message_row).transpose()
             }
@@ -894,17 +944,18 @@ impl MamStorage for SqlxMamStorage {
 
     async fn get_message_by_stanza_id(
         &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let archive_jid_str = archive_jid.to_string();
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (stanza_id = ? OR origin_id = ?) ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(stanza_id)
-                .bind(stanza_id)
+                .bind(&archive_jid_str)
+                .bind(stanza_id.as_str())
+                .bind(stanza_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_sqlite_message_row).transpose()
@@ -913,8 +964,8 @@ impl MamStorage for SqlxMamStorage {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (stanza_id = $2 OR origin_id = $2) ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(stanza_id)
+                .bind(&archive_jid_str)
+                .bind(stanza_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_postgres_message_row).transpose()
@@ -924,16 +975,17 @@ impl MamStorage for SqlxMamStorage {
 
     async fn get_message_by_message_id(
         &self,
-        archive_jid: &str,
-        message_id: &str,
+        archive_jid: &BareJid,
+        message_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let archive_jid_str = archive_jid.to_string();
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND stanza_id = ? ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(message_id)
+                .bind(&archive_jid_str)
+                .bind(message_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_sqlite_message_row).transpose()
@@ -942,8 +994,8 @@ impl MamStorage for SqlxMamStorage {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND stanza_id = $2 ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(message_id)
+                .bind(&archive_jid_str)
+                .bind(message_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_postgres_message_row).transpose()
@@ -953,17 +1005,18 @@ impl MamStorage for SqlxMamStorage {
 
     async fn get_message_by_archive_or_stanza_id(
         &self,
-        archive_jid: &str,
-        stanza_id: &str,
+        archive_jid: &BareJid,
+        stanza_id: &RichMessageId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let archive_jid_str = archive_jid.to_string();
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = ? AND (id = ? OR stanza_id = ?) ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(stanza_id)
-                .bind(stanza_id)
+                .bind(&archive_jid_str)
+                .bind(stanza_id.as_str())
+                .bind(stanza_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_sqlite_message_row).transpose()
@@ -972,8 +1025,8 @@ impl MamStorage for SqlxMamStorage {
                 let row = sqlx::query(&format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = $1 AND (id = $2 OR stanza_id = $2) ORDER BY timestamp DESC LIMIT 1"
                 ))
-                .bind(archive_jid)
-                .bind(stanza_id)
+                .bind(&archive_jid_str)
+                .bind(stanza_id.as_str())
                 .fetch_optional(pool)
                 .await?;
                 row.as_ref().map(decode_postgres_message_row).transpose()
@@ -982,20 +1035,21 @@ impl MamStorage for SqlxMamStorage {
     }
 
     #[instrument(skip(self))]
-    async fn count_messages(&self, room_jid: &str) -> Result<u32, MamStorageError> {
+    async fn count_messages(&self, room_jid: &BareJid) -> Result<u32, MamStorageError> {
+        let room_jid_str = room_jid.to_string();
         let count = match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut builder = QueryBuilder::<Sqlite>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
-                builder.push_bind(room_jid);
+                builder.push_bind(&room_jid_str);
                 builder.build_query_scalar::<i64>().fetch_one(pool).await?
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut builder = QueryBuilder::<Postgres>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
-                builder.push_bind(room_jid);
+                builder.push_bind(&room_jid_str);
                 builder.build_query_scalar::<i64>().fetch_one(pool).await?
             }
         };
@@ -1006,15 +1060,16 @@ impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self))]
     async fn delete_before(
         &self,
-        room_jid: &str,
+        room_jid: &BareJid,
         before: DateTime<Utc>,
     ) -> Result<u64, MamStorageError> {
+        let room_jid_str = room_jid.to_string();
         let deleted = match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut builder =
                     QueryBuilder::<Sqlite>::new("DELETE FROM mam_messages WHERE room_jid = ");
                 builder
-                    .push_bind(room_jid)
+                    .push_bind(&room_jid_str)
                     .push(" AND timestamp < ")
                     .push_bind(before.to_rfc3339());
                 builder.build().execute(pool).await?.rows_affected()
@@ -1023,7 +1078,7 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder =
                     QueryBuilder::<Postgres>::new("DELETE FROM mam_messages WHERE room_jid = ");
                 builder
-                    .push_bind(room_jid)
+                    .push_bind(&room_jid_str)
                     .push(" AND timestamp < ")
                     .push_bind(before);
                 builder.build().execute(pool).await?.rows_affected()
@@ -1037,10 +1092,10 @@ impl MamStorage for SqlxMamStorage {
     #[instrument(skip(self, tombstone))]
     async fn replace_with_tombstone(
         &self,
-        archive_id: &str,
-        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+        archive_id: &ArchiveId,
+        tombstone: ArchivedTombstone,
     ) -> Result<bool, MamStorageError> {
-        use waddle_xmpp_core::mam::{ArchivedRichMessage, ArchivedRichPayload};
+        use waddle_xmpp_core::mam::ArchivedRichPayload;
         let payload = ArchivedRichMessage {
             payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
             reply: None,
@@ -1053,22 +1108,22 @@ impl MamStorage for SqlxMamStorage {
         let rows = match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
                 let mut builder = QueryBuilder::<Sqlite>::new(
-                    "UPDATE mam_messages SET body = '', stanza_xml = NULL, thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                    "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, rich_payload = ",
                 );
                 builder
                     .push_bind(encoded.as_str())
                     .push(" WHERE id = ")
-                    .push_bind(archive_id);
+                    .push_bind(archive_id.as_str());
                 builder.build().execute(pool).await?.rows_affected()
             }
             MamDatabaseBackend::Postgres(pool) => {
                 let mut builder = QueryBuilder::<Postgres>::new(
-                    "UPDATE mam_messages SET body = '', stanza_xml = NULL, thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                    "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, rich_payload = ",
                 );
                 builder
                     .push_bind(encoded.as_str())
                     .push(" WHERE id = ")
-                    .push_bind(archive_id);
+                    .push_bind(archive_id.as_str());
                 builder.build().execute(pool).await?.rows_affected()
             }
         };
@@ -1086,56 +1141,83 @@ impl MamStorage for SqlxMamStorage {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use uuid::Uuid;
 
     async fn create_test_storage() -> SqlxMamStorage {
         SqlxMamStorage::open_in_memory().await.unwrap()
     }
 
+    fn bare(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
+
+    fn jid(s: &str) -> Jid {
+        Jid::from_str(s).expect("valid jid")
+    }
+
+    fn new_archive_id() -> ArchiveId {
+        ArchiveId::new(Uuid::now_v7().to_string()).expect("UUID is non-empty")
+    }
+
+    fn fixture_message(archive: &BareJid, from: &str, body: &str) -> ArchivedMessage {
+        ArchivedMessage {
+            id: new_archive_id(),
+            timestamp: Utc::now(),
+            from: jid(from),
+            to: archive.clone(),
+            body: RichText::new(body),
+            stanza_id: None,
+            thread: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
+            stanza_xml: None,
+            rich: None,
+            nickname_generation: None,
+        }
+    }
+
     #[tokio::test]
     async fn test_store_and_retrieve_message() {
         let storage = create_test_storage().await;
+        let archive = bare("room@conference.example.com");
 
-        let msg = ArchivedMessage {
-            id: String::new(),
-            timestamp: Utc::now(),
-            from: "user@example.com/nick".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "Hello, world!".to_string(),
-            stanza_id: Some("abc123".to_string()),
-            ..Default::default()
-        };
+        let mut msg = fixture_message(&archive, "user@example.com/nick", "Hello, world!");
+        msg.stanza_id = Some(StanzaId::new("abc123", archive.clone()));
 
-        let archive_id = storage
-            .store_message("room@conference.example.com", &msg)
+        let archive_id = storage.store_message(&archive, &msg).await.unwrap();
+        assert!(!archive_id.as_str().is_empty());
+
+        let retrieved = storage
+            .get_message(&archive_id)
             .await
-            .unwrap();
-        assert!(!archive_id.is_empty());
-
-        let retrieved = storage.get_message(&archive_id).await.unwrap();
-        assert!(retrieved.is_some());
-
-        let retrieved = retrieved.unwrap();
+            .unwrap()
+            .expect("archived");
         assert_eq!(retrieved.id, archive_id);
-        assert_eq!(retrieved.body, "Hello, world!");
-        assert_eq!(retrieved.stanza_id, Some("abc123".to_string()));
+        assert_eq!(
+            retrieved.body.as_ref().map(RichText::as_str),
+            Some("Hello, world!")
+        );
+        assert_eq!(
+            retrieved.stanza_id.as_ref().map(|sid| sid.id.as_str()),
+            Some("abc123")
+        );
     }
 
     #[tokio::test]
     async fn test_store_and_retrieve_reply_thread_metadata() {
         let storage = create_test_storage().await;
+        let archive = bare("room@conference.example.com");
 
         let msg = ArchivedMessage {
-            id: String::new(),
+            id: new_archive_id(),
             timestamp: Utc::now(),
-            from: "room@conference.example.com/alice".to_string(),
-            to: "room@conference.example.com".to_string(),
-            body: "Reply body".to_string(),
-            stanza_id: Some("archive-stanza-1".to_string()),
-            thread_id: Some("thread-root-1".to_string()),
-            reply_to_id: Some("parent-message-1".to_string()),
-            reply_to_jid: Some("bob@example.com".to_string()),
-            origin_id: Some("origin-abc".to_string()),
-            message_type: "groupchat".to_string(),
+            from: jid("room@conference.example.com/alice"),
+            to: archive.clone(),
+            body: RichText::new("Reply body"),
+            stanza_id: Some(StanzaId::new("archive-stanza-1", archive.clone())),
+            thread: Some(Thread("thread-root-1".to_owned())),
+            origin_id: OriginId::new("origin-abc"),
+            message_type: MessageType::Groupchat,
             stanza_xml: Some(
                 "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='room@conference.example.com' type='groupchat' id='archive-stanza-1'><body>Reply body</body></message>".to_string(),
             ),
@@ -1143,10 +1225,7 @@ mod tests {
             nickname_generation: None,
         };
 
-        let archive_id = storage
-            .store_message("room@conference.example.com", &msg)
-            .await
-            .unwrap();
+        let archive_id = storage.store_message(&archive, &msg).await.unwrap();
 
         let retrieved = storage
             .get_message(&archive_id)
@@ -1154,34 +1233,31 @@ mod tests {
             .unwrap()
             .expect("archived message");
 
-        assert_eq!(retrieved.thread_id.as_deref(), Some("thread-root-1"));
-        assert_eq!(retrieved.reply_to_id.as_deref(), Some("parent-message-1"));
-        assert_eq!(retrieved.reply_to_jid.as_deref(), Some("bob@example.com"));
-        assert_eq!(retrieved.origin_id.as_deref(), Some("origin-abc"));
-        assert_eq!(retrieved.message_type, "groupchat");
+        assert_eq!(
+            retrieved.thread.as_ref().map(|t| t.0.as_str()),
+            Some("thread-root-1")
+        );
+        assert_eq!(
+            retrieved.origin_id.as_ref().map(OriginId::as_str),
+            Some("origin-abc")
+        );
+        assert_eq!(retrieved.message_type, MessageType::Groupchat);
         assert!(retrieved.stanza_xml.is_some());
     }
 
     #[tokio::test]
     async fn test_query_with_pagination() {
         let storage = create_test_storage().await;
-        let archive = "room@conference.example.com";
+        let archive = bare("room@conference.example.com");
 
         for body in ["one", "two", "three"] {
-            let msg = ArchivedMessage {
-                id: String::new(),
-                timestamp: Utc::now(),
-                from: "user@example.com/device".to_string(),
-                to: archive.to_string(),
-                body: body.to_string(),
-                ..Default::default()
-            };
-            storage.store_message(archive, &msg).await.unwrap();
+            let msg = fixture_message(&archive, "user@example.com/device", body);
+            storage.store_message(&archive, &msg).await.unwrap();
         }
 
         let page_one = storage
             .query_messages(
-                archive,
+                &archive,
                 &MamQuery {
                     max: Some(2),
                     ..Default::default()
@@ -1194,7 +1270,7 @@ mod tests {
 
         let page_two = storage
             .query_messages(
-                archive,
+                &archive,
                 &MamQuery {
                     after_id: page_one.last_id.clone(),
                     ..Default::default()
@@ -1203,7 +1279,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(page_two.messages.len(), 1);
-        assert_eq!(page_two.messages[0].body, "three");
+        assert_eq!(
+            page_two.messages[0].body.as_ref().map(RichText::as_str),
+            Some("three")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1212,28 +1291,24 @@ mod tests {
         std::fs::create_dir_all(&artifacts).expect("artifacts dir");
         let path = artifacts.join(format!("mam-{}.db", uuid::Uuid::new_v4()));
         let database_url = format!("sqlite://{}", path.display());
-        let archive = "room@conference.example.com";
+        let archive = bare("room@conference.example.com");
 
         {
             let storage = SqlxMamStorage::open(&database_url).await.expect("storage");
-            let msg = ArchivedMessage {
-                id: String::new(),
-                timestamp: Utc::now(),
-                from: "user@example.com/device".to_string(),
-                to: archive.to_string(),
-                body: "persisted".to_string(),
-                ..Default::default()
-            };
-            storage.store_message(archive, &msg).await.expect("store");
+            let msg = fixture_message(&archive, "user@example.com/device", "persisted");
+            storage.store_message(&archive, &msg).await.expect("store");
         }
 
         let reopened = SqlxMamStorage::open(&database_url).await.expect("reopen");
         let result = reopened
-            .query_messages(archive, &MamQuery::default())
+            .query_messages(&archive, &MamQuery::default())
             .await
             .expect("query");
         assert_eq!(result.messages.len(), 1);
-        assert_eq!(result.messages[0].body, "persisted");
+        assert_eq!(
+            result.messages[0].body.as_ref().map(RichText::as_str),
+            Some("persisted")
+        );
 
         for cleanup in [
             path.clone(),
@@ -1245,39 +1320,36 @@ mod tests {
     }
 
     // XEP-0059 §2.5: an empty <before/> element requests the last page of
-    // results. Regression test for a bug where `before_id = Some("")` was
-    // collapsed to "no pagination" and the query returned the *first* page
-    // (oldest N) instead of the last page (newest N).
+    // results. Regression test for the case where `last_page=true` (the typed
+    // equivalent of pre-typing `before_id = Some("")`) must signal backward
+    // pagination so the query returns the newest N rows, not the oldest N.
     #[tokio::test]
     async fn test_empty_before_returns_last_page() {
         let storage = create_test_storage().await;
-        let archive = "room@conference.example.com";
+        let archive = bare("room@conference.example.com");
 
         for body in ["one", "two", "three", "four", "five", "six"] {
-            let msg = ArchivedMessage {
-                id: String::new(),
-                timestamp: Utc::now(),
-                from: "user@example.com/device".to_string(),
-                to: archive.to_string(),
-                body: body.to_string(),
-                ..Default::default()
-            };
-            storage.store_message(archive, &msg).await.unwrap();
+            let msg = fixture_message(&archive, "user@example.com/device", body);
+            storage.store_message(&archive, &msg).await.unwrap();
         }
 
         let last_page = storage
             .query_messages(
-                archive,
+                &archive,
                 &MamQuery {
                     max: Some(3),
-                    before_id: Some(String::new()),
+                    last_page: true,
                     ..Default::default()
                 },
             )
             .await
             .unwrap();
 
-        let bodies: Vec<&str> = last_page.messages.iter().map(|m| m.body.as_str()).collect();
+        let bodies: Vec<&str> = last_page
+            .messages
+            .iter()
+            .filter_map(|m| m.body.as_ref().map(RichText::as_str))
+            .collect();
         assert_eq!(bodies, vec!["four", "five", "six"]);
         assert!(!last_page.complete);
     }


### PR DESCRIPTION
## Summary

PR B of the two-PR plan for #228. Stacked on top of #252 (PR A); PR-B-only diff shows just the typed-`ArchivedMessage` work.

This PR retypes `waddle-xmpp-core::mam::ArchivedMessage` and the `MamStorage` trait so protocol data is carried as typed values per the typed-payloads hard rule.

## ArchivedMessage shape changes

| Field | Before | After |
|---|---|---|
| `id` | `String` | `ArchiveId(String)` non-empty newtype |
| `from` | `String` | `Jid` |
| `to` | `String` | `BareJid` |
| `body` | `String` (NOT NULL, empty=absent) | `Option<RichText>` (RFC 6121 §5.2.2; non-empty when present) |
| `stanza_id` | `Option<String>` | `Option<xep0359::StanzaId>` (`by` reconstructed from `archive_jid` per XEP-0359 §4) |
| `thread_id` | `Option<String>` | `thread: Option<xmpp_parsers::message::Thread>` |
| `reply_to_id` | `Option<String>` | **deleted** (canonical in `rich.reply`) |
| `reply_to_jid` | `Option<String>` | **deleted** |
| `origin_id` | `Option<String>` | `Option<xep0359::OriginId>` (non-empty) |
| `message_type` | `String` | `xmpp_parsers::message::MessageType` |
| struct-level `Serialize/Deserialize` | derived | **dropped** |
| `impl Default` | empty/sentinel | **dropped** |

`stanza_xml: Option<String>` and `rich: Option<ArchivedRichMessage>` retain their current shapes (both are JSON / serialized blobs at the SQL boundary).

## Trait surface changes

- `archive_jid: &str` → `&BareJid`
- `archive_id: &str` → `&ArchiveId`
- Stanza-id lookup parameters: `&str` → `&RichMessageId`
- `MamQuery::with: Option<String>` → `Option<Jid>`
- `MamQuery::before_id` / `after_id`, `MamResult::first_id` / `last_id`: `Option<String>` → `Option<ArchiveId>`
- New `MamQuery::last_page: bool` preserves XEP-0059 §2.5 "empty `<before/>`" semantics that the previous `Some(String::new())` encoded.

## Wire-visible behaviour changes

These are intentional XEP-conformance tightenings, not regressions:

- **Malformed `<with/>` JID** in a MAM query IQ now returns `bad-request` (XEP-0313 §4.1.2 + RFC 6122). The previous code silently used the unparsed string as a SQL `LIKE` prefix and returned an empty result set.
- **Empty `from` JID** on a groupchat message now refuses to archive (returns no archive id) instead of storing `from = ""`. The bail-out was hoisted above `add_mam_stanza_id` in `fc61ed4` so the broadcast prototype no longer carries a dangling `<stanza-id>` for a row that was never written.
- **Whitespace-only origin-id** (`<origin-id id='   '/>`) is rejected at parse time per XEP-0359 §3 (uniqueness implies non-emptiness). Previously stored verbatim. (Fix already in PR A; recapping here because it's the same surface.)

## SQL schema (rewrite, no migration tooling per "no production data" rule)

- Drop columns: `reply_to_id`, `reply_to_jid`
- Drop index: `idx_mam_room_reply_to` (was speculative; no query ever used it)
- Change: `body TEXT NOT NULL` → `body TEXT NULL`
- Otherwise unchanged

## Code deletions

- `build_legacy_inner_message` in `waddle-xmpp-core::mam` — `rich`-payload path is canonical now.
- Duplicate `extract_reply_reference` and `mam_message_type` helpers in `websocket/handlers/message.rs`.
- `Self::generate_archive_id` paths in storage impls — production callers always pre-generate.
- `impl Default for ArchivedMessage`.

## Decode error handling (Q11)

Malformed stored values (unparseable JID, empty `ArchiveId`, unknown `message_type`, etc.) → `MamStorageError::Serialization(...)` per row, fail-loud. The typed-payloads rule says "parsing untyped storage rows happens exactly once, as early as possible" — that's the row decoder.

## Bench crate

`bench-storage-backends/crates/bench-{core,sqlite,postgres,clickhouse}` mirror updated to track the new SQL row shape: drop `reply_to_id`/`reply_to_jid` columns, nullable `body`. Bench types stay string-typed (it's an SQL I/O harness, not a protocol-handling crate).

## Out of scope (filed during grilling / review)

- #250 — XEP-0201 `<thread parent>` round-tripping (deliberately keeping current lossy shape).
- #251 — client-side `waddle-xmpp-client::ArchivedMessage` typing.
- #253 — XEP-0490 `DisplayedSync` typing.

## Plan reference

#228 grilling thread: Q2 (JID typing), Q3 (MessageType), Q4 (StanzaId reconstruction), Q5 (OriginId), Q6 (Thread), Q7 (drop flat reply fields), Q8 (ArchiveId), Q9 (Option<RichText> body), Q10 (trait surface), Q11 (decode errors), Q12 (drop Default), Q13 (server-side scope), Q14 (bench update), Q15 (two-PR plan).

## Stacking

Based on `refactor/228-relocate-xep0359-to-core`. Once #252 merges, will re-target `main`.

## Test plan

- [x] `cargo build --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p waddle-xmpp-core` — 102 pass (incl. all rich-archive round-trip cases ported to typed shape)
- [x] `cargo test -p waddle-xmpp` — pass
- [x] `cargo test -p waddle-server` — 318 lib + integration suites pass
- [x] `cargo build` in `bench-storage-backends/` — clean
- [ ] CI green before flipping to ready-for-review