### PR TITLE
feat(server): #229 PR14 — bridge DispatchToRoom interpreter arm to legacy MUC fan-out

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -48,6 +48,7 @@
 //!   `ValidateOAuthBearer`, `SetTimer`, `CancelTimer`,
 //!   `RegisterConnection` — wired in later migration steps.
 
+use crate::auth::Session;
 use kameo::actor::ActorRef;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -140,6 +141,19 @@ pub struct Deps<'a> {
     /// bridge in favour of a dedicated room handler chain (Q7
     /// option C).
     pub web_socket_state: Option<&'a WebSocketState>,
+    /// The authenticated `Session` of the connection that emitted the
+    /// outbound events being interpreted, when one is available.
+    ///
+    /// Threaded through so the
+    /// [`OutboundEvent::DispatchToRoom`] bridge arm can preserve the
+    /// legacy managed-room owner check (e.g. the announcements room
+    /// permits server owners to post; everyone else is forbidden).
+    /// Without this, every dispatcher-driven groupchat send would
+    /// fail the owner override and the announcements room would
+    /// reject server owners — a regression vs the legacy
+    /// `handle_message` path. `None` for unauthenticated dispatch
+    /// flows (early connection lifecycle, unit tests).
+    pub authenticated_session: Option<&'a Session>,
 }
 
 impl<'a> Deps<'a> {
@@ -156,6 +170,7 @@ impl<'a> Deps<'a> {
             extension_manager: None,
             room_registry: None,
             web_socket_state: None,
+            authenticated_session: None,
         }
     }
 
@@ -176,6 +191,7 @@ impl<'a> Deps<'a> {
             extension_manager: None,
             room_registry: None,
             web_socket_state: None,
+            authenticated_session: None,
         }
     }
 
@@ -194,6 +210,7 @@ impl<'a> Deps<'a> {
             extension_manager: Some(extension_manager),
             room_registry: None,
             web_socket_state: None,
+            authenticated_session: None,
         }
     }
 
@@ -215,6 +232,7 @@ impl<'a> Deps<'a> {
             extension_manager: None,
             room_registry: Some(room_registry),
             web_socket_state: None,
+            authenticated_session: None,
         }
     }
 }
@@ -313,7 +331,15 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                 }
             }
             OutboundEvent::DispatchToRoom { room, message } => {
-                dispatch_to_room(deps, room, *message).await;
+                // The legacy MUC bridge is the only producer of the
+                // sender's echo + stanza-level error replies (managed-
+                // room owner check, rich-target validation). Forward
+                // those frames into `outcome.frames` so the sender
+                // sees them; otherwise sender-pass DispatchToRoom is
+                // a black hole on this path. Codex P1 + Qodo bug #3
+                // + Copilot review on PR #274.
+                let frames = dispatch_to_room(deps, room, *message).await;
+                outcome.frames.extend(frames);
             }
             OutboundEvent::BroadcastToRoom { room, .. } => {
                 warn!(
@@ -693,43 +719,43 @@ async fn deliver_peer_to_full(
 /// actor receives `BuildGroupchatBroadcast` without standing up a full
 /// `WebSocketState`. Production wires `web_socket_state`.
 ///
-/// The frames the legacy helper would have written back to the sender
-/// (the sender's own echo, or a stanza-level error reply) are NOT
-/// surfaced through `outcome.frames` — the dispatcher path's recipient
-/// pipeline owns sender echo via `RouteToConnection`/`SendStanza`, and
-/// re-emitting the legacy echo here would produce duplicates. This
-/// matches the recipient-pass contract documented on
-/// [`OutboundEvent::DispatchToRoom`].
-async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Message) {
+/// Returns the frames the sender connection should write back —
+/// today this is the sender's own echo (or a stanza-level error
+/// reply when validation fails). The interpreter caller appends
+/// these into [`InterpretOutcome::frames`] so the sender-pass
+/// `DispatchToRoom` event isn't a black hole. Codex P1 + Qodo +
+/// Copilot review on PR #274.
+async fn dispatch_to_room(
+    deps: &Deps<'_>,
+    room_jid: jid::BareJid,
+    message: Message,
+) -> Vec<String> {
     if let Some(state) = deps.web_socket_state {
         let Some(sender_full) = sender_full_jid(&message) else {
             warn!(
                 room = %room_jid,
                 "DispatchToRoom: message.from is missing or not a full JID; dropping"
             );
-            return;
+            return Vec::new();
         };
         // Production path: full legacy MUC fan-out via the shared
-        // helper. Sender echo + error replies, if any, are emitted
-        // back to the sender by the legacy path's caller; the
-        // dispatcher path's sender-side pipeline already handles
-        // that surface separately, so we discard the helper's frame
-        // return here. (See note in this fn's docstring.)
-        let _frames = deliver_groupchat_via_room_actor(
+        // helper. The legacy helper consults `authenticated_session`
+        // for the managed-room owner check (announcements room
+        // admits server owners only). We thread the connection's
+        // session through `Deps` (PR14 review fix) so that owner
+        // override survives the dispatcher path; passing `&None`
+        // here would always reject server owners on the
+        // announcements room. Codex P2 + Qodo bug #4 + Copilot
+        // review on PR #274.
+        let owned_session = deps.authenticated_session.cloned();
+        return deliver_groupchat_via_room_actor(
             state,
             room_jid,
             sender_full,
             message,
-            // The legacy helper consults `authenticated_session`
-            // only for the managed-room owner check; the sender
-            // pass's caller (dispatcher main loop) already verified
-            // session presence before dispatch. Passing `&None` is
-            // safe — it only suppresses the owner override which
-            // does not apply on this path.
-            &None,
+            &owned_session,
         )
         .await;
-        return;
     }
 
     let Some(room_registry) = deps.room_registry else {
@@ -739,7 +765,7 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
             "DispatchToRoom: neither web_socket_state nor room_registry provided in Deps; \
              dropping. Production must populate web_socket_state."
         );
-        return;
+        return Vec::new();
     };
 
     // Slimmed test-only path: look up the room actor through the
@@ -754,7 +780,7 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
             room = %room_jid,
             "DispatchToRoom (test path): message.from is missing or not a full JID; dropping"
         );
-        return;
+        return Vec::new();
     };
 
     let room_actor = match room_registry
@@ -769,7 +795,7 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
                 room = %room_jid,
                 "DispatchToRoom (test path): room not registered; dropping"
             );
-            return;
+            return Vec::new();
         }
         Err(error) => {
             warn!(
@@ -777,7 +803,7 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
                 error = ?error,
                 "DispatchToRoom (test path): room registry lookup failed; dropping"
             );
-            return;
+            return Vec::new();
         }
     };
 
@@ -796,7 +822,7 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
                 error = ?error,
                 "DispatchToRoom (test path): sender not permitted to broadcast; dropping"
             );
-            return;
+            return Vec::new();
         }
     };
 
@@ -825,6 +851,9 @@ async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Mess
             }
         }
     }
+    // Test path doesn't surface a sender echo; the production path
+    // returns the legacy helper's frames above.
+    Vec::new()
 }
 
 /// Extract the sender's full JID from a typed groupchat `Message`.
@@ -1307,6 +1336,7 @@ mod tests {
             extension_manager: None,
             room_registry: None,
             web_socket_state: None,
+            authenticated_session: None,
         };
         let _outcome = interpret(
             vec![OutboundEvent::SendCarbons {

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -48,6 +48,7 @@
 //!   `ValidateOAuthBearer`, `SetTimer`, `CancelTimer`,
 //!   `RegisterConnection` — wired in later migration steps.
 
+use kameo::actor::ActorRef;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
@@ -58,17 +59,22 @@ use waddle_xmpp::inbox::storage::InboxStorage;
 use waddle_xmpp::mam::projection::build_direct_archived_message;
 use waddle_xmpp::mam::storage::MamStorage;
 use waddle_xmpp::mam::ArchivedMessage as MamArchivedMessage;
+use waddle_xmpp::muc::room_actor::BuildGroupchatBroadcast;
+use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parser::stanza_to_string;
 use waddle_xmpp::protocol::event::{
     ArchivedMessage as ProtocolArchivedMessage, InboundEvent, MessageRef, StanzaIdRef,
     StanzaIdValue,
 };
 use waddle_xmpp::protocol::{CarbonKind, OutboundEvent};
-use waddle_xmpp::registry::ConnectionRegistry;
+use waddle_xmpp::registry::{BroadcastOutcome, ConnectionRegistry};
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::Stanza;
 use xmpp_parsers::message::Message;
 use xmpp_parsers::minidom::Element;
+
+use crate::server::routes::websocket::handlers::message::deliver_groupchat_via_room_actor;
+use crate::server::routes::websocket::WebSocketState;
 
 /// Outcome of interpreting a batch of [`OutboundEvent`]s.
 ///
@@ -115,6 +121,25 @@ pub struct Deps<'a> {
     /// `None` in unit tests that don't exercise the
     /// [`OutboundEvent::RequestEnrichment`] arm.
     pub extension_manager: Option<&'a Arc<ExtensionManager>>,
+    /// MUC room-registry actor. Used by the
+    /// [`OutboundEvent::DispatchToRoom`] arm to look up the per-room
+    /// actor and (in unit tests that don't supply a full
+    /// `web_socket_state`) drive a slimmed `BuildGroupchatBroadcast`
+    /// fan-out so the actor wiring can be exercised without standing
+    /// up the full WebSocket route stack.
+    pub room_registry: Option<&'a ActorRef<RoomRegistryActor>>,
+    /// WebSocket route state. Required by
+    /// [`OutboundEvent::DispatchToRoom`] to invoke the legacy MUC
+    /// fan-out helper (managed-room owner check, rich-target
+    /// validation, retraction tombstones, MAM archive, inbox
+    /// projection, occupant fan-out). `None` in unit tests; always
+    /// supplied in production.
+    ///
+    /// PR14 in #229 introduces this bridge so the dispatcher cutover
+    /// can land without regressing MUC delivery; PR17 retires the
+    /// bridge in favour of a dedicated room handler chain (Q7
+    /// option C).
+    pub web_socket_state: Option<&'a WebSocketState>,
 }
 
 impl<'a> Deps<'a> {
@@ -129,6 +154,8 @@ impl<'a> Deps<'a> {
             mam_storage: None,
             inbox_storage: None,
             extension_manager: None,
+            room_registry: None,
+            web_socket_state: None,
         }
     }
 
@@ -147,6 +174,8 @@ impl<'a> Deps<'a> {
             mam_storage: Some(mam_storage),
             inbox_storage: Some(inbox_storage),
             extension_manager: None,
+            room_registry: None,
+            web_socket_state: None,
         }
     }
 
@@ -163,6 +192,29 @@ impl<'a> Deps<'a> {
             mam_storage: None,
             inbox_storage: None,
             extension_manager: Some(extension_manager),
+            room_registry: None,
+            web_socket_state: None,
+        }
+    }
+
+    /// Build a `Deps` for unit tests that exercise the
+    /// [`OutboundEvent::DispatchToRoom`] arm without a full
+    /// `WebSocketState`. The room registry handle drives the slimmer
+    /// `BuildGroupchatBroadcast` + connection-registry fan-out path so
+    /// tests can assert that the room actor is reached.
+    #[cfg(test)]
+    pub fn test_with_room_registry(
+        connection_registry: &'a ConnectionRegistry,
+        room_registry: &'a ActorRef<RoomRegistryActor>,
+    ) -> Self {
+        Self {
+            connection_registry,
+            sm_session_registry: None,
+            mam_storage: None,
+            inbox_storage: None,
+            extension_manager: None,
+            room_registry: Some(room_registry),
+            web_socket_state: None,
         }
     }
 }
@@ -260,12 +312,8 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
                     }
                 }
             }
-            OutboundEvent::DispatchToRoom { room, .. } => {
-                warn!(
-                    variant = "DispatchToRoom",
-                    room = %room,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::DispatchToRoom { room, message } => {
+                dispatch_to_room(deps, room, *message).await;
             }
             OutboundEvent::BroadcastToRoom { room, .. } => {
                 warn!(
@@ -624,6 +672,168 @@ async fn deliver_peer_to_full(
             warn!(jid = %target, "RouteToConnection: target channel closed, dropping");
         }
     }
+}
+
+/// Bridge the [`OutboundEvent::DispatchToRoom`] arm to the legacy MUC
+/// fan-out path.
+///
+/// The dispatcher chain (#229 PR9) emits `DispatchToRoom` for sender-pass
+/// groupchat sends and the eventual room handler chain (PR17) will own
+/// the per-room fan-out directly. Until that lands, this helper bridges
+/// the dispatcher arm to the existing legacy MUC delivery code in
+/// `routes::websocket::handlers::message::deliver_groupchat_via_room_actor`
+/// so semantics stay bit-for-bit identical regardless of which routing
+/// path triggered delivery.
+///
+/// The `web_socket_state` carries every dependency the helper needs
+/// (managed-room owner check, MAM storage, inbox storage, connection +
+/// SM registries, room-registry actor). When `web_socket_state` is
+/// `None` and only `room_registry` is provided, this helper drives a
+/// slimmer test-only fan-out so unit tests can assert that the room
+/// actor receives `BuildGroupchatBroadcast` without standing up a full
+/// `WebSocketState`. Production wires `web_socket_state`.
+///
+/// The frames the legacy helper would have written back to the sender
+/// (the sender's own echo, or a stanza-level error reply) are NOT
+/// surfaced through `outcome.frames` — the dispatcher path's recipient
+/// pipeline owns sender echo via `RouteToConnection`/`SendStanza`, and
+/// re-emitting the legacy echo here would produce duplicates. This
+/// matches the recipient-pass contract documented on
+/// [`OutboundEvent::DispatchToRoom`].
+async fn dispatch_to_room(deps: &Deps<'_>, room_jid: jid::BareJid, message: Message) {
+    if let Some(state) = deps.web_socket_state {
+        let Some(sender_full) = sender_full_jid(&message) else {
+            warn!(
+                room = %room_jid,
+                "DispatchToRoom: message.from is missing or not a full JID; dropping"
+            );
+            return;
+        };
+        // Production path: full legacy MUC fan-out via the shared
+        // helper. Sender echo + error replies, if any, are emitted
+        // back to the sender by the legacy path's caller; the
+        // dispatcher path's sender-side pipeline already handles
+        // that surface separately, so we discard the helper's frame
+        // return here. (See note in this fn's docstring.)
+        let _frames = deliver_groupchat_via_room_actor(
+            state,
+            room_jid,
+            sender_full,
+            message,
+            // The legacy helper consults `authenticated_session`
+            // only for the managed-room owner check; the sender
+            // pass's caller (dispatcher main loop) already verified
+            // session presence before dispatch. Passing `&None` is
+            // safe — it only suppresses the owner override which
+            // does not apply on this path.
+            &None,
+        )
+        .await;
+        return;
+    }
+
+    let Some(room_registry) = deps.room_registry else {
+        warn!(
+            variant = "DispatchToRoom",
+            room = %room_jid,
+            "DispatchToRoom: neither web_socket_state nor room_registry provided in Deps; \
+             dropping. Production must populate web_socket_state."
+        );
+        return;
+    };
+
+    // Slimmed test-only path: look up the room actor through the
+    // registry, ask it to build the per-occupant broadcast, and fan
+    // out via the connection registry. No managed-room owner check,
+    // no MAM archive write, no inbox projection, no rich-target
+    // validation, no retraction tombstones — those run only on the
+    // production path. Used by L1 interpreter tests to assert the
+    // actor wiring.
+    let Some(sender_full) = sender_full_jid(&message) else {
+        warn!(
+            room = %room_jid,
+            "DispatchToRoom (test path): message.from is missing or not a full JID; dropping"
+        );
+        return;
+    };
+
+    let room_actor = match room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            warn!(
+                room = %room_jid,
+                "DispatchToRoom (test path): room not registered; dropping"
+            );
+            return;
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                error = ?error,
+                "DispatchToRoom (test path): room registry lookup failed; dropping"
+            );
+            return;
+        }
+    };
+
+    let broadcast = match room_actor
+        .ask(BuildGroupchatBroadcast {
+            sender_jid: sender_full.clone(),
+            message,
+        })
+        .await
+    {
+        Ok(broadcast) => broadcast,
+        Err(error) => {
+            warn!(
+                sender = %sender_full,
+                room = %room_jid,
+                error = ?error,
+                "DispatchToRoom (test path): sender not permitted to broadcast; dropping"
+            );
+            return;
+        }
+    };
+
+    for outbound in broadcast.messages {
+        if outbound.to == sender_full {
+            // Sender echo is the dispatcher pipeline's responsibility on
+            // this path; do not re-emit it here.
+            continue;
+        }
+        let stanza = Stanza::Message(outbound.message);
+        match deps
+            .connection_registry
+            .try_send_to(&outbound.to, stanza.clone())
+        {
+            BroadcastOutcome::Delivered => {
+                debug!(jid = %outbound.to, "DispatchToRoom (test path): delivered");
+            }
+            BroadcastOutcome::DroppedFull => {
+                debug!(jid = %outbound.to, "DispatchToRoom (test path): mailbox full");
+            }
+            BroadcastOutcome::DroppedClosed => {
+                debug!(jid = %outbound.to, "DispatchToRoom (test path): channel closed");
+            }
+            BroadcastOutcome::NotConnected => {
+                debug!(jid = %outbound.to, "DispatchToRoom (test path): target offline");
+            }
+        }
+    }
+}
+
+/// Extract the sender's full JID from a typed groupchat `Message`.
+///
+/// Returns `None` when `message.from` is missing or carries only a
+/// bare JID — both are protocol-error states for a sender-pass
+/// groupchat dispatch and the caller drops the event.
+fn sender_full_jid(message: &Message) -> Option<jid::FullJid> {
+    message.from.clone()?.try_into_full().ok()
 }
 
 async fn enrich_message_event(deps: &Deps<'_>, mut message: Message) -> Message {
@@ -1095,6 +1305,8 @@ mod tests {
             mam_storage: None,
             inbox_storage: None,
             extension_manager: None,
+            room_registry: None,
+            web_socket_state: None,
         };
         let _outcome = interpret(
             vec![OutboundEvent::SendCarbons {
@@ -2114,5 +2326,158 @@ mod tests {
         assert_eq!(outcome.frames.len(), 2);
         assert!(outcome.frames[0].contains("id=\"a\""));
         assert!(outcome.frames[1].contains("id=\"b\""));
+    }
+
+    // -----------------------------------------------------------------
+    // #229 PR14 — DispatchToRoom interpreter arm bridges to legacy MUC
+    // fan-out
+    // -----------------------------------------------------------------
+
+    /// L1 interpreter test for the `OutboundEvent::DispatchToRoom`
+    /// arm: spawns a `RoomRegistryActor`, registers a populated test
+    /// room, fires the event through `interpret(...)`, and asserts the
+    /// room actor produced a per-occupant broadcast that landed on the
+    /// connection-registry queue of the non-sender occupant. This
+    /// pins the contract that the DispatchToRoom arm is no longer a
+    /// warn-stub and reaches the room actor with
+    /// `BuildGroupchatBroadcast`. Production semantics
+    /// (managed-room owner check, MAM archive, inbox projection,
+    /// rich-target validation, retraction tombstones) flow through
+    /// the legacy MUC fan-out helper exercised by the integration
+    /// tests in `crates/waddle-server/tests/xep0359_stanza_ids_ws.rs`.
+    #[tokio::test]
+    async fn dispatch_to_room_bridges_to_room_actor_and_fans_out_to_occupants() {
+        use waddle_xmpp::muc::room_actor::Join;
+        use waddle_xmpp::muc::room_registry_actor::GetOrCreateRoom;
+        use waddle_xmpp::muc::RoomConfig;
+        use waddle_xmpp::{Affiliation, Role};
+
+        let registry = ConnectionRegistry::new();
+        let room_registry = kameo::spawn(RoomRegistryActor::new("muc.example.com".to_string()));
+
+        let room_jid: jid::BareJid = "testroom@muc.example.com".parse().expect("parse room jid");
+        let alice_full: jid::FullJid = "alice@example.com/web".parse().expect("parse alice jid");
+        let bob_full: jid::FullJid = "bob@example.com/web".parse().expect("parse bob jid");
+
+        // Alice and Bob are both occupants. Alice sends; Bob must
+        // receive the broadcast on his connection-registry queue.
+        let room_actor = room_registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "waddle-test".to_string(),
+                channel_id: "test-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room");
+        room_actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: alice_full.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("alice join");
+        room_actor
+            .ask(Join {
+                nick: "bob".to_string(),
+                real_jid: bob_full.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("bob join");
+
+        let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+        registry.register_with_carbons(bob_full.clone(), bob_tx, false);
+
+        // Build a typed groupchat message addressed to the room with
+        // alice's full JID stamped as `from` (the sender pass already
+        // does this before emitting `DispatchToRoom`).
+        let mut message =
+            xmpp_parsers::message::Message::new(Some(jid::Jid::from(room_jid.clone())));
+        message.id = Some("dispatch-to-room-1".to_string());
+        message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+        message.from = Some(jid::Jid::from(alice_full.clone()));
+        message.bodies.insert(
+            String::new(),
+            xmpp_parsers::message::Body("hello room".to_string()),
+        );
+
+        let events = vec![OutboundEvent::DispatchToRoom {
+            room: room_jid.clone(),
+            message: Box::new(message),
+        }];
+        let outcome = interpret(
+            events,
+            &Deps::test_with_room_registry(&registry, &room_registry),
+        )
+        .await;
+
+        assert!(
+            outcome.frames.is_empty(),
+            "DispatchToRoom must not surface frames through outcome.frames \
+             (sender echo is owned by the dispatcher's recipient pipeline)"
+        );
+        assert!(!outcome.close);
+
+        let bob_queue = drain_inbound(&mut bob_rx);
+        assert_eq!(
+            bob_queue.len(),
+            1,
+            "bob must receive exactly one broadcast frame from the room actor"
+        );
+        let stanza = &bob_queue[0].stanza;
+        let msg = match stanza {
+            Stanza::Message(m) => m,
+            other => panic!("expected Message stanza on bob's queue, got {other:?}"),
+        };
+        assert_eq!(
+            msg.type_,
+            xmpp_parsers::message::MessageType::Groupchat,
+            "fan-out must preserve type='groupchat'"
+        );
+        assert!(
+            msg.from
+                .as_ref()
+                .and_then(|j| j.resource())
+                .map(|r| r.as_str() == "alice")
+                .unwrap_or(false),
+            "broadcast `from` must be the room JID with sender's MUC nick",
+        );
+        let body = msg
+            .bodies
+            .get(&String::new())
+            .expect("broadcast carries the original body");
+        assert_eq!(body.0, "hello room");
+    }
+
+    /// Without either `web_socket_state` or `room_registry`, the
+    /// arm must drop the event with a warn — the dispatcher's
+    /// downstream effects do not run, but neither do they panic.
+    /// Pinned so a regression that "silently" relies on something
+    /// unset surfaces here rather than as a missing wire frame.
+    #[tokio::test]
+    async fn dispatch_to_room_drops_when_no_room_registry_or_state_in_deps() {
+        let registry = ConnectionRegistry::new();
+        let room_jid: jid::BareJid = "testroom@muc.example.com".parse().expect("parse room jid");
+        let mut message =
+            xmpp_parsers::message::Message::new(Some(jid::Jid::from(room_jid.clone())));
+        message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+        message.from = Some(
+            "alice@example.com/web"
+                .parse::<jid::FullJid>()
+                .map(jid::Jid::from)
+                .expect("from"),
+        );
+
+        let events = vec![OutboundEvent::DispatchToRoom {
+            room: room_jid,
+            message: Box::new(message),
+        }];
+        let outcome = interpret(events, &Deps::registry_only(&registry)).await;
+        assert!(outcome.frames.is_empty());
+        assert!(!outcome.close);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -304,6 +304,8 @@ pub async fn handle_iq_with_conn_state(
             mam_storage: Some(&state.deps.protocol.mam_storage),
             inbox_storage: Some(&state.deps.protocol.inbox_storage),
             extension_manager: Some(&state.deps.protocol.extension_manager),
+            room_registry: Some(&state.deps.protocol.room_registry),
+            web_socket_state: Some(state),
         };
         let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
         if outcome.close {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -306,6 +306,7 @@ pub async fn handle_iq_with_conn_state(
             extension_manager: Some(&state.deps.protocol.extension_manager),
             room_registry: Some(&state.deps.protocol.room_registry),
             web_socket_state: Some(state),
+            authenticated_session: authenticated_session.as_ref(),
         };
         let outcome = crate::server::routes::interpret::interpret(events, &deps).await;
         if outcome.close {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -73,289 +73,14 @@ pub async fn handle_message(
         // Parse room JID (strip resource if present)
         let room_jid = to_jid.to_bare();
 
-        debug!(room = %room_jid, sender = %sender_jid, "Groupchat message");
-
-        if waddle_xmpp::parse_managed_room_jid(&room_jid).as_deref() == Some("announcements")
-            && !session_is_server_owner(state, authenticated_session).await
-        {
-            return vec![stanza_to_xml(&Stanza::Message(forbidden_message_error(
-                &incoming, &room_jid, sender_jid,
-            )))];
-        }
-
-        let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-            warn!(room = %room_jid, "Message to non-existent room");
-            return vec![];
-        };
-
-        // Build a prototype message, enrich once, then ask the room actor to fan it out.
-        let mut prototype = incoming.clone();
-        prototype.id = prototype
-            .id
-            .clone()
-            .or_else(|| Some(uuid::Uuid::new_v4().to_string()));
-        prototype.type_ = XmppMessageType::Groupchat;
-        remove_stanza_ids_by(&mut prototype, &room_jid.to_string());
-
-        // Enrich links with extension-provided XML elements (fail-open).
-        let _embeds_added = state
-            .deps
-            .protocol
-            .extension_manager
-            .enrich_message(&mut prototype)
-            .await;
-
-        let broadcast = match room_actor
-            .ask(BuildGroupchatBroadcast {
-                sender_jid: sender_jid.clone(),
-                message: prototype.clone(),
-            })
-            .await
-        {
-            Ok(broadcast) => broadcast,
-            Err(error) => {
-                warn!(
-                    sender = %sender_jid,
-                    room = %room_jid,
-                    error = ?error,
-                    "Sender not permitted to broadcast to MUC room"
-                );
-                return vec![];
-            }
-        };
-        let sender_nick = broadcast.sender_nick;
-        let mut local_messages = broadcast.messages;
-        let occupant_bare_jids = broadcast.occupant_bare_jids;
-        let sender_nickname_generation = broadcast.sender_nickname_generation;
-
-        let from_room_jid = format!("{}/{}", room_jid, sender_nick);
-        if let Ok(from_jid) = from_room_jid.parse::<FullJid>() {
-            prototype.from = Some(jid::Jid::from(from_jid));
-        } else {
-            prototype.from = Some(jid::Jid::from(sender_jid.clone()));
-        }
-        prototype.to = None;
-
-        if let Err(error) =
-            validate_rich_message_targets(state, &room_jid, &prototype, true, Some(&room_actor))
-                .await
-        {
-            return vec![stanza_to_xml(&Stanza::Message(error_message(
-                &incoming,
-                &jid::Jid::from(room_jid.clone()),
-                &jid::Jid::from(sender_jid.clone()),
-                error,
-            )))];
-        }
-
-        // XEP-0424 §"prevent further distribution… by replacing the
-        // original message with a tombstone": after authorization
-        // passes, mutate the room archive's original row in place.
-        if let Some(RetractionKind::Request(retraction)) =
-            extract_retraction_from_message(&prototype)
-        {
-            apply_retraction_tombstones(
-                state,
-                std::slice::from_ref(&room_jid),
-                &prototype,
-                &retraction.retracts_id,
-                Utc::now(),
-                true,
-            )
-            .await;
-        }
-
-        // Archive body-bearing and rich protocol room messages in XMPP MAM storage.
-        let archive_id =
-            archive_groupchat_message(state, &room_jid, &mut prototype, sender_nickname_generation)
-                .await;
-
-        if should_project_message(&prototype) {
-            let timestamp = Utc::now().timestamp();
-            let sender_bare = sender_jid.to_bare();
-            let entry = groupchat_entry(room_jid.clone(), &prototype, timestamp);
-
-            if let Err(error) = state
-                .deps
-                .protocol
-                .inbox_storage
-                .upsert(&sender_bare, entry.clone(), false)
-                .await
-            {
-                warn!(jid = %sender_bare, room = %room_jid, error = %error, "Failed to update sender inbox for groupchat");
-            }
-
-            // Thread-level inbox projection: if the message carries a <thread/>,
-            // upsert a thread-scoped entry alongside the channel-level one.
-            let thread_entry = prototype.thread.as_ref().map(|thread| {
-                // Resolve thread title from Waddle thread metadata or first message preview.
-                let forum_title = waddle_xmpp::xep::xep0508::extract_forum_action(&prototype)
-                    .and_then(|action| match action {
-                        waddle_xmpp::xep::xep0508::ForumAction::CreateThread(tc) => Some(tc.title),
-                        _ => None,
-                    });
-                let title = forum_title.or_else(|| preview_text(&prototype));
-                let author_nick = prototype
-                    .from
-                    .as_ref()
-                    .and_then(|jid| jid.resource().map(|r| r.to_string()));
-                groupchat_thread_entry(
-                    room_jid.clone(),
-                    &prototype,
-                    timestamp,
-                    &thread.0,
-                    title.as_deref(),
-                    author_nick.as_deref(),
-                )
-            });
-
-            let mut projected_bares = std::collections::HashSet::new();
-            for occupant_bare in occupant_bare_jids
-                .iter()
-                .filter_map(|jid| jid.parse::<BareJid>().ok())
-                .filter(|jid| projected_bares.insert(jid.clone()))
-            {
-                match state
-                    .deps
-                    .protocol
-                    .inbox_storage
-                    .upsert(&occupant_bare, entry.clone(), true)
-                    .await
-                {
-                    Ok(updated) => push_inbox_update(state, &occupant_bare, &updated).await,
-                    Err(error) => {
-                        warn!(jid = %occupant_bare, room = %room_jid, error = %error, "Failed to update occupant inbox for groupchat");
-                    }
-                }
-
-                // Push thread-level entry too
-                if let Some(ref thread_entry) = thread_entry {
-                    match state
-                        .deps
-                        .protocol
-                        .inbox_storage
-                        .upsert(&occupant_bare, thread_entry.clone(), true)
-                        .await
-                    {
-                        Ok(updated) => push_inbox_update(state, &occupant_bare, &updated).await,
-                        Err(error) => {
-                            warn!(jid = %occupant_bare, room = %room_jid, error = %error, "Failed to update occupant thread inbox");
-                        }
-                    }
-                }
-            }
-
-            // Upsert thread entry for sender too (without incrementing unread)
-            if let Some(ref thread_entry) = thread_entry {
-                if let Err(error) = state
-                    .deps
-                    .protocol
-                    .inbox_storage
-                    .upsert(&sender_bare, thread_entry.clone(), false)
-                    .await
-                {
-                    warn!(jid = %sender_bare, room = %room_jid, error = %error, "Failed to update sender thread inbox");
-                }
-            }
-        }
-
-        // Send to all occupants. Groupchat broadcasts are fire-and-forget:
-        // message bodies are already archived to MAM, so any occupant the
-        // server can't reach right now (backpressured or stale) will pick up
-        // the message on their next MAM catch-up. Blocking here is what
-        // caused join cascades under zombie load.
-        //
-        // Accounting invariant for the broadcast log below:
-        //   `intended = delivered + dropped_full + dropped_closed + not_connected`
-        // The sender is always one of `occupants` in a groupchat send but is
-        // reached via the direct echo response (not `try_send_to`), so the
-        // echo path counts as one `delivered` to keep the invariant true.
-        let mut echo_response = None;
-        let mut delivered = 0u32;
-        let mut dropped_full = 0u32;
-        let mut dropped_closed = 0u32;
-        let mut not_connected = 0u32;
-        let intended = local_messages.len();
-        for mut outbound in local_messages.drain(..) {
-            if let Some(ref archive_id) = archive_id {
-                add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid.to_string());
-            }
-
-            if outbound.to == *sender_jid {
-                // Echo back to sender — serialize the enriched prototype
-                echo_response = Some(stanza_to_xml(&Stanza::Message(outbound.message)));
-                delivered += 1;
-            } else {
-                let stanza = Stanza::Message(outbound.message);
-                match state
-                    .deps
-                    .protocol
-                    .connection_registry
-                    .try_send_to(&outbound.to, stanza.clone())
-                {
-                    BroadcastOutcome::Delivered => delivered += 1,
-                    BroadcastOutcome::DroppedFull => dropped_full += 1,
-                    BroadcastOutcome::DroppedClosed => match state
-                        .deps
-                        .protocol
-                        .sm_session_registry
-                        .record_stanza_for_detached_bound_resource(&outbound.to, &stanza)
-                        .await
-                    {
-                        Ok(true) => delivered += 1,
-                        Ok(false) => dropped_closed += 1,
-                        Err(error) => {
-                            warn!(
-                                jid = %outbound.to,
-                                error = %error,
-                                "Failed to record groupchat stanza for detached resource after closed live send"
-                            );
-                            dropped_closed += 1;
-                        }
-                    },
-                    BroadcastOutcome::NotConnected => {
-                        match state
-                            .deps
-                            .protocol
-                            .sm_session_registry
-                            .record_stanza_for_detached_bound_resource(&outbound.to, &stanza)
-                            .await
-                        {
-                            Ok(true) => delivered += 1,
-                            Ok(false) => not_connected += 1,
-                            Err(error) => {
-                                warn!(
-                                    jid = %outbound.to,
-                                    error = %error,
-                                    "Failed to record groupchat stanza for detached resource"
-                                );
-                                not_connected += 1;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        debug_assert_eq!(
-            intended as u32,
-            delivered + dropped_full + dropped_closed + not_connected,
-            "broadcast accounting must cover every occupant exactly once"
-        );
-
-        info!(
-            room = %room_jid,
-            sender = %sender_nick,
-            intended,
-            delivered,
-            dropped_full,
-            dropped_closed,
-            not_connected,
-            "Groupchat message broadcast"
-        );
-
-        // Return the echo to the sender
-        return echo_response.into_iter().collect();
+        return deliver_groupchat_via_room_actor(
+            state,
+            room_jid,
+            sender_jid.clone(),
+            incoming,
+            authenticated_session,
+        )
+        .await;
     }
 
     // Handle direct messages, including default/normal messages and XEP-0249
@@ -654,6 +379,315 @@ pub async fn handle_message(
 
     debug!(msg_type = ?incoming.type_, "Message stanza received");
     vec![]
+}
+
+/// Deliver a groupchat `<message type='groupchat'>` to a local MUC
+/// room: managed-room owner check, `BuildGroupchatBroadcast`, rich-target
+/// validation, retraction tombstones, MAM archive write, inbox
+/// projection, and per-occupant fan-out via the connection registry.
+///
+/// Shared between the legacy `handle_message` Groupchat branch and the
+/// sans-I/O dispatcher's [`OutboundEvent::DispatchToRoom`] interpreter
+/// arm, so MUC fan-out semantics stay bit-for-bit identical regardless
+/// of which routing path triggered delivery. PR17 in #229 will retire
+/// this helper in favour of a dedicated room handler chain (Q7
+/// option C); until then both call sites share one implementation here.
+///
+/// Returns the wire frames the caller should write back to the sender —
+/// today this is the sender's own echo (or a stanza-level error reply
+/// when validation fails).
+///
+/// [`OutboundEvent::DispatchToRoom`]: waddle_xmpp::protocol::OutboundEvent::DispatchToRoom
+pub(crate) async fn deliver_groupchat_via_room_actor(
+    state: &WebSocketState,
+    room_jid: BareJid,
+    sender_jid: FullJid,
+    incoming: xmpp_parsers::message::Message,
+    authenticated_session: &Option<Session>,
+) -> Vec<String> {
+    debug!(room = %room_jid, sender = %sender_jid, "Groupchat message");
+
+    if waddle_xmpp::parse_managed_room_jid(&room_jid).as_deref() == Some("announcements")
+        && !session_is_server_owner(state, authenticated_session).await
+    {
+        return vec![stanza_to_xml(&Stanza::Message(forbidden_message_error(
+            &incoming,
+            &room_jid,
+            &sender_jid,
+        )))];
+    }
+
+    let Some(room_actor) = get_room_actor(state, &room_jid).await else {
+        warn!(room = %room_jid, "Message to non-existent room");
+        return vec![];
+    };
+
+    // Build a prototype message, enrich once, then ask the room actor to fan it out.
+    let mut prototype = incoming.clone();
+    prototype.id = prototype
+        .id
+        .clone()
+        .or_else(|| Some(uuid::Uuid::new_v4().to_string()));
+    prototype.type_ = XmppMessageType::Groupchat;
+    remove_stanza_ids_by(&mut prototype, &room_jid.to_string());
+
+    // Enrich links with extension-provided XML elements (fail-open).
+    let _embeds_added = state
+        .deps
+        .protocol
+        .extension_manager
+        .enrich_message(&mut prototype)
+        .await;
+
+    let broadcast = match room_actor
+        .ask(BuildGroupchatBroadcast {
+            sender_jid: sender_jid.clone(),
+            message: prototype.clone(),
+        })
+        .await
+    {
+        Ok(broadcast) => broadcast,
+        Err(error) => {
+            warn!(
+                sender = %sender_jid,
+                room = %room_jid,
+                error = ?error,
+                "Sender not permitted to broadcast to MUC room"
+            );
+            return vec![];
+        }
+    };
+    let sender_nick = broadcast.sender_nick;
+    let mut local_messages = broadcast.messages;
+    let occupant_bare_jids = broadcast.occupant_bare_jids;
+    let sender_nickname_generation = broadcast.sender_nickname_generation;
+
+    let from_room_jid = format!("{}/{}", room_jid, sender_nick);
+    if let Ok(from_jid) = from_room_jid.parse::<FullJid>() {
+        prototype.from = Some(jid::Jid::from(from_jid));
+    } else {
+        prototype.from = Some(jid::Jid::from(sender_jid.clone()));
+    }
+    prototype.to = None;
+
+    if let Err(error) =
+        validate_rich_message_targets(state, &room_jid, &prototype, true, Some(&room_actor)).await
+    {
+        return vec![stanza_to_xml(&Stanza::Message(error_message(
+            &incoming,
+            &jid::Jid::from(room_jid.clone()),
+            &jid::Jid::from(sender_jid.clone()),
+            error,
+        )))];
+    }
+
+    // XEP-0424 §"prevent further distribution… by replacing the
+    // original message with a tombstone": after authorization
+    // passes, mutate the room archive's original row in place.
+    if let Some(RetractionKind::Request(retraction)) = extract_retraction_from_message(&prototype) {
+        apply_retraction_tombstones(
+            state,
+            std::slice::from_ref(&room_jid),
+            &prototype,
+            &retraction.retracts_id,
+            Utc::now(),
+            true,
+        )
+        .await;
+    }
+
+    // Archive body-bearing and rich protocol room messages in XMPP MAM storage.
+    let archive_id =
+        archive_groupchat_message(state, &room_jid, &mut prototype, sender_nickname_generation)
+            .await;
+
+    if should_project_message(&prototype) {
+        let timestamp = Utc::now().timestamp();
+        let sender_bare = sender_jid.to_bare();
+        let entry = groupchat_entry(room_jid.clone(), &prototype, timestamp);
+
+        if let Err(error) = state
+            .deps
+            .protocol
+            .inbox_storage
+            .upsert(&sender_bare, entry.clone(), false)
+            .await
+        {
+            warn!(jid = %sender_bare, room = %room_jid, error = %error, "Failed to update sender inbox for groupchat");
+        }
+
+        // Thread-level inbox projection: if the message carries a <thread/>,
+        // upsert a thread-scoped entry alongside the channel-level one.
+        let thread_entry =
+            prototype.thread.as_ref().map(|thread| {
+                // Resolve thread title from Waddle thread metadata or first message preview.
+                let forum_title = waddle_xmpp::xep::xep0508::extract_forum_action(&prototype)
+                    .and_then(|action| match action {
+                        waddle_xmpp::xep::xep0508::ForumAction::CreateThread(tc) => Some(tc.title),
+                        _ => None,
+                    });
+                let title = forum_title.or_else(|| preview_text(&prototype));
+                let author_nick = prototype
+                    .from
+                    .as_ref()
+                    .and_then(|jid| jid.resource().map(|r| r.to_string()));
+                groupchat_thread_entry(
+                    room_jid.clone(),
+                    &prototype,
+                    timestamp,
+                    &thread.0,
+                    title.as_deref(),
+                    author_nick.as_deref(),
+                )
+            });
+
+        let mut projected_bares = std::collections::HashSet::new();
+        for occupant_bare in occupant_bare_jids
+            .iter()
+            .filter_map(|jid| jid.parse::<BareJid>().ok())
+            .filter(|jid| projected_bares.insert(jid.clone()))
+        {
+            match state
+                .deps
+                .protocol
+                .inbox_storage
+                .upsert(&occupant_bare, entry.clone(), true)
+                .await
+            {
+                Ok(updated) => push_inbox_update(state, &occupant_bare, &updated).await,
+                Err(error) => {
+                    warn!(jid = %occupant_bare, room = %room_jid, error = %error, "Failed to update occupant inbox for groupchat");
+                }
+            }
+
+            // Push thread-level entry too
+            if let Some(ref thread_entry) = thread_entry {
+                match state
+                    .deps
+                    .protocol
+                    .inbox_storage
+                    .upsert(&occupant_bare, thread_entry.clone(), true)
+                    .await
+                {
+                    Ok(updated) => push_inbox_update(state, &occupant_bare, &updated).await,
+                    Err(error) => {
+                        warn!(jid = %occupant_bare, room = %room_jid, error = %error, "Failed to update occupant thread inbox");
+                    }
+                }
+            }
+        }
+
+        // Upsert thread entry for sender too (without incrementing unread)
+        if let Some(ref thread_entry) = thread_entry {
+            if let Err(error) = state
+                .deps
+                .protocol
+                .inbox_storage
+                .upsert(&sender_bare, thread_entry.clone(), false)
+                .await
+            {
+                warn!(jid = %sender_bare, room = %room_jid, error = %error, "Failed to update sender thread inbox");
+            }
+        }
+    }
+
+    // Send to all occupants. Groupchat broadcasts are fire-and-forget:
+    // message bodies are already archived to MAM, so any occupant the
+    // server can't reach right now (backpressured or stale) will pick up
+    // the message on their next MAM catch-up. Blocking here is what
+    // caused join cascades under zombie load.
+    //
+    // Accounting invariant for the broadcast log below:
+    //   `intended = delivered + dropped_full + dropped_closed + not_connected`
+    // The sender is always one of `occupants` in a groupchat send but is
+    // reached via the direct echo response (not `try_send_to`), so the
+    // echo path counts as one `delivered` to keep the invariant true.
+    let mut echo_response = None;
+    let mut delivered = 0u32;
+    let mut dropped_full = 0u32;
+    let mut dropped_closed = 0u32;
+    let mut not_connected = 0u32;
+    let intended = local_messages.len();
+    for mut outbound in local_messages.drain(..) {
+        if let Some(ref archive_id) = archive_id {
+            add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid.to_string());
+        }
+
+        if outbound.to == sender_jid {
+            // Echo back to sender — serialize the enriched prototype
+            echo_response = Some(stanza_to_xml(&Stanza::Message(outbound.message)));
+            delivered += 1;
+        } else {
+            let stanza = Stanza::Message(outbound.message);
+            match state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(&outbound.to, stanza.clone())
+            {
+                BroadcastOutcome::Delivered => delivered += 1,
+                BroadcastOutcome::DroppedFull => dropped_full += 1,
+                BroadcastOutcome::DroppedClosed => match state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .record_stanza_for_detached_bound_resource(&outbound.to, &stanza)
+                    .await
+                {
+                    Ok(true) => delivered += 1,
+                    Ok(false) => dropped_closed += 1,
+                    Err(error) => {
+                        warn!(
+                            jid = %outbound.to,
+                            error = %error,
+                            "Failed to record groupchat stanza for detached resource after closed live send"
+                        );
+                        dropped_closed += 1;
+                    }
+                },
+                BroadcastOutcome::NotConnected => {
+                    match state
+                        .deps
+                        .protocol
+                        .sm_session_registry
+                        .record_stanza_for_detached_bound_resource(&outbound.to, &stanza)
+                        .await
+                    {
+                        Ok(true) => delivered += 1,
+                        Ok(false) => not_connected += 1,
+                        Err(error) => {
+                            warn!(
+                                jid = %outbound.to,
+                                error = %error,
+                                "Failed to record groupchat stanza for detached resource"
+                            );
+                            not_connected += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    debug_assert_eq!(
+        intended as u32,
+        delivered + dropped_full + dropped_closed + not_connected,
+        "broadcast accounting must cover every occupant exactly once"
+    );
+
+    info!(
+        room = %room_jid,
+        sender = %sender_nick,
+        intended,
+        delivered,
+        dropped_full,
+        dropped_closed,
+        not_connected,
+        "Groupchat message broadcast"
+    );
+
+    // Return the echo to the sender
+    echo_response.into_iter().collect()
 }
 
 async fn session_is_server_owner(state: &WebSocketState, session: &Option<Session>) -> bool {

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -805,6 +805,8 @@ fn build_interpret_deps(state: &WebSocketState) -> crate::server::routes::interp
         mam_storage: Some(&state.deps.protocol.mam_storage),
         inbox_storage: Some(&state.deps.protocol.inbox_storage),
         extension_manager: Some(&state.deps.protocol.extension_manager),
+        room_registry: Some(&state.deps.protocol.room_registry),
+        web_socket_state: Some(state),
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -655,7 +655,10 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                 let events = sm.handle(InboundEvent::StanzaFromPeer(Box::new(
                                     outbound_stanza.stanza,
                                 )));
-                                let interpret_deps = build_interpret_deps(state.as_ref());
+                                let interpret_deps = build_interpret_deps(
+                                    state.as_ref(),
+                                    conn.authenticated_session.as_ref(),
+                                );
                                 let (frames, close) =
                                     drive_interpret_loop(events, sm, &interpret_deps).await;
                                 // Always best-effort flush the
@@ -798,7 +801,17 @@ fn build_internal_server_error_stream_error(text: &str) -> String {
 /// per-connection main loop needs to resolve recipient-pass outbound
 /// events. Centralized so the deps shape stays in sync with the IQ
 /// flow's callsite — both go through the same `interpret()`.
-fn build_interpret_deps(state: &WebSocketState) -> crate::server::routes::interpret::Deps<'_> {
+///
+/// `authenticated_session` is threaded through so the
+/// [`OutboundEvent::DispatchToRoom`] bridge arm can preserve the
+/// legacy managed-room owner check (announcements room admits server
+/// owners only). Without it the dispatcher path's owner override
+/// would always fail. The recipient-pass path the main loop drives
+/// passes the connection's own session here.
+fn build_interpret_deps<'a>(
+    state: &'a WebSocketState,
+    authenticated_session: Option<&'a crate::auth::Session>,
+) -> crate::server::routes::interpret::Deps<'a> {
     crate::server::routes::interpret::Deps {
         connection_registry: &state.deps.protocol.connection_registry,
         sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
@@ -807,6 +820,7 @@ fn build_interpret_deps(state: &WebSocketState) -> crate::server::routes::interp
         extension_manager: Some(&state.deps.protocol.extension_manager),
         room_registry: Some(&state.deps.protocol.room_registry),
         web_socket_state: Some(state),
+        authenticated_session,
     }
 }
 
@@ -842,10 +856,11 @@ async fn drain_outbound_into_replay(
     state: &WebSocketState,
     state_machine: Option<&mut XmppStateMachine>,
     sm_state: &mut StreamManagementState,
+    authenticated_session: Option<&crate::auth::Session>,
     outbound_rx: &mut mpsc::Receiver<OutboundStanza>,
     detached_stream_id: Option<&str>,
 ) {
-    let deps = build_interpret_deps(state);
+    let deps = build_interpret_deps(state, authenticated_session);
     let mut sm_borrow: Option<&mut XmppStateMachine> = state_machine;
     while let Ok(outbound_stanza) = outbound_rx.try_recv() {
         match outbound_stanza.kind {
@@ -1048,6 +1063,7 @@ async fn cleanup_connection_shutdown(
             state,
             conn.state_machine.as_mut(),
             &mut conn.sm_state,
+            conn.authenticated_session.as_ref(),
             outbound_rx,
             None,
         )
@@ -1112,6 +1128,7 @@ async fn cleanup_connection_shutdown(
                         state,
                         conn.state_machine.as_mut(),
                         &mut conn.sm_state,
+                        conn.authenticated_session.as_ref(),
                         outbound_rx,
                         Some(&stream_id),
                     )
@@ -3129,7 +3146,7 @@ mod tests {
         );
 
         let initial_events = vec![OutboundEvent::SendStanza(Box::new(Stanza::Message(msg)))];
-        let deps = build_interpret_deps(state.as_ref());
+        let deps = build_interpret_deps(state.as_ref(), None);
         let (frames, close) = drive_interpret_loop(initial_events, sm, &deps).await;
 
         assert!(!close, "SendStanza alone never requests transport close");
@@ -3183,7 +3200,7 @@ mod tests {
         let events = sm.handle(InboundEvent::StanzaFromPeer(Box::new(Stanza::Message(
             peer_msg,
         ))));
-        let deps = build_interpret_deps(state.as_ref());
+        let deps = build_interpret_deps(state.as_ref(), None);
         let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
 
         // Recipient pass terminates with at least one SendStanza
@@ -3248,6 +3265,7 @@ mod tests {
             state.as_ref(),
             conn.state_machine.as_mut(),
             &mut conn.sm_state,
+            None,
             &mut rx,
             None,
         )
@@ -3307,6 +3325,7 @@ mod tests {
             state.as_ref(),
             conn.state_machine.as_mut(),
             &mut conn.sm_state,
+            None,
             &mut rx,
             None,
         )


### PR DESCRIPTION
## Summary

Stage-2 precondition for the eventual `message.rs::handle_message` cutover [#229](https://github.com/waddle-social/waddle/issues/229). Wires the `OutboundEvent::DispatchToRoom { room, message }` interpreter arm (emitted by the dispatcher chain's `RouteHandler` for groupchat) to the legacy MUC fan-out logic. Without this bridge, dispatcher-driven groupchat messages would never deliver — `DispatchToRoom` was a warn-stub.

The eventual room handler chain (Option C from #229 Q7) lands as PR17 and will replace this bridge with stateless `protocol/room/` handlers (`OccupancyValidationHandler`, `MucCanonicalizeHandler`, `MucArchiveHandler`, `ReflectorHandler`). For now this bridge gives parity so the message.rs cutover can land without regressing MUC.

Stacked on PR1–PR13. Independent of PR15 (offline persistence), so can land in parallel.

## Scope

1. **Refactor**: extract the legacy MUC fan-out body from `handle_message`'s groupchat branch into a reusable async helper `deliver_groupchat_via_room_actor(...)` in `routes/websocket/handlers/message.rs`. Bit-for-bit preservation:
   - Permissions / managed-room owner check.
   - `room_actor.ask(BuildGroupchatBroadcast{...})`.
   - Rich-target validation, retraction tombstones, archive, inbox projection.
   - Occupant fan-out via `try_send_to`.
   - Broadcast accounting invariant + log line.
   Legacy `handle_message`'s groupchat branch now calls into the helper instead of inlining the body.

2. **Interpreter wiring**:
   - `interpret::Deps<'_>` grows `room_registry` and `web_socket_state` (both `Option<...>` so unit tests that don't exercise the MUC arm stay simple).
   - `OutboundEvent::DispatchToRoom` arm calls `dispatch_to_room(deps, room, message)` which thin-wraps `deliver_groupchat_via_room_actor` via the deps' `web_socket_state`.
   - `iq.rs` callsite passes `state.deps.protocol.room_registry` and `state` for the new fields.

## XEP conformance

The bridge preserves every existing MUC behavior — XEP-0045 occupancy, XEP-0359 room stamping, XEP-0313 archive, XEP-0424 retraction tombstones, XEP-0461 reply validation, etc. The integration tests under `crates/waddle-server/tests/xep*_ws.rs` are the gating criterion.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` green — including the existing groupchat integration tests
- [x] `message.rs`'s groupchat branch shrinks to a thin call into the helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)