### PR TITLE
feat(server): #229 PR12 — switch RouteToConnection to PeerStanza

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -223,29 +223,40 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                 // archive, XEP-0280 received-carbons, inbox
                 // projection, then `SendStanza` to the wire.
                 //
-                // `jid` is a typed `Jid` (full or bare). The current
-                // registry only supports full-JID delivery, so
-                // bare-JID targets are logged and dropped — RFC 6121
-                // §8.5 highest-priority resource selection lives in
-                // a follow-up PR.
+                // `jid` is a typed `Jid` — full or bare. Full-JID
+                // targets deliver to that single resource. Bare-JID
+                // targets go through RFC 6121 §8.5.2.1 resource
+                // selection (highest-priority available resources;
+                // tie-broken by delivering to all of them).
+                //
+                // Known design gap (`#229` follow-up): when the
+                // target has *no* connected resources (offline /
+                // detached / `ChannelClosed` for every selected
+                // resource), recipient-side persistence
+                // (recipient MAM archive, inbox projection,
+                // received-carbons fan-out) is currently lost
+                // because those effects only run during a recipient
+                // pass that requires a live destination machine.
+                // The eventual `message.rs` cutover needs an offline
+                // fallback (sender-side recipient-archive write OR a
+                // headless recipient-pass runner). Tracked in the
+                // local plan and the issue's follow-ups.
                 match jid.clone().try_into_full() {
-                    Ok(full) => match registry.send_peer_to(&full, *stanza).await {
-                        waddle_xmpp::registry::SendResult::Sent => {
-                            debug!(jid = %full, "RouteToConnection: peer-stanza queued for recipient pass");
-                        }
-                        waddle_xmpp::registry::SendResult::NotConnected => {
-                            debug!(jid = %full, "RouteToConnection: target offline, dropping");
-                        }
-                        waddle_xmpp::registry::SendResult::ChannelClosed => {
-                            warn!(jid = %full, "RouteToConnection: target channel closed, dropping");
-                        }
-                    },
+                    Ok(full) => deliver_peer_to_full(registry, &full, *stanza).await,
                     Err(bare) => {
-                        warn!(
-                            bare_jid = %bare,
-                            "RouteToConnection: bare-JID resource selection (RFC 6121 §8.5) \
-                             not yet wired; dropping this event"
-                        );
+                        let targets = registry.select_routable_resources_for_user(&bare);
+                        if targets.is_empty() {
+                            debug!(
+                                bare_jid = %bare,
+                                "RouteToConnection: bare-JID has no available resources \
+                                 (RFC 6121 §8.5.2.1.1); dropping. Offline-recipient \
+                                 persistence is a known #229 follow-up."
+                            );
+                        } else {
+                            for full in targets {
+                                deliver_peer_to_full(registry, &full, (*stanza).clone()).await;
+                            }
+                        }
                     }
                 }
             }
@@ -591,6 +602,30 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
 /// returned unchanged. This matches legacy `message.rs` behavior so
 /// the dispatcher cutover (#229 PR9) does not regress UX when a wasm
 /// extension is misbehaving.
+/// Deliver a single `Stanza` to a specific full-JID destination as
+/// a [`waddle_xmpp::registry::DeliveryKind::PeerStanza`] so the
+/// destination's main loop runs the recipient pass before any wire
+/// write. Centralizes the per-target send + result-logging shape so
+/// both the full-JID and bare-JID-resource-selection arms of
+/// [`OutboundEvent::RouteToConnection`] go through the same path.
+async fn deliver_peer_to_full(
+    registry: &waddle_xmpp::registry::ConnectionRegistry,
+    target: &jid::FullJid,
+    stanza: Stanza,
+) {
+    match registry.send_peer_to(target, stanza).await {
+        waddle_xmpp::registry::SendResult::Sent => {
+            debug!(jid = %target, "RouteToConnection: peer-stanza queued for recipient pass");
+        }
+        waddle_xmpp::registry::SendResult::NotConnected => {
+            debug!(jid = %target, "RouteToConnection: target offline, dropping");
+        }
+        waddle_xmpp::registry::SendResult::ChannelClosed => {
+            warn!(jid = %target, "RouteToConnection: target channel closed, dropping");
+        }
+    }
+}
+
 async fn enrich_message_event(deps: &Deps<'_>, mut message: Message) -> Message {
     let Some(extension_manager) = deps.extension_manager else {
         debug!(
@@ -1948,6 +1983,121 @@ mod tests {
             }
             other => panic!("expected EnrichmentComplete, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // #229 PR12 — RouteToConnection delivers as PeerStanza
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn route_to_connection_full_jid_queues_peer_stanza_kind() {
+        // Locks in the staged-cutover contract: full-JID
+        // RouteToConnection events queue an OutboundStanza tagged
+        // PeerStanza so the destination's main loop runs the
+        // recipient pass before any wire write.
+        use waddle_xmpp::registry::DeliveryKind;
+        let registry = ConnectionRegistry::new();
+        let bob: jid::FullJid = "bob@example.com/desk".parse().expect("jid");
+        let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+        registry.register_with_carbons(bob.clone(), bob_tx, false);
+
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "hi");
+        let events = vec![OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(bob.clone()),
+            stanza: Box::new(Stanza::Message(msg)),
+        }];
+        let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
+
+        let queued = drain_inbound(&mut bob_rx);
+        assert_eq!(queued.len(), 1, "delivered to bob's queue exactly once");
+        assert_eq!(
+            queued[0].kind,
+            DeliveryKind::PeerStanza,
+            "RouteToConnection MUST tag PeerStanza so the destination main \
+             loop runs the recipient pass; got {:?}",
+            queued[0].kind
+        );
+    }
+
+    #[tokio::test]
+    async fn route_to_connection_bare_jid_selects_highest_priority_available_resources() {
+        // RFC 6121 §8.5.2.1 resource selection: deliver to every
+        // resource tied at the highest available priority. A
+        // bare-JID `to` from the sender pass (handlers/route.rs
+        // emits `message.to` verbatim) lands here; without selection
+        // the cutover would silently drop bare-targeted 1:1 traffic.
+        use waddle_xmpp::registry::DeliveryKind;
+        let registry = ConnectionRegistry::new();
+        let bob_desk: jid::FullJid = "bob@example.com/desk".parse().expect("jid");
+        let bob_phone: jid::FullJid = "bob@example.com/phone".parse().expect("jid");
+        let bob_tablet: jid::FullJid = "bob@example.com/tablet".parse().expect("jid");
+        let (desk_tx, mut desk_rx) = tokio::sync::mpsc::channel(8);
+        let (phone_tx, mut phone_rx) = tokio::sync::mpsc::channel(8);
+        let (tablet_tx, mut tablet_rx) = tokio::sync::mpsc::channel(8);
+        registry.register_with_carbons(bob_desk.clone(), desk_tx, false);
+        registry.register_with_carbons(bob_phone.clone(), phone_tx, false);
+        registry.register_with_carbons(bob_tablet.clone(), tablet_tx, false);
+        // desk + phone available at priority 5 (tied); tablet at
+        // lower priority 1. Tablet must NOT receive.
+        registry.update_presence(&bob_desk, true, 5);
+        registry.update_presence(&bob_phone, true, 5);
+        registry.update_presence(&bob_tablet, true, 1);
+
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "hi bare");
+        let events = vec![OutboundEvent::RouteToConnection {
+            jid: "bob@example.com".parse::<jid::Jid>().expect("bare jid"),
+            stanza: Box::new(Stanza::Message(msg)),
+        }];
+        let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
+
+        let desk_q = drain_inbound(&mut desk_rx);
+        let phone_q = drain_inbound(&mut phone_rx);
+        let tablet_q = drain_inbound(&mut tablet_rx);
+        assert_eq!(
+            desk_q.len(),
+            1,
+            "desk (tied at max priority) gets the message"
+        );
+        assert_eq!(
+            phone_q.len(),
+            1,
+            "phone (tied at max priority) gets the message"
+        );
+        assert!(
+            tablet_q.is_empty(),
+            "tablet (lower priority) is excluded by RFC 6121 §8.5.2.1.2"
+        );
+        for q in [&desk_q, &phone_q] {
+            assert_eq!(q[0].kind, DeliveryKind::PeerStanza);
+        }
+    }
+
+    #[tokio::test]
+    async fn route_to_connection_bare_jid_with_no_available_resources_drops() {
+        // Known design gap: when the bare-JID target has no
+        // available resources, the recipient-pass side effects
+        // (recipient archive, inbox) do NOT run. Documented as a
+        // known #229 follow-up. This test pins the current behavior
+        // (drop) so the gap doesn't quietly mutate before the
+        // follow-up lands an offline-pass strategy.
+        let registry = ConnectionRegistry::new();
+        let bob_desk: jid::FullJid = "bob@example.com/desk".parse().expect("jid");
+        let (desk_tx, mut desk_rx) = tokio::sync::mpsc::channel(8);
+        registry.register_with_carbons(bob_desk.clone(), desk_tx, false);
+        // Registered but presence NOT made available — `bob_desk`
+        // is not eligible per §8.5.2.1.1.
+
+        let msg = chat_msg("alice@example.com/web", "bob@example.com", "hi");
+        let events = vec![OutboundEvent::RouteToConnection {
+            jid: "bob@example.com".parse::<jid::Jid>().expect("bare jid"),
+            stanza: Box::new(Stanza::Message(msg)),
+        }];
+        let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
+
+        assert!(
+            drain_inbound(&mut desk_rx).is_empty(),
+            "no available resources -> no delivery (offline-pass is a #229 follow-up)"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -213,26 +213,25 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
             // content into logs.
             // -------------------------------------------------------
             OutboundEvent::RouteToConnection { jid, stanza } => {
-                // Until the per-connection state-machine routing for
-                // `StanzaFromPeer` lands (issue #229 PR5), preserve the
-                // legacy "write to peer's outbound channel" behaviour so
-                // existing integration tests stay green. The semantic
-                // change to "feed StanzaFromPeer into the destination
-                // machine" is wired alongside the message.rs cutover
-                // in PR5.
+                // #229 PR12 cutover: the destination's main loop is
+                // now wired (PR11) to dispatch on `DeliveryKind` and
+                // run the recipient-pass pipeline for `PeerStanza`
+                // values, so we deliver as `PeerStanza`. The
+                // recipient's `XmppStateMachine::on_peer_stanza`
+                // takes it from there: XEP-0191 incoming block,
+                // XEP-0359 recipient stamp, XEP-0313 recipient-side
+                // archive, XEP-0280 received-carbons, inbox
+                // projection, then `SendStanza` to the wire.
                 //
-                // `jid` is now a typed `Jid` (full or bare); the
-                // current legacy registry only supports full-JID
-                // delivery, so bare-JID targets are logged and
-                // deferred to PR5's resource-selection logic. This
-                // is a *temporary* gap during the staged migration;
-                // it does not regress existing behaviour because no
-                // production handler emits `RouteToConnection` with a
-                // bare JID until PR5 cuts over.
+                // `jid` is a typed `Jid` (full or bare). The current
+                // registry only supports full-JID delivery, so
+                // bare-JID targets are logged and dropped — RFC 6121
+                // §8.5 highest-priority resource selection lives in
+                // a follow-up PR.
                 match jid.clone().try_into_full() {
-                    Ok(full) => match registry.send_to(&full, *stanza).await {
+                    Ok(full) => match registry.send_peer_to(&full, *stanza).await {
                         waddle_xmpp::registry::SendResult::Sent => {
-                            debug!(jid = %full, "RouteToConnection delivered");
+                            debug!(jid = %full, "RouteToConnection: peer-stanza queued for recipient pass");
                         }
                         waddle_xmpp::registry::SendResult::NotConnected => {
                             debug!(jid = %full, "RouteToConnection: target offline, dropping");
@@ -244,8 +243,8 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                     Err(bare) => {
                         warn!(
                             bare_jid = %bare,
-                            "RouteToConnection: bare-JID resource selection lands in PR5; \
-                             dropping this event for now"
+                            "RouteToConnection: bare-JID resource selection (RFC 6121 §8.5) \
+                             not yet wired; dropping this event"
                         );
                     }
                 }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -378,13 +378,49 @@ impl ConnectionRegistry {
         self.connections.len()
     }
 
-    /// Send a stanza to a connected user.
+    /// Send a stanza to a connected user as a [`DeliveryKind::DirectFrame`]
+    /// — the destination's main loop writes it straight to the wire
+    /// without running the recipient pass.
+    ///
+    /// This is the right call for server-generated frames (carbons,
+    /// IQ replies, SM acks, …). For peer-routed stanzas that should
+    /// run through the recipient pipeline, use [`Self::send_peer_to`].
     ///
     /// This waits for outbound channel capacity instead of dropping stanzas when
     /// a connection is temporarily backpressured. Closed channels are treated as
     /// stale connections and removed from the registry.
     #[instrument(skip(self, stanza), fields(to = %jid))]
     pub async fn send_to(&self, jid: &FullJid, stanza: Stanza) -> SendResult {
+        self.send_to_with_kind(jid, stanza, DeliveryKind::DirectFrame)
+            .await
+    }
+
+    /// Send a stanza to a connected user as a [`DeliveryKind::PeerStanza`]
+    /// — the destination's main loop feeds
+    /// [`crate::protocol::InboundEvent::StanzaFromPeer`] into its
+    /// state machine so the recipient-pass pipeline (XEP-0191
+    /// incoming block, XEP-0359 recipient stamp, XEP-0313 archive,
+    /// XEP-0280 received-carbons, inbox projection) runs before any
+    /// wire write.
+    ///
+    /// Used by the [`crate::protocol::OutboundEvent::RouteToConnection`]
+    /// interpreter arm starting in #229 PR12.
+    #[instrument(skip(self, stanza), fields(to = %jid))]
+    pub async fn send_peer_to(&self, jid: &FullJid, stanza: Stanza) -> SendResult {
+        self.send_to_with_kind(jid, stanza, DeliveryKind::PeerStanza)
+            .await
+    }
+
+    /// Inner helper shared by [`Self::send_to`] and [`Self::send_peer_to`]
+    /// so the queueing / replacement / channel-closed paths stay in
+    /// one place. The only thing the public callers vary is the
+    /// [`DeliveryKind`] tag on the queued [`OutboundStanza`].
+    async fn send_to_with_kind(
+        &self,
+        jid: &FullJid,
+        stanza: Stanza,
+        kind: DeliveryKind,
+    ) -> SendResult {
         let sender = match self.connections.get(jid) {
             Some(entry) => entry.value().sender.clone(),
             None => {
@@ -393,11 +429,14 @@ impl ConnectionRegistry {
             }
         };
 
-        let outbound = OutboundStanza::new(stanza.clone());
+        let outbound = OutboundStanza {
+            stanza: stanza.clone(),
+            kind,
+        };
 
         match sender.send(outbound).await {
             Ok(()) => {
-                debug!("Stanza queued for delivery");
+                debug!(?kind, "Stanza queued for delivery");
                 SendResult::Sent
             }
             Err(_) => {
@@ -407,10 +446,10 @@ impl ConnectionRegistry {
                     let current = entry.value().sender.clone();
                     drop(entry);
                     if !current.same_channel(&sender) {
-                        let outbound = OutboundStanza::new(stanza);
+                        let outbound = OutboundStanza { stanza, kind };
                         return match current.send(outbound).await {
                             Ok(()) => {
-                                debug!("Stanza queued for replacement connection");
+                                debug!(?kind, "Stanza queued for replacement connection");
                                 SendResult::Sent
                             }
                             Err(_) => {

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -414,7 +414,11 @@ impl ConnectionRegistry {
     /// Inner helper shared by [`Self::send_to`] and [`Self::send_peer_to`]
     /// so the queueing / replacement / channel-closed paths stay in
     /// one place. The only thing the public callers vary is the
-    /// [`DeliveryKind`] tag on the queued [`OutboundStanza`].
+    /// [`DeliveryKind`] tag on the queued [`OutboundStanza`], which
+    /// is built via the same [`OutboundStanza::new`] / [`OutboundStanza::peer_stanza`]
+    /// constructors every other call site uses — no manual struct
+    /// literal here so the kind→constructor mapping stays in one
+    /// place.
     async fn send_to_with_kind(
         &self,
         jid: &FullJid,
@@ -429,12 +433,12 @@ impl ConnectionRegistry {
             }
         };
 
-        let outbound = OutboundStanza {
-            stanza: stanza.clone(),
-            kind,
+        let make_outbound = |s: Stanza| match kind {
+            DeliveryKind::DirectFrame => OutboundStanza::new(s),
+            DeliveryKind::PeerStanza => OutboundStanza::peer_stanza(s),
         };
 
-        match sender.send(outbound).await {
+        match sender.send(make_outbound(stanza.clone())).await {
             Ok(()) => {
                 debug!(?kind, "Stanza queued for delivery");
                 SendResult::Sent
@@ -446,8 +450,7 @@ impl ConnectionRegistry {
                     let current = entry.value().sender.clone();
                     drop(entry);
                     if !current.same_channel(&sender) {
-                        let outbound = OutboundStanza { stanza, kind };
-                        return match current.send(outbound).await {
+                        return match current.send(make_outbound(stanza)).await {
                             Ok(()) => {
                                 debug!(?kind, "Stanza queued for replacement connection");
                                 SendResult::Sent
@@ -462,6 +465,38 @@ impl ConnectionRegistry {
                 SendResult::ChannelClosed
             }
         }
+    }
+
+    /// RFC 6121 §8.5.2.1 destination-resource selection for bare-JID
+    /// 1:1 message routing.
+    ///
+    /// Returns every currently-connected resource of `bare_jid` whose
+    /// advertised presence priority equals the maximum among the
+    /// user's available resources. Per §8.5.2.1.1, only resources
+    /// that have advertised availability (positive presence) are
+    /// eligible; per §8.5.2.1.2, when multiple resources tie at the
+    /// highest priority the server SHOULD deliver to all of them.
+    ///
+    /// Returns `Vec::new()` when the user has no available
+    /// resources — caller should fall back to offline-storage
+    /// semantics.
+    pub fn select_routable_resources_for_user(&self, bare_jid: &BareJid) -> Vec<FullJid> {
+        let candidates: Vec<(FullJid, i8)> = self
+            .connections
+            .iter()
+            .filter(|entry| {
+                entry.key().to_bare() == *bare_jid && entry.value().is_presence_available()
+            })
+            .map(|entry| (entry.key().clone(), entry.value().presence_priority()))
+            .collect();
+        let Some(max_priority) = candidates.iter().map(|(_, p)| *p).max() else {
+            return Vec::new();
+        };
+        candidates
+            .into_iter()
+            .filter(|(_, p)| *p == max_priority)
+            .map(|(jid, _)| jid)
+            .collect()
     }
 
     /// Non-blocking send. Returns a typed `BroadcastOutcome` describing


### PR DESCRIPTION
## Summary

Stage 2c of the [#229](https://github.com/waddle-social/waddle/issues/229) cutover. Switches the `OutboundEvent::RouteToConnection` interpreter arm to deliver via the new `OutboundStanza::peer_stanza` constructor (PR10), so the destination connection's main loop (PR11) feeds `InboundEvent::StanzaFromPeer` into its state machine and runs the recipient pass before any wire write.

Stacked on PR1–PR11 (all merged).

## Scope

- `ConnectionRegistry::send_peer_to(jid, stanza)` — new public method that delivers `DeliveryKind::PeerStanza`. Existing `send_to` is unchanged in semantics (still `DirectFrame`); both share an inner `send_to_with_kind` helper.
- `interpret()` `RouteToConnection` arm now calls `send_peer_to(...)` instead of `send_to(...)`.

## Why this scope (and what's deferred)

The original PR12 plan combined this switch with `message.rs` thin-adapter swap + `routing::route_message_local` decommission. Both surface feature gaps that need separate work:

- **`message.rs` thin-adapter swap**: the dispatcher chain's `BlockingFilterHandler` reads from the per-connection `MessageContext.blocklist` (session-state snapshot per #229 Q5), but production loads the blocklist from `DatabaseBlockingStorage` per-message. A correct cutover requires populating the SM's blocklist on bind from the DB — filed as a follow-up. Without that, `xep0054_0049_0191_ws::websocket_blocking_prevents_direct_message_delivery` regresses.
- **`routing::route_message_local` decommission**: blocked on the `message.rs` cutover removing its last caller.

This PR ships the contained, behavior-preserving piece.

## Production behavior today

Unchanged. The legacy `message.rs::handle_message` path still routes via `routing::route_message_local` which calls `send_to` (DirectFrame). No production caller emits `RouteToConnection` yet — that becomes live once a follow-up cuts `message.rs` over.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)