### PR TITLE
feat(server): #229 PR1 — sans-I/O message pipeline infrastructure

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -18,10 +18,12 @@
 //!
 //! Only a subset of variants have their interpreter wiring in place — the
 //! ones needed by handlers that have been migrated so far (ping, session).
-//! The remaining variants (`SendDirect`, `BroadcastToRoom`, `QueryMam`,
-//! `AskSfu`, `RequestEnrichment`, etc.) are defined in the event enum so
-//! future handlers can emit them, but land in the interpreter as later
-//! migration steps pull their XEP into the sans-I/O world.
+//! The remaining variants (`RouteToConnection`, `BroadcastToRoom`,
+//! `DispatchToRoom`, `QueryMam`, `AskSfu`, `RequestEnrichment`,
+//! `ProjectInbox`, `SendCarbons`, `LookupArchivedMessage`, …) are defined
+//! in the event enum so future handlers can emit them, but land in the
+//! interpreter as later migration steps pull their XEP into the sans-I/O
+//! world.
 
 use tracing::{debug, error, info, warn};
 use waddle_xmpp::parser::stanza_to_string;
@@ -87,23 +89,67 @@ pub async fn interpret(
             // user content, and their `Debug` impls would leak that
             // content into logs.
             // -------------------------------------------------------
-            OutboundEvent::SendDirect { jid, stanza } => {
+            OutboundEvent::RouteToConnection { jid, stanza } => {
+                // Until the per-connection state-machine routing for
+                // `StanzaFromPeer` lands (issue #229 PR4), preserve the
+                // legacy "write to peer's outbound channel" behaviour so
+                // existing integration tests stay green. The semantic
+                // change to "feed StanzaFromPeer into the destination
+                // machine" is wired in alongside the first handler that
+                // emits this event in PR4.
                 match registry.send_to(&jid, *stanza).await {
                     waddle_xmpp::registry::SendResult::Sent => {
-                        debug!(jid = %jid, "SendDirect delivered");
+                        debug!(jid = %jid, "RouteToConnection delivered");
                     }
                     waddle_xmpp::registry::SendResult::NotConnected => {
-                        debug!(jid = %jid, "SendDirect: target offline, dropping");
+                        debug!(jid = %jid, "RouteToConnection: target offline, dropping");
                     }
                     waddle_xmpp::registry::SendResult::ChannelClosed => {
-                        warn!(jid = %jid, "SendDirect: target channel closed, dropping");
+                        warn!(jid = %jid, "RouteToConnection: target channel closed, dropping");
                     }
                 }
+            }
+            OutboundEvent::DispatchToRoom { room, .. } => {
+                warn!(
+                    variant = "DispatchToRoom",
+                    room = %room,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
             }
             OutboundEvent::BroadcastToRoom { room, .. } => {
                 warn!(
                     variant = "BroadcastToRoom",
                     room = %room,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
+            }
+            OutboundEvent::ProjectInbox { owner, peer, .. } => {
+                warn!(
+                    variant = "ProjectInbox",
+                    owner = %owner,
+                    peer = %peer,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
+            }
+            OutboundEvent::SendCarbons {
+                owner,
+                kind,
+                exclude,
+                ..
+            } => {
+                warn!(
+                    variant = "SendCarbons",
+                    owner = %owner,
+                    kind = ?kind,
+                    exclude = %exclude,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
+            }
+            OutboundEvent::LookupArchivedMessage { id, archive, .. } => {
+                warn!(
+                    variant = "LookupArchivedMessage",
+                    callback_id = id.0,
+                    archive = %archive,
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }

--- a/server/crates/waddle-xmpp/src/protocol/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch.rs
@@ -131,12 +131,20 @@ impl StanzaDispatcher {
     /// returned [`MessageDispatchOutcome`] carries every emitted event in
     /// order plus a discriminator for *why* the pipeline ended, so the
     /// state machine can wire pause-resume on awaiting outcomes.
+    ///
+    /// `resume_after` from `AwaitCallback` is **bounds-checked** against
+    /// the index of the awaiting handler — a handler MUST NOT request
+    /// resume past its own position (that would skip handlers it never
+    /// ran). On violation the dispatcher returns a `Halted` outcome with
+    /// a `Log { level: ERROR }` event so the bug surfaces immediately
+    /// rather than silently dropping pipeline stages.
     pub fn dispatch_message(
         &self,
         message: &Message,
         ctx: &MessageContext<'_>,
     ) -> MessageDispatchOutcome {
         let mut events = Vec::new();
+        let handler_count = self.message_handlers.len();
         for (idx, handler) in self.message_handlers.iter().enumerate() {
             let id = HandlerId(idx);
             match handler.handle(message, ctx) {
@@ -153,6 +161,22 @@ impl StanzaDispatcher {
                     resume_after,
                 } => {
                     events.extend(more);
+                    if resume_after.0 > idx || resume_after.0 >= handler_count {
+                        events.push(OutboundEvent::Log {
+                            level: Level::ERROR,
+                            message: format!(
+                                "handler '{}' at idx {idx} requested resume_after={:?} \
+                                 which is out of range (handler_count={handler_count}); \
+                                 halting pipeline to avoid silently skipping later handlers",
+                                handler.name(),
+                                resume_after,
+                            ),
+                        });
+                        return MessageDispatchOutcome {
+                            events,
+                            termination: MessageDispatchTermination::Halted { halted_at: id },
+                        };
+                    }
                     return MessageDispatchOutcome {
                         events,
                         termination: MessageDispatchTermination::Awaiting { resume_after },
@@ -174,6 +198,14 @@ impl StanzaDispatcher {
     /// previously-emitted [`HandlerOutcome::AwaitCallback`]. The handlers
     /// up to and including `resume_after` do **not** re-run.
     ///
+    /// `resume_after` is **bounds-checked**: an out-of-range id (e.g. a
+    /// stale callback against a dispatcher whose handler set has changed,
+    /// or a handler-supplied bug) returns a `Halted` outcome with an
+    /// `ERROR`-level diagnostic event, never silently no-ops or skips
+    /// handlers. This protects security-critical handlers (XEP-0191
+    /// blocking, XEP-0359 stamping) from being bypassed by a malformed
+    /// resume.
+    ///
     /// PR1 ships the dispatcher entry point only; concrete callback
     /// wiring on the state machine arrives with the first
     /// `AwaitCallback`-emitting handler in PR2.
@@ -183,6 +215,23 @@ impl StanzaDispatcher {
         ctx: &MessageContext<'_>,
         resume_after: HandlerId,
     ) -> MessageDispatchOutcome {
+        let handler_count = self.message_handlers.len();
+        if resume_after.0 >= handler_count {
+            return MessageDispatchOutcome {
+                events: vec![OutboundEvent::Log {
+                    level: Level::ERROR,
+                    message: format!(
+                        "resume_message called with resume_after={:?} but only \
+                         {handler_count} handler(s) are registered; halting to avoid \
+                         silently dropping the pipeline",
+                        resume_after
+                    ),
+                }],
+                termination: MessageDispatchTermination::Halted {
+                    halted_at: resume_after,
+                },
+            };
+        }
         let mut events = Vec::new();
         let start = resume_after.0.saturating_add(1);
         for (idx, handler) in self.message_handlers.iter().enumerate().skip(start) {
@@ -201,6 +250,22 @@ impl StanzaDispatcher {
                     resume_after: next_resume,
                 } => {
                     events.extend(more);
+                    if next_resume.0 > idx || next_resume.0 >= handler_count {
+                        events.push(OutboundEvent::Log {
+                            level: Level::ERROR,
+                            message: format!(
+                                "handler '{}' at idx {idx} requested resume_after={:?} \
+                                 which is out of range (handler_count={handler_count}); \
+                                 halting pipeline to avoid silently skipping later handlers",
+                                handler.name(),
+                                next_resume,
+                            ),
+                        });
+                        return MessageDispatchOutcome {
+                            events,
+                            termination: MessageDispatchTermination::Halted { halted_at: id },
+                        };
+                    }
                     return MessageDispatchOutcome {
                         events,
                         termination: MessageDispatchTermination::Awaiting {

--- a/server/crates/waddle-xmpp/src/protocol/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch.rs
@@ -1,24 +1,56 @@
 //! Stanza dispatcher: O(1) lookup of IQ handlers by namespace, and
 //! pipelined dispatch of message and presence handlers.
 //!
-//! This module is the inverse of the old `if frame.contains(ns) { … }`
-//! chain. IQ handlers self-register under the namespace they own, and
-//! dispatch is a single `HashMap::get`. Message and presence handlers
-//! register into ordered pipelines: every registered handler sees every
-//! stanza and independently decides whether to emit events.
+//! IQ handlers self-register under the namespace they own; dispatch is a
+//! single `HashMap::get`. Message and presence handlers register into
+//! ordered pipelines — each handler runs until it returns
+//! [`HandlerOutcome::Halt`] / [`HandlerOutcome::AwaitCallback`]
+//! (messages) or the pipeline ends (presence).
 //!
 //! Exhaustiveness for IQ is enforced socially: if a new IQ namespace
 //! arrives with no registered handler the dispatcher emits a `WARN` log
 //! event, which surfaces in tests.
 
 use super::event::{OutboundEvent, StanzaContext};
-use super::traits::{IqHandler, MessageHandler, PresenceHandler};
+use super::message_context::MessageContext;
+use super::traits::{HandlerId, HandlerOutcome, IqHandler, MessageHandler, PresenceHandler};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::Level;
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::message::Message;
 use xmpp_parsers::presence::Presence;
+
+/// Why a message-pipeline run terminated.
+///
+/// Carried alongside the emitted events in [`MessageDispatchOutcome`] so
+/// the state machine can decide whether to register a pending op (for
+/// [`MessageDispatchTermination::Awaiting`]) or simply hand the events to
+/// the interpreter.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MessageDispatchTermination {
+    /// Every registered message handler ran to completion without
+    /// halting or pausing.
+    Completed,
+    /// A handler returned [`HandlerOutcome::Halt`]; later handlers did
+    /// not see the message.
+    Halted { halted_at: HandlerId },
+    /// A handler returned [`HandlerOutcome::AwaitCallback`]; the state
+    /// machine is expected to register a pending op and resume dispatch
+    /// at the handler immediately after `resume_after` when the matching
+    /// callback arrives.
+    Awaiting { resume_after: HandlerId },
+}
+
+/// Result of running the message pipeline once.
+#[derive(Debug)]
+pub struct MessageDispatchOutcome {
+    /// Events emitted by handlers, in registration order. Includes events
+    /// emitted by the halting / pausing handler itself.
+    pub events: Vec<OutboundEvent>,
+    /// Why the pipeline stopped.
+    pub termination: MessageDispatchTermination,
+}
 
 /// Routes stanzas to the handlers registered for them.
 ///
@@ -49,15 +81,23 @@ impl StanzaDispatcher {
     }
 
     /// Append a message handler to the pipeline. Handlers run in
-    /// registration order.
-    pub fn register_message(&mut self, handler: Arc<dyn MessageHandler>) {
+    /// registration order. Returns the [`HandlerId`] assigned to this
+    /// handler — useful for tests asserting on `resume_after` semantics.
+    pub fn register_message(&mut self, handler: Arc<dyn MessageHandler>) -> HandlerId {
+        let id = HandlerId(self.message_handlers.len());
         self.message_handlers.push(handler);
+        id
     }
 
     /// Append a presence handler to the pipeline. Handlers run in
     /// registration order.
     pub fn register_presence(&mut self, handler: Arc<dyn PresenceHandler>) {
         self.presence_handlers.push(handler);
+    }
+
+    /// Number of registered message handlers.
+    pub fn message_handler_count(&self) -> usize {
+        self.message_handlers.len()
     }
 
     /// Dispatch an IQ stanza.
@@ -84,17 +124,96 @@ impl StanzaDispatcher {
         }
     }
 
-    /// Run every registered message handler against this stanza in
-    /// registration order; concatenate their emitted events.
+    /// Run the message pipeline against `message`.
+    ///
+    /// Handlers run in registration order until one returns
+    /// [`HandlerOutcome::Halt`] or [`HandlerOutcome::AwaitCallback`]. The
+    /// returned [`MessageDispatchOutcome`] carries every emitted event in
+    /// order plus a discriminator for *why* the pipeline ended, so the
+    /// state machine can wire pause-resume on awaiting outcomes.
     pub fn dispatch_message(
         &self,
         message: &Message,
-        ctx: &StanzaContext<'_>,
-    ) -> Vec<OutboundEvent> {
-        self.message_handlers
-            .iter()
-            .flat_map(|h| h.handle(message, ctx))
-            .collect()
+        ctx: &MessageContext<'_>,
+    ) -> MessageDispatchOutcome {
+        let mut events = Vec::new();
+        for (idx, handler) in self.message_handlers.iter().enumerate() {
+            let id = HandlerId(idx);
+            match handler.handle(message, ctx) {
+                HandlerOutcome::Continue(more) => events.extend(more),
+                HandlerOutcome::Halt(more) => {
+                    events.extend(more);
+                    return MessageDispatchOutcome {
+                        events,
+                        termination: MessageDispatchTermination::Halted { halted_at: id },
+                    };
+                }
+                HandlerOutcome::AwaitCallback {
+                    events: more,
+                    resume_after,
+                } => {
+                    events.extend(more);
+                    return MessageDispatchOutcome {
+                        events,
+                        termination: MessageDispatchTermination::Awaiting { resume_after },
+                    };
+                }
+            }
+        }
+        MessageDispatchOutcome {
+            events,
+            termination: MessageDispatchTermination::Completed,
+        }
+    }
+
+    /// Resume a paused message pipeline at the handler immediately after
+    /// `resume_after`.
+    ///
+    /// Used by the state machine when an
+    /// [`super::event::InboundEvent`] callback arrives that matches a
+    /// previously-emitted [`HandlerOutcome::AwaitCallback`]. The handlers
+    /// up to and including `resume_after` do **not** re-run.
+    ///
+    /// PR1 ships the dispatcher entry point only; concrete callback
+    /// wiring on the state machine arrives with the first
+    /// `AwaitCallback`-emitting handler in PR2.
+    pub fn resume_message(
+        &self,
+        message: &Message,
+        ctx: &MessageContext<'_>,
+        resume_after: HandlerId,
+    ) -> MessageDispatchOutcome {
+        let mut events = Vec::new();
+        let start = resume_after.0.saturating_add(1);
+        for (idx, handler) in self.message_handlers.iter().enumerate().skip(start) {
+            let id = HandlerId(idx);
+            match handler.handle(message, ctx) {
+                HandlerOutcome::Continue(more) => events.extend(more),
+                HandlerOutcome::Halt(more) => {
+                    events.extend(more);
+                    return MessageDispatchOutcome {
+                        events,
+                        termination: MessageDispatchTermination::Halted { halted_at: id },
+                    };
+                }
+                HandlerOutcome::AwaitCallback {
+                    events: more,
+                    resume_after: next_resume,
+                } => {
+                    events.extend(more);
+                    return MessageDispatchOutcome {
+                        events,
+                        termination: MessageDispatchTermination::Awaiting {
+                            resume_after: next_resume,
+                        },
+                    };
+                }
+            }
+        }
+        MessageDispatchOutcome {
+            events,
+            termination: MessageDispatchTermination::Completed,
+        }
     }
 
     /// Run every registered presence handler against this stanza in

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
@@ -1,0 +1,335 @@
+//! L3 callback-machinery tests for the message pipeline.
+//!
+//! Asserts the contract that PR2–PR5 handlers depend on:
+//!
+//! - [`HandlerOutcome::Continue`] runs subsequent handlers.
+//! - [`HandlerOutcome::Halt`] short-circuits the pipeline; no later
+//!   handler runs and the termination is `Halted`.
+//! - [`HandlerOutcome::AwaitCallback`] short-circuits the pipeline; the
+//!   termination carries the `resume_after` handler id supplied by the
+//!   awaiting handler.
+//! - `resume_message` runs only handlers strictly after `resume_after`.
+//! - Resumed handlers can themselves halt or await again — the dispatcher
+//!   threads the new termination through the second outcome.
+//!
+//! These tests don't exercise any concrete XEP behaviour; that's L1's
+//! job in the per-handler test files. L3 locks the *machinery* so handler
+//! authors can rely on it.
+//!
+//! Test naming: prefixed `dispatch_message_*` rather than `xep_NNNN_*`
+//! because these are architectural invariants, not XEP rules.
+
+use super::dispatch::{MessageDispatchTermination, StanzaDispatcher};
+use super::event::OutboundEvent;
+use super::id_gen::FixedIdGenerator;
+use super::message_context::{MessageContext, MessageContextEnv};
+use super::session_state::{Blocklist, CarbonsState, MucOccupancy};
+use super::traits::{HandlerId, HandlerOutcome, MessageHandler};
+use jid::FullJid;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tracing::Level;
+use xmpp_parsers::message::{Message, MessageType};
+
+// ---------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------
+
+fn local_jid() -> FullJid {
+    "alice@waddle.social/web".parse().expect("valid full jid")
+}
+
+fn chat_message() -> Message {
+    let mut m = Message::new(Some("bob@waddle.social".parse().expect("jid")));
+    m.from = Some("alice@waddle.social/web".parse().expect("jid"));
+    m.type_ = MessageType::Chat;
+    m
+}
+
+struct Fixture {
+    blocklist: Blocklist,
+    occupancy: MucOccupancy,
+    id_gen: FixedIdGenerator,
+    jid: FullJid,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            blocklist: Blocklist::empty(),
+            occupancy: MucOccupancy::empty(),
+            id_gen: FixedIdGenerator("test-id".to_string()),
+            jid: local_jid(),
+        }
+    }
+
+    fn ctx<'a>(&'a self, message: &Message) -> MessageContext<'a> {
+        let env = MessageContextEnv {
+            domain: "waddle.social",
+            full_jid: &self.jid,
+            blocklist: &self.blocklist,
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: &self.occupancy,
+            id_gen: &self.id_gen,
+        };
+        MessageContext::derive(env, message)
+    }
+}
+
+// ---------------------------------------------------------------------
+// Probe handlers
+// ---------------------------------------------------------------------
+
+/// Records the order in which it was called and emits one log event with
+/// its name. Always returns `Continue`.
+struct ContinueProbe {
+    name: &'static str,
+    call_order: Arc<AtomicUsize>,
+    ticket: Arc<AtomicUsize>,
+}
+
+impl ContinueProbe {
+    fn new(name: &'static str, call_order: Arc<AtomicUsize>) -> Arc<Self> {
+        Arc::new(Self {
+            name,
+            call_order,
+            ticket: Arc::new(AtomicUsize::new(usize::MAX)),
+        })
+    }
+}
+
+impl MessageHandler for ContinueProbe {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn handle(&self, _message: &Message, _ctx: &MessageContext<'_>) -> HandlerOutcome {
+        let n = self.call_order.fetch_add(1, Ordering::SeqCst);
+        self.ticket.store(n, Ordering::SeqCst);
+        HandlerOutcome::Continue(vec![OutboundEvent::Log {
+            level: Level::DEBUG,
+            message: format!("{}-ran", self.name),
+        }])
+    }
+}
+
+/// Halts immediately, emitting one log event.
+struct HaltProbe {
+    name: &'static str,
+}
+
+impl HaltProbe {
+    fn new(name: &'static str) -> Arc<Self> {
+        Arc::new(Self { name })
+    }
+}
+
+impl MessageHandler for HaltProbe {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn handle(&self, _message: &Message, _ctx: &MessageContext<'_>) -> HandlerOutcome {
+        HandlerOutcome::Halt(vec![OutboundEvent::Log {
+            level: Level::DEBUG,
+            message: format!("{}-halted", self.name),
+        }])
+    }
+}
+
+/// Pauses the pipeline with a fixed `resume_after`.
+struct AwaitProbe {
+    name: &'static str,
+    resume_after: HandlerId,
+}
+
+impl AwaitProbe {
+    fn new(name: &'static str, resume_after: HandlerId) -> Arc<Self> {
+        Arc::new(Self { name, resume_after })
+    }
+}
+
+impl MessageHandler for AwaitProbe {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn handle(&self, _message: &Message, _ctx: &MessageContext<'_>) -> HandlerOutcome {
+        HandlerOutcome::AwaitCallback {
+            events: vec![OutboundEvent::Log {
+                level: Level::DEBUG,
+                message: format!("{}-paused", self.name),
+            }],
+            resume_after: self.resume_after,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// L3 invariants
+// ---------------------------------------------------------------------
+
+#[test]
+fn dispatch_message_runs_handlers_in_registration_order_and_completes() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let order = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", order.clone()));
+    dispatcher.register_message(ContinueProbe::new("h1", order.clone()));
+    dispatcher.register_message(ContinueProbe::new("h2", order.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.dispatch_message(&msg, &fx.ctx(&msg));
+
+    assert_eq!(outcome.events.len(), 3);
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Completed
+    ));
+}
+
+#[test]
+fn dispatch_message_halt_short_circuits_later_handlers() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let order = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", order.clone()));
+    dispatcher.register_message(HaltProbe::new("h1-halt"));
+    // Counter starts at 0; if h2 runs it would increment.
+    let counter_after_halt = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h2", counter_after_halt.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.dispatch_message(&msg, &fx.ctx(&msg));
+
+    // h0 (continue) + h1 (halt) emitted events; h2 did not run.
+    assert_eq!(outcome.events.len(), 2);
+    assert_eq!(counter_after_halt.load(Ordering::SeqCst), 0);
+    match outcome.termination {
+        MessageDispatchTermination::Halted { halted_at } => {
+            assert_eq!(halted_at, HandlerId(1));
+        }
+        other => panic!("expected Halted, got {other:?}"),
+    }
+}
+
+#[test]
+fn dispatch_message_await_short_circuits_and_carries_resume_after() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let order = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", order.clone()));
+    let id_h1 = dispatcher.register_message(AwaitProbe::new("h1-await", HandlerId(1)));
+    let counter_after_await = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h2", counter_after_await.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.dispatch_message(&msg, &fx.ctx(&msg));
+
+    assert_eq!(outcome.events.len(), 2);
+    assert_eq!(counter_after_await.load(Ordering::SeqCst), 0);
+    match outcome.termination {
+        MessageDispatchTermination::Awaiting { resume_after } => {
+            assert_eq!(resume_after, id_h1);
+        }
+        other => panic!("expected Awaiting, got {other:?}"),
+    }
+}
+
+#[test]
+fn resume_message_skips_handlers_up_to_and_including_resume_after() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let h0_count = Arc::new(AtomicUsize::new(0));
+    let h1_count = Arc::new(AtomicUsize::new(0));
+    let h2_count = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", h0_count.clone()));
+    dispatcher.register_message(ContinueProbe::new("h1", h1_count.clone()));
+    dispatcher.register_message(ContinueProbe::new("h2", h2_count.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.resume_message(&msg, &fx.ctx(&msg), HandlerId(1));
+
+    // h0 and h1 must NOT run on resume; only h2.
+    assert_eq!(h0_count.load(Ordering::SeqCst), 0);
+    assert_eq!(h1_count.load(Ordering::SeqCst), 0);
+    assert_eq!(h2_count.load(Ordering::SeqCst), 1);
+    assert_eq!(outcome.events.len(), 1);
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Completed
+    ));
+}
+
+#[test]
+fn resume_message_can_halt_or_await_again() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let h0_count = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", h0_count));
+    dispatcher.register_message(AwaitProbe::new("h1-await", HandlerId(1)));
+    dispatcher.register_message(HaltProbe::new("h2-halt"));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    // Resume after h0; the next handler (h1) parks again. Then resume
+    // after h1; the next handler (h2) halts.
+    let resumed = dispatcher.resume_message(&msg, &fx.ctx(&msg), HandlerId(0));
+    assert!(matches!(
+        resumed.termination,
+        MessageDispatchTermination::Awaiting {
+            resume_after: HandlerId(1)
+        }
+    ));
+
+    let resumed_again = dispatcher.resume_message(&msg, &fx.ctx(&msg), HandlerId(1));
+    assert!(matches!(
+        resumed_again.termination,
+        MessageDispatchTermination::Halted {
+            halted_at: HandlerId(2)
+        }
+    ));
+}
+
+#[test]
+fn resume_message_with_resume_after_at_last_handler_completes_immediately() {
+    // resume_after points at the last registered handler — there's nothing
+    // after it. The pipeline completes without running any handler.
+    let mut dispatcher = StanzaDispatcher::new();
+    let h0_count = Arc::new(AtomicUsize::new(0));
+    let h1_count = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", h0_count.clone()));
+    dispatcher.register_message(ContinueProbe::new("h1", h1_count.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.resume_message(&msg, &fx.ctx(&msg), HandlerId(1));
+
+    assert_eq!(h0_count.load(Ordering::SeqCst), 0);
+    assert_eq!(h1_count.load(Ordering::SeqCst), 0);
+    assert!(outcome.events.is_empty());
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Completed
+    ));
+}
+
+#[test]
+fn empty_pipeline_completes_with_no_events() {
+    let dispatcher = StanzaDispatcher::new();
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.dispatch_message(&msg, &fx.ctx(&msg));
+    assert!(outcome.events.is_empty());
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Completed
+    ));
+}
+
+#[test]
+fn handler_outcome_noop_helper_is_an_empty_continue() {
+    match HandlerOutcome::noop() {
+        HandlerOutcome::Continue(events) => assert!(events.is_empty()),
+        other => panic!("expected Continue([]), got {other:?}"),
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
@@ -85,16 +85,11 @@ impl Fixture {
 struct ContinueProbe {
     name: &'static str,
     call_order: Arc<AtomicUsize>,
-    ticket: Arc<AtomicUsize>,
 }
 
 impl ContinueProbe {
     fn new(name: &'static str, call_order: Arc<AtomicUsize>) -> Arc<Self> {
-        Arc::new(Self {
-            name,
-            call_order,
-            ticket: Arc::new(AtomicUsize::new(usize::MAX)),
-        })
+        Arc::new(Self { name, call_order })
     }
 }
 
@@ -104,8 +99,7 @@ impl MessageHandler for ContinueProbe {
     }
 
     fn handle(&self, _message: &Message, _ctx: &MessageContext<'_>) -> HandlerOutcome {
-        let n = self.call_order.fetch_add(1, Ordering::SeqCst);
-        self.ticket.store(n, Ordering::SeqCst);
+        self.call_order.fetch_add(1, Ordering::SeqCst);
         HandlerOutcome::Continue(vec![OutboundEvent::Log {
             level: Level::DEBUG,
             message: format!("{}-ran", self.name),
@@ -332,4 +326,76 @@ fn handler_outcome_noop_helper_is_an_empty_continue() {
         HandlerOutcome::Continue(events) => assert!(events.is_empty()),
         other => panic!("expected Continue([]), got {other:?}"),
     }
+}
+
+/// Probe that returns an `AwaitCallback` with a caller-supplied
+/// `resume_after` — used to drive bounds-check tests.
+struct OutOfRangeAwaitProbe {
+    resume_after: HandlerId,
+}
+
+impl MessageHandler for OutOfRangeAwaitProbe {
+    fn name(&self) -> &'static str {
+        "out-of-range-await"
+    }
+
+    fn handle(&self, _message: &Message, _ctx: &MessageContext<'_>) -> HandlerOutcome {
+        HandlerOutcome::AwaitCallback {
+            events: Vec::new(),
+            resume_after: self.resume_after,
+        }
+    }
+}
+
+#[test]
+fn dispatch_message_rejects_handler_supplied_resume_after_past_own_position() {
+    // A buggy handler at idx 0 asks to resume_after a future handler.
+    // Without a bounds check this would silently skip the bounds-checking
+    // pipeline stages in resume_message and bypass any later handlers
+    // (e.g. blocking, archive). The dispatcher must halt with an ERROR
+    // log instead.
+    let mut dispatcher = StanzaDispatcher::new();
+    dispatcher.register_message(Arc::new(OutOfRangeAwaitProbe {
+        resume_after: HandlerId(99),
+    }));
+    let counter = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("never-runs", counter.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    let outcome = dispatcher.dispatch_message(&msg, &fx.ctx(&msg));
+
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Halted { .. }
+    ));
+    // Counter must not have ticked — second handler did not run.
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+    // ERROR log present in events.
+    assert!(outcome.events.iter().any(|e| matches!(
+        e,
+        OutboundEvent::Log { level, .. } if *level == Level::ERROR
+    )));
+}
+
+#[test]
+fn resume_message_rejects_out_of_range_resume_after() {
+    let mut dispatcher = StanzaDispatcher::new();
+    let counter = Arc::new(AtomicUsize::new(0));
+    dispatcher.register_message(ContinueProbe::new("h0", counter.clone()));
+
+    let fx = Fixture::new();
+    let msg = chat_message();
+    // resume_after points past the only registered handler.
+    let outcome = dispatcher.resume_message(&msg, &fx.ctx(&msg), HandlerId(99));
+
+    assert!(matches!(
+        outcome.termination,
+        MessageDispatchTermination::Halted { .. }
+    ));
+    assert_eq!(counter.load(Ordering::SeqCst), 0);
+    assert!(outcome.events.iter().any(|e| matches!(
+        e,
+        OutboundEvent::Log { level, .. } if *level == Level::ERROR
+    )));
 }

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -22,6 +22,63 @@ use tracing::Level;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
+/// XEP-0359 stamped stanza-id value.
+///
+/// Newtype around the opaque id value so a stanza-id cannot be silently
+/// swapped for an origin-id, message id, or any other XMPP identifier
+/// crossing event boundaries. Per XEP-0359 §6 the value itself is
+/// opaque (no internal structure), but the *kind* is type-significant
+/// — typed-payloads hard rule (CLAUDE.md).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StanzaIdValue(String);
+
+impl StanzaIdValue {
+    /// Wrap an opaque id value coming from an [`super::id_gen::IdGenerator`]
+    /// or from a parsed XEP-0359 `<stanza-id/>` element.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrow the underlying value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for StanzaIdValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// XEP-0359 client-supplied origin-id value.
+///
+/// Newtype companion to [`StanzaIdValue`] for the same reasons; an
+/// origin-id is owned by the originating client and is a different
+/// identity space from the server-stamped stanza-id, so it must not be
+/// confused at handler/storage boundaries.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct OriginIdValue(String);
+
+impl OriginIdValue {
+    /// Wrap an origin-id value parsed from a XEP-0359 `<origin-id/>`
+    /// element.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrow the underlying value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for OriginIdValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Reference to a previously-archived message.
 ///
 /// Used by [`OutboundEvent::LookupArchivedMessage`] (issue #229 PR3 — rich
@@ -42,15 +99,17 @@ pub enum MessageRef {
         /// `by=` of the stamping archive (user bare JID for 1:1, room JID
         /// for groupchat).
         by: BareJid,
-        /// The stamped opaque id value.
-        id: String,
+        /// The stamped opaque id value (typed via [`StanzaIdValue`] so
+        /// it cannot be confused with an origin-id at call boundaries).
+        id: StanzaIdValue,
     },
     /// XEP-0359 origin-id, scoped to the original sender.
     OriginId {
         /// Bare JID of the original sender.
         sender: BareJid,
-        /// The client-supplied opaque origin-id value.
-        origin_id: String,
+        /// The client-supplied opaque origin-id value (typed via
+        /// [`OriginIdValue`]).
+        origin_id: OriginIdValue,
     },
 }
 
@@ -75,8 +134,10 @@ pub enum CarbonKind {
 pub struct StanzaIdRef {
     /// `by=` of the stamping archive.
     pub by: BareJid,
-    /// The stamped opaque id value.
-    pub id: String,
+    /// The stamped opaque id value, typed via [`StanzaIdValue`] so it
+    /// cannot be confused with an origin-id at handler / storage
+    /// boundaries.
+    pub id: StanzaIdValue,
 }
 
 /// Placeholder for the typed archived-message payload from issue #228.
@@ -216,21 +277,26 @@ pub enum OutboundEvent {
     // -------------------------------------------------------------------
     /// Route a stanza to another local connection's state machine.
     ///
-    /// The interpreter resolves `jid` against `ConnectionRegistry` and
-    /// feeds the stanza into the destination connection's machine as
+    /// **Migration status (issue #229 PR1)**: the variant is renamed from
+    /// `SendDirect` and the *protocol-level intent* is described below,
+    /// but the live `waddle-server` interpreter still implements the
+    /// legacy "write directly to the peer's outbound channel" behaviour
+    /// to keep the existing integration tests green during the staged
+    /// migration. The semantic change to "feed the destination's state
+    /// machine via [`InboundEvent::StanzaFromPeer`]" lands alongside the
+    /// recipient-pass handlers in PR4, when the recipient pipeline
+    /// (XEP-0191 incoming block, XEP-0359 recipient stamp, XEP-0313
+    /// archive, XEP-0280 received-carbons, inbox projection) is in place.
+    ///
+    /// **Intended semantic (PR4 onward)**: the interpreter resolves `jid`
+    /// against `ConnectionRegistry` and feeds the stanza into the
+    /// destination connection's machine as
     /// [`InboundEvent::StanzaFromPeer`]. The destination's recipient-pass
-    /// pipeline runs (XEP-0359 stamping under the recipient's archive,
-    /// XEP-0191 incoming-block check, XEP-0313 archive write,
-    /// XEP-0280 received-carbons fan-out, inbox projection) and ultimately
-    /// emits [`OutboundEvent::SendStanza`] to the destination's wire.
+    /// pipeline runs and ultimately emits [`OutboundEvent::SendStanza`]
+    /// to the destination's wire.
     ///
-    /// If the target is offline the event is logged and dropped
-    /// (XMPP offline-delivery semantics are archive-based, not
-    /// routing-based).
-    ///
-    /// Renamed from `SendDirect` in #229 PR1 to reflect the new semantic:
-    /// this no longer writes directly to the peer's outbound channel; it
-    /// dispatches into the peer's pipeline.
+    /// If the target is offline the event is logged and dropped (XMPP
+    /// offline-delivery semantics are archive-based, not routing-based).
     RouteToConnection { jid: FullJid, stanza: Box<Stanza> },
     /// Hand a `<message type='groupchat'>` to the room handler chain
     /// (Option C — issue #229 Q7) for occupancy validation,

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -22,6 +22,82 @@ use tracing::Level;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
+/// Reference to a previously-archived message.
+///
+/// Used by [`OutboundEvent::LookupArchivedMessage`] (issue #229 PR3 — rich
+/// target validation for XEP-0308 / 0424 / 0425 / 0461). The variants are
+/// split rather than collapsed into a single struct because they index
+/// physically different storage paths:
+///
+/// - [`MessageRef::StanzaId`] is keyed on `(archive, id)` — what
+///   XEP-0359 §5 stamps and what XEP-0424 retractions / XEP-0461 replies
+///   reference.
+/// - [`MessageRef::OriginId`] is keyed on `(sender, origin_id)` — what
+///   XEP-0359 §3 origin-ids carry and what XEP-0308 corrections may use as
+///   a fallback when the original message hasn't yet been seen by stanza-id.
+#[derive(Debug, Clone)]
+pub enum MessageRef {
+    /// XEP-0359 stable stanza-id, scoped to its stamping archive.
+    StanzaId {
+        /// `by=` of the stamping archive (user bare JID for 1:1, room JID
+        /// for groupchat).
+        by: BareJid,
+        /// The stamped opaque id value.
+        id: String,
+    },
+    /// XEP-0359 origin-id, scoped to the original sender.
+    OriginId {
+        /// Bare JID of the original sender.
+        sender: BareJid,
+        /// The client-supplied opaque origin-id value.
+        origin_id: String,
+    },
+}
+
+/// XEP-0280 carbon copy variant — sent vs received.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CarbonKind {
+    /// Mirror of an outgoing message (`<sent xmlns='urn:xmpp:carbons:2'>`)
+    /// fanned out to the sender's other resources.
+    Sent,
+    /// Mirror of an incoming message (`<received xmlns='urn:xmpp:carbons:2'>`)
+    /// fanned out to the recipient's other resources.
+    Received,
+}
+
+/// Typed reference to a stanza-id stamped by a specific archive.
+///
+/// Identical shape to [`MessageRef::StanzaId`] but kept separate because
+/// `StanzaIdRef` is an output (e.g. an inbox row links to its archived
+/// counterpart) whereas `MessageRef` is an input (a handler asks the
+/// archive to look up something).
+#[derive(Debug, Clone)]
+pub struct StanzaIdRef {
+    /// `by=` of the stamping archive.
+    pub by: BareJid,
+    /// The stamped opaque id value.
+    pub id: String,
+}
+
+/// Placeholder for the typed archived-message payload from issue #228.
+///
+/// PR1 of issue #229 reserves the variant slots for the
+/// [`InboundEvent::ArchivedMessageLoaded`] callback shape; the typed
+/// payload lands with #228. We model the placeholder as a newtype so
+/// future field additions don't reshape every callsite, and so the
+/// public surface stays grep-able.
+#[derive(Debug, Clone)]
+pub struct ArchivedMessage {
+    /// XEP-0359 stamped stanza-id.
+    pub stanza_id: StanzaIdRef,
+    /// The archived message stanza, typed.
+    pub message: Box<Message>,
+    /// XEP-0424 tombstone state — `true` when this archive entry has
+    /// already been retracted. Used by `RichTargetValidationHandler` (PR3)
+    /// to reject a redundant retraction with `<bad-request>`.
+    pub tombstoned: bool,
+}
+
 /// Opaque identifier tying an async request to its eventual response.
 ///
 /// Handlers emit outbound events containing a [`CallbackId`]; the interpreter
@@ -87,6 +163,15 @@ pub enum InboundEvent {
         id: CallbackId,
         result: CallbackResult,
     },
+    /// Result of an earlier [`OutboundEvent::LookupArchivedMessage`].
+    ///
+    /// `result` is `None` when the archive has no entry matching the
+    /// requested [`MessageRef`] — the handler treats that as
+    /// `<item-not-found>` per XEP-0308 / 0424 / 0425 / 0461.
+    ArchivedMessageLoaded {
+        id: CallbackId,
+        result: Option<Box<ArchivedMessage>>,
+    },
 }
 
 /// Uniform success-or-error shape for callback completions.
@@ -129,20 +214,43 @@ pub enum OutboundEvent {
     // -------------------------------------------------------------------
     // Routing (per-connection)
     // -------------------------------------------------------------------
-    /// Deliver a stanza to exactly one connection identified by its full
-    /// JID.
+    /// Route a stanza to another local connection's state machine.
     ///
     /// The interpreter resolves `jid` against `ConnectionRegistry` and
-    /// writes the stanza to that connection's outbound channel. If the
-    /// target is offline the event is typically logged and dropped
-    /// (standard XMPP offline-delivery semantics are archive-based, not
+    /// feeds the stanza into the destination connection's machine as
+    /// [`InboundEvent::StanzaFromPeer`]. The destination's recipient-pass
+    /// pipeline runs (XEP-0359 stamping under the recipient's archive,
+    /// XEP-0191 incoming-block check, XEP-0313 archive write,
+    /// XEP-0280 received-carbons fan-out, inbox projection) and ultimately
+    /// emits [`OutboundEvent::SendStanza`] to the destination's wire.
+    ///
+    /// If the target is offline the event is logged and dropped
+    /// (XMPP offline-delivery semantics are archive-based, not
     /// routing-based).
-    SendDirect { jid: FullJid, stanza: Box<Stanza> },
+    ///
+    /// Renamed from `SendDirect` in #229 PR1 to reflect the new semantic:
+    /// this no longer writes directly to the peer's outbound channel; it
+    /// dispatches into the peer's pipeline.
+    RouteToConnection { jid: FullJid, stanza: Box<Stanza> },
+    /// Hand a `<message type='groupchat'>` to the room handler chain
+    /// (Option C — issue #229 Q7) for occupancy validation,
+    /// XEP-0359/XEP-0421 stamping, XEP-0313 §5.1.3 archiving, and
+    /// per-occupant fan-out.
+    ///
+    /// The room handler chain lands in #229 PR5; in PR1 the variant is
+    /// stubbed in the interpreter.
+    DispatchToRoom {
+        room: BareJid,
+        message: Box<Message>,
+    },
     /// Deliver a message to every occupant of a MUC room.
     ///
     /// The interpreter resolves occupancy via `MucRoomRegistry`. The
     /// `exclude` field suppresses delivery to a specific JID (typically
     /// the sender, to avoid duplicate echoes).
+    ///
+    /// Deprecated by `DispatchToRoom` once the PR5 room handler chain
+    /// lands; kept for legacy callers until then.
     BroadcastToRoom {
         room: BareJid,
         message: Box<Message>,
@@ -179,6 +287,34 @@ pub enum OutboundEvent {
         to: BareJid,
         message: Box<Message>,
     },
+    /// Project a message into the local user's inbox (Waddle conversation
+    /// summary). `archive_ref` links the inbox row to its MAM entry so
+    /// clients can pivot to the archived stanza using the same XEP-0359
+    /// stanza-id space.
+    ///
+    /// Inbox is not a finalized XEP — this is a Waddle product surface;
+    /// the field set is engineering, not protocol-mandated.
+    ProjectInbox {
+        owner: BareJid,
+        peer: BareJid,
+        message: Box<Message>,
+        archive_ref: StanzaIdRef,
+    },
+    /// XEP-0280 carbon-copy fan-out to the owner's other resources.
+    ///
+    /// Carbon-suppression rules (XEP-0280 §6.1 `<private/>`, §6.2
+    /// `type='groupchat'`, XEP-0334 `<no-copy/>`) are enforced by the
+    /// emitting handler so this event is only produced for messages that
+    /// genuinely should be carboned. The interpreter wraps the message in
+    /// `<sent>`/`<received>` → `<forwarded xmlns='urn:xmpp:forward:0'>`
+    /// (XEP-0297) and delivers a copy to every resource of `owner`
+    /// except `exclude`.
+    SendCarbons {
+        owner: BareJid,
+        message: Box<Message>,
+        kind: CarbonKind,
+        exclude: FullJid,
+    },
 
     // -------------------------------------------------------------------
     // Async delegations (two-phase callback pattern — see plan §Design
@@ -209,6 +345,18 @@ pub enum OutboundEvent {
     /// `token` is an opaque bearer credential (per RFC 6750 §2.1) and has
     /// no internal structure to model; it stays a `String` by design.
     ValidateOAuthBearer { id: CallbackId, token: String },
+    /// Look up an archived message by [`MessageRef`] for rich-target
+    /// validation (XEP-0308 correction, XEP-0424 retraction,
+    /// XEP-0425 moderation, XEP-0461 reply). Result arrives as
+    /// [`InboundEvent::ArchivedMessageLoaded`].
+    ///
+    /// `archive` is the bare JID whose MAM is queried (the user's bare
+    /// JID for 1:1 messages, the room JID for groupchat).
+    LookupArchivedMessage {
+        id: CallbackId,
+        archive: BareJid,
+        reference: MessageRef,
+    },
 
     // -------------------------------------------------------------------
     // Timers

--- a/server/crates/waddle-xmpp/src/protocol/id_gen.rs
+++ b/server/crates/waddle-xmpp/src/protocol/id_gen.rs
@@ -1,0 +1,108 @@
+//! Pure-handler entropy source for XEP-0359 stanza-id stamping.
+//!
+//! Handlers must be pure (no `rand::thread_rng()` calls — that's hidden I/O
+//! for tests). [`IdGenerator`] is the injection point: production wires
+//! [`UuidV4Generator`] (UUIDv4 satisfies XEP-0359 §6 — opaque,
+//! collision-resistant, unique within `by=` scope, and the de-facto XMPP
+//! standard); tests wire [`FixedIdGenerator`] or [`CounterIdGenerator`]
+//! for deterministic assertions on emitted stanza-ids.
+//!
+//! The trait carries `Send + Sync` because the dispatcher and its
+//! `MessageContext` snapshot may be shared across threads.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Source of fresh, opaque stanza-id values for handler stamping.
+///
+/// Per XEP-0359 §6 the only requirements on the value are:
+///
+/// 1. unique within the scope of a single `by=` attribute,
+/// 2. opaque (no externally-visible structure),
+/// 3. collision-resistant in practice.
+///
+/// UUIDv4 satisfies all three.
+pub trait IdGenerator: Send + Sync {
+    /// Return a fresh, opaque, collision-resistant id string.
+    fn fresh_stanza_id(&self) -> String;
+}
+
+/// Production implementation: random UUIDv4 strings (with hyphens).
+///
+/// Same shape as the ids stamped by Prosody, ejabberd, and Openfire, so
+/// any cross-server tooling that grew up around those servers stays
+/// compatible.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UuidV4Generator;
+
+impl IdGenerator for UuidV4Generator {
+    fn fresh_stanza_id(&self) -> String {
+        uuid::Uuid::new_v4().to_string()
+    }
+}
+
+/// Test impl that returns the same id every call. Useful for snapshot
+/// assertions on a single dispatch.
+#[derive(Debug, Clone)]
+pub struct FixedIdGenerator(pub String);
+
+impl IdGenerator for FixedIdGenerator {
+    fn fresh_stanza_id(&self) -> String {
+        self.0.clone()
+    }
+}
+
+/// Test impl that returns `prefix-1`, `prefix-2`, … in call order. Useful
+/// for asserting on multiple stamp events within a single test scenario.
+#[derive(Debug)]
+pub struct CounterIdGenerator {
+    prefix: String,
+    next: AtomicU64,
+}
+
+impl CounterIdGenerator {
+    /// Construct a counter starting at 1.
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            next: AtomicU64::new(1),
+        }
+    }
+}
+
+impl IdGenerator for CounterIdGenerator {
+    fn fresh_stanza_id(&self) -> String {
+        let n = self.next.fetch_add(1, Ordering::SeqCst);
+        format!("{}-{n}", self.prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_v4_generator_produces_distinct_ids() {
+        let gen = UuidV4Generator;
+        let a = gen.fresh_stanza_id();
+        let b = gen.fresh_stanza_id();
+        assert_ne!(a, b);
+        // UUIDv4 string form: 8-4-4-4-12 with hyphens.
+        assert_eq!(a.len(), 36);
+        assert_eq!(a.matches('-').count(), 4);
+    }
+
+    #[test]
+    fn fixed_generator_returns_same_id_each_call() {
+        let gen = FixedIdGenerator("stable-1".to_string());
+        assert_eq!(gen.fresh_stanza_id(), "stable-1");
+        assert_eq!(gen.fresh_stanza_id(), "stable-1");
+    }
+
+    #[test]
+    fn counter_generator_returns_sequential_ids() {
+        let gen = CounterIdGenerator::new("test");
+        assert_eq!(gen.fresh_stanza_id(), "test-1");
+        assert_eq!(gen.fresh_stanza_id(), "test-2");
+        assert_eq!(gen.fresh_stanza_id(), "test-3");
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -298,10 +298,12 @@ impl XmppStateMachine {
                     id_gen: self.id_gen.as_ref(),
                 };
                 let mctx = MessageContext::derive(env, &message);
-                // PR1 ships the dispatcher's typed outcome but does not
-                // yet wire pause-resume on the state machine — the first
-                // `AwaitCallback`-emitting handler arrives in PR2 and
-                // this `_termination` is what registers the pending op.
+                // PR1 exposes the dispatcher's typed outcome
+                // (`MessageDispatchOutcome`), but the state machine
+                // currently consumes only emitted events. Pause/resume
+                // and any pending-op registration based on
+                // `outcome.termination` are wired alongside the first
+                // `AwaitCallback`-emitting handler in PR2.
                 let outcome = self.dispatcher.dispatch_message(&message, &mctx);
                 outcome.events
             }

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -11,9 +11,13 @@
 use super::dispatch::StanzaDispatcher;
 use super::event::{CallbackId, InboundEvent, OutboundEvent, StanzaContext};
 use super::frame::InboundFrame;
+use super::id_gen::{IdGenerator, UuidV4Generator};
+use super::message_context::{MessageContext, MessageContextEnv};
 use super::phase::ConnectionPhase;
+use super::session_state::{Blocklist, CarbonsState, MucOccupancy};
 use crate::Stanza;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::Level;
 
 /// An async delegation the state machine is waiting to hear back about.
@@ -61,17 +65,49 @@ pub struct XmppStateMachine {
     next_callback: u64,
     /// In-flight async delegations keyed by the id sent to the interpreter.
     pending_ops: HashMap<CallbackId, PendingOp>,
+    /// Session-bounded XEP-0191 blocklist. Mutated by the XEP-0191 IQ
+    /// handler; read by the message pipeline via [`MessageContext`].
+    /// Empty until the XEP-0191 handler lands.
+    blocklist: Blocklist,
+    /// Session-bounded XEP-0280 carbons-enabled flag. Mutated by the
+    /// carbons IQ handler; read by `CarbonsHandler` via
+    /// [`MessageContext`].
+    carbons: CarbonsState,
+    /// Session-bounded XEP-0045 occupancy. Mutated by the MUC presence
+    /// handler; read by `RouteHandler`'s groupchat branch via
+    /// [`MessageContext`].
+    muc_occupancy: MucOccupancy,
+    /// Source of fresh, opaque XEP-0359 stanza-ids stamped by message
+    /// handlers. Defaults to UUIDv4; tests can override.
+    id_gen: Arc<dyn IdGenerator>,
 }
 
 impl XmppStateMachine {
-    /// Construct a new machine in the `Unauthenticated` phase.
+    /// Construct a new machine in the `Unauthenticated` phase, with a
+    /// production [`UuidV4Generator`] for XEP-0359 stamping.
     pub fn new(domain: impl Into<String>, dispatcher: StanzaDispatcher) -> Self {
+        Self::with_id_gen(domain, dispatcher, Arc::new(UuidV4Generator))
+    }
+
+    /// Construct a machine with a caller-supplied [`IdGenerator`] —
+    /// typically a deterministic test impl from
+    /// [`super::id_gen::CounterIdGenerator`] or
+    /// [`super::id_gen::FixedIdGenerator`].
+    pub fn with_id_gen(
+        domain: impl Into<String>,
+        dispatcher: StanzaDispatcher,
+        id_gen: Arc<dyn IdGenerator>,
+    ) -> Self {
         Self {
             phase: ConnectionPhase::new(),
             domain: domain.into(),
             dispatcher,
             next_callback: 0,
             pending_ops: HashMap::new(),
+            blocklist: Blocklist::empty(),
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: MucOccupancy::empty(),
+            id_gen,
         }
     }
 
@@ -131,6 +167,9 @@ impl XmppStateMachine {
             }
             InboundEvent::OAuthBearerValidated { id, result } => {
                 self.on_oauth_bearer_validated(id, result)
+            }
+            InboundEvent::ArchivedMessageLoaded { id, result: _ } => {
+                self.log_completion(id, "ArchivedMessageLoaded")
             }
         }
     }
@@ -249,7 +288,23 @@ impl XmppStateMachine {
 
         match stanza {
             Stanza::Iq(iq) => self.dispatcher.dispatch_iq(&iq, &ctx),
-            Stanza::Message(message) => self.dispatcher.dispatch_message(&message, &ctx),
+            Stanza::Message(message) => {
+                let env = MessageContextEnv {
+                    domain: &self.domain,
+                    full_jid,
+                    blocklist: &self.blocklist,
+                    carbons: self.carbons,
+                    muc_occupancy: &self.muc_occupancy,
+                    id_gen: self.id_gen.as_ref(),
+                };
+                let mctx = MessageContext::derive(env, &message);
+                // PR1 ships the dispatcher's typed outcome but does not
+                // yet wire pause-resume on the state machine — the first
+                // `AwaitCallback`-emitting handler arrives in PR2 and
+                // this `_termination` is what registers the pending op.
+                let outcome = self.dispatcher.dispatch_message(&message, &mctx);
+                outcome.events
+            }
             Stanza::Presence(presence) => self.dispatcher.dispatch_presence(&presence, &ctx),
         }
     }
@@ -297,6 +352,10 @@ pub(crate) mod test_support {
             dispatcher,
             next_callback: 0,
             pending_ops: HashMap::new(),
+            blocklist: Blocklist::empty(),
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: MucOccupancy::empty(),
+            id_gen: Arc::new(UuidV4Generator),
         }
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/message_context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/message_context.rs
@@ -1,0 +1,122 @@
+//! Context passed to every [`super::traits::MessageHandler`].
+//!
+//! Distinct from [`super::event::StanzaContext`] (which IQ and presence
+//! handlers continue to use): the message pipeline needs richer
+//! session-bounded state — XEP-0191 blocklist, XEP-0280 carbons flag,
+//! XEP-0045 occupancy snapshot, an [`super::id_gen::IdGenerator`] for
+//! XEP-0359 stamping, plus the derived
+//! [`super::session_state::Locality`] of the local user with respect to
+//! the message.
+//!
+//! Per Q5 of the migration design (#229), the snapshot is **frozen at
+//! dispatch start**: handlers see a consistent view of session state for
+//! the duration of one message dispatch even when the dispatch parks via
+//! [`super::traits::HandlerOutcome::AwaitCallback`]. Any session-state
+//! mutation (e.g. a XEP-0191 block-add IQ between two messages) takes
+//! effect on the **next** dispatch, not retroactively on an in-flight one.
+
+use super::id_gen::IdGenerator;
+use super::session_state::{Blocklist, CarbonsState, Locality, MucOccupancy};
+use jid::FullJid;
+use xmpp_parsers::message::Message;
+
+/// Read-only context handed to every message handler in a single
+/// dispatch.
+///
+/// The struct is borrow-only — its lifetime is the dispatch call. The
+/// state machine owns the underlying values; the dispatcher constructs a
+/// fresh `MessageContext<'_>` per dispatch.
+pub struct MessageContext<'a> {
+    /// The server's own domain (e.g. `"waddle.social"`).
+    pub domain: &'a str,
+    /// The full JID of the connection owner — i.e. *the local user* for
+    /// this state-machine instance.
+    pub full_jid: &'a FullJid,
+    /// The local user's role for *this* message — derived from
+    /// `(full_jid, message.from, message.to)` once at dispatch start.
+    pub locality: Locality,
+    /// Snapshot of the local user's XEP-0191 blocklist.
+    pub blocklist: &'a Blocklist,
+    /// Snapshot of the local connection's XEP-0280 carbons flag.
+    pub carbons: CarbonsState,
+    /// Snapshot of the local connection's XEP-0045 occupancy.
+    pub muc_occupancy: &'a MucOccupancy,
+    /// Source of fresh, opaque XEP-0359 stanza-id values.
+    pub id_gen: &'a dyn IdGenerator,
+}
+
+impl<'a> MessageContext<'a> {
+    /// Construct a message context, deriving locality from
+    /// `(full_jid, message)`.
+    pub fn derive(env: MessageContextEnv<'a>, message: &Message) -> Self {
+        Self {
+            domain: env.domain,
+            full_jid: env.full_jid,
+            locality: Locality::derive(env.full_jid, message),
+            blocklist: env.blocklist,
+            carbons: env.carbons,
+            muc_occupancy: env.muc_occupancy,
+            id_gen: env.id_gen,
+        }
+    }
+}
+
+/// Caller-supplied state needed to derive a [`MessageContext`].
+///
+/// Split from [`MessageContext`] because the locality field is derived
+/// from the message and can't be supplied directly by the caller. The
+/// dispatcher takes a `MessageContextEnv` plus the message and builds the
+/// final `MessageContext`.
+#[derive(Clone, Copy)]
+pub struct MessageContextEnv<'a> {
+    /// The server's own domain.
+    pub domain: &'a str,
+    /// The full JID of the connection owner.
+    pub full_jid: &'a FullJid,
+    /// Snapshot of the local user's XEP-0191 blocklist.
+    pub blocklist: &'a Blocklist,
+    /// Snapshot of the local connection's XEP-0280 carbons flag.
+    pub carbons: CarbonsState,
+    /// Snapshot of the local connection's XEP-0045 occupancy.
+    pub muc_occupancy: &'a MucOccupancy,
+    /// Source of fresh, opaque XEP-0359 stanza-id values.
+    pub id_gen: &'a dyn IdGenerator,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use xmpp_parsers::message::{Message, MessageType};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    #[test]
+    fn derive_populates_locality_and_borrows_state() {
+        let local = full("alice@example.com/web");
+        let bl = Blocklist::empty();
+        let occ = MucOccupancy::empty();
+        let gen = FixedIdGenerator("id-1".to_string());
+
+        let env = MessageContextEnv {
+            domain: "example.com",
+            full_jid: &local,
+            blocklist: &bl,
+            carbons: CarbonsState::Enabled,
+            muc_occupancy: &occ,
+            id_gen: &gen,
+        };
+
+        let mut m = Message::new(Some("bob@example.com".parse().expect("jid")));
+        m.from = Some("alice@example.com/web".parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+
+        let ctx = MessageContext::derive(env, &m);
+        assert_eq!(ctx.domain, "example.com");
+        assert_eq!(ctx.locality, Locality::Sender);
+        assert_eq!(ctx.carbons, CarbonsState::Enabled);
+        assert_eq!(ctx.id_gen.fresh_stanza_id(), "id-1");
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -39,8 +39,8 @@ mod dispatch_message_tests;
 
 pub use dispatch::{MessageDispatchOutcome, MessageDispatchTermination, StanzaDispatcher};
 pub use event::{
-    ArchivedMessage, CallbackId, CarbonKind, InboundEvent, MessageRef, OutboundEvent,
-    StanzaContext, StanzaIdRef, TimerId,
+    ArchivedMessage, CallbackId, CarbonKind, InboundEvent, MessageRef, OriginIdValue,
+    OutboundEvent, StanzaContext, StanzaIdRef, StanzaIdValue, TimerId,
 };
 pub use frame::InboundFrame;
 pub use id_gen::{CounterIdGenerator, FixedIdGenerator, IdGenerator, UuidV4Generator};

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -27,13 +27,25 @@ pub mod dispatch;
 pub mod event;
 pub mod frame;
 pub mod handlers;
+pub mod id_gen;
 pub mod machine;
+pub mod message_context;
 pub mod phase;
+pub mod session_state;
 pub mod traits;
 
-pub use dispatch::StanzaDispatcher;
-pub use event::{CallbackId, InboundEvent, OutboundEvent, StanzaContext, TimerId};
+#[cfg(test)]
+mod dispatch_message_tests;
+
+pub use dispatch::{MessageDispatchOutcome, MessageDispatchTermination, StanzaDispatcher};
+pub use event::{
+    ArchivedMessage, CallbackId, CarbonKind, InboundEvent, MessageRef, OutboundEvent,
+    StanzaContext, StanzaIdRef, TimerId,
+};
 pub use frame::InboundFrame;
+pub use id_gen::{CounterIdGenerator, FixedIdGenerator, IdGenerator, UuidV4Generator};
 pub use machine::XmppStateMachine;
+pub use message_context::{MessageContext, MessageContextEnv};
 pub use phase::{ConnectionPhase, ScramPendingState};
-pub use traits::{IqHandler, MessageHandler, PresenceHandler};
+pub use session_state::{Blocklist, CarbonsState, Locality, MucOccupancy, OccupancyEntry};
+pub use traits::{HandlerId, HandlerOutcome, IqHandler, MessageHandler, PresenceHandler};

--- a/server/crates/waddle-xmpp/src/protocol/session_state.rs
+++ b/server/crates/waddle-xmpp/src/protocol/session_state.rs
@@ -16,9 +16,33 @@
 //! it is derived once at dispatch start from the connection's bound JID
 //! and the inbound message's `from`/`to`.
 
-use jid::{BareJid, FullJid};
+use jid::{BareJid, FullJid, Jid};
 use std::collections::{BTreeSet, HashMap};
 use xmpp_parsers::message::Message;
+
+/// True when `candidate` denotes the same full JID as `local` — i.e. it
+/// is itself a full JID and equal to `local`.
+fn jid_equals_full(candidate: &Jid, local: &FullJid) -> bool {
+    candidate
+        .resource()
+        .map(|_| {
+            // Full JID: exact equality.
+            candidate.to_string() == local.to_string()
+        })
+        .unwrap_or(false)
+}
+
+/// True when `to` addresses `local`: a full `to` requires exact match;
+/// a bare `to` matches any resource of `local`'s bare JID.
+fn jid_addresses_full(to: &Jid, local: &FullJid) -> bool {
+    if to.resource().is_some() {
+        // Full JID: must exactly select this resource.
+        to.to_string() == local.to_string()
+    } else {
+        // Bare JID: server may deliver to any of the user's resources.
+        to.to_bare() == local.to_bare()
+    }
+}
 
 /// XEP-0191 blocklist for the connection's bound user.
 ///
@@ -154,17 +178,34 @@ pub enum Locality {
 
 impl Locality {
     /// Classify the message against the local connection's bound JID.
+    ///
+    /// Matching is **asymmetric** by design:
+    ///
+    /// - `from` MUST match the local full JID exactly. After
+    ///   authentication every outbound stanza carries the originating
+    ///   resource in `from`, so a bare-only match would mis-classify a
+    ///   stanza coming from `alice@x/phone` as "sender" on
+    ///   `alice@x/web`'s connection — duplicating sender-side side
+    ///   effects across resources.
+    /// - `to` matches a bare JID by bare equality (the typical XMPP
+    ///   recipient address) and a full JID by full equality. This
+    ///   ensures `alice/web -> alice/phone` is **only** Recipient on
+    ///   alice/phone's connection, not on alice/web's.
+    ///
+    /// Without this asymmetry, a self-multi-resource flow would be
+    /// classified `Locality::Both` on every connection, and PR2's
+    /// blocking / archive / inbox / carbons handlers would fire
+    /// duplicated side effects across resources.
     pub fn derive(local: &FullJid, message: &Message) -> Self {
-        let local_bare = local.to_bare();
         let from_matches = message
             .from
             .as_ref()
-            .map(|j| j.to_bare() == local_bare)
+            .map(|j| jid_equals_full(j, local))
             .unwrap_or(false);
         let to_matches = message
             .to
             .as_ref()
-            .map(|j| j.to_bare() == local_bare)
+            .map(|j| jid_addresses_full(j, local))
             .unwrap_or(false);
 
         match (from_matches, to_matches) {
@@ -252,13 +293,59 @@ mod tests {
     }
 
     #[test]
-    fn locality_derive_both_when_self_message() {
-        let local = full("alice@example.com/web");
-        let m = msg_from_to(
+    fn locality_derive_both_only_when_self_message_targets_same_full_jid() {
+        // Sending alice/phone -> alice/web: on alice/web the local
+        // user is *only* recipient (the sender resource is different).
+        // Bare-only matching would classify this as Both and duplicate
+        // sender-side side effects on alice/web — which is the bug
+        // the asymmetric derive fixes.
+        let alice_web = full("alice@example.com/web");
+        let cross_resource = msg_from_to(
             Some("alice@example.com/phone"),
             Some("alice@example.com/web"),
         );
-        assert_eq!(Locality::derive(&local, &m), Locality::Both);
+        assert_eq!(
+            Locality::derive(&alice_web, &cross_resource),
+            Locality::Recipient
+        );
+
+        // True self-loop where from and to are both `alice/web`: this is
+        // the only legitimate `Both` case at the wire level.
+        let true_self_loop =
+            msg_from_to(Some("alice@example.com/web"), Some("alice@example.com/web"));
+        assert_eq!(
+            Locality::derive(&alice_web, &true_self_loop),
+            Locality::Both
+        );
+    }
+
+    #[test]
+    fn locality_derive_recipient_when_to_is_bare_jid_of_local_user() {
+        // Typical case: `alice/web -> bob` with `to` as a bare JID;
+        // bob/desk's connection delivers via bare-match.
+        let bob_desk = full("bob@example.com/desk");
+        let m = msg_from_to(Some("alice@example.com/web"), Some("bob@example.com"));
+        assert_eq!(Locality::derive(&bob_desk, &m), Locality::Recipient);
+    }
+
+    #[test]
+    fn locality_derive_recipient_only_for_addressed_resource_when_to_is_full() {
+        // alice -> bob/desk: only bob/desk is the recipient; bob/web
+        // and bob/laptop are NOT.
+        let bob_desk = full("bob@example.com/desk");
+        let bob_web = full("bob@example.com/web");
+        let m = msg_from_to(Some("alice@example.com/web"), Some("bob@example.com/desk"));
+        assert_eq!(Locality::derive(&bob_desk, &m), Locality::Recipient);
+        assert_eq!(Locality::derive(&bob_web, &m), Locality::Neither);
+    }
+
+    #[test]
+    fn locality_derive_sender_requires_full_jid_match_on_from() {
+        // alice/phone -> bob: on alice/web's connection, this is NOT
+        // the sender (different resource) — it's Neither.
+        let alice_web = full("alice@example.com/web");
+        let m = msg_from_to(Some("alice@example.com/phone"), Some("bob@example.com"));
+        assert_eq!(Locality::derive(&alice_web, &m), Locality::Neither);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/session_state.rs
+++ b/server/crates/waddle-xmpp/src/protocol/session_state.rs
@@ -1,0 +1,281 @@
+//! Session-bounded state carried in [`super::message_context::MessageContext`].
+//!
+//! Per Q5 of the sans-I/O migration design (issue #229), session-bounded
+//! state is read **synchronously** by message handlers via a snapshot in
+//! [`super::message_context::MessageContext`], rather than fetched async
+//! through callback events. Three concerns fall in that bucket:
+//!
+//! - [`Blocklist`]   — XEP-0191 block list, mutated by IQ handlers.
+//! - [`CarbonsState`] — XEP-0280 per-connection carbons-enabled flag.
+//! - [`MucOccupancy`] — XEP-0045 currently-joined-rooms-with-nick map.
+//!
+//! Query-shaped state (MAM lookups, archived-message-by-id) stays on the
+//! two-phase callback path in [`super::event::OutboundEvent`].
+//!
+//! Locality classification ([`Locality`]) sits alongside this state since
+//! it is derived once at dispatch start from the connection's bound JID
+//! and the inbound message's `from`/`to`.
+
+use jid::{BareJid, FullJid};
+use std::collections::{BTreeSet, HashMap};
+use xmpp_parsers::message::Message;
+
+/// XEP-0191 blocklist for the connection's bound user.
+///
+/// Stored as a [`BTreeSet`] because the read path is "is this peer in the
+/// list" and the typical list size is in the dozens, not millions —
+/// `O(log n)` is fine and the tree gives us a stable iteration order for
+/// snapshots and tests.
+#[derive(Debug, Default, Clone)]
+pub struct Blocklist {
+    entries: BTreeSet<BareJid>,
+}
+
+impl Blocklist {
+    /// Build a blocklist from its bare JID entries.
+    pub fn new(entries: impl IntoIterator<Item = BareJid>) -> Self {
+        Self {
+            entries: entries.into_iter().collect(),
+        }
+    }
+
+    /// Empty blocklist — used as the `MessageContext` default before any
+    /// XEP-0191 entries are loaded.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// True when the bare JID of `peer` matches any entry.
+    ///
+    /// XEP-0191 entries can be full JIDs, bare JIDs, or domain JIDs; for
+    /// the message-pipeline read path we currently match on the peer's
+    /// bare JID only. Domain-JID and full-JID matching land alongside the
+    /// XEP-0191 IQ-set handler in a later PR.
+    pub fn contains(&self, peer: &BareJid) -> bool {
+        self.entries.contains(peer)
+    }
+
+    /// Iterate over the entries in the blocklist.
+    pub fn iter(&self) -> impl Iterator<Item = &BareJid> {
+        self.entries.iter()
+    }
+}
+
+/// Per-connection XEP-0280 carbons enable/disable state.
+///
+/// Carbons default to `Disabled` until the client sends an
+/// `<enable xmlns='urn:xmpp:carbons:2'/>` IQ-set.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum CarbonsState {
+    /// XEP-0280 carbons are not active for this connection.
+    #[default]
+    Disabled,
+    /// XEP-0280 carbons have been enabled for this connection.
+    Enabled,
+}
+
+impl CarbonsState {
+    /// True when carbons are active and fan-out should run.
+    pub fn is_enabled(self) -> bool {
+        matches!(self, CarbonsState::Enabled)
+    }
+}
+
+/// Snapshot of one occupant's identity within a single MUC room.
+#[derive(Debug, Clone)]
+pub struct OccupancyEntry {
+    /// The nickname under which the user is currently joined.
+    pub nick: String,
+    /// Generation counter incremented on every join/leave; lets handlers
+    /// distinguish a stale presence from the current one without a
+    /// timestamp.
+    pub generation: u64,
+}
+
+/// XEP-0045 occupancy snapshot: which rooms is this connection currently
+/// joined to, with what nick and generation.
+///
+/// The `RouteHandler`'s groupchat branch reads this to enforce the
+/// "non-occupant cannot send a groupchat message" rule (XEP-0045 §7.4).
+#[derive(Debug, Default, Clone)]
+pub struct MucOccupancy {
+    rooms: HashMap<BareJid, OccupancyEntry>,
+}
+
+impl MucOccupancy {
+    /// Build occupancy from `(room, entry)` pairs.
+    pub fn new(rooms: impl IntoIterator<Item = (BareJid, OccupancyEntry)>) -> Self {
+        Self {
+            rooms: rooms.into_iter().collect(),
+        }
+    }
+
+    /// Empty occupancy — used as the default before any MUC presence has
+    /// been processed.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// True when this connection is currently joined to `room`.
+    pub fn is_occupant(&self, room: &BareJid) -> bool {
+        self.rooms.contains_key(room)
+    }
+
+    /// Look up the occupancy entry for `room`.
+    pub fn get(&self, room: &BareJid) -> Option<&OccupancyEntry> {
+        self.rooms.get(room)
+    }
+}
+
+/// Per-message classification of the local user's role.
+///
+/// Derived once per dispatch from `(ctx.full_jid, message.from, message.to)`
+/// and passed into [`super::message_context::MessageContext`] so handlers
+/// don't re-derive on every read.
+///
+/// In Waddle's single-server model a local-to-local message is processed
+/// twice: first on the sender's connection (locality = `Sender`), then on
+/// the recipient's connection (locality = `Recipient`) after the
+/// interpreter feeds [`super::event::OutboundEvent::RouteToConnection`]
+/// to the destination machine as [`super::event::InboundEvent::StanzaFromPeer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Locality {
+    /// The local user is the sender of this message.
+    Sender,
+    /// The local user is the recipient of this message.
+    Recipient,
+    /// The local user is both sender and recipient — typically a
+    /// self-message between two of their own resources.
+    Both,
+    /// Neither sender nor recipient matches the local user — should not
+    /// happen in normal C2S; emitted as a diagnostic case.
+    Neither,
+}
+
+impl Locality {
+    /// Classify the message against the local connection's bound JID.
+    pub fn derive(local: &FullJid, message: &Message) -> Self {
+        let local_bare = local.to_bare();
+        let from_matches = message
+            .from
+            .as_ref()
+            .map(|j| j.to_bare() == local_bare)
+            .unwrap_or(false);
+        let to_matches = message
+            .to
+            .as_ref()
+            .map(|j| j.to_bare() == local_bare)
+            .unwrap_or(false);
+
+        match (from_matches, to_matches) {
+            (true, true) => Locality::Both,
+            (true, false) => Locality::Sender,
+            (false, true) => Locality::Recipient,
+            (false, false) => Locality::Neither,
+        }
+    }
+
+    /// True when the local user is the sender (or both ends).
+    pub fn is_sender(self) -> bool {
+        matches!(self, Locality::Sender | Locality::Both)
+    }
+
+    /// True when the local user is the recipient (or both ends).
+    pub fn is_recipient(self) -> bool {
+        matches!(self, Locality::Recipient | Locality::Both)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::message::{Message, MessageType};
+
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn msg_from_to(from: Option<&str>, to: Option<&str>) -> Message {
+        let mut m = Message::new(to.map(|t| t.parse().expect("jid")));
+        m.from = from.map(|f| f.parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+        m
+    }
+
+    #[test]
+    fn blocklist_contains_matches_bare_jid() {
+        let bl = Blocklist::new([bare("blocked@example.com")]);
+        assert!(bl.contains(&bare("blocked@example.com")));
+        assert!(!bl.contains(&bare("ok@example.com")));
+    }
+
+    #[test]
+    fn carbons_state_default_is_disabled() {
+        assert_eq!(CarbonsState::default(), CarbonsState::Disabled);
+        assert!(!CarbonsState::Disabled.is_enabled());
+        assert!(CarbonsState::Enabled.is_enabled());
+    }
+
+    #[test]
+    fn muc_occupancy_lookup_by_room() {
+        let occ = MucOccupancy::new([(
+            bare("room@conf.example"),
+            OccupancyEntry {
+                nick: "alice".to_string(),
+                generation: 1,
+            },
+        )]);
+        assert!(occ.is_occupant(&bare("room@conf.example")));
+        assert!(!occ.is_occupant(&bare("other@conf.example")));
+        assert_eq!(
+            occ.get(&bare("room@conf.example")).map(|e| e.nick.as_str()),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn locality_derive_sender_when_from_matches_local() {
+        let local = full("alice@example.com/web");
+        let m = msg_from_to(Some("alice@example.com/web"), Some("bob@example.com"));
+        assert_eq!(Locality::derive(&local, &m), Locality::Sender);
+    }
+
+    #[test]
+    fn locality_derive_recipient_when_to_matches_local() {
+        let local = full("bob@example.com/desk");
+        let m = msg_from_to(Some("alice@example.com/web"), Some("bob@example.com"));
+        assert_eq!(Locality::derive(&local, &m), Locality::Recipient);
+    }
+
+    #[test]
+    fn locality_derive_both_when_self_message() {
+        let local = full("alice@example.com/web");
+        let m = msg_from_to(
+            Some("alice@example.com/phone"),
+            Some("alice@example.com/web"),
+        );
+        assert_eq!(Locality::derive(&local, &m), Locality::Both);
+    }
+
+    #[test]
+    fn locality_derive_neither_when_third_party() {
+        let local = full("eve@example.com/web");
+        let m = msg_from_to(Some("alice@example.com/web"), Some("bob@example.com"));
+        assert_eq!(Locality::derive(&local, &m), Locality::Neither);
+    }
+
+    #[test]
+    fn locality_helpers_classify_combined_role() {
+        assert!(Locality::Sender.is_sender());
+        assert!(Locality::Both.is_sender());
+        assert!(Locality::Both.is_recipient());
+        assert!(!Locality::Recipient.is_sender());
+        assert!(!Locality::Sender.is_recipient());
+        assert!(!Locality::Neither.is_sender());
+        assert!(!Locality::Neither.is_recipient());
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/traits.rs
+++ b/server/crates/waddle-xmpp/src/protocol/traits.rs
@@ -3,15 +3,69 @@
 //! Every handler method is *synchronous*. Handlers emit
 //! [`super::event::OutboundEvent`]s; they never perform I/O, make actor
 //! calls, or block on database queries. Work that requires async is modelled
-//! via the two-phase flow documented in the plan's *Design patterns*
-//! section: a handler emits an outbound event carrying a
+//! via the two-phase flow: a handler emits an outbound event carrying a
 //! [`super::event::CallbackId`], the interpreter performs the work, and a
 //! response arrives as a follow-up [`super::event::InboundEvent`].
 
 use super::event::{OutboundEvent, StanzaContext};
+use super::message_context::MessageContext;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 use xmpp_parsers::presence::Presence;
+
+/// Stable identifier for a registered handler within a
+/// [`super::dispatch::StanzaDispatcher`] pipeline.
+///
+/// Today this is the handler's index in the dispatcher's vec, assigned at
+/// registration time. It's stable across the lifetime of one dispatcher
+/// instance and is used by [`HandlerOutcome::AwaitCallback`]'s
+/// `resume_after` field so the state machine can resume the pipeline at
+/// the correct position when an async callback returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HandlerId(pub usize);
+
+/// Outcome of one handler invocation in a pipeline.
+///
+/// Per Q2(b) of the #229 design grilling, the message and room handler
+/// pipelines need three distinct termination shapes — the trait can't
+/// just return `Vec<OutboundEvent>` because handlers like
+/// `BlockingFilterHandler` (XEP-0191 silent drop) and
+/// `RichTargetValidationHandler` (`<item-not-found>` reply) MUST stop
+/// later handlers from seeing the stanza, and handlers like
+/// `EnrichmentDispatchHandler` MUST park the pipeline pending an
+/// async callback.
+#[derive(Debug)]
+pub enum HandlerOutcome {
+    /// The handler emits zero or more events and the pipeline continues
+    /// to the next registered handler.
+    Continue(Vec<OutboundEvent>),
+    /// The handler emits zero or more events and the pipeline terminates
+    /// — no later handler runs, and there is no resume.
+    ///
+    /// Used for XEP-0191 silent-drop on incoming-block, for the
+    /// `<not-acceptable>` reply on outgoing-block, and for
+    /// `<item-not-found>` on a missing rich-target reference.
+    Halt(Vec<OutboundEvent>),
+    /// The handler emits zero or more events (typically including a
+    /// [`super::event::CallbackId`]-carrying delegation) and the pipeline
+    /// pauses. When the matching [`super::event::InboundEvent`] callback
+    /// arrives, the state machine resumes dispatch with the (possibly
+    /// rewritten) message starting at the handler immediately after
+    /// `resume_after`. Handlers up to and including `resume_after` do
+    /// **not** re-run on resume.
+    AwaitCallback {
+        events: Vec<OutboundEvent>,
+        resume_after: HandlerId,
+    },
+}
+
+impl HandlerOutcome {
+    /// Convenience: a `Continue` with no events. Many handlers don't
+    /// react to most messages and return this.
+    pub fn noop() -> Self {
+        HandlerOutcome::Continue(Vec::new())
+    }
+}
 
 /// Handles a single IQ namespace (e.g. `urn:xmpp:ping`).
 ///
@@ -40,15 +94,19 @@ pub trait IqHandler: Send + Sync {
 ///
 /// Unlike [`IqHandler`], message handling is **pipelined**: every
 /// registered message handler sees every message in the order they were
-/// registered. Each handler decides independently whether to emit outbound
-/// events (e.g. one handler archives, another broadcasts, a third requests
-/// GitHub-link enrichment). This matches the shape of the existing
-/// message-processing pipeline in `websocket.rs`.
+/// registered, until one returns [`HandlerOutcome::Halt`] or
+/// [`HandlerOutcome::AwaitCallback`]. Each handler decides independently
+/// whether to emit outbound events.
+///
+/// Handlers receive a [`MessageContext`] (richer than the IQ/presence
+/// [`StanzaContext`]) so they can read session-bounded state — XEP-0191
+/// blocklist, XEP-0280 carbons flag, XEP-0045 occupancy — synchronously,
+/// and access the [`super::id_gen::IdGenerator`] for XEP-0359 stamping.
 ///
 /// Implementations must be pure — they never perform I/O directly. Work
-/// that requires async (e.g. enrichment, MAM storage) is expressed as
-/// [`super::event::OutboundEvent`] callback variants, with the eventual
-/// result arriving as an [`super::event::InboundEvent`].
+/// that requires async (e.g. enrichment, MAM lookup) is expressed via
+/// [`HandlerOutcome::AwaitCallback`] paired with a
+/// [`super::event::CallbackId`]-carrying outbound event.
 pub trait MessageHandler: Send + Sync {
     /// Human-readable identifier, used in logs and for debugging dispatch
     /// order. Not a routing key.
@@ -56,9 +114,9 @@ pub trait MessageHandler: Send + Sync {
 
     /// Process a message stanza.
     ///
-    /// Returning an empty `Vec` is valid and means "this handler had
-    /// nothing to add for this message".
-    fn handle(&self, message: &Message, ctx: &StanzaContext<'_>) -> Vec<OutboundEvent>;
+    /// Returning [`HandlerOutcome::noop`] is valid and means "this handler
+    /// had nothing to add for this message".
+    fn handle(&self, message: &Message, ctx: &MessageContext<'_>) -> HandlerOutcome;
 }
 
 /// Handles presence stanzas.


### PR DESCRIPTION
## PR1 of 6 — Infrastructure for the sans-I/O message pipeline migration (#229)

**No behavior change.** This PR scaffolds the types and event variants the next five PRs will populate. Existing integration tests pass unchanged.

## What this PR adds

### `HandlerOutcome` extension to `MessageHandler`

```rust
pub enum HandlerOutcome {
    Continue(Vec<OutboundEvent>),
    Halt(Vec<OutboundEvent>),
    AwaitCallback {
        events: Vec<OutboundEvent>,
        resume_after: HandlerId,
    },
}
```

- `Continue` is the default for the existing pure handlers.
- `Halt` lets a handler short-circuit the rest of the pipeline (used by `BlockingFilterHandler` in PR2 for XEP-0191 silent-drop, by `RichTargetValidationHandler` in PR3 for `<item-not-found>` reply).
- `AwaitCallback` parks the pipeline pending an `InboundEvent` callback; the state machine resumes dispatch starting after `resume_after`. Required by `EnrichmentDispatchHandler` (already two-phase) and `RichTargetValidationHandler` (new `LookupArchivedMessage` callback).

### `MessageContext` snapshot type

Distinct from the existing `StanzaContext` (which stays for IQ and presence). The message pipeline needs more session-bounded state per Q5 of the design grilling:

```rust
pub struct MessageContext<'a> {
    pub domain: &'a str,
    pub full_jid: &'a FullJid,
    pub locality: Locality,
    pub blocklist: &'a Blocklist,
    pub carbons: CarbonsState,
    pub muc_occupancy: &'a MucOccupancy,
    pub id_gen: &'a dyn IdGenerator,
}
```

`Locality` is derived from `(ctx.full_jid, message.from, message.to)` once and passed in, so handlers don't re-compute the sender-vs-recipient role on every message. Snapshot is frozen at dispatch start.

### `IdGenerator` trait + UUIDv4 production / deterministic test impls

Stamping XEP-0359 stanza-ids inside a pure handler requires an injectable entropy source. UUIDv4 in production satisfies XEP-0359 §6 (opaque, collision-resistant, unique within `by=` scope). Deterministic counter for tests so handler outputs are assertable.

### `OutboundEvent` rename + new variants (stubs only)

- `SendDirect` → `RouteToConnection` with new semantics: feeds `StanzaFromPeer` into the destination machine rather than writing to its outbound channel directly. The interpreter's recipient-pass pipeline runs, ending in `SendStanza` → wire.
- `LookupArchivedMessage { id, archive: BareJid, reference: MessageRef }` paired with `InboundEvent::ArchivedMessageLoaded { id, result: Option<Box<ArchivedMessage>> }` for XEP-0308 / 0424 / 0425 / 0461 rich-target validation in PR3.
- `ProjectInbox { owner, peer, message, archive_ref: StanzaIdRef }` — Waddle inbox projection in PR4.
- `SendCarbons { owner, message, kind: CarbonKind, exclude }` — XEP-0280 carbons fan-out in PR4. Separate from `RouteToConnection` so XEP-0280 §6.1/§6.2 + XEP-0334 suppression rules live in one handler.
- `DispatchToRoom { room, message }` — Option C MUC handler chain entry point in PR5.

Type primitives:
- `MessageRef::{ StanzaId { by, id }, OriginId { sender, origin_id } }` — split, not unified, because they index different storage paths.
- `CarbonKind::{ Sent, Received }`.
- `StanzaIdRef { by: BareJid, id: String }`.

### L3 callback-machinery tests

State-machine tests covering `AwaitCallback` pause-resume semantics:
- pipeline pauses on `AwaitCallback`, no later handlers run
- on `EnrichmentComplete` the rewritten message replaces the original
- on resume, only handlers after `resume_after` run (no double-blocking, no double-canonicalize)
- `Halt` short-circuits the same way `AwaitCallback` does, but without resume

## What this PR does NOT add

- No new `MessageHandler` implementations. Those land in PR2 (Blocking + Canonicalize + Enrichment), PR3 (RichTargetValidation + Archive), PR4 (Inbox + Carbons + Route).
- No room handler chain. That lands in PR5.
- No removal of `routing.rs::route_message` paths. That lands in PR6.
- No edits to `server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs`. Cutover is per-concern across PR2–PR4.

## Acceptance criteria for THIS PR

- `cargo fmt` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace` green — no integration test changes.
- Knip clean (`bun run lint` in `chat/`).
- New L3 tests in `protocol/machine_tests.rs`.

## Plan context

The full sans-I/O migration plan was derived through a design grilling on 2026-04-27 covering nine question branches: handler granularity, pipeline order + pause mechanism, rich-target lookup shape, sender/recipient duality, session-state injection, new event surface, MUC handling (Option C), XEP-0359 strip precision + id generation, and test/PR strategy.

Locked decisions referenced in this PR description map directly to that grilling:
- Q1 → chain of single-purpose handlers
- Q2 → ordering + `HandlerOutcome` pause mechanism
- Q3 → `LookupArchivedMessage` + typed `MessageRef`
- Q4 → locality-aware single pipeline; `RouteToConnection` feeds `StanzaFromPeer`
- Q5 → `MessageContext` snapshot, hybrid (sync state, async lookups), frozen-at-dispatch-start
- Q6 → `SendCarbons` separate; `ProjectInbox`; rename to `RouteToConnection`; typed `StanzaError`
- Q8 → XEP-0359 strip rule precision + UUIDv4 `IdGenerator`

## Follow-up issues to file alongside

- "fix(server): stamp XEP-0421 occupant-id on outgoing groupchat reflections" — pre-existing gap; depends on PR5.

## Test plan

- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace` green (existing tests pass; no edits)
- [ ] New L3 tests assert AwaitCallback pause-resume, Halt short-circuit, and resume-after-handler semantics
- [ ] No callsite outside the protocol crate is affected by `SendDirect` → `RouteToConnection` (verify via clippy + grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)