### PR TITLE
feat(chat): add virtual infinite timelines

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,8 @@
         "@nanostores/vue": "^1.1.0",
         "@opentelemetry/api": "^1.9.1",
         "@tailwindcss/vite": "^4.2.3",
+        "@tanstack/vue-query": "^5.100.6",
+        "@tanstack/vue-virtual": "^3.13.24",
         "@tiptap/core": "^3.22.4",
         "@tiptap/extension-link": "^3.22.4",
         "@tiptap/extension-placeholder": "^3.22.4",
@@ -626,6 +628,16 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.3", "", { "dependencies": { "@tailwindcss/node": "4.2.3", "@tailwindcss/oxide": "4.2.3", "tailwindcss": "4.2.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pEvbC/NoOqxvqjy6IgelSakbzwin865CmOxJxmz3CSEbHJ2aF1B2183ALVasN0o6dOGhYfnVJOKKxVoyag+XeA=="],
 
+    "@tanstack/match-sorter-utils": ["@tanstack/match-sorter-utils@8.19.4", "", { "dependencies": { "remove-accents": "0.5.0" } }, "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.100.6", "", {}, "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg=="],
+
+    "@tanstack/virtual-core": ["@tanstack/virtual-core@3.14.0", "", {}, "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q=="],
+
+    "@tanstack/vue-query": ["@tanstack/vue-query@5.100.6", "", { "dependencies": { "@tanstack/match-sorter-utils": "^8.19.4", "@tanstack/query-core": "5.100.6", "@vue/devtools-api": "^6.6.3", "vue-demi": "^0.14.10" }, "peerDependencies": { "@vue/composition-api": "^1.1.2", "vue": "^2.6.0 || ^3.3.0" }, "optionalPeers": ["@vue/composition-api"] }, "sha512-aUvBla5roKKI311C4KHg+n0dHe+s9MKXwhUcro6Ajvu0L6IERoZ+/CjRqUCUgd5Y51ytuZAJl85uahgp7ViVlg=="],
+
+    "@tanstack/vue-virtual": ["@tanstack/vue-virtual@3.13.24", "", { "dependencies": { "@tanstack/virtual-core": "3.14.0" }, "peerDependencies": { "vue": "^2.7.0 || ^3.0.0" } }, "sha512-A0k2qF0zFSUStXSZkGXABouXr2Tw2Ztl/cVIYG9qy84uR8W7UNjAcX3DvzBS3YnDcwvLxab8v7dbmYBZ39itDA=="],
+
     "@tiptap/core": ["@tiptap/core@3.22.4", "", { "peerDependencies": { "@tiptap/pm": "3.22.4" } }, "sha512-vGIGm/HpqLg8EAAQXQ+koV+/S828OEpzocfWcPOwo1u2QUVf9dQG47Yy6JJ8zFFaJwfv4dBcOXli+7BrJwsxDQ=="],
 
     "@tiptap/extension-blockquote": ["@tiptap/extension-blockquote@3.22.4", "", { "peerDependencies": { "@tiptap/core": "3.22.4" } }, "sha512-7/61kNPbGFhMgM//zMknD0pSb69rGdRIkpulXOWS1JBrFHkH6hjZDfrOETNzgKkO+NlmzVl9rXSTv0xauS3lzA=="],
@@ -741,6 +753,8 @@
     "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.32", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.32", "@vue/compiler-dom": "3.5.32", "@vue/compiler-ssr": "3.5.32", "@vue/shared": "3.5.32", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.8", "source-map-js": "^1.2.1" } }, "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg=="],
 
     "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/shared": "3.5.32" } }, "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@6.6.4", "", {}, "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="],
 
     "@vue/devtools-core": ["@vue/devtools-core@8.1.1", "", { "dependencies": { "@vue/devtools-kit": "^8.1.1", "@vue/devtools-shared": "^8.1.1" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-bCCsSABp1/ot4j8xJEycM6Mtt2wbuucfByr6hMgjbYhrtlscOJypZKvy8f1FyWLYrLTchB5Qz216Lm92wfbq0A=="],
 
@@ -1294,6 +1308,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "remove-accents": ["remove-accents@0.5.0", "", {}, "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A=="],
+
     "request-light": ["request-light@0.7.0", "", {}, "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
@@ -1493,6 +1509,8 @@
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
     "vue": ["vue@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/compiler-sfc": "3.5.32", "@vue/runtime-dom": "3.5.32", "@vue/server-renderer": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw=="],
+
+    "vue-demi": ["vue-demi@0.14.10", "", { "peerDependencies": { "@vue/composition-api": "^1.0.0-rc.1", "vue": "^3.0.0-0 || ^2.6.0" }, "optionalPeers": ["@vue/composition-api"], "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 

--- a/chat/astro.config.mjs
+++ b/chat/astro.config.mjs
@@ -44,5 +44,9 @@ export default defineConfig({
     },
   },
 
-  integrations: [vue()],
+  integrations: [
+    vue({
+      appEntrypoint: "/src/vue-app.ts",
+    }),
+  ],
 });

--- a/chat/knip.json
+++ b/chat/knip.json
@@ -3,6 +3,7 @@
   "entry": [
     "src/components/ChatApp.vue",
     "src/components/XmppProvider.vue",
+    "src/vue-app.ts",
     "src/service-worker/sw-template.js",
     "scripts/*.mjs",
     "tests/**/*.test.ts"

--- a/chat/package.json
+++ b/chat/package.json
@@ -27,6 +27,8 @@
     "@nanostores/vue": "^1.1.0",
     "@opentelemetry/api": "^1.9.1",
     "@tailwindcss/vite": "^4.2.3",
+    "@tanstack/vue-query": "^5.100.6",
+    "@tanstack/vue-virtual": "^3.13.24",
     "@tiptap/core": "^3.22.4",
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -149,6 +149,12 @@ const activeTypingUsers = computed(() =>
 const activeIsLoadingMessages = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingMessages.value : messaging.isLoadingMessages.value,
 );
+const activeIsLoadingOlderMessages = computed(() =>
+  ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingOlderMessages.value : messaging.isLoadingOlderMessages.value,
+);
+const activeHasOlderMessages = computed(() =>
+  ui.sidebarMode.value === "dms" ? dmMessaging.hasOlderMessages.value : messaging.hasOlderMessages.value,
+);
 const activeIsSending = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.isSending.value : messaging.isSending.value,
 );
@@ -488,10 +494,7 @@ function openThread(threadId: string) {
     return;
   }
   activeThreadStack.value = [threadId];
-  const known = messaging.messages.value.some((m) => m.id === threadId);
-  if (!known) {
-    void messaging.backfillThread(threadId);
-  }
+  void messaging.backfillThread(threadId);
 }
 
 async function onSelectThread(channelId: string, threadId: string) {
@@ -516,10 +519,7 @@ function pushThread(threadId: string) {
     return;
   }
   activeThreadStack.value = [...activeThreadStack.value, threadId];
-  const known = messaging.messages.value.some((m) => m.id === threadId);
-  if (!known) {
-    void messaging.backfillThread(threadId);
-  }
+  void messaging.backfillThread(threadId);
 }
 
 function popThreadTo(index: number) {
@@ -564,6 +564,14 @@ function searchActiveMessages(query: string) {
 
 function clearActiveSearch() {
   activeTarget.value.clearSearch();
+}
+
+function loadOlderActiveMessages() {
+  void activeTarget.value.loadOlderMessages();
+}
+
+function loadOlderThreadMessages(threadId: string) {
+  void messaging.loadOlderThreadMessages(threadId);
 }
 
 // --- Deep linking ---
@@ -698,16 +706,12 @@ async function applyRouteTarget(route: ReturnType<typeof parseRoute>, requestId:
     await messaging.loadMessages(waddles.currentChannel.value?.spaceId ?? "", waddles.activeChannelId.value);
   }
 
-  // Restore the thread panel from the URL. If the outermost thread root isn't
-  // in the freshly loaded history, MAM-backfill it so the panel has something
-  // to render.
+  // Restore the thread panel from the URL and initialize paging for every
+  // visible thread pane. Dedupe in the messaging composable keeps already
+  // loaded roots/replies stable.
   activeThreadStack.value = route.threadStack;
-  const outerThreadId = route.threadStack[0];
-  if (outerThreadId) {
-    const known = messaging.messages.value.some((m) => m.id === outerThreadId);
-    if (!known) {
-      void messaging.backfillThread(outerThreadId);
-    }
+  for (const threadId of route.threadStack) {
+    void messaging.backfillThread(threadId);
   }
 }
 
@@ -1178,6 +1182,8 @@ onUnmounted(() => {
               :update-available="appUpdate.updateAvailable.value"
               :is-applying-update="appUpdate.isApplyingUpdate.value"
               :is-loading-messages="activeIsLoadingMessages"
+              :is-loading-older-messages="activeIsLoadingOlderMessages"
+              :has-older-messages="activeHasOlderMessages"
               :is-sending="activeIsSending"
               :can-manage-channels="waddles.canManageChannels.value"
               :member-count="waddles.members.value.length"
@@ -1205,6 +1211,7 @@ onUnmounted(() => {
               @displayed="markActiveDisplayed"
               @search="searchActiveMessages"
               @clear-search="clearActiveSearch"
+              @load-older="loadOlderActiveMessages"
               @edit-channel="openChannelEdit"
               @open-nav="ui.showMobileNav.value = true"
               @open-details="ui.showMobileDetails.value = true"
@@ -1265,6 +1272,8 @@ onUnmounted(() => {
                :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="messaging.slowModeCooldown.value"
               :is-sending="false"
+              :is-loading-older-replies="messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 2] ?? '')"
+              :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false"
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
               :hide-composer="true"
@@ -1275,6 +1284,7 @@ onUnmounted(() => {
               @retract-message="retractActiveMessage"
               @react-message="reactActiveMessage"
               @displayed="markActiveDisplayed"
+              @load-older="loadOlderThreadMessages"
             />
           </div>
 
@@ -1298,6 +1308,8 @@ onUnmounted(() => {
                :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="messaging.slowModeCooldown.value"
               :is-sending="messaging.isSending.value"
+              :is-loading-older-replies="messaging.loadingOlderThreadIds.value.has(activeThreadStack[activeThreadStack.length - 1] ?? '')"
+              :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false"
               :upload-progress="messaging.uploadProgress.value"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
               @close="closeThreadPanel"
@@ -1310,6 +1322,7 @@ onUnmounted(() => {
               @displayed="markActiveDisplayed"
               @select-gif="sendGif"
               @typing="notifyActiveComposing"
+              @load-older="loadOlderThreadMessages"
             />
           </div>
         </div>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance } from "vue";
 import { AlertCircle, CheckCircle2, Hash, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
@@ -21,6 +21,7 @@ import ChatHeader from "@/components/chat/ChatHeader.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
 import UserProfileDrawer from "@/components/chat/UserProfileDrawer.vue";
+import VirtualTimeline from "@/components/chat/VirtualTimeline.vue";
 
 const draft = defineModel<string>("draft", { required: true });
 const forumTitle = defineModel<string>("forumTitle", { default: "" });
@@ -37,6 +38,8 @@ const props = defineProps<{
   updateAvailable: boolean;
   isApplyingUpdate: boolean;
   isLoadingMessages: boolean;
+  isLoadingOlderMessages: boolean;
+  hasOlderMessages: boolean;
   isSending: boolean;
   canManageChannels: boolean;
   memberCount: number;
@@ -80,6 +83,7 @@ const emit = defineEmits<{
   openDm: [peerJid: string];
   openThread: [threadId: string];
   refreshUpdate: [];
+  loadOlder: [];
 }>();
 
 // Hide thread members from the main feed — they live inside the thread panel.
@@ -94,6 +98,7 @@ const orderedFeedMessages = computed(() =>
 const newMessagesDividerPlacement = computed(() =>
   getNewMessagesDividerPlacement(scrollDirection.value),
 );
+const olderSentinelPosition = computed(() => scrollDirection.value === "social" ? "end" : "start");
 
 const replyingTo = ref<{ id: string; author: string; body?: string; preview?: string } | null>(null);
 
@@ -164,7 +169,10 @@ function cancelPendingFlash() {
   }
 }
 
-function scrollToMessage(messageId: string) {
+async function scrollToMessage(messageId: string) {
+  if (await virtualTimelineRef.value?.scrollToMessageId(messageId, "center")) {
+    await nextTick();
+  }
   const el = findMessageElementById(messagesContainer.value, messageId);
   const notice = getReplyJumpNotice(el instanceof HTMLElement);
   if (!notice && el instanceof HTMLElement) {
@@ -209,9 +217,22 @@ function onSelectGif(url: string) {
 }
 
 const messagesContainer = ref<HTMLDivElement | null>(null);
+const virtualTimelineRef = ref<(ComponentPublicInstance & {
+  scrollElement: HTMLDivElement | null;
+  scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
+}) | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
   messagesContainer.value = el;
   void nextTick(updateCurrentDayMarker);
+};
+const setVirtualTimelineRef = (
+  instance: (ComponentPublicInstance & {
+    scrollElement: HTMLDivElement | null;
+    scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
+  }) | null,
+) => {
+  virtualTimelineRef.value = instance;
+  setMessagesContainer(instance?.scrollElement ?? null);
 };
 const currentDayMarkerLabel = ref("");
 const composerRef = ref<MessageComposerHandle | null>(null);
@@ -743,6 +764,7 @@ function dayDividerLabel(createdAt: string): string {
 
     <!-- Messages -->
     <div
+      v-if="isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
       :ref="setMessagesContainer"
       class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
       @scroll="updateCurrentDayMarker"
@@ -785,8 +807,20 @@ function dayDividerLabel(createdAt: string): string {
         </div>
       </div>
 
-      <div v-else class="chat-message-lane chat-message-list">
-        <template v-for="msg in orderedFeedMessages" :key="msg.id">
+    </div>
+
+    <VirtualTimeline
+      v-else
+      :ref="setVirtualTimelineRef"
+      :items="orderedFeedMessages"
+      :has-older="hasOlderMessages"
+      :loading-older="isLoadingOlderMessages"
+      :sentinel-position="olderSentinelPosition"
+      aria-label="Messages"
+      @scroll="updateCurrentDayMarker"
+      @load-older="emit('loadOlder')"
+    >
+      <template #item="{ item: msg }">
           <div
             v-if="showDayDividerBefore(msg.id)"
             class="chat-day-divider type-section-label"
@@ -838,9 +872,8 @@ function dayDividerLabel(createdAt: string): string {
             <span>New messages</span>
             <div class="flex-1 h-px bg-destructive/40" />
           </div>
-        </template>
-      </div>
-    </div>
+      </template>
+    </VirtualTimeline>
 
     <!-- Typing indicator -->
     <div

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref, watch, type ComponentPublicInstance } from "vue";
 import { X, CornerDownRight, MessageSquarePlus, ChevronRight, ChevronLeft } from "lucide-vue-next";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
+import VirtualTimeline from "@/components/chat/VirtualTimeline.vue";
 import type { TimelineMessage, MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { OccupantHat, OccupantPresence, RoomHats, RoomPresence } from "@/lib/xmpp-client";
@@ -30,6 +31,8 @@ const props = defineProps<{
   mentionCandidates: MentionCandidate[];
   slowModeCooldown: number;
   isSending: boolean;
+  isLoadingOlderReplies?: boolean;
+  hasOlderReplies?: boolean;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   channelName: string;
   /**
@@ -57,6 +60,7 @@ const emit = defineEmits<{
   displayed: [messageId: string];
   selectGif: [url: string];
   typing: [];
+  loadOlder: [threadId: string];
 }>();
 
 const { mode: scrollDirectionMode } = useScrollDirection();
@@ -73,6 +77,10 @@ const orderedChildren = computed(() => {
   const children = activeEntry.value?.directChildren ?? [];
   return orderTimelineForScrollDirection(children, scrollDirectionMode.value);
 });
+const orderedThreadMessages = computed(() => {
+  const root = activeEntry.value?.root;
+  return root ? [root, ...orderedChildren.value] : [...orderedChildren.value];
+});
 
 // Burst window matches the main feed (ContentArea.vue): same author + < 5 min
 // apart + same day, no intervening other-author message in rendered order.
@@ -81,8 +89,7 @@ const BURST_WINDOW_MS = 5 * 60 * 1000;
 const threadDisplayMeta = computed(() => {
   const grouped = new Set<string>();
   const dayDivider = new Set<string>();
-  const root = activeEntry.value?.root;
-  const sequence: TimelineMessage[] = root ? [root, ...orderedChildren.value] : [...orderedChildren.value];
+  const sequence = orderedThreadMessages.value;
   for (let i = 0; i < sequence.length; i++) {
     const cur = sequence[i];
     if (!cur) continue;
@@ -116,6 +123,7 @@ function dayDividerLabel(createdAt: string): string {
 const isTopPinned = computed(() =>
   isTopPinnedScrollDirection(scrollDirectionMode.value),
 );
+const olderSentinelPosition = computed(() => scrollDirectionMode.value === "social" ? "end" : "start");
 
 const scrollContainerRef = ref<HTMLElement | null>(null);
 const currentDayMarkerLabel = ref("");
@@ -179,19 +187,18 @@ function setScrollContainerRef(el: HTMLElement | null) {
   void nextTick(updateCurrentDayMarker);
 }
 
+const setVirtualTimelineRef = (
+  instance: (ComponentPublicInstance & { scrollElement: HTMLDivElement | null }) | null,
+) => {
+  setScrollContainerRef(instance?.scrollElement ?? null);
+};
+
 // Switching threads resets composer state and scrolls to the pinned edge.
 watch(activeThreadId, () => {
   replyingTo.value = null;
   draft.value = "";
   void scrollToPinnedEdge();
 });
-
-watch(
-  () => activeEntry.value?.directChildren.length,
-  () => {
-    void scrollToPinnedEdge();
-  },
-);
 
 watch(scrollDirectionMode, () => {
   void scrollToPinnedEdge();
@@ -345,23 +352,34 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     </div>
 
     <div
-      :ref="setScrollContainerRef"
-      class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4"
-      @scroll="updateCurrentDayMarker"
+      v-if="activeEntry && !activeEntry.root"
+      class="type-caption flex-shrink-0 bg-muted/35 px-4 py-2 text-muted-foreground"
     >
-      <div v-if="activeEntry" class="chat-panel-stack">
-        <div v-if="!activeEntry.root" class="type-caption rounded-lg bg-muted/40 px-3 py-2 text-muted-foreground">
-          Thread root isn't in the loaded history. Scroll the main channel or reload to backfill.
-        </div>
+      Thread root isn't in the loaded history. Scroll the main channel or reload to backfill.
+    </div>
+
+    <VirtualTimeline
+      v-if="activeEntry"
+      :ref="setVirtualTimelineRef"
+      :items="orderedThreadMessages"
+      :has-older="hasOlderReplies ?? false"
+      :loading-older="isLoadingOlderReplies ?? false"
+      :sentinel-position="olderSentinelPosition"
+      aria-label="Thread messages"
+      content-class="chat-panel-stack"
+      @scroll="updateCurrentDayMarker"
+      @load-older="activeThreadId && emit('loadOlder', activeThreadId)"
+    >
+      <template #item="{ item: message }">
         <MessageCard
-          v-if="activeEntry.root"
-          :message="activeEntry.root"
+          v-if="message.id === activeEntry.root?.id"
+          :message="message"
           :current-user="currentUser"
-          :avatar-url="avatarUrlByAuthor[activeEntry.root.author] ?? null"
-          :hats="hatsFor(activeEntry.root.author)"
-          :presence="presenceFor(activeEntry.root.author)"
-          :last-seen="roomLastSeen[activeEntry.root.author]"
-          :author-jid="authorJidByNick?.[activeEntry.root.author]"
+          :avatar-url="avatarUrlByAuthor[message.author] ?? null"
+          :hats="hatsFor(message.author)"
+          :presence="presenceFor(message.author)"
+          :last-seen="roomLastSeen[message.author]"
+          :author-jid="authorJidByNick?.[message.author]"
           :thread-reply-count="activeEntry.count"
           hide-thread-chip
           @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
@@ -370,30 +388,29 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
           @reply="beginReplyInThread"
           @open-thread="onOpenThreadFromCard"
         />
-
-        <template v-for="child in orderedChildren" :key="child.id">
+        <template v-else>
           <div
-            v-if="showDayDividerBefore(child.id)"
+            v-if="showDayDividerBefore(message.id)"
             class="chat-day-divider type-section-label"
-            :data-day-marker-created-at="child.createdAt"
+            :data-day-marker-created-at="message.createdAt"
             role="separator"
-            :aria-label="dayDividerLabel(child.createdAt)"
+            :aria-label="dayDividerLabel(message.createdAt)"
           >
             <div class="chat-day-divider__rule" />
-            <span class="chat-day-divider__label">{{ dayDividerLabel(child.createdAt) }}</span>
+            <span class="chat-day-divider__label">{{ dayDividerLabel(message.createdAt) }}</span>
             <div class="chat-day-divider__rule" />
           </div>
           <div class="relative group/thread-child">
             <MessageCard
-              :message="child"
+              :message="message"
               :current-user="currentUser"
-              :avatar-url="avatarUrlByAuthor[child.author] ?? null"
-              :hats="hatsFor(child.author)"
-              :presence="presenceFor(child.author)"
-              :last-seen="roomLastSeen[child.author]"
-              :author-jid="authorJidByNick?.[child.author]"
-              :thread-reply-count="threadIndex.get(child.id)?.count ?? 0"
-              :grouped="isGroupedFollowUp(child.id)"
+              :avatar-url="avatarUrlByAuthor[message.author] ?? null"
+              :hats="hatsFor(message.author)"
+              :presence="presenceFor(message.author)"
+              :last-seen="roomLastSeen[message.author]"
+              :author-jid="authorJidByNick?.[message.author]"
+              :thread-reply-count="threadIndex.get(message.id)?.count ?? 0"
+              :grouped="isGroupedFollowUp(message.id)"
               hide-thread-chip
               @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
               @retract="(id) => emit('retractMessage', id)"
@@ -403,20 +420,20 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             />
           <div class="chat-thread-actions">
             <button
-              v-if="replyChildHasNestedThread(child)"
+              v-if="replyChildHasNestedThread(message)"
               type="button"
               class="type-caption inline-flex items-center gap-1 text-primary/80 hover:text-primary transition-colors"
-              @click="onOpenThreadFromCard(child.id)"
+              @click="onOpenThreadFromCard(message.id)"
             >
               <CornerDownRight class="w-3 h-3" />
-              <span>{{ threadIndex.get(child.id)?.count ?? 0 }} in sub-thread</span>
+              <span>{{ threadIndex.get(message.id)?.count ?? 0 }} in sub-thread</span>
             </button>
             <button
               v-else
               type="button"
               class="type-caption inline-flex items-center gap-1 text-muted-foreground hover:text-primary transition-colors opacity-60 group-hover/thread-child:opacity-100 focus-visible:opacity-100"
               title="Start sub-thread"
-              @click="startSubThread(child)"
+              @click="startSubThread(message)"
             >
               <MessageSquarePlus class="w-3 h-3" />
               <span>Start sub-thread</span>
@@ -424,20 +441,25 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
           </div>
           </div>
         </template>
+      </template>
+    </VirtualTimeline>
 
-        <div
-          v-if="activeEntry.directChildren.length === 0 && !hideComposer"
-          class="type-caption text-center py-8 text-muted-foreground"
-        >
-          No replies yet. Start the conversation.
-        </div>
-      </div>
-      <div
-        v-else
-        class="type-caption text-center py-10 text-muted-foreground"
-      >
+    <div
+      v-else
+      :ref="setScrollContainerRef"
+      class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4"
+      @scroll="updateCurrentDayMarker"
+    >
+      <div class="type-caption text-center py-10 text-muted-foreground">
         Loading thread…
       </div>
+    </div>
+
+    <div
+      v-if="activeEntry?.directChildren.length === 0 && !hideComposer"
+      class="type-caption flex-shrink-0 text-center py-3 text-muted-foreground"
+    >
+      No replies yet. Start the conversation.
     </div>
 
     <!-- Composer: bottom-pinned mode (chat mode) - hidden in parent context pane -->

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -32,13 +32,13 @@ function itemForVirtualIndex(index: number): TimelineMessage | null {
   return props.items[index - offset] ?? null;
 }
 
-const virtualizer = useVirtualizer({
-  count: rowCount,
+const virtualizer = useVirtualizer(computed(() => ({
+  count: rowCount.value,
   getScrollElement: () => scrollElement.value,
-  estimateSize: (index) => (index === sentinelIndex.value ? 44 : 112),
+  estimateSize: (index: number) => (index === sentinelIndex.value ? 44 : 112),
   overscan: 8,
-  getItemKey: (index) => itemForVirtualIndex(index)?.id ?? "older-history-sentinel",
-});
+  getItemKey: (index: number) => itemForVirtualIndex(index)?.id ?? "older-history-sentinel",
+})));
 
 const virtualItems = computed(() => virtualizer.value.getVirtualItems());
 const totalSize = computed(() => virtualizer.value.getTotalSize());

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch, watchEffect } from "vue";
+import { useVirtualizer } from "@tanstack/vue-virtual";
+import type { TimelineMessage } from "@/lib/chat-ui";
+
+const props = withDefaults(defineProps<{
+  items: TimelineMessage[];
+  hasOlder: boolean;
+  loadingOlder: boolean;
+  sentinelPosition: "start" | "end";
+  ariaLabel: string;
+  contentClass?: string;
+}>(), {
+  contentClass: "chat-message-lane chat-message-list",
+});
+
+const emit = defineEmits<{
+  loadOlder: [];
+  scroll: [event: Event];
+}>();
+
+const scrollElement = ref<HTMLDivElement | null>(null);
+const hasOlderSentinel = computed(() => props.hasOlder || props.loadingOlder);
+const rowCount = computed(() => props.items.length + (hasOlderSentinel.value ? 1 : 0));
+const sentinelIndex = computed(() =>
+  !hasOlderSentinel.value ? -1 : props.sentinelPosition === "start" ? 0 : rowCount.value - 1,
+);
+
+function itemForVirtualIndex(index: number): TimelineMessage | null {
+  if (index === sentinelIndex.value) return null;
+  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
+  return props.items[index - offset] ?? null;
+}
+
+const virtualizer = useVirtualizer({
+  count: rowCount,
+  getScrollElement: () => scrollElement.value,
+  estimateSize: (index) => (index === sentinelIndex.value ? 44 : 112),
+  overscan: 8,
+  getItemKey: (index) => itemForVirtualIndex(index)?.id ?? "older-history-sentinel",
+});
+
+const virtualItems = computed(() => virtualizer.value.getVirtualItems());
+const totalSize = computed(() => virtualizer.value.getTotalSize());
+
+function maybeLoadOlder() {
+  if (!props.hasOlder || props.loadingOlder || sentinelIndex.value === -1) return;
+  const visible = virtualItems.value.some((item) => item.index === sentinelIndex.value);
+  if (visible) emit("loadOlder");
+}
+
+watchEffect(maybeLoadOlder);
+
+watch(
+  () => props.items.length,
+  () => {
+    void nextTick(() => virtualizer.value.measure());
+  },
+);
+
+async function scrollToMessageId(messageId: string, align: "start" | "center" | "end" = "center") {
+  const index = props.items.findIndex((item) => item.id === messageId);
+  if (index === -1) return false;
+  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
+  virtualizer.value.scrollToIndex(index + offset, { align });
+  await nextTick();
+  return true;
+}
+
+defineExpose({ scrollElement, scrollToMessageId });
+</script>
+
+<template>
+  <div
+    ref="scrollElement"
+    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+    :aria-label="ariaLabel"
+    @scroll="(event) => { emit('scroll', event); maybeLoadOlder(); }"
+  >
+    <div :class="contentClass" :style="{ height: `${totalSize}px`, position: 'relative' }">
+      <div
+        v-for="virtualRow in virtualItems"
+        :key="virtualRow.key"
+        :data-index="virtualRow.index"
+        :ref="virtualizer.measureElement"
+        class="absolute left-0 top-0 w-full"
+        :style="{ transform: `translateY(${virtualRow.start}px)` }"
+      >
+        <slot
+          v-if="itemForVirtualIndex(virtualRow.index)"
+          name="item"
+          :item="itemForVirtualIndex(virtualRow.index)"
+        />
+        <div
+          v-else
+          class="type-caption flex items-center justify-center py-3 text-muted-foreground"
+          data-older-history-sentinel
+        >
+          <button
+            v-if="hasOlder && !loadingOlder"
+            type="button"
+            class="rounded-full border border-border bg-background px-3 py-1.5 transition-colors hover:bg-muted"
+            @click="emit('loadOlder')"
+          >
+            Load older messages
+          </button>
+          <span v-else>Loading older messages…</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -121,6 +121,8 @@ export function useDmMessaging(
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
   const isLoadingMessages = ref(false);
+  const isLoadingOlderMessages = ref(false);
+  const hasOlderMessages = ref(true);
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const typingUsers = ref<string[]>([]);
@@ -130,6 +132,7 @@ export function useDmMessaging(
   const firstUnseenId = ref<string | null>(null);
 
   let messageRequestId = 0;
+  let oldestArchiveId: string | null = null;
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -317,6 +320,86 @@ export function useDmMessaging(
     });
   }
 
+  function buildTimelineFromMamResults(
+    mamResults: LiveDmMessage[],
+    existing: TimelineMessage[] = [],
+  ): TimelineMessage[] {
+    const regular: LiveDmMessage[] = [];
+    const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
+    const retractionUpdates: string[] = [];
+    const correctionUpdates: {
+      targetId: string;
+      correctionFromJid: string;
+      body: string;
+      markup?: LiveDmMessage["markup"];
+      references?: LiveDmMessage["references"];
+      githubEmbeds?: LiveDmMessage["githubEmbeds"];
+    }[] = [];
+    for (const msg of mamResults) {
+      if (msg._reactionTarget && msg._reactionEmojis) {
+        reactionUpdates.push({ targetId: msg._reactionTarget, nick: msg.nick, emojis: msg._reactionEmojis });
+      } else if (msg.retractsId) {
+        retractionUpdates.push(msg.retractsId);
+      } else if (msg.replacesId) {
+        correctionUpdates.push({
+          targetId: msg.replacesId,
+          correctionFromJid: msg.fromJid,
+          body: msg.body,
+          markup: msg.markup,
+          references: msg.references,
+          githubEmbeds: msg.githubEmbeds,
+        });
+      } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
+        regular.push(msg);
+      }
+    }
+    const byId = new Map<string, TimelineMessage>();
+    for (const message of existing) indexMessageByIds(byId, message);
+    const timeline = [...existing];
+    for (const raw of regular) {
+      if (findMessageById(timeline, raw.id)) continue;
+      const tm = fromLiveDmMessage(session.value!, raw, (id) => byId.get(id));
+      indexMessageByIds(byId, tm);
+      timeline.push(tm);
+    }
+    for (const update of correctionUpdates) {
+      const target = findMessageById(timeline, update.targetId);
+      if (!target || !isSameDmCorrectionSender(target, update.correctionFromJid)) continue;
+      target.body = update.body;
+      target.isEdited = true;
+      if (update.markup && update.markup.length > 0) target.markup = update.markup;
+      else delete target.markup;
+      if (update.references && update.references.length > 0) target.references = update.references;
+      else delete target.references;
+      if (update.githubEmbeds && update.githubEmbeds.length > 0) {
+        target.githubEmbeds = update.githubEmbeds;
+      } else if (target.githubEmbeds?.length) {
+        const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
+        if (surviving.length > 0) target.githubEmbeds = surviving;
+        else delete target.githubEmbeds;
+      } else {
+        delete target.githubEmbeds;
+      }
+    }
+    for (const retractsId of retractionUpdates) {
+      const target = findMessageById(timeline, retractsId);
+      if (!target) continue;
+      target.body = "";
+      target.isRetracted = true;
+    }
+    for (const update of reactionUpdates) {
+      const target = findMessageById(timeline, update.targetId);
+      if (!target) continue;
+      const reactions: Record<string, string[]> = target.reactions ? { ...target.reactions } : {};
+      for (const emoji of update.emojis) {
+        if (!reactions[emoji]) reactions[emoji] = [];
+        if (!reactions[emoji].includes(update.nick)) reactions[emoji].push(update.nick);
+      }
+      target.reactions = reactions;
+    }
+    return timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
   function mergeLiveMessage(msg: TimelineMessage) {
     // Self-echo reconciliation: match by id first; otherwise body-match only
     // against messages still awaiting reconciliation so duplicates don't
@@ -417,96 +500,26 @@ export function useDmMessaging(
     if (!session.value) return;
     const requestId = ++messageRequestId;
     isLoadingMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    hasOlderMessages.value = true;
+    oldestArchiveId = null;
     firstUnseenId.value = null;
     clearActionError();
     pendingEchoClientIds.clear();
     messages.value = appendQueuedMessages([], peerJid);
     try {
-      const mamResults = xmppClient.value ? await xmppClient.value.queryPersonalMam(peerJid, 100) : [];
+      const page = xmppClient.value && "queryPersonalMamPage" in xmppClient.value
+        ? await xmppClient.value.queryPersonalMamPage(peerJid, 100, { type: "latest" })
+        : null;
+      const mamResults = page
+        ? page.messages
+        : xmppClient.value
+          ? await xmppClient.value.queryPersonalMam(peerJid, 100)
+          : [];
       if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
-      const regular: LiveDmMessage[] = [];
-      const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
-      const retractionUpdates: string[] = [];
-      const correctionUpdates: {
-        targetId: string;
-        correctionFromJid: string;
-        body: string;
-        markup?: LiveDmMessage["markup"];
-        references?: LiveDmMessage["references"];
-        githubEmbeds?: LiveDmMessage["githubEmbeds"];
-      }[] = [];
-      for (const msg of mamResults) {
-        if (msg._reactionTarget && msg._reactionEmojis) {
-          reactionUpdates.push({
-            targetId: msg._reactionTarget,
-            nick: msg.nick,
-            emojis: msg._reactionEmojis,
-          });
-        } else if (msg.retractsId) {
-          retractionUpdates.push(msg.retractsId);
-        } else if (msg.replacesId) {
-          correctionUpdates.push({
-            targetId: msg.replacesId,
-            correctionFromJid: msg.fromJid,
-            body: msg.body,
-            markup: msg.markup,
-            references: msg.references,
-            githubEmbeds: msg.githubEmbeds,
-          });
-        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
-          regular.push(msg);
-        }
-      }
-      const byId = new Map<string, TimelineMessage>();
-      const timeline = regular.map((m) => {
-        const tm = fromLiveDmMessage(session.value!, m, (id) => byId.get(id));
-        indexMessageByIds(byId, tm);
-        return tm;
-      });
-      for (const update of correctionUpdates) {
-        const target = findMessageById(timeline, update.targetId);
-        if (!target || !isSameDmCorrectionSender(target, update.correctionFromJid)) continue;
-        target.body = update.body;
-        target.isEdited = true;
-        if (update.markup && update.markup.length > 0) {
-          target.markup = update.markup;
-        } else {
-          delete target.markup;
-        }
-        if (update.references && update.references.length > 0) {
-          target.references = update.references;
-        } else {
-          delete target.references;
-        }
-        if (update.githubEmbeds && update.githubEmbeds.length > 0) {
-          target.githubEmbeds = update.githubEmbeds;
-        } else if (target.githubEmbeds?.length) {
-          const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
-          if (surviving.length > 0) {
-            target.githubEmbeds = surviving;
-          } else {
-            delete target.githubEmbeds;
-          }
-        } else {
-          delete target.githubEmbeds;
-        }
-      }
-      for (const retractsId of retractionUpdates) {
-        const target = findMessageById(timeline, retractsId);
-        if (!target) continue;
-        target.body = "";
-        target.isRetracted = true;
-      }
-      for (const update of reactionUpdates) {
-        const target = findMessageById(timeline, update.targetId);
-        if (!target) continue;
-        const reactions: Record<string, string[]> = target.reactions ? { ...target.reactions } : {};
-        for (const emoji of update.emojis) {
-          if (!reactions[emoji]) reactions[emoji] = [];
-          if (!reactions[emoji].includes(update.nick)) reactions[emoji].push(update.nick);
-        }
-        target.reactions = reactions;
-      }
+      oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
+      hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
+      const timeline = buildTimelineFromMamResults(mamResults);
       const timelineWithQueue = appendQueuedMessages(timeline, peerJid);
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) isLoadingMessages.value = false;
@@ -539,6 +552,39 @@ export function useDmMessaging(
         actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
         isLoadingMessages.value = false;
       }
+    }
+  }
+
+  async function loadOlderMessages() {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    const before = oldestArchiveId;
+    if (!client || !peerJid || !before || !hasOlderMessages.value || isLoadingOlderMessages.value) return;
+    if (!("queryPersonalMamPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      activePeerJid.value === peerJid;
+    const el = timelineEl.value;
+    const previousHeight = el?.scrollHeight ?? 0;
+    const previousTop = el?.scrollTop ?? 0;
+    isLoadingOlderMessages.value = true;
+    try {
+      const page = await client.queryPersonalMamPage(peerJid, 100, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      oldestArchiveId = page.firstArchiveId ?? oldestArchiveId;
+      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before;
+      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), peerJid);
+      await nextTick();
+      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
+        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
+      }
+    } catch (e) {
+      if (isCurrentRequest()) actionError.value = normalizeError(e);
+    } finally {
+      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
     }
   }
 
@@ -811,12 +857,15 @@ export function useDmMessaging(
     firstUnseenId,
     draft,
     isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
     isSending,
     typingUsers,
     timelineEl,
     searchResults,
     isSearching,
     loadMessages,
+    loadOlderMessages,
     sendMessage,
     uploadProgress,
     editMessage,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -246,6 +246,10 @@ export function useMessaging(
   const draft = ref("");
   const forumPostTitle = ref("");
   const isLoadingMessages = ref(false);
+  const isLoadingOlderMessages = ref(false);
+  const hasOlderMessages = ref(true);
+  const loadingOlderThreadIds = ref<Set<string>>(new Set());
+  const threadHasOlder = ref<Record<string, boolean>>({});
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const typingUsers = ref<string[]>([]);
@@ -264,6 +268,8 @@ export function useMessaging(
   let slowModeTimer: ReturnType<typeof setInterval> | null = null;
 
   let messageRequestId = 0;
+  let oldestArchiveId: string | null = null;
+  const oldestThreadArchiveIds = new Map<string, string>();
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -770,12 +776,110 @@ export function useMessaging(
     return !m.threadId || m.id === m.threadId;
   }
 
+  function buildTimelineFromMamResults(
+    mamResults: LiveRoomMessage[],
+    existing: TimelineMessage[] = [],
+  ): TimelineMessage[] {
+    const regularMessages: LiveRoomMessage[] = [];
+    const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
+    const retractionUpdates: string[] = [];
+    const correctionUpdates: {
+      targetId: string;
+      correctionSender: { authorJid: string; authorRealJid?: string };
+      body: string;
+      markup?: MarkupSpan[];
+      references?: MessageReference[];
+      githubEmbeds?: LiveRoomMessage["githubEmbeds"];
+    }[] = [];
+
+    for (const msg of mamResults) {
+      if (msg._reactionTarget && msg._reactionEmojis) {
+        reactionUpdates.push({
+          targetId: msg._reactionTarget,
+          nick: msg.nick,
+          emojis: msg._reactionEmojis,
+        });
+      } else if (msg.retractsId) {
+        retractionUpdates.push(msg.retractsId);
+      } else if (msg.replacesId) {
+        correctionUpdates.push({
+          targetId: msg.replacesId,
+          correctionSender: mucCorrectionSender(msg),
+          body: msg.body,
+          markup: msg.markup,
+          references: msg.references,
+          githubEmbeds: msg.githubEmbeds,
+        });
+      } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
+        regularMessages.push(msg);
+      }
+    }
+
+    const byId = new Map<string, TimelineMessage>();
+    for (const message of existing) {
+      indexMessageByIds(byId, message);
+    }
+    const timeline = [...existing];
+    for (const raw of regularMessages) {
+      if (findMessageById(timeline, raw.id)) continue;
+      const tm = fromLiveMessage(session.value!, raw, (id) => byId.get(id));
+      indexMessageByIds(byId, tm);
+      timeline.push(tm);
+    }
+
+    for (const update of correctionUpdates) {
+      const target = findMessageById(timeline, update.targetId);
+      if (!target || !isSameMucCorrectionSender(target, update.correctionSender)) continue;
+      target.body = update.body;
+      target.isEdited = true;
+      if (update.markup && update.markup.length > 0) target.markup = update.markup;
+      else delete target.markup;
+      if (update.references && update.references.length > 0) target.references = update.references;
+      else delete target.references;
+      if (update.githubEmbeds && update.githubEmbeds.length > 0) {
+        target.githubEmbeds = update.githubEmbeds;
+      } else if (target.githubEmbeds?.length) {
+        const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
+        if (surviving.length > 0) target.githubEmbeds = surviving;
+        else delete target.githubEmbeds;
+      } else {
+        delete target.githubEmbeds;
+      }
+    }
+
+    for (const retractsId of retractionUpdates) {
+      const target = findMessageById(timeline, retractsId);
+      if (!target) continue;
+      target.body = "";
+      target.isRetracted = true;
+    }
+
+    for (const update of reactionUpdates) {
+      const target = findMessageById(timeline, update.targetId);
+      if (!target) continue;
+      const reactions: Record<string, string[]> = target.reactions ? { ...target.reactions } : {};
+      for (const emoji of update.emojis) {
+        if (!reactions[emoji]) reactions[emoji] = [];
+        if (!reactions[emoji].includes(update.nick)) reactions[emoji].push(update.nick);
+      }
+      target.reactions = reactions;
+    }
+
+    return applyForumContext(timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt)));
+  }
+
   async function loadMessages(spaceId: string, channelId: string) {
     if (!session.value) return;
 
     const requestId = ++messageRequestId;
     const roomJid = roomBareJidFor(session.value, channelId);
     isLoadingMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    hasOlderMessages.value = true;
+    oldestArchiveId = null;
+    loadingOlderThreadIds.value = new Set();
+    threadHasOlder.value = {};
+    oldestThreadArchiveIds.clear();
     // Reset the divider anchor up-front: a previous conversation's id could
     // coincidentally match a message in the new timeline, and an aborted
     // request (requestId mismatch) would otherwise leave stale state.
@@ -786,9 +890,14 @@ export function useMessaging(
 
     try {
       // XEP-0313: Load message history via MAM (XMPP-native)
-      const mamResults = xmppClient.value
-        ? await xmppClient.value.queryMam(spaceId, channelId, 100)
-        : [];
+      const page = xmppClient.value && "queryMamPage" in xmppClient.value
+        ? await xmppClient.value.queryMamPage(spaceId, channelId, 100, { type: "latest" })
+        : null;
+      const mamResults = page
+        ? page.messages
+        : xmppClient.value
+          ? await xmppClient.value.queryMam(spaceId, channelId, 100)
+          : [];
 
       if (
         requestId !== messageRequestId ||
@@ -798,103 +907,9 @@ export function useMessaging(
         return;
       }
 
-      // Separate regular messages from timeline updates
-      const regularMessages: LiveRoomMessage[] = [];
-      const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
-      const retractionUpdates: string[] = [];
-      const correctionUpdates: {
-        targetId: string;
-        correctionSender: { authorJid: string; authorRealJid?: string };
-        body: string;
-        markup?: MarkupSpan[];
-        references?: MessageReference[];
-        githubEmbeds?: LiveRoomMessage["githubEmbeds"];
-      }[] = [];
-
-      for (const msg of mamResults) {
-        if (msg._reactionTarget && msg._reactionEmojis) {
-          reactionUpdates.push({
-            targetId: msg._reactionTarget,
-            nick: msg.nick,
-            emojis: msg._reactionEmojis,
-          });
-        } else if (msg.retractsId) {
-          retractionUpdates.push(msg.retractsId);
-        } else if (msg.replacesId) {
-          correctionUpdates.push({
-            targetId: msg.replacesId,
-            correctionSender: mucCorrectionSender(msg),
-            body: msg.body,
-            markup: msg.markup,
-            references: msg.references,
-            githubEmbeds: msg.githubEmbeds,
-          });
-        } else if (msg.body || (msg.sharedFiles && msg.sharedFiles.length > 0) || msg.isSticker || (msg.githubEmbeds && msg.githubEmbeds.length > 0)) {
-          regularMessages.push(msg);
-        }
-      }
-
-      // Convert to timeline messages; accumulate in a map so replies that land
-      // after their parent in the MAM batch can resolve a preview.
-      const byId = new Map<string, TimelineMessage>();
-      const timeline = regularMessages.map((m) => {
-        const tm = fromLiveMessage(session.value!, m, (id) => byId.get(id));
-        indexMessageByIds(byId, tm);
-        return tm;
-      });
-
-      for (const update of correctionUpdates) {
-        const target = findMessageById(timeline, update.targetId);
-        if (!target || !isSameMucCorrectionSender(target, update.correctionSender)) continue;
-        target.body = update.body;
-        target.isEdited = true;
-        if (update.markup && update.markup.length > 0) {
-          target.markup = update.markup;
-        } else {
-          delete target.markup;
-        }
-        if (update.references && update.references.length > 0) {
-          target.references = update.references;
-        } else {
-          delete target.references;
-        }
-        if (update.githubEmbeds && update.githubEmbeds.length > 0) {
-          target.githubEmbeds = update.githubEmbeds;
-        } else if (target.githubEmbeds?.length) {
-          const surviving = target.githubEmbeds.filter((e) => update.body.includes(e.url));
-          if (surviving.length > 0) {
-            target.githubEmbeds = surviving;
-          } else {
-            delete target.githubEmbeds;
-          }
-        } else {
-          delete target.githubEmbeds;
-        }
-      }
-
-      for (const retractsId of retractionUpdates) {
-        const target = findMessageById(timeline, retractsId);
-        if (!target) continue;
-        target.body = "";
-        target.isRetracted = true;
-      }
-
-      // Apply reactions from MAM history
-      for (const update of reactionUpdates) {
-        const target = findMessageById(timeline, update.targetId);
-        if (target) {
-          const reactions: Record<string, string[]> = target.reactions ? { ...target.reactions } : {};
-          for (const emoji of update.emojis) {
-            if (!reactions[emoji]) reactions[emoji] = [];
-            if (!reactions[emoji].includes(update.nick)) {
-              reactions[emoji].push(update.nick);
-            }
-          }
-          target.reactions = reactions;
-        }
-      }
-
-      const timelineWithQueue = appendQueuedMessages(applyForumContext(timeline), roomJid);
+      oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
+      hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
+      const timelineWithQueue = appendQueuedMessages(buildTimelineFromMamResults(mamResults), roomJid);
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) {
         isLoadingMessages.value = false;
@@ -933,6 +948,42 @@ export function useMessaging(
     }
   }
 
+  async function loadOlderMessages() {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value ?? "";
+    const channelId = activeChannelId.value;
+    const before = oldestArchiveId;
+    if (!client || !channelId || !before || !hasOlderMessages.value || isLoadingOlderMessages.value) return;
+    if (!("queryMamPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      (activeSpaceId.value ?? "") === spaceId &&
+      activeChannelId.value === channelId;
+
+    const el = timelineEl.value;
+    const previousHeight = el?.scrollHeight ?? 0;
+    const previousTop = el?.scrollTop ?? 0;
+    isLoadingOlderMessages.value = true;
+    try {
+      const page = await client.queryMamPage(spaceId, channelId, 100, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      oldestArchiveId = page.firstArchiveId ?? oldestArchiveId;
+      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before;
+      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), roomBareJidFor(session.value!, channelId));
+      await nextTick();
+      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
+        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
+      }
+    } catch (e) {
+      if (isCurrentRequest()) actionError.value = normalizeError(e);
+    } finally {
+      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
+    }
+  }
+
   /**
    * Backfill a thread via XEP-0313 MAM filtered by thread id. Returns every
    * archived reply whose `<thread>` element matches `threadId`. The thread
@@ -945,29 +996,59 @@ export function useMessaging(
     const spaceId = activeSpaceId.value;
     const channelId = activeChannelId.value;
     if (!client || !channelId || !threadId || !session.value) return;
-    const results = await client.queryMamByThread(spaceId ?? "", channelId, threadId, 100);
+    const requestId = messageRequestId;
+    const page = "queryMamThreadPage" in client
+      ? await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "latest" })
+      : null;
+    const results = page ? page.messages : await client.queryMamByThread(spaceId ?? "", channelId, threadId, 100);
     if (
       xmppClient.value !== client ||
       (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
-      activeChannelId.value !== channelId
+      activeChannelId.value !== channelId ||
+      requestId !== messageRequestId
     ) {
       return;
     }
-    const appended: TimelineMessage[] = [];
-    const localById = new Map<string, TimelineMessage>();
-    for (const message of messages.value) {
-      indexMessageByIds(localById, message);
+    if (page?.firstArchiveId) oldestThreadArchiveIds.set(threadId, page.firstArchiveId);
+    threadHasOlder.value = {
+      ...threadHasOlder.value,
+      [threadId]: page ? !page.complete && !!page.firstArchiveId : results.length >= 100,
+    };
+    const next = buildTimelineFromMamResults(results, messages.value);
+    if (next.length === messages.value.length) return;
+    messages.value = next;
+  }
+
+  async function loadOlderThreadMessages(threadId: string): Promise<void> {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value;
+    const channelId = activeChannelId.value;
+    const before = oldestThreadArchiveIds.get(threadId);
+    if (!client || !channelId || !threadId || !before || loadingOlderThreadIds.value.has(threadId)) return;
+    if (!("queryMamThreadPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      (activeSpaceId.value ?? "") === (spaceId ?? "") &&
+      activeChannelId.value === channelId;
+    loadingOlderThreadIds.value = new Set([...loadingOlderThreadIds.value, threadId]);
+    try {
+      const page = await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      if (page.firstArchiveId) oldestThreadArchiveIds.set(threadId, page.firstArchiveId);
+      threadHasOlder.value = {
+        ...threadHasOlder.value,
+        [threadId]: !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before,
+      };
+      messages.value = buildTimelineFromMamResults(page.messages, messages.value);
+    } catch (e) {
+      if (isCurrentRequest()) actionError.value = normalizeError(e);
+    } finally {
+      const next = new Set(loadingOlderThreadIds.value);
+      next.delete(threadId);
+      loadingOlderThreadIds.value = next;
     }
-    for (const raw of results) {
-      if (findMessageById(messages.value, raw.id)) continue;
-      const tm = fromLiveMessage(session.value, raw, (id) => localById.get(id));
-      indexMessageByIds(localById, tm);
-      appended.push(tm);
-    }
-    if (appended.length === 0) return;
-    messages.value = [...messages.value, ...appended].sort((a, b) =>
-      a.createdAt.localeCompare(b.createdAt),
-    );
   }
 
   async function selectChannel(channelId: string) {
@@ -1312,6 +1393,8 @@ export function useMessaging(
     draft,
     forumPostTitle,
     isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
     isSending,
     timelineEl,
     currentRoomJid,
@@ -1321,7 +1404,11 @@ export function useMessaging(
     roomLastSeen,
     slowModeCooldown,
     loadMessages,
+    loadOlderMessages,
     backfillThread,
+    loadOlderThreadMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
     selectChannel,
     sendMessage,
     uploadProgress,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -8,7 +8,7 @@ import type { WaddleHat } from "./extensions/hats";
 import type {
   ChatStateEvent, ChatStateType, DiscoveredChannel, DisplayedEvent,
   DmChatStateEvent, DmDisplayedEvent, DmReactionEvent, ListRoomMembersOptions, LiveDmMessage, LiveRoomMessage,
-  OccupantPresence, PresenceUpdateEvent, ReactionEvent, RoomActivityEvent,
+  MamHistoryPage, MamPageParam, OccupantPresence, PresenceUpdateEvent, ReactionEvent, RoomActivityEvent,
   RoomHats, RoomPresence, RosterContact, SessionLifecycleEvent, XmppErrorEvent, XmppStatusSnapshot,
 } from "./types";
 import { barePeerJid, jidDomain, roomBareJidFor } from "./jid";
@@ -1180,11 +1180,34 @@ export class BrowserXmppClient {
     await this.connect(); await this.switchRoom(w, c);
     return this.xmpp ? history.queryMam(this.xmpp, this.roomJidForChannel(c), max) : [];
   }
+  async queryMamPage(
+    w: string,
+    c: string,
+    max = 100,
+    pageParam: MamPageParam = { type: "latest" },
+  ): Promise<MamHistoryPage<LiveRoomMessage>> {
+    await this.connect(); await this.switchRoom(w, c);
+    return this.xmpp
+      ? history.queryMamPage(this.xmpp, this.roomJidForChannel(c), max, pageParam)
+      : { messages: [], complete: true };
+  }
   async queryMamByThread(w: string, c: string, threadId: string, max = 100): Promise<LiveRoomMessage[]> {
     await this.connect(); await this.switchRoom(w, c);
     return this.xmpp
       ? history.queryMamByThread(this.xmpp, this.roomJidForChannel(c), threadId, max)
       : [];
+  }
+  async queryMamThreadPage(
+    w: string,
+    c: string,
+    threadId: string,
+    max = 100,
+    pageParam: MamPageParam = { type: "latest" },
+  ): Promise<MamHistoryPage<LiveRoomMessage>> {
+    await this.connect(); await this.switchRoom(w, c);
+    return this.xmpp
+      ? history.queryMamThreadPage(this.xmpp, this.roomJidForChannel(c), threadId, max, pageParam)
+      : { messages: [], complete: true };
   }
   async searchMessages(_spaceId: string, c: string, query: string, max = 20) {
     await this.connect();
@@ -1194,6 +1217,17 @@ export class BrowserXmppClient {
     await this.connect();
     const selfBare = barePeerJid(this.session.jid);
     return this.xmpp ? dmHistory.queryPersonalMam(this.xmpp, selfBare, barePeerJid(peerJid), max) : [];
+  }
+  async queryPersonalMamPage(
+    peerJid: string,
+    max = 100,
+    pageParam: MamPageParam = { type: "latest" },
+  ): Promise<MamHistoryPage<LiveDmMessage>> {
+    await this.connect();
+    const selfBare = barePeerJid(this.session.jid);
+    return this.xmpp
+      ? dmHistory.queryPersonalMamPage(this.xmpp, selfBare, barePeerJid(peerJid), max, pageParam)
+      : { messages: [], complete: true };
   }
   async searchDmMessages(peerJid: string, query: string, max = 20) {
     await this.connect();

--- a/chat/src/lib/xmpp/dm-history.ts
+++ b/chat/src/lib/xmpp/dm-history.ts
@@ -1,6 +1,6 @@
 import type { Agent } from "stanza";
 import type { ReceivedMessage } from "stanza/protocol";
-import type { LiveDmMessage } from "./types";
+import type { LiveDmMessage, MamHistoryPage, MamPageParam } from "./types";
 import { barePeerJid } from "./jid";
 import { dispatchChat } from "./dm-parsing";
 
@@ -28,6 +28,12 @@ function withArchivedMessageId(
     ...innerMsg,
     id: innerMsg.id ?? mamResultId ?? crypto.randomUUID(),
   } as ReceivedMessage;
+}
+
+function pagingForPageParam(max: number, pageParam: MamPageParam) {
+  return pageParam.type === "latest"
+    ? { max, before: "" }
+    : { max, before: pageParam.before };
 }
 
 export async function queryPersonalMam(
@@ -66,8 +72,23 @@ export async function queryPersonalMam(
     throw err;
   }
 
+  return parseDmMamResult(result, selfBareJid, peerBareJid).messages;
+}
+
+function parseDmMamResult(
+  result: Awaited<ReturnType<Agent["searchHistory"]>>,
+  selfBareJid: string,
+  peerBareJid: string,
+): MamHistoryPage<LiveDmMessage> {
   const collected: LiveDmMessage[] = [];
-  if (!result.results) return collected;
+  if (!result.results) {
+    return {
+      messages: collected,
+      firstArchiveId: result.paging?.first,
+      lastArchiveId: result.paging?.last,
+      complete: result.complete === true,
+    };
+  }
 
   for (const mamResult of result.results) {
     const innerMsg = mamResult.item?.message;
@@ -121,7 +142,38 @@ export async function queryPersonalMam(
     }
   }
 
-  return collected;
+  return {
+    messages: collected,
+    firstArchiveId: result.paging?.first,
+    lastArchiveId: result.paging?.last,
+    complete: result.complete === true,
+  };
+}
+
+export async function queryPersonalMamPage(
+  xmpp: Agent,
+  selfBareJid: string,
+  peerBareJid: string,
+  max: number,
+  pageParam: MamPageParam = { type: "latest" },
+): Promise<MamHistoryPage<LiveDmMessage>> {
+  const fields = [
+    { name: "FORM_TYPE", type: "hidden" as const, value: "urn:xmpp:mam:2" },
+    { name: "with", value: peerBareJid },
+  ];
+
+  let result;
+  try {
+    result = await xmpp.searchHistory(selfBareJid, {
+      paging: pagingForPageParam(max, pageParam),
+      form: { type: "submit", fields },
+    });
+  } catch (err) {
+    if (isItemNotFound(err)) return { messages: [], complete: true };
+    throw err;
+  }
+
+  return parseDmMamResult(result, selfBareJid, peerBareJid);
 }
 
 export async function searchDmMessages(

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -1,8 +1,14 @@
 /** XEP-0313 / XEP-0431: MAM history queries. */
 import type { Agent } from "stanza";
 import type { ReceivedMessage } from "stanza/protocol";
-import type { LiveRoomMessage } from "./types";
+import type { LiveRoomMessage, MamHistoryPage, MamPageParam } from "./types";
 import { dispatchGroupchat } from "./message-parsing";
+
+function pagingForPageParam(max: number, pageParam: MamPageParam) {
+  return pageParam.type === "latest"
+    ? { max, before: "" }
+    : { max, before: pageParam.before };
+}
 
 function withArchivedMessageId(
   mamResultId: string | undefined,
@@ -46,6 +52,13 @@ export async function queryMam(
         }
       : { paging: { max, before: "" } },
   );
+  return parseRoomMamResult(result, roomJid).messages;
+}
+
+function parseRoomMamResult(
+  result: Awaited<ReturnType<Agent["searchHistory"]>>,
+  roomJid: string,
+): MamHistoryPage<LiveRoomMessage> {
   const collected: LiveRoomMessage[] = [];
 
   if (result.results) {
@@ -98,7 +111,24 @@ export async function queryMam(
       }
     }
   }
-  return collected;
+  return {
+    messages: collected,
+    firstArchiveId: result.paging?.first,
+    lastArchiveId: result.paging?.last,
+    complete: result.complete === true,
+  };
+}
+
+export async function queryMamPage(
+  xmpp: Agent,
+  roomJid: string,
+  max: number,
+  pageParam: MamPageParam = { type: "latest" },
+): Promise<MamHistoryPage<LiveRoomMessage>> {
+  const result = await xmpp.searchHistory(roomJid, {
+    paging: pagingForPageParam(max, pageParam),
+  });
+  return parseRoomMamResult(result, roomJid);
 }
 
 /**
@@ -124,59 +154,29 @@ export async function queryMamByThread(
       ],
     },
   });
-  const collected: LiveRoomMessage[] = [];
+  return parseRoomMamResult(result, roomJid).messages;
+}
 
-  if (result.results) {
-    for (const mamResult of result.results) {
-      const innerMsg = mamResult.item?.message;
-      if (!innerMsg) continue;
+export async function queryMamThreadPage(
+  xmpp: Agent,
+  roomJid: string,
+  threadId: string,
+  max: number,
+  pageParam: MamPageParam = { type: "latest" },
+): Promise<MamHistoryPage<LiveRoomMessage>> {
+  if (!threadId) return { messages: [], complete: true };
 
-      const timestamp = mamResult.item.delay?.timestamp
-        ? mamResult.item.delay.timestamp.toISOString()
-        : new Date().toISOString();
-      const archivedMsg = withArchivedMessageId(mamResult.id, innerMsg as ReceivedMessage);
-      let parsedMessage: LiveRoomMessage | null = null;
-      let reactionUpdate: { targetId: string; emojis: string[]; nick: string } | null = null;
-
-      dispatchGroupchat(archivedMsg, {
-        currentRoom: roomJid,
-        selfNick: "",
-        onMessage: (msg) => {
-          parsedMessage = { ...msg, createdAt: timestamp };
-        },
-        onReaction: (event) => {
-          reactionUpdate = {
-            targetId: event.messageId,
-            emojis: event.emojis,
-            nick: event.nick,
-          };
-        },
-        onChatState: null,
-        onDisplayed: null,
-        onActivity: null,
-      });
-
-      if (parsedMessage) {
-        collected.push(parsedMessage);
-        continue;
-      }
-
-      if (reactionUpdate) {
-        const { nick, targetId, emojis } = reactionUpdate;
-        collected.push({
-          id: archivedMsg.id ?? crypto.randomUUID(),
-          roomJid,
-          nick,
-          body: "",
-          createdAt: timestamp,
-          type: "subject",
-          _reactionTarget: targetId,
-          _reactionEmojis: emojis,
-        });
-      }
-    }
-  }
-  return collected;
+  const result = await xmpp.searchHistory(roomJid, {
+    paging: pagingForPageParam(max, pageParam),
+    form: {
+      type: "submit",
+      fields: [
+        { name: "FORM_TYPE", type: "hidden", value: "urn:xmpp:mam:2" },
+        { name: "{urn:xmpp:mam:2}thread", value: threadId },
+      ],
+    },
+  });
+  return parseRoomMamResult(result, roomJid);
 }
 
 /** XEP-0431: Full-text search in MAM. Throws on IQ/transport errors. */

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -17,6 +17,17 @@ export interface XmppStatusSnapshot {
  */
 export type SessionLifecycleEvent = { type: "resumed" } | { type: "fresh" };
 
+export type MamPageParam =
+  | { type: "latest" }
+  | { type: "before"; before: string };
+
+export interface MamHistoryPage<T> {
+  messages: T[];
+  firstArchiveId?: string;
+  lastArchiveId?: string;
+  complete: boolean;
+}
+
 /**
  * Transport- or protocol-level failure classification, surfaced via
  * `BrowserXmppClient.onError` for telemetry / diagnostics. Different

--- a/chat/src/vue-app.ts
+++ b/chat/src/vue-app.ts
@@ -1,0 +1,15 @@
+import type { App } from "vue";
+import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+export default (app: App) => {
+  app.use(VueQueryPlugin, { queryClient });
+};

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import { ref } from "vue";
 import type { Agent } from "stanza";
-import { queryPersonalMam } from "../src/lib/xmpp/dm-history";
-import { queryMam } from "../src/lib/xmpp/history";
+import { queryPersonalMam, queryPersonalMamPage } from "../src/lib/xmpp/dm-history";
+import { queryMam, queryMamPage, queryMamThreadPage } from "../src/lib/xmpp/history";
 import { useDmMessaging } from "../src/composables/useDmMessaging";
 import { useMessaging } from "../src/composables/useMessaging";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
@@ -10,6 +10,14 @@ import { handlerStubs } from "./helpers/xmpp-client-mock";
 function makeMamAgent(results: unknown[]) {
   return {
     searchHistory: mock(async () => ({ results })),
+  } as unknown as Agent & {
+    searchHistory: ReturnType<typeof mock>;
+  };
+}
+
+function makeMamPageAgent(page: { results?: unknown[]; paging?: unknown; complete?: boolean }) {
+  return {
+    searchHistory: mock(async () => page),
   } as unknown as Agent & {
     searchHistory: ReturnType<typeof mock>;
   };
@@ -25,6 +33,26 @@ describe("MAM history parsing", () => {
       "room@muc.example.com",
       { paging: { max: 20, before: "" } },
     );
+  });
+
+  test("paged room history requests latest and older pages with RSM before cursors", async () => {
+    const xmpp = makeMamPageAgent({
+      results: [],
+      paging: { first: "archive-1", last: "archive-20" },
+      complete: false,
+    });
+
+    const latest = await queryMamPage(xmpp, "room@muc.example.com", 20, { type: "latest" });
+    const older = await queryMamPage(xmpp, "room@muc.example.com", 20, {
+      type: "before",
+      before: "archive-1",
+    });
+
+    expect(xmpp.searchHistory.mock.calls[0]?.[1]).toEqual({ paging: { max: 20, before: "" } });
+    expect(xmpp.searchHistory.mock.calls[1]?.[1]).toEqual({ paging: { max: 20, before: "archive-1" } });
+    expect(latest.firstArchiveId).toBe("archive-1");
+    expect(latest.lastArchiveId).toBe("archive-20");
+    expect(older.complete).toBe(false);
   });
 
   test("parses archived room reactions, corrections, and retractions with original stanza IDs", async () => {
@@ -199,6 +227,49 @@ describe("MAM history parsing", () => {
         paging: { max: 20, before: "" },
       }),
     );
+  });
+
+  test("paged DM history keeps the with filter and uses RSM before cursors", async () => {
+    const xmpp = makeMamPageAgent({
+      results: [],
+      paging: { first: "dm-1", last: "dm-20" },
+      complete: true,
+    });
+
+    const page = await queryPersonalMamPage(
+      xmpp,
+      "alice@example.com",
+      "bob@example.com",
+      20,
+      { type: "before", before: "dm-1" },
+    );
+
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    expect(callArgs?.[0]).toBe("alice@example.com");
+    expect((callArgs?.[1] as { paging?: unknown })?.paging).toEqual({ max: 20, before: "dm-1" });
+    const fields =
+      ((callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form?.fields) ?? [];
+    expect(fields.find((field) => field.name === "with")?.value).toBe("bob@example.com");
+    expect(page.firstArchiveId).toBe("dm-1");
+    expect(page.complete).toBe(true);
+  });
+
+  test("paged thread history uses the XEP-0313 thread form field and RSM before cursor", async () => {
+    const xmpp = makeMamPageAgent({ results: [], paging: { first: "thread-1" }, complete: false });
+
+    await queryMamThreadPage(
+      xmpp,
+      "room@muc.example.com",
+      "thread-42",
+      20,
+      { type: "before", before: "thread-1" },
+    );
+
+    const callArgs = xmpp.searchHistory.mock.calls[0];
+    expect((callArgs?.[1] as { paging?: unknown })?.paging).toEqual({ max: 20, before: "thread-1" });
+    const fields =
+      ((callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form?.fields) ?? [];
+    expect(fields.find((field) => field.name === "{urn:xmpp:mam:2}thread")?.value).toBe("thread-42");
   });
 
   // Reconnect catch-up: an iPhone/Safari session that drops its websocket


### PR DESCRIPTION
## Plan

- Add `@tanstack/vue-query` and `@tanstack/vue-virtual` to `chat/` with Bun.
- Configure Vue Query through Astro's Vue `appEntrypoint` and `VueQueryPlugin`.
- Add typed paged MAM interfaces and paged XMPP client methods for room, DM, and thread history while keeping existing catch-up `start`/`end` behavior.
- Use XEP-0313 and XEP-0059 RSM paging only: latest pages with `before: ""`, older pages with `before: firstArchiveId`.
- Add a shared virtual timeline component using TanStack Virtual with dynamic measurement, stable keys, overscan, older-history sentinel, and exposed scroll element.
- Replace plain message `v-for` rendering in `ContentArea.vue` and `ThreadPanel.vue` with the virtual timeline.
- Preserve existing behavior for day dividers, new-message divider, grouped messages, current-day marker, reply/search jumps, optimistic sends, queued messages, edits, retractions, reactions, and live XMPP appends.
- Add load-older paths guarded by TanStack Query's single-fetch state to avoid overlapping page fetches.

## Implementation Notes

- `src/vue-app.ts` installs `VueQueryPlugin` through Astro's Vue `appEntrypoint`.
- Room, DM, and thread MAM page fetches use XEP-0313 plus XEP-0059 RSM `before` cursors only.
- `VirtualTimeline.vue` unwraps reactive options before passing them to TanStack Virtual so timelines render rows on initial open.
- `ContentArea.vue` and `ThreadPanel.vue` use the shared virtual timeline while preserving existing scroll roots and message slots.
- `src/composables/useMessaging.ts` and `src/composables/useDmMessaging.ts` guard older-page loads and stale conversation switches.

## Knip Note

`src/vue-app.ts` is a targeted `knip` entry because Astro consumes it through Vue `appEntrypoint`; this keeps `@tanstack/vue-query` visible without broad ignores.

## Test Plan

- Add MAM history tests for latest, older, DM, room, and thread queries and page cursor parsing.
- Add messaging composable coverage for initial load, older-page merge, dedupe, pending update application, queued-message preservation, and request cancellation on conversation switch.
- Preserve scroll behavior for `chat` and `social` modes through existing scroll-direction tests and virtual timeline integration.
- Preserve thread behavior for virtualized root/replies, older reply paging, and unchanged missing-root warning behavior.
- Run `cd chat && bun test && bun run lint && bun run build`.

## Verification

- `cd chat && bun test`
- `cd chat && bun run lint`
- `cd chat && bun run build`

## XEP Review

Checked local `xeps/xep-0313.xml`, `xeps/xep-0059.xml`, and `xeps/xep-0201.xml`.