### PR TITLE
fix(chat): refine date markers and channel list header

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -211,7 +211,9 @@ function onSelectGif(url: string) {
 const messagesContainer = ref<HTMLDivElement | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
   messagesContainer.value = el;
+  void nextTick(updateCurrentDayMarker);
 };
+const currentDayMarkerLabel = ref("");
 const composerRef = ref<MessageComposerHandle | null>(null);
 const setComposerRef = (instance: MessageComposerHandle | null) => {
   composerRef.value = instance;
@@ -439,6 +441,46 @@ function showDividerAfter(messageId: string): boolean {
   return props.firstUnseenId === messageId && newMessagesDividerPlacement.value === "after";
 }
 
+function updateCurrentDayMarker() {
+  const container = messagesContainer.value;
+  if (!container) {
+    currentDayMarkerLabel.value = "";
+    return;
+  }
+
+  const messageEls = [...container.querySelectorAll<HTMLElement>("[data-message-created-at]")];
+  if (messageEls.length === 0) {
+    currentDayMarkerLabel.value = "";
+    return;
+  }
+
+  const containerTop = container.getBoundingClientRect().top;
+  const probeTop = containerTop + 1;
+  let current = messageEls[0];
+  for (const el of messageEls) {
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom < probeTop) {
+      current = el;
+      continue;
+    }
+    if (rect.top <= probeTop || current === messageEls[0]) {
+      current = el;
+    }
+    break;
+  }
+
+  const createdAt = current.dataset.messageCreatedAt;
+  currentDayMarkerLabel.value = createdAt ? formatDayDivider(createdAt) : "";
+}
+
+watch(
+  [orderedFeedMessages, () => props.isLoadingMessages, conversationScope],
+  () => {
+    void nextTick(updateCurrentDayMarker);
+  },
+  { flush: "post" },
+);
+
 // Burst window: same author + < 5 min apart + same day, with no
 // intervening other-author message in the rendered order.
 const BURST_WINDOW_MS = 5 * 60 * 1000;
@@ -451,10 +493,7 @@ const messageDisplayMeta = computed(() => {
     const cur = list[i];
     if (!cur) continue;
     const prev = i > 0 ? list[i - 1] : null;
-    if (!prev) {
-      dayDivider.add(cur.id);
-      continue;
-    }
+    if (!prev) continue;
     const sameDay = isSameDay(prev.createdAt, cur.createdAt);
     if (!sameDay) dayDivider.add(cur.id);
     if (
@@ -689,8 +728,23 @@ function dayDividerLabel(createdAt: string): string {
       </div>
     </div>
 
+    <div
+      v-if="currentDayMarkerLabel"
+      class="chat-current-day-marker type-section-label"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="chat-current-day-marker__lane">
+        <span class="chat-current-day-marker__label">{{ currentDayMarkerLabel }}</span>
+      </div>
+    </div>
+
     <!-- Messages -->
-    <div :ref="setMessagesContainer" class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]">
+    <div
+      :ref="setMessagesContainer"
+      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+      @scroll="updateCurrentDayMarker"
+    >
       <div v-if="isLoadingMessages" class="type-caption flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
         <div class="flex items-center justify-center gap-1.5">
           <span class="typing-dot" />

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -448,28 +448,30 @@ function updateCurrentDayMarker() {
     return;
   }
 
-  const messageEls = [...container.querySelectorAll<HTMLElement>("[data-message-created-at]")];
-  if (messageEls.length === 0) {
+  const markerEls = [
+    ...container.querySelectorAll<HTMLElement>("[data-day-marker-created-at], [data-message-created-at]"),
+  ];
+  if (markerEls.length === 0) {
     currentDayMarkerLabel.value = "";
     return;
   }
 
   const containerTop = container.getBoundingClientRect().top;
   const probeTop = containerTop + 1;
-  let current = messageEls[0];
-  for (const el of messageEls) {
+  let current = markerEls[0];
+  for (const el of markerEls) {
     const rect = el.getBoundingClientRect();
     if (rect.bottom < probeTop) {
       current = el;
       continue;
     }
-    if (rect.top <= probeTop || current === messageEls[0]) {
+    if (rect.top <= probeTop || current === markerEls[0]) {
       current = el;
     }
     break;
   }
 
-  const createdAt = current.dataset.messageCreatedAt;
+  const createdAt = current.dataset.dayMarkerCreatedAt ?? current.dataset.messageCreatedAt;
   currentDayMarkerLabel.value = createdAt ? formatDayDivider(createdAt) : "";
 }
 
@@ -788,6 +790,7 @@ function dayDividerLabel(createdAt: string): string {
           <div
             v-if="showDayDividerBefore(msg.id)"
             class="chat-day-divider type-section-label"
+            :data-day-marker-created-at="msg.createdAt"
             role="separator"
             :aria-label="dayDividerLabel(msg.createdAt)"
           >

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -614,6 +614,7 @@ watch(
   <div
     v-if="message.isRetracted"
     :data-message-id="message.id"
+    :data-message-created-at="message.createdAt"
     class="chat-message-grid opacity-35 animate-message-in"
     :class="grouped ? 'chat-message-grouped' : ''"
   >
@@ -645,6 +646,7 @@ watch(
     v-else
     ref="bubbleEl"
     :data-message-id="message.id"
+    :data-message-created-at="message.createdAt"
     :data-sheet-open="sheetOpen ? 'true' : 'false'"
     class="chat-message-grid group relative ring-1 ring-transparent transition-colors duration-150 animate-message-in"
     :class="[

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -147,29 +147,36 @@ function updateCurrentDayMarker() {
     return;
   }
 
-  const messageEls = [...container.querySelectorAll<HTMLElement>("[data-message-created-at]")];
-  if (messageEls.length === 0) {
+  const markerEls = [
+    ...container.querySelectorAll<HTMLElement>("[data-day-marker-created-at], [data-message-created-at]"),
+  ];
+  if (markerEls.length === 0) {
     currentDayMarkerLabel.value = "";
     return;
   }
 
   const containerTop = container.getBoundingClientRect().top;
   const probeTop = containerTop + 1;
-  let current = messageEls[0];
-  for (const el of messageEls) {
+  let current = markerEls[0];
+  for (const el of markerEls) {
     const rect = el.getBoundingClientRect();
     if (rect.bottom < probeTop) {
       current = el;
       continue;
     }
-    if (rect.top <= probeTop || current === messageEls[0]) {
+    if (rect.top <= probeTop || current === markerEls[0]) {
       current = el;
     }
     break;
   }
 
-  const createdAt = current.dataset.messageCreatedAt;
+  const createdAt = current.dataset.dayMarkerCreatedAt ?? current.dataset.messageCreatedAt;
   currentDayMarkerLabel.value = createdAt ? formatDayDivider(createdAt) : "";
+}
+
+function setScrollContainerRef(el: HTMLElement | null) {
+  scrollContainerRef.value = el;
+  void nextTick(updateCurrentDayMarker);
 }
 
 // Switching threads resets composer state and scrolls to the pinned edge.
@@ -185,6 +192,10 @@ watch(
     void scrollToPinnedEdge();
   },
 );
+
+watch(scrollDirectionMode, () => {
+  void scrollToPinnedEdge();
+});
 
 watch(
   [activeEntry, orderedChildren],
@@ -334,7 +345,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     </div>
 
     <div
-      ref="scrollContainerRef"
+      :ref="setScrollContainerRef"
       class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4"
       @scroll="updateCurrentDayMarker"
     >
@@ -364,6 +375,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
           <div
             v-if="showDayDividerBefore(child.id)"
             class="chat-day-divider type-section-label"
+            :data-day-marker-created-at="child.createdAt"
             role="separator"
             :aria-label="dayDividerLabel(child.createdAt)"
           >

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -118,6 +118,7 @@ const isTopPinned = computed(() =>
 );
 
 const scrollContainerRef = ref<HTMLElement | null>(null);
+const currentDayMarkerLabel = ref("");
 const draft = ref("");
 const replyingTo = ref<{ id: string; author: string; body?: string } | null>(null);
 
@@ -136,6 +137,39 @@ async function scrollToPinnedEdge() {
   const el = scrollContainerRef.value;
   if (!el) return;
   el.scrollTop = getPinnedScrollTop(el, scrollDirectionMode.value);
+  updateCurrentDayMarker();
+}
+
+function updateCurrentDayMarker() {
+  const container = scrollContainerRef.value;
+  if (!container) {
+    currentDayMarkerLabel.value = "";
+    return;
+  }
+
+  const messageEls = [...container.querySelectorAll<HTMLElement>("[data-message-created-at]")];
+  if (messageEls.length === 0) {
+    currentDayMarkerLabel.value = "";
+    return;
+  }
+
+  const containerTop = container.getBoundingClientRect().top;
+  const probeTop = containerTop + 1;
+  let current = messageEls[0];
+  for (const el of messageEls) {
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom < probeTop) {
+      current = el;
+      continue;
+    }
+    if (rect.top <= probeTop || current === messageEls[0]) {
+      current = el;
+    }
+    break;
+  }
+
+  const createdAt = current.dataset.messageCreatedAt;
+  currentDayMarkerLabel.value = createdAt ? formatDayDivider(createdAt) : "";
 }
 
 // Switching threads resets composer state and scrolls to the pinned edge.
@@ -150,6 +184,14 @@ watch(
   () => {
     void scrollToPinnedEdge();
   },
+);
+
+watch(
+  [activeEntry, orderedChildren],
+  () => {
+    void nextTick(updateCurrentDayMarker);
+  },
+  { flush: "post" },
 );
 
 const breadcrumbLabels = computed(() =>
@@ -280,7 +322,22 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     </div>
 
     <!-- Messages scroll area -->
-    <div ref="scrollContainerRef" class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4">
+    <div
+      v-if="currentDayMarkerLabel"
+      class="chat-current-day-marker type-section-label"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="chat-current-day-marker__lane">
+        <span class="chat-current-day-marker__label">{{ currentDayMarkerLabel }}</span>
+      </div>
+    </div>
+
+    <div
+      ref="scrollContainerRef"
+      class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4"
+      @scroll="updateCurrentDayMarker"
+    >
       <div v-if="activeEntry" class="chat-panel-stack">
         <div v-if="!activeEntry.root" class="type-caption rounded-lg bg-muted/40 px-3 py-2 text-muted-foreground">
           Thread root isn't in the loaded history. Scroll the main channel or reload to backfill.

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -107,10 +107,6 @@ const emit = defineEmits<{
     <!-- Channel list -->
     <div class="chat-pane-scroll chat-sidebar-scroll">
       <div class="chat-panel-stack">
-        <span class="type-section-label px-2 text-sidebar-muted">
-          Channels
-        </span>
-
         <div v-if="isLoading" class="type-caption text-center py-10 text-sidebar-muted">
           <div class="flex items-center justify-center gap-1">
             <span class="typing-dot" />

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -203,23 +203,21 @@ const DAY_DIVIDER_FORMATTER = new Intl.DateTimeFormat("en", {
   day: "numeric",
 });
 
-function startOfDay(date: Date): number {
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+function localDayOrdinal(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / (24 * 60 * 60 * 1000);
 }
 
-export function formatDayDivider(value: string) {
+export function formatDayDivider(value: string, now = new Date()) {
   const date = new Date(value);
-  const today = startOfDay(new Date());
-  const target = startOfDay(date);
-  const oneDay = 24 * 60 * 60 * 1000;
-  if (target === today) return "Today";
-  if (target === today - oneDay) return "Yesterday";
+  const dayOffset = localDayOrdinal(now) - localDayOrdinal(date);
+  if (dayOffset === 0) return "Today";
+  if (dayOffset === 1) return "Yesterday";
   // Older messages get a full weekday + month + day banner.
   return DAY_DIVIDER_FORMATTER.format(date);
 }
 
 export function isSameDay(a: string, b: string): boolean {
-  return startOfDay(new Date(a)) === startOfDay(new Date(b));
+  return localDayOrdinal(new Date(a)) === localDayOrdinal(new Date(b));
 }
 
 export function useMessaging(

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -1079,27 +1079,72 @@
   white-space: nowrap;
 }
 
-/* Sticky day banner above the first message of each calendar day. Mirrors
- * the existing "New messages" divider but in muted tone and with a blurred
- * backdrop so it stays legible while pinning at the top of the viewport. */
+.chat-current-day-marker {
+  flex-shrink: 0;
+  padding: var(--space-xs) var(--chat-content-inline) 0;
+  color: var(--muted-foreground);
+}
+
+.chat-current-day-marker__lane {
+  display: flex;
+  width: min(100%, var(--chat-message-lane));
+  margin-inline: auto;
+  align-items: center;
+  gap: var(--space-sm);
+  justify-content: center;
+  background: color-mix(in oklab, var(--background) 82%, transparent);
+  padding-block: 0 0.375rem;
+}
+
+.chat-current-day-marker__lane::before,
+.chat-current-day-marker__lane::after {
+  content: "";
+  height: 1px;
+  flex: 1;
+}
+
+.chat-current-day-marker__lane::before {
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in oklab, var(--border) 58%, transparent) 18%,
+    color-mix(in oklab, var(--border) 58%, transparent) 100%
+  );
+}
+
+.chat-current-day-marker__lane::after {
+  background: linear-gradient(
+    to left,
+    transparent,
+    color-mix(in oklab, var(--border) 58%, transparent) 18%,
+    color-mix(in oklab, var(--border) 58%, transparent) 100%
+  );
+}
+
+.chat-current-day-marker__label {
+  border: 1px solid color-mix(in oklab, var(--border) 76%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--background) 76%, transparent);
+  box-shadow: 0 1px 2px color-mix(in oklab, var(--foreground) 8%, transparent);
+  padding: 0.25rem 0.625rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.6875rem;
+  line-height: 1;
+}
+
 .chat-day-divider {
-  position: sticky;
-  top: 0;
-  z-index: 1;
   display: flex;
   align-items: center;
   gap: var(--space-sm);
-  padding-block: var(--space-xs);
+  padding-block: var(--space-md) var(--space-sm);
   color: var(--muted-foreground);
-  background: color-mix(in oklab, var(--background) 80%, transparent);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
 }
 
 .chat-day-divider__rule {
   flex: 1;
   height: 1px;
-  background: color-mix(in oklab, var(--border) 70%, transparent);
+  background: color-mix(in oklab, var(--border) 55%, transparent);
 }
 
 .chat-day-divider__label {

--- a/chat/tests/day-divider.test.ts
+++ b/chat/tests/day-divider.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { formatDayDivider, isSameDay } from "../src/composables/useMessaging";
+
+function localIso(
+  year: number,
+  monthIndex: number,
+  day: number,
+  hour = 12,
+  minute = 0,
+): string {
+  return new Date(year, monthIndex, day, hour, minute).toISOString();
+}
+
+describe("day divider labels", () => {
+  test("labels today and yesterday by local calendar day", () => {
+    const now = new Date(2026, 3, 27, 12);
+
+    expect(formatDayDivider(localIso(2026, 3, 27, 0, 5), now)).toBe("Today");
+    expect(formatDayDivider(localIso(2026, 3, 26, 23, 55), now)).toBe("Yesterday");
+  });
+
+  test("falls back to a dated divider for older messages", () => {
+    const now = new Date(2026, 3, 27, 12);
+
+    expect(formatDayDivider(localIso(2026, 3, 25), now)).toBe("Sat, Apr 25");
+  });
+
+  test("compares days by local calendar date", () => {
+    expect(isSameDay(localIso(2026, 3, 27, 0, 5), localIso(2026, 3, 27, 23, 55))).toBe(true);
+    expect(isSameDay(localIso(2026, 3, 26, 23, 55), localIso(2026, 3, 27, 0, 5))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Plan

- Inspect the chat UI code that renders Today/Yesterday date markers and the Channels sidebar header.
- Fix day-divider labels so Today and Yesterday are based on local calendar days rather than fixed millisecond offsets.
- Replace overlapping sticky in-list date separators with one reserved current-day marker aligned to the message lane, with faded line rules and translucent styling.
- Keep regular date separators in the message flow so they do not stack over messages.
- Remove the duplicate "Channels" label in the channel sidebar.
- Run focused and full chat checks.

## XEP review

This is a local chat UI rendering fix. The existing ./xeps checkout was reviewed for applicability; no XMPP wire shape or advertised XEP behavior is changed.

## Verification

- `bun test tests/day-divider.test.ts`
- `bun run lint`
- `bun test`
- `bun run build`
- `git diff --check`