### PR TITLE
fix(chat): target XEP-0308 edits by original message id

### DIFF
--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -78,9 +78,6 @@ jobs:
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}
   fmt:
     name: fmt
     runs-on: ubuntu-latest
@@ -109,9 +106,6 @@ jobs:
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}
   publishContainerImage:
     name: publishContainerImage
     runs-on: ubuntu-latest
@@ -143,10 +137,10 @@ jobs:
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}
         CUENV_ARCH: amd64
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -182,6 +176,3 @@ jobs:
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/waddle-server-githubenricher.yml
+++ b/.github/workflows/waddle-server-githubenricher.yml
@@ -48,6 +48,3 @@ jobs:
       run: cuenv ci --pipeline githubEnricher --path server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/waddle-server-githubenricherpullrequest.yml
+++ b/.github/workflows/waddle-server-githubenricherpullrequest.yml
@@ -45,6 +45,3 @@ jobs:
       run: cuenv ci --pipeline githubEnricherPullRequest --path server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
+++ b/.github/workflows/waddle-server-publish-tags-to-flakehub.yml
@@ -58,7 +58,4 @@ jobs:
       run: cuenv ci --pipeline Publish tags to FlakeHub --path server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}
         CUENV_ENVIRONMENT: flakehub

--- a/.github/workflows/waddle-server-pullrequest.yml
+++ b/.github/workflows/waddle-server-pullrequest.yml
@@ -48,6 +48,3 @@ jobs:
       run: cuenv ci --pipeline pullRequest --path server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/.github/workflows/waddle-server-xmppcompliance.yml
+++ b/.github/workflows/waddle-server-xmppcompliance.yml
@@ -61,6 +61,3 @@ jobs:
       run: cuenv ci --pipeline xmppCompliance --path server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
-        GITHUB_REF_TYPE: ${{ github.ref_type }}
-        GITHUB_REF_NAME: ${{ github.ref_name }}

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -47,6 +47,7 @@ function fromLiveDmMessage(
     createdAt: msg.createdAt,
     isSelf: barePeerJid(msg.fromJid) === barePeerJid(session.jid),
   };
+  if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
   if (msg.wireIds?.length) tm.wireIds = msg.wireIds;
   if (msg.mentions?.length) tm.mentions = msg.mentions;
   if (msg.markup?.length) tm.markup = msg.markup;
@@ -73,6 +74,7 @@ function queuedDmMessageToTimeline(
 ): TimelineMessage {
   const message: TimelineMessage = {
     id: queued.id,
+    correctionTargetId: queued.id,
     author: session.username,
     authorJid: session.jid,
     body: queued.body || (queued.files?.[0]?.url ?? ""),
@@ -273,15 +275,20 @@ export function useDmMessaging(
     messages.value = messages.value.map((m) => (matchMessageId(m, retractsId) ? { ...m, body: "", isRetracted: true } : m));
   }
 
+  function isSameDmCorrectionSender(target: TimelineMessage, correctionFromJid: string): boolean {
+    return barePeerJid(target.authorJid ?? "") === barePeerJid(correctionFromJid);
+  }
+
   function applyCorrection(
     replacesId: string,
     newBody: string,
+    correctionFromJid: string,
     markup?: LiveDmMessage["markup"],
     references?: LiveDmMessage["references"],
     githubEmbeds?: LiveDmMessage["githubEmbeds"],
   ) {
     messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId)) return m;
+      if (!matchMessageId(m, replacesId) || !isSameDmCorrectionSender(m, correctionFromJid)) return m;
       const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
       if (markup && markup.length > 0) {
         updated.markup = markup;
@@ -422,6 +429,7 @@ export function useDmMessaging(
       const retractionUpdates: string[] = [];
       const correctionUpdates: {
         targetId: string;
+        correctionFromJid: string;
         body: string;
         markup?: LiveDmMessage["markup"];
         references?: LiveDmMessage["references"];
@@ -439,6 +447,7 @@ export function useDmMessaging(
         } else if (msg.replacesId) {
           correctionUpdates.push({
             targetId: msg.replacesId,
+            correctionFromJid: msg.fromJid,
             body: msg.body,
             markup: msg.markup,
             references: msg.references,
@@ -456,7 +465,7 @@ export function useDmMessaging(
       });
       for (const update of correctionUpdates) {
         const target = findMessageById(timeline, update.targetId);
-        if (!target) continue;
+        if (!target || !isSameDmCorrectionSender(target, update.correctionFromJid)) continue;
         target.body = update.body;
         target.isEdited = true;
         if (update.markup && update.markup.length > 0) {
@@ -596,6 +605,7 @@ export function useDmMessaging(
           pendingEchoClientIds.add(msgId);
           const optimistic: TimelineMessage = {
             id: msgId,
+            correctionTargetId: msgId,
             author: session.value.username,
             authorJid: session.value.jid,
             body: bodyText || (attachments?.[0]?.url ?? ""),
@@ -678,7 +688,8 @@ export function useDmMessaging(
 
   async function editMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {
     if (!xmppClient.value || !activePeerJid.value || !newBody.trim()) return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    const message = findMessageById(messages.value, messageId);
+    const targetId = message?.correctionTargetId ?? messageId;
     clearActionError();
     try {
       await xmppClient.value.sendDmCorrection(activePeerJid.value, newBody, targetId, markup, references);
@@ -766,7 +777,7 @@ export function useDmMessaging(
       return;
     }
     if (msg.replacesId) {
-      applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references, msg.githubEmbeds);
+      applyCorrection(msg.replacesId, msg.body, msg.fromJid, msg.markup, msg.references, msg.githubEmbeds);
       return;
     }
     mergeLiveMessage(

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -45,14 +45,17 @@ export function fromLiveMessage(
   msg: LiveRoomMessage,
   parentLookup?: (id: string) => { body?: string } | undefined,
 ): TimelineMessage {
+  const authorOccupantJid = `${msg.roomJid}/${msg.nick}`;
   const tm: TimelineMessage = {
     id: msg.id,
     author: msg.nick,
-    authorJid: msg.authorRealJid ?? `${msg.roomJid}/${msg.nick}`,
+    authorJid: msg.authorRealJid ?? authorOccupantJid,
+    authorOccupantJid,
     body: msg.body,
     createdAt: msg.createdAt,
     isSelf: msg.nick === session.username,
   };
+  if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
   if (msg.authorRealJid) tm.authorRealJid = msg.authorRealJid;
   if (msg.wireIds && msg.wireIds.length > 0) {
     tm.wireIds = msg.wireIds;
@@ -140,6 +143,7 @@ function queuedRoomMessageToTimeline(
 ): TimelineMessage {
   const message: TimelineMessage = {
     id: queued.id,
+    correctionTargetId: queued.id,
     author: session.username,
     authorJid: `${roomJid}/${session.username}`,
     body: queued.body || (queued.files?.[0]?.url ?? ""),
@@ -310,7 +314,14 @@ export function useMessaging(
 
         // XEP-0308: Handle message corrections
         if (msg.replacesId) {
-          applyCorrection(msg.replacesId, msg.body, msg.markup, msg.references, msg.githubEmbeds);
+          applyCorrection(
+            msg.replacesId,
+            msg.body,
+            mucCorrectionSender(msg),
+            msg.markup,
+            msg.references,
+            msg.githubEmbeds,
+          );
           return;
         }
 
@@ -561,17 +572,41 @@ export function useMessaging(
     );
   }
 
+  function mucCorrectionSender(msg: Pick<LiveRoomMessage, "roomJid" | "nick" | "authorRealJid">): {
+    authorJid: string;
+    authorRealJid?: string;
+  } {
+    return {
+      authorJid: `${msg.roomJid}/${msg.nick}`,
+      ...(msg.authorRealJid ? { authorRealJid: msg.authorRealJid } : {}),
+    };
+  }
+
+  function isSameMucCorrectionSender(
+    target: TimelineMessage,
+    correction: { authorJid: string; authorRealJid?: string },
+  ): boolean {
+    if ((target.authorOccupantJid ?? target.authorJid) !== correction.authorJid) return false;
+    if (target.authorRealJid && correction.authorRealJid) {
+      return barePeerJid(target.authorRealJid) === barePeerJid(correction.authorRealJid);
+    }
+    return true;
+  }
+
   function applyCorrection(
     replacesId: string,
     newBody: string,
+    correctionSender: { authorJid: string; authorRealJid?: string },
     markup?: MarkupSpan[],
     references?: MessageReference[],
     githubEmbeds?: LiveRoomMessage["githubEmbeds"],
   ) {
-    const idx = messages.value.findIndex((m) => matchMessageId(m, replacesId));
+    const idx = messages.value.findIndex((m) =>
+      matchMessageId(m, replacesId) && isSameMucCorrectionSender(m, correctionSender)
+    );
     if (idx === -1) return;
     messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId)) return m;
+      if (!matchMessageId(m, replacesId) || !isSameMucCorrectionSender(m, correctionSender)) return m;
       const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
       if (markup && markup.length > 0) {
         updated.markup = markup;
@@ -769,6 +804,7 @@ export function useMessaging(
       const retractionUpdates: string[] = [];
       const correctionUpdates: {
         targetId: string;
+        correctionSender: { authorJid: string; authorRealJid?: string };
         body: string;
         markup?: MarkupSpan[];
         references?: MessageReference[];
@@ -787,6 +823,7 @@ export function useMessaging(
         } else if (msg.replacesId) {
           correctionUpdates.push({
             targetId: msg.replacesId,
+            correctionSender: mucCorrectionSender(msg),
             body: msg.body,
             markup: msg.markup,
             references: msg.references,
@@ -808,7 +845,7 @@ export function useMessaging(
 
       for (const update of correctionUpdates) {
         const target = findMessageById(timeline, update.targetId);
-        if (!target) continue;
+        if (!target || !isSameMucCorrectionSender(target, update.correctionSender)) continue;
         target.body = update.body;
         target.isEdited = true;
         if (update.markup && update.markup.length > 0) {
@@ -1034,6 +1071,7 @@ export function useMessaging(
         // Optimistic insert: show message immediately with "sending" status
         const optimistic: TimelineMessage = {
           id: msgId,
+          correctionTargetId: msgId,
           author: session.value.username,
           authorJid: `${currentRoomJid.value}/${session.value.username}`,
           body: bodyText || (attachments?.[0]?.url ?? ""),
@@ -1176,7 +1214,8 @@ export function useMessaging(
   async function editMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {
     if (!xmppClient.value || !activeChannelId.value || !newBody.trim())
       return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    const message = findMessageById(messages.value, messageId);
+    const targetId = message?.correctionTargetId ?? messageId;
 
     clearActionError();
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -39,9 +39,13 @@ export interface TimelineMessage {
   id: string;
   /** Equivalent wire-level ids (XEP-0359 stanza/origin ids, echoed ids). */
   wireIds?: string[];
+  /** XEP-0308 correction target: original sender message id/origin-id. */
+  correctionTargetId?: string;
   author: string;
   /** Actual bare JID when known; otherwise the room occupant JID. */
   authorJid?: string;
+  /** Full MUC occupant JID used for same-occupant protocol checks. */
+  authorOccupantJid?: string;
   /** XEP-0313 MUC archive real JID from muc#user item@jid, when present. */
   authorRealJid?: string;
   body: string;

--- a/chat/src/lib/xmpp/dm-parsing.ts
+++ b/chat/src/lib/xmpp/dm-parsing.ts
@@ -78,6 +78,7 @@ export function dispatchChat(msg: ReceivedMessage, h: DmHandlers): void {
     createdAt: new Date().toISOString(),
     type: "message",
   };
+  if (messageIds.correctionTargetId) liveMsg.correctionTargetId = messageIds.correctionTargetId;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;
   if (msg.replace) {
     liveMsg.replacesId = msg.replace;

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -14,6 +14,7 @@ type MessageExtensionsTarget = Pick<
   LiveRoomMessage,
   | "id"
   | "wireIds"
+  | "correctionTargetId"
   | "body"
   | "mentions"
   | "references"
@@ -90,7 +91,7 @@ function extractMucUserRealJid(msg: ReceivedMessage): string | undefined {
 export function resolveMessageIds(
   msg: ReceivedMessage,
   preferredStanzaBy?: string,
-): { id: string; wireIds?: string[] } {
+): { id: string; wireIds?: string[]; correctionTargetId: string } {
   const extMsg = ext(msg);
   const originId = extMsg.originId as OriginIdPayload | undefined;
   const stanzaIds = asArray(extMsg.stanzaIds as StanzaIdPayload | StanzaIdPayload[] | undefined);
@@ -98,10 +99,13 @@ export function resolveMessageIds(
     ? stanzaIds.find((candidate) => candidate.by === preferredStanzaBy)?.id
     : undefined;
 
-  return splitMessageIds(
-    preferredStanzaId ?? stanzaIds[0]?.id ?? originId?.id ?? msg.id,
-    [msg.id, originId?.id, ...stanzaIds.map((candidate) => candidate.id)],
-  );
+  return {
+    ...splitMessageIds(
+      preferredStanzaId ?? stanzaIds[0]?.id ?? originId?.id ?? msg.id,
+      [msg.id, originId?.id, ...stanzaIds.map((candidate) => candidate.id)],
+    ),
+    correctionTargetId: originId?.id ?? msg.id ?? "",
+  };
 }
 
 /** Populate a LiveRoomMessage with data from XEP extensions on the stanza. */
@@ -412,6 +416,7 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
     createdAt: new Date().toISOString(),
     type: msg.body || hasNonBodyMessagePayload(msg) ? "message" : "subject",
   };
+  if (messageIds.correctionTargetId) liveMsg.correctionTargetId = messageIds.correctionTargetId;
   const authorRealJid = extractMucUserRealJid(msg);
   if (authorRealJid) liveMsg.authorRealJid = authorRealJid;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -63,6 +63,8 @@ export interface ReplyPreview {
 export interface LiveRoomMessage {
   id: string;
   wireIds?: string[];
+  /** XEP-0308 correction target: original sender message id/origin-id. */
+  correctionTargetId?: string;
   roomJid: string;
   nick: string;
   body: string;
@@ -105,6 +107,8 @@ export interface LiveRoomMessage {
 export interface LiveDmMessage {
   id: string;
   wireIds?: string[];
+  /** XEP-0308 correction target: original sender message id/origin-id. */
+  correctionTargetId?: string;
   peerJid: string;
   fromJid: string;
   nick: string;

--- a/chat/tests/dm-parsing.test.ts
+++ b/chat/tests/dm-parsing.test.ts
@@ -181,6 +181,7 @@ describe("dispatchChat", () => {
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].id).toBe("stable-1");
     expect(h.messages[0].wireIds).toEqual(["echo-1", "client-1"]);
+    expect(h.messages[0].correctionTargetId).toBe("client-1");
   });
 
   test("dispatches message corrections", () => {

--- a/chat/tests/edit-targeting.test.ts
+++ b/chat/tests/edit-targeting.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { useDmMessaging } from "../src/composables/useDmMessaging";
+import { useMessaging } from "../src/composables/useMessaging";
+import { handlerStubs } from "./helpers/xmpp-client-mock";
+import type { LiveDmMessage, LiveRoomMessage } from "../src/lib/xmpp-client";
+
+function session(partial: Partial<WaddleSession> = {}): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+    ...partial,
+  } as WaddleSession;
+}
+
+describe("edit targeting", () => {
+  test("room edits target the XEP-0308 correction id, not the rendered stanza id", async () => {
+    const sendCorrection = mock(async () => "edit-1");
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendCorrection } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "room-stanza-id",
+        wireIds: ["original-message-id"],
+        correctionTargetId: "original-message-id",
+        author: "alice",
+        authorJid: "c1@muc.example.com/alice",
+        body: "tyop",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    await messaging.editMessage("room-stanza-id", "typo");
+
+    expect(sendCorrection).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "typo",
+      "original-message-id",
+      undefined,
+      undefined,
+    );
+  });
+
+  test("room corrections from a different occupant do not rewrite the target", async () => {
+    let onMessage: ((msg: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({
+        ...handlerStubs(),
+        setMessageHandler: (handler: (msg: LiveRoomMessage) => void) => {
+          onMessage = handler;
+        },
+      } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "room-stanza-id",
+        wireIds: ["alice-original"],
+        correctionTargetId: "alice-original",
+        author: "alice",
+        authorJid: "c1@muc.example.com/alice",
+        body: "alice text",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    onMessage?.({
+      id: "bob-edit",
+      roomJid: "c1@muc.example.com",
+      nick: "bob",
+      body: "forged edit",
+      createdAt: "2024-01-01T00:00:01Z",
+      type: "message",
+      replacesId: "alice-original",
+    });
+
+    expect(messaging.messages.value[0].body).toBe("alice text");
+    expect(messaging.messages.value[0].isEdited).toBeUndefined();
+  });
+
+  test("room corrections require the same full occupant JID even when real bare JID matches", () => {
+    let onMessage: ((msg: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({
+        ...handlerStubs(),
+        setMessageHandler: (handler: (msg: LiveRoomMessage) => void) => {
+          onMessage = handler;
+        },
+      } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "room-stanza-id",
+        wireIds: ["alice-original"],
+        correctionTargetId: "alice-original",
+        author: "alice",
+        authorJid: "c1@muc.example.com/alice",
+        authorRealJid: "alice@example.com",
+        body: "alice text",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    onMessage?.({
+      id: "alice-after-nick-change-edit",
+      roomJid: "c1@muc.example.com",
+      nick: "alice-renamed",
+      authorRealJid: "alice@example.com/phone",
+      body: "renamed edit",
+      createdAt: "2024-01-01T00:00:01Z",
+      type: "message",
+      replacesId: "alice-original",
+    });
+
+    expect(messaging.messages.value[0].body).toBe("alice text");
+    expect(messaging.messages.value[0].isEdited).toBeUndefined();
+  });
+
+  test("room corrections apply when a real author JID is known and the occupant JID matches", () => {
+    let onMessage: ((msg: LiveRoomMessage) => void) | null = null;
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({
+        ...handlerStubs(),
+        setMessageHandler: (handler: (msg: LiveRoomMessage) => void) => {
+          onMessage = handler;
+        },
+      } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "room-stanza-id",
+        wireIds: ["alice-original"],
+        correctionTargetId: "alice-original",
+        author: "alice",
+        authorJid: "alice@example.com/desktop",
+        authorOccupantJid: "c1@muc.example.com/alice",
+        authorRealJid: "alice@example.com/desktop",
+        body: "alice text",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    onMessage?.({
+      id: "alice-edit",
+      roomJid: "c1@muc.example.com",
+      nick: "alice",
+      authorRealJid: "alice@example.com/phone",
+      body: "edited text",
+      createdAt: "2024-01-01T00:00:01Z",
+      type: "message",
+      replacesId: "alice-original",
+    });
+
+    expect(messaging.messages.value[0].body).toBe("edited text");
+    expect(messaging.messages.value[0].isEdited).toBe(true);
+  });
+
+  test("DM edits target the XEP-0308 correction id, not the rendered stanza id", async () => {
+    const sendDmCorrection = mock(async () => "edit-1");
+    const actionError = ref("");
+    const messaging = useDmMessaging(
+      ref(session()),
+      ref({ sendDmCorrection } as never),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "server-stanza-id",
+        wireIds: ["original-message-id"],
+        correctionTargetId: "original-message-id",
+        author: "alice",
+        authorJid: "alice@example.com/desktop",
+        body: "helo",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    await messaging.editMessage("server-stanza-id", "hello");
+
+    expect(sendDmCorrection).toHaveBeenCalledWith(
+      "bob@example.com",
+      "hello",
+      "original-message-id",
+      undefined,
+      undefined,
+    );
+  });
+
+  test("DM corrections from a different bare JID do not rewrite the target", () => {
+    const actionError = ref("");
+    const messaging = useDmMessaging(
+      ref(session()),
+      ref({} as never),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        id: "server-stanza-id",
+        wireIds: ["alice-original"],
+        correctionTargetId: "alice-original",
+        author: "alice",
+        authorJid: "alice@example.com/desktop",
+        body: "alice text",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+    ];
+
+    messaging.onIncomingMessage({
+      id: "bob-edit",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/phone",
+      nick: "bob",
+      body: "forged edit",
+      createdAt: "2024-01-01T00:00:01Z",
+      type: "message",
+      replacesId: "alice-original",
+    } as LiveDmMessage);
+
+    expect(messaging.messages.value[0].body).toBe("alice text");
+    expect(messaging.messages.value[0].isEdited).toBeUndefined();
+  });
+});

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -309,6 +309,24 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].id).toBe("stable-1");
     expect(h.messages[0].wireIds).toEqual(["echo-1", "client-1", "server-1"]);
+    expect(h.messages[0].correctionTargetId).toBe("client-1");
+  });
+
+  test("uses the sender message id as the correction target when no origin id exists", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "echo-1",
+        body: "editable",
+        stanzaIds: [{ id: "stable-1", by: "general@muc.waddle.social" }],
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].id).toBe("stable-1");
+    expect(h.messages[0].wireIds).toEqual(["echo-1"]);
+    expect(h.messages[0].correctionTargetId).toBe("echo-1");
   });
 
   test("leaves replyTo undefined when no reply element is present", () => {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1198,6 +1198,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "cuengine"
+version = "0.40.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362041d5247f767697fe29f2e40f896ff672715faee60544dc2440e550b53c03"
+dependencies = [
+ "cc",
+ "libc",
+ "lru 0.16.4",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +1979,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2686,6 +2705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5781,6 +5809,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "cuengine",
  "dashmap",
  "elliptic-curve",
  "futures",
@@ -5791,7 +5820,7 @@ dependencies = [
  "jid",
  "jsonwebtoken",
  "kameo",
- "lru",
+ "lru 0.12.5",
  "object_store",
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -5811,6 +5840,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/server/Justfile
+++ b/server/Justfile
@@ -15,6 +15,10 @@ integration:
 websocket:
     cargo test -p waddle-server --test xep0092_software_version_ws --test xep0012_0202_ws --test xep0054_0049_0191_ws --verbose
 
+# Run CUE-authored XMPP E2E protocol scenarios.
+e2e:
+    cargo test -p waddle-server --test xmpp_e2e_cue --verbose
+
 # Run only inline unit tests.
 unit:
     cargo test -p waddle-xmpp --lib --verbose

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -97,6 +97,8 @@ wiremock = "0.6"
 http-body-util = "0.1"
 tokio-tungstenite = "0.24"
 pbkdf2 = { version = "0.12", features = ["hmac"] }
+cuengine = "0.40.6"
+tempfile = "3.14"
 
 [[bin]]
 name = "waddle-server"

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -1,0 +1,927 @@
+//! CUE-authored XMPP E2E scenarios over the active WebSocket C2S transport.
+
+mod ws_common;
+
+use anyhow::{anyhow, Context, Result};
+use jid::Jid;
+use serde::Deserialize;
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+use waddle_xmpp::Stanza;
+use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::message::{Body, Message, MessageType};
+use xmpp_parsers::minidom::Element;
+use xmpp_parsers::presence::Presence;
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+const RECV_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug, Deserialize)]
+struct ScenarioFile {
+    scenario: Scenario,
+}
+
+#[derive(Debug, Deserialize)]
+struct Scenario {
+    name: String,
+    domain: String,
+    users: BTreeMap<String, User>,
+    steps: Vec<Step>,
+}
+
+#[derive(Debug, Deserialize)]
+struct User {
+    devices: BTreeMap<String, Actor>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Actor {
+    user: String,
+    device: String,
+    username: String,
+    resource: String,
+    #[serde(rename = "bareJid")]
+    bare_jid: String,
+    jid: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind")]
+enum Step {
+    #[serde(rename = "enableCarbons")]
+    EnableCarbons { actor: Actor },
+    #[serde(rename = "sendMessage")]
+    SendMessage {
+        from: Actor,
+        to: Option<Actor>,
+        #[serde(rename = "toJid")]
+        to_jid: Option<String>,
+        #[serde(rename = "type")]
+        type_: MessageKind,
+        id: Option<String>,
+        body: Option<String>,
+        #[serde(default)]
+        payloads: Vec<Payload>,
+    },
+    #[serde(rename = "expectMessage")]
+    ExpectMessage {
+        target: Actor,
+        body: Option<String>,
+        from: Option<Actor>,
+        #[serde(default)]
+        payloads: Vec<Payload>,
+        #[serde(default)]
+        contains: Vec<String>,
+    },
+    #[serde(rename = "expectCarbon")]
+    ExpectCarbon {
+        target: Actor,
+        carbon: CarbonKind,
+        body: Option<String>,
+        #[serde(default)]
+        payloads: Vec<Payload>,
+        #[serde(default)]
+        contains: Vec<String>,
+    },
+    #[serde(rename = "joinMuc")]
+    JoinMuc {
+        actor: Actor,
+        room: String,
+        nick: String,
+    },
+    #[serde(rename = "setMucAffiliation")]
+    SetMucAffiliation {
+        actor: Actor,
+        room: String,
+        jid: String,
+        affiliation: String,
+        id: Option<String>,
+    },
+    #[serde(rename = "expectMucAffiliation")]
+    ExpectMucAffiliation {
+        actor: Actor,
+        room: String,
+        jid: String,
+        affiliation: String,
+        id: Option<String>,
+    },
+    #[serde(rename = "expectMucAdminDenied")]
+    ExpectMucAdminDenied {
+        actor: Actor,
+        room: String,
+        jid: String,
+        affiliation: String,
+        id: Option<String>,
+    },
+    #[serde(rename = "expectPresence")]
+    ExpectPresence {
+        target: Actor,
+        contains: Vec<String>,
+    },
+    #[serde(rename = "queryMam")]
+    QueryMam {
+        actor: Actor,
+        archive: String,
+        id: Option<String>,
+        max: u32,
+    },
+    #[serde(rename = "expectMamResult")]
+    ExpectMamResult {
+        body: Option<String>,
+        #[serde(default)]
+        payloads: Vec<Payload>,
+        #[serde(default)]
+        contains: Vec<String>,
+    },
+    #[serde(rename = "expectNoStanza")]
+    ExpectNoStanza {
+        target: Actor,
+        body: Option<String>,
+        #[serde(default)]
+        contains: Vec<String>,
+        millis: u64,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum MessageKind {
+    Chat,
+    Normal,
+    Groupchat,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum CarbonKind {
+    Sent,
+    Received,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "kind")]
+enum Payload {
+    #[serde(rename = "fileShare")]
+    FileShare {
+        disposition: String,
+        name: String,
+        #[serde(rename = "mediaType")]
+        media_type: String,
+        size: u64,
+        url: String,
+    },
+    #[serde(rename = "linkMetadata")]
+    LinkMetadata {
+        about: String,
+        title: String,
+        description: String,
+        url: String,
+    },
+}
+
+struct ScenarioContext {
+    clients: HashMap<String, WsXmppClient>,
+    pending_frames: HashMap<String, VecDeque<String>>,
+    last_mam_frames: Vec<String>,
+}
+
+#[tokio::test]
+async fn cue_scenarios_run_over_websocket() -> Result<()> {
+    let _serial = TEST_SERIAL.lock().await;
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/xmpp_e2e_scenarios");
+    let mut scenarios = Vec::new();
+    for scenario_file in discover_scenario_files(&root)? {
+        let scenario = load_scenario_from_file(&root, &scenario_file)
+            .with_context(|| format!("load {}", scenario_file.display()))?;
+        scenarios.push((scenario_file, scenario));
+    }
+
+    for (scenario_file, scenario) in scenarios {
+        run_scenario(scenario)
+            .await
+            .with_context(|| format!("scenario {} failed", scenario_file.display()))?;
+    }
+    Ok(())
+}
+
+fn discover_scenario_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for entry in fs::read_dir(root).with_context(|| format!("read {}", root.display()))? {
+        let path = entry?.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("cue")
+            && path.file_name().and_then(|name| name.to_str()) != Some("schema.cue")
+        {
+            files.push(path);
+        }
+    }
+    files.sort();
+    if files.is_empty() {
+        return Err(anyhow!("no CUE scenario files in {}", root.display()));
+    }
+    Ok(files)
+}
+
+fn load_scenario_from_file(root: &Path, scenario_file: &Path) -> Result<Scenario> {
+    let temp_dir = tempfile::tempdir().context("create temporary CUE package")?;
+    copy_dir_recursive(&root.join("cue.mod"), &temp_dir.path().join("cue.mod"))?;
+    fs::copy(root.join("schema.cue"), temp_dir.path().join("schema.cue"))?;
+    fs::copy(scenario_file, temp_dir.path().join("scenario.cue"))?;
+
+    let parsed: ScenarioFile =
+        cuengine::evaluate_cue_package_typed(temp_dir.path(), "xmpp_e2e_scenarios")
+            .with_context(|| format!("evaluate CUE package for {}", scenario_file.display()))?;
+    validate_scenario(&parsed.scenario)?;
+    Ok(parsed.scenario)
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
+    fs::create_dir_all(target).with_context(|| format!("create {}", target.display()))?;
+    for entry in fs::read_dir(source).with_context(|| format!("read {}", source.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let destination = target.join(entry.file_name());
+        if path.is_dir() {
+            copy_dir_recursive(&path, &destination)?;
+        } else {
+            fs::copy(&path, &destination)
+                .with_context(|| format!("copy {} to {}", path.display(), destination.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_scenario(scenario: &Scenario) -> Result<()> {
+    if scenario.users.is_empty() {
+        return Err(anyhow!("scenario {} has no users", scenario.name));
+    }
+    if scenario.steps.is_empty() {
+        return Err(anyhow!("scenario {} has no steps", scenario.name));
+    }
+    Ok(())
+}
+
+async fn run_scenario(scenario: Scenario) -> Result<()> {
+    let accounts = scenario_accounts(&scenario);
+    let account_refs = accounts
+        .iter()
+        .map(|(username, password)| (username.as_str(), password.as_str()))
+        .collect::<Vec<_>>();
+    let server = TestServer::start_with_extra_accounts(&account_refs);
+    let mut clients = HashMap::new();
+
+    for user in scenario.users.values() {
+        for actor in user.devices.values() {
+            let admin_password = server.fixed_account_password();
+            let password = accounts
+                .get(&actor.username)
+                .map(String::as_str)
+                .or_else(|| (actor.username == "admin").then_some(admin_password))
+                .ok_or_else(|| anyhow!("missing password for {}", actor.username))?;
+            let client = WsXmppClient::connect_and_auth(
+                &server.ws_url(),
+                &scenario.domain,
+                &actor.username,
+                password,
+                &actor.resource,
+            )
+            .await
+            .map_err(|error| anyhow!("connect {}.{}: {error}", actor.user, actor.device))?;
+            clients.insert(actor_key(actor), client);
+        }
+    }
+
+    let mut ctx = ScenarioContext {
+        clients,
+        pending_frames: HashMap::new(),
+        last_mam_frames: Vec::new(),
+    };
+
+    for (index, step) in scenario.steps.iter().enumerate() {
+        execute_step(&mut ctx, step)
+            .await
+            .with_context(|| format!("step {index} in scenario {}", scenario.name))?;
+    }
+
+    close_clients(ctx.clients).await;
+    Ok(())
+}
+
+fn scenario_accounts(scenario: &Scenario) -> BTreeMap<String, String> {
+    let mut accounts = BTreeMap::new();
+    for user in scenario.users.values() {
+        for actor in user.devices.values() {
+            if actor.username == "admin" {
+                continue;
+            }
+            accounts
+                .entry(actor.username.clone())
+                .or_insert_with(|| format!("{}-{}", actor.username, uuid::Uuid::new_v4()));
+        }
+    }
+    accounts
+}
+
+async fn close_clients(clients: HashMap<String, WsXmppClient>) {
+    for client in clients.into_values() {
+        client.close().await;
+    }
+}
+
+async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
+    match step {
+        Step::EnableCarbons { actor } => {
+            let id = format!("cue-enable-carbons-{}", uuid::Uuid::new_v4());
+            let enable = Element::builder("enable", "urn:xmpp:carbons:2").build();
+            let iq = Iq {
+                from: None,
+                to: None,
+                id: id.clone(),
+                payload: IqType::Set(enable),
+            };
+            let client = client_mut(ctx, actor)?;
+            client
+                .send(&stanza_xml(Stanza::Iq(iq))?)
+                .await
+                .map_err(|error| anyhow!(error))?;
+            let response = recv_matching(ctx, actor, |frame| frame.contains(&id)).await?;
+            assert_contains_all(&response, ["type=\"result\""], "enable carbons response")?;
+        }
+        Step::SendMessage {
+            from,
+            to,
+            to_jid,
+            type_,
+            id,
+            body,
+            payloads,
+        } => {
+            let to = to_jid
+                .clone()
+                .or_else(|| to.as_ref().map(|actor| actor.jid.clone()))
+                .ok_or_else(|| anyhow!("sendMessage requires to or toJid"))?;
+            let mut message = Message::new_with_type(message_type(type_), Some(to.parse::<Jid>()?));
+            message.id = id.clone();
+            if let Some(body) = body {
+                message.bodies.insert(String::new(), Body(body.clone()));
+            }
+            for payload in payloads {
+                message.payloads.push(payload_element(payload));
+            }
+            if body.is_some()
+                && payloads
+                    .iter()
+                    .any(|payload| matches!(payload, Payload::FileShare { .. }))
+            {
+                validate_file_share_fallback_body(body.as_deref(), payloads)?;
+                message.payloads.push(file_share_fallback_element());
+            }
+            let xml = stanza_xml(Stanza::Message(message))?;
+            client_mut(ctx, from)?
+                .send(&xml)
+                .await
+                .map_err(|error| anyhow!(error))?;
+        }
+        Step::ExpectMessage {
+            target,
+            body,
+            from,
+            payloads,
+            contains,
+        } => {
+            let mut expected = contains.clone();
+            if let Some(body) = body {
+                expected.push(body_text_marker(body));
+            }
+            expected.extend(payload_expectations(payloads)?);
+            if let Some(from) = from {
+                expected.push(format!("from=\"{}", from.bare_jid));
+            }
+            let frame = recv_matching(ctx, target, |frame| {
+                frame.contains("<message")
+                    && body
+                        .as_ref()
+                        .is_none_or(|body| frame_contains_body(frame, body))
+                    && from
+                        .as_ref()
+                        .is_none_or(|from| frame.contains(&format!("from=\"{}", from.bare_jid)))
+                    && payload_expectations(payloads)
+                        .map(|parts| parts.iter().all(|part| frame.contains(part)))
+                        .unwrap_or(false)
+                    && contains.iter().all(|part| frame.contains(part))
+            })
+            .await?;
+            assert_contains_all(&frame, &expected, "message expectation")?;
+        }
+        Step::ExpectCarbon {
+            target,
+            carbon,
+            body,
+            payloads,
+            contains,
+        } => {
+            let carbon_tag = match carbon {
+                CarbonKind::Sent => "<sent",
+                CarbonKind::Received => "<received",
+            };
+            let mut expected = contains.clone();
+            expected.push("urn:xmpp:carbons:2".to_string());
+            expected.push(carbon_tag.to_string());
+            if let Some(body) = body {
+                expected.push(body_text_marker(body));
+            }
+            expected.extend(payload_expectations(payloads)?);
+            let frame = recv_matching(ctx, target, |frame| {
+                frame.contains("urn:xmpp:carbons:2")
+                    && frame.contains(carbon_tag)
+                    && body
+                        .as_ref()
+                        .is_none_or(|body| frame_contains_body(frame, body))
+                    && payload_expectations(payloads)
+                        .map(|parts| parts.iter().all(|part| frame.contains(part)))
+                        .unwrap_or(false)
+                    && contains.iter().all(|part| frame.contains(part))
+            })
+            .await?;
+            assert_contains_all(&frame, &expected, "carbon expectation")?;
+        }
+        Step::JoinMuc { actor, room, nick } => {
+            let mut presence = Presence::available();
+            presence.to = Some(format!("{room}/{nick}").parse()?);
+            presence.payloads.push(
+                Element::builder("x", "http://jabber.org/protocol/muc")
+                    .append(
+                        Element::builder("history", "http://jabber.org/protocol/muc")
+                            .attr("maxstanzas", "0")
+                            .build(),
+                    )
+                    .build(),
+            );
+            let xml = stanza_xml(Stanza::Presence(presence))?;
+            let client = client_mut(ctx, actor)?;
+            client.send(&xml).await.map_err(|error| anyhow!(error))?;
+            recv_until(ctx, actor, |frame| {
+                frame.contains("status code=\"110\"") || frame.contains("<subject")
+            })
+            .await?;
+        }
+        Step::SetMucAffiliation {
+            actor,
+            room,
+            jid,
+            affiliation,
+            id,
+        } => {
+            let id = id
+                .clone()
+                .unwrap_or_else(|| format!("cue-muc-admin-set-{}", uuid::Uuid::new_v4()));
+            send_muc_admin_iq(ctx, actor, room, jid, affiliation, &id, IqKind::Set).await?;
+            let response = recv_matching(ctx, actor, |frame| frame.contains(&id)).await?;
+            assert_contains_all(&response, ["type=\"result\""], "MUC admin set response")?;
+        }
+        Step::ExpectMucAffiliation {
+            actor,
+            room,
+            jid,
+            affiliation,
+            id,
+        } => {
+            let id = id
+                .clone()
+                .unwrap_or_else(|| format!("cue-muc-admin-get-{}", uuid::Uuid::new_v4()));
+            send_muc_admin_iq(ctx, actor, room, jid, affiliation, &id, IqKind::Get).await?;
+            let response = recv_matching(ctx, actor, |frame| frame.contains(&id)).await?;
+            assert_contains_all(
+                &response,
+                [
+                    "type=\"result\"",
+                    "http://jabber.org/protocol/muc#admin",
+                    jid.as_str(),
+                    affiliation.as_str(),
+                ],
+                "MUC admin affiliation query",
+            )?;
+        }
+        Step::ExpectMucAdminDenied {
+            actor,
+            room,
+            jid,
+            affiliation,
+            id,
+        } => {
+            let id = id
+                .clone()
+                .unwrap_or_else(|| format!("cue-muc-admin-denied-{}", uuid::Uuid::new_v4()));
+            send_muc_admin_iq(ctx, actor, room, jid, affiliation, &id, IqKind::Set).await?;
+            let response = recv_matching(ctx, actor, |frame| frame.contains(&id)).await?;
+            assert_contains_all(
+                &response,
+                ["type=\"error\"", "forbidden"],
+                "MUC admin denial",
+            )?;
+        }
+        Step::ExpectPresence { target, contains } => {
+            let frame = recv_matching(ctx, target, |frame| {
+                frame.contains("<presence") && contains.iter().all(|part| frame.contains(part))
+            })
+            .await?;
+            assert_contains_all(&frame, contains, "presence expectation")?;
+        }
+        Step::QueryMam {
+            actor,
+            archive,
+            id,
+            max,
+        } => {
+            let id = id
+                .clone()
+                .unwrap_or_else(|| format!("cue-mam-{}", uuid::Uuid::new_v4()));
+            let rsm = Element::builder("set", "http://jabber.org/protocol/rsm")
+                .append(
+                    Element::builder("max", "http://jabber.org/protocol/rsm")
+                        .append(max.to_string())
+                        .build(),
+                )
+                .build();
+            let query = Element::builder("query", "urn:xmpp:mam:2")
+                .append(rsm)
+                .build();
+            let iq = Iq {
+                from: None,
+                to: Some(archive.parse()?),
+                id: id.clone(),
+                payload: IqType::Set(query),
+            };
+            client_mut(ctx, actor)?
+                .send(&stanza_xml(Stanza::Iq(iq))?)
+                .await
+                .map_err(|error| anyhow!(error))?;
+            ctx.last_mam_frames = recv_until(ctx, actor, |frame| {
+                frame.contains("urn:xmpp:mam:2") && frame.contains("<fin") && frame.contains(&id)
+            })
+            .await?;
+        }
+        Step::ExpectMamResult {
+            body,
+            payloads,
+            contains,
+        } => {
+            let payload_expectations = payload_expectations(payloads)?;
+            let matched = ctx.last_mam_frames.iter().find(|frame| {
+                frame.contains("<forwarded")
+                    && body
+                        .as_ref()
+                        .is_none_or(|body| frame_contains_body(frame, body))
+                    && payload_expectations.iter().all(|part| frame.contains(part))
+                    && contains.iter().all(|part| frame.contains(part))
+            });
+            let Some(frame) = matched else {
+                return Err(anyhow!(
+                    "no MAM result matched body {:?} and contains {:?}; frames: {:?}",
+                    body,
+                    contains,
+                    ctx.last_mam_frames
+                ));
+            };
+            if let Some(body) = body {
+                assert_contains_all(frame, std::slice::from_ref(body), "MAM result body")?;
+            }
+            assert_contains_all(frame, &payload_expectations, "MAM result payloads")?;
+            assert_contains_all(frame, contains, "MAM result contains")?;
+        }
+        Step::ExpectNoStanza {
+            target,
+            body,
+            contains,
+            millis,
+        } => {
+            let deadline = Instant::now() + Duration::from_millis(*millis);
+            let mut non_matching_frames = Vec::new();
+            loop {
+                let now = Instant::now();
+                if now >= deadline {
+                    break;
+                }
+                let Some(frame) = recv_timeout(ctx, target, deadline - now).await? else {
+                    break;
+                };
+                let matches = body
+                    .as_ref()
+                    .is_none_or(|body| frame_contains_body(&frame, body))
+                    && contains.iter().all(|part| frame.contains(part));
+                if matches {
+                    return Err(anyhow!("unexpected matching stanza: {frame}"));
+                }
+                non_matching_frames.push(frame);
+            }
+            for frame in non_matching_frames.into_iter().rev() {
+                push_pending_front(ctx, target, frame);
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn recv_matching<F>(ctx: &mut ScenarioContext, actor: &Actor, predicate: F) -> Result<String>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut non_matching_frames = Vec::new();
+    loop {
+        let frame = recv_next(ctx, actor).await?;
+        if predicate(&frame) {
+            for frame in non_matching_frames.into_iter().rev() {
+                push_pending_front(ctx, actor, frame);
+            }
+            return Ok(frame);
+        }
+        non_matching_frames.push(frame);
+    }
+}
+
+async fn recv_until<F>(
+    ctx: &mut ScenarioContext,
+    actor: &Actor,
+    predicate: F,
+) -> Result<Vec<String>>
+where
+    F: Fn(&str) -> bool,
+{
+    let mut frames = Vec::new();
+    loop {
+        let frame = recv_next(ctx, actor).await?;
+        let done = predicate(&frame);
+        frames.push(frame);
+        if done {
+            return Ok(frames);
+        }
+    }
+}
+
+async fn recv_next(ctx: &mut ScenarioContext, actor: &Actor) -> Result<String> {
+    recv_timeout(ctx, actor, RECV_TIMEOUT)
+        .await?
+        .ok_or_else(|| anyhow!("Timeout waiting for message"))
+}
+
+async fn recv_timeout(
+    ctx: &mut ScenarioContext,
+    actor: &Actor,
+    timeout: Duration,
+) -> Result<Option<String>> {
+    let key = actor_key(actor);
+    if let Some(frame) = ctx
+        .pending_frames
+        .get_mut(&key)
+        .and_then(VecDeque::pop_front)
+    {
+        return Ok(Some(frame));
+    }
+    match client_mut(ctx, actor)?.recv_timeout(timeout).await {
+        Ok(frame) => Ok(Some(frame)),
+        Err(error) if error == "Timeout waiting for message" => Ok(None),
+        Err(error) => Err(anyhow!(error)),
+    }
+}
+
+fn push_pending_front(ctx: &mut ScenarioContext, actor: &Actor, frame: String) {
+    ctx.pending_frames
+        .entry(actor_key(actor))
+        .or_default()
+        .push_front(frame);
+}
+
+fn client_mut<'a>(ctx: &'a mut ScenarioContext, actor: &Actor) -> Result<&'a mut WsXmppClient> {
+    ctx.clients
+        .get_mut(&actor_key(actor))
+        .ok_or_else(|| anyhow!("unknown actor {}.{}", actor.user, actor.device))
+}
+
+fn actor_key(actor: &Actor) -> String {
+    format!("{}.{}", actor.user, actor.device)
+}
+
+fn message_type(kind: &MessageKind) -> MessageType {
+    match kind {
+        MessageKind::Chat => MessageType::Chat,
+        MessageKind::Normal => MessageType::Normal,
+        MessageKind::Groupchat => MessageType::Groupchat,
+    }
+}
+
+enum IqKind {
+    Get,
+    Set,
+}
+
+async fn send_muc_admin_iq(
+    ctx: &mut ScenarioContext,
+    actor: &Actor,
+    room: &str,
+    jid: &str,
+    affiliation: &str,
+    id: &str,
+    kind: IqKind,
+) -> Result<()> {
+    let item = match kind {
+        IqKind::Get => Element::builder("item", "http://jabber.org/protocol/muc#admin")
+            .attr("affiliation", affiliation)
+            .build(),
+        IqKind::Set => Element::builder("item", "http://jabber.org/protocol/muc#admin")
+            .attr("jid", jid)
+            .attr("affiliation", affiliation)
+            .build(),
+    };
+    let query = Element::builder("query", "http://jabber.org/protocol/muc#admin")
+        .append(item)
+        .build();
+    let payload = match kind {
+        IqKind::Get => IqType::Get(query),
+        IqKind::Set => IqType::Set(query),
+    };
+    let iq = Iq {
+        from: None,
+        to: Some(room.parse()?),
+        id: id.to_string(),
+        payload,
+    };
+    client_mut(ctx, actor)?
+        .send(&stanza_xml(Stanza::Iq(iq))?)
+        .await
+        .map_err(|error| anyhow!(error))?;
+    Ok(())
+}
+
+fn payload_element(payload: &Payload) -> Element {
+    match payload {
+        Payload::FileShare {
+            disposition,
+            name,
+            media_type,
+            size,
+            url,
+        } => Element::builder("file-sharing", "urn:xmpp:sfs:0")
+            .attr("disposition", disposition.as_str())
+            .append(
+                Element::builder("file", "urn:xmpp:file:metadata:0")
+                    .append(
+                        Element::builder("media-type", "urn:xmpp:file:metadata:0")
+                            .append(media_type.as_str())
+                            .build(),
+                    )
+                    .append(
+                        Element::builder("name", "urn:xmpp:file:metadata:0")
+                            .append(name.as_str())
+                            .build(),
+                    )
+                    .append(
+                        Element::builder("size", "urn:xmpp:file:metadata:0")
+                            .append(size.to_string())
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("sources", "urn:xmpp:sfs:0")
+                    .append(
+                        Element::builder("url-data", "http://jabber.org/protocol/url-data")
+                            .attr("target", url.as_str())
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+        Payload::LinkMetadata {
+            about,
+            title,
+            description,
+            url,
+        } => Element::builder("Description", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+            .prefix(
+                Some("rdf".to_string()),
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            )
+            .expect("static RDF prefix is unique")
+            .attr("rdf:about", about.as_str())
+            .append(
+                Element::builder("title", "https://ogp.me/ns#")
+                    .append(title.as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("description", "https://ogp.me/ns#")
+                    .append(description.as_str())
+                    .build(),
+            )
+            .append(
+                Element::builder("url", "https://ogp.me/ns#")
+                    .append(url.as_str())
+                    .build(),
+            )
+            .build(),
+    }
+}
+
+fn payload_expectations(payloads: &[Payload]) -> Result<Vec<String>> {
+    let mut expected = Vec::new();
+    for payload in payloads {
+        match payload {
+            Payload::FileShare {
+                disposition,
+                name,
+                media_type,
+                size,
+                url,
+            } => {
+                expected.extend([
+                    "urn:xmpp:sfs:0".to_string(),
+                    "urn:xmpp:file:metadata:0".to_string(),
+                    "http://jabber.org/protocol/url-data".to_string(),
+                    "disposition=".to_string(),
+                    disposition.clone(),
+                    text_node_marker(media_type),
+                    text_node_marker(name),
+                    text_node_marker(&size.to_string()),
+                    "target=".to_string(),
+                    url.clone(),
+                ]);
+            }
+            Payload::LinkMetadata {
+                about,
+                title,
+                description,
+                url,
+            } => {
+                expected.extend([
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#".to_string(),
+                    "https://ogp.me/ns#".to_string(),
+                    "rdf:about=".to_string(),
+                    about.clone(),
+                    text_node_marker(title),
+                    text_node_marker(description),
+                    text_node_marker(url),
+                ]);
+            }
+        }
+    }
+    Ok(expected)
+}
+
+fn validate_file_share_fallback_body(body: Option<&str>, payloads: &[Payload]) -> Result<()> {
+    let Some(body) = body else {
+        return Ok(());
+    };
+    let represented_by_payload = payloads.iter().any(|payload| match payload {
+        Payload::FileShare { url, .. } => body == url,
+        Payload::LinkMetadata { .. } => false,
+    });
+    if represented_by_payload {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "fileShare body is marked as XEP-0428 fallback, so it must be represented by the file-sharing payload"
+        ))
+    }
+}
+
+fn file_share_fallback_element() -> Element {
+    Element::builder("fallback", "urn:xmpp:fallback:0")
+        .attr("for", "urn:xmpp:sfs:0")
+        .append(Element::builder("body", "urn:xmpp:fallback:0").build())
+        .build()
+}
+
+fn stanza_xml(stanza: Stanza) -> Result<String> {
+    let mut buf = Vec::new();
+    stanza.to_element().write_to(&mut buf)?;
+    Ok(String::from_utf8(buf)?)
+}
+
+fn frame_contains_body(frame: &str, body: &str) -> bool {
+    frame.contains("<body") && frame.contains(&body_text_marker(body))
+}
+
+fn body_text_marker(body: &str) -> String {
+    format!(">{body}</body>")
+}
+
+fn text_node_marker(value: &str) -> String {
+    format!(">{value}</")
+}
+
+fn assert_contains_all<I, S>(frame: &str, expected: I, context: &str) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    for part in expected {
+        let part = part.as_ref();
+        if !frame.contains(part) {
+            return Err(anyhow!("{context} expected {part:?}, got: {frame}"));
+        }
+    }
+    Ok(())
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -181,6 +181,8 @@ enum Payload {
         description: String,
         url: String,
     },
+    #[serde(rename = "messageCorrection")]
+    MessageCorrection { id: String },
 }
 
 struct ScenarioContext {
@@ -822,6 +824,11 @@ fn payload_element(payload: &Payload) -> Element {
                     .build(),
             )
             .build(),
+        Payload::MessageCorrection { id } => {
+            Element::builder("replace", "urn:xmpp:message-correct:0")
+                .attr("id", id.as_str())
+                .build()
+        }
     }
 }
 
@@ -865,6 +872,9 @@ fn payload_expectations(payloads: &[Payload]) -> Result<Vec<String>> {
                     text_node_marker(url),
                 ]);
             }
+            Payload::MessageCorrection { id } => {
+                expected.extend(["urn:xmpp:message-correct:0".to_string(), id.clone()]);
+            }
         }
     }
     Ok(expected)
@@ -876,7 +886,7 @@ fn validate_file_share_fallback_body(body: Option<&str>, payloads: &[Payload]) -
     };
     let represented_by_payload = payloads.iter().any(|payload| match payload {
         Payload::FileShare { url, .. } => body == url,
-        Payload::LinkMetadata { .. } => false,
+        Payload::LinkMetadata { .. } | Payload::MessageCorrection { .. } => false,
     });
     if represented_by_payload {
         Ok(())

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/cue.mod/module.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/cue.mod/module.cue
@@ -1,0 +1,4 @@
+module: "github.com/waddle-social/waddle/server/crates/waddle-server/tests/xmpp_e2e_scenarios"
+language: {
+	version: "v0.14.0"
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/dm_delivery_mam.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/dm_delivery_mam.cue
@@ -1,0 +1,46 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "dm-delivery-and-mam"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-dm-1"
+			body: "hello-from-cue-scenario"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "hello-from-cue-scenario"
+		},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-dm-mam"
+		},
+		#ExpectMamResult & {
+			body: "hello-from-cue-scenario"
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_admin_affiliations.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_admin_affiliations.cue
@@ -1,0 +1,86 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "muc-admin-affiliations"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "admin"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-admin-affiliations@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice"},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-set-member"
+		},
+		#ExpectMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-query-member"
+		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "admin"
+			id:          "cue-muc-set-admin"
+		},
+		#ExpectMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "admin"
+			id:          "cue-muc-query-admin"
+		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "owner"
+			id:          "cue-muc-set-owner"
+		},
+		#ExpectMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "owner"
+			id:          "cue-muc-query-owner"
+		},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-muc-restore-member"
+		},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob"},
+		#ExpectMucAdminDenied & {
+			actor:       bobPhone
+			room:        roomJid
+			jid:         alicePhone.bareJid
+			affiliation: "outcast"
+			id:          "cue-muc-member-cannot-admin"
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_groupchat_fanout.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/muc_groupchat_fanout.cue
@@ -1,0 +1,63 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "muc-groupchat-fanout"
+	users: {
+		alice: devices: {
+			phone: #Actor & {
+				user:     "alice"
+				device:   "phone"
+				username: "admin"
+				resource: "phone"
+				domain:   scenario.domain
+			}
+			desktop: #Actor & {
+				user:     "alice"
+				device:   "desktop"
+				username: "admin"
+				resource: "desktop"
+				domain:   scenario.domain
+			}
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-fanout@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let aliceDesktop = users.alice.devices.desktop
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice-phone"},
+		#JoinMuc & {actor: aliceDesktop, room: roomJid, nick: "alice-desktop"},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
+		#SendMessage & {
+			from: alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-muc-fanout"
+			body:  "muc fanout message to all joined devices"
+		},
+		#ExpectMessage & {
+			target: alicePhone
+			body:   "muc fanout message to all joined devices"
+			contains: [roomJid]
+		},
+		#ExpectMessage & {
+			target: aliceDesktop
+			body:   "muc fanout message to all joined devices"
+			contains: [roomJid]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   "muc fanout message to all joined devices"
+			contains: [roomJid]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/multi_device_carbons.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/multi_device_carbons.cue
@@ -1,0 +1,77 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "multi-device-carbons"
+	users: {
+		alice: devices: {
+			phone: #Actor & {
+				user:     "alice"
+				device:   "phone"
+				username: "alice"
+				resource: "phone"
+				domain:   scenario.domain
+			}
+			desktop: #Actor & {
+				user:     "alice"
+				device:   "desktop"
+				username: "alice"
+				resource: "desktop"
+				domain:   scenario.domain
+			}
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let aliceDesktop = users.alice.devices.desktop
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#EnableCarbons & {actor: aliceDesktop},
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-carbon-sent"
+			body: "sent-carbon-proof"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "sent-carbon-proof"
+		},
+		#ExpectCarbon & {
+			target: aliceDesktop
+			carbon: "sent"
+			body:   "sent-carbon-proof"
+		},
+		#SendMessage & {
+			from: bobPhone
+			to:   alicePhone
+			id:   "cue-carbon-received"
+			body: "received-carbon-proof"
+		},
+		#ExpectMessage & {
+			target: alicePhone
+			from:   bobPhone
+			body:   "received-carbon-proof"
+		},
+		#ExpectCarbon & {
+			target: aliceDesktop
+			carbon: "received"
+			body:   "received-carbon-proof"
+		},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-carbon-mam"
+		},
+		#ExpectMamResult & {body: "sent-carbon-proof"},
+		#ExpectMamResult & {body: "received-carbon-proof"},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -1,0 +1,184 @@
+package xmpp_e2e_scenarios
+
+#Actor: {
+	user:     string
+	device:   string
+	username: string
+	resource: string
+	domain:   string
+	bareJid:  "\(username)@\(domain)"
+	jid:      "\(bareJid)/\(resource)"
+	...
+}
+
+#User: {
+	devices: [string]: #Actor
+	...
+}
+
+#Scenario: {
+	name:   string
+	domain: *"localhost" | string
+	users: [string]: #User
+	steps: [...#Step]
+	...
+}
+
+#Step:
+	#EnableCarbons |
+	#SendMessage |
+	#ExpectMessage |
+	#ExpectCarbon |
+	#JoinMuc |
+	#SetMucAffiliation |
+	#ExpectMucAffiliation |
+	#ExpectMucAdminDenied |
+	#ExpectPresence |
+	#QueryMam |
+	#ExpectMamResult |
+	#ExpectNoStanza
+
+#EnableCarbons: {
+	kind:  "enableCarbons"
+	actor: #Actor
+	...
+}
+
+#SendMessage: {
+	kind: "sendMessage"
+	from: #Actor
+	#Destination
+	type: *"chat" | "normal" | "groupchat"
+	id?:  string
+	body?: string
+	payloads?: [...#Payload]
+	...
+}
+
+#Destination: (#ActorDestination | #JidDestination)
+
+#ActorDestination: {
+	to: #Actor
+	toJid?: _|_
+}
+
+#JidDestination: {
+	to?: _|_
+	toJid: string
+}
+
+#ExpectMessage: {
+	kind:   "expectMessage"
+	target: #Actor
+	body?:  string
+	from?:  #Actor
+	payloads?: [...#ExpectedPayload]
+	contains?: [...string]
+	...
+}
+
+#ExpectCarbon: {
+	kind:   "expectCarbon"
+	target: #Actor
+	carbon: "sent" | "received"
+	body?:  string
+	payloads?: [...#ExpectedPayload]
+	contains?: [...string]
+	...
+}
+
+#JoinMuc: {
+	kind:  "joinMuc"
+	actor: #Actor
+	room:  string
+	nick:  *actor.username | string
+	...
+}
+
+#SetMucAffiliation: {
+	kind:        "setMucAffiliation"
+	actor:       #Actor
+	room:        string
+	jid:         string
+	affiliation: #MucAffiliation
+	id?:         string
+	...
+}
+
+#ExpectMucAffiliation: {
+	kind:        "expectMucAffiliation"
+	actor:       #Actor
+	room:        string
+	jid:         string
+	affiliation: #MucAffiliation
+	id?:         string
+	...
+}
+
+#ExpectMucAdminDenied: {
+	kind:        "expectMucAdminDenied"
+	actor:       #Actor
+	room:        string
+	jid:         string
+	affiliation: #MucAffiliation
+	id?:         string
+	...
+}
+
+#MucAffiliation: "owner" | "admin" | "member" | "none" | "outcast"
+
+#ExpectPresence: {
+	kind:   "expectPresence"
+	target: #Actor
+	contains: [...string] & [string, ...string]
+	...
+}
+
+#QueryMam: {
+	kind:    "queryMam"
+	actor:   #Actor
+	archive: string
+	id?:     string
+	max:     *50 | int & >=1
+	...
+}
+
+#ExpectMamResult: {
+	kind: "expectMamResult"
+	body?: string
+	payloads?: [...#ExpectedPayload]
+	contains?: [...string]
+	...
+}
+
+#ExpectNoStanza: {
+	kind:   "expectNoStanza"
+	target: #Actor
+	body?:  string
+	contains?: [...string]
+	millis: *250 | int & >=1
+	...
+}
+
+#Payload: #FileShare | #LinkMetadata
+
+#ExpectedPayload: #FileShare | #LinkMetadata
+
+#FileShare: {
+	kind:        "fileShare"
+	disposition: *"inline" | "attachment"
+	name:        string
+	mediaType:   string
+	size:        int & >=0
+	url:         string
+	...
+}
+
+#LinkMetadata: {
+	kind:        "linkMetadata"
+	about:       string
+	title:       string
+	description: string
+	url:         string
+	...
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -160,9 +160,15 @@ package xmpp_e2e_scenarios
 	...
 }
 
-#Payload: #FileShare | #LinkMetadata
+#Payload: #FileShare | #LinkMetadata | #MessageCorrection
 
-#ExpectedPayload: #FileShare | #LinkMetadata
+#ExpectedPayload: #FileShare | #LinkMetadata | #MessageCorrection
+
+#MessageCorrection: {
+	kind: "messageCorrection"
+	id:   string
+	...
+}
 
 #FileShare: {
 	kind:        "fileShare"

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_message_correction.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_message_correction.cue
@@ -1,0 +1,66 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0308-message-correction"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-edit-original"
+			body: "helo from cue"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "helo from cue"
+		},
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-edit-correction"
+			body: "hello from cue"
+			payloads: [
+				#MessageCorrection & {id: "cue-edit-original"},
+			]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "hello from cue"
+			payloads: [
+				#MessageCorrection & {id: "cue-edit-original"},
+			]
+		},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-edit-mam"
+		},
+		#ExpectMamResult & {
+			body: "hello from cue"
+			payloads: [
+				#MessageCorrection & {id: "cue-edit-original"},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_muc_message_correction.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0308_muc_message_correction.cue
@@ -1,0 +1,59 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0308-muc-message-correction"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "admin"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-edit@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice-phone"},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
+		#SendMessage & {
+			from: alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-muc-edit-original"
+			body:  "helo from muc cue"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   "helo from muc cue"
+			contains: [roomJid, "cue-muc-edit-original"]
+		},
+		#SendMessage & {
+			from: alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-muc-edit-correction"
+			body:  "hello from muc cue"
+			payloads: [
+				#MessageCorrection & {id: "cue-muc-edit-original"},
+			]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   "hello from muc cue"
+			payloads: [
+				#MessageCorrection & {id: "cue-muc-edit-original"},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0447_stateless_file_sharing.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0447_stateless_file_sharing.cue
@@ -1,0 +1,70 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0447-stateless-file-sharing"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+	let fileUrl = "https://files.example.com/report.pdf"
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-xep-0447"
+			body: fileUrl
+			payloads: [
+				#FileShare & {
+					name:      "report.pdf"
+					mediaType: "application/pdf"
+					size:      4096
+					url:       fileUrl
+				},
+			]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   fileUrl
+			payloads: [
+				#FileShare & {
+					name:      "report.pdf"
+					mediaType: "application/pdf"
+					size:      4096
+					url:       fileUrl
+				},
+			]
+		},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-xep-0447-mam"
+		},
+		#ExpectMamResult & {
+			body: fileUrl
+			payloads: [
+				#FileShare & {
+					name:      "report.pdf"
+					mediaType: "application/pdf"
+					size:      4096
+					url:       fileUrl
+				},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0511_link_metadata.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0511_link_metadata.cue
@@ -1,0 +1,72 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0511-link-metadata"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+	let linked = "https://the.link.example.com/what-was-linked-to"
+	let canonical = "https://example.com/canonical-url/for/what-was-linked-to"
+	let linkBody = "sharing a useful link: \(linked)"
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-xep-0511"
+			body: linkBody
+			payloads: [
+				#LinkMetadata & {
+					about:       linked
+					title:       "The Best Webpage"
+					description: "This is a great webpage and you will really like it"
+					url:         canonical
+				},
+			]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   linkBody
+			payloads: [
+				#LinkMetadata & {
+					about:       linked
+					title:       "The Best Webpage"
+					description: "This is a great webpage and you will really like it"
+					url:         canonical
+				},
+			]
+		},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-xep-0511-mam"
+		},
+		#ExpectMamResult & {
+			body: linkBody
+			payloads: [
+				#LinkMetadata & {
+					about:       linked
+					title:       "The Best Webpage"
+					description: "This is a great webpage and you will really like it"
+					url:         canonical
+				},
+			]
+		},
+	]
+}

--- a/server/env.cue
+++ b/server/env.cue
@@ -140,6 +140,7 @@ schema.#Project & {
 			}
 			tasks: [
 				_t.xmppUnitTests,
+				_t.xmppCueE2e,
 				_t.xmppServerTests,
 				_t.xmppXepIntegration,
 			]
@@ -327,6 +328,11 @@ schema.#Project & {
 
 		xmppServerTests: xRust.#Test & {
 			args: ["test", "--package", "waddle-server", "--verbose"]
+			inputs: _rustInputs
+		}
+
+		xmppCueE2e: xRust.#Test & {
+			args: ["test", "--package", "waddle-server", "--test", "xmpp_e2e_cue", "--verbose"]
 			inputs: _rustInputs
 		}
 


### PR DESCRIPTION
## Summary

This PR does two related pieces of XMPP conformance work:

- restores the CUE-authored XMPP E2E scenario harness for the active WebSocket C2S server path
- fixes XEP-0308 message correction targeting in the chat UI so edits target the original sender message id / origin-id, not a room/server stanza-id

## Server / CUE E2E Coverage

- Reintroduces CUE scenarios under the active `waddle-server` test crate instead of the deleted TCP harness.
- Runs scenarios through `WsXmppClient` over `/ws` with SCRAM-authenticated test users.
- Keeps scenarios semantic at the CUE layer while Rust builds and validates typed XMPP stanzas.
- Covers basic messaging, MAM-backed assertions, and XEP-0308 MUC message correction.
- Adds a MUC correction scenario proving `<replace id="..."/>` uses the original message id.

## Chat XEP-0308 Fix

- Follows XEP-0308: `<replace id="..."/>` targets the original sender message id / origin-id.
- Keeps rendered timeline identity on stable stanza IDs where available, so replies, reactions, markers, and scrolling still use the stable message ids they expect.
- Tracks a separate `correctionTargetId` through room and DM parsing, queued messages, optimistic sends, and edit submission.
- Preserves the full MUC occupant JID separately from the real bare JID so same-occupant correction checks stay correct in non-anonymous rooms.
- Enforces correction sender identity before applying inbound edits:
  - DMs require the same bare sender JID.
  - MUCs require the same full room occupant JID.
  - When both real JIDs are known, MUC corrections also require the same bare real JID.

## Tests / Verification

- `bun test` in `chat/`
- `bun run lint` in `chat/`
- `bunx astro check` in `chat/`
- `cargo test --package waddle-server --test xmpp_e2e_cue -- --nocapture` in `server/`
- adversarial review pass after fixes: no actionable XEP-0308/message-correction issues found
- GitHub CI is green:
  - `waddle-chat-pullRequest`
  - `waddle-server-pullRequest`
  - `waddle-server-xmppCompliance`
  - CodeQL and analysis jobs
