### PR TITLE
Hybrid browser tab unread indicator

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -10,6 +10,7 @@ import { useUiState } from "@/composables/useUiState";
 import { useAppUpdate } from "@/composables/useAppUpdate";
 import { useNotifications } from "@/composables/useNotifications";
 import { useChannelUnread } from "@/composables/useChannelUnread";
+import { useTabUnreadIndicator } from "@/composables/useTabUnreadIndicator";
 import { useVersion } from "@/composables/useVersion";
 import { useRosterContacts } from "@/composables/useRosterContacts";
 import { buildDmPath, buildPath, buildSettingsPath, parseRoute, pushDmRoute, pushRoute, pushSettingsRoute, resolveChannel, shouldLoadStructureForRoute } from "@/composables/useRouting";
@@ -227,6 +228,21 @@ const activeDmPeer = computed(() => {
 });
 
 const computedChannelUnreadMap = computed(() => channelUnread.channelUnreadMap());
+// Thread rows are drill-down detail; room unread already carries the
+// server-equivalent conversation total, so the browser badge must not add both.
+const totalTabUnreadCount = computed(() =>
+  connectionStore.appState === "ready" && session.value && xmppClient.value
+    ? dmConversations.totalUnreadCount.value + channelUnread.totalUnreadCount.value
+    : 0
+);
+useTabUnreadIndicator(totalTabUnreadCount, {
+  shouldAcceptServiceWorkerUnreadCount: () =>
+    connectionStore.appState === "ready" && !!session.value && !!xmppClient.value,
+  onServiceWorkerUnreadCount: () => Promise.all([
+    dmConversations.hydrateFromInbox(),
+    channelUnread.hydrateFromInbox(),
+  ]).then((results) => results.every(Boolean)),
+});
 
 const notifications = useNotifications();
 const appUpdate = useAppUpdate();
@@ -383,6 +399,7 @@ watch(xmppClient, (client) => {
     dmMessaging.onMessageQueueStatus(id, status);
   });
   client.setInboxPushHandler((entry) => {
+    dmConversations.onInboxPush(entry);
     channelUnread.onInboxPush(entry);
   });
   client.setSessionLifecycleHandler((event) => {
@@ -767,6 +784,7 @@ async function handleLogout() {
   messaging.disconnect();
   dmMessaging.disconnect();
   waddles.clearData();
+  channelUnread.clearAll();
   rosterContacts.clearRosterContacts();
   setupPromptShown = false;
   messaging.clearMessages();

--- a/chat/src/composables/useChannelUnread.ts
+++ b/chat/src/composables/useChannelUnread.ts
@@ -27,7 +27,7 @@ export function useChannelUnread(
   const inboxState = ref<InboxState>(createInboxState());
   let hydrateRequestId = 0;
 
-  const totalUnreadCount = computed(() => {
+  const totalChannelUnreadCount = computed(() => {
     let total = 0;
     for (const entry of inboxState.value.channels.values()) {
       if (entry.kind !== "muc") continue;
@@ -36,33 +36,56 @@ export function useChannelUnread(
     return total;
   });
 
+  const totalThreadUnreadCount = computed(() => {
+    let total = 0;
+    for (const entry of inboxState.value.threads.values()) {
+      if (entry.kind !== "muc") continue;
+      total += entry.unread;
+    }
+    return total;
+  });
+
+  // Server total unread counts conversation rows only; thread rows are nested detail.
+  const totalUnreadCount = totalChannelUnreadCount;
+
   const totalMentionCount = computed(() => {
     // Server doesn't track mentions separately yet — return 0
     return 0;
   });
 
-  async function hydrateFromInbox() {
+  async function hydrateFromInbox(): Promise<boolean> {
     const client = xmppClient.value;
-    if (!client) return;
+    if (!client) {
+      inboxState.value = createInboxState();
+      return false;
+    }
 
     const requestId = ++hydrateRequestId;
     try {
       const inbox = await client.fetchInbox();
-      if (requestId !== hydrateRequestId || client !== xmppClient.value) return;
+      if (requestId !== hydrateRequestId || client !== xmppClient.value) return false;
 
       inboxState.value = applyEntries(createInboxState(), inbox.conversations);
+      return true;
     } catch {
       // best-effort
+      return false;
     }
   }
 
   /** Handle a server-pushed inbox entry (headline message with absolute unread count). */
   function onInboxPush(entry: InboxEntry) {
+    if (entry.kind !== "muc") return;
     inboxState.value = applyEntry(inboxState.value, entry);
   }
 
   function clearUnread(roomJid: string) {
     inboxState.value = markReadInState(inboxState.value, roomJid);
+  }
+
+  function clearAll() {
+    hydrateRequestId += 1;
+    inboxState.value = createInboxState();
   }
 
   function markRead(roomJid: string) {
@@ -107,11 +130,14 @@ export function useChannelUnread(
 
   return {
     inboxState,
+    totalChannelUnreadCount,
+    totalThreadUnreadCount,
     totalUnreadCount,
     totalMentionCount,
     hydrateFromInbox,
     onInboxPush,
     clearUnread,
+    clearAll,
     markRead,
     markThreadRead,
     channelUnreadMap,

--- a/chat/src/composables/useDmConversations.ts
+++ b/chat/src/composables/useDmConversations.ts
@@ -41,11 +41,15 @@ export function useDmConversations(
   const localReadAtByJid = ref<Record<string, number>>({});
 
   const hasUnread = computed(() => conversations.value.some((c) => c.unreadCount > 0));
+  const totalUnreadCount = computed(() =>
+    conversations.value.reduce((total, conversation) => total + Math.max(0, conversation.unreadCount), 0)
+  );
   const selfBareJid = computed(() => barePeerJid(session.value?.jid ?? ""));
 
   let inboxRequestId = 0;
   const pendingMarkRead = new Set<string>();
   const queuedMarkRead = new Set<string>();
+  const inboxAccountedMessageIdsByJid = new Map<string, Set<string>>();
 
   function storageKey() {
     const bare = session.value ? barePeerJid(session.value.jid) : "";
@@ -133,6 +137,25 @@ export function useDmConversations(
       });
   }
 
+  function rememberInboxAccountedMessage(entry: InboxEntry) {
+    if (!entry.lastStanzaId) return;
+    const bare = barePeerJid(entry.partner);
+    const messageIds = inboxAccountedMessageIdsByJid.get(bare) ?? new Set<string>();
+    messageIds.add(entry.lastStanzaId);
+    while (messageIds.size > 20) {
+      const oldest = messageIds.values().next().value;
+      if (!oldest) break;
+      messageIds.delete(oldest);
+    }
+    inboxAccountedMessageIdsByJid.set(bare, messageIds);
+  }
+
+  function wasUnreadAccountedByInbox(peerJid: string, msg: LiveDmMessage): boolean {
+    const messageIds = inboxAccountedMessageIdsByJid.get(barePeerJid(peerJid));
+    if (!messageIds) return false;
+    return [msg.id, ...(msg.wireIds ?? [])].some((messageId) => messageIds.has(messageId));
+  }
+
   function mergeInboxEntry(existing: DmConversation | undefined, entry: InboxEntry): DmConversation {
     const bare = barePeerJid(entry.partner);
     const serverTimestamp = inboxTimestamp(entry.lastUpdated);
@@ -168,16 +191,22 @@ export function useDmConversations(
     for (const entry of entries) {
       if (entry.kind !== "direct") continue;
       const bare = barePeerJid(entry.partner);
+      rememberInboxAccountedMessage(entry);
       merged.set(bare, mergeInboxEntry(merged.get(bare), entry));
     }
 
     conversations.value = sortByRecent([...merged.values()]);
   }
 
-  async function hydrateFromInbox() {
+  function onInboxPush(entry: InboxEntry) {
+    if (entry.kind !== "direct") return;
+    mergeInboxConversations([entry]);
+  }
+
+  async function hydrateFromInbox(): Promise<boolean> {
     const currentClient = xmppClient.value;
     const currentSessionJid = session.value?.jid ?? null;
-    if (!currentClient || !currentSessionJid) return;
+    if (!currentClient || !currentSessionJid) return false;
 
     const requestId = ++inboxRequestId;
     try {
@@ -186,15 +215,17 @@ export function useDmConversations(
         requestId !== inboxRequestId
         || currentClient !== xmppClient.value
         || currentSessionJid !== (session.value?.jid ?? null)
-      ) return;
+      ) return false;
 
       const directConversations = inbox.conversations.filter((conversation) => conversation.kind === "direct");
       mergeInboxConversations(directConversations);
       for (const conversation of directConversations) {
         void currentClient.subscribeToPeerPresence(barePeerJid(conversation.partner)).catch(() => undefined);
       }
+      return true;
     } catch {
       // best-effort
+      return false;
     }
   }
 
@@ -236,7 +267,9 @@ export function useDmConversations(
     const existing = ensureConversation(bare);
     const isSelfMessage = barePeerJid(msg.fromJid) === selfBareJid.value;
     const isActiveConversation = activePeerJid.value === bare;
-    const shouldIncrementUnread = !isSelfMessage && !isActiveConversation;
+    const shouldIncrementUnread = !isSelfMessage
+      && !isActiveConversation
+      && !wasUnreadAccountedByInbox(bare, msg);
 
     conversations.value = sortByRecent(conversations.value.map((c) => (
       c.peerJid === bare
@@ -270,6 +303,7 @@ export function useDmConversations(
       inboxRequestId += 1;
       pendingMarkRead.clear();
       queuedMarkRead.clear();
+      inboxAccountedMessageIdsByJid.clear();
       conversations.value = [];
       activePeerJid.value = null;
       presenceByJid.value = {};
@@ -288,9 +322,11 @@ export function useDmConversations(
     conversations,
     activePeerJid,
     hasUnread,
+    totalUnreadCount,
     openDm,
     closeDm,
     hydrateFromInbox,
+    onInboxPush,
     markRead,
     receiveIncomingDm,
     updatePresence,

--- a/chat/src/composables/useTabUnreadIndicator.ts
+++ b/chat/src/composables/useTabUnreadIndicator.ts
@@ -1,0 +1,236 @@
+import { getCurrentInstance, onUnmounted, watch, type Ref } from "vue";
+
+const BASE_TITLE = "Waddle";
+const UNREAD_TITLE = "* Waddle";
+const FAVICON_URL = "/favicon-32x32.png";
+const MESSAGE_TYPE = "waddle:unread-count";
+
+interface TabUnreadIndicatorOptions {
+  onServiceWorkerUnreadCount?: (unreadCount: number) => boolean | Promise<boolean>;
+  shouldAcceptServiceWorkerUnreadCount?: () => boolean;
+}
+
+type BadgeNavigator = Navigator & {
+  setAppBadge?: (contents?: number) => Promise<void>;
+  clearAppBadge?: () => Promise<void>;
+};
+
+type FaviconLink = HTMLLinkElement & {
+  href: string;
+};
+
+interface FaviconSnapshot {
+  link: FaviconLink;
+  href: string;
+  type: string | null;
+  sizes: string | null;
+}
+
+export function useTabUnreadIndicator(
+  unreadCount: Readonly<Ref<number>>,
+  options: TabUnreadIndicatorOptions = {},
+) {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return { stop: () => {} };
+  }
+
+  const faviconLinks = ensureFaviconLinks();
+  let unreadFaviconHref: string | null = null;
+  let faviconGeneration = 0;
+  let serviceWorkerRefreshId = 0;
+  let deferLocalUnreadUpdates = false;
+  let deferredLocalUnreadChanged = false;
+  let disposed = false;
+
+  async function applyUnreadCount(value: number) {
+    if (disposed) return;
+    const count = normalizeUnreadCount(value);
+    document.title = count > 0 ? UNREAD_TITLE : BASE_TITLE;
+    void updateAppBadge(count);
+    await updateFavicons(
+      count,
+      faviconLinks,
+      () => ++faviconGeneration,
+      () => faviconGeneration,
+      () => disposed,
+    );
+  }
+
+  async function updateFavicons(
+    count: number,
+    links: FaviconSnapshot[],
+    nextGeneration: () => number,
+    currentGeneration: () => number,
+    isDisposed: () => boolean,
+  ) {
+    const generation = nextGeneration();
+    if (isDisposed()) return;
+    if (count <= 0) {
+      restoreFaviconLinks(links);
+      return;
+    }
+
+    try {
+      unreadFaviconHref ??= await drawUnreadFavicon();
+    } catch {
+      unreadFaviconHref = FAVICON_URL;
+    }
+    if (isDisposed() || generation !== currentGeneration()) return;
+    for (const snapshot of links) {
+      snapshot.link.href = unreadFaviconHref;
+      snapshot.link.setAttribute("href", unreadFaviconHref);
+      snapshot.link.setAttribute("type", "image/png");
+    }
+  }
+
+  const stopWatch = watch(
+    unreadCount,
+    (count) => {
+      if (deferLocalUnreadUpdates) {
+        deferredLocalUnreadChanged = true;
+        return;
+      }
+      void applyUnreadCount(count);
+    },
+    { immediate: true },
+  );
+
+  const handleServiceWorkerMessage = (event: MessageEvent) => {
+    if (disposed) return;
+    const data = event.data as { type?: string; unreadCount?: unknown } | undefined;
+    if (data?.type !== MESSAGE_TYPE) return;
+    if (options.shouldAcceptServiceWorkerUnreadCount && !options.shouldAcceptServiceWorkerUnreadCount()) {
+      void applyUnreadCount(unreadCount.value);
+      return;
+    }
+    const serviceWorkerUnreadCount = normalizeUnreadCount(data.unreadCount);
+    const refreshId = ++serviceWorkerRefreshId;
+    deferLocalUnreadUpdates = true;
+    deferredLocalUnreadChanged = false;
+    void applyUnreadCount(serviceWorkerUnreadCount);
+    void Promise.resolve(options.onServiceWorkerUnreadCount?.(serviceWorkerUnreadCount))
+      .catch(() => false)
+      .then((didRefresh) => {
+        if (disposed || refreshId !== serviceWorkerRefreshId) return;
+        const shouldApplyLocalUnread = didRefresh || deferredLocalUnreadChanged;
+        deferLocalUnreadUpdates = false;
+        deferredLocalUnreadChanged = false;
+        if (shouldApplyLocalUnread) {
+          void applyUnreadCount(unreadCount.value);
+        }
+      });
+  };
+
+  navigator.serviceWorker?.addEventListener("message", handleServiceWorkerMessage);
+
+  function stop() {
+    if (disposed) return;
+    disposed = true;
+    faviconGeneration += 1;
+    serviceWorkerRefreshId += 1;
+    deferLocalUnreadUpdates = false;
+    deferredLocalUnreadChanged = false;
+    stopWatch();
+    navigator.serviceWorker?.removeEventListener("message", handleServiceWorkerMessage);
+    document.title = BASE_TITLE;
+    restoreFaviconLinks(faviconLinks);
+    void updateAppBadge(0);
+  }
+
+  if (getCurrentInstance()) {
+    onUnmounted(stop);
+  }
+
+  return { stop };
+}
+
+function normalizeUnreadCount(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value ?? 0);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+  return Math.floor(parsed);
+}
+
+function ensureFaviconLinks(): FaviconSnapshot[] {
+  const existing = Array.from(document.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]'));
+  if (existing.length > 0) return existing.map((link) => snapshotFaviconLink(link as FaviconLink));
+
+  const link = document.createElement("link") as FaviconLink;
+  link.rel = "icon";
+  link.type = "image/png";
+  link.setAttribute("sizes", "32x32");
+  link.href = FAVICON_URL;
+  link.setAttribute("href", FAVICON_URL);
+  document.head.appendChild(link);
+  return [snapshotFaviconLink(link)];
+}
+
+function snapshotFaviconLink(link: FaviconLink): FaviconSnapshot {
+  return {
+    link,
+    href: link.getAttribute("href") || link.href || FAVICON_URL,
+    type: link.getAttribute("type"),
+    sizes: link.getAttribute("sizes"),
+  };
+}
+
+function restoreFaviconLinks(links: FaviconSnapshot[]) {
+  for (const snapshot of links) {
+    snapshot.link.href = snapshot.href;
+    snapshot.link.setAttribute("href", snapshot.href);
+    restoreOptionalAttribute(snapshot.link, "type", snapshot.type);
+    restoreOptionalAttribute(snapshot.link, "sizes", snapshot.sizes);
+  }
+}
+
+function restoreOptionalAttribute(link: FaviconLink, name: string, value: string | null) {
+  if (value === null) {
+    link.removeAttribute(name);
+    return;
+  }
+  link.setAttribute(name, value);
+}
+
+async function updateAppBadge(count: number) {
+  const badgeNavigator = navigator as BadgeNavigator;
+  try {
+    if (count > 0 && typeof badgeNavigator.setAppBadge === "function") {
+      await badgeNavigator.setAppBadge(count);
+      return;
+    }
+    if (count === 0 && typeof badgeNavigator.clearAppBadge === "function") {
+      await badgeNavigator.clearAppBadge();
+    }
+  } catch {
+    // best-effort browser chrome integration
+  }
+}
+
+async function drawUnreadFavicon(): Promise<string> {
+  const image = await loadImage(FAVICON_URL);
+  const canvas = document.createElement("canvas");
+  const size = 32;
+  canvas.width = size;
+  canvas.height = size;
+  const context = canvas.getContext("2d");
+  if (!context) return FAVICON_URL;
+
+  context.drawImage(image, 0, 0, size, size);
+  context.fillStyle = "#dc2626";
+  context.lineWidth = 2;
+  context.strokeStyle = "#ffffff";
+  context.beginPath();
+  context.arc(28, 4, 5, 0, Math.PI * 2);
+  context.fill();
+  context.stroke();
+
+  return canvas.toDataURL("image/png");
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`Failed to load favicon ${src}`));
+    image.src = src;
+  });
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1484,6 +1484,10 @@ export class BrowserXmppClient {
         lastUpdated?: number;
         unread?: number;
         preview?: string;
+        thread?: string;
+        threadTitle?: string;
+        replyCount?: number;
+        author?: string;
       };
     }).inboxPush;
     if (!push?.partner) return;
@@ -1494,6 +1498,10 @@ export class BrowserXmppClient {
       lastUpdated: typeof push.lastUpdated === "number" ? push.lastUpdated : 0,
       unread: typeof push.unread === "number" ? push.unread : 0,
       preview: push.preview || undefined,
+      thread: push.thread || undefined,
+      threadTitle: push.threadTitle || undefined,
+      replyCount: typeof push.replyCount === "number" ? push.replyCount : undefined,
+      author: push.author || undefined,
     });
   }
 

--- a/chat/src/service-worker/sw-template.js
+++ b/chat/src/service-worker/sw-template.js
@@ -2,6 +2,7 @@
 
 const CACHE_NAME = "waddle-__WADDLE_BUILD_SHA__";
 const NOTIFICATION_ICON_URL = "/android-chrome-192x192.png";
+const UNREAD_COUNT_MESSAGE_TYPE = "waddle:unread-count";
 const PRECACHE_URLS = [
   "/offline.html",
   "/manifest.webmanifest",
@@ -92,13 +93,18 @@ self.addEventListener("push", (event) => {
     const text = event.data?.text() ?? "";
     data = { title: "Waddle", body: text };
   }
+  const unreadCount = parseUnreadCount(data);
   event.waitUntil(
-    self.registration.showNotification(data.title ?? "Waddle", {
-      body: data.body ?? "",
-      tag: data.roomJid,
-      icon: NOTIFICATION_ICON_URL,
-      data: { url: data.url ?? roomJidToPath(data.roomJid) },
-    }),
+    Promise.all([
+      updateAppBadge(unreadCount),
+      postUnreadCountToClients(unreadCount),
+      self.registration.showNotification(data.title ?? "Waddle", {
+        body: data.body ?? "",
+        tag: data.roomJid,
+        icon: NOTIFICATION_ICON_URL,
+        data: { url: data.url ?? roomJidToPath(data.roomJid) },
+      }),
+    ]),
   );
 });
 
@@ -123,4 +129,39 @@ function roomJidToPath(roomJid) {
   const parts = localpart.split("_");
   if (parts.length < 2) return "/";
   return `/${encodeURIComponent(parts[0])}/${encodeURIComponent(parts[1])}`;
+}
+
+function parseUnreadCount(data) {
+  const value = data?.unreadCount ?? data?.totalUnread ?? data?.["message-count"];
+  if (value === undefined || value === null) return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.floor(parsed);
+}
+
+async function updateAppBadge(unreadCount) {
+  if (unreadCount === null) return;
+  try {
+    if (unreadCount > 0 && typeof navigator.setAppBadge === "function") {
+      await navigator.setAppBadge(unreadCount);
+      return;
+    }
+    if (unreadCount === 0 && typeof navigator.clearAppBadge === "function") {
+      await navigator.clearAppBadge();
+    }
+  } catch {
+    // best-effort browser chrome integration
+  }
+}
+
+async function postUnreadCountToClients(unreadCount) {
+  if (unreadCount === null) return;
+  try {
+    const windowClients = await clients.matchAll({ type: "window", includeUncontrolled: true });
+    for (const client of windowClients) {
+      client.postMessage?.({ type: UNREAD_COUNT_MESSAGE_TYPE, unreadCount });
+    }
+  } catch {
+    // best-effort open-window sync
+  }
 }

--- a/chat/tests/channel-unread.test.ts
+++ b/chat/tests/channel-unread.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelUnread } from "../src/composables/useChannelUnread";
+import type { BrowserXmppClient, InboxEntry } from "../src/lib/xmpp-client";
+
+type MockClient = BrowserXmppClient & {
+  fetchInbox: ReturnType<typeof mock>;
+  markInboxRead: ReturnType<typeof mock>;
+};
+
+function makeClient(conversations: InboxEntry[] = []): MockClient {
+  return {
+    fetchInbox: mock(() => Promise.resolve({
+      totalUnread: conversations.reduce((sum, conversation) => sum + conversation.unread, 0),
+      conversations,
+    })),
+    markInboxRead: mock(() => Promise.resolve()),
+  } as unknown as MockClient;
+}
+
+const channelEntry: InboxEntry = {
+  partner: "space_channel@conference.example.com",
+  kind: "muc",
+  lastStanzaId: "sid-1",
+  lastUpdated: 100,
+  unread: 2,
+};
+
+const threadEntry: InboxEntry = {
+  partner: "space_channel@conference.example.com",
+  kind: "muc",
+  lastStanzaId: "sid-2",
+  lastUpdated: 200,
+  unread: 3,
+  thread: "thread-1",
+  threadTitle: "Planning",
+};
+
+describe("useChannelUnread", () => {
+  test("hydrates channel and thread unread totals", async () => {
+    const client = makeClient([
+      channelEntry,
+      threadEntry,
+      {
+        partner: "bob@example.com",
+        kind: "direct",
+        lastStanzaId: "sid-3",
+        lastUpdated: 300,
+        unread: 7,
+      },
+    ]);
+    const composable = useChannelUnread(ref<BrowserXmppClient | null>(client));
+
+    await composable.hydrateFromInbox();
+
+    expect(composable.totalChannelUnreadCount.value).toBe(2);
+    expect(composable.totalThreadUnreadCount.value).toBe(3);
+    expect(composable.totalUnreadCount.value).toBe(2);
+    expect(composable.channelUnreadMap()).toMatchObject({
+      space_channel: { unread: 2, mentions: 0 },
+    });
+  });
+
+  test("updates totals from inbox pushes and ignores direct entries", () => {
+    const composable = useChannelUnread(ref<BrowserXmppClient | null>(null));
+
+    composable.onInboxPush(channelEntry);
+    composable.onInboxPush(threadEntry);
+    composable.onInboxPush({
+      partner: "bob@example.com",
+      kind: "direct",
+      lastStanzaId: "sid-3",
+      lastUpdated: 300,
+      unread: 7,
+    });
+
+    expect(composable.totalChannelUnreadCount.value).toBe(2);
+    expect(composable.totalThreadUnreadCount.value).toBe(3);
+    expect(composable.totalUnreadCount.value).toBe(2);
+  });
+
+  test("markRead and markThreadRead clear their own totals", () => {
+    const client = makeClient();
+    const composable = useChannelUnread(ref<BrowserXmppClient | null>(client));
+    composable.onInboxPush(channelEntry);
+    composable.onInboxPush(threadEntry);
+
+    composable.markRead("space_channel@conference.example.com");
+
+    expect(composable.totalChannelUnreadCount.value).toBe(0);
+    expect(composable.totalThreadUnreadCount.value).toBe(3);
+    expect(composable.totalUnreadCount.value).toBe(0);
+    expect(client.markInboxRead).toHaveBeenCalledWith("space_channel@conference.example.com");
+
+    composable.markThreadRead("space_channel@conference.example.com", "thread-1");
+
+    expect(composable.totalThreadUnreadCount.value).toBe(0);
+    expect(composable.totalUnreadCount.value).toBe(0);
+    expect(client.markInboxRead).toHaveBeenCalledWith("space_channel@conference.example.com", "thread-1");
+  });
+
+  test("clears stale unread state without a client", async () => {
+    const client = ref<BrowserXmppClient | null>(makeClient());
+    const composable = useChannelUnread(client);
+    composable.onInboxPush(channelEntry);
+    composable.onInboxPush(threadEntry);
+
+    client.value = null;
+    const hydrated = await composable.hydrateFromInbox();
+
+    expect(hydrated).toBe(false);
+    expect(composable.totalChannelUnreadCount.value).toBe(0);
+    expect(composable.totalThreadUnreadCount.value).toBe(0);
+    expect(composable.totalUnreadCount.value).toBe(0);
+  });
+});

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -5,7 +5,7 @@ import { ref } from "vue";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { useDmMessaging } from "../src/composables/useDmMessaging";
 import { useMessaging } from "../src/composables/useMessaging";
-import { BrowserXmppClient, roomBareJidFor } from "../src/lib/xmpp-client";
+import { BrowserXmppClient, roomBareJidFor, type InboxEntry } from "../src/lib/xmpp-client";
 import { listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
@@ -285,6 +285,52 @@ describe("carbon forwarding", () => {
       peerJid: "bob@example.com",
       body: "hello from another resource path",
     }));
+  });
+});
+
+describe("inbox push adapter", () => {
+  test("preserves thread metadata from inbound inbox pushes", () => {
+    const client = new BrowserXmppClient(session());
+    const inboxEntries: InboxEntry[] = [];
+    client.setInboxPushHandler((entry) => {
+      inboxEntries.push(entry);
+    });
+    const xmpp = Object.assign(new EventEmitter(), {}) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("message", {
+      type: "headline",
+      from: "example.com",
+      to: "alice@example.com/desktop",
+      inboxPush: {
+        partner: "space_channel@muc.example.com",
+        kind: "muc",
+        lastStanzaId: "sid-thread",
+        lastUpdated: 1_700_000,
+        unread: 2,
+        preview: "thread reply",
+        thread: "thread-1",
+        threadTitle: "Planning",
+        replyCount: 5,
+        author: "bob",
+      },
+    });
+
+    expect(inboxEntries).toEqual([
+      {
+        partner: "space_channel@muc.example.com",
+        kind: "muc",
+        lastStanzaId: "sid-thread",
+        lastUpdated: 1_700_000,
+        unread: 2,
+        preview: "thread reply",
+        thread: "thread-1",
+        threadTitle: "Planning",
+        replyCount: 5,
+        author: "bob",
+      },
+    ]);
   });
 });
 

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -53,6 +53,7 @@ describe("useDmConversations", () => {
     expect(composable.conversations.value).toEqual([]);
     expect(composable.activePeerJid.value).toBeNull();
     expect(composable.hasUnread.value).toBe(false);
+    expect(composable.totalUnreadCount.value).toBe(0);
   });
 
   test("openDm creates a conversation and sets activePeerJid", async () => {
@@ -114,6 +115,7 @@ describe("useDmConversations", () => {
       lastMessageBody: "from inbox",
       unreadCount: 2,
     });
+    expect(composable.totalUnreadCount.value).toBe(2);
     expect(client.subscribeToPeerPresence).toHaveBeenCalledWith("bob@example.com");
   });
 
@@ -147,6 +149,7 @@ describe("useDmConversations", () => {
     expect(composable.conversations.value[0].unreadCount).toBe(1);
     expect(composable.conversations.value[0].lastMessageBody).toBe("hello");
     expect(composable.hasUnread.value).toBe(true);
+    expect(composable.totalUnreadCount.value).toBe(1);
   });
 
   test("receiveIncomingDm does not increment unread for active conversation", async () => {
@@ -154,6 +157,7 @@ describe("useDmConversations", () => {
     await composable.openDm("bob@example.com");
     composable.receiveIncomingDm(makeDmMessage());
     expect(composable.conversations.value[0].unreadCount).toBe(0);
+    expect(composable.totalUnreadCount.value).toBe(0);
   });
 
   test("receiveIncomingDm syncs inbox read for the active conversation", async () => {
@@ -193,6 +197,7 @@ describe("useDmConversations", () => {
 
     expect(composable.conversations.value[0].unreadCount).toBe(0);
     expect(composable.hasUnread.value).toBe(false);
+    expect(composable.totalUnreadCount.value).toBe(0);
     expect(client.markInboxRead).toHaveBeenCalledWith("bob@example.com");
   });
 
@@ -201,9 +206,89 @@ describe("useDmConversations", () => {
     composable.receiveIncomingDm(makeDmMessage());
     composable.receiveIncomingDm(makeDmMessage({ id: "msg-2" }));
     expect(composable.conversations.value[0].unreadCount).toBe(2);
+    expect(composable.totalUnreadCount.value).toBe(2);
     composable.markRead("bob@example.com");
     expect(composable.conversations.value[0].unreadCount).toBe(0);
     expect(composable.hasUnread.value).toBe(false);
+    expect(composable.totalUnreadCount.value).toBe(0);
+  });
+
+  test("onInboxPush applies direct unread totals and ignores non-DM entries", () => {
+    const { composable } = makeComposable();
+
+    composable.onInboxPush({
+      partner: "bob@example.com",
+      kind: "direct",
+      lastStanzaId: "sid-1",
+      lastUpdated: epochSeconds("2026-01-02T12:00:00Z"),
+      unread: 4,
+      preview: "from push",
+    });
+    composable.onInboxPush({
+      partner: "general@conference.example.com",
+      kind: "muc",
+      lastStanzaId: "sid-2",
+      lastUpdated: epochSeconds("2026-01-02T12:05:00Z"),
+      unread: 3,
+      preview: "ignore me",
+    });
+
+    expect(composable.conversations.value).toHaveLength(1);
+    expect(composable.conversations.value[0]).toMatchObject({
+      peerJid: "bob@example.com",
+      lastMessageBody: "from push",
+      unreadCount: 4,
+    });
+    expect(composable.totalUnreadCount.value).toBe(4);
+  });
+
+  test("does not double-count a DM already accounted by an inbox push", () => {
+    const { composable } = makeComposable();
+
+    composable.onInboxPush({
+      partner: "bob@example.com",
+      kind: "direct",
+      lastStanzaId: "server-stanza-1",
+      lastUpdated: epochSeconds("2026-01-02T12:00:00Z"),
+      unread: 4,
+      preview: "from push",
+    });
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "server-stanza-1",
+      body: "same message",
+      createdAt: "2026-01-02T12:00:01Z",
+    }));
+
+    expect(composable.conversations.value[0]).toMatchObject({
+      lastMessageBody: "same message",
+      unreadCount: 4,
+    });
+    expect(composable.totalUnreadCount.value).toBe(4);
+
+    composable.onInboxPush({
+      partner: "bob@example.com",
+      kind: "direct",
+      lastStanzaId: "server-stanza-2",
+      lastUpdated: epochSeconds("2026-01-02T12:00:02Z"),
+      unread: 5,
+      preview: "from push again",
+    });
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "client-origin-2",
+      wireIds: ["server-stanza-2"],
+      body: "same wire id message",
+      createdAt: "2026-01-02T12:00:02Z",
+    }));
+
+    expect(composable.conversations.value[0].unreadCount).toBe(5);
+
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "server-stanza-3",
+      body: "new message",
+      createdAt: "2026-01-02T12:00:03Z",
+    }));
+
+    expect(composable.conversations.value[0].unreadCount).toBe(6);
   });
 
   test("updatePresence updates conversation presence", async () => {

--- a/chat/tests/service-worker-push.test.ts
+++ b/chat/tests/service-worker-push.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+type Listener = (event: Record<string, unknown>) => void;
+
+function loadServiceWorker(windowClients: Array<Record<string, unknown>> = []) {
+  const listeners = new Map<string, Listener[]>();
+  const setAppBadge = mock(async (_count?: number) => {});
+  const clearAppBadge = mock(async () => {});
+  const showNotification = mock(async (_title: string, _options: NotificationOptions) => {});
+  const clients = {
+    matchAll: mock(async (_options?: unknown) => windowClients),
+    openWindow: mock(async (_url: string) => null),
+  };
+  const self = {
+    location: { origin: "https://chat.example.test" },
+    clients: { claim: mock(async () => {}) },
+    registration: { showNotification },
+    skipWaiting: mock(async () => {}),
+    addEventListener: (type: string, listener: Listener) => {
+      const existing = listeners.get(type) ?? [];
+      listeners.set(type, [...existing, listener]);
+    },
+  };
+  const caches = {
+    open: mock(async () => ({ addAll: mock(async (_urls: string[]) => {}) })),
+    keys: mock(async () => []),
+    delete: mock(async (_key: string) => true),
+    match: mock(async (_request: unknown) => null),
+  };
+  const code = readFileSync(
+    new URL("../src/service-worker/sw-template.js", import.meta.url),
+    "utf8",
+  ).replaceAll("__WADDLE_BUILD_SHA__", "test-sha");
+
+  new Function("self", "caches", "fetch", "clients", "navigator", "URL", code)(
+    self,
+    caches,
+    mock(async (_request: unknown) => ({ ok: false })),
+    clients,
+    { setAppBadge, clearAppBadge },
+    URL,
+  );
+
+  function dispatch(type: string, event: Record<string, unknown>) {
+    for (const listener of listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  return { dispatch, setAppBadge, clearAppBadge, showNotification, clients };
+}
+
+function makePushEvent(data: { json?: () => unknown; text?: () => string }) {
+  const waits: Array<Promise<unknown>> = [];
+  return {
+    data,
+    waitUntil: (promise: Promise<unknown>) => {
+      waits.push(Promise.resolve(promise));
+    },
+    done: () => Promise.all(waits),
+  };
+}
+
+describe("service worker push handling", () => {
+  test("sets the app badge and posts unread count to open clients", async () => {
+    const client = { postMessage: mock((_message: unknown) => {}) };
+    const worker = loadServiceWorker([client]);
+    const event = makePushEvent({
+      json: () => ({
+        title: "Mention",
+        body: "hello",
+        roomJid: "space_channel@conference.example.com",
+        url: "/space/channel",
+        "message-count": 6,
+      }),
+    });
+
+    worker.dispatch("push", event);
+    await event.done();
+
+    expect(worker.setAppBadge).toHaveBeenCalledWith(6);
+    expect(worker.clients.matchAll).toHaveBeenCalledWith({
+      type: "window",
+      includeUncontrolled: true,
+    });
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: "waddle:unread-count",
+      unreadCount: 6,
+    });
+    expect(worker.showNotification).toHaveBeenCalledWith("Mention", {
+      body: "hello",
+      tag: "space_channel@conference.example.com",
+      icon: "/android-chrome-192x192.png",
+      data: { url: "/space/channel" },
+    });
+  });
+
+  test("clears the app badge when push unread count is zero", async () => {
+    const client = { postMessage: mock((_message: unknown) => {}) };
+    const worker = loadServiceWorker([client]);
+    const event = makePushEvent({
+      json: () => ({
+        title: "Waddle",
+        body: "",
+        roomJid: "space_channel@conference.example.com",
+        unreadCount: 0,
+      }),
+    });
+
+    worker.dispatch("push", event);
+    await event.done();
+
+    expect(worker.clearAppBadge).toHaveBeenCalled();
+    expect(client.postMessage).toHaveBeenCalledWith({
+      type: "waddle:unread-count",
+      unreadCount: 0,
+    });
+  });
+
+  test("keeps text notification fallback for non-json push payloads", async () => {
+    const worker = loadServiceWorker();
+    const event = makePushEvent({
+      json: () => {
+        throw new Error("not json");
+      },
+      text: () => "raw push text",
+    });
+
+    worker.dispatch("push", event);
+    await event.done();
+
+    expect(worker.setAppBadge).not.toHaveBeenCalled();
+    expect(worker.clearAppBadge).not.toHaveBeenCalled();
+    expect(worker.clients.matchAll).not.toHaveBeenCalled();
+    expect(worker.showNotification).toHaveBeenCalledWith("Waddle", {
+      body: "raw push text",
+      tag: undefined,
+      icon: "/android-chrome-192x192.png",
+      data: { url: "/" },
+    });
+  });
+});

--- a/chat/tests/tab-unread-indicator.test.ts
+++ b/chat/tests/tab-unread-indicator.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { nextTick, ref } from "vue";
+import { useTabUnreadIndicator } from "../src/composables/useTabUnreadIndicator";
+
+const originalWindow = globalThis.window;
+const originalDocument = globalThis.document;
+const originalNavigator = globalThis.navigator;
+const originalImage = globalThis.Image;
+let autoLoadImages = true;
+let pendingImages: FakeImage[] = [];
+
+class FakeLinkElement {
+  rel: string;
+  type: string;
+  href: string;
+  private attributes: Map<string, string>;
+
+  constructor(attributes: Record<string, string> = {
+    rel: "icon",
+    type: "image/png",
+    sizes: "32x32",
+    href: "/favicon-32x32.png",
+  }) {
+    this.attributes = new Map(Object.entries(attributes));
+    this.rel = attributes.rel ?? "icon";
+    this.type = attributes.type ?? "";
+    this.href = attributes.href ?? "";
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+    if (name === "href") this.href = value;
+    if (name === "type") this.type = value;
+    if (name === "rel") this.rel = value;
+  }
+
+  removeAttribute(name: string) {
+    this.attributes.delete(name);
+    if (name === "type") this.type = "";
+  }
+}
+
+class FakeImage {
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private value = "";
+
+  get src() {
+    return this.value;
+  }
+
+  set src(value: string) {
+    this.value = value;
+    if (!autoLoadImages) {
+      pendingImages.push(this);
+      return;
+    }
+    queueMicrotask(() => this.onload?.());
+  }
+}
+
+let links: FakeLinkElement[];
+let serviceWorker: EventTarget;
+let setAppBadge: ReturnType<typeof mock>;
+let clearAppBadge: ReturnType<typeof mock>;
+let querySelectorAll: ReturnType<typeof mock>;
+let canvasContext: {
+  drawImage: ReturnType<typeof mock>;
+  beginPath: ReturnType<typeof mock>;
+  arc: ReturnType<typeof mock>;
+  fill: ReturnType<typeof mock>;
+  stroke: ReturnType<typeof mock>;
+  fillStyle: string;
+  lineWidth: number;
+  strokeStyle: string;
+};
+
+async function flushPromises() {
+  await nextTick();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  autoLoadImages = true;
+  pendingImages = [];
+  links = [
+    new FakeLinkElement({ rel: "icon", type: "image/svg+xml", href: "/waddle-logo.svg" }),
+    new FakeLinkElement({ rel: "icon", type: "image/png", sizes: "32x32", href: "/favicon-32x32.png" }),
+    new FakeLinkElement({ rel: "icon", type: "image/png", sizes: "16x16", href: "/favicon-16x16.png" }),
+    new FakeLinkElement({ rel: "shortcut icon", href: "/favicon.ico" }),
+  ];
+  serviceWorker = new EventTarget();
+  setAppBadge = mock(async (_count?: number) => {});
+  clearAppBadge = mock(async () => {});
+  canvasContext = {
+    drawImage: mock(() => {}),
+    beginPath: mock(() => {}),
+    arc: mock(() => {}),
+    fill: mock(() => {}),
+    stroke: mock(() => {}),
+    fillStyle: "",
+    lineWidth: 0,
+    strokeStyle: "",
+  };
+
+  querySelectorAll = mock((_selector: string) => links);
+
+  const documentMock = {
+    title: "Waddle",
+    head: {
+      appendChild: mock((_node: unknown) => {}),
+    },
+    querySelectorAll,
+    createElement: mock((tagName: string) => {
+      if (tagName === "canvas") {
+        return {
+          width: 0,
+          height: 0,
+          getContext: mock(() => canvasContext),
+          toDataURL: mock(() => "data:image/png;base64,unread-dot"),
+        };
+      }
+      return new FakeLinkElement();
+    }),
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    writable: true,
+    value: new EventTarget(),
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    writable: true,
+    value: documentMock,
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    writable: true,
+    value: {
+      serviceWorker,
+      setAppBadge,
+      clearAppBadge,
+    },
+  });
+  Object.defineProperty(globalThis, "Image", {
+    configurable: true,
+    writable: true,
+    value: FakeImage,
+  });
+});
+
+afterEach(() => {
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+  } else {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      writable: true,
+      value: originalWindow,
+    });
+  }
+
+  if (originalDocument === undefined) {
+    Reflect.deleteProperty(globalThis, "document");
+  } else {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      writable: true,
+      value: originalDocument,
+    });
+  }
+
+  if (originalNavigator === undefined) {
+    Reflect.deleteProperty(globalThis, "navigator");
+  } else {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      writable: true,
+      value: originalNavigator,
+    });
+  }
+
+  if (originalImage === undefined) {
+    Reflect.deleteProperty(globalThis, "Image");
+  } else {
+    Object.defineProperty(globalThis, "Image", {
+      configurable: true,
+      writable: true,
+      value: originalImage,
+    });
+  }
+});
+
+describe("useTabUnreadIndicator", () => {
+  test("updates title, favicon, and app badge for unread counts", async () => {
+    const count = ref(3);
+    const indicator = useTabUnreadIndicator(count);
+
+    await flushPromises();
+
+    expect(document.title).toBe("* Waddle");
+    expect(setAppBadge).toHaveBeenCalledWith(3);
+    expect(querySelectorAll).toHaveBeenCalledWith('link[rel~="icon"]');
+    expect(links.map((item) => item.href)).toEqual([
+      "data:image/png;base64,unread-dot",
+      "data:image/png;base64,unread-dot",
+      "data:image/png;base64,unread-dot",
+      "data:image/png;base64,unread-dot",
+    ]);
+    expect(links.map((item) => item.getAttribute("type"))).toEqual([
+      "image/png",
+      "image/png",
+      "image/png",
+      "image/png",
+    ]);
+    expect(canvasContext.arc).toHaveBeenCalledWith(28, 4, 5, 0, Math.PI * 2);
+    expect(canvasContext.fillStyle).toBe("#dc2626");
+    expect(canvasContext.lineWidth).toBe(2);
+    expect(canvasContext.strokeStyle).toBe("#ffffff");
+    expect(canvasContext.stroke).toHaveBeenCalled();
+
+    count.value = 0;
+    await flushPromises();
+
+    expect(document.title).toBe("Waddle");
+    expect(clearAppBadge).toHaveBeenCalled();
+    expect(links.map((item) => item.href)).toEqual([
+      "/waddle-logo.svg",
+      "/favicon-32x32.png",
+      "/favicon-16x16.png",
+      "/favicon.ico",
+    ]);
+    expect(links.map((item) => item.getAttribute("type"))).toEqual([
+      "image/svg+xml",
+      "image/png",
+      "image/png",
+      null,
+    ]);
+
+    indicator.stop();
+  });
+
+  test("uses service worker unread messages as a tab sync nudge", async () => {
+    const count = ref(0);
+    const hydration = deferred<boolean>();
+    const onServiceWorkerUnreadCount = mock((_count: number) => hydration.promise);
+    const indicator = useTabUnreadIndicator(count, { onServiceWorkerUnreadCount });
+    await flushPromises();
+
+    const event = Object.assign(new Event("message"), {
+      data: { type: "waddle:unread-count", unreadCount: 5 },
+    });
+    serviceWorker.dispatchEvent(event);
+    await flushPromises();
+
+    expect(onServiceWorkerUnreadCount).toHaveBeenCalledWith(5);
+    expect(document.title).toBe("* Waddle");
+    expect(setAppBadge).toHaveBeenCalledWith(5);
+
+    count.value = 5;
+    hydration.resolve(true);
+    await flushPromises();
+
+    expect(document.title).toBe("* Waddle");
+    expect(setAppBadge).toHaveBeenCalledWith(5);
+
+    indicator.stop();
+  });
+
+  test("reconciles deferred local changes when inbox refresh does not complete", async () => {
+    const count = ref(0);
+    const hydration = deferred<boolean>();
+    const indicator = useTabUnreadIndicator(count, {
+      onServiceWorkerUnreadCount: mock((_count: number) => hydration.promise),
+    });
+    await flushPromises();
+
+    serviceWorker.dispatchEvent(Object.assign(new Event("message"), {
+      data: { type: "waddle:unread-count", unreadCount: 7 },
+    }));
+    await flushPromises();
+
+    count.value = 2;
+    await flushPromises();
+
+    hydration.resolve(false);
+    await flushPromises();
+
+    expect(document.title).toBe("* Waddle");
+    expect(setAppBadge).toHaveBeenCalledWith(2);
+
+    indicator.stop();
+  });
+
+  test("ignores in-flight favicon and service worker work after stop", async () => {
+    autoLoadImages = false;
+    const count = ref(3);
+    const hydration = deferred<boolean>();
+    const indicator = useTabUnreadIndicator(count, {
+      onServiceWorkerUnreadCount: mock((_count: number) => hydration.promise),
+    });
+    await nextTick();
+
+    expect(document.title).toBe("* Waddle");
+
+    serviceWorker.dispatchEvent(Object.assign(new Event("message"), {
+      data: { type: "waddle:unread-count", unreadCount: 8 },
+    }));
+    await flushPromises();
+    expect(document.title).toBe("* Waddle");
+
+    indicator.stop();
+    count.value = 9;
+    hydration.resolve(true);
+    for (const image of pendingImages) {
+      image.onload?.();
+    }
+    await flushPromises();
+
+    expect(document.title).toBe("Waddle");
+    expect(links.map((item) => item.href)).toEqual([
+      "/waddle-logo.svg",
+      "/favicon-32x32.png",
+      "/favicon-16x16.png",
+      "/favicon.ico",
+    ]);
+    expect(setAppBadge).not.toHaveBeenCalledWith(9);
+  });
+
+  test("ignores service worker unread messages when the app should not accept them", async () => {
+    const count = ref(0);
+    const onServiceWorkerUnreadCount = mock((_count: number) => true);
+    const indicator = useTabUnreadIndicator(count, {
+      shouldAcceptServiceWorkerUnreadCount: () => false,
+      onServiceWorkerUnreadCount,
+    });
+    await flushPromises();
+
+    serviceWorker.dispatchEvent(Object.assign(new Event("message"), {
+      data: { type: "waddle:unread-count", unreadCount: 9 },
+    }));
+    await flushPromises();
+
+    expect(onServiceWorkerUnreadCount).not.toHaveBeenCalled();
+    expect(document.title).toBe("Waddle");
+    expect(clearAppBadge).toHaveBeenCalled();
+
+    indicator.stop();
+  });
+});

--- a/server/crates/waddle-xmpp/src/push/sender.rs
+++ b/server/crates/waddle-xmpp/src/push/sender.rs
@@ -17,6 +17,7 @@ pub trait WebPushSender: Send + Sync + 'static {
         title: &str,
         body: &str,
         room_jid: &str,
+        unread_count: u64,
     ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>>;
 }
 
@@ -51,23 +52,13 @@ impl WebPushSender for HttpWebPushSender {
         title: &str,
         body: &str,
         room_jid: &str,
+        unread_count: u64,
     ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
         let endpoint = subscription.endpoint.clone();
-        let subscription_endpoint = subscription.endpoint.clone();
-        let subscription_p256dh = subscription.p256dh.clone();
-        let subscription_auth = subscription.auth_key.clone();
         // This sender targets an application relay/gateway endpoint. The relay is
         // responsible for performing standards-compliant Web Push (VAPID/encryption)
         // using the subscription keys supplied below.
-        let payload = serde_json::json!({
-            "title": title,
-            "body": body,
-            "roomJid": room_jid,
-            "url": room_jid_to_path(room_jid),
-            "endpoint": subscription_endpoint,
-            "p256dh": subscription_p256dh,
-            "auth": subscription_auth,
-        });
+        let payload = relay_payload(subscription, title, body, room_jid, unread_count);
         Box::pin(async move {
             let ep = endpoint.as_deref().ok_or(PushError::MissingEndpoint)?;
             match self.client.post(ep).json(&payload).send().await {
@@ -105,6 +96,7 @@ pub async fn notify_mentioned_users<S, W>(
     sender_nick: &str,
     body: &str,
     room_jid: &str,
+    unread_count: u64,
 ) where
     S: PushSubscriptionStore + ?Sized,
     W: WebPushSender + ?Sized,
@@ -129,13 +121,32 @@ pub async fn notify_mentioned_users<S, W>(
         };
         for sub in &subs {
             if let Err(e) = sender
-                .send_notification(sub, &title, &preview, room_jid)
+                .send_notification(sub, &title, &preview, room_jid, unread_count)
                 .await
             {
                 debug!(user_jid = %jid, error = %e, "Push notification failed");
             }
         }
     }
+}
+
+fn relay_payload(
+    subscription: &PushSubscription,
+    title: &str,
+    body: &str,
+    room_jid: &str,
+    unread_count: u64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "title": title,
+        "body": body,
+        "roomJid": room_jid,
+        "url": room_jid_to_path(room_jid),
+        "message-count": unread_count,
+        "endpoint": subscription.endpoint.as_deref(),
+        "p256dh": subscription.p256dh.as_deref(),
+        "auth": subscription.auth_key.as_deref(),
+    })
 }
 
 #[cfg(test)]
@@ -160,6 +171,7 @@ mod tests {
             _: &str,
             _: &str,
             _: &str,
+            _: u64,
         ) -> Pin<Box<dyn Future<Output = Result<(), PushError>> + Send + '_>> {
             self.0.fetch_add(1, Ordering::SeqCst);
             Box::pin(async { Ok(()) })
@@ -189,6 +201,7 @@ mod tests {
             "charlie",
             "Hey!",
             "room@muc",
+            3,
         )
         .await;
         assert_eq!(sender.count(), 1); // only alice has a sub
@@ -205,9 +218,35 @@ mod tests {
             "bob",
             "Hi",
             "room@muc",
+            0,
         )
         .await;
         assert_eq!(sender.count(), 0);
+    }
+
+    #[test]
+    fn relay_payload_includes_xep_0357_message_count() {
+        let subscription = PushSubscription {
+            user_jid: "alice@ex".into(),
+            service_jid: "push.ex".into(),
+            node: Some("n1".into()),
+            endpoint: Some("https://ep".into()),
+            p256dh: Some("BASE64KEY".into()),
+            auth_key: Some("BASE64AUTH".into()),
+        };
+        let payload = relay_payload(
+            &subscription,
+            "Waddle",
+            "New message",
+            "c2@conference.example.com",
+            6,
+        );
+
+        assert_eq!(payload["message-count"], 6);
+        assert_eq!(payload["url"], "/c2");
+        assert_eq!(payload["endpoint"], "https://ep");
+        assert_eq!(payload["p256dh"], "BASE64KEY");
+        assert_eq!(payload["auth"], "BASE64AUTH");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `useTabUnreadIndicator(unreadCount)` for binary tab unread signaling: `* Waddle`, a favicon marker, and app badge updates where supported.
- Wire combined unread state from DMs and channel inbox state into `ChatApp.vue`, including service-worker sync nudges that refresh inbox state only when the live chat session can accept them.
- Extend service-worker push handling to parse unread totals, update/clear app badges, and post unread-count messages to open clients while preserving existing notification behavior.
- Include WebPush relay `message-count` in the server push payload so the service worker can consume the XEP-0357 summary count without changing XMPP stanza shapes.

## Notes

- The tab title intentionally does not show the count; it only shows an unread indicator.
- The favicon marker is a small red dot with a white border, centered over the top-right favicon corner.
- Thread rows are tracked for unread state but not added on top of channel totals for the tab indicator.

## Verification

- `chat/`: `bun test` — 429 passing tests.
- `chat/`: `bun run lint` — clean.
- `chat/`: `bun run build` — clean; existing Vite inspector-port fallback and chunk-size warning only.
- `server/`: `cargo fmt --all` — clean.
- `server/`: `cargo test -p waddle-xmpp push::sender` — 4 passing targeted push tests.
- `server/`: `cargo clippy -p waddle-xmpp -- -D warnings` — clean.