### PR TITLE
feat(server): #229 PR17 — MUC handler chain infrastructure + close XEP-0421 + XEP-0045 §7.4 gaps

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -531,10 +531,12 @@ fn visitor_may_not_speak_message_error(
 /// Typed reply for transient server-side broadcast failures (room
 /// actor mailbox closed, internal broadcast preparation error, etc.).
 /// Maps to the wire reply
-/// `<error type='cancel'><internal-server-error/></error>` so
-/// clients see a server-fault classification rather than a misleading
-/// `<not-acceptable/>` (which would imply the message itself was
-/// invalid).
+/// `<error type='wait'><internal-server-error/></error>` per
+/// RFC 6120 §8.3.2's guidance for transient server faults — the
+/// client may retry. Mirrors `internal_server_error_for_lookup` and
+/// other repo-wide internal-server-error sites (Copilot review on
+/// PR #277). Distinct from `<not-acceptable/>` so clients can tell
+/// "your message is malformed" from "the server hiccuped".
 fn internal_server_error_message(
     incoming: &xmpp_parsers::message::Message,
     room_jid: &BareJid,
@@ -545,7 +547,7 @@ fn internal_server_error_message(
         &jid::Jid::from(room_jid.clone()),
         &jid::Jid::from(sender_jid.clone()),
         StanzaError::new(
-            ErrorType::Cancel,
+            ErrorType::Wait,
             DefinedCondition::InternalServerError,
             "en",
             "Internal server error while delivering groupchat message.",

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -155,7 +155,17 @@ pub(crate) async fn deliver_groupchat_via_room_actor(
                 error = ?error,
                 "Sender not permitted to broadcast to MUC room"
             );
-            return vec![];
+            // XEP-0045 §7.4: a non-occupant attempting to send to a
+            // room MUST receive a `<not-acceptable type='cancel'/>`
+            // reply. Closes the gap PR16 documented (legacy path
+            // silently dropped). Mirrors the typed reply
+            // `protocol::room::OccupancyValidationHandler` emits in
+            // the room handler chain (#229 PR17).
+            return vec![stanza_to_xml(&Stanza::Message(not_occupant_message_error(
+                &incoming,
+                &room_jid,
+                &sender_jid,
+            )))];
         }
     };
     let sender_nick = broadcast.sender_nick;
@@ -309,10 +319,28 @@ pub(crate) async fn deliver_groupchat_via_room_actor(
     let mut dropped_closed = 0u32;
     let mut not_connected = 0u32;
     let intended = local_messages.len();
+    // XEP-0421: stamp the sender's stable occupant-id on every
+    // reflected copy. Closes the gap PR16 documented (legacy fan-out
+    // path stamped occupant-id only on presence joins/leaves, never
+    // on outgoing groupchat reflections). The id is server-derived
+    // from `(sender_bare, room_bare)` via HMAC-SHA256 of the
+    // deployment's occupant-id secret — same user across nicks /
+    // sessions yields the same id; can't be spoofed by clients.
+    let sender_bare_str = sender_jid.to_bare().to_string();
+    let room_jid_str = room_jid.to_string();
+    let sender_occupant_id = waddle_xmpp::xep::xep0421::generate_occupant_id(
+        &sender_bare_str,
+        &room_jid_str,
+        waddle_xmpp::muc::presence::OCCUPANT_ID_SECRET,
+    );
     for mut outbound in local_messages.drain(..) {
         if let Some(ref archive_id) = archive_id {
             add_mam_stanza_id(&mut outbound.message, archive_id, &room_jid.to_string());
         }
+        waddle_xmpp::xep::xep0421::set_occupant_id_on_message(
+            &mut outbound.message,
+            &sender_occupant_id,
+        );
 
         if outbound.to == sender_jid {
             // Echo back to sender — serialize the enriched prototype
@@ -406,6 +434,29 @@ async fn session_is_server_owner(state: &WebSocketState, session: &Option<Sessio
         })
         .await
         .is_ok_and(|response| response.allowed)
+}
+
+/// Build the XEP-0045 §7.4 typed `<not-acceptable type='cancel'/>` reply
+/// for a non-occupant sender. Mirrors the reply
+/// `protocol::room::OccupancyValidationHandler` emits — the chain runs
+/// against an `OccupantSnapshot` list and halts with this exact shape
+/// when `sender_snapshot()` returns `None` (sender is not in the room).
+fn not_occupant_message_error(
+    incoming: &xmpp_parsers::message::Message,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+) -> xmpp_parsers::message::Message {
+    error_message(
+        incoming,
+        &jid::Jid::from(room_jid.clone()),
+        &jid::Jid::from(sender_jid.clone()),
+        StanzaError::new(
+            ErrorType::Cancel,
+            DefinedCondition::NotAcceptable,
+            "en",
+            "Only room occupants may send messages to this room.",
+        ),
+    )
 }
 
 fn forbidden_message_error(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -11,7 +11,7 @@ use waddle_xmpp::{
         ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
         ArchivedRichPayload, RichMessageId, RichText, STANZA_ID_NS,
     },
-    muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor},
+    muc::room_actor::{BuildGroupchatBroadcast, GetNicknameGeneration, RoomActor, RoomActorError},
     parser::message_to_string,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
     registry::BroadcastOutcome,
@@ -148,24 +148,49 @@ pub(crate) async fn deliver_groupchat_via_room_actor(
         .await
     {
         Ok(broadcast) => broadcast,
-        Err(error) => {
+        // The room actor's typed `BuildGroupchatBroadcast` errors map
+        // 1:1 to wire stanza errors (Codex P2 + Qodo bug #3 review on
+        // PR #277): only genuine non-occupant senders see XEP-0045
+        // §7.4 `<not-acceptable/>`; visitors in moderated rooms see
+        // §7.5 `<forbidden/>`; everything else (broadcast prep
+        // failures, unrelated `RoomActorError` variants) is a
+        // server-side fault and must surface as
+        // `<internal-server-error/>` so clients don't get a
+        // misleading "you're not in the room" reply during a
+        // transient issue. Transport-level kameo errors (mailbox
+        // closed, etc.) also fall to internal-server-error.
+        Err(kameo::error::SendError::HandlerError(RoomActorError::SenderNotOccupant(_))) => {
             warn!(
                 sender = %sender_jid,
                 room = %room_jid,
-                error = ?error,
-                "Sender not permitted to broadcast to MUC room"
+                "XEP-0045 §7.4: sender is not an occupant of the room"
             );
-            // XEP-0045 §7.4: a non-occupant attempting to send to a
-            // room MUST receive a `<not-acceptable type='cancel'/>`
-            // reply. Closes the gap PR16 documented (legacy path
-            // silently dropped). Mirrors the typed reply
-            // `protocol::room::OccupancyValidationHandler` emits in
-            // the room handler chain (#229 PR17).
             return vec![stanza_to_xml(&Stanza::Message(not_occupant_message_error(
                 &incoming,
                 &room_jid,
                 &sender_jid,
             )))];
+        }
+        Err(kameo::error::SendError::HandlerError(RoomActorError::VisitorMayNotSpeak(_))) => {
+            warn!(
+                sender = %sender_jid,
+                room = %room_jid,
+                "XEP-0045 §7.5: visitor may not speak in moderated room"
+            );
+            return vec![stanza_to_xml(&Stanza::Message(
+                visitor_may_not_speak_message_error(&incoming, &room_jid, &sender_jid),
+            ))];
+        }
+        Err(error) => {
+            warn!(
+                sender = %sender_jid,
+                room = %room_jid,
+                error = ?error,
+                "Groupchat broadcast preparation failed; replying with internal-server-error"
+            );
+            return vec![stanza_to_xml(&Stanza::Message(
+                internal_server_error_message(&incoming, &room_jid, &sender_jid),
+            ))];
         }
     };
     let sender_nick = broadcast.sender_nick;
@@ -323,14 +348,17 @@ pub(crate) async fn deliver_groupchat_via_room_actor(
     // reflected copy. Closes the gap PR16 documented (legacy fan-out
     // path stamped occupant-id only on presence joins/leaves, never
     // on outgoing groupchat reflections). The id is server-derived
-    // from `(sender_bare, room_bare)` via HMAC-SHA256 of the
-    // deployment's occupant-id secret — same user across nicks /
-    // sessions yields the same id; can't be spoofed by clients.
-    let sender_bare_str = sender_jid.to_bare().to_string();
-    let room_jid_str = room_jid.to_string();
+    // from `(sender_bare, room_bare)` via HMAC-SHA256 keyed by the
+    // process-wide `OCCUPANT_ID_SECRET` constant — same user across
+    // nicks / sessions yields the same id; can't be spoofed by
+    // clients. The constant is shared with `presence.rs` so MUC
+    // presence and outgoing groupchat reflections produce matching
+    // ids; a future change can thread a per-deployment configured
+    // secret through `WebSocketState` if rotation / per-tenant
+    // isolation becomes a requirement (Copilot review on PR #277).
     let sender_occupant_id = waddle_xmpp::xep::xep0421::generate_occupant_id(
-        &sender_bare_str,
-        &room_jid_str,
+        &sender_jid.to_bare(),
+        &room_jid,
         waddle_xmpp::muc::presence::OCCUPANT_ID_SECRET,
     );
     for mut outbound in local_messages.drain(..) {
@@ -473,6 +501,54 @@ fn forbidden_message_error(
             DefinedCondition::Forbidden,
             "en",
             "Sender is not permitted to address this resource.",
+        ),
+    )
+}
+
+/// XEP-0045 §7.5 typed reply for a visitor in a moderated room.
+/// The sender IS an occupant but their role is `visitor` and the
+/// room's `moderated` flag forbids visitors from sending messages
+/// to the room. Maps `RoomActorError::VisitorMayNotSpeak` to the
+/// wire reply `<error type='auth'><forbidden/></error>`.
+fn visitor_may_not_speak_message_error(
+    incoming: &xmpp_parsers::message::Message,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+) -> xmpp_parsers::message::Message {
+    error_message(
+        incoming,
+        &jid::Jid::from(room_jid.clone()),
+        &jid::Jid::from(sender_jid.clone()),
+        StanzaError::new(
+            ErrorType::Auth,
+            DefinedCondition::Forbidden,
+            "en",
+            "Visitors may not send messages to this moderated room.",
+        ),
+    )
+}
+
+/// Typed reply for transient server-side broadcast failures (room
+/// actor mailbox closed, internal broadcast preparation error, etc.).
+/// Maps to the wire reply
+/// `<error type='cancel'><internal-server-error/></error>` so
+/// clients see a server-fault classification rather than a misleading
+/// `<not-acceptable/>` (which would imply the message itself was
+/// invalid).
+fn internal_server_error_message(
+    incoming: &xmpp_parsers::message::Message,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+) -> xmpp_parsers::message::Message {
+    error_message(
+        incoming,
+        &jid::Jid::from(room_jid.clone()),
+        &jid::Jid::from(sender_jid.clone()),
+        StanzaError::new(
+            ErrorType::Cancel,
+            DefinedCondition::InternalServerError,
+            "en",
+            "Internal server error while delivering groupchat message.",
         ),
     )
 }

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -19,6 +19,17 @@ use crate::XmppError;
 /// the message-side groupchat reflection stamping (#229 PR17 room
 /// chain) so the same user resolves to the same occupant-id across
 /// presence joins/leaves AND outgoing groupchat messages.
+///
+/// **Deployment-config gap (Copilot review on PR #277, post-#229
+/// follow-up):** XEP-0421 §3 recommends the occupant-id derivation be
+/// keyed by a per-deployment secret so occupant-ids are unlinkable
+/// across deployments. Today this is a process-wide compiled-in
+/// constant. The new room handler chain takes the secret via
+/// [`crate::protocol::room::context::RoomContext::occupant_id_secret`]
+/// so a follow-up PR can thread a configured, rotatable secret from
+/// `WebSocketState` (or equivalent app state) through the production
+/// `presence.rs` and `message.rs` call sites and demote this constant
+/// to a `#[cfg(test)]` default.
 pub const OCCUPANT_ID_SECRET: &[u8] = b"waddle-xmpp-occupant-id-v1";
 
 /// Namespace for MUC user protocol.

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -14,7 +14,12 @@ use xmpp_parsers::presence::{Presence, Type as PresenceType};
 use crate::types::{Affiliation, Role};
 use crate::XmppError;
 
-const OCCUPANT_ID_SECRET: &[u8] = b"waddle-xmpp-occupant-id-v1";
+/// Server-side secret used to derive the XEP-0421 stable occupant-id
+/// HMAC. Shared between the presence-side stamping (this module) and
+/// the message-side groupchat reflection stamping (#229 PR17 room
+/// chain) so the same user resolves to the same occupant-id across
+/// presence joins/leaves AND outgoing groupchat messages.
+pub const OCCUPANT_ID_SECRET: &[u8] = b"waddle-xmpp-occupant-id-v1";
 
 /// Namespace for MUC user protocol.
 pub const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -434,8 +434,8 @@ fn add_presence_identity_payloads(
 
     if let Some(occupant_bare_jid) = occupant_bare_jid {
         let occupant_id = crate::xep::xep0421::generate_occupant_id(
-            &occupant_bare_jid.to_string(),
-            &from_room_jid.to_bare().to_string(),
+            &occupant_bare_jid,
+            &from_room_jid.to_bare(),
             OCCUPANT_ID_SECRET,
         );
         crate::xep::xep0421::set_occupant_id_on_presence(presence, &occupant_id);

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -142,6 +142,19 @@ pub enum RoomActorError {
     OccupantNotFound(String),
     #[error("join is forbidden (members_only={members_only})")]
     JoinForbidden { members_only: bool },
+    /// XEP-0045 §7.4: sender is not an occupant of this room. Maps to
+    /// the typed stanza error `<error type='cancel'><not-acceptable/></error>`.
+    #[error("sender '{0}' is not an occupant of this room")]
+    SenderNotOccupant(FullJid),
+    /// XEP-0045 §7.5: a visitor in a moderated room may not speak.
+    /// Maps to the typed stanza error `<error type='auth'><forbidden/></error>`.
+    #[error("visitor '{0}' may not speak in a moderated room")]
+    VisitorMayNotSpeak(FullJid),
+    /// Broadcast prep failed inside the room (occupant lookup, role
+    /// check, etc.). Maps to `<error type='cancel'><internal-server-error/></error>`
+    /// because it represents a server-side issue, not a client error.
+    #[error("groupchat broadcast preparation failed: {0}")]
+    BroadcastFailed(String),
 }
 
 impl RoomActor {
@@ -421,19 +434,17 @@ impl kameo::message::Message<BuildGroupchatBroadcast> for RoomActor {
         let sender_occupant = self
             .room
             .find_occupant_by_real_jid(&msg.sender_jid)
-            .ok_or_else(|| RoomActorError::OccupantNotFound(msg.sender_jid.to_string()))?;
+            .ok_or_else(|| RoomActorError::SenderNotOccupant(msg.sender_jid.clone()))?;
         let sender_nick = sender_occupant.nick.clone();
 
         if self.room.config.moderated && sender_occupant.role == Role::Visitor {
-            return Err(RoomActorError::OccupantNotFound(
-                "Visitors cannot speak in moderated rooms".to_string(),
-            ));
+            return Err(RoomActorError::VisitorMayNotSpeak(msg.sender_jid.clone()));
         }
 
         let messages = self
             .room
             .broadcast_message(&sender_nick, &msg.message)
-            .map_err(|error| RoomActorError::OccupantNotFound(error.to_string()))?;
+            .map_err(|error| RoomActorError::BroadcastFailed(error.to_string()))?;
 
         let sender_jid_for_filter = msg.sender_jid;
         let occupant_bare_jids: Vec<String> = self

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -151,8 +151,10 @@ pub enum RoomActorError {
     #[error("visitor '{0}' may not speak in a moderated room")]
     VisitorMayNotSpeak(FullJid),
     /// Broadcast prep failed inside the room (occupant lookup, role
-    /// check, etc.). Maps to `<error type='cancel'><internal-server-error/></error>`
-    /// because it represents a server-side issue, not a client error.
+    /// check, etc.). Maps to `<error type='wait'><internal-server-error/></error>`
+    /// because it represents a transient server-side fault — clients
+    /// may retry. Matches RFC 6120 §8.3.2 guidance and other
+    /// repo-wide `<internal-server-error/>` emission sites.
     #[error("groupchat broadcast preparation failed: {0}")]
     BroadcastFailed(String),
 }

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -31,6 +31,7 @@ pub mod id_gen;
 pub mod machine;
 pub mod message_context;
 pub mod phase;
+pub mod room;
 pub mod session_state;
 pub mod traits;
 

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -40,6 +40,8 @@ mod dispatch_message_l2_tests;
 #[cfg(test)]
 mod dispatch_message_tests;
 #[cfg(test)]
+mod wire_trace_l4_room_tests;
+#[cfg(test)]
 mod wire_trace_l4_tests;
 
 pub use dispatch::{MessageDispatchOutcome, MessageDispatchTermination, StanzaDispatcher};

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -1,0 +1,164 @@
+//! XEP-0313 §5.1.3 archive-eligibility for groupchat reflections.
+//!
+//! Mirrors [`super::super::handlers::archive::ArchiveHandler`] for the
+//! room-locality chain. On eligibility, emits
+//! [`super::super::event::OutboundEvent::ArchiveGroupchat`]; the
+//! interpreter persists under the room's bare JID (XEP-0313 §5.1.3
+//! groupchat archives are keyed by room).
+//!
+//! Eligibility rules (XEP-0313 §5.1.3 + Waddle protocol-event archive
+//! semantics):
+//!
+//! - `<no-store/>` (XEP-0334 §3) suppresses; `<store/>` overrides.
+//! - Body / subject-bearing groupchat messages are archived.
+//! - Body-less *protocol* messages (reactions, retractions, moderation,
+//!   file shares, stickers) are archived so MAM replay reproduces the
+//!   timeline. Mirrors the legacy `should_archive_groupchat_message`
+//!   heuristic from `message.rs`.
+
+use super::super::event::OutboundEvent;
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::xep::{
+    has_file_sharing, is_moderation_request_message, is_moderation_result_message,
+    is_reaction_message, is_retraction_message, is_sticker_message, should_skip_storage,
+};
+use xmpp_parsers::message::{Message, MessageType};
+
+/// XEP-0313 archive handler for the room handler chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MucArchiveHandler;
+
+impl RoomHandler for MucArchiveHandler {
+    fn name(&self) -> &'static str {
+        "xep-0313-muc-archive"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        if !is_archivable(message) {
+            return RoomHandlerOutcome::Continue(Vec::new());
+        }
+        let event = OutboundEvent::ArchiveGroupchat {
+            room: ctx.room.clone(),
+            sender: ctx.sender_full.clone(),
+            message: Box::new(message.clone()),
+        };
+        RoomHandlerOutcome::Continue(vec![event])
+    }
+}
+
+/// XEP-0313 §5.1.3 archive-eligibility for groupchat. Mirrors the
+/// legacy `should_archive_groupchat_message` heuristic.
+pub fn is_archivable(message: &Message) -> bool {
+    if matches!(message.type_, MessageType::Error) || should_skip_storage(message) {
+        return false;
+    }
+    if !message.bodies.is_empty() || !message.subjects.is_empty() {
+        return true;
+    }
+    is_reaction_message(message)
+        || is_retraction_message(message)
+        || is_moderation_request_message(message)
+        || is_moderation_result_message(message)
+        || has_file_sharing(message)
+        || is_sticker_message(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use crate::xep::xep0334::Hint;
+    use jid::{BareJid, FullJid, Jid};
+    use minidom::Element;
+    use xmpp_parsers::message::{Body, Message, MessageType};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn groupchat(room: &BareJid, sender: &FullJid, body: &str) -> Message {
+        let mut m = Message::new(Some(Jid::from(room.clone())));
+        m.from = Some(Jid::from(sender.clone()));
+        m.type_ = MessageType::Groupchat;
+        if !body.is_empty() {
+            m.bodies.insert(String::new(), Body(body.to_string()));
+        }
+        m
+    }
+
+    fn run<'a>(room: &'a BareJid, sender: &'a FullJid, msg: &'a mut Message) -> Vec<OutboundEvent> {
+        let occupants = vec![OccupantSnapshot {
+            full_jid: sender.clone(),
+            nick: "alice".to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }];
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let ctx = RoomContext {
+            room,
+            sender_full: sender,
+            occupants: &occupants,
+            managed_room_forbidden: false,
+            id_gen: &id_gen,
+            occupant_id_secret: b"test-secret",
+        };
+        match MucArchiveHandler.handle(msg, &ctx) {
+            RoomHandlerOutcome::Continue(e) => e,
+            RoomHandlerOutcome::Halt(_) => panic!("archive never halts"),
+        }
+    }
+
+    #[test]
+    fn xep_0313_archives_eligible_groupchat() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        let events = run(&room, &sender, &mut msg);
+        let archives: Vec<_> = events
+            .iter()
+            .filter_map(|e| match e {
+                OutboundEvent::ArchiveGroupchat { room, .. } => Some(room.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(archives, vec![room]);
+    }
+
+    #[test]
+    fn xep_0313_skips_no_store_groupchat() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "ephemeral");
+        msg.payloads.push(
+            Element::builder(Hint::NoStore.element_name(), crate::xep::xep0334::NS_HINTS).build(),
+        );
+        let events = run(&room, &sender, &mut msg);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "no-store hint must suppress archive"
+        );
+    }
+
+    #[test]
+    fn xep_0313_skips_bodyless_groupchat() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        // Bodyless, subjectless, no rich payload.
+        let mut msg = groupchat(&room, &sender, "");
+        let events = run(&room, &sender, &mut msg);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "bodyless protocol-event-less message is not archived"
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -4,7 +4,7 @@
 //! Mutates the in-flight message so subsequent room handlers (archive,
 //! reflector) and the eventual wire write see the canonicalized form.
 //!
-//! Three rewrites in order:
+//! Four rewrites in order:
 //!
 //! 1. **Strip same-`by=room`** XEP-0359 `<stanza-id>` siblings (XEP-0359
 //!    §5 strip rule, room scope). Defends against client spoofing of a
@@ -64,24 +64,28 @@ impl RoomHandler for MucCanonicalizeHandler {
         add_stanza_id(message, &id, &ctx.room.to_string());
 
         // 3. Rewrite `from='room/nick'` and drop `to` (the reflector
-        //    fills `to` per occupant).
+        //    fills `to` per occupant). If the sender nick is somehow
+        //    not representable as a resourcepart, do NOT fall back to
+        //    the sender's real full JID — that would leak the user's
+        //    identity in the reflection and violate XEP-0045 §7.2.13
+        //    (Copilot review on PR #277). Use a non-identifying
+        //    `room/unknown` resource instead.
         let from_room_nick = ctx
             .room
             .clone()
             .with_resource_str(&sender.nick)
+            .or_else(|_| ctx.room.clone().with_resource_str("unknown"))
             .map(Jid::from)
-            .unwrap_or_else(|_| Jid::from(ctx.sender_full.clone()));
+            .unwrap_or_else(|_| Jid::from(ctx.room.clone()));
         message.from = Some(from_room_nick);
         message.to = None;
 
         // 4. Stamp XEP-0421 occupant-id (server-derived stable id —
         //    same user across nicks/sessions yields the same id).
+        //    Typed JIDs in/out (typed-payloads hard rule); HMAC bytes
+        //    are produced at the I/O boundary inside the helper.
         let bare = sender.bare_jid();
-        let occupant_id = generate_occupant_id(
-            &bare.to_string(),
-            &ctx.room.to_string(),
-            ctx.occupant_id_secret,
-        );
+        let occupant_id = generate_occupant_id(&bare, ctx.room, ctx.occupant_id_secret);
         set_occupant_id_on_message(message, &occupant_id);
 
         RoomHandlerOutcome::Continue(Vec::new())
@@ -201,11 +205,7 @@ mod tests {
         let id = extract_occupant_id_from_message(&msg).expect("occupant-id stamped");
 
         // Stable: same (user, room) yields same id with the same secret.
-        let expected = generate_occupant_id(
-            &sender.to_bare().to_string(),
-            &room.to_string(),
-            b"test-secret",
-        );
+        let expected = generate_occupant_id(&sender.to_bare(), &room, b"test-secret");
         assert_eq!(id, expected);
         // Non-empty.
         assert!(!id.as_str().is_empty());

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -1,0 +1,247 @@
+//! XEP-0045 + XEP-0359 + XEP-0421 canonicalization for groupchat
+//! reflections.
+//!
+//! Mutates the in-flight message so subsequent room handlers (archive,
+//! reflector) and the eventual wire write see the canonicalized form.
+//!
+//! Three rewrites in order:
+//!
+//! 1. **Strip same-`by=room`** XEP-0359 `<stanza-id>` siblings (XEP-0359
+//!    §5 strip rule, room scope). Defends against client spoofing of a
+//!    stamp claiming to come from the room archive.
+//! 2. **Stamp** a fresh `<stanza-id by='room' id='<UUID>'>` from the
+//!    [`super::super::id_gen::IdGenerator`].
+//! 3. **Rewrite** `from='room/<sender_nick>'` per XEP-0045 §7.2.13:
+//!    every reflected message MUST carry the room JID + the sender's
+//!    nickname as the resource. Drops `to` so the per-occupant fan-out
+//!    in [`super::reflector::ReflectorHandler`] can stamp the
+//!    occupant-specific `to`.
+//! 4. **Stamp** the XEP-0421 stable `<occupant-id>` for the sender,
+//!    derived as `HMAC-SHA256(room_secret, room_jid + ':' + sender_bare)`.
+//!    Closes the gap PR16 documented: the legacy fan-out path stamped
+//!    occupant-id only on presence joins/leaves, never on outgoing
+//!    groupchat reflections.
+
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::xep::xep0359::{add_stanza_id, is_stanza_id_element};
+use crate::xep::xep0421::{generate_occupant_id, set_occupant_id_on_message};
+use jid::{BareJid, Jid};
+use xmpp_parsers::message::Message;
+
+/// XEP-0045 + XEP-0359 + XEP-0421 canonicalize handler for the room
+/// chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MucCanonicalizeHandler;
+
+impl RoomHandler for MucCanonicalizeHandler {
+    fn name(&self) -> &'static str {
+        "muc-canonicalize"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        let Some(sender) = ctx.sender_snapshot() else {
+            // OccupancyValidationHandler should have halted before us.
+            // Be defensive: skip canonicalization if somehow not.
+            return RoomHandlerOutcome::Continue(Vec::new());
+        };
+
+        // 1. Strip same-`by=room` stanza-id siblings (typed BareJid
+        //    equality so case-folded variants strip; mirrors the 1:1
+        //    `CanonicalizeHandler`'s logic).
+        message.payloads.retain(|p| {
+            if !is_stanza_id_element(p) {
+                return true;
+            }
+            match p.attr("by").and_then(|raw| raw.parse::<BareJid>().ok()) {
+                Some(parsed) => parsed != *ctx.room,
+                None => true,
+            }
+        });
+
+        // 2. Stamp a fresh stanza-id.
+        let id = ctx.id_gen.fresh_stanza_id();
+        add_stanza_id(message, &id, &ctx.room.to_string());
+
+        // 3. Rewrite `from='room/nick'` and drop `to` (the reflector
+        //    fills `to` per occupant).
+        let from_room_nick = ctx
+            .room
+            .clone()
+            .with_resource_str(&sender.nick)
+            .map(Jid::from)
+            .unwrap_or_else(|_| Jid::from(ctx.sender_full.clone()));
+        message.from = Some(from_room_nick);
+        message.to = None;
+
+        // 4. Stamp XEP-0421 occupant-id (server-derived stable id —
+        //    same user across nicks/sessions yields the same id).
+        let bare = sender.bare_jid();
+        let occupant_id = generate_occupant_id(
+            &bare.to_string(),
+            &ctx.room.to_string(),
+            ctx.occupant_id_secret,
+        );
+        set_occupant_id_on_message(message, &occupant_id);
+
+        RoomHandlerOutcome::Continue(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::event::OutboundEvent;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use crate::xep::xep0359::{build_stanza_id_element, extract_stanza_ids};
+    use crate::xep::xep0421::{extract_occupant_id_from_message, OccupantId};
+    use jid::FullJid;
+    use xmpp_parsers::message::{Body, Message, MessageType};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn groupchat(room: &BareJid, sender: &FullJid, body: &str) -> Message {
+        let mut m = Message::new(Some(Jid::from(room.clone())));
+        m.from = Some(Jid::from(sender.clone()));
+        m.type_ = MessageType::Groupchat;
+        m.bodies.insert(String::new(), Body(body.to_string()));
+        m
+    }
+
+    fn run<'a>(
+        room: &'a BareJid,
+        sender: &'a FullJid,
+        nick: &'a str,
+        msg: &'a mut Message,
+        fresh: &'a str,
+    ) -> Vec<OutboundEvent> {
+        let occupants = vec![OccupantSnapshot {
+            full_jid: sender.clone(),
+            nick: nick.to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }];
+        let id_gen = FixedIdGenerator(fresh.to_string());
+        let ctx = RoomContext {
+            room,
+            sender_full: sender,
+            occupants: &occupants,
+            managed_room_forbidden: false,
+            id_gen: &id_gen,
+            occupant_id_secret: b"test-secret",
+        };
+        match MucCanonicalizeHandler.handle(msg, &ctx) {
+            RoomHandlerOutcome::Continue(e) => e,
+            RoomHandlerOutcome::Halt(_) => panic!("canonicalize never halts"),
+        }
+    }
+
+    #[test]
+    fn xep_0359_strips_same_by_room_stanza_id_siblings() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        // Client-supplied claim with same `by=room`.
+        msg.payloads
+            .push(build_stanza_id_element("spoofed", "team@conf.example.com"));
+        run(&room, &sender, "alice-nick", &mut msg, "fresh-room-id");
+
+        let stamps = extract_stanza_ids(&msg);
+        let room_stamps: Vec<_> = stamps
+            .iter()
+            .filter(|s| s.by == "team@conf.example.com")
+            .collect();
+        assert_eq!(room_stamps.len(), 1);
+        assert_eq!(room_stamps[0].id, "fresh-room-id");
+    }
+
+    #[test]
+    fn xep_0359_stamps_canonical_stanza_id_by_room() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+        let stamps = extract_stanza_ids(&msg);
+        assert!(stamps
+            .iter()
+            .any(|s| s.by == "team@conf.example.com" && s.id == "stamp-1"));
+    }
+
+    #[test]
+    fn xep_0359_preserves_cross_archive_stanza_ids() {
+        // A foreign `<stanza-id by='other'/>` must be preserved.
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        msg.payloads
+            .push(build_stanza_id_element("alice-A1", "alice@example.com"));
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+        let stamps = extract_stanza_ids(&msg);
+        assert!(stamps
+            .iter()
+            .any(|s| s.by == "alice@example.com" && s.id == "alice-A1"));
+        assert!(stamps
+            .iter()
+            .any(|s| s.by == "team@conf.example.com" && s.id == "stamp-1"));
+    }
+
+    #[test]
+    fn xep_0421_stamps_stable_occupant_id_on_groupchat_reflection() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+        let id = extract_occupant_id_from_message(&msg).expect("occupant-id stamped");
+
+        // Stable: same (user, room) yields same id with the same secret.
+        let expected = generate_occupant_id(
+            &sender.to_bare().to_string(),
+            &room.to_string(),
+            b"test-secret",
+        );
+        assert_eq!(id, expected);
+        // Non-empty.
+        assert!(!id.as_str().is_empty());
+        assert_ne!(id, OccupantId::new("placeholder"));
+    }
+
+    #[test]
+    fn xep_0421_strips_client_spoofed_occupant_id() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        // Client tries to spoof someone else's occupant-id.
+        msg.payloads
+            .push(crate::xep::xep0421::build_occupant_id_element(
+                &OccupantId::new("attacker-supplied-id"),
+            ));
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+        let id = extract_occupant_id_from_message(&msg).expect("occupant-id present");
+        assert_ne!(id, OccupantId::new("attacker-supplied-id"));
+        // Exactly one occupant-id element after canonicalization.
+        let count = msg
+            .payloads
+            .iter()
+            .filter(|p| crate::xep::xep0421::is_occupant_id_element(p))
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn xep_0045_rewrites_from_to_room_slash_nick() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+        let from = msg.from.as_ref().expect("from set");
+        assert_eq!(from.to_string(), "team@conf.example.com/alice-nick");
+        assert!(msg.to.is_none(), "to is dropped for fan-out");
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/context.rs
@@ -1,0 +1,100 @@
+//! Room-locality context for the MUC handler chain.
+//!
+//! Mirrors [`super::super::message_context::MessageContext`] but for
+//! groupchat dispatch: instead of describing a single connection's
+//! session-bounded state, [`RoomContext`] describes the **room's** state
+//! at the moment a sender-pass groupchat message enters the chain. Per
+//! Q5 of the #229 design, the snapshot is *frozen at dispatch start* —
+//! every handler in the chain sees the same occupant set, sender nick,
+//! and managed-room flags throughout one dispatch.
+//!
+//! The interpreter's [`super::super::event::OutboundEvent::DispatchToRoom`]
+//! arm constructs a [`RoomContext`] by querying the per-room actor for its
+//! occupancy + nickname + role data and threading the connection's
+//! authenticated session (for the managed-room owner check), then runs
+//! the chain against the resulting snapshot.
+
+use super::super::id_gen::IdGenerator;
+use crate::types::{Affiliation, Role};
+use jid::{BareJid, FullJid};
+
+/// Snapshot of one occupant of the room, frozen at dispatch start.
+///
+/// Carries the typed identity needed by the chain handlers:
+/// the occupant's bare JID for XEP-0421 occupant-id derivation,
+/// the occupant's full JID(s) for per-resource fan-out, and the
+/// occupant's nickname for XEP-0045 `from='room/nick'` rewriting.
+#[derive(Debug, Clone)]
+pub struct OccupantSnapshot {
+    /// The full JID this snapshot represents (one entry per session if
+    /// an occupant has multiple resources joined under the same nick).
+    pub full_jid: FullJid,
+    /// The MUC nickname this occupant is joined under.
+    pub nick: String,
+    /// XEP-0045 affiliation (owner/admin/member/none/outcast).
+    pub affiliation: Affiliation,
+    /// XEP-0045 role (moderator/participant/visitor/none).
+    pub role: Role,
+}
+
+impl OccupantSnapshot {
+    /// The bare JID of this occupant (the user's account, stripped of
+    /// resource). Used for XEP-0421 occupant-id derivation — same user
+    /// across multiple resources gets the same occupant id.
+    pub fn bare_jid(&self) -> BareJid {
+        self.full_jid.to_bare()
+    }
+}
+
+/// Read-only context handed to every [`super::traits::RoomHandler`] in a
+/// single MUC dispatch.
+///
+/// The struct is borrow-only — its lifetime is the dispatch call. The
+/// interpreter owns the underlying values and constructs a fresh
+/// `RoomContext<'_>` per dispatch.
+pub struct RoomContext<'a> {
+    /// The room's bare JID (e.g. `team@conference.example.com`). Used
+    /// for the XEP-0359 `<stanza-id by='room'/>` stamp, the
+    /// `from='room/nick'` rewrite, and the XEP-0421 occupant-id
+    /// derivation.
+    pub room: &'a BareJid,
+    /// The full JID of the sending occupant — the connection that
+    /// emitted the groupchat message. Used to resolve the sender's
+    /// occupancy snapshot for the XEP-0045 §7.4 occupancy check and
+    /// for the `from='room/nick'` rewrite.
+    pub sender_full: &'a FullJid,
+    /// The room's occupancy at dispatch start (Q5 frozen-snapshot
+    /// semantic). Indexed iteration only — handlers don't need a
+    /// hash lookup at this scale (typical room ≤ 200 occupants).
+    pub occupants: &'a [OccupantSnapshot],
+    /// True when the room is the managed `announcements` room and the
+    /// sender is NOT a server owner.
+    ///
+    /// Pre-derived by the interpreter so the
+    /// [`super::occupancy_validation::OccupancyValidationHandler`]
+    /// can short-circuit with a typed `<forbidden/>` reply without
+    /// awaiting an async permission check.
+    pub managed_room_forbidden: bool,
+    /// Source of fresh, opaque XEP-0359 stanza-id values for the
+    /// canonical `<stanza-id by='room'/>` stamp the
+    /// [`super::canonicalize::MucCanonicalizeHandler`] applies.
+    pub id_gen: &'a dyn IdGenerator,
+    /// Server-side secret used to derive the XEP-0421 stable occupant-id
+    /// (per-(room, bare-jid) HMAC). Borrowed from the deployment config
+    /// so tests can substitute a fixture without mutating global state.
+    pub occupant_id_secret: &'a [u8],
+}
+
+impl<'a> RoomContext<'a> {
+    /// Look up the sender's occupancy snapshot in the frozen list.
+    ///
+    /// Returns `None` when the sender is not currently joined to the
+    /// room — the
+    /// [`super::occupancy_validation::OccupancyValidationHandler`] uses
+    /// this to enforce the XEP-0045 §7.4 sender-occupancy gate.
+    pub fn sender_snapshot(&self) -> Option<&'a OccupantSnapshot> {
+        self.occupants
+            .iter()
+            .find(|o| &o.full_jid == self.sender_full)
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
@@ -1,0 +1,161 @@
+//! Room handler chain dispatcher.
+//!
+//! Mirrors [`super::super::dispatch::StanzaDispatcher`]'s message pipeline
+//! shape (registration order, halt-or-continue stepping) but for the
+//! groupchat-locality chain. Run from the
+//! [`super::super::event::OutboundEvent::DispatchToRoom`] interpreter arm.
+
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::protocol::event::OutboundEvent;
+use std::sync::Arc;
+use xmpp_parsers::message::Message;
+
+/// Result of running the room chain once.
+#[derive(Debug)]
+pub struct RoomDispatchOutcome {
+    /// Events emitted by handlers in registration order.
+    pub events: Vec<OutboundEvent>,
+    /// True when a handler halted the chain (e.g. occupancy validation
+    /// failed and emitted a typed error reply). Diagnostic only — the
+    /// interpreter pumps `events` regardless.
+    pub halted: bool,
+}
+
+/// Ordered chain of [`RoomHandler`] stages.
+///
+/// Cheap to clone (handlers sit behind `Arc`) so the same dispatcher
+/// can be shared between sender-pass dispatches and tests.
+#[derive(Clone, Default)]
+pub struct RoomDispatcher {
+    handlers: Vec<Arc<dyn RoomHandler>>,
+}
+
+impl RoomDispatcher {
+    /// Create an empty dispatcher.
+    pub fn new() -> Self {
+        Self {
+            handlers: Vec::new(),
+        }
+    }
+
+    /// Append a handler to the chain. Handlers run in registration
+    /// order.
+    pub fn register(&mut self, handler: Arc<dyn RoomHandler>) {
+        self.handlers.push(handler);
+    }
+
+    /// Number of registered handlers — used by tests to assert the
+    /// chain shape.
+    pub fn handler_count(&self) -> usize {
+        self.handlers.len()
+    }
+
+    /// Run the chain against `message` with `ctx`.
+    pub fn dispatch(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomDispatchOutcome {
+        let mut events = Vec::new();
+        for handler in &self.handlers {
+            match handler.handle(message, ctx) {
+                RoomHandlerOutcome::Continue(more) => events.extend(more),
+                RoomHandlerOutcome::Halt(more) => {
+                    events.extend(more);
+                    return RoomDispatchOutcome {
+                        events,
+                        halted: true,
+                    };
+                }
+            }
+        }
+        RoomDispatchOutcome {
+            events,
+            halted: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::context::{OccupantSnapshot, RoomContext};
+    use super::super::traits::{RoomHandler, RoomHandlerOutcome};
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::types::{Affiliation, Role};
+    use jid::{BareJid, FullJid};
+    use xmpp_parsers::message::{Message, MessageType};
+
+    struct CountHandler {
+        name: &'static str,
+        halt: bool,
+    }
+
+    impl RoomHandler for CountHandler {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn handle(&self, _message: &mut Message, _ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+            if self.halt {
+                RoomHandlerOutcome::Halt(Vec::new())
+            } else {
+                RoomHandlerOutcome::Continue(Vec::new())
+            }
+        }
+    }
+
+    fn fixture_ctx<'a>(
+        room: &'a BareJid,
+        sender_full: &'a FullJid,
+        occupants: &'a [OccupantSnapshot],
+        gen: &'a FixedIdGenerator,
+    ) -> RoomContext<'a> {
+        RoomContext {
+            room,
+            sender_full,
+            occupants,
+            managed_room_forbidden: false,
+            id_gen: gen,
+            occupant_id_secret: b"test-secret",
+        }
+    }
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    #[test]
+    fn dispatch_runs_handlers_in_order_until_halt() {
+        let room = bare("room@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![OccupantSnapshot {
+            full_jid: sender.clone(),
+            nick: "alice".to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }];
+        let id_gen = FixedIdGenerator("fresh-id".to_string());
+        let ctx = fixture_ctx(&room, &sender, &occupants, &id_gen);
+
+        let mut chain = RoomDispatcher::new();
+        chain.register(Arc::new(CountHandler {
+            name: "first",
+            halt: false,
+        }));
+        chain.register(Arc::new(CountHandler {
+            name: "halter",
+            halt: true,
+        }));
+        chain.register(Arc::new(CountHandler {
+            name: "after-halt",
+            halt: false,
+        }));
+
+        let mut msg = Message::new(Some(jid::Jid::from(room.clone())));
+        msg.from = Some(jid::Jid::from(sender.clone()));
+        msg.type_ = MessageType::Groupchat;
+
+        let outcome = chain.dispatch(&mut msg, &ctx);
+        assert!(outcome.halted, "chain halted at the second handler");
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -1,0 +1,59 @@
+//! MUC room handler chain.
+//!
+//! Per #229 Q7 option C, MUC delivery runs through a stateless room
+//! handler chain dispatched from the
+//! [`super::event::OutboundEvent::DispatchToRoom`] interpreter arm. The
+//! chain mirrors the user-side message pipeline shape (one handler per
+//! XEP concern, registered in fixed order, ordered events emitted)
+//! against a [`context::RoomContext`] frozen-at-dispatch-start snapshot.
+//!
+//! Locked Q7 chain order:
+//!
+//! 1. [`occupancy_validation::OccupancyValidationHandler`] — XEP-0045
+//!    §7.4 (only occupants may send) + Waddle managed-room policy.
+//! 2. [`canonicalize::MucCanonicalizeHandler`] — XEP-0359 stanza-id
+//!    `by=room`, XEP-0421 occupant-id stamp, `from='room/nick'` rewrite.
+//! 3. [`archive::MucArchiveHandler`] — XEP-0313 §5.1.3 archive-eligibility
+//!    → emits [`super::event::OutboundEvent::ArchiveGroupchat`].
+//! 4. [`reflector::ReflectorHandler`] — per-occupant fan-out via
+//!    [`super::event::OutboundEvent::RouteToConnection`].
+
+pub mod archive;
+pub mod canonicalize;
+pub mod context;
+pub mod dispatch;
+pub mod occupancy_validation;
+pub mod reflector;
+pub mod traits;
+
+use std::sync::Arc;
+
+pub use context::{OccupantSnapshot, RoomContext};
+pub use dispatch::{RoomDispatchOutcome, RoomDispatcher};
+pub use traits::{RoomHandler, RoomHandlerOutcome};
+
+/// Register the locked Q7 room handler chain on `dispatcher` in order.
+pub fn register_default_room_handlers(dispatcher: &mut RoomDispatcher) {
+    dispatcher.register(Arc::new(occupancy_validation::OccupancyValidationHandler));
+    dispatcher.register(Arc::new(canonicalize::MucCanonicalizeHandler));
+    dispatcher.register(Arc::new(archive::MucArchiveHandler));
+    dispatcher.register(Arc::new(reflector::ReflectorHandler));
+}
+
+/// Build a [`RoomDispatcher`] with the default chain registered.
+pub fn default_room_dispatcher() -> RoomDispatcher {
+    let mut d = RoomDispatcher::new();
+    register_default_room_handlers(&mut d);
+    d
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_dispatcher_registers_four_handlers() {
+        let d = default_room_dispatcher();
+        assert_eq!(d.handler_count(), 4);
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
@@ -1,0 +1,227 @@
+//! XEP-0045 §7.4 sender-occupancy gate.
+//!
+//! Per [XEP-0045 §7.4]:
+//!
+//! > Only occupants are allowed to send messages to the room. If a
+//! > non-occupant sends a message to the room, the service MUST refuse
+//! > to deliver the message and return a `<not-acceptable/>` error to
+//! > the sender.
+//!
+//! [XEP-0045 §7.4]: https://xmpp.org/extensions/xep-0045.html#message
+//!
+//! This handler also enforces the Waddle-specific managed-room policy
+//! for the `announcements` room: only server owners may post. The
+//! [`super::context::RoomContext`] field `managed_room_forbidden` is
+//! pre-derived by the interpreter (so the handler stays sync) — when
+//! true the handler emits `<forbidden type='auth'/>` and halts.
+//!
+//! Closes the gap PR16 documented: the legacy
+//! `deliver_groupchat_via_room_actor` bridge silently dropped on
+//! `BuildGroupchatBroadcast` errors and never produced a typed XEP-0045
+//! reply. This handler emits the typed reply directly.
+
+use super::super::handlers::errors::{message_error_reply, send_message_error};
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use jid::Jid;
+use xmpp_parsers::message::{Message, MessageType};
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+/// Sender-occupancy gate for the room handler chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OccupancyValidationHandler;
+
+impl RoomHandler for OccupancyValidationHandler {
+    fn name(&self) -> &'static str {
+        "xep-0045-occupancy-validation"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        // Managed-room owner check (Waddle-specific). The interpreter
+        // resolves this against the authenticated session and the
+        // `announcements` localpart marker before constructing the
+        // context, so the handler stays sync.
+        if ctx.managed_room_forbidden {
+            let reply = forbidden_reply(message, ctx);
+            return RoomHandlerOutcome::Halt(vec![send_message_error(reply)]);
+        }
+
+        // XEP-0045 §7.4: non-occupants cannot send to the room.
+        if ctx.sender_snapshot().is_none() {
+            let reply = not_acceptable_reply(message, ctx);
+            return RoomHandlerOutcome::Halt(vec![send_message_error(reply)]);
+        }
+
+        RoomHandlerOutcome::Continue(Vec::new())
+    }
+}
+
+/// Build the XEP-0045 §7.4 typed `<not-acceptable type='cancel'/>` reply
+/// addressed from the room JID back to the sender.
+fn not_acceptable_reply(incoming: &Message, ctx: &RoomContext<'_>) -> Message {
+    // Force the message-error reply to come "from the room" so clients
+    // can attribute the rejection — `message_error_reply` swaps from/to
+    // verbatim, which would put the original `to=room` value into
+    // `from`; we then refresh `to` to the sender's full JID.
+    let mut reply = message_error_reply(
+        incoming,
+        StanzaError::new(
+            ErrorType::Cancel,
+            DefinedCondition::NotAcceptable,
+            "en",
+            "Only room occupants may send messages to this room.",
+        ),
+    );
+    reply.from = Some(Jid::from(ctx.room.clone()));
+    reply.to = Some(Jid::from(ctx.sender_full.clone()));
+    reply.type_ = MessageType::Error;
+    reply
+}
+
+/// Build the managed-room `<forbidden type='auth'/>` reply.
+fn forbidden_reply(incoming: &Message, ctx: &RoomContext<'_>) -> Message {
+    let mut reply = message_error_reply(
+        incoming,
+        StanzaError::new(
+            ErrorType::Auth,
+            DefinedCondition::Forbidden,
+            "en",
+            "Sender is not permitted to address this resource.",
+        ),
+    );
+    reply.from = Some(Jid::from(ctx.room.clone()));
+    reply.to = Some(Jid::from(ctx.sender_full.clone()));
+    reply.type_ = MessageType::Error;
+    reply
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::event::OutboundEvent;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use crate::Stanza;
+    use jid::{BareJid, FullJid};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn groupchat_to(room: &BareJid, sender: &FullJid, body: &str) -> Message {
+        let mut m = Message::new(Some(Jid::from(room.clone())));
+        m.from = Some(Jid::from(sender.clone()));
+        m.type_ = MessageType::Groupchat;
+        m.bodies
+            .insert(String::new(), xmpp_parsers::message::Body(body.to_string()));
+        m
+    }
+
+    fn run_with(
+        room: &BareJid,
+        sender: &FullJid,
+        occupants: Vec<OccupantSnapshot>,
+        managed_forbidden: bool,
+        msg: &mut Message,
+    ) -> RoomHandlerOutcome {
+        let id_gen = FixedIdGenerator("fresh".to_string());
+        let ctx = RoomContext {
+            room,
+            sender_full: sender,
+            occupants: &occupants,
+            managed_room_forbidden: managed_forbidden,
+            id_gen: &id_gen,
+            occupant_id_secret: b"test-secret",
+        };
+        OccupancyValidationHandler.handle(msg, &ctx)
+    }
+
+    fn extract_error(outcome: &RoomHandlerOutcome) -> &Message {
+        let events = match outcome {
+            RoomHandlerOutcome::Halt(e) => e,
+            RoomHandlerOutcome::Continue(_) => panic!("expected Halt"),
+        };
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Message(m) => m,
+                _ => panic!("expected Message stanza"),
+            },
+            _ => panic!("expected SendStanza"),
+        }
+    }
+
+    #[test]
+    fn xep_0045_non_occupant_sender_receives_not_acceptable_error() {
+        let room = bare("room@conf.example.com");
+        let sender = full("alice@example.com/web");
+        // Empty occupant list — alice is not a member.
+        let mut msg = groupchat_to(&room, &sender, "hi");
+        let outcome = run_with(&room, &sender, Vec::new(), false, &mut msg);
+        let reply = extract_error(&outcome);
+        assert_eq!(reply.type_, MessageType::Error);
+        assert_eq!(
+            reply.to.as_ref().map(|j| j.to_string()),
+            Some(sender.to_string())
+        );
+        assert_eq!(
+            reply.from.as_ref().map(|j| j.to_string()),
+            Some(room.to_string())
+        );
+        // Inspect the typed StanzaError to confirm the defined-condition.
+        let err_elem = reply
+            .payloads
+            .iter()
+            .find(|p| p.name() == "error")
+            .expect("error payload present");
+        let parsed =
+            StanzaError::try_from(err_elem.clone()).expect("typed StanzaError parses from element");
+        assert_eq!(parsed.type_, ErrorType::Cancel);
+        assert_eq!(parsed.defined_condition, DefinedCondition::NotAcceptable);
+    }
+
+    #[test]
+    fn xep_0045_occupant_sender_passes_through() {
+        let room = bare("room@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![OccupantSnapshot {
+            full_jid: sender.clone(),
+            nick: "alice".to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }];
+        let mut msg = groupchat_to(&room, &sender, "hi");
+        let outcome = run_with(&room, &sender, occupants, false, &mut msg);
+        match outcome {
+            RoomHandlerOutcome::Continue(events) => assert!(events.is_empty()),
+            RoomHandlerOutcome::Halt(_) => panic!("occupant must pass through"),
+        }
+    }
+
+    #[test]
+    fn managed_room_forbidden_emits_typed_forbidden_error() {
+        let room = bare("announcements@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![OccupantSnapshot {
+            full_jid: sender.clone(),
+            nick: "alice".to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }];
+        let mut msg = groupchat_to(&room, &sender, "important announcement");
+        let outcome = run_with(&room, &sender, occupants, true, &mut msg);
+        let reply = extract_error(&outcome);
+        let err_elem = reply
+            .payloads
+            .iter()
+            .find(|p| p.name() == "error")
+            .expect("error payload");
+        let parsed = StanzaError::try_from(err_elem.clone()).expect("typed StanzaError");
+        assert_eq!(parsed.type_, ErrorType::Auth);
+        assert_eq!(parsed.defined_condition, DefinedCondition::Forbidden);
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
@@ -1,0 +1,166 @@
+//! Per-occupant fan-out: emit one
+//! [`super::super::event::OutboundEvent::RouteToConnection`] per
+//! occupant of the room.
+//!
+//! Per XEP-0045 §7.2.13 (and the legacy
+//! `MucRoom::broadcast_message`), the room MUST reflect the message to
+//! every occupant *including the sender* so the sender gets a confirmed
+//! echo of their own send. We follow the same semantic here: each
+//! occupant gets a `RouteToConnection` carrying a personalized copy of
+//! the canonicalized message with `to=<recipient_full>` filled in.
+//!
+//! The interpreter's `RouteToConnection` arm handles the per-recipient
+//! delivery + detached XEP-0198 SM session queueing already (#229 PR12 +
+//! PR15), so the reflector handler is dumb fan-out: build N copies, set
+//! `to`, emit N events.
+
+use super::super::event::OutboundEvent;
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::Stanza;
+use jid::Jid;
+use xmpp_parsers::message::Message;
+
+/// Per-occupant fan-out for the room handler chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReflectorHandler;
+
+impl RoomHandler for ReflectorHandler {
+    fn name(&self) -> &'static str {
+        "xep-0045-reflector"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        let mut events = Vec::with_capacity(ctx.occupants.len());
+        for occupant in ctx.occupants {
+            let mut copy = message.clone();
+            copy.to = Some(Jid::from(occupant.full_jid.clone()));
+            events.push(OutboundEvent::RouteToConnection {
+                jid: Jid::from(occupant.full_jid.clone()),
+                stanza: Box::new(Stanza::Message(copy)),
+            });
+        }
+        RoomHandlerOutcome::Continue(events)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use jid::{BareJid, FullJid};
+    use xmpp_parsers::message::{Body, Message, MessageType};
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn run_with_occupants(
+        room: &BareJid,
+        sender: &FullJid,
+        occupants: Vec<OccupantSnapshot>,
+        msg: &mut Message,
+    ) -> Vec<OutboundEvent> {
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let ctx = RoomContext {
+            room,
+            sender_full: sender,
+            occupants: &occupants,
+            managed_room_forbidden: false,
+            id_gen: &id_gen,
+            occupant_id_secret: b"test-secret",
+        };
+        match ReflectorHandler.handle(msg, &ctx) {
+            RoomHandlerOutcome::Continue(e) => e,
+            RoomHandlerOutcome::Halt(_) => panic!("reflector never halts"),
+        }
+    }
+
+    fn occ(full_jid: FullJid, nick: &str) -> OccupantSnapshot {
+        OccupantSnapshot {
+            full_jid,
+            nick: nick.to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }
+    }
+
+    fn route_targets(events: &[OutboundEvent]) -> Vec<jid::Jid> {
+        events
+            .iter()
+            .filter_map(|e| match e {
+                OutboundEvent::RouteToConnection { jid, .. } => Some(jid.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn make_groupchat() -> Message {
+        let mut m = Message::new(None::<jid::Jid>);
+        m.type_ = MessageType::Groupchat;
+        m.bodies
+            .insert(String::new(), Body("hi everyone".to_string()));
+        m
+    }
+
+    #[test]
+    fn xep_0045_fans_out_route_to_connection_per_occupant() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let bob = full("bob@example.com/desk");
+        let charlie = full("charlie@example.com/lap");
+        let occupants = vec![
+            occ(alice.clone(), "alice"),
+            occ(bob.clone(), "bob"),
+            occ(charlie.clone(), "charlie"),
+        ];
+        let mut msg = make_groupchat();
+        let events = run_with_occupants(&room, &alice, occupants, &mut msg);
+        let targets = route_targets(&events);
+        assert_eq!(targets.len(), 3);
+        let target_strings: Vec<String> = targets.iter().map(|j| j.to_string()).collect();
+        assert!(target_strings.contains(&alice.to_string()));
+        assert!(target_strings.contains(&bob.to_string()));
+        assert!(target_strings.contains(&charlie.to_string()));
+    }
+
+    #[test]
+    fn xep_0045_includes_sender_in_reflection() {
+        // XEP-0045 §7.2.13: room reflects to every occupant *including*
+        // the sender so the sender confirms their message landed.
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let occupants = vec![occ(alice.clone(), "alice")];
+        let mut msg = make_groupchat();
+        let events = run_with_occupants(&room, &alice, occupants, &mut msg);
+        let targets = route_targets(&events);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].to_string(), alice.to_string());
+    }
+
+    #[test]
+    fn xep_0045_each_route_carries_personalized_to_address() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let bob = full("bob@example.com/desk");
+        let occupants = vec![occ(alice.clone(), "alice"), occ(bob.clone(), "bob")];
+        let mut msg = make_groupchat();
+        let events = run_with_occupants(&room, &alice, occupants, &mut msg);
+        for event in &events {
+            if let OutboundEvent::RouteToConnection { jid, stanza } = event {
+                if let Stanza::Message(m) = stanza.as_ref() {
+                    assert_eq!(
+                        m.to.as_ref().map(|j| j.to_string()),
+                        Some(jid.to_string()),
+                        "each routed copy carries `to` matching its target"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/traits.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/traits.rs
@@ -1,0 +1,64 @@
+//! Handler trait for the MUC room handler chain.
+//!
+//! Per #229 Q1, every handler is single-purpose and synchronous. Room
+//! handlers receive a [`super::context::RoomContext`] (the frozen-at-
+//! dispatch-start occupancy + sender + room state) plus the in-flight
+//! `<message type='groupchat'>` and emit
+//! [`super::super::event::OutboundEvent`]s.
+//!
+//! Handlers may mutate the in-flight message — XEP-0421 occupant-id
+//! stamping, XEP-0359 stanza-id stamping, `from='room/nick'` rewriting
+//! all rewrite the message so subsequent handlers see the canonicalized
+//! form. The mutation is per-dispatch only; the interpreter discards
+//! the rewritten message after the chain completes.
+//!
+//! The room chain is run *to completion* — there is no `AwaitCallback`
+//! variant for room handlers because every concern they own
+//! (canonicalization, archive eligibility, fan-out) is synchronous.
+//! [`HandlerOutcome`] mirrors the user-side handler outcome shape so a
+//! `Halt` cleanly stops the chain after a typed error reply.
+
+use super::super::event::OutboundEvent;
+use super::context::RoomContext;
+use xmpp_parsers::message::Message;
+
+/// Outcome of one room-handler invocation.
+///
+/// Mirrors [`super::super::traits::HandlerOutcome`] without the
+/// `AwaitCallback` variant — room dispatch is fully synchronous.
+#[derive(Debug)]
+pub enum RoomHandlerOutcome {
+    /// The handler emits zero or more events and the chain continues to
+    /// the next handler.
+    Continue(Vec<OutboundEvent>),
+    /// The handler emits zero or more events and the chain terminates.
+    /// Used for the XEP-0045 §7.4 sender-occupancy `<not-acceptable/>`
+    /// reply and the managed-room `<forbidden/>` reply.
+    Halt(Vec<OutboundEvent>),
+}
+
+impl RoomHandlerOutcome {
+    /// Convenience: a `Continue` with no events.
+    pub fn noop() -> Self {
+        RoomHandlerOutcome::Continue(Vec::new())
+    }
+}
+
+/// One stage of the MUC room handler chain.
+///
+/// Implementations must be pure: no I/O, no blocking, no actor sends.
+/// The chain is registered into a [`super::dispatch::RoomDispatcher`]
+/// in the locked Q7 order:
+/// `OccupancyValidation → MucCanonicalize → MucArchive → Reflector`.
+pub trait RoomHandler: Send + Sync {
+    /// Human-readable identifier, used in logs and tests.
+    fn name(&self) -> &'static str;
+
+    /// Process a groupchat message stanza.
+    ///
+    /// `message` is `&mut Message` because canonicalization handlers
+    /// (XEP-0359 stanza-id, XEP-0421 occupant-id, `from='room/nick'`
+    /// rewrite) mutate the in-flight message so downstream handlers
+    /// see the rewritten form.
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome;
+}

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
@@ -1,0 +1,257 @@
+//! L4 wire-trace tests for the MUC room handler chain (#229 PR17).
+//!
+//! These tests exercise the room chain end-to-end — frozen
+//! [`super::room::RoomContext`], all four handlers in registration
+//! order, deterministic [`super::id_gen::FixedIdGenerator`] — and assert
+//! on the exact event shape the chain produces.
+//!
+//! The chain is the locked Q7 option C order:
+//!
+//! 1. `OccupancyValidationHandler` (XEP-0045 §7.4 + managed-room policy)
+//! 2. `MucCanonicalizeHandler` (XEP-0359 strip+stamp `by=room`,
+//!    XEP-0421 occupant-id, `from='room/nick'`)
+//! 3. `MucArchiveHandler` (XEP-0313 §5.1.3 → `ArchiveGroupchat`)
+//! 4. `ReflectorHandler` (per-occupant `RouteToConnection`)
+
+use super::event::OutboundEvent;
+use super::id_gen::FixedIdGenerator;
+use super::room::{default_room_dispatcher, OccupantSnapshot, RoomContext};
+use crate::types::{Affiliation, Role};
+use crate::xep::xep0359::{extract_stanza_ids, NS_SID};
+use crate::xep::xep0421::{extract_occupant_id_from_message, generate_occupant_id};
+use crate::Stanza;
+use jid::{BareJid, FullJid, Jid};
+use xmpp_parsers::message::{Body, Message, MessageType};
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+const TEST_OCCUPANT_ID_SECRET: &[u8] = b"l4-test-occupant-id-secret";
+
+fn full(s: &str) -> FullJid {
+    s.parse().expect("valid full jid")
+}
+fn bare(s: &str) -> BareJid {
+    s.parse().expect("valid bare jid")
+}
+
+fn occ(full_jid: FullJid, nick: &str) -> OccupantSnapshot {
+    OccupantSnapshot {
+        full_jid,
+        nick: nick.to_string(),
+        affiliation: Affiliation::Member,
+        role: Role::Participant,
+    }
+}
+
+fn groupchat(room: &BareJid, sender: &FullJid, body: &str) -> Message {
+    let mut m = Message::new(Some(Jid::from(room.clone())));
+    m.from = Some(Jid::from(sender.clone()));
+    m.type_ = MessageType::Groupchat;
+    m.id = Some("client-msg-id".to_string());
+    m.bodies.insert(String::new(), Body(body.to_string()));
+    m
+}
+
+#[test]
+fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
+    // Two occupants in `team@conf.example.com`: alice (sender) and bob.
+    // Alice sends `<message type='groupchat' to='room' body='hi'>`.
+    //
+    // Run the full room chain. Assert on:
+    //   - Each occupant gets a `RouteToConnection` (XEP-0045 §7.2.13
+    //     fan-out includes sender for echo).
+    //   - Each routed copy carries:
+    //       - `from='team@conf.example.com/alice-nick'` (XEP-0045)
+    //       - `<stanza-id by='team@conf.example.com'>` (XEP-0359)
+    //       - `<occupant-id>` matching the deterministic HMAC for
+    //         (alice@example.com, team@conf.example.com)
+    //   - `ArchiveGroupchat` emitted with `room=team@conf.example.com`
+    //     and the sender's full JID.
+    let room = bare("team@conf.example.com");
+    let alice = full("alice@example.com/web");
+    let bob = full("bob@example.com/desk");
+
+    let occupants = vec![
+        occ(alice.clone(), "alice-nick"),
+        occ(bob.clone(), "bob-nick"),
+    ];
+    let id_gen = FixedIdGenerator("room-archive-id-1".to_string());
+    let ctx = RoomContext {
+        room: &room,
+        sender_full: &alice,
+        occupants: &occupants,
+        managed_room_forbidden: false,
+        id_gen: &id_gen,
+        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+    };
+
+    let mut msg = groupchat(&room, &alice, "hi everyone");
+    let dispatcher = default_room_dispatcher();
+    let outcome = dispatcher.dispatch(&mut msg, &ctx);
+
+    assert!(!outcome.halted, "occupant sender must not halt");
+
+    // Archive event present.
+    let archive_events: Vec<_> = outcome
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            OutboundEvent::ArchiveGroupchat { room, sender, .. } => {
+                Some((room.clone(), sender.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(archive_events.len(), 1, "exactly one archive write");
+    assert_eq!(archive_events[0].0, room);
+    assert_eq!(archive_events[0].1, alice);
+
+    // Fan-out targets — both alice and bob in occupant order.
+    let routes: Vec<&Message> = outcome
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            OutboundEvent::RouteToConnection { stanza, .. } => match stanza.as_ref() {
+                Stanza::Message(m) => Some(m),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(routes.len(), 2, "fan-out to both occupants");
+
+    // Every reflected copy carries the canonical stamps.
+    let expected_occupant_id = generate_occupant_id(
+        &alice.to_bare().to_string(),
+        &room.to_string(),
+        TEST_OCCUPANT_ID_SECRET,
+    );
+    for route in &routes {
+        // from='room/alice-nick'
+        assert_eq!(
+            route.from.as_ref().map(|j| j.to_string()),
+            Some("team@conf.example.com/alice-nick".to_string()),
+            "reflected copy carries XEP-0045 `from='room/nick'`"
+        );
+        // `<stanza-id by='room' id='room-archive-id-1'>`
+        let stamps = extract_stanza_ids(route);
+        let room_stamp = stamps
+            .iter()
+            .find(|s| s.by == "team@conf.example.com")
+            .expect("room-stamped stanza-id present");
+        assert_eq!(room_stamp.id, "room-archive-id-1");
+        // `<occupant-id id='<HMAC>'>`
+        let occupant_id = extract_occupant_id_from_message(route)
+            .expect("occupant-id stamped on every reflection");
+        assert_eq!(occupant_id, expected_occupant_id);
+    }
+}
+
+#[test]
+fn xep_0045_non_occupant_halts_chain_with_typed_not_acceptable() {
+    // Alice is not in the room — `OccupancyValidationHandler` halts the
+    // chain with the typed XEP-0045 §7.4 reply. Assert: no
+    // `ArchiveGroupchat`, no `RouteToConnection`, exactly one
+    // `SendStanza` carrying the typed error.
+    let room = bare("team@conf.example.com");
+    let alice = full("alice@example.com/web");
+
+    let id_gen = FixedIdGenerator("ignored".to_string());
+    let ctx = RoomContext {
+        room: &room,
+        sender_full: &alice,
+        occupants: &[], // empty — alice is NOT a member
+        managed_room_forbidden: false,
+        id_gen: &id_gen,
+        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+    };
+
+    let mut msg = groupchat(&room, &alice, "intruder");
+    let outcome = default_room_dispatcher().dispatch(&mut msg, &ctx);
+    assert!(outcome.halted, "non-occupant must halt the chain");
+
+    let archive = outcome
+        .events
+        .iter()
+        .filter(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. }))
+        .count();
+    let routes = outcome
+        .events
+        .iter()
+        .filter(|e| matches!(e, OutboundEvent::RouteToConnection { .. }))
+        .count();
+    assert_eq!(archive, 0, "halted chain does not archive");
+    assert_eq!(routes, 0, "halted chain does not reflect");
+
+    let send_stanzas: Vec<&Message> = outcome
+        .events
+        .iter()
+        .filter_map(|e| match e {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Message(m) => Some(m),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(send_stanzas.len(), 1, "exactly one error reply");
+    assert_eq!(send_stanzas[0].type_, MessageType::Error);
+    let err_elem = send_stanzas[0]
+        .payloads
+        .iter()
+        .find(|p| p.name() == "error")
+        .expect("error payload");
+    let parsed = StanzaError::try_from(err_elem.clone()).expect("typed StanzaError");
+    assert_eq!(parsed.type_, ErrorType::Cancel);
+    assert_eq!(parsed.defined_condition, DefinedCondition::NotAcceptable);
+}
+
+#[test]
+fn xep_0359_room_chain_strips_client_spoofed_room_stanza_id() {
+    // Q8(a) regression: client tries to spoof `<stanza-id by='room'/>`
+    // — the canonicalize handler strips the spoof under the room's
+    // typed BareJid equality and stamps the genuine value.
+    let room = bare("team@conf.example.com");
+    let alice = full("alice@example.com/web");
+    let occupants = vec![occ(alice.clone(), "alice-nick")];
+    let id_gen = FixedIdGenerator("genuine-room-id".to_string());
+    let ctx = RoomContext {
+        room: &room,
+        sender_full: &alice,
+        occupants: &occupants,
+        managed_room_forbidden: false,
+        id_gen: &id_gen,
+        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+    };
+
+    let mut msg = groupchat(&room, &alice, "spoof attempt");
+    msg.payloads
+        .push(crate::xep::xep0359::build_stanza_id_element(
+            "client-claim",
+            "team@conf.example.com",
+        ));
+
+    let outcome = default_room_dispatcher().dispatch(&mut msg, &ctx);
+    assert!(!outcome.halted);
+
+    // Pull the first reflection and inspect its room-stamped stanza-id.
+    let reflected = outcome
+        .events
+        .iter()
+        .find_map(|e| match e {
+            OutboundEvent::RouteToConnection { stanza, .. } => match stanza.as_ref() {
+                Stanza::Message(m) => Some(m),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("at least one reflection");
+    // Exactly ONE `<stanza-id by='room'/>`, with the genuine id.
+    let room_stamps: Vec<_> = reflected
+        .payloads
+        .iter()
+        .filter(|p| p.name() == "stanza-id" && p.ns() == NS_SID)
+        .filter(|p| p.attr("by") == Some("team@conf.example.com"))
+        .collect();
+    assert_eq!(room_stamps.len(), 1, "spoofed stamp stripped");
+    assert_eq!(room_stamps[0].attr("id"), Some("genuine-room-id"));
+}

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
@@ -120,11 +120,8 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
     assert_eq!(routes.len(), 2, "fan-out to both occupants");
 
     // Every reflected copy carries the canonical stamps.
-    let expected_occupant_id = generate_occupant_id(
-        &alice.to_bare().to_string(),
-        &room.to_string(),
-        TEST_OCCUPANT_ID_SECRET,
-    );
+    let expected_occupant_id =
+        generate_occupant_id(&alice.to_bare(), &room, TEST_OCCUPANT_ID_SECRET);
     for route in &routes {
         // from='room/alice-nick'
         assert_eq!(

--- a/server/crates/waddle-xmpp/src/xep/xep0421.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0421.rs
@@ -89,18 +89,24 @@ impl OccupantIdCarrier for Presence {
 
 /// Generate a stable occupant ID from a user's bare JID and room JID.
 ///
-/// Uses HMAC-SHA-256 with the room JID as key and user JID as message,
-/// producing a hex-encoded opaque identifier. The same inputs always
-/// produce the same output.
+/// Uses HMAC-SHA-256 with the deployment server-secret as key and the
+/// room + user JID as message, producing a hex-encoded opaque
+/// identifier. The same inputs always produce the same output.
+///
+/// Takes typed JIDs (typed-payloads hard rule) — the canonical JID
+/// string form is generated at the HMAC boundary only, never carried
+/// across function boundaries as `String`.
 pub fn generate_occupant_id(
-    user_bare_jid: &str,
-    room_jid: &str,
+    user_bare_jid: &jid::BareJid,
+    room_jid: &jid::BareJid,
     server_secret: &[u8],
 ) -> OccupantId {
     let mut mac = HmacSha256::new_from_slice(server_secret).expect("HMAC accepts any key length");
-    mac.update(room_jid.as_bytes());
+    // `BareJid::as_str` returns the canonical string form; we hash
+    // bytes at the I/O boundary only.
+    mac.update(room_jid.as_str().as_bytes());
     mac.update(b":");
-    mac.update(user_bare_jid.as_bytes());
+    mac.update(user_bare_jid.as_str().as_bytes());
     let result = mac.finalize().into_bytes();
 
     // Use first 16 bytes (128 bits) for a shorter but still unique ID
@@ -178,30 +184,46 @@ mod tests {
 
     const TEST_SECRET: &[u8] = b"waddle-test-secret-key-for-occupant-ids";
 
+    fn alice() -> jid::BareJid {
+        "alice@example.com".parse().expect("bare")
+    }
+    fn bob() -> jid::BareJid {
+        "bob@example.com".parse().expect("bare")
+    }
+    fn room() -> jid::BareJid {
+        "room@muc.example.com".parse().expect("bare")
+    }
+    fn room1() -> jid::BareJid {
+        "room1@muc.example.com".parse().expect("bare")
+    }
+    fn room2() -> jid::BareJid {
+        "room2@muc.example.com".parse().expect("bare")
+    }
+
     #[test]
     fn test_generate_occupant_id_deterministic() {
-        let id1 = generate_occupant_id("alice@example.com", "room@muc.example.com", TEST_SECRET);
-        let id2 = generate_occupant_id("alice@example.com", "room@muc.example.com", TEST_SECRET);
+        let id1 = generate_occupant_id(&alice(), &room(), TEST_SECRET);
+        let id2 = generate_occupant_id(&alice(), &room(), TEST_SECRET);
         assert_eq!(id1, id2);
     }
 
     #[test]
     fn test_generate_different_users() {
-        let alice = generate_occupant_id("alice@example.com", "room@muc.example.com", TEST_SECRET);
-        let bob = generate_occupant_id("bob@example.com", "room@muc.example.com", TEST_SECRET);
-        assert_ne!(alice, bob);
+        let alice_id = generate_occupant_id(&alice(), &room(), TEST_SECRET);
+        let bob_id = generate_occupant_id(&bob(), &room(), TEST_SECRET);
+        assert_ne!(alice_id, bob_id);
     }
 
     #[test]
     fn test_generate_different_rooms() {
-        let room1 = generate_occupant_id("alice@example.com", "room1@muc.example.com", TEST_SECRET);
-        let room2 = generate_occupant_id("alice@example.com", "room2@muc.example.com", TEST_SECRET);
-        assert_ne!(room1, room2);
+        let r1 = generate_occupant_id(&alice(), &room1(), TEST_SECRET);
+        let r2 = generate_occupant_id(&alice(), &room2(), TEST_SECRET);
+        assert_ne!(r1, r2);
     }
 
     #[test]
     fn test_generate_id_length() {
-        let id = generate_occupant_id("alice@example.com", "room@muc.example.com", TEST_SECRET);
+        let id = generate_occupant_id(&alice(), &room(), TEST_SECRET);
         // 16 bytes = 32 hex chars
         assert_eq!(id.0.len(), 32);
     }


### PR DESCRIPTION
## Summary

PR17 lands two pieces of work:

1. **New `protocol/room/` module** — the stateless MUC room handler chain (Q7 option C):
   - `OccupancyValidationHandler` — XEP-0045 §7.4 sender-occupancy check
   - `MucCanonicalizeHandler` — XEP-0359 stanza-id `by=room` strip + stamp, XEP-0421 occupant-id stamp, room-rewrite of `from='room/nick'`
   - `MucArchiveHandler` — XEP-0313 §5.1.3 → `OutboundEvent::ArchiveGroupchat`
   - `ReflectorHandler` — per-occupant `RouteToConnection`
   - `RoomContext` snapshot mirroring `MessageContext` (Q5 frozen-at-dispatch)
   - L1 unit tests per handler (17 new tests, `xep_NNNN_*` named) + L4 wire-trace (3 tests)

2. **Closes two XEP conformance gaps in the legacy fan-out path** (`message.rs::deliver_groupchat_via_room_actor`) so production benefits immediately, ahead of the cutover:
   - **XEP-0421** occupant-id stamping on outgoing groupchat reflections (was: only stamped on presence joins/leaves)
   - **XEP-0045 §7.4** typed `<error type='cancel'><not-acceptable/></error>` reply for non-occupant senders (was: silent drop on `BuildGroupchatBroadcast` error). Plus typed `<error type='auth'><forbidden/></error>` for visitors in moderated rooms (XEP-0045 §7.5) and `<error type='wait'><internal-server-error/></error>` for transient broadcast prep failures — differentiated via new `RoomActorError::{SenderNotOccupant, VisitorMayNotSpeak, BroadcastFailed}` typed variants.

## Deferred to a follow-up PR

The cutover — switching `OutboundEvent::DispatchToRoom`'s interpreter arm from PR14's legacy bridge to running this room handler chain, then deleting `deliver_groupchat_via_room_actor` (~870 LOC) — is **not** in this PR. The legacy bridge depends on:

- per-occupant inbox projection (channel + thread)
- retraction tombstones
- rich-target validation against MAM
- room actor's `BuildGroupchatBroadcast` (role / affiliation checks)
- async managed-room owner check (permission actor)

Migrating all of this into the synchronous handler chain (or new interpreter arms) without regressing the 78 integration tests is a substantial separate effort. The chain is in place, fully tested, and ready for that follow-up. This PR ships the conformance fixes + the chain infrastructure so the next PR can focus solely on cutover plumbing.

## Acceptance gates

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` clean — 1622 + 359 + 78 tests green; existing integration tests pass without modification
- [x] XEP-0421 occupant-id gap closed (production)
- [x] XEP-0045 §7.4 sender-occupancy typed reply (production)
- [x] XEP-0045 §7.5 visitor-may-not-speak typed reply (production, added in review round 2)
- [x] Differentiated transient broadcast failures → `<internal-server-error type='wait'/>` (review round 3)
- [ ] `message.rs` ≤200 LOC — DEFERRED with cutover (file is currently ~1080 LOC; the cutover will retire ~870 LOC of `deliver_groupchat_via_room_actor`)
- [ ] `BroadcastToRoom` decommissioned — DEFERRED with cutover

## Out of scope (post-#229 follow-ups)

- **MUC cutover**: switch `DispatchToRoom` arm to the new chain + delete `deliver_groupchat_via_room_actor`
- **Detached XEP-0198 replay recipient-pass**: close XEP-0359 §5 stanza-id gap on resume
- **Decommission `routing.rs::route_message`** for messages
- **Per-deployment XEP-0421 occupant-id secret**: thread a configured, rotatable secret from `WebSocketState` through `presence.rs` + `message.rs` call sites, demoting the process-wide constant to a `#[cfg(test)]` default. The new room chain already takes it via `RoomContext::occupant_id_secret`; the legacy paths still use the constant.
- **Centralize XEP-0045 §7.4 / §7.5 stanza-error construction**: today the legacy bridge and the room chain each construct the typed replies; a follow-up can extract shared builders so they can't drift.

See `docs/superpowers/plans/2026-04-28-issue-229-sans-io-message-pipeline-remaining-prs.md` PR17 section.

## Test plan

- All existing `crates/waddle-server/tests/*_ws.rs` integration tests pass without modification (XEP-0359, XEP-0280 carbons, XEP-0313 MAM, XEP-0191 blocking, XEP-0308 LMC, XEP-0424 retraction, XEP-0461 reply, XEP-0045 MUC).
- 17 L1 + 3 L4 new tests for the room chain.
- Verify in production: bob receives groupchat reflection from alice with `<occupant-id>` (XEP-0421); a non-occupant sender receives `<error type='cancel'><not-acceptable/></error>` (XEP-0045 §7.4); a visitor in a moderated room receives `<error type='auth'><forbidden/></error>` (XEP-0045 §7.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)