### PR TITLE
feat(server): #229 PR3 — phase-2 handlers (rich-target validation, archive)

### DIFF
--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -1,0 +1,330 @@
+//! XEP-0313: Message Archive Management — direct (1:1) archival.
+//!
+//! Locality-aware:
+//!
+//! - **Sender pass** (`Locality::Sender` / `Locality::Both`): emit
+//!   [`OutboundEvent::ArchiveDirect`] keyed under the sender's bare
+//!   JID — the sender's own MAM archive captures their outgoing copy.
+//! - **Recipient pass** (`Locality::Recipient` / `Locality::Both`):
+//!   emit [`OutboundEvent::ArchiveDirect`] keyed under the recipient's
+//!   bare JID — the recipient's MAM archive captures the incoming copy.
+//!   This is what gives a local-to-local message *two* archive entries
+//!   (sender-side + recipient-side), each with its own XEP-0359
+//!   stanza-id `by=` attribution.
+//! - **Groupchat**: skipped — the room handler chain (PR5) owns the
+//!   single room-side archive write per XEP-0313 §5.1.3.
+//! - **Error / Headline / non-Chat-or-Normal**: skipped per XEP-0313
+//!   §5.1.3 archive-eligibility rules and XEP-0334 hint precedence.
+//!
+//! XEP-0313 §5.1.3 archive-eligibility rules implemented here:
+//!
+//! - Body-less and subject-only messages are not archived (heuristic:
+//!   require a non-empty body or a payload that constitutes archivable
+//!   content like a XEP-0424 retraction or XEP-0308 correction).
+//! - XEP-0334 `<no-store>` / `<no-permanent-store>` hints suppress
+//!   archive (with `<store>` overriding back on per §3 of that XEP).
+//!
+//! The handler does not perform the archive write — it emits the
+//! typed event and the interpreter persists. Multiple `ArchiveDirect`
+//! events from a single dispatch (sender-side and recipient-side
+//! when locality is `Both`) flow through the same interpreter arm.
+
+use crate::protocol::event::OutboundEvent;
+use crate::protocol::message_context::MessageContext;
+use crate::protocol::traits::{HandlerOutcome, MessageHandler};
+use crate::xep::xep0334::HintCarrier;
+use jid::BareJid;
+use xmpp_parsers::message::{Body, Message, MessageType};
+
+/// XEP-0313 archive handler for the user-side message pipeline.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ArchiveHandler;
+
+impl MessageHandler for ArchiveHandler {
+    fn name(&self) -> &'static str {
+        "xep-0313-archive"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &MessageContext<'_>) -> HandlerOutcome {
+        if !is_archivable(message) {
+            return HandlerOutcome::Continue(Vec::new());
+        }
+
+        let mut events: Vec<OutboundEvent> = Vec::new();
+        let local_bare = ctx.full_jid.to_bare();
+        let from_bare = message.from.as_ref().map(|j| j.to_bare());
+        let to_bare = message.to.as_ref().map(|j| j.to_bare());
+
+        // Sender-side write — keyed under the local user's archive when
+        // the local user is the sender. Use the message's `from`/`to`
+        // for the canonical (from, to) tuple; fall back to `local_bare`
+        // if the message lacks an explicit address.
+        if ctx.locality.is_sender() {
+            if let Some(to) = to_bare.clone() {
+                events.push(OutboundEvent::ArchiveDirect {
+                    from: from_bare.clone().unwrap_or_else(|| local_bare.clone()),
+                    to,
+                    message: Box::new(message.clone()),
+                });
+            }
+        }
+
+        // Recipient-side write — keyed under the local user's archive
+        // when the local user is the recipient. Distinct entry from
+        // the sender-side write (different `by=` archive in XEP-0359
+        // terms).
+        if ctx.locality.is_recipient() && !is_self_loop(&from_bare, &to_bare) {
+            if let Some(from) = from_bare.clone() {
+                events.push(OutboundEvent::ArchiveDirect {
+                    from,
+                    to: to_bare.unwrap_or_else(|| local_bare.clone()),
+                    message: Box::new(message.clone()),
+                });
+            }
+        }
+
+        HandlerOutcome::Continue(events)
+    }
+}
+
+/// True when `from.bare() == to.bare()` AND both are present.
+///
+/// Used to suppress duplicate sender+recipient archive writes for true
+/// self-loops — `Locality::Both` would otherwise stamp the same entry
+/// twice. Cross-resource self-messages (alice/web → alice/phone)
+/// produce `Locality::Recipient` on alice/phone (per the asymmetric
+/// `Locality::derive` in PR1) and `Locality::Sender` on alice/web, so
+/// they correctly produce one entry per locus and don't trip this
+/// guard.
+fn is_self_loop(from: &Option<BareJid>, to: &Option<BareJid>) -> bool {
+    matches!((from, to), (Some(f), Some(t)) if f == t)
+}
+
+/// XEP-0313 §5.1.3 archive-eligibility heuristic.
+///
+/// Returns `true` when the message should be archived.
+pub fn is_archivable(message: &Message) -> bool {
+    // Skip non-archivable types.
+    match message.type_ {
+        MessageType::Chat | MessageType::Normal => {}
+        // Groupchat is the room chain's job; error / headline are
+        // never archived.
+        MessageType::Groupchat | MessageType::Error | MessageType::Headline => return false,
+    }
+    // XEP-0334 hint precedence (`<store>` overrides `<no-store>`).
+    if message.should_skip_archive() {
+        return false;
+    }
+    // Skip subject-only messages — XEP-0313 §5.1.3 lists these as
+    // non-archivable since they're typically MUC subject changes that
+    // the room would handle.
+    if !message.subjects.is_empty() && !has_substantive_body(message) {
+        return false;
+    }
+    // Require either a non-empty body or a substantive payload (e.g.
+    // a XEP-0424 retraction, XEP-0308 correction). Pure presence-like
+    // messages with no body and no archivable payload are dropped.
+    has_substantive_body(message) || has_archivable_payload(message)
+}
+
+fn has_substantive_body(message: &Message) -> bool {
+    message
+        .bodies
+        .values()
+        .any(|Body(text)| !text.trim().is_empty())
+}
+
+fn has_archivable_payload(message: &Message) -> bool {
+    use crate::xep::{xep0308, xep0424};
+    xep0308::is_correction_message(message)
+        || xep0424::is_retraction_message(message)
+        || xep0424::is_tombstone_message(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::message_context::MessageContextEnv;
+    use crate::protocol::session_state::{Blocklist, CarbonsState, MucOccupancy};
+    use crate::xep::xep0334::Hint;
+    use jid::FullJid;
+    use minidom::Element;
+    use xmpp_parsers::message::{Body, Message, MessageType, Subject};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn chat_with_body(from: &str, to: &str, body: &str) -> Message {
+        let mut m = Message::new(Some(to.parse().expect("jid")));
+        m.from = Some(from.parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+        m.bodies.insert(String::new(), Body(body.to_string()));
+        m
+    }
+
+    fn run(local: &FullJid, msg: &mut Message) -> HandlerOutcome {
+        let bl = Blocklist::empty();
+        let occ = MucOccupancy::empty();
+        let gen = FixedIdGenerator("test".to_string());
+        let env = MessageContextEnv {
+            domain: "example.com",
+            full_jid: local,
+            blocklist: &bl,
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: &occ,
+            id_gen: &gen,
+        };
+        let ctx = MessageContext::derive(env, msg);
+        ArchiveHandler.handle(msg, &ctx)
+    }
+
+    fn extract_archive_events(outcome: &HandlerOutcome) -> Vec<(BareJid, BareJid)> {
+        match outcome {
+            HandlerOutcome::Continue(events) => events
+                .iter()
+                .filter_map(|e| match e {
+                    OutboundEvent::ArchiveDirect { from, to, .. } => {
+                        Some((from.clone(), to.clone()))
+                    }
+                    _ => None,
+                })
+                .collect(),
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Locality + (from, to) shape
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn xep_0313_sender_pass_emits_one_archive_direct_keyed_for_local_user() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_events(&outcome);
+        assert_eq!(archives.len(), 1);
+        assert_eq!(archives[0].0, bare("alice@example.com"));
+        assert_eq!(archives[0].1, bare("bob@example.com"));
+    }
+
+    #[test]
+    fn xep_0313_recipient_pass_emits_one_archive_direct_for_recipient_archive() {
+        let local = full("bob@example.com/desk");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_events(&outcome);
+        assert_eq!(archives.len(), 1);
+        assert_eq!(archives[0].0, bare("alice@example.com"));
+        assert_eq!(archives[0].1, bare("bob@example.com"));
+    }
+
+    #[test]
+    fn xep_0313_neither_locality_emits_nothing() {
+        let local = full("eve@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_archive_events(&outcome).len(), 0);
+    }
+
+    #[test]
+    fn xep_0313_self_loop_to_same_resource_emits_single_archive_not_double() {
+        // alice/web -> alice/web. Locality::Both; sender-side fires;
+        // recipient-side suppressed by the self-loop guard so we get
+        // one archive entry, not two.
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "alice@example.com/web", "echo");
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_events(&outcome);
+        assert_eq!(archives.len(), 1);
+    }
+
+    // -----------------------------------------------------------------
+    // XEP-0313 §5.1.3 + XEP-0334 hint precedence
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn xep_0313_groupchat_is_skipped_user_side() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "room@conf.example.com", "shouted");
+        msg.type_ = MessageType::Groupchat;
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0313_error_messages_are_not_archived() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "boom");
+        msg.type_ = MessageType::Error;
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0313_body_less_message_is_not_archived() {
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Chat;
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0313_subject_only_message_is_not_archived() {
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Chat;
+        msg.subjects
+            .insert(String::new(), Subject("New Topic".to_string()));
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0334_no_store_hint_suppresses_archive() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "ephemeral");
+        msg.payloads.push(
+            Element::builder(Hint::NoStore.element_name(), crate::xep::xep0334::NS_HINTS).build(),
+        );
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0334_store_hint_overrides_no_store() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "force store");
+        msg.payloads.push(
+            Element::builder(Hint::NoStore.element_name(), crate::xep::xep0334::NS_HINTS).build(),
+        );
+        msg.payloads.push(
+            Element::builder(Hint::Store.element_name(), crate::xep::xep0334::NS_HINTS).build(),
+        );
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_archive_events(&outcome).len(), 1);
+    }
+
+    #[test]
+    fn xep_0313_retraction_without_body_is_archivable_payload() {
+        // A XEP-0424 retraction may have no body but still warrants
+        // archival — clients query MAM to see the tombstone.
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Chat;
+        msg.payloads
+            .push(crate::xep::xep0424::build_retract_element("stanza-X"));
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_archive_events(&outcome).len(), 1);
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -31,9 +31,9 @@
 
 use crate::protocol::event::OutboundEvent;
 use crate::protocol::message_context::MessageContext;
+use crate::protocol::session_state::Locality;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
 use crate::xep::xep0334::HintCarrier;
-use jid::BareJid;
 use xmpp_parsers::message::{Body, Message, MessageType};
 
 /// XEP-0313 archive handler for the user-side message pipeline.
@@ -58,7 +58,10 @@ impl MessageHandler for ArchiveHandler {
         // Sender-side write — keyed under the local user's archive when
         // the local user is the sender. Use the message's `from`/`to`
         // for the canonical (from, to) tuple; fall back to `local_bare`
-        // if the message lacks an explicit address.
+        // if the message lacks an explicit address. Also covers the
+        // `Locality::Both` true self-loop (alice/web -> alice/web), in
+        // which case the recipient-side branch below is skipped to
+        // avoid double-stamping the same archive.
         if ctx.locality.is_sender() {
             if let Some(to) = to_bare.clone() {
                 events.push(OutboundEvent::ArchiveDirect {
@@ -69,12 +72,15 @@ impl MessageHandler for ArchiveHandler {
             }
         }
 
-        // Recipient-side write — keyed under the local user's archive
-        // when the local user is the recipient. Distinct entry from
-        // the sender-side write (different `by=` archive in XEP-0359
-        // terms).
-        if ctx.locality.is_recipient() && !is_self_loop(&from_bare, &to_bare) {
-            if let Some(from) = from_bare.clone() {
+        // Recipient-side write — fires on `Locality::Recipient` (which
+        // includes cross-resource self-chat like alice/web -> alice/phone
+        // on alice/phone's connection, where alice's archive captures the
+        // incoming copy distinct from the sender-side outgoing copy).
+        // Suppressed for `Locality::Both` because the sender branch
+        // above already wrote the single event for that degenerate
+        // self-loop case.
+        if matches!(ctx.locality, Locality::Recipient) {
+            if let Some(from) = from_bare {
                 events.push(OutboundEvent::ArchiveDirect {
                     from,
                     to: to_bare.unwrap_or_else(|| local_bare.clone()),
@@ -85,19 +91,6 @@ impl MessageHandler for ArchiveHandler {
 
         HandlerOutcome::Continue(events)
     }
-}
-
-/// True when `from.bare() == to.bare()` AND both are present.
-///
-/// Used to suppress duplicate sender+recipient archive writes for true
-/// self-loops — `Locality::Both` would otherwise stamp the same entry
-/// twice. Cross-resource self-messages (alice/web → alice/phone)
-/// produce `Locality::Recipient` on alice/phone (per the asymmetric
-/// `Locality::derive` in PR1) and `Locality::Sender` on alice/web, so
-/// they correctly produce one entry per locus and don't trip this
-/// guard.
-fn is_self_loop(from: &Option<BareJid>, to: &Option<BareJid>) -> bool {
-    matches!((from, to), (Some(f), Some(t)) if f == t)
 }
 
 /// XEP-0313 §5.1.3 archive-eligibility heuristic.
@@ -115,16 +108,17 @@ pub fn is_archivable(message: &Message) -> bool {
     if message.should_skip_archive() {
         return false;
     }
+    let has_body = has_substantive_body(message);
     // Skip subject-only messages — XEP-0313 §5.1.3 lists these as
     // non-archivable since they're typically MUC subject changes that
     // the room would handle.
-    if !message.subjects.is_empty() && !has_substantive_body(message) {
+    if !message.subjects.is_empty() && !has_body {
         return false;
     }
     // Require either a non-empty body or a substantive payload (e.g.
     // a XEP-0424 retraction, XEP-0308 correction). Pure presence-like
     // messages with no body and no archivable payload are dropped.
-    has_substantive_body(message) || has_archivable_payload(message)
+    has_body || has_archivable_payload(message)
 }
 
 fn has_substantive_body(message: &Message) -> bool {
@@ -148,7 +142,7 @@ mod tests {
     use crate::protocol::message_context::MessageContextEnv;
     use crate::protocol::session_state::{Blocklist, CarbonsState, MucOccupancy};
     use crate::xep::xep0334::Hint;
-    use jid::FullJid;
+    use jid::{BareJid, FullJid};
     use minidom::Element;
     use xmpp_parsers::message::{Body, Message, MessageType, Subject};
 
@@ -234,15 +228,37 @@ mod tests {
     }
 
     #[test]
-    fn xep_0313_self_loop_to_same_resource_emits_single_archive_not_double() {
+    fn xep_0313_true_self_loop_same_resource_emits_single_archive_not_double() {
         // alice/web -> alice/web. Locality::Both; sender-side fires;
-        // recipient-side suppressed by the self-loop guard so we get
-        // one archive entry, not two.
+        // recipient-side branch skipped because Both already covered
+        // by sender-side. One archive entry, not two.
         let local = full("alice@example.com/web");
         let mut msg = chat_with_body("alice@example.com/web", "alice@example.com/web", "echo");
         let outcome = run(&local, &mut msg);
         let archives = extract_archive_events(&outcome);
         assert_eq!(archives.len(), 1);
+    }
+
+    #[test]
+    fn xep_0313_cross_resource_self_chat_emits_recipient_side_archive() {
+        // alice/web -> alice/phone, observed from alice/phone's
+        // connection. Locality::Recipient (the asymmetric derive in
+        // PR1 ensures cross-resource self-chat is NOT classified as
+        // Both). The recipient-side write must fire so alice's
+        // archive captures the incoming copy on alice/phone — earlier
+        // versions of this handler suppressed the write whenever the
+        // bare JIDs matched, losing the entry.
+        let local = full("alice@example.com/phone");
+        let mut msg = chat_with_body(
+            "alice@example.com/web",
+            "alice@example.com/phone",
+            "ping yourself",
+        );
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_events(&outcome);
+        assert_eq!(archives.len(), 1);
+        assert_eq!(archives[0].0, bare("alice@example.com"));
+        assert_eq!(archives[0].1, bare("alice@example.com"));
     }
 
     // -----------------------------------------------------------------

--- a/server/crates/waddle-xmpp/src/protocol/handlers/errors.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/errors.rs
@@ -67,6 +67,40 @@ pub fn send_message_error(reply: Message) -> super::super::event::OutboundEvent 
     super::super::event::OutboundEvent::SendStanza(Box::new(Stanza::Message(reply)))
 }
 
+/// Build an `<item-not-found type='cancel'/>` reply for a rich-target
+/// reference (XEP-0308 / 0424 / 0461) whose target message is not in
+/// the archive.
+pub fn item_not_found_reply(incoming: &Message, text: &str) -> Message {
+    let error = StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ItemNotFound,
+        "en",
+        text,
+    );
+    message_error_reply(incoming, error)
+}
+
+/// Build a `<not-acceptable type='cancel'/>` reply for a rich-target
+/// where the requesting user is not the original author (XEP-0308 §7.1
+/// correction; XEP-0424 §3.4 retraction).
+pub fn not_acceptable_reply(incoming: &Message, text: &str) -> Message {
+    let error = StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::NotAcceptable,
+        "en",
+        text,
+    );
+    message_error_reply(incoming, error)
+}
+
+/// Build a `<bad-request type='modify'/>` reply for a malformed or
+/// inapplicable rich-target request (e.g. retraction of an
+/// already-tombstoned message — XEP-0424 §3.5).
+pub fn bad_request_reply(incoming: &Message, text: &str) -> Message {
+    let error = StanzaError::new(ErrorType::Modify, DefinedCondition::BadRequest, "en", text);
+    message_error_reply(incoming, error)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
@@ -24,12 +24,14 @@
 //! - XEP-0045 muc#owner (needs MUC registry)
 //! - XEP-0166 Jingle (needs SfuServiceActor)
 
+pub mod archive;
 pub mod blocking_filter;
 pub mod canonicalize;
 pub mod carbons;
 pub mod enrichment_dispatch;
 pub mod errors;
 pub mod ping;
+pub mod rich_target_validation;
 pub mod session;
 pub mod time;
 pub mod version;

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -1,0 +1,554 @@
+//! Rich-target validation for XEP-0308 (correction), XEP-0424
+//! (retraction), XEP-0425 (moderated retraction), and XEP-0461 (reply).
+//!
+//! These XEPs all reference a *previously sent* message: a correction
+//! `<replace id='X'/>` claims to update message X, a retraction
+//! `<retract id='X'/>` claims to remove message X, and a reply
+//! `<reply id='X' to='Y'/>` claims to thread under message X.
+//!
+//! The handler runs on the **sender pass** only — once a rich-target
+//! request reaches the recipient pipeline, validation has already
+//! passed sender-side, and re-running it would either spam the same
+//! lookup or, worse, produce a divergent decision against a recipient
+//! archive that doesn't contain the same message.
+//!
+//! Two-phase callback:
+//!
+//! 1. [`MessageHandler::handle`] inspects the message for rich-target
+//!    payloads. If none are present, the handler returns
+//!    `Continue(no events)`. If one IS present, it emits a
+//!    [`OutboundEvent::LookupArchivedMessage`] carrying the typed
+//!    [`MessageRef`] and returns
+//!    `HandlerOutcome::AwaitCallback(events)`.
+//! 2. [`RichTargetValidationHandler::handle_completion`] is called by
+//!    the state machine when the matching
+//!    `InboundEvent::ArchivedMessageLoaded` arrives. It applies the
+//!    XEP-specific validation rules and either returns
+//!    `Continue(events)` (resume the pipeline) or `Halt(events)` with
+//!    a typed error reply.
+//!
+//! XEP-conformance test names use `xep_0308_*`, `xep_0424_*`, and
+//! `xep_0461_*` prefixes per the #229 Q9(b) convention so
+//! `cargo test xep_0424` returns every retraction-rule test.
+//!
+//! # Out of scope (PR3)
+//!
+//! - Per-XEP completion-event dispatch in the state machine
+//!   (`on_archived_message_loaded`) — wired in PR4 along with handler
+//!   registration. PR3 ships the handler shape and the completion
+//!   logic as a free function on the type so tests exercise both
+//!   halves end-to-end without going through the state machine.
+//! - XEP-0425 moderator-authorisation check (the moderator-side
+//!   variant of XEP-0424). The room handler chain in PR5 owns
+//!   moderator authorisation; the user-side handler here only enforces
+//!   author-equality on user-initiated retractions.
+
+use super::errors::{
+    bad_request_reply, item_not_found_reply, not_acceptable_reply, send_message_error,
+};
+use crate::protocol::event::{
+    ArchivedMessage, CallbackId, MessageRef, OriginIdValue, OutboundEvent, StanzaIdValue,
+};
+use crate::protocol::message_context::MessageContext;
+use crate::protocol::traits::{HandlerOutcome, MessageHandler};
+use crate::xep::{xep0308, xep0424, xep0461};
+use jid::BareJid;
+use xmpp_parsers::message::Message;
+
+/// Sentinel callback id used by handlers that emit
+/// `LookupArchivedMessage`. The state machine swaps the sentinel for a
+/// real allocation when registering the pending op (PR4 cutover).
+pub const RICH_TARGET_LOOKUP_CALLBACK_SENTINEL: CallbackId = CallbackId(0);
+
+/// Discriminator for which rich-target XEP a request belongs to.
+///
+/// Stored alongside the dispatched callback context so the completion
+/// handler knows which XEP rule set to apply when the lookup returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RichTargetKind {
+    /// XEP-0308 Last Message Correction.
+    Correction,
+    /// XEP-0424 Message Retraction (user-initiated).
+    Retraction,
+    /// XEP-0461 Message Replies.
+    Reply,
+}
+
+/// What the dispatch step detected on the inbound message.
+///
+/// Returned alongside the outbound events so the state machine can
+/// stash the kind in its pending-op map and route the eventual
+/// completion to the right rule set.
+#[derive(Debug, Clone)]
+pub struct DetectedRichTarget {
+    /// Which XEP rule set applies.
+    pub kind: RichTargetKind,
+    /// Typed reference into the archive.
+    pub reference: MessageRef,
+    /// The originating sender's bare JID — used by
+    /// [`RichTargetValidationHandler::handle_completion`] for the
+    /// author-equality check.
+    pub author: BareJid,
+}
+
+/// Pipeline handler that detects rich-target requests and emits the
+/// archive lookup needed to validate them.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RichTargetValidationHandler;
+
+impl MessageHandler for RichTargetValidationHandler {
+    fn name(&self) -> &'static str {
+        "xep-rich-target-validation"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &MessageContext<'_>) -> HandlerOutcome {
+        // Sender pass only.
+        if !ctx.locality.is_sender() {
+            return HandlerOutcome::Continue(Vec::new());
+        }
+        let Some(detected) = detect(message, ctx) else {
+            return HandlerOutcome::Continue(Vec::new());
+        };
+        HandlerOutcome::AwaitCallback(vec![OutboundEvent::LookupArchivedMessage {
+            id: RICH_TARGET_LOOKUP_CALLBACK_SENTINEL,
+            archive: detected.author.clone(),
+            reference: detected.reference,
+        }])
+    }
+}
+
+impl RichTargetValidationHandler {
+    /// Apply the XEP rule set for `kind` given the result of the
+    /// archive lookup.
+    ///
+    /// Returns `Continue` (resume pipeline) on success, `Halt` with a
+    /// typed error reply on every failure mode.
+    pub fn handle_completion(
+        kind: RichTargetKind,
+        original: &Message,
+        result: Option<&ArchivedMessage>,
+        author: &BareJid,
+    ) -> HandlerOutcome {
+        let Some(archived) = result else {
+            // XEP-0424 §3.4 / XEP-0461 §3.3: target not found.
+            let reply = item_not_found_reply(
+                original,
+                match kind {
+                    RichTargetKind::Correction => "Correction target message not found.",
+                    RichTargetKind::Retraction => "Retraction target message not found.",
+                    RichTargetKind::Reply => "Reply target message not found.",
+                },
+            );
+            return HandlerOutcome::Halt(vec![send_message_error(reply)]);
+        };
+
+        match kind {
+            RichTargetKind::Correction => validate_correction(original, archived, author),
+            RichTargetKind::Retraction => validate_retraction(original, archived, author),
+            // XEP-0461 §3.3: reply target only needs to exist.
+            RichTargetKind::Reply => HandlerOutcome::Continue(Vec::new()),
+        }
+    }
+}
+
+/// Inspect `message` for a rich-target payload and build the typed
+/// dispatch context for it. Public so handler tests and the future
+/// `on_archived_message_loaded` wiring can reuse the detection logic.
+pub fn detect(message: &Message, ctx: &MessageContext<'_>) -> Option<DetectedRichTarget> {
+    let author = ctx.full_jid.to_bare();
+
+    // XEP-0308 correction — references the original message's `id`
+    // attribute, which clients commonly correlate with the
+    // XEP-0359 origin-id.
+    if let Some(correction) = xep0308::extract_correction_from_message(message) {
+        return Some(DetectedRichTarget {
+            kind: RichTargetKind::Correction,
+            reference: MessageRef::OriginId {
+                sender: author.clone(),
+                origin_id: OriginIdValue::new(correction.replaces_id),
+            },
+            author,
+        });
+    }
+
+    // XEP-0424 retraction — references the target message by its
+    // XEP-0359 stanza-id stamped under the user's archive.
+    if let Some(xep0424::RetractionKind::Request(retraction)) =
+        xep0424::extract_retraction_from_message(message)
+    {
+        return Some(DetectedRichTarget {
+            kind: RichTargetKind::Retraction,
+            reference: MessageRef::StanzaId {
+                by: author.clone(),
+                id: StanzaIdValue::new(retraction.retracts_id),
+            },
+            author,
+        });
+    }
+
+    // XEP-0461 reply — references the target message by stanza-id.
+    if let Some(reply) = xep0461::parse_reply_from_message(message) {
+        return Some(DetectedRichTarget {
+            kind: RichTargetKind::Reply,
+            reference: MessageRef::StanzaId {
+                by: author.clone(),
+                id: StanzaIdValue::new(reply.id),
+            },
+            author,
+        });
+    }
+
+    None
+}
+
+fn validate_correction(
+    original: &Message,
+    archived: &ArchivedMessage,
+    author: &BareJid,
+) -> HandlerOutcome {
+    if !same_author(archived, author) {
+        let reply =
+            not_acceptable_reply(original, "Only the original sender may correct a message.");
+        return HandlerOutcome::Halt(vec![send_message_error(reply)]);
+    }
+    HandlerOutcome::Continue(Vec::new())
+}
+
+fn validate_retraction(
+    original: &Message,
+    archived: &ArchivedMessage,
+    author: &BareJid,
+) -> HandlerOutcome {
+    if !same_author(archived, author) {
+        let reply =
+            not_acceptable_reply(original, "Only the original sender may retract a message.");
+        return HandlerOutcome::Halt(vec![send_message_error(reply)]);
+    }
+    if archived.tombstoned {
+        // XEP-0424 §3.5 — retracting an already-tombstoned message is a
+        // no-op at best; reject with bad-request to surface the bug to
+        // the client.
+        let reply = bad_request_reply(original, "Target message has already been retracted.");
+        return HandlerOutcome::Halt(vec![send_message_error(reply)]);
+    }
+    HandlerOutcome::Continue(Vec::new())
+}
+
+fn same_author(archived: &ArchivedMessage, author: &BareJid) -> bool {
+    archived
+        .message
+        .from
+        .as_ref()
+        .map(|from| from.to_bare() == *author)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::event::StanzaIdRef;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::message_context::MessageContextEnv;
+    use crate::protocol::session_state::{Blocklist, CarbonsState, MucOccupancy};
+    use crate::xep::xep0308::build_replace_element;
+    use crate::xep::xep0424::build_retract_element;
+    use crate::xep::xep0461::{build_reply_element, ReplyReference};
+    use crate::Stanza;
+    use jid::FullJid;
+    use xmpp_parsers::message::{Body, Message, MessageType};
+    use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn chat_with_body(from: &str, to: &str, body: &str) -> Message {
+        let mut m = Message::new(Some(to.parse().expect("jid")));
+        m.from = Some(from.parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+        m.bodies.insert(String::new(), Body(body.to_string()));
+        m
+    }
+
+    fn ctx_for<'a>(
+        local: &'a FullJid,
+        bl: &'a Blocklist,
+        occ: &'a MucOccupancy,
+        gen: &'a FixedIdGenerator,
+        msg: &Message,
+    ) -> MessageContext<'a> {
+        let env = MessageContextEnv {
+            domain: "example.com",
+            full_jid: local,
+            blocklist: bl,
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: occ,
+            id_gen: gen,
+        };
+        MessageContext::derive(env, msg)
+    }
+
+    fn run(local: &FullJid, msg: &mut Message) -> HandlerOutcome {
+        let bl = Blocklist::empty();
+        let occ = MucOccupancy::empty();
+        let gen = FixedIdGenerator("test".to_string());
+        let ctx = ctx_for(local, &bl, &occ, &gen, msg);
+        RichTargetValidationHandler.handle(msg, &ctx)
+    }
+
+    fn archived_message_from(from: &str, body: &str) -> ArchivedMessage {
+        let mut m = Message::new(Some("bob@example.com".parse().expect("jid")));
+        m.from = Some(from.parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+        m.bodies.insert(String::new(), Body(body.to_string()));
+        ArchivedMessage {
+            stanza_id: StanzaIdRef {
+                by: bare("alice@example.com"),
+                id: StanzaIdValue::new("archive-A1"),
+            },
+            message: Box::new(m),
+            tombstoned: false,
+        }
+    }
+
+    fn extract_lookup_event(outcome: &HandlerOutcome) -> (&CallbackId, &BareJid, &MessageRef) {
+        let events = match outcome {
+            HandlerOutcome::AwaitCallback(events) => events,
+            other => panic!("expected AwaitCallback, got {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            OutboundEvent::LookupArchivedMessage {
+                id,
+                archive,
+                reference,
+            } => (id, archive, reference),
+            other => panic!("expected LookupArchivedMessage, got {other:?}"),
+        }
+    }
+
+    fn extract_error_payload(outcome: &HandlerOutcome) -> StanzaError {
+        let events = match outcome {
+            HandlerOutcome::Halt(events) => events,
+            other => panic!("expected Halt, got {other:?}"),
+        };
+        let stanza = match &events[0] {
+            OutboundEvent::SendStanza(s) => s,
+            other => panic!("expected SendStanza, got {other:?}"),
+        };
+        let msg = match stanza.as_ref() {
+            Stanza::Message(m) => m,
+            other => panic!("expected Message, got {other:?}"),
+        };
+        let elem = msg
+            .payloads
+            .iter()
+            .find(|p| p.name() == "error")
+            .expect("error payload");
+        StanzaError::try_from(elem.clone()).expect("typed parse")
+    }
+
+    // -----------------------------------------------------------------
+    // Detection — produces the typed lookup event with the right kind
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn xep_0308_correction_emits_lookup_with_origin_id() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "fixed text");
+        msg.payloads.push(build_replace_element("orig-msg-1"));
+
+        let outcome = run(&local, &mut msg);
+        let (_id, archive, reference) = extract_lookup_event(&outcome);
+        assert_eq!(*archive, bare("alice@example.com"));
+        match reference {
+            MessageRef::OriginId { sender, origin_id } => {
+                assert_eq!(*sender, bare("alice@example.com"));
+                assert_eq!(origin_id.as_str(), "orig-msg-1");
+            }
+            other => panic!("expected OriginId ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xep_0424_retraction_emits_lookup_with_stanza_id() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body(
+            "alice@example.com/web",
+            "bob@example.com",
+            "I take that back",
+        );
+        msg.payloads.push(build_retract_element("stanza-X"));
+
+        let outcome = run(&local, &mut msg);
+        let (_id, _archive, reference) = extract_lookup_event(&outcome);
+        match reference {
+            MessageRef::StanzaId { by, id } => {
+                assert_eq!(*by, bare("alice@example.com"));
+                assert_eq!(id.as_str(), "stanza-X");
+            }
+            other => panic!("expected StanzaId ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xep_0461_reply_emits_lookup_with_stanza_id() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "agreed");
+        msg.payloads.push(build_reply_element(
+            &ReplyReference::new("stanza-Y").with_to("bob@example.com"),
+        ));
+
+        let outcome = run(&local, &mut msg);
+        let (_id, _archive, reference) = extract_lookup_event(&outcome);
+        match reference {
+            MessageRef::StanzaId { by: _, id } => {
+                assert_eq!(id.as_str(), "stanza-Y");
+            }
+            other => panic!("expected StanzaId ref, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_without_rich_target_continues() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn recipient_pass_skips_rich_target_validation() {
+        let local = full("bob@example.com/desk");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "fixed text");
+        msg.payloads.push(build_replace_element("orig-msg-1"));
+        let outcome = run(&local, &mut msg);
+        // Validation is the sender's job — recipient pass does nothing.
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    // -----------------------------------------------------------------
+    // Completion — XEP rule branches
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn xep_0424_retraction_target_not_found_emits_item_not_found() {
+        let original = chat_with_body(
+            "alice@example.com/web",
+            "bob@example.com",
+            "I take that back",
+        );
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Retraction,
+            &original,
+            None,
+            &bare("alice@example.com"),
+        );
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.type_, ErrorType::Cancel);
+        assert_eq!(parsed.defined_condition, DefinedCondition::ItemNotFound);
+    }
+
+    #[test]
+    fn xep_0461_reply_target_not_found_emits_item_not_found() {
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "agreed");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Reply,
+            &original,
+            None,
+            &bare("alice@example.com"),
+        );
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.defined_condition, DefinedCondition::ItemNotFound);
+    }
+
+    #[test]
+    fn xep_0308_correction_by_non_author_emits_not_acceptable() {
+        // The corrector is alice but the archived message was sent by
+        // mallory — XEP-0308 §7.1 forbids cross-author correction.
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "edit");
+        let archived = archived_message_from("mallory@example.com/web", "original");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Correction,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.defined_condition, DefinedCondition::NotAcceptable);
+    }
+
+    #[test]
+    fn xep_0424_retraction_by_non_author_emits_not_acceptable() {
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "retract");
+        let archived = archived_message_from("mallory@example.com/web", "victim");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Retraction,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.defined_condition, DefinedCondition::NotAcceptable);
+    }
+
+    #[test]
+    fn xep_0424_retraction_of_already_tombstoned_message_emits_bad_request() {
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "retract");
+        let mut archived = archived_message_from("alice@example.com/web", "original");
+        archived.tombstoned = true;
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Retraction,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.defined_condition, DefinedCondition::BadRequest);
+        assert_eq!(parsed.type_, ErrorType::Modify);
+    }
+
+    #[test]
+    fn xep_0308_correction_by_same_author_continues() {
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "edit");
+        let archived = archived_message_from("alice@example.com/web", "original");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Correction,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0424_retraction_by_same_author_continues() {
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "retract");
+        let archived = archived_message_from("alice@example.com/web", "original");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Retraction,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn xep_0461_reply_existence_is_sufficient_regardless_of_author() {
+        // §3.3 — a reply doesn't impose author-equality.
+        let original = chat_with_body("alice@example.com/web", "bob@example.com", "agreed");
+        let archived = archived_message_from("mallory@example.com/web", "thread root");
+        let outcome = RichTargetValidationHandler::handle_completion(
+            RichTargetKind::Reply,
+            &original,
+            Some(&archived),
+            &bare("alice@example.com"),
+        );
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -53,7 +53,7 @@ use crate::protocol::message_context::MessageContext;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
 use crate::xep::{xep0308, xep0424, xep0461};
 use jid::BareJid;
-use xmpp_parsers::message::Message;
+use xmpp_parsers::message::{Message, MessageType};
 
 /// Sentinel callback id used by handlers that emit
 /// `LookupArchivedMessage`. The state machine swaps the sentinel for a
@@ -106,6 +106,16 @@ impl MessageHandler for RichTargetValidationHandler {
         if !ctx.locality.is_sender() {
             return HandlerOutcome::Continue(Vec::new());
         }
+        // Groupchat rich-targets reference messages in the **room's**
+        // archive, not the user's. Validating them against
+        // `ctx.full_jid.to_bare()` would systematically miss every
+        // legitimate MUC retraction / correction / reply and respond
+        // with `<item-not-found/>`. The room handler chain in PR5
+        // owns groupchat rich-target validation against the room's
+        // archive (XEP-0313 §5.1.3).
+        if matches!(message.type_, MessageType::Groupchat) {
+            return HandlerOutcome::Continue(Vec::new());
+        }
         let Some(detected) = detect(message, ctx) else {
             return HandlerOutcome::Continue(Vec::new());
         };
@@ -130,15 +140,21 @@ impl RichTargetValidationHandler {
         author: &BareJid,
     ) -> HandlerOutcome {
         let Some(archived) = result else {
-            // XEP-0424 §3.4 / XEP-0461 §3.3: target not found.
-            let reply = item_not_found_reply(
-                original,
-                match kind {
-                    RichTargetKind::Correction => "Correction target message not found.",
-                    RichTargetKind::Retraction => "Retraction target message not found.",
-                    RichTargetKind::Reply => "Reply target message not found.",
-                },
-            );
+            let reply = match kind {
+                // XEP-0308: a correction must reference an existing
+                // message; without one, the request is invalid.
+                RichTargetKind::Correction => {
+                    item_not_found_reply(original, "Correction target message not found.")
+                }
+                // XEP-0424 §3.4: target not found.
+                RichTargetKind::Retraction => {
+                    item_not_found_reply(original, "Retraction target message not found.")
+                }
+                // XEP-0461 §3.3: target not found.
+                RichTargetKind::Reply => {
+                    item_not_found_reply(original, "Reply target message not found.")
+                }
+            };
             return HandlerOutcome::Halt(vec![send_message_error(reply)]);
         };
 
@@ -428,6 +444,25 @@ mod tests {
         msg.payloads.push(build_replace_element("orig-msg-1"));
         let outcome = run(&local, &mut msg);
         // Validation is the sender's job — recipient pass does nothing.
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
+    }
+
+    #[test]
+    fn groupchat_rich_target_is_skipped_user_side() {
+        // Groupchat rich-targets reference messages in the room's
+        // archive, not the user's. The user-side handler must not
+        // validate against ctx.full_jid.to_bare() — that would miss
+        // every legitimate MUC retraction. The room chain (PR5) owns
+        // this validation against the room's archive.
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body(
+            "alice@example.com/web",
+            "room@conf.example.com",
+            "I take that back",
+        );
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(build_retract_element("stanza-X"));
+        let outcome = run(&local, &mut msg);
         assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
     }
 


### PR DESCRIPTION
## PR3 of 6 — Phase-2 message handlers (#229), stacked on #256 (PR2)

**Base is `main` for compatibility with GitHub's diff machinery.** PR2 (#256) must merge first; until then the PR3 diff includes PR2's commits.

This PR adds two more sans-I/O `MessageHandler` impls plus their per-XEP test suites. Like PR2, the handlers are NOT yet registered in the live dispatcher — registration + cutover from `message.rs` lands in PR4 in one focused atomic switch. Existing integration tests pass unchanged.

## What this PR adds

### `RichTargetValidationHandler` — XEP-0308 / 0424 / 0425 / 0461

`protocol/handlers/rich_target_validation.rs`. Sender-pass only.

- Detects `<replace>` (XEP-0308 correction), `<retract>` (XEP-0424 retraction), `<reply>` (XEP-0461 reply) on the inbound message.
- Emits `LookupArchivedMessage { id, archive, reference }` paired with `HandlerOutcome::AwaitCallback` so the interpreter can resolve the typed `MessageRef` against MAM.
- The companion `handle_completion(...)` runs when `InboundEvent::ArchivedMessageLoaded` arrives:
  - **Not found** → `Halt` with `<item-not-found type='cancel'/>` reply (XEP-0424 §3.4, XEP-0461 §3.3).
  - **Wrong sender** for correction (XEP-0308 §7.1) or retraction (XEP-0424 §3.4) → `Halt` with `<not-acceptable type='cancel'/>`.
  - **Already tombstoned** for retraction (XEP-0424 §3.5, typed `ArchivedMessage::tombstoned` flag) → `Halt` with `<bad-request>`.
  - **Valid** → `Continue` (resume pipeline).

### `ArchiveHandler` — XEP-0313

`protocol/handlers/archive.rs`. Locality-aware:

- **Sender pass** + **Recipient pass**: emit `ArchiveDirect` for `Chat`/`Normal` that pass §5.1.3 archive-eligibility (skip subject-only, body-less, XEP-0334 `<no-store/>`).
- **`Groupchat`**: skipped — room chain owns archive write.

## Out of scope

- Handler registration in `register_default_message_handlers` — PR4 atomic cutover.
- `message.rs` cutover — PR4.
- MUC handler chain — PR5.
- Routing.rs decommission — PR6.

## Test plan

- [ ] cargo fmt --check clean
- [ ] cargo clippy --workspace --all-targets -- -D warnings clean
- [ ] cargo test --workspace green
- [ ] L1 test suites for each handler land in the same PR; names `xep_0308_*`, `xep_0313_*`, `xep_0424_*`, `xep_0461_*`
- [ ] No callsite changes outside `protocol/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)