### PR TITLE
feat(server): #229 PR7 — storage arms (ArchiveDirect + ProjectInbox)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -104,6 +104,23 @@ impl<'a> Deps<'a> {
             inbox_storage: None,
         }
     }
+
+    /// Build a `Deps` for unit tests that exercise the storage arms
+    /// (`ArchiveDirect`, `ProjectInbox`). SM fan-out is left disabled
+    /// so the carbon-detached path stays an independent test concern.
+    #[cfg(test)]
+    pub fn test_with_storage(
+        connection_registry: &'a ConnectionRegistry,
+        mam_storage: &'a Arc<dyn MamStorage>,
+        inbox_storage: &'a Arc<dyn InboxStorage>,
+    ) -> Self {
+        Self {
+            connection_registry,
+            sm_session_registry: None,
+            mam_storage: Some(mam_storage),
+            inbox_storage: Some(inbox_storage),
+        }
+    }
 }
 
 /// Execute the side effects described by `events`.
@@ -434,8 +451,12 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                 // XEP-0359 `<stanza-id by=archive_jid/>` stamp on the
                 // typed message, so the projection serializer captures
                 // it for replay.
-                let archived =
-                    build_direct_archived_message(&from.to_string(), &to.to_string(), &message);
+                let archived = build_direct_archived_message(
+                    &archive_jid.to_string(),
+                    &from.to_string(),
+                    &to.to_string(),
+                    &message,
+                );
                 let archive_jid_str = archive_jid.to_string();
                 match mam_storage
                     .store_message(archive_jid_str.as_str(), &archived)
@@ -827,19 +848,6 @@ mod tests {
     // XEP-0313 — ArchiveDirect persistence
     // -----------------------------------------------------------------
 
-    fn make_deps_with_storage<'a>(
-        registry: &'a ConnectionRegistry,
-        mam: &'a Arc<dyn MamStorage>,
-        inbox: &'a Arc<dyn InboxStorage>,
-    ) -> Deps<'a> {
-        Deps {
-            connection_registry: registry,
-            sm_session_registry: None,
-            mam_storage: Some(mam),
-            inbox_storage: Some(inbox),
-        }
-    }
-
     #[tokio::test]
     async fn xep_0313_archive_direct_persists_to_mam_storage() {
         use waddle_xmpp::mam::storage::InMemoryMamStorage;
@@ -847,7 +855,7 @@ mod tests {
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
         let inbox: Arc<dyn InboxStorage> =
             Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
-        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
         let archive_jid: jid::BareJid = "alice@example.com".parse().expect("bare");
         let from: jid::BareJid = "alice@example.com".parse().expect("bare");
@@ -880,6 +888,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn xep_0359_archive_ref_pivots_inbox_row_to_mam_row_by_stanza_id() {
+        // End-to-end of the bug Qodo + Codex flagged: inbox writes
+        // `archive_ref` from the canonical XEP-0359 `<stanza-id>`
+        // stamp, and `MamStorage::get_message_by_stanza_id` must
+        // resolve that same id against `archive_jid`. If the
+        // projection ever stops using the canonical stamp as
+        // `ArchivedMessage.stanza_id`/`id`, the inbox row points at a
+        // dangling stanza-id and clients can't pivot to the archive.
+        use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
+        use waddle_xmpp::xep::xep0359::build_stanza_id_element;
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+        let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+        let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let mut msg = chat_msg("alice@example.com/web", "bob@example.com", "pivot test");
+        msg.id = Some("wire-id".to_string());
+        // Simulate CanonicalizeHandler stamping the canonical id
+        // under alice's archive — the same id InboxHandler will
+        // emit as `archive_ref`.
+        let canonical_id = "alice-canonical-1";
+        msg.payloads
+            .push(build_stanza_id_element(canonical_id, "alice@example.com"));
+
+        let events = vec![
+            OutboundEvent::ArchiveDirect {
+                archive_jid: alice.clone(),
+                from: alice.clone(),
+                to: bob.clone(),
+                message: Box::new(msg.clone()),
+            },
+            OutboundEvent::ProjectInbox {
+                owner: alice.clone(),
+                peer: bob.clone(),
+                message: Box::new(msg),
+                archive_ref: StanzaIdRef {
+                    by: alice.clone(),
+                    id: StanzaIdValue::new(canonical_id),
+                },
+                increment_unread: false,
+            },
+        ];
+        let _outcome = interpret(events, &deps).await;
+
+        // Inbox row carries the canonical stamp.
+        let entries = inbox_concrete.list(&alice).await.expect("inbox list");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].last_stanza_id, canonical_id);
+
+        // The same id resolves a MAM row in alice's archive — pivot
+        // works.
+        let row = mam
+            .get_message_by_stanza_id(&alice.to_string(), canonical_id)
+            .await
+            .expect("mam lookup")
+            .expect("MAM row keyed by canonical stanza-id");
+        assert_eq!(row.id, canonical_id);
+        assert_eq!(row.body, "pivot test");
+    }
+
+    #[tokio::test]
     async fn xep_0313_archive_direct_writes_one_entry_per_event() {
         // Sender pass + recipient pass on the same dispatch (true
         // local-to-local) emit two events with distinct archive_jids
@@ -889,7 +963,7 @@ mod tests {
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
         let inbox: Arc<dyn InboxStorage> =
             Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
-        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
         let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
         let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
@@ -1013,7 +1087,7 @@ mod tests {
         let mam: Arc<dyn MamStorage> = Arc::new(FailingMam);
         let inbox: Arc<dyn InboxStorage> =
             Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
-        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
         let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
         let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
@@ -1044,7 +1118,7 @@ mod tests {
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
         let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
         let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
-        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
         let owner: jid::BareJid = "alice@example.com".parse().expect("bare");
         let peer: jid::BareJid = "bob@example.com".parse().expect("bare");
@@ -1084,7 +1158,7 @@ mod tests {
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
         let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
         let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
-        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
         let owner: jid::BareJid = "bob@example.com".parse().expect("bare");
         let peer: jid::BareJid = "alice@example.com".parse().expect("bare");

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -26,14 +26,18 @@
 //! - [`OutboundEvent::SendCarbons`] — XEP-0280 carbon fan-out via the
 //!   XEP-0297 `<sent>`/`<received>` envelope, including detached
 //!   XEP-0198 resumable sessions.
+//! - [`OutboundEvent::ArchiveDirect`] — XEP-0313 §5.1 personal MAM
+//!   write keyed under `archive_jid`. Eligibility was vetted by
+//!   [`waddle_xmpp::protocol::handlers::archive::ArchiveHandler`].
+//! - [`OutboundEvent::ProjectInbox`] — Waddle inbox upsert keyed by
+//!   `(owner, peer)` with `archive_ref` linking back to the MAM entry.
 //! - [`OutboundEvent::UnregisterConnection`] — drop from the registry.
 //!
 //! Stubbed (warn-logged until migration steps land them):
-//! - `BroadcastToRoom`, `DispatchToRoom` — MUC handler chain (PR8+).
-//! - `ProjectInbox`, `ArchiveDirect`, `ArchiveGroupchat` — need
-//!   storage references in the interpreter [`Deps`] (PR7+).
+//! - `BroadcastToRoom`, `DispatchToRoom`, `ArchiveGroupchat` — MUC
+//!   handler chain (PR10).
 //! - `LookupArchivedMessage`, `RequestEnrichment` — need callback
-//!   plumbing back into the state machine (PR8+).
+//!   plumbing back into the state machine (PR8).
 //! - `AskSfu`, `QueryMam`, `LoadScramCredentials`,
 //!   `ValidateOAuthBearer`, `SetTimer`, `CancelTimer`,
 //!   `RegisterConnection` — wired in later migration steps.
@@ -41,6 +45,10 @@
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use waddle_xmpp::carbons::{build_received_carbon, build_sent_carbon};
+use waddle_xmpp::inbox::runtime::direct_message_entry;
+use waddle_xmpp::inbox::storage::InboxStorage;
+use waddle_xmpp::mam::projection::build_direct_archived_message;
+use waddle_xmpp::mam::storage::MamStorage;
 use waddle_xmpp::parser::stanza_to_string;
 use waddle_xmpp::protocol::{CarbonKind, OutboundEvent};
 use waddle_xmpp::registry::ConnectionRegistry;
@@ -62,9 +70,9 @@ pub struct InterpretOutcome {
 /// Typed dependency context for the interpreter.
 ///
 /// Grows as later migration steps add storage/actor handles
-/// (`MamStorage`, inbox storage, `extension_manager`, etc.). Threading
-/// dependencies through one struct rather than as loose function
-/// parameters keeps the call-site churn small.
+/// (`extension_manager`, etc.). Threading dependencies through one
+/// struct rather than as loose function parameters keeps the call-site
+/// churn small.
 #[derive(Clone)]
 pub struct Deps<'a> {
     pub connection_registry: &'a ConnectionRegistry,
@@ -74,18 +82,26 @@ pub struct Deps<'a> {
     /// history while resumable. `None` in unit tests that don't
     /// exercise SM behaviour.
     pub sm_session_registry: Option<&'a Arc<InMemorySmSessionRegistry>>,
+    /// XEP-0313 MAM persistence backend. `None` in unit tests that
+    /// don't exercise archive writes; production wiring (`iq.rs`)
+    /// always supplies it.
+    pub mam_storage: Option<&'a Arc<dyn MamStorage>>,
+    /// Waddle inbox-projection backend. `None` in unit tests; always
+    /// supplied in production.
+    pub inbox_storage: Option<&'a Arc<dyn InboxStorage>>,
 }
 
 impl<'a> Deps<'a> {
     /// Build a minimal `Deps` with only the connection registry — a
     /// test-only convenience for unit tests that don't exercise SM
-    /// fan-out. Production code constructs `Deps` directly so the
-    /// dependency surface is explicit at every call site.
+    /// fan-out, archive, or inbox storage.
     #[cfg(test)]
     pub fn registry_only(connection_registry: &'a ConnectionRegistry) -> Self {
         Self {
             connection_registry,
             sm_session_registry: None,
+            mam_storage: None,
+            inbox_storage: None,
         }
     }
 }
@@ -187,13 +203,45 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }
-            OutboundEvent::ProjectInbox { owner, peer, .. } => {
-                warn!(
-                    variant = "ProjectInbox",
-                    owner = %owner,
-                    peer = %peer,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::ProjectInbox {
+                owner,
+                peer,
+                message,
+                archive_ref,
+                increment_unread,
+            } => {
+                let Some(inbox_storage) = deps.inbox_storage else {
+                    debug!(
+                        owner = %owner,
+                        peer = %peer,
+                        "ProjectInbox: no inbox_storage in Deps; skipping (test fixture?)"
+                    );
+                    continue;
+                };
+                // Build the inbox entry from the typed message, then
+                // overwrite its stanza-id with the typed `archive_ref`
+                // so the inbox row links to the canonicalized MAM
+                // entry the handler stamped (rather than re-deriving
+                // from the wire `<message id=...>`).
+                let timestamp = chrono::Utc::now().timestamp();
+                let mut entry = direct_message_entry(peer.clone(), &message, timestamp);
+                entry.last_stanza_id = archive_ref.id.as_str().to_string();
+                if let Err(error) = inbox_storage.upsert(&owner, entry, increment_unread).await {
+                    warn!(
+                        owner = %owner,
+                        peer = %peer,
+                        %error,
+                        "ProjectInbox: inbox upsert failed; dropping projection"
+                    );
+                } else {
+                    debug!(
+                        owner = %owner,
+                        peer = %peer,
+                        archive_ref = archive_ref.id.as_str(),
+                        increment_unread,
+                        "ProjectInbox: persisted"
+                    );
+                }
             }
             OutboundEvent::SendCarbons {
                 owner,
@@ -365,13 +413,54 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }
-            OutboundEvent::ArchiveDirect { from, to, .. } => {
-                warn!(
-                    variant = "ArchiveDirect",
-                    from = %from,
-                    to = %to,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::ArchiveDirect {
+                archive_jid,
+                from,
+                to,
+                message,
+            } => {
+                let Some(mam_storage) = deps.mam_storage else {
+                    debug!(
+                        archive_jid = %archive_jid,
+                        from = %from,
+                        to = %to,
+                        "ArchiveDirect: no mam_storage in Deps; skipping (test fixture?)"
+                    );
+                    continue;
+                };
+                // Per XEP-0313 §5.1.3, the eligibility check is
+                // upstream (ArchiveHandler) — the interpreter just
+                // persists. The handler also already canonicalized the
+                // XEP-0359 `<stanza-id by=archive_jid/>` stamp on the
+                // typed message, so the projection serializer captures
+                // it for replay.
+                let archived =
+                    build_direct_archived_message(&from.to_string(), &to.to_string(), &message);
+                let archive_jid_str = archive_jid.to_string();
+                match mam_storage
+                    .store_message(archive_jid_str.as_str(), &archived)
+                    .await
+                {
+                    Ok(archive_id) => {
+                        debug!(
+                            archive_jid = %archive_jid,
+                            archive_id,
+                            "ArchiveDirect: persisted"
+                        );
+                    }
+                    Err(error) => {
+                        // Archive errors must not block dispatch — the
+                        // message is already on the wire to other
+                        // resources via routing/carbons. Log and drop.
+                        warn!(
+                            archive_jid = %archive_jid,
+                            from = %from,
+                            to = %to,
+                            %error,
+                            "ArchiveDirect: store_message failed; dropping archive write"
+                        );
+                    }
+                }
             }
             OutboundEvent::RequestEnrichment { id, .. } => {
                 warn!(
@@ -706,6 +795,8 @@ mod tests {
         let deps = Deps {
             connection_registry: &registry,
             sm_session_registry: Some(&sm),
+            mam_storage: None,
+            inbox_storage: None,
         };
         let _outcome = interpret(
             vec![OutboundEvent::SendCarbons {
@@ -729,6 +820,292 @@ mod tests {
         assert!(
             !session.unacked_stanzas.is_empty(),
             "detached SM session must have at least one queued carbon for resume"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // XEP-0313 — ArchiveDirect persistence
+    // -----------------------------------------------------------------
+
+    fn make_deps_with_storage<'a>(
+        registry: &'a ConnectionRegistry,
+        mam: &'a Arc<dyn MamStorage>,
+        inbox: &'a Arc<dyn InboxStorage>,
+    ) -> Deps<'a> {
+        Deps {
+            connection_registry: registry,
+            sm_session_registry: None,
+            mam_storage: Some(mam),
+            inbox_storage: Some(inbox),
+        }
+    }
+
+    #[tokio::test]
+    async fn xep_0313_archive_direct_persists_to_mam_storage() {
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> =
+            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+
+        let archive_jid: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let from: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let to: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let mut msg = chat_msg("alice@example.com/web", "bob@example.com", "hello");
+        msg.id = Some("orig-1".to_string());
+
+        let events = vec![OutboundEvent::ArchiveDirect {
+            archive_jid: archive_jid.clone(),
+            from,
+            to,
+            message: Box::new(msg),
+        }];
+        let _outcome = interpret(events, &deps).await;
+
+        let stored = mam
+            .query_messages(&archive_jid.to_string(), &Default::default())
+            .await
+            .expect("query");
+        assert_eq!(
+            stored.messages.len(),
+            1,
+            "ArchiveDirect persists exactly one row"
+        );
+        let row = &stored.messages[0];
+        assert_eq!(row.from, "alice@example.com");
+        assert_eq!(row.to, "bob@example.com");
+        assert_eq!(row.body, "hello");
+        assert_eq!(row.stanza_id.as_deref(), Some("orig-1"));
+    }
+
+    #[tokio::test]
+    async fn xep_0313_archive_direct_writes_one_entry_per_event() {
+        // Sender pass + recipient pass on the same dispatch (true
+        // local-to-local) emit two events with distinct archive_jids
+        // — the interpreter writes one entry per archive.
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> =
+            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+
+        let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "yo");
+
+        let events = vec![
+            OutboundEvent::ArchiveDirect {
+                archive_jid: alice.clone(),
+                from: alice.clone(),
+                to: bob.clone(),
+                message: Box::new(msg.clone()),
+            },
+            OutboundEvent::ArchiveDirect {
+                archive_jid: bob.clone(),
+                from: alice.clone(),
+                to: bob.clone(),
+                message: Box::new(msg),
+            },
+        ];
+        let _outcome = interpret(events, &deps).await;
+
+        let alice_archive = mam
+            .query_messages(&alice.to_string(), &Default::default())
+            .await
+            .expect("query alice");
+        let bob_archive = mam
+            .query_messages(&bob.to_string(), &Default::default())
+            .await
+            .expect("query bob");
+        assert_eq!(
+            alice_archive.messages.len(),
+            1,
+            "alice archive has the sender-pass entry"
+        );
+        assert_eq!(
+            bob_archive.messages.len(),
+            1,
+            "bob archive has the recipient-pass entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep_0313_archive_direct_drops_when_storage_errors() {
+        // Storage errors must NOT fail dispatch. We use a fake that
+        // always errors and assert interpret returns normally; the
+        // archive write is logged-and-dropped.
+        use async_trait::async_trait;
+        use waddle_xmpp::mam::storage::{MamStorage, MamStorageError};
+        use waddle_xmpp::mam::{ArchivedMessage, MamQuery, MamResult};
+
+        struct FailingMam;
+        #[async_trait]
+        impl MamStorage for FailingMam {
+            async fn store_message(
+                &self,
+                _: &str,
+                _: &ArchivedMessage,
+            ) -> Result<String, MamStorageError> {
+                Err(MamStorageError::Database("simulated".into()))
+            }
+            async fn query_messages(
+                &self,
+                _: &str,
+                _: &MamQuery,
+            ) -> Result<MamResult, MamStorageError> {
+                Ok(MamResult {
+                    messages: Vec::new(),
+                    complete: true,
+                    first_id: None,
+                    last_id: None,
+                    count: Some(0),
+                })
+            }
+            async fn get_message(
+                &self,
+                _: &str,
+            ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+                Ok(None)
+            }
+            async fn replace_with_tombstone(
+                &self,
+                _: &str,
+                _: waddle_xmpp::mam::ArchivedTombstone,
+            ) -> Result<bool, MamStorageError> {
+                Ok(false)
+            }
+            async fn get_message_by_stanza_id(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+                Ok(None)
+            }
+            async fn get_message_by_message_id(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+                Ok(None)
+            }
+            async fn get_message_by_archive_or_stanza_id(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+                Ok(None)
+            }
+            async fn count_messages(&self, _: &str) -> Result<u32, MamStorageError> {
+                Ok(0)
+            }
+            async fn delete_before(
+                &self,
+                _: &str,
+                _: chrono::DateTime<chrono::Utc>,
+            ) -> Result<u64, MamStorageError> {
+                Ok(0)
+            }
+        }
+
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(FailingMam);
+        let inbox: Arc<dyn InboxStorage> =
+            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+
+        let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "yo");
+        let events = vec![OutboundEvent::ArchiveDirect {
+            archive_jid: alice.clone(),
+            from: alice,
+            to: bob,
+            message: Box::new(msg),
+        }];
+        let outcome = interpret(events, &deps).await;
+        // No frames, no close — error swallowed.
+        assert!(outcome.frames.is_empty());
+        assert!(!outcome.close);
+    }
+
+    // -----------------------------------------------------------------
+    // Inbox projection
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn inbox_project_writes_owner_peer_keyed_row_with_typed_archive_ref() {
+        use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
+
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+        let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+
+        let owner: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let peer: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let mut msg = chat_msg("alice@example.com/web", "bob@example.com", "hi there");
+        msg.id = Some("origin-X".to_string());
+
+        let events = vec![OutboundEvent::ProjectInbox {
+            owner: owner.clone(),
+            peer: peer.clone(),
+            message: Box::new(msg),
+            archive_ref: StanzaIdRef {
+                by: owner.clone(),
+                id: StanzaIdValue::new("alice-archive-1"),
+            },
+            increment_unread: false,
+        }];
+        let _outcome = interpret(events, &deps).await;
+
+        let entries = inbox_concrete.list(&owner).await.expect("list");
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.partner, peer);
+        assert_eq!(
+            entry.last_stanza_id, "alice-archive-1",
+            "last_stanza_id is sourced from the typed archive_ref, not the wire id"
+        );
+        assert_eq!(entry.unread, 0, "increment_unread=false leaves unread at 0");
+    }
+
+    #[tokio::test]
+    async fn inbox_project_increment_unread_bumps_recipient_count() {
+        use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
+
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+        let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+        let deps = make_deps_with_storage(&registry, &mam, &inbox);
+
+        let owner: jid::BareJid = "bob@example.com".parse().expect("bare");
+        let peer: jid::BareJid = "alice@example.com".parse().expect("bare");
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "hi bob");
+
+        let events = vec![OutboundEvent::ProjectInbox {
+            owner: owner.clone(),
+            peer: peer.clone(),
+            message: Box::new(msg),
+            archive_ref: StanzaIdRef {
+                by: owner.clone(),
+                id: StanzaIdValue::new("bob-archive-1"),
+            },
+            increment_unread: true,
+        }];
+        let _outcome = interpret(events, &deps).await;
+
+        let total = inbox_concrete.total_unread(&owner).await.expect("unread");
+        assert_eq!(
+            total, 1,
+            "increment_unread=true bumps the owner's unread count"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -301,6 +301,8 @@ pub async fn handle_iq_with_conn_state(
         let deps = crate::server::routes::interpret::Deps {
             connection_registry: &state.deps.protocol.connection_registry,
             sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
+            mam_storage: Some(&state.deps.protocol.mam_storage),
+            inbox_storage: Some(&state.deps.protocol.inbox_storage),
         };
         let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
         if outcome.close {

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -13,6 +13,7 @@
 //! `waddle-xmpp-core` so server and client crates can share typed history
 //! primitives without runtime coupling.
 
+pub mod projection;
 pub mod storage;
 
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -1,0 +1,253 @@
+//! Typed projection from a wire-shape [`Message`] to the persistent
+//! [`ArchivedMessage`] shape MAM storage expects.
+//!
+//! Used by the sans-I/O dispatcher's storage interpreter
+//! ([`OutboundEvent::ArchiveDirect`]) — keeps the conversion in one
+//! place so handler-emitted typed events are projected consistently
+//! whether the call site is the legacy `message.rs` path (until #229
+//! PR9 cuts over) or the dispatcher.
+//!
+//! Archive eligibility (XEP-0313 §5.1.3 + XEP-0334 hint precedence) is
+//! enforced by [`super::super::protocol::handlers::archive::ArchiveHandler`]
+//! upstream; this module is a pure data projection and assumes the
+//! caller already vetted the message.
+//!
+//! [`OutboundEvent::ArchiveDirect`]: super::super::protocol::event::OutboundEvent::ArchiveDirect
+
+use chrono::Utc;
+use xmpp_parsers::message::{Message, MessageType};
+
+use super::{
+    ArchivedMention, ArchivedMessage, ArchivedReactionSet, ArchivedReference, ArchivedReply,
+    ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, RichMessageId, RichText,
+    STANZA_ID_NS,
+};
+use crate::parser::message_to_string;
+use crate::xep::{
+    extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
+    extract_references_from_message, extract_retraction_from_message, parse_reply_from_message,
+    RetractionKind, NS_REPLY,
+};
+
+/// Build the [`ArchivedMessage`] persisted form of a one-to-one
+/// (chat / normal) `<message/>` for direct MAM storage.
+///
+/// `from` and `to` are the canonical bare-JID tuple for the archive
+/// row — the caller (interpreter) supplies them so the projection
+/// does not duplicate the pass-aware logic that lives in the
+/// [`super::super::protocol::handlers::archive::ArchiveHandler`]. The
+/// `id` field is left empty: storage assigns the row id at write time.
+pub fn build_direct_archived_message(from: &str, to: &str, message: &Message) -> ArchivedMessage {
+    let body = prototype_body(message)
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default();
+    let (reply_to_id, reply_to_jid) = extract_reply_reference(message);
+    let origin_id = extract_origin_id(message);
+    let rich = rich_archive_payload(message);
+    let stanza_xml = serialize_message_xml(message);
+
+    ArchivedMessage {
+        id: String::new(),
+        timestamp: Utc::now(),
+        from: from.to_string(),
+        to: to.to_string(),
+        body,
+        stanza_id: message.id.clone(),
+        thread_id: message.thread.as_ref().map(|thread| thread.0.clone()),
+        reply_to_id,
+        reply_to_jid,
+        origin_id,
+        message_type: mam_message_type(&message.type_),
+        stanza_xml,
+        rich,
+        nickname_generation: None,
+    }
+}
+
+fn mam_message_type(message_type: &MessageType) -> String {
+    match message_type {
+        MessageType::Chat => "chat".to_string(),
+        MessageType::Error => "error".to_string(),
+        MessageType::Groupchat => "groupchat".to_string(),
+        MessageType::Headline => "headline".to_string(),
+        MessageType::Normal => "normal".to_string(),
+    }
+}
+
+fn prototype_body(message: &Message) -> Option<String> {
+    message
+        .bodies
+        .get("")
+        .or_else(|| message.bodies.values().next())
+        .map(|body| body.0.clone())
+}
+
+fn extract_origin_id(message: &Message) -> Option<String> {
+    message
+        .payloads
+        .iter()
+        .find(|payload| payload.name() == "origin-id" && payload.ns() == STANZA_ID_NS)
+        .and_then(|origin| origin.attr("id").map(ToOwned::to_owned))
+}
+
+fn extract_reply_reference(message: &Message) -> (Option<String>, Option<String>) {
+    let Some(reply) = message
+        .payloads
+        .iter()
+        .find(|payload| payload.name() == "reply" && payload.ns() == NS_REPLY)
+    else {
+        return (None, None);
+    };
+    (
+        reply.attr("id").map(ToOwned::to_owned),
+        reply.attr("to").map(ToOwned::to_owned),
+    )
+}
+
+fn serialize_message_xml(message: &Message) -> Option<String> {
+    message_to_string(message).ok()
+}
+
+fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
+    let payload = extract_correction_from_message(message)
+        .and_then(|correction| {
+            RichMessageId::new(correction.replaces_id)
+                .map(|replaces_id| ArchivedRichPayload::Correction { replaces_id })
+        })
+        .or_else(|| {
+            extract_retraction_from_message(message).and_then(|kind| match kind {
+                RetractionKind::Request(retraction) => RichMessageId::new(retraction.retracts_id)
+                    .map(|target_id| {
+                        ArchivedRichPayload::Retraction(ArchivedRetraction {
+                            target_id,
+                            stamp: None,
+                            retraction_id: message.id.clone().and_then(RichMessageId::new),
+                        })
+                    }),
+                RetractionKind::Tombstone(retracted) => message.id.clone().and_then(|id| {
+                    RichMessageId::new(id).map(|target_id| {
+                        ArchivedRichPayload::Retraction(ArchivedRetraction {
+                            target_id,
+                            stamp: chrono::DateTime::parse_from_rfc3339(&retracted.stamp)
+                                .ok()
+                                .map(|stamp| stamp.with_timezone(&Utc)),
+                            retraction_id: None,
+                        })
+                    })
+                }),
+            })
+        })
+        .or_else(|| {
+            extract_reactions_from_message(message).and_then(|reactions| {
+                RichMessageId::new(reactions.message_id).map(|target_id| {
+                    ArchivedRichPayload::Reactions(ArchivedReactionSet {
+                        target_id,
+                        emojis: reactions
+                            .emojis
+                            .into_iter()
+                            .filter_map(RichText::new)
+                            .collect(),
+                    })
+                })
+            })
+        });
+
+    let reply = parse_reply_from_message(message).and_then(|reply| {
+        RichMessageId::new(reply.id).map(|id| ArchivedReply {
+            id,
+            to: reply.to.and_then(|to| to.parse().ok()),
+        })
+    });
+
+    let references = extract_references_from_message(message)
+        .into_iter()
+        .filter_map(|reference| {
+            let ref_type = RichText::new(reference.ref_type.as_str())?;
+            Some(ArchivedReference {
+                ref_type,
+                begin: reference.begin.and_then(|value| value.try_into().ok()),
+                end: reference.end.and_then(|value| value.try_into().ok()),
+                uri: reference.uri.and_then(RichText::new),
+                anchor: reference.anchor.and_then(RichText::new),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mentions = extract_explicit_mentions(message)
+        .map(|mentions| {
+            mentions
+                .mentions
+                .into_iter()
+                .map(|mention| ArchivedMention {
+                    begin: mention.begin,
+                    end: mention.end,
+                    jid: mention.jid,
+                    occupant_id: mention.occupant_id.and_then(RichText::new),
+                    mentions: mention.mentions.and_then(RichText::new),
+                    uri: mention.uri.and_then(RichText::new),
+                    active: mention.active,
+                    noping: mention.noping,
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    if payload.is_none() && reply.is_none() && references.is_empty() && mentions.is_empty() {
+        None
+    } else {
+        Some(ArchivedRichMessage {
+            payload,
+            reply,
+            references,
+            mentions,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::message::{Body, MessageType};
+
+    fn chat_with_body(from: &str, to: &str, body: &str) -> Message {
+        let mut m = Message::new(Some(to.parse().expect("jid")));
+        m.from = Some(from.parse().expect("jid"));
+        m.type_ = MessageType::Chat;
+        m.id = Some("orig-1".to_string());
+        m.bodies.insert(String::new(), Body(body.to_string()));
+        m
+    }
+
+    #[test]
+    fn xep_0313_projects_canonical_fields_for_direct_chat() {
+        let msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let archived = build_direct_archived_message("alice@example.com", "bob@example.com", &msg);
+        assert!(archived.id.is_empty(), "id assigned by storage at write");
+        assert_eq!(archived.from, "alice@example.com");
+        assert_eq!(archived.to, "bob@example.com");
+        assert_eq!(archived.body, "hi");
+        assert_eq!(archived.stanza_id.as_deref(), Some("orig-1"));
+        assert_eq!(archived.message_type, "chat");
+        assert!(archived.rich.is_none());
+        assert!(
+            archived.stanza_xml.is_some(),
+            "stanza_xml is serialized for replay fidelity"
+        );
+    }
+
+    #[test]
+    fn xep_0313_projects_correction_into_rich_payload() {
+        use crate::xep::xep0308::build_correction_message;
+        let to: jid::Jid = "bob@example.com".parse().expect("jid");
+        let from: jid::Jid = "alice@example.com/web".parse().expect("jid");
+        let msg = build_correction_message(Some(to), Some(from), "fixed text", "old-id");
+        let archived = build_direct_archived_message("alice@example.com", "bob@example.com", &msg);
+        let rich = archived.rich.expect("correction projects rich payload");
+        match rich.payload {
+            Some(ArchivedRichPayload::Correction { replaces_id }) => {
+                assert_eq!(replaces_id.as_str(), "old-id");
+            }
+            other => panic!("expected Correction, got {other:?}"),
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -2,10 +2,11 @@
 //! [`ArchivedMessage`] shape MAM storage expects.
 //!
 //! Used by the sans-I/O dispatcher's storage interpreter
-//! ([`OutboundEvent::ArchiveDirect`]) — keeps the conversion in one
-//! place so handler-emitted typed events are projected consistently
-//! whether the call site is the legacy `message.rs` path (until #229
-//! PR9 cuts over) or the dispatcher.
+//! ([`OutboundEvent::ArchiveDirect`]) to keep the conversion in one
+//! place so dispatcher-emitted typed archive events are projected
+//! consistently before persistence. The legacy `message.rs` path
+//! still owns its own copies of these helpers until #229 PR9 cuts
+//! over and deletes them; this module supersedes that code.
 //!
 //! Archive eligibility (XEP-0313 §5.1.3 + XEP-0334 hint precedence) is
 //! enforced by [`super::super::protocol::handlers::archive::ArchiveHandler`]
@@ -15,6 +16,7 @@
 //! [`OutboundEvent::ArchiveDirect`]: super::super::protocol::event::OutboundEvent::ArchiveDirect
 
 use chrono::Utc;
+use tracing::warn;
 use xmpp_parsers::message::{Message, MessageType};
 
 use super::{
@@ -23,6 +25,7 @@ use super::{
     STANZA_ID_NS,
 };
 use crate::parser::message_to_string;
+use crate::xep::xep0359::extract_stanza_id_by;
 use crate::xep::{
     extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
     extract_references_from_message, extract_retraction_from_message, parse_reply_from_message,
@@ -32,12 +35,36 @@ use crate::xep::{
 /// Build the [`ArchivedMessage`] persisted form of a one-to-one
 /// (chat / normal) `<message/>` for direct MAM storage.
 ///
+/// `archive_jid` identifies whose personal archive this row belongs
+/// to and is used to look up the canonical XEP-0359
+/// `<stanza-id by='archive_jid' id='…'/>` stamp that
+/// [`super::super::protocol::handlers::canonicalize::CanonicalizeHandler`]
+/// stamped upstream. That id is then used as **both** the storage
+/// primary key (`ArchivedMessage.id`) and the canonical lookup field
+/// (`ArchivedMessage.stanza_id`) so:
+///
+/// - inbox `archive_ref` (also sourced from the same XEP-0359 stamp)
+///   pivots cleanly to the MAM row by id, and
+/// - [`super::storage::MamStorage::get_message_by_stanza_id`] resolves
+///   that same id against `archive_jid`.
+///
 /// `from` and `to` are the canonical bare-JID tuple for the archive
 /// row — the caller (interpreter) supplies them so the projection
-/// does not duplicate the pass-aware logic that lives in the
-/// [`super::super::protocol::handlers::archive::ArchiveHandler`]. The
-/// `id` field is left empty: storage assigns the row id at write time.
-pub fn build_direct_archived_message(from: &str, to: &str, message: &Message) -> ArchivedMessage {
+/// does not duplicate the pass-aware logic that lives in
+/// [`super::super::protocol::handlers::archive::ArchiveHandler`].
+///
+/// If the canonical stamp is missing (test fixture or misconfigured
+/// chain), the row falls back to an empty `id` (the storage backend
+/// will generate one) and `stanza_id` is taken from the wire
+/// `<message id=...>` for legacy parity. Production paths always run
+/// `CanonicalizeHandler` before `ArchiveHandler` per the locked
+/// Q2(a) order, so this fallback is defensive only.
+pub fn build_direct_archived_message(
+    archive_jid: &str,
+    from: &str,
+    to: &str,
+    message: &Message,
+) -> ArchivedMessage {
     let body = prototype_body(message)
         .map(|value| value.trim().to_string())
         .unwrap_or_default();
@@ -46,13 +73,19 @@ pub fn build_direct_archived_message(from: &str, to: &str, message: &Message) ->
     let rich = rich_archive_payload(message);
     let stanza_xml = serialize_message_xml(message);
 
+    let canonical_stamp = extract_stanza_id_by(message, archive_jid);
+    let (id, stanza_id) = match canonical_stamp {
+        Some(stamp) => (stamp.clone(), Some(stamp)),
+        None => (String::new(), message.id.clone()),
+    };
+
     ArchivedMessage {
-        id: String::new(),
+        id,
         timestamp: Utc::now(),
         from: from.to_string(),
         to: to.to_string(),
         body,
-        stanza_id: message.id.clone(),
+        stanza_id,
         thread_id: message.thread.as_ref().map(|thread| thread.0.clone()),
         reply_to_id,
         reply_to_jid,
@@ -105,7 +138,21 @@ fn extract_reply_reference(message: &Message) -> (Option<String>, Option<String>
 }
 
 fn serialize_message_xml(message: &Message) -> Option<String> {
-    message_to_string(message).ok()
+    match message_to_string(message) {
+        Ok(xml) => Some(xml),
+        Err(error) => {
+            // Replay fidelity is degraded if we can't capture the wire
+            // form, but the archive row still persists with body and
+            // typed metadata; warn-log so serializer regressions don't
+            // hide behind a silent `None`.
+            warn!(
+                message_id = message.id.as_deref().unwrap_or(""),
+                %error,
+                "MAM projection: failed to serialize message XML; storing without stanza_xml"
+            );
+            None
+        }
+    }
 }
 
 fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
@@ -220,13 +267,26 @@ mod tests {
 
     #[test]
     fn xep_0313_projects_canonical_fields_for_direct_chat() {
+        // No XEP-0359 stamp on the message — defensive fallback path.
         let msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
-        let archived = build_direct_archived_message("alice@example.com", "bob@example.com", &msg);
-        assert!(archived.id.is_empty(), "id assigned by storage at write");
+        let archived = build_direct_archived_message(
+            "alice@example.com",
+            "alice@example.com",
+            "bob@example.com",
+            &msg,
+        );
+        assert!(
+            archived.id.is_empty(),
+            "no canonical stamp -> storage assigns id at write"
+        );
         assert_eq!(archived.from, "alice@example.com");
         assert_eq!(archived.to, "bob@example.com");
         assert_eq!(archived.body, "hi");
-        assert_eq!(archived.stanza_id.as_deref(), Some("orig-1"));
+        assert_eq!(
+            archived.stanza_id.as_deref(),
+            Some("orig-1"),
+            "fallback stanza_id is the wire <message id=...>"
+        );
         assert_eq!(archived.message_type, "chat");
         assert!(archived.rich.is_none());
         assert!(
@@ -236,12 +296,67 @@ mod tests {
     }
 
     #[test]
+    fn xep_0359_canonical_stamp_drives_archive_id_and_stanza_id() {
+        // Production path: CanonicalizeHandler stamps a fresh
+        // `<stanza-id by='alice@example.com' id='canon-1'/>` on the
+        // message before ArchiveHandler emits ArchiveDirect. The
+        // projection MUST use that id as both the storage primary key
+        // and the lookup field so inbox->MAM pivot works (the
+        // InboxHandler emits the same id as `archive_ref`).
+        use crate::xep::xep0359::build_stanza_id_element;
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        msg.payloads
+            .push(build_stanza_id_element("canon-1", "alice@example.com"));
+        let archived = build_direct_archived_message(
+            "alice@example.com",
+            "alice@example.com",
+            "bob@example.com",
+            &msg,
+        );
+        assert_eq!(
+            archived.id, "canon-1",
+            "canonical XEP-0359 stamp becomes the storage primary key"
+        );
+        assert_eq!(
+            archived.stanza_id.as_deref(),
+            Some("canon-1"),
+            "canonical XEP-0359 stamp also fills stanza_id for stanza-id lookups"
+        );
+    }
+
+    #[test]
+    fn xep_0359_canonical_stamp_picks_archive_jid_specific_stamp() {
+        // Recipient pass: the message carries Alice's stamp AND Bob's
+        // stamp. The projection picks the one matching `archive_jid`
+        // — Bob's, since this is Bob's archive write.
+        use crate::xep::xep0359::build_stanza_id_element;
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        msg.payloads
+            .push(build_stanza_id_element("alice-A1", "alice@example.com"));
+        msg.payloads
+            .push(build_stanza_id_element("bob-B1", "bob@example.com"));
+        let archived = build_direct_archived_message(
+            "bob@example.com",
+            "alice@example.com",
+            "bob@example.com",
+            &msg,
+        );
+        assert_eq!(archived.id, "bob-B1");
+        assert_eq!(archived.stanza_id.as_deref(), Some("bob-B1"));
+    }
+
+    #[test]
     fn xep_0313_projects_correction_into_rich_payload() {
         use crate::xep::xep0308::build_correction_message;
         let to: jid::Jid = "bob@example.com".parse().expect("jid");
         let from: jid::Jid = "alice@example.com/web".parse().expect("jid");
         let msg = build_correction_message(Some(to), Some(from), "fixed text", "old-id");
-        let archived = build_direct_archived_message("alice@example.com", "bob@example.com", &msg);
+        let archived = build_direct_archived_message(
+            "alice@example.com",
+            "alice@example.com",
+            "bob@example.com",
+            &msg,
+        );
         let rich = archived.rich.expect("correction projects rich payload");
         match rich.payload {
             Some(ArchivedRichPayload::Correction { replaces_id }) => {

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
@@ -59,7 +59,9 @@ impl MessageHandler for ArchiveProbe {
             .as_ref()
             .map(|j| j.to_bare())
             .unwrap_or_else(|| "unknown@example.com".parse().expect("bare"));
+        let archive_jid = from_bare.clone();
         HandlerOutcome::Continue(vec![OutboundEvent::ArchiveDirect {
+            archive_jid,
             from: from_bare,
             to: to_bare,
             message: Box::new(message.clone()),

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -363,7 +363,15 @@ pub enum OutboundEvent {
         message: Box<Message>,
     },
     /// Persist a one-to-one direct message to the MAM archive.
+    ///
+    /// `archive_jid` identifies which personal archive to write to —
+    /// the locality-aware [`super::handlers::archive::ArchiveHandler`]
+    /// emits this field as the local user's bare JID, so the interpreter
+    /// is dumb glue that does not need to reason about sender/recipient
+    /// pass semantics. `from` and `to` carry the canonical message tuple
+    /// for telemetry and remain on the typed `message` payload.
     ArchiveDirect {
+        archive_jid: BareJid,
         from: BareJid,
         to: BareJid,
         message: Box<Message>,
@@ -373,6 +381,12 @@ pub enum OutboundEvent {
     /// clients can pivot to the archived stanza using the same XEP-0359
     /// stanza-id space.
     ///
+    /// `increment_unread` is set by the locality-aware
+    /// [`super::handlers::inbox::InboxHandler`]: `true` on the recipient
+    /// pass (the message is *new* for this owner), `false` on the sender
+    /// pass (it's the owner's own outgoing copy and shouldn't bump
+    /// their unread count).
+    ///
     /// Inbox is not a finalized XEP — this is a Waddle product surface;
     /// the field set is engineering, not protocol-mandated.
     ProjectInbox {
@@ -380,6 +394,7 @@ pub enum OutboundEvent {
         peer: BareJid,
         message: Box<Message>,
         archive_ref: StanzaIdRef,
+        increment_unread: bool,
     },
     /// XEP-0280 carbon-copy fan-out to the owner's other resources.
     ///

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -64,8 +64,10 @@ impl MessageHandler for ArchiveHandler {
         // avoid double-stamping the same archive.
         if ctx.locality.is_sender() {
             if let Some(to) = to_bare.clone() {
+                let from = from_bare.clone().unwrap_or_else(|| local_bare.clone());
                 events.push(OutboundEvent::ArchiveDirect {
-                    from: from_bare.clone().unwrap_or_else(|| local_bare.clone()),
+                    archive_jid: from.clone(),
+                    from,
                     to,
                     message: Box::new(message.clone()),
                 });
@@ -81,9 +83,11 @@ impl MessageHandler for ArchiveHandler {
         // self-loop case.
         if matches!(ctx.locality, Locality::Recipient) {
             if let Some(from) = from_bare {
+                let to = to_bare.unwrap_or_else(|| local_bare.clone());
                 events.push(OutboundEvent::ArchiveDirect {
+                    archive_jid: to.clone(),
                     from,
-                    to: to_bare.unwrap_or_else(|| local_bare.clone()),
+                    to,
                     message: Box::new(message.clone()),
                 });
             }
@@ -193,6 +197,19 @@ mod tests {
         }
     }
 
+    fn extract_archive_jids(outcome: &HandlerOutcome) -> Vec<BareJid> {
+        match outcome {
+            HandlerOutcome::Continue(events) => events
+                .iter()
+                .filter_map(|e| match e {
+                    OutboundEvent::ArchiveDirect { archive_jid, .. } => Some(archive_jid.clone()),
+                    _ => None,
+                })
+                .collect(),
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------
     // Locality + (from, to) shape
     // -----------------------------------------------------------------
@@ -237,6 +254,31 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let archives = extract_archive_events(&outcome);
         assert_eq!(archives.len(), 1);
+    }
+
+    #[test]
+    fn xep_0313_sender_pass_archive_jid_is_local_user_bare() {
+        // The archive_jid the interpreter writes to MUST be the local
+        // user's archive on the sender pass (so the interpreter does
+        // not need to know which side it's on).
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_jids(&outcome);
+        assert_eq!(archives.len(), 1);
+        assert_eq!(archives[0], bare("alice@example.com"));
+    }
+
+    #[test]
+    fn xep_0313_recipient_pass_archive_jid_is_local_user_bare() {
+        // Same invariant on the recipient pass: archive_jid is the
+        // local user's bare, not the message sender's.
+        let local = full("bob@example.com/desk");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run(&local, &mut msg);
+        let archives = extract_archive_jids(&outcome);
+        assert_eq!(archives.len(), 1);
+        assert_eq!(archives[0], bare("bob@example.com"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
@@ -71,18 +71,31 @@ impl MessageHandler for InboxHandler {
         match ctx.locality {
             Locality::Sender => {
                 if let Some(peer) = to_bare {
-                    events.push(build(owner, peer, message, &local_archive_id));
+                    // Sender pass: this owner is the message author, so
+                    // their unread count must NOT bump for their own
+                    // outgoing copy.
+                    events.push(build(owner, peer, message, &local_archive_id, false));
                 }
             }
             Locality::Recipient => {
                 if let Some(peer) = from_bare {
-                    events.push(build(owner, peer, message, &local_archive_id));
+                    // Recipient pass: a brand-new message arriving for
+                    // this owner — bump their unread count.
+                    events.push(build(owner, peer, message, &local_archive_id, true));
                 }
             }
             Locality::Both => {
                 // Self-loop alice/web -> alice/web — one inbox entry,
-                // peer = owner.
-                events.push(build(owner.clone(), owner, message, &local_archive_id));
+                // peer = owner. The owner is both author and recipient;
+                // legacy parity says do not bump unread for self-sent
+                // messages.
+                events.push(build(
+                    owner.clone(),
+                    owner,
+                    message,
+                    &local_archive_id,
+                    false,
+                ));
             }
             Locality::Neither => {}
         }
@@ -95,6 +108,7 @@ fn build(
     peer: BareJid,
     message: &Message,
     local_archive_id: &str,
+    increment_unread: bool,
 ) -> OutboundEvent {
     OutboundEvent::ProjectInbox {
         owner: owner.clone(),
@@ -104,6 +118,7 @@ fn build(
             by: owner,
             id: StanzaIdValue::new(local_archive_id),
         },
+        increment_unread,
     }
 }
 
@@ -192,6 +207,21 @@ mod tests {
         }
     }
 
+    fn extract_inbox_increments(outcome: &HandlerOutcome) -> Vec<bool> {
+        match outcome {
+            HandlerOutcome::Continue(events) => events
+                .iter()
+                .filter_map(|e| match e {
+                    OutboundEvent::ProjectInbox {
+                        increment_unread, ..
+                    } => Some(*increment_unread),
+                    _ => None,
+                })
+                .collect(),
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------
     // Locality / peer attribution
     // -----------------------------------------------------------------
@@ -231,6 +261,42 @@ mod tests {
         let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
         let outcome = run(&local, &mut msg);
         assert!(extract_inbox(&outcome).is_empty());
+    }
+
+    #[test]
+    fn inbox_sender_pass_does_not_increment_unread() {
+        // Sender pass: the owner is the author, so unread must not
+        // bump for their own outgoing copy.
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        msg.payloads
+            .push(build_stanza_id_element("alice-A1", "alice@example.com"));
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_inbox_increments(&outcome), vec![false]);
+    }
+
+    #[test]
+    fn inbox_recipient_pass_increments_unread() {
+        // Recipient pass: a new message arriving for this owner —
+        // bump unread.
+        let local = full("bob@example.com/desk");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        msg.payloads
+            .push(build_stanza_id_element("bob-B1", "bob@example.com"));
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_inbox_increments(&outcome), vec![true]);
+    }
+
+    #[test]
+    fn inbox_self_loop_does_not_increment_unread() {
+        // Self-loop alice→alice: one event, owner=peer, do not bump
+        // unread (matches legacy parity for messages you sent yourself).
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "alice@example.com/web", "echo");
+        msg.payloads
+            .push(build_stanza_id_element("alice-self", "alice@example.com"));
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_inbox_increments(&outcome), vec![false]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Part of the [#229](https://github.com/waddle-social/waddle/issues/229) sans-I/O message pipeline migration. Wires the two synchronous storage-write interpreter arms so the dispatcher path can persist messages and inbox rows once handlers are registered (PR9).

Stacked on PR1–PR6 (all merged). After this PR, only the callback-shaped arms (`LookupArchivedMessage`, `RequestEnrichment` — PR8) remain before cutover (PR9).

## Scope

1. **Grow `interpret::Deps<'_>`** with `MamStorage` + `InboxStorage` handles. Add a `Deps::test_with_storage(...)` helper for tests that exercise these arms.
2. **Implement `OutboundEvent::ArchiveDirect`** against `MamStorage::store_message`. Use the local user's bare JID (`from` for `Locality::Sender`, `to` for `Locality::Recipient`) as `archive_jid`. Multiple events from one dispatch (sender + recipient on local-to-local) each persist independently.
3. **Implement `OutboundEvent::ProjectInbox`** against `InboxStorage` with the typed `archive_ref: StanzaIdValue` flowing through.
4. **Remove `warn-stub`** for both arms; update module-level "Current coverage" docs.
5. Update production callsite in `iq.rs`.

## Out of scope

- `LookupArchivedMessage`, `RequestEnrichment` (PR8 — callback plumbing).
- `BroadcastToRoom`, `DispatchToRoom`, `ArchiveGroupchat` (PR10 — MUC chain).
- Production cutover; handlers registered via `register_default_message_handlers` are still inert.

## XEP conformance

- **XEP-0313 §5.1.3**: archive eligibility was already enforced by `ArchiveHandler` (PR3). The interpreter just persists what the handler emitted; no re-checking of hints / type / etc.
- **XEP-0359 §5**: the message already carries the canonicalized `<stanza-id by=...>` from `CanonicalizeHandler` (PR2). The interpreter must NOT add another stamp.

## Test plan

- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace` green
- [ ] `xep_0313_archive_direct_persists_to_mam_storage` — fake `MamStorage` records writes
- [ ] `xep_0313_archive_direct_writes_one_entry_per_event` — sender + recipient events each persist
- [ ] `inbox_project_writes_owner_peer_keyed_row_with_typed_archive_ref` — fake inbox storage shape
- [ ] Existing carbon tests pass with extended `Deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)