### PR TITLE
fix(chat): anchor timelines to active edge

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -24,6 +24,7 @@ import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import ContentArea from "@/components/chat/ContentArea.vue";
 import ThreadPanel from "@/components/chat/ThreadPanel.vue";
+import type { ScrollDirectionMode } from "@/lib/scroll-direction";
 import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
@@ -92,21 +93,30 @@ const dmMessaging = useDmMessaging(
   ui.clearActionError,
 );
 
-const contentAreaRef = ref<ComponentPublicInstance & { messagesContainer: HTMLDivElement | null } | null>(null);
+type ContentAreaHandle = ComponentPublicInstance & {
+  messagesContainer: HTMLDivElement | null;
+  scrollToPinnedEdge: (mode: ScrollDirectionMode) => Promise<boolean>;
+};
+const contentAreaRef = ref<ContentAreaHandle | null>(null);
 const setContentAreaRef = (
-  instance: (ComponentPublicInstance & { messagesContainer: HTMLDivElement | null }) | null,
+  instance: ContentAreaHandle | null,
 ) => {
   contentAreaRef.value = instance;
 };
 
 watchEffect(() => {
   const timeline = contentAreaRef.value?.messagesContainer ?? null;
+  const edgeScroller = contentAreaRef.value?.scrollToPinnedEdge ?? null;
   if (ui.sidebarMode.value === "dms") {
     dmMessaging.timelineEl.value = timeline;
+    dmMessaging.timelineEdgeScroller.value = edgeScroller;
     messaging.timelineEl.value = null;
+    messaging.timelineEdgeScroller.value = null;
   } else {
     messaging.timelineEl.value = timeline;
+    messaging.timelineEdgeScroller.value = edgeScroller;
     dmMessaging.timelineEl.value = null;
+    dmMessaging.timelineEdgeScroller.value = null;
   }
 });
 

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -6,8 +6,10 @@ import { getConnectionNoticeCopy } from "@/lib/connection-notice";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import {
+  getPinnedScrollTop,
   getNewMessagesDividerPlacement,
   orderTimelineForScrollDirection,
+  type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
 import { extractFilesFromEvent } from "@/lib/xmpp/file-upload";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
@@ -217,19 +219,18 @@ function onSelectGif(url: string) {
 }
 
 const messagesContainer = ref<HTMLDivElement | null>(null);
-const virtualTimelineRef = ref<(ComponentPublicInstance & {
+type VirtualTimelineHandle = ComponentPublicInstance & {
   scrollElement: HTMLDivElement | null;
   scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
-}) | null>(null);
+  scrollToPinnedEdge: (mode: ScrollDirectionMode) => Promise<boolean>;
+};
+const virtualTimelineRef = ref<VirtualTimelineHandle | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
   messagesContainer.value = el;
   void nextTick(updateCurrentDayMarker);
 };
 const setVirtualTimelineRef = (
-  instance: (ComponentPublicInstance & {
-    scrollElement: HTMLDivElement | null;
-    scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
-  }) | null,
+  instance: VirtualTimelineHandle | null,
 ) => {
   virtualTimelineRef.value = instance;
   setMessagesContainer(instance?.scrollElement ?? null);
@@ -355,7 +356,16 @@ const updateNoticeBody = computed(() =>
     : "A newer version is ready. Refresh to load it.",
 );
 
-defineExpose({ messagesContainer });
+async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
+  if (await virtualTimelineRef.value?.scrollToPinnedEdge(mode)) return true;
+  await nextTick();
+  const el = messagesContainer.value;
+  if (!el) return false;
+  el.scrollTop = getPinnedScrollTop(el, mode);
+  return true;
+}
+
+defineExpose({ messagesContainer, scrollToPinnedEdge });
 
 function doSearch() {
   emit("search", searchInput.value);

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch, type ComponentPublicInstance } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance, type Ref } from "vue";
 import { X, CornerDownRight, MessageSquarePlus, ChevronRight, ChevronLeft } from "lucide-vue-next";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
@@ -9,7 +9,12 @@ import type { MentionCandidate } from "@/lib/mentions";
 import type { OccupantHat, OccupantPresence, RoomHats, RoomPresence } from "@/lib/xmpp-client";
 import type { ThreadEntry, ThreadIndex } from "@/composables/useThreads";
 import { useScrollDirection } from "@/composables/useScrollDirection";
-import { isTopPinnedScrollDirection, orderTimelineForScrollDirection, getPinnedScrollTop } from "@/lib/scroll-direction";
+import {
+  isTopPinnedScrollDirection,
+  orderTimelineForScrollDirection,
+  type ScrollDirectionMode,
+} from "@/lib/scroll-direction";
+import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
 import { formatDayDivider, isSameDay } from "@/composables/useMessaging";
 
 const props = defineProps<{
@@ -81,6 +86,11 @@ const orderedThreadMessages = computed(() => {
   const root = activeEntry.value?.root;
   return root ? [root, ...orderedChildren.value] : [...orderedChildren.value];
 });
+const newestThreadMessageId = computed(() =>
+  activeEntry.value?.directChildren.at(-1)?.id
+    ?? activeEntry.value?.root?.id
+    ?? null,
+);
 
 // Burst window matches the main feed (ContentArea.vue): same author + < 5 min
 // apart + same day, no intervening other-author message in rendered order.
@@ -126,26 +136,58 @@ const isTopPinned = computed(() =>
 const olderSentinelPosition = computed(() => scrollDirectionMode.value === "social" ? "end" : "start");
 
 const scrollContainerRef = ref<HTMLElement | null>(null);
+const virtualTimelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
+const pinnedEdgeScroller = createPinnedEdgeScroller({
+  element: scrollContainerRef,
+  mode: scrollDirectionMode,
+  virtualScroll: virtualTimelineEdgeScroller,
+});
 const currentDayMarkerLabel = ref("");
 const draft = ref("");
 const replyingTo = ref<{ id: string; author: string; body?: string } | null>(null);
+let olderLoadSnapshot: {
+  element: HTMLElement;
+  height: number;
+  mode: ScrollDirectionMode;
+  threadId: string | null;
+  top: number;
+  token: number;
+} | null = null;
+let olderLoadRestoreToken = 0;
 
 type ComposerHandle = { focus: () => void };
 const composerRef = ref<ComposerHandle | null>(null);
+type VirtualTimelineHandle = ComponentPublicInstance & {
+  scrollElement: HTMLDivElement | null;
+  scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
+};
 
 function setComposerRef(el: ComposerHandle | null) {
   composerRef.value = el;
 }
 
 async function scrollToPinnedEdge() {
-  // Two ticks: first lets Vue flush the DOM update, second gives the browser
-  // time to recalculate layout (scrollHeight) before we set scrollTop.
-  await nextTick();
-  await nextTick();
-  const el = scrollContainerRef.value;
-  if (!el) return;
-  el.scrollTop = getPinnedScrollTop(el, scrollDirectionMode.value);
+  await pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
   updateCurrentDayMarker();
+}
+
+function newestRenderedMessage() {
+  return orderedChildren.value[0]
+    ?? activeEntry.value?.root
+    ?? null;
+}
+
+function oldestRenderedMessage() {
+  const children = orderedChildren.value;
+  return children[children.length - 1]
+    ?? activeEntry.value?.root
+    ?? null;
+}
+
+function activeEdgeMessage(mode: ScrollDirectionMode) {
+  return isTopPinnedScrollDirection(mode)
+    ? newestRenderedMessage()
+    : (orderedThreadMessages.value[orderedThreadMessages.value.length - 1] ?? oldestRenderedMessage());
 }
 
 function updateCurrentDayMarker() {
@@ -187,10 +229,18 @@ function setScrollContainerRef(el: HTMLElement | null) {
   void nextTick(updateCurrentDayMarker);
 }
 
-const setVirtualTimelineRef = (
-  instance: (ComponentPublicInstance & { scrollElement: HTMLDivElement | null }) | null,
-) => {
+const setVirtualTimelineRef = (instance: VirtualTimelineHandle | null) => {
   setScrollContainerRef(instance?.scrollElement ?? null);
+  virtualTimelineEdgeScroller.value = instance
+    ? async (mode) => {
+        const target = activeEdgeMessage(mode);
+        if (!target) return false;
+        return instance.scrollToMessageId(
+          target.id,
+          isTopPinnedScrollDirection(mode) ? "start" : "end",
+        );
+      }
+    : null;
 };
 
 // Switching threads resets composer state and scrolls to the pinned edge.
@@ -205,12 +255,61 @@ watch(scrollDirectionMode, () => {
 });
 
 watch(
+  () => props.isLoadingOlderReplies,
+  (loading, wasLoading) => {
+    if (loading) {
+      pinnedEdgeScroller.disconnect();
+      const el = scrollContainerRef.value;
+      olderLoadRestoreToken++;
+      olderLoadSnapshot = el
+        ? {
+            element: el,
+            height: el.scrollHeight,
+            mode: scrollDirectionMode.value,
+            threadId: activeThreadId.value,
+            top: el.scrollTop,
+            token: olderLoadRestoreToken,
+          }
+        : null;
+      return;
+    }
+    if (!wasLoading || !olderLoadSnapshot) return;
+    const snapshot = olderLoadSnapshot;
+    olderLoadSnapshot = null;
+    void nextTick(() => {
+      const el = scrollContainerRef.value;
+      if (
+        !props.isLoadingOlderReplies
+        && snapshot.token === olderLoadRestoreToken
+        && el === snapshot.element
+        && activeThreadId.value === snapshot.threadId
+        && scrollDirectionMode.value === snapshot.mode
+        && !isTopPinnedScrollDirection(scrollDirectionMode.value)
+      ) {
+        el.scrollTop = snapshot.top + (el.scrollHeight - snapshot.height);
+      }
+      updateCurrentDayMarker();
+    });
+  },
+);
+
+watch(
   [activeEntry, orderedChildren],
   () => {
     void nextTick(updateCurrentDayMarker);
   },
   { flush: "post" },
 );
+
+watch(newestThreadMessageId, (newest, previousNewest) => {
+  if (newest && previousNewest && newest !== previousNewest) {
+    void scrollToPinnedEdge();
+  }
+});
+
+onBeforeUnmount(() => {
+  pinnedEdgeScroller.disconnect();
+});
 
 const breadcrumbLabels = computed(() =>
   props.threadStack.map((id) => {

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -2,6 +2,10 @@
 import { computed, nextTick, ref, watch, watchEffect } from "vue";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import {
+  isTopPinnedScrollDirection,
+  type ScrollDirectionMode,
+} from "@/lib/scroll-direction";
 
 const props = withDefaults(defineProps<{
   items: TimelineMessage[];
@@ -67,7 +71,18 @@ async function scrollToMessageId(messageId: string, align: "start" | "center" | 
   return true;
 }
 
-defineExpose({ scrollElement, scrollToMessageId });
+async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
+  if (props.items.length === 0) return false;
+  const itemIndex = isTopPinnedScrollDirection(mode) ? 0 : props.items.length - 1;
+  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
+  virtualizer.value.scrollToIndex(itemIndex + offset, {
+    align: isTopPinnedScrollDirection(mode) ? "start" : "end",
+  });
+  await nextTick();
+  return true;
+}
+
+defineExpose({ scrollElement, scrollToMessageId, scrollToPinnedEdge });
 </script>
 
 <template>

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -828,6 +828,17 @@ export function useDmMessaging(
     void alignTimelineToPreference();
   });
 
+  watch(
+    [timelineEl, timelineEdgeScroller],
+    ([el, edgeScroller]) => {
+      if (!el || !edgeScroller || isLoadingMessages.value) return;
+      if (!messages.value.some(isFeedVisible)) return;
+      firstUnseenId.value = null;
+      void scrollToPinnedEdgeAndPin();
+    },
+    { flush: "post" },
+  );
+
   return {
     messages,
     firstUnseenId,

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -26,8 +26,9 @@ import {
   mergeMessageIds,
 } from "@/lib/message-ids";
 import { findMessageElementById } from "@/lib/message-targeting";
-import { getPinnedScrollTop, isTopPinnedScrollDirection } from "@/lib/scroll-direction";
-import { dmKey, getLastSeen, setLastSeen } from "@/lib/last-seen-store";
+import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
+import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
+import { dmKey, setLastSeen } from "@/lib/last-seen-store";
 import {
   listQueuedDmMessages,
   type PersistedQueuedDmMessage,
@@ -125,6 +126,12 @@ export function useDmMessaging(
   const hasOlderMessages = ref(true);
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
+  const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
+  const pinnedEdgeScroller = createPinnedEdgeScroller({
+    element: timelineEl,
+    mode: scrollDirection,
+    virtualScroll: timelineEdgeScroller,
+  });
   const typingUsers = ref<string[]>([]);
   const searchResults = ref<{ id: string; nick: string; body: string; createdAt: string }[]>([]);
   const isSearching = ref(false);
@@ -156,29 +163,11 @@ export function useDmMessaging(
   }
 
   async function scrollToPinnedEdge() {
-    await nextTick();
-    await nextTick();
-    const el = timelineEl.value;
-    if (!el) return;
-    el.scrollTop = getPinnedScrollTop(el, scrollDirection.value);
+    await pinnedEdgeScroller.scrollToPinnedEdge();
   }
 
-  // Initial-load variant: re-pin for ~500ms so late layout (images, avatars,
-  // markup reflow) doesn't strand the user above the newest message. Not
-  // used per-message — ResizeObserver allocation per live message would be
-  // O(n) overhead. Same pattern as useMessaging.ts.
   async function scrollToPinnedEdgeAndPin() {
-    await scrollToPinnedEdge();
-    const el = timelineEl.value;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
-      el.scrollTop = getPinnedScrollTop(el, scrollDirection.value);
-    });
-    observer.observe(el);
-    for (const child of Array.from(el.children)) {
-      observer.observe(child);
-    }
-    setTimeout(() => observer.disconnect(), 500);
+    await pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
   }
 
   async function scrollFirstUnseenIntoView(messageId: string) {
@@ -439,7 +428,7 @@ export function useDmMessaging(
     const peerJid = activePeerJid.value;
     messages.value = [...messages.value, msg];
     // Always snaps to the active edge, so last-seen advances in lockstep.
-    void scrollToPinnedEdge();
+    void scrollToPinnedEdgeAndPin();
     if (peerJid && isFeedVisible(msg)) {
       setLastSeen(dmKey(barePeerJid(peerJid)), msg.id);
     }
@@ -503,6 +492,7 @@ export function useDmMessaging(
     isLoadingOlderMessages.value = false;
     hasOlderMessages.value = true;
     oldestArchiveId = null;
+    pinnedEdgeScroller.disconnect();
     firstUnseenId.value = null;
     clearActionError();
     pendingEchoClientIds.clear();
@@ -524,27 +514,11 @@ export function useDmMessaging(
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) isLoadingMessages.value = false;
 
-      // See useMessaging.loadMessages — same last-seen anchor semantics,
-      // keyed by peer bare JID. Anchor is computed against feed-visible
-      // messages so it always matches something ContentArea renders.
       const key = dmKey(barePeerJid(peerJid));
-      const lastSeenId = getLastSeen(key);
-      const lastSeenIdx = lastSeenId
-        ? timelineWithQueue.findIndex((m) => matchMessageId(m, lastSeenId))
-        : -1;
-      const firstUnseen =
-        lastSeenIdx !== -1 && lastSeenIdx < timelineWithQueue.length - 1
-          ? timelineWithQueue.slice(lastSeenIdx + 1).find(isFeedVisible)
-          : undefined;
-      if (firstUnseen) {
-        firstUnseenId.value = firstUnseen.id;
-        await scrollFirstUnseenIntoView(firstUnseen.id);
-      } else {
-        firstUnseenId.value = null;
-        await scrollToPinnedEdgeAndPin();
-        const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
-        if (newest) setLastSeen(key, newest.id);
-      }
+      firstUnseenId.value = null;
+      await scrollToPinnedEdgeAndPin();
+      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
+      if (newest) setLastSeen(key, newest.id);
     } catch (e) {
       if (requestId === messageRequestId) {
         const queuedOnly = appendQueuedMessages([], peerJid);
@@ -682,7 +656,7 @@ export function useDmMessaging(
             }));
           }
           messages.value = [...messages.value, optimistic];
-          void scrollToPinnedEdge();
+          void scrollToPinnedEdgeAndPin();
         }
         if (fromComposer) draft.value = "";
         if (composingTimeout) {
@@ -798,6 +772,7 @@ export function useDmMessaging(
 
   function clearMessages() {
     messageRequestId++;
+    pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
     messages.value = [];
     isLoadingMessages.value = false;
@@ -808,6 +783,7 @@ export function useDmMessaging(
   function disconnect() {
     messageRequestId++;
     searchRequestId++;
+    pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
     isLoadingMessages.value = false;
     isSearching.value = false;
@@ -862,6 +838,7 @@ export function useDmMessaging(
     isSending,
     typingUsers,
     timelineEl,
+    timelineEdgeScroller,
     searchResults,
     isSearching,
     loadMessages,

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -140,6 +140,7 @@ export function useDmMessaging(
 
   let messageRequestId = 0;
   let oldestArchiveId: string | null = null;
+  let initialLatestPagePinned = false;
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -167,7 +168,7 @@ export function useDmMessaging(
   }
 
   async function scrollToPinnedEdgeAndPin() {
-    await pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
+    return pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
   }
 
   async function scrollFirstUnseenIntoView(messageId: string) {
@@ -488,6 +489,7 @@ export function useDmMessaging(
   async function loadMessages(peerJid: string) {
     if (!session.value) return;
     const requestId = ++messageRequestId;
+    initialLatestPagePinned = false;
     isLoadingMessages.value = true;
     isLoadingOlderMessages.value = false;
     hasOlderMessages.value = true;
@@ -516,7 +518,9 @@ export function useDmMessaging(
 
       const key = dmKey(barePeerJid(peerJid));
       firstUnseenId.value = null;
-      await scrollToPinnedEdgeAndPin();
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) setLastSeen(key, newest.id);
     } catch (e) {
@@ -533,7 +537,9 @@ export function useDmMessaging(
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     const before = oldestArchiveId;
-    if (!client || !peerJid || !before || !hasOlderMessages.value || isLoadingOlderMessages.value) return;
+    if (!client || !peerJid || !before || !initialLatestPagePinned || !hasOlderMessages.value || isLoadingOlderMessages.value) {
+      return;
+    }
     if (!("queryPersonalMamPage" in client)) return;
     const requestId = messageRequestId;
     const isCurrentRequest = () =>
@@ -774,6 +780,10 @@ export function useDmMessaging(
     messageRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
     messages.value = [];
     isLoadingMessages.value = false;
     firstUnseenId.value = null;
@@ -785,6 +795,10 @@ export function useDmMessaging(
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
     isLoadingMessages.value = false;
     isSearching.value = false;
     firstUnseenId.value = null;
@@ -830,11 +844,23 @@ export function useDmMessaging(
 
   watch(
     [timelineEl, timelineEdgeScroller],
-    ([el, edgeScroller]) => {
+    async ([el, edgeScroller]) => {
       if (!el || !edgeScroller || isLoadingMessages.value) return;
       if (!messages.value.some(isFeedVisible)) return;
+      const requestId = messageRequestId;
+      const peerJid = activePeerJid.value;
       firstUnseenId.value = null;
-      void scrollToPinnedEdgeAndPin();
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (
+        pinned &&
+        requestId === messageRequestId &&
+        activePeerJid.value === peerJid &&
+        messages.value.some(isFeedVisible)
+      ) {
+        initialLatestPagePinned = true;
+        const newest = [...messages.value].reverse().find(isFeedVisible);
+        if (peerJid && newest) setLastSeen(dmKey(barePeerJid(peerJid)), newest.id);
+      }
     },
     { flush: "post" },
   );

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -1359,6 +1359,17 @@ export function useMessaging(
     void alignTimelineToPreference();
   });
 
+  watch(
+    [timelineEl, timelineEdgeScroller],
+    ([el, edgeScroller]) => {
+      if (!el || !edgeScroller || isLoadingMessages.value) return;
+      if (!messages.value.some(isFeedVisible)) return;
+      firstUnseenId.value = null;
+      void scrollToPinnedEdgeAndPin();
+    },
+    { flush: "post" },
+  );
+
   return {
     xmppStatus,
     messages,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -31,8 +31,9 @@ import {
   mergeMessageIds,
 } from "@/lib/message-ids";
 import { findMessageElementById } from "@/lib/message-targeting";
-import { getPinnedScrollTop, isTopPinnedScrollDirection } from "@/lib/scroll-direction";
-import { getLastSeen, roomKey, setLastSeen } from "@/lib/last-seen-store";
+import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
+import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
+import { roomKey, setLastSeen } from "@/lib/last-seen-store";
 import {
   listQueuedRoomMessages,
   type PersistedQueuedRoomMessage,
@@ -252,6 +253,12 @@ export function useMessaging(
   const threadHasOlder = ref<Record<string, boolean>>({});
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
+  const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
+  const pinnedEdgeScroller = createPinnedEdgeScroller({
+    element: timelineEl,
+    mode: scrollDirection,
+    virtualScroll: timelineEdgeScroller,
+  });
   const typingUsers = ref<string[]>([]);
   const roomHats = ref<RoomHats>({});
   const roomPresence = ref<RoomPresence>({});
@@ -470,29 +477,11 @@ export function useMessaging(
   }
 
   async function scrollToPinnedEdge() {
-    await nextTick();
-    await nextTick();
-    const el = timelineEl.value;
-    if (!el) return;
-    el.scrollTop = getPinnedScrollTop(el, scrollDirection.value);
+    await pinnedEdgeScroller.scrollToPinnedEdge();
   }
 
-  // Initial-load variant: after scrolling, re-pin for ~500ms via a
-  // ResizeObserver so late layout (images, avatars, markup reflow) doesn't
-  // strand the user above the newest message. Not used per-message —
-  // ResizeObserver allocation per live message would be O(n) overhead.
   async function scrollToPinnedEdgeAndPin() {
-    await scrollToPinnedEdge();
-    const el = timelineEl.value;
-    if (!el || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => {
-      el.scrollTop = getPinnedScrollTop(el, scrollDirection.value);
-    });
-    observer.observe(el);
-    for (const child of Array.from(el.children)) {
-      observer.observe(child);
-    }
-    setTimeout(() => observer.disconnect(), 500);
+    await pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
   }
 
   function persistLastSeen(channelId: string, messageId: string) {
@@ -691,7 +680,7 @@ export function useMessaging(
     // mergeLiveMessage always snaps to the active edge, so last-seen should advance
     // in lockstep regardless of the user's prior scroll position — if we're
     // scrolling them to the message, by definition they can see it.
-    void scrollToPinnedEdge();
+    void scrollToPinnedEdgeAndPin();
     if (channelId && isFeedVisible(msg)) {
       persistLastSeen(channelId, msg.id);
     }
@@ -880,6 +869,7 @@ export function useMessaging(
     loadingOlderThreadIds.value = new Set();
     threadHasOlder.value = {};
     oldestThreadArchiveIds.clear();
+    pinnedEdgeScroller.disconnect();
     // Reset the divider anchor up-front: a previous conversation's id could
     // coincidentally match a message in the new timeline, and an aborted
     // request (requestId mismatch) would otherwise leave stale state.
@@ -915,29 +905,10 @@ export function useMessaging(
         isLoadingMessages.value = false;
       }
 
-      // Restore scroll position: if we have a last-seen anchor that's still
-      // in the MAM window AND there are unseen *feed-visible* messages after
-      // it, park the view on the first such message and render a divider
-      // above it. ContentArea renders `feedMessages` (thread replies hidden),
-      // so the anchor must match something actually rendered. Otherwise
-      // scroll to bottom and track the newest feed message as last-seen.
-      const lastSeenId = getLastSeen(roomKey(channelId));
-      const lastSeenIdx = lastSeenId
-        ? timelineWithQueue.findIndex((m) => matchMessageId(m, lastSeenId))
-        : -1;
-      const firstUnseen =
-        lastSeenIdx !== -1 && lastSeenIdx < timelineWithQueue.length - 1
-          ? timelineWithQueue.slice(lastSeenIdx + 1).find(isFeedVisible)
-          : undefined;
-      if (firstUnseen) {
-        firstUnseenId.value = firstUnseen.id;
-        await scrollFirstUnseenIntoView(firstUnseen.id);
-      } else {
-        firstUnseenId.value = null;
-        await scrollToPinnedEdgeAndPin();
-        const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
-        if (newest) persistLastSeen(channelId, newest.id);
-      }
+      firstUnseenId.value = null;
+      await scrollToPinnedEdgeAndPin();
+      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
+      if (newest) persistLastSeen(channelId, newest.id);
     } catch (e) {
       if (requestId === messageRequestId) {
         const queuedOnly = appendQueuedMessages([], roomJid);
@@ -1195,7 +1166,7 @@ export function useMessaging(
         }
         pendingEchoClientIds.add(msgId);
         messages.value = applyForumContext([...messages.value, optimistic]);
-        void scrollToPinnedEdge();
+        void scrollToPinnedEdgeAndPin();
       }
 
       // Clear draft on successful send (triggers ChatEditor clear via watcher)
@@ -1317,6 +1288,7 @@ export function useMessaging(
   function disconnect() {
     messageRequestId++;
     searchRequestId++;
+    pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
     // $xmppStatus is authoritative and owned by XmppProvider; do not write it here.
     clearTypingState();
@@ -1327,6 +1299,7 @@ export function useMessaging(
 
   function clearMessages() {
     messageRequestId++;
+    pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
     messages.value = [];
     isLoadingMessages.value = false;
@@ -1397,6 +1370,7 @@ export function useMessaging(
     hasOlderMessages,
     isSending,
     timelineEl,
+    timelineEdgeScroller,
     currentRoomJid,
     typingUsers,
     roomHats,

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -276,6 +276,7 @@ export function useMessaging(
 
   let messageRequestId = 0;
   let oldestArchiveId: string | null = null;
+  let initialLatestPagePinned = false;
   const oldestThreadArchiveIds = new Map<string, string>();
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
@@ -481,7 +482,7 @@ export function useMessaging(
   }
 
   async function scrollToPinnedEdgeAndPin() {
-    await pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
+    return pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
   }
 
   function persistLastSeen(channelId: string, messageId: string) {
@@ -862,6 +863,7 @@ export function useMessaging(
 
     const requestId = ++messageRequestId;
     const roomJid = roomBareJidFor(session.value, channelId);
+    initialLatestPagePinned = false;
     isLoadingMessages.value = true;
     isLoadingOlderMessages.value = false;
     hasOlderMessages.value = true;
@@ -906,7 +908,16 @@ export function useMessaging(
       }
 
       firstUnseenId.value = null;
-      await scrollToPinnedEdgeAndPin();
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (
+        !pinned ||
+        requestId !== messageRequestId ||
+        (activeSpaceId.value ?? "") !== spaceId ||
+        activeChannelId.value !== channelId
+      ) {
+        return;
+      }
+      initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) persistLastSeen(channelId, newest.id);
     } catch (e) {
@@ -924,7 +935,16 @@ export function useMessaging(
     const spaceId = activeSpaceId.value ?? "";
     const channelId = activeChannelId.value;
     const before = oldestArchiveId;
-    if (!client || !channelId || !before || !hasOlderMessages.value || isLoadingOlderMessages.value) return;
+    if (
+      !client ||
+      !channelId ||
+      !before ||
+      !initialLatestPagePinned ||
+      !hasOlderMessages.value ||
+      isLoadingOlderMessages.value
+    ) {
+      return;
+    }
     if (!("queryMamPage" in client)) return;
     const requestId = messageRequestId;
     const isCurrentRequest = () =>
@@ -1290,6 +1310,10 @@ export function useMessaging(
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
     // $xmppStatus is authoritative and owned by XmppProvider; do not write it here.
     clearTypingState();
     isLoadingMessages.value = false;
@@ -1301,6 +1325,10 @@ export function useMessaging(
     messageRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
     messages.value = [];
     isLoadingMessages.value = false;
     clearTypingState();
@@ -1361,11 +1389,25 @@ export function useMessaging(
 
   watch(
     [timelineEl, timelineEdgeScroller],
-    ([el, edgeScroller]) => {
+    async ([el, edgeScroller]) => {
       if (!el || !edgeScroller || isLoadingMessages.value) return;
       if (!messages.value.some(isFeedVisible)) return;
+      const requestId = messageRequestId;
+      const spaceId = activeSpaceId.value ?? "";
+      const channelId = activeChannelId.value;
       firstUnseenId.value = null;
-      void scrollToPinnedEdgeAndPin();
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (
+        pinned &&
+        requestId === messageRequestId &&
+        (activeSpaceId.value ?? "") === spaceId &&
+        activeChannelId.value === channelId &&
+        messages.value.some(isFeedVisible)
+      ) {
+        initialLatestPagePinned = true;
+        const newest = [...messages.value].reverse().find(isFeedVisible);
+        if (channelId && newest) persistLastSeen(channelId, newest.id);
+      }
     },
     { flush: "post" },
   );

--- a/chat/src/lib/last-seen-store.ts
+++ b/chat/src/lib/last-seen-store.ts
@@ -22,16 +22,6 @@ function storage(): Storage | null {
   }
 }
 
-export function getLastSeen(key: string): string | null {
-  const s = storage();
-  if (!s) return null;
-  try {
-    return s.getItem(key);
-  } catch {
-    return null;
-  }
-}
-
 export function setLastSeen(key: string, messageId: string): void {
   const s = storage();
   if (!s) return;

--- a/chat/src/lib/pinned-edge-scroll.ts
+++ b/chat/src/lib/pinned-edge-scroll.ts
@@ -1,0 +1,111 @@
+import { nextTick, watch, type Ref } from "vue";
+import {
+  getPinnedScrollTop,
+  type ScrollDirectionMode,
+} from "@/lib/scroll-direction";
+
+type EdgeScrollFn = (mode: ScrollDirectionMode) => boolean | Promise<boolean>;
+type ScrollTarget = {
+  element: HTMLElement | null;
+  mode: ScrollDirectionMode;
+  token: number;
+  virtualScroll: EdgeScrollFn | null;
+};
+
+export function createPinnedEdgeScroller(options: {
+  element: Ref<HTMLElement | null>;
+  mode: Ref<ScrollDirectionMode>;
+  virtualScroll?: Ref<EdgeScrollFn | null>;
+}) {
+  let settleObserver: ResizeObserver | null = null;
+  let settleTimer: ReturnType<typeof setTimeout> | null = null;
+  let generation = 0;
+  let settleGeneration = 0;
+
+  function disconnectSettleLock() {
+    generation++;
+    if (settleTimer) {
+      clearTimeout(settleTimer);
+      settleTimer = null;
+    }
+    settleObserver?.disconnect();
+    settleObserver = null;
+  }
+
+  function captureTarget(): ScrollTarget {
+    return {
+      element: options.element.value,
+      mode: options.mode.value,
+      token: generation,
+      virtualScroll: options.virtualScroll?.value ?? null,
+    };
+  }
+
+  async function pinTarget(target: ScrollTarget): Promise<boolean> {
+    if (target.virtualScroll && await target.virtualScroll(target.mode)) {
+      return target.token === generation;
+    }
+    if (target.token !== generation) return false;
+
+    if (!target.element) return false;
+    target.element.scrollTop = getPinnedScrollTop(target.element, target.mode);
+    return true;
+  }
+
+  async function pinCurrent(token: number): Promise<boolean> {
+    const target = captureTarget();
+    if (target.virtualScroll && await target.virtualScroll(target.mode)) {
+      return target.token === generation && token === generation;
+    }
+    if (target.token !== generation || token !== generation) return false;
+
+    const currentElement = options.element.value;
+    if (!currentElement) return false;
+    currentElement.scrollTop = getPinnedScrollTop(currentElement, options.mode.value);
+    return true;
+  }
+
+  function refreshSettleLock() {
+    const el = options.element.value;
+    if (!el || typeof ResizeObserver === "undefined") return;
+
+    const target = captureTarget();
+    settleGeneration = target.token;
+    settleObserver?.disconnect();
+    settleObserver = new ResizeObserver(() => {
+      if (settleGeneration !== generation) return;
+      void pinTarget(target);
+    });
+    settleObserver.observe(el);
+    for (const child of Array.from(el.children)) {
+      settleObserver.observe(child);
+    }
+
+    if (settleTimer) clearTimeout(settleTimer);
+    settleTimer = setTimeout(disconnectSettleLock, 500);
+  }
+
+  async function scrollToPinnedEdge(optionsForScroll: { settle?: boolean } = {}) {
+    const token = generation;
+    await nextTick();
+    await nextTick();
+    if (token !== generation) return false;
+    const didScroll = await pinCurrent(token);
+    if (token !== generation) return false;
+    if (didScroll && optionsForScroll.settle) {
+      refreshSettleLock();
+    }
+    return didScroll;
+  }
+
+  watch(
+    () => [options.element.value, options.virtualScroll?.value ?? null] as const,
+    () => disconnectSettleLock(),
+    { flush: "sync" },
+  );
+
+  return {
+    disconnect: disconnectSettleLock,
+    scrollToPinnedEdge,
+  };
+}

--- a/chat/tests/scroll-direction.test.ts
+++ b/chat/tests/scroll-direction.test.ts
@@ -50,6 +50,19 @@ function makeTimelineEl() {
   } as unknown as HTMLDivElement;
 }
 
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+async function flushAsync() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await nextTick();
+}
+
 const originalWindow = globalThis.window;
 const originalLocalStorage = globalThis.localStorage;
 
@@ -342,6 +355,7 @@ describe("scroll direction preference", () => {
 
     await messaging.loadMessages("w1", "c1");
     expect(virtualScroll).not.toHaveBeenCalled();
+    expect(localStorage.getItem(roomKey("c1"))).toBeNull();
 
     messaging.timelineEl.value = makeTimelineEl();
     messaging.timelineEdgeScroller.value = virtualScroll;
@@ -349,8 +363,268 @@ describe("scroll direction preference", () => {
     await nextTick();
     await nextTick();
     await nextTick();
+    await flushAsync();
 
     expect(virtualScroll).toHaveBeenCalledWith("chat");
+    expect(localStorage.getItem(roomKey("c1"))).toBe("room-2");
+  });
+
+  test("room initial load waits for a scroll target before persisting last-seen or older loading", async () => {
+    const queryMamPage = mock(async (_spaceId, _channelId, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "room-0",
+              roomJid: "w1-c1@rooms.example.com",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "room-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "room-1",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "room-2",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "room-1",
+        complete: false,
+      };
+    });
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMamPage } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+    await messaging.loadOlderMessages();
+
+    expect(localStorage.getItem(roomKey("c1"))).toBeNull();
+    expect(queryMamPage).toHaveBeenCalledTimes(1);
+  });
+
+  test("room initial load does not persist last-seen after the active channel changes during edge pin", async () => {
+    const activeChannelId = ref("c1");
+    const pin = deferred();
+    const queryMam = mock(async () => [
+      {
+        id: "room-1",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "room-2",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const virtualScroll = mock(async () => {
+      await pin.promise;
+      return true;
+    });
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMam } as never) as never,
+      ref("w1"),
+      activeChannelId,
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    messaging.timelineEl.value = makeTimelineEl();
+    messaging.timelineEdgeScroller.value = virtualScroll;
+
+    const load = messaging.loadMessages("w1", "c1");
+    await flushAsync();
+    expect(virtualScroll).toHaveBeenCalledWith("chat");
+
+    activeChannelId.value = "c2";
+    pin.resolve();
+    await load;
+
+    expect(localStorage.getItem(roomKey("c1"))).toBeNull();
+  });
+
+  test("room older-history loads are blocked until the latest page is pinned", async () => {
+    const pin = deferred();
+    const queryMamPage = mock(async (_spaceId, _channelId, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "room-0",
+              roomJid: "w1-c1@rooms.example.com",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "room-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "room-1",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "room-2",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "room-1",
+        complete: false,
+      };
+    });
+    const virtualScroll = mock(async () => {
+      await pin.promise;
+      return true;
+    });
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMamPage } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    messaging.timelineEl.value = makeTimelineEl();
+    messaging.timelineEdgeScroller.value = virtualScroll;
+
+    const load = messaging.loadMessages("w1", "c1");
+    await flushAsync();
+    await messaging.loadOlderMessages();
+    expect(queryMamPage).toHaveBeenCalledTimes(1);
+
+    pin.resolve();
+    await load;
+    await messaging.loadOlderMessages();
+
+    expect(queryMamPage).toHaveBeenCalledTimes(2);
+    expect(messaging.messages.value.map((message) => message.id)).toContain("room-0");
+  });
+
+  test("room clear blocks older-history loads until a fresh latest page is pinned", async () => {
+    const queryMamPage = mock(async (_spaceId, _channelId, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "room-0",
+              roomJid: "w1-c1@rooms.example.com",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "room-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "room-1",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "room-2",
+            roomJid: "w1-c1@rooms.example.com",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "room-1",
+        complete: false,
+      };
+    });
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMamPage } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    messaging.timelineEl.value = makeTimelineEl();
+
+    await messaging.loadMessages("w1", "c1");
+    await messaging.loadOlderMessages();
+    expect(queryMamPage).toHaveBeenCalledTimes(2);
+
+    messaging.clearMessages();
+    await messaging.loadOlderMessages();
+    expect(queryMamPage).toHaveBeenCalledTimes(2);
   });
 
   test("DM initial load ignores older last-seen and persists the newest visible message", async () => {
@@ -432,6 +706,7 @@ describe("scroll direction preference", () => {
 
     await dm.loadMessages("bob@example.com");
     expect(virtualScroll).not.toHaveBeenCalled();
+    expect(localStorage.getItem(dmKey("bob@example.com"))).toBeNull();
 
     dm.timelineEl.value = makeTimelineEl();
     dm.timelineEdgeScroller.value = virtualScroll;
@@ -439,8 +714,267 @@ describe("scroll direction preference", () => {
     await nextTick();
     await nextTick();
     await nextTick();
+    await flushAsync();
 
     expect(virtualScroll).toHaveBeenCalledWith("chat");
+    expect(localStorage.getItem(dmKey("bob@example.com"))).toBe("dm-2");
+  });
+
+  test("DM initial load waits for a scroll target before persisting last-seen or older loading", async () => {
+    const queryPersonalMamPage = mock(async (_peerJid, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "dm-0",
+              peerJid: "bob@example.com",
+              fromJid: "bob@example.com/tablet",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "dm-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "dm-1",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/phone",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "dm-2",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/laptop",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "dm-1",
+        complete: false,
+      };
+    });
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMamPage } as never) as never,
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await dm.loadMessages("bob@example.com");
+    await dm.loadOlderMessages();
+
+    expect(localStorage.getItem(dmKey("bob@example.com"))).toBeNull();
+    expect(queryPersonalMamPage).toHaveBeenCalledTimes(1);
+  });
+
+  test("DM initial load does not persist last-seen after the active peer changes during edge pin", async () => {
+    const activePeerJid = ref("bob@example.com");
+    const pin = deferred();
+    const queryPersonalMam = mock(async () => [
+      {
+        id: "dm-1",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/phone",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "dm-2",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/laptop",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const virtualScroll = mock(async () => {
+      await pin.promise;
+      return true;
+    });
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMam } as never) as never,
+      activePeerJid,
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+    dm.timelineEdgeScroller.value = virtualScroll;
+
+    const load = dm.loadMessages("bob@example.com");
+    await flushAsync();
+    expect(virtualScroll).toHaveBeenCalledWith("chat");
+
+    activePeerJid.value = "carol@example.com";
+    pin.resolve();
+    await load;
+
+    expect(localStorage.getItem(dmKey("bob@example.com"))).toBeNull();
+  });
+
+  test("DM older-history loads are blocked until the latest page is pinned", async () => {
+    const pin = deferred();
+    const queryPersonalMamPage = mock(async (_peerJid, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "dm-0",
+              peerJid: "bob@example.com",
+              fromJid: "bob@example.com/tablet",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "dm-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "dm-1",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/phone",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "dm-2",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/laptop",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "dm-1",
+        complete: false,
+      };
+    });
+    const virtualScroll = mock(async () => {
+      await pin.promise;
+      return true;
+    });
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMamPage } as never) as never,
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+    dm.timelineEdgeScroller.value = virtualScroll;
+
+    const load = dm.loadMessages("bob@example.com");
+    await flushAsync();
+    await dm.loadOlderMessages();
+    expect(queryPersonalMamPage).toHaveBeenCalledTimes(1);
+
+    pin.resolve();
+    await load;
+    await dm.loadOlderMessages();
+
+    expect(queryPersonalMamPage).toHaveBeenCalledTimes(2);
+    expect(dm.messages.value.map((message) => message.id)).toContain("dm-0");
+  });
+
+  test("DM clear blocks older-history loads until a fresh latest page is pinned", async () => {
+    const queryPersonalMamPage = mock(async (_peerJid, _max, pageParam) => {
+      if (pageParam.type === "before") {
+        return {
+          messages: [
+            {
+              id: "dm-0",
+              peerJid: "bob@example.com",
+              fromJid: "bob@example.com/tablet",
+              nick: "bob",
+              body: "oldest",
+              createdAt: "2023-12-31T23:59:50Z",
+              type: "message" as const,
+            },
+          ],
+          firstArchiveId: "dm-0",
+          complete: true,
+        };
+      }
+      return {
+        messages: [
+          {
+            id: "dm-1",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/phone",
+            nick: "bob",
+            body: "earlier",
+            createdAt: "2024-01-01T00:00:00Z",
+            type: "message" as const,
+          },
+          {
+            id: "dm-2",
+            peerJid: "bob@example.com",
+            fromJid: "bob@example.com/laptop",
+            nick: "bob",
+            body: "later",
+            createdAt: "2024-01-01T00:00:10Z",
+            type: "message" as const,
+          },
+        ],
+        firstArchiveId: "dm-1",
+        complete: false,
+      };
+    });
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMamPage } as never) as never,
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+
+    await dm.loadMessages("bob@example.com");
+    await dm.loadOlderMessages();
+    expect(queryPersonalMamPage).toHaveBeenCalledTimes(2);
+
+    dm.clearMessages();
+    await dm.loadOlderMessages();
+    expect(queryPersonalMamPage).toHaveBeenCalledTimes(2);
   });
 
   test("live DM messages pin to the active edge in chat and social modes", async () => {

--- a/chat/tests/scroll-direction.test.ts
+++ b/chat/tests/scroll-direction.test.ts
@@ -9,7 +9,9 @@ import {
   orderTimelineForScrollDirection,
   readStoredScrollDirection,
 } from "../src/lib/scroll-direction";
+import { dmKey, roomKey, setLastSeen } from "../src/lib/last-seen-store";
 import type { WaddleSession } from "../src/lib/server-auth";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
 
 function createStorageMock() {
   const values = new Map<string, string>();
@@ -183,6 +185,39 @@ describe("scroll direction preference", () => {
     expect(messaging.messages.value.at(-1)?.body).toBe("hello world");
   });
 
+  test("pins room timelines to the bottom for optimistic sends in chat mode", async () => {
+    const sendChatState = mock(async () => undefined);
+    const sendGroupMessage = mock(async () => ({ id: "client-1", state: "sending" as const }));
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({
+        ...handlerStubs(),
+        sendChatState,
+        sendGroupMessage,
+      } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    const timelineEl = makeTimelineEl();
+    messaging.timelineEl.value = timelineEl;
+
+    await messaging.sendMessage("hello world");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await nextTick();
+    await nextTick();
+
+    expect(timelineEl.scrollTop).toBe(480);
+    expect(messaging.messages.value.at(-1)?.body).toBe("hello world");
+  });
+
   test("pins room timelines to the top in social mode without reordering stored messages", async () => {
     setScrollDirection("social");
     const queryMam = mock(async () => [
@@ -224,6 +259,178 @@ describe("scroll direction preference", () => {
 
     expect(messaging.messages.value.map((message) => message.id)).toEqual(["room-1", "room-2"]);
     expect(timelineEl.scrollTop).toBe(0);
+  });
+
+  test("room initial load ignores older last-seen and persists the newest visible message", async () => {
+    setLastSeen(roomKey("c1"), "room-1");
+    const queryMam = mock(async () => [
+      {
+        id: "room-1",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "room-2",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMam } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    const timelineEl = makeTimelineEl();
+    messaging.timelineEl.value = timelineEl;
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.firstUnseenId.value).toBeNull();
+    expect(timelineEl.scrollTop).toBe(480);
+    expect(localStorage.getItem(roomKey("c1"))).toBe("room-2");
+  });
+
+  test("DM initial load ignores older last-seen and persists the newest visible message", async () => {
+    setLastSeen(dmKey("bob@example.com"), "dm-1");
+    const queryPersonalMam = mock(async () => [
+      {
+        id: "dm-1",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/phone",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "dm-2",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/laptop",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMam } as never) as never,
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    const timelineEl = makeTimelineEl();
+    dm.timelineEl.value = timelineEl;
+
+    await dm.loadMessages("bob@example.com");
+
+    expect(dm.firstUnseenId.value).toBeNull();
+    expect(timelineEl.scrollTop).toBe(480);
+    expect(localStorage.getItem(dmKey("bob@example.com"))).toBe("dm-2");
+  });
+
+  test("live DM messages pin to the active edge in chat and social modes", async () => {
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref(null),
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    const timelineEl = makeTimelineEl();
+    dm.timelineEl.value = timelineEl;
+
+    dm.onIncomingMessage({
+      id: "dm-live-chat",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/phone",
+      nick: "bob",
+      body: "chat edge",
+      createdAt: "2024-01-01T00:00:00Z",
+      type: "message",
+    });
+    await nextTick();
+    await nextTick();
+    expect(timelineEl.scrollTop).toBe(480);
+
+    setScrollDirection("social");
+    timelineEl.scrollTop = 240;
+    dm.onIncomingMessage({
+      id: "dm-live-social",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/phone",
+      nick: "bob",
+      body: "social edge",
+      createdAt: "2024-01-01T00:00:10Z",
+      type: "message",
+    });
+    await nextTick();
+    await nextTick();
+    expect(timelineEl.scrollTop).toBe(0);
+  });
+
+  test("live room messages pin through the virtual timeline edge scroller when available", async () => {
+    let liveHandler: ((msg: LiveRoomMessage) => void) | null = null;
+    const virtualScroll = mock(async () => true);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({
+        ...handlerStubs(),
+        setMessageHandler: (handler: (msg: LiveRoomMessage) => void) => {
+          liveHandler = handler;
+        },
+      } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    const timelineEl = makeTimelineEl();
+    messaging.timelineEl.value = timelineEl;
+    messaging.timelineEdgeScroller.value = virtualScroll;
+
+    liveHandler?.({
+      id: "room-live",
+      roomJid: "c1@muc.example.com",
+      nick: "bob",
+      body: "from room",
+      createdAt: "2024-01-01T00:00:00Z",
+      type: "message",
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(virtualScroll).toHaveBeenCalledWith("chat");
+    expect(timelineEl.scrollTop).toBe(240);
   });
 
   test("re-pins an open DM timeline when the preference changes", async () => {

--- a/chat/tests/scroll-direction.test.ts
+++ b/chat/tests/scroll-direction.test.ts
@@ -305,6 +305,54 @@ describe("scroll direction preference", () => {
     expect(localStorage.getItem(roomKey("c1"))).toBe("room-2");
   });
 
+  test("room initial load re-pins when the virtual timeline ref appears after messages", async () => {
+    const queryMam = mock(async () => [
+      {
+        id: "room-1",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "room-2",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const virtualScroll = mock(async () => true);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), queryMam } as never) as never,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+    expect(virtualScroll).not.toHaveBeenCalled();
+
+    messaging.timelineEl.value = makeTimelineEl();
+    messaging.timelineEdgeScroller.value = virtualScroll;
+    await nextTick();
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    expect(virtualScroll).toHaveBeenCalledWith("chat");
+  });
+
   test("DM initial load ignores older last-seen and persists the newest visible message", async () => {
     setLastSeen(dmKey("bob@example.com"), "dm-1");
     const queryPersonalMam = mock(async () => [
@@ -346,6 +394,53 @@ describe("scroll direction preference", () => {
     expect(dm.firstUnseenId.value).toBeNull();
     expect(timelineEl.scrollTop).toBe(480);
     expect(localStorage.getItem(dmKey("bob@example.com"))).toBe("dm-2");
+  });
+
+  test("DM initial load re-pins when the virtual timeline ref appears after messages", async () => {
+    const queryPersonalMam = mock(async () => [
+      {
+        id: "dm-1",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/phone",
+        nick: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+      },
+      {
+        id: "dm-2",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com/laptop",
+        nick: "bob",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+      },
+    ]);
+    const virtualScroll = mock(async () => true);
+    const actionError = ref("");
+    const dm = useDmMessaging(
+      ref(session()),
+      ref({ queryPersonalMam } as never) as never,
+      ref("bob@example.com"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await dm.loadMessages("bob@example.com");
+    expect(virtualScroll).not.toHaveBeenCalled();
+
+    dm.timelineEl.value = makeTimelineEl();
+    dm.timelineEdgeScroller.value = virtualScroll;
+    await nextTick();
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    expect(virtualScroll).toHaveBeenCalledWith("chat");
   });
 
   test("live DM messages pin to the active edge in chat and social modes", async () => {


### PR DESCRIPTION
# Fix Chat Timeline Edge Anchoring

## Summary
- Treat this as a local chat UI scroll/focus fix only. Keep XEP-0313 MAM latest-page queries and chronological message storage unchanged.
- Latest message focus wins on initial conversation load. New live/optimistic messages always pin to the active edge: bottom in chat mode, top in social mode.

## Key Changes
- Replace one-shot `scrollTop` snaps with a reusable pinned-edge scroll helper for room and DM messaging. It should refresh a short settling lock instead of stacking observers, so late virtual row measurement, images, avatars, and markup reflow cannot strand the view away from the newest message.
- Route pinned-edge scrolling through the virtual timeline when available: expose a timeline edge-scroll method that uses `scrollToIndex(0, start)` for social mode and the last rendered message with `end` alignment for chat mode, with the current raw `scrollTop` behavior as fallback.
- Change room and DM initial load policy: after the latest MAM page renders, set `firstUnseenId` to `null`, pin to the active edge, and persist the newest feed-visible message as last-seen. Do not focus the stored first-unseen divider when opening the page.
- Apply the same edge-following behavior to thread panels when new thread replies arrive, without disturbing older-history loads. Older-history loads must preserve the current viewport because the newest rendered message id does not change.

## Test Plan
- Add room and DM tests where stored last-seen points to an older message, then loading the latest page still focuses the newest message and leaves `firstUnseenId` null.
- Add room and DM tests for live incoming/optimistic messages in both chat and social modes, asserting bottom/top anchoring respectively.
- Add coverage for thread-panel newest-reply anchoring if the existing test harness can mount that component cleanly; otherwise document it as browser-verified.
- Run from `chat/`: `bun test tests/scroll-direction.test.ts`, then `bun test && bun run lint`.

## Assumptions
- "Always anchored" means active timelines should follow new messages even if the user had scrolled away.
- "First opening the page" means opening/loading a conversation should show the latest message, not the first unread divider.
- Scope is `chat/` only. No dev server unless explicitly requested.
- No XMPP wire-shape changes are needed; XEP-0313 latest-page and XEP-0333 displayed-marker behavior stay intact.
- After implementation, use adversarial review agents focused on scroll virtualization, social-mode ordering, and last-seen/MAM behavior, then fix real actionable findings before pushing and monitoring CI.
