### PR TITLE
fix(chat): auto-mark-read when all messages are read

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -11,6 +11,8 @@ import { useAppUpdate } from "@/composables/useAppUpdate";
 import { useNotifications } from "@/composables/useNotifications";
 import { useChannelUnread } from "@/composables/useChannelUnread";
 import { useTabUnreadIndicator } from "@/composables/useTabUnreadIndicator";
+import { useWindowVisibility } from "@/composables/useWindowVisibility";
+import { useReadReceipts } from "@/composables/useReadReceipts";
 import { useVersion } from "@/composables/useVersion";
 import { useRosterContacts } from "@/composables/useRosterContacts";
 import { buildDmPath, buildPath, buildSettingsPath, parseRoute, pushDmRoute, pushRoute, pushSettingsRoute, resolveChannel, shouldLoadStructureForRoute } from "@/composables/useRouting";
@@ -242,6 +244,59 @@ useTabUnreadIndicator(totalTabUnreadCount, {
     dmConversations.hydrateFromInbox(),
     channelUnread.hydrateFromInbox(),
   ]).then((results) => results.every(Boolean)),
+});
+
+const { isWindowFocused } = useWindowVisibility();
+const readReceiptsKind = computed<"channel" | "dm" | null>(() => {
+  if (ui.sidebarMode.value === "dms") {
+    return dmConversations.activePeerJid.value ? "dm" : null;
+  }
+  return waddles.activeChannelId.value ? "channel" : null;
+});
+const readReceiptsActiveRoomJid = computed<string | null>(() => {
+  if (readReceiptsKind.value !== "channel") return null;
+  const channelId = waddles.activeChannelId.value;
+  const sess = session.value;
+  if (!channelId || !sess) return null;
+  return roomBareJidFor(sess, channelId);
+});
+const readReceiptsActivePeerJid = computed<string | null>(() =>
+  readReceiptsKind.value === "dm" ? dmConversations.activePeerJid.value : null,
+);
+const readReceiptsIsPinnedAtEdge = computed<boolean>(() =>
+  readReceiptsKind.value === "dm"
+    ? dmMessaging.isPinnedAtEdge.value
+    : messaging.isPinnedAtEdge.value,
+);
+const readReceiptsLatestRemoteId = computed<string | null>(() =>
+  readReceiptsKind.value === "dm"
+    ? dmMessaging.latestRemoteMessageId.value
+    : messaging.latestRemoteMessageId.value,
+);
+const readReceiptsUnreadCount = computed<number>(() => {
+  if (readReceiptsKind.value === "dm") {
+    const peer = readReceiptsActivePeerJid.value;
+    if (!peer) return 0;
+    return dmConversations.conversations.value.find((c) => c.peerJid === peer)?.unreadCount ?? 0;
+  }
+  if (readReceiptsKind.value === "channel") {
+    const channelId = waddles.activeChannelId.value;
+    if (!channelId) return 0;
+    return computedChannelUnreadMap.value[channelId]?.unread ?? 0;
+  }
+  return 0;
+});
+useReadReceipts({
+  isWindowFocused,
+  isPinnedAtEdge: readReceiptsIsPinnedAtEdge,
+  activeKind: readReceiptsKind,
+  activeRoomJid: readReceiptsActiveRoomJid,
+  activePeerJid: readReceiptsActivePeerJid,
+  latestRemoteMessageId: readReceiptsLatestRemoteId,
+  unreadCountForActive: readReceiptsUnreadCount,
+  markChannelRead: (jid) => channelUnread.markRead(jid),
+  markDmRead: (peer) => dmConversations.markRead(peer),
+  markDisplayed: (id) => activeTarget.value.markDisplayed(id),
 });
 
 const notifications = useNotifications();
@@ -805,9 +860,13 @@ async function selectChannel(channelId: string) {
   if (connectionStore.session) {
     const roomJid = roomBareJidFor(connectionStore.session, channelId);
     messaging.clearChannelActivity(roomJid);
-    channelUnread.markRead(roomJid);
   }
-  await messaging.loadMessages(waddles.currentChannel.value?.spaceId ?? "", channelId);
+  const unreadAtLoad = computedChannelUnreadMap.value[channelId]?.unread ?? 0;
+  await messaging.loadMessages(
+    waddles.currentChannel.value?.spaceId ?? "",
+    channelId,
+    unreadAtLoad,
+  );
   ui.showMobileNav.value = false;
 }
 
@@ -816,8 +875,10 @@ async function handleOpenDm(peerJid: string) {
   ui.sidebarMode.value = "dms";
   await dmConversations.openDm(peerJid);
   dmMessaging.clearMessages();
-  if (dmConversations.activePeerJid.value) {
-    await dmMessaging.loadMessages(dmConversations.activePeerJid.value);
+  const activePeer = dmConversations.activePeerJid.value;
+  if (activePeer) {
+    const unreadAtLoad = dmConversations.conversations.value.find((c) => c.peerJid === activePeer)?.unreadCount ?? 0;
+    await dmMessaging.loadMessages(activePeer, unreadAtLoad);
   }
   ui.showMobileNav.value = false;
 }
@@ -1236,7 +1297,6 @@ onUnmounted(() => {
               @edit-message="editActiveMessage"
               @retract-message="retractActiveMessage"
               @react-message="reactActiveMessage"
-              @displayed="markActiveDisplayed"
               @search="searchActiveMessages"
               @clear-search="clearActiveSearch"
               @load-older="loadOlderActiveMessages"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -76,7 +76,6 @@ const emit = defineEmits<{
   editMessage: [messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]];
   retractMessage: [messageId: string];
   reactMessage: [messageId: string, emoji: string];
-  displayed: [messageId: string];
   editChannel: [];
   openNav: [];
   openDetails: [];
@@ -261,11 +260,6 @@ const conversationScope = computed(() => [
   props.channel?.id ?? "",
   props.dmPeer?.peerJid ?? "",
 ].join(":"));
-const lastDisplayedMessageId = ref<string | null>(null);
-const latestRemoteMessageId = computed(() => {
-  const last = [...props.messages].reverse().find((message) => !message.isSelf && !message.isRetracted);
-  return last?.id ?? null;
-});
 const hasSeenOnline = ref(props.xmppStatus.state === "online");
 const showReconnectedNotice = ref(false);
 let reconnectedNoticeTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -431,19 +425,11 @@ function onDrop(e: DragEvent) {
   if (files.length > 0) composerRef.value?.addAttachments(files);
 }
 
-// XEP-0333: Send one displayed marker per latest remote message id.
-watch(latestRemoteMessageId, (messageId) => {
-  if (!messageId || messageId === lastDisplayedMessageId.value) return;
-  lastDisplayedMessageId.value = messageId;
-  emit("displayed", messageId);
-});
-
 watch(conversationScope, () => {
   cancelReply();
   clearReplyJumpNotice();
   clearReconnectedNotice();
   forumTitle.value = "";
-  lastDisplayedMessageId.value = null;
 });
 
 // Clear reply context only on successful send; preserve on failure so user can retry

--- a/chat/src/composables/useDmConversations.ts
+++ b/chat/src/composables/useDmConversations.ts
@@ -250,7 +250,6 @@ export function useDmConversations(
     const bare = barePeerJid(peerJid);
     ensureConversation(bare);
     activePeerJid.value = bare;
-    markRead(bare);
     try {
       await xmppClient.value?.subscribeToPeerPresence(bare);
     } catch {
@@ -283,10 +282,6 @@ export function useDmConversations(
           }
         : c
     )));
-
-    if (!isSelfMessage && isActiveConversation) {
-      markRead(bare, { forceSync: true });
-    }
   }
 
   function updatePresence(event: PresenceUpdateEvent) {

--- a/chat/src/composables/useDmMessaging.ts
+++ b/chat/src/composables/useDmMessaging.ts
@@ -1,4 +1,4 @@
-import { nextTick, ref, watch, type Ref } from "vue";
+import { computed, nextTick, ref, watch, type Ref } from "vue";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
@@ -137,6 +137,14 @@ export function useDmMessaging(
   const isSearching = ref(false);
   const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const firstUnseenId = ref<string | null>(null);
+  const latestRemoteMessageId = computed<string | null>(() => {
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const m = messages.value[i];
+      if (!m || m.isSelf || m.isRetracted) continue;
+      return m.id;
+    }
+    return null;
+  });
 
   let messageRequestId = 0;
   let oldestArchiveId: string | null = null;
@@ -486,7 +494,7 @@ export function useDmMessaging(
     })();
   }
 
-  async function loadMessages(peerJid: string) {
+  async function loadMessages(peerJid: string, unreadAtLoad = 0) {
     if (!session.value) return;
     const requestId = ++messageRequestId;
     initialLatestPagePinned = false;
@@ -517,7 +525,10 @@ export function useDmMessaging(
       if (requestId === messageRequestId) isLoadingMessages.value = false;
 
       const key = dmKey(barePeerJid(peerJid));
-      firstUnseenId.value = null;
+      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
+      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
+        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
+        : null;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
       initialLatestPagePinned = true;
@@ -849,7 +860,6 @@ export function useDmMessaging(
       if (!messages.value.some(isFeedVisible)) return;
       const requestId = messageRequestId;
       const peerJid = activePeerJid.value;
-      firstUnseenId.value = null;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
         pinned &&
@@ -900,5 +910,7 @@ export function useDmMessaging(
     onMessageDeliveryFailure,
     onSessionLifecycle,
     scrollToPinnedEdge,
+    isPinnedAtEdge: pinnedEdgeScroller.isPinnedAtEdge,
+    latestRemoteMessageId,
   };
 }

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -266,6 +266,14 @@ export function useMessaging(
   const slowModeCooldown = ref(0);
   const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const firstUnseenId = ref<string | null>(null);
+  const latestRemoteMessageId = computed<string | null>(() => {
+    for (let i = messages.value.length - 1; i >= 0; i--) {
+      const m = messages.value[i];
+      if (!m || m.isSelf || m.isRetracted) continue;
+      return m.id;
+    }
+    return null;
+  });
   const activeChannels = ref<Set<string>>(new Set());
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
@@ -858,7 +866,7 @@ export function useMessaging(
     return applyForumContext(timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt)));
   }
 
-  async function loadMessages(spaceId: string, channelId: string) {
+  async function loadMessages(spaceId: string, channelId: string, unreadAtLoad = 0) {
     if (!session.value) return;
 
     const requestId = ++messageRequestId;
@@ -907,7 +915,10 @@ export function useMessaging(
         isLoadingMessages.value = false;
       }
 
-      firstUnseenId.value = null;
+      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
+      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
+        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
+        : null;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
         !pinned ||
@@ -1395,7 +1406,6 @@ export function useMessaging(
       const requestId = messageRequestId;
       const spaceId = activeSpaceId.value ?? "";
       const channelId = activeChannelId.value;
-      firstUnseenId.value = null;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
         pinned &&
@@ -1456,6 +1466,8 @@ export function useMessaging(
     clearSearch,
     clearChannelActivity,
     scrollToPinnedEdge,
+    isPinnedAtEdge: pinnedEdgeScroller.isPinnedAtEdge,
+    latestRemoteMessageId,
     lastMentionActivity,
     onMessageQueueStatus,
     onMessageAck,

--- a/chat/src/composables/useReadReceipts.ts
+++ b/chat/src/composables/useReadReceipts.ts
@@ -1,0 +1,78 @@
+import { watch, type Ref } from "vue";
+
+type ReadReceiptsActiveKind = "channel" | "dm" | null;
+
+interface UseReadReceiptsOptions {
+  isWindowFocused: Readonly<Ref<boolean>>;
+  isPinnedAtEdge: Readonly<Ref<boolean>>;
+  activeKind: Readonly<Ref<ReadReceiptsActiveKind>>;
+  activeRoomJid: Readonly<Ref<string | null>>;
+  activePeerJid: Readonly<Ref<string | null>>;
+  latestRemoteMessageId: Readonly<Ref<string | null>>;
+  unreadCountForActive: Readonly<Ref<number>>;
+  markChannelRead: (roomJid: string) => void;
+  markDmRead: (peerJid: string) => void;
+  markDisplayed: (messageId: string) => void;
+}
+
+export function useReadReceipts(options: UseReadReceiptsOptions) {
+  let lastDispatchedDisplayedId: string | null = null;
+  let lastReadActiveKey: string | null = null;
+
+  function activeKey(): string | null {
+    const kind = options.activeKind.value;
+    if (kind === "channel") {
+      const jid = options.activeRoomJid.value;
+      return jid ? `channel:${jid}` : null;
+    }
+    if (kind === "dm") {
+      const jid = options.activePeerJid.value;
+      return jid ? `dm:${jid}` : null;
+    }
+    return null;
+  }
+
+  watch(
+    () => ({
+      kind: options.activeKind.value,
+      roomJid: options.activeRoomJid.value,
+      peerJid: options.activePeerJid.value,
+      focused: options.isWindowFocused.value,
+      pinned: options.isPinnedAtEdge.value,
+      latestId: options.latestRemoteMessageId.value,
+      unread: options.unreadCountForActive.value,
+    }),
+    (state) => {
+      const key = activeKey();
+      if (key !== lastReadActiveKey) {
+        lastDispatchedDisplayedId = null;
+        lastReadActiveKey = key;
+      }
+
+      if (!state.focused || !state.pinned) return;
+      if (!state.kind) return;
+      if (!state.latestId) return;
+
+      const target = state.kind === "channel" ? state.roomJid : state.peerJid;
+      if (!target) return;
+
+      const idChanged = state.latestId !== lastDispatchedDisplayedId;
+      const hasUnread = state.unread > 0;
+      if (!idChanged && !hasUnread) return;
+
+      if (idChanged) {
+        lastDispatchedDisplayedId = state.latestId;
+        options.markDisplayed(state.latestId);
+      }
+
+      if (hasUnread) {
+        if (state.kind === "channel") {
+          options.markChannelRead(target);
+        } else {
+          options.markDmRead(target);
+        }
+      }
+    },
+    { immediate: true },
+  );
+}

--- a/chat/src/composables/useWindowVisibility.ts
+++ b/chat/src/composables/useWindowVisibility.ts
@@ -1,0 +1,32 @@
+import { onScopeDispose, ref, type Ref } from "vue";
+
+function readFocused(): boolean {
+  if (typeof document === "undefined") return true;
+  if (document.visibilityState !== "visible") return false;
+  return typeof document.hasFocus === "function" ? document.hasFocus() : true;
+}
+
+export function useWindowVisibility(): { isWindowFocused: Readonly<Ref<boolean>> } {
+  const isWindowFocused = ref(readFocused());
+
+  if (typeof window === "undefined") {
+    return { isWindowFocused };
+  }
+
+  function update() {
+    const next = readFocused();
+    if (isWindowFocused.value !== next) isWindowFocused.value = next;
+  }
+
+  document.addEventListener("visibilitychange", update);
+  window.addEventListener("focus", update);
+  window.addEventListener("blur", update);
+
+  onScopeDispose(() => {
+    document.removeEventListener("visibilitychange", update);
+    window.removeEventListener("focus", update);
+    window.removeEventListener("blur", update);
+  });
+
+  return { isWindowFocused };
+}

--- a/chat/src/lib/pinned-edge-scroll.ts
+++ b/chat/src/lib/pinned-edge-scroll.ts
@@ -1,8 +1,11 @@
-import { nextTick, watch, type Ref } from "vue";
+import { nextTick, ref, watch, type Ref } from "vue";
 import {
   getPinnedScrollTop,
+  isTopPinnedScrollDirection,
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
+
+const PINNED_EDGE_TOLERANCE_PX = 64;
 
 type EdgeScrollFn = (mode: ScrollDirectionMode) => boolean | Promise<boolean>;
 type ScrollTarget = {
@@ -11,6 +14,17 @@ type ScrollTarget = {
   token: number;
   virtualScroll: EdgeScrollFn | null;
 };
+
+function computeIsPinned(el: HTMLElement, mode: ScrollDirectionMode): boolean {
+  const scrollTop = typeof el.scrollTop === "number" ? el.scrollTop : 0;
+  if (isTopPinnedScrollDirection(mode)) {
+    return scrollTop <= PINNED_EDGE_TOLERANCE_PX;
+  }
+  const scrollHeight = typeof el.scrollHeight === "number" ? el.scrollHeight : 0;
+  const clientHeight = typeof el.clientHeight === "number" ? el.clientHeight : 0;
+  const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+  return distanceFromBottom <= PINNED_EDGE_TOLERANCE_PX;
+}
 
 export function createPinnedEdgeScroller(options: {
   element: Ref<HTMLElement | null>;
@@ -21,6 +35,42 @@ export function createPinnedEdgeScroller(options: {
   let settleTimer: ReturnType<typeof setTimeout> | null = null;
   let generation = 0;
   let settleGeneration = 0;
+
+  const isPinnedAtEdge = ref(true);
+
+  let trackedElement: HTMLElement | null = null;
+  let scrollListener: (() => void) | null = null;
+
+  function recomputePinned() {
+    const el = options.element.value;
+    if (!el) {
+      if (isPinnedAtEdge.value !== true) isPinnedAtEdge.value = true;
+      return;
+    }
+    const next = computeIsPinned(el, options.mode.value);
+    if (isPinnedAtEdge.value !== next) isPinnedAtEdge.value = next;
+  }
+
+  function attachScrollListener() {
+    const el = options.element.value;
+    if (el === trackedElement) return;
+    if (trackedElement && scrollListener && typeof trackedElement.removeEventListener === "function") {
+      trackedElement.removeEventListener("scroll", scrollListener);
+    }
+    trackedElement = el;
+    scrollListener = null;
+    if (!el) {
+      isPinnedAtEdge.value = true;
+      return;
+    }
+    if (typeof el.addEventListener !== "function") {
+      recomputePinned();
+      return;
+    }
+    scrollListener = () => recomputePinned();
+    el.addEventListener("scroll", scrollListener, { passive: true });
+    recomputePinned();
+  }
 
   function disconnectSettleLock() {
     generation++;
@@ -43,18 +93,21 @@ export function createPinnedEdgeScroller(options: {
 
   async function pinTarget(target: ScrollTarget): Promise<boolean> {
     if (target.virtualScroll && await target.virtualScroll(target.mode)) {
+      recomputePinned();
       return target.token === generation;
     }
     if (target.token !== generation) return false;
 
     if (!target.element) return false;
     target.element.scrollTop = getPinnedScrollTop(target.element, target.mode);
+    recomputePinned();
     return true;
   }
 
   async function pinCurrent(token: number): Promise<boolean> {
     const target = captureTarget();
     if (target.virtualScroll && await target.virtualScroll(target.mode)) {
+      recomputePinned();
       return target.token === generation && token === generation;
     }
     if (target.token !== generation || token !== generation) return false;
@@ -62,6 +115,7 @@ export function createPinnedEdgeScroller(options: {
     const currentElement = options.element.value;
     if (!currentElement) return false;
     currentElement.scrollTop = getPinnedScrollTop(currentElement, options.mode.value);
+    recomputePinned();
     return true;
   }
 
@@ -100,12 +154,27 @@ export function createPinnedEdgeScroller(options: {
 
   watch(
     () => [options.element.value, options.virtualScroll?.value ?? null] as const,
-    () => disconnectSettleLock(),
-    { flush: "sync" },
+    () => {
+      disconnectSettleLock();
+      attachScrollListener();
+    },
+    { flush: "sync", immediate: true },
   );
 
+  watch(() => options.mode.value, () => recomputePinned());
+
+  function disconnect() {
+    disconnectSettleLock();
+    if (trackedElement && scrollListener && typeof trackedElement.removeEventListener === "function") {
+      trackedElement.removeEventListener("scroll", scrollListener);
+    }
+    trackedElement = null;
+    scrollListener = null;
+  }
+
   return {
-    disconnect: disconnectSettleLock,
+    disconnect,
     scrollToPinnedEdge,
+    isPinnedAtEdge: isPinnedAtEdge as Readonly<Ref<boolean>>,
   };
 }

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -160,7 +160,10 @@ describe("useDmConversations", () => {
     expect(composable.totalUnreadCount.value).toBe(0);
   });
 
-  test("receiveIncomingDm syncs inbox read for the active conversation", async () => {
+  test("receiveIncomingDm does not auto-sync inbox read for active conversation", async () => {
+    // Auto-mark-read responsibility lives in useReadReceipts (gated on
+    // viewport + window focus); useDmConversations only suppresses the
+    // unread increment for the active conversation.
     const client = makeClient();
     const { composable } = makeComposable({ client });
 
@@ -168,7 +171,7 @@ describe("useDmConversations", () => {
     composable.receiveIncomingDm(makeDmMessage());
 
     expect(composable.conversations.value[0].unreadCount).toBe(0);
-    expect(client.markInboxRead).toHaveBeenCalledWith("bob@example.com");
+    expect(client.markInboxRead).not.toHaveBeenCalled();
   });
 
   test("receiveIncomingDm does not increment unread for self-sent messages", () => {
@@ -179,7 +182,9 @@ describe("useDmConversations", () => {
     expect(composable.conversations.value[0].unreadCount).toBe(0);
   });
 
-  test("openDm clears inbox unread locally and syncs markInboxRead", async () => {
+  test("openDm does not auto-mark-read on its own", async () => {
+    // Auto-mark-read responsibility lives in useReadReceipts (gated on
+    // viewport + window focus); openDm only sets the active peer.
     const client = makeClient([
       {
         partner: "bob@example.com",
@@ -195,10 +200,10 @@ describe("useDmConversations", () => {
     await composable.hydrateFromInbox();
     await composable.openDm("bob@example.com");
 
-    expect(composable.conversations.value[0].unreadCount).toBe(0);
-    expect(composable.hasUnread.value).toBe(false);
-    expect(composable.totalUnreadCount.value).toBe(0);
-    expect(client.markInboxRead).toHaveBeenCalledWith("bob@example.com");
+    expect(composable.conversations.value[0].unreadCount).toBe(3);
+    expect(composable.hasUnread.value).toBe(true);
+    expect(composable.totalUnreadCount.value).toBe(3);
+    expect(client.markInboxRead).not.toHaveBeenCalled();
   });
 
   test("markRead resets unread count", () => {

--- a/chat/tests/use-read-receipts.test.ts
+++ b/chat/tests/use-read-receipts.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, mock } from "bun:test";
+import { effectScope, ref } from "vue";
+import { useReadReceipts } from "../src/composables/useReadReceipts";
+
+type Harness = {
+  isWindowFocused: ReturnType<typeof ref<boolean>>;
+  isPinnedAtEdge: ReturnType<typeof ref<boolean>>;
+  activeKind: ReturnType<typeof ref<"channel" | "dm" | null>>;
+  activeRoomJid: ReturnType<typeof ref<string | null>>;
+  activePeerJid: ReturnType<typeof ref<string | null>>;
+  latestRemoteMessageId: ReturnType<typeof ref<string | null>>;
+  unreadCountForActive: ReturnType<typeof ref<number>>;
+  markChannelRead: ReturnType<typeof mock>;
+  markDmRead: ReturnType<typeof mock>;
+  markDisplayed: ReturnType<typeof mock>;
+  stop: () => void;
+};
+
+function makeHarness(initial: Partial<Pick<Harness,
+  "activeKind" | "activeRoomJid" | "activePeerJid" |
+  "latestRemoteMessageId" | "unreadCountForActive"
+>> & { focused?: boolean; pinned?: boolean } = {}): Harness {
+  const isWindowFocused = ref(initial.focused ?? true);
+  const isPinnedAtEdge = ref(initial.pinned ?? true);
+  const activeKind = ref<"channel" | "dm" | null>(null);
+  const activeRoomJid = ref<string | null>(null);
+  const activePeerJid = ref<string | null>(null);
+  const latestRemoteMessageId = ref<string | null>(null);
+  const unreadCountForActive = ref<number>(0);
+  const markChannelRead = mock(() => undefined);
+  const markDmRead = mock(() => undefined);
+  const markDisplayed = mock(() => undefined);
+
+  const scope = effectScope();
+  scope.run(() => {
+    useReadReceipts({
+      isWindowFocused,
+      isPinnedAtEdge,
+      activeKind,
+      activeRoomJid,
+      activePeerJid,
+      latestRemoteMessageId,
+      unreadCountForActive,
+      markChannelRead,
+      markDmRead,
+      markDisplayed,
+    });
+  });
+
+  return {
+    isWindowFocused,
+    isPinnedAtEdge,
+    activeKind,
+    activeRoomJid,
+    activePeerJid,
+    latestRemoteMessageId,
+    unreadCountForActive,
+    markChannelRead,
+    markDmRead,
+    markDisplayed,
+    stop: () => scope.stop(),
+  };
+}
+
+describe("useReadReceipts", () => {
+  test("does nothing when no active conversation", async () => {
+    const h = makeHarness();
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 5;
+    await Promise.resolve();
+    expect(h.markDisplayed).not.toHaveBeenCalled();
+    expect(h.markChannelRead).not.toHaveBeenCalled();
+    expect(h.markDmRead).not.toHaveBeenCalled();
+    h.stop();
+  });
+
+  test("dispatches markRead and markDisplayed for active channel when focused + pinned + unread", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 3;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledWith("m1");
+    expect(h.markChannelRead).toHaveBeenCalledWith("room@chat.example.com");
+    expect(h.markDmRead).not.toHaveBeenCalled();
+    h.stop();
+  });
+
+  test("dispatches markRead and markDisplayed for active DM when focused + pinned + unread", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "dm";
+    h.activePeerJid.value = "bob@example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 1;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledWith("m1");
+    expect(h.markDmRead).toHaveBeenCalledWith("bob@example.com");
+    expect(h.markChannelRead).not.toHaveBeenCalled();
+    h.stop();
+  });
+
+  test("does not dispatch when window is unfocused", async () => {
+    const h = makeHarness({ focused: false });
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 3;
+    await Promise.resolve();
+    expect(h.markDisplayed).not.toHaveBeenCalled();
+    expect(h.markChannelRead).not.toHaveBeenCalled();
+
+    h.isWindowFocused.value = true;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledWith("m1");
+    expect(h.markChannelRead).toHaveBeenCalledWith("room@chat.example.com");
+    h.stop();
+  });
+
+  test("does not dispatch when not pinned at edge", async () => {
+    const h = makeHarness({ pinned: false });
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 3;
+    await Promise.resolve();
+    expect(h.markChannelRead).not.toHaveBeenCalled();
+
+    h.isPinnedAtEdge.value = true;
+    await Promise.resolve();
+    expect(h.markChannelRead).toHaveBeenCalledWith("room@chat.example.com");
+    h.stop();
+  });
+
+  test("does not dispatch markDisplayed twice for the same id", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 1;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledTimes(1);
+
+    h.unreadCountForActive.value = 0;
+    await Promise.resolve();
+    h.unreadCountForActive.value = 0;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledTimes(1);
+    h.stop();
+  });
+
+  test("dispatches markDisplayed again when latestId advances", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 1;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledWith("m1");
+
+    h.unreadCountForActive.value = 0;
+    h.latestRemoteMessageId.value = "m2";
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledWith("m2");
+    expect(h.markDisplayed).toHaveBeenCalledTimes(2);
+    // unread is 0, so markRead should not have been called for the second event.
+    expect(h.markChannelRead).toHaveBeenCalledTimes(1);
+    h.stop();
+  });
+
+  test("resets dedup tracking when active conversation changes", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room-a@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 2;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledTimes(1);
+
+    h.activeRoomJid.value = "room-b@chat.example.com";
+    h.latestRemoteMessageId.value = "m1";
+    h.unreadCountForActive.value = 4;
+    await Promise.resolve();
+    expect(h.markDisplayed).toHaveBeenCalledTimes(2);
+    expect(h.markChannelRead).toHaveBeenLastCalledWith("room-b@chat.example.com");
+    h.stop();
+  });
+});


### PR DESCRIPTION
## Summary

Fix the chat read mechanic so that the inbox unread count actually clears when the user has read all messages, and the timeline "new messages" divider renders.

Today:
- Channels' `markRead()` only fires on channel-switch (`ChatApp.vue:808`). New messages arriving in the currently-viewed channel never clear unread until you leave and come back.
- `firstUnseenId` is only ever assigned `null` — the "new messages" timeline divider in `ContentArea.vue` has nothing to anchor on.
- XEP-0333 `<displayed/>` markers and the Waddle inbox `<mark-read>` IQ are completely decoupled. The displayed-marker path fires regardless of viewport visibility or window focus.

After this PR:
- Both displayed-marker dispatch (XEP-0333) and inbox mark-read (`urn:waddle:inbox:0`) are gated by `(active conversation && pinned-bottom && window-focused)`, centralized in a new `useReadReceipts` composable.
- `firstUnseenId` is populated from the captured-at-load unread count, so the divider actually shows when entering a channel with backlog.
- The three scattered ad-hoc mark-read call sites (`selectChannel`, `openDm`, DM-incoming auto-mark) are removed in favor of the single composable.

## Plan

### Bugs

1. **Channels never auto-clear unread while viewing.** `markRead(roomJid)` is only called from `selectChannel()`. If the user is already in a channel and a new message arrives, OR opens a channel and scrolls through the backlog, the inbox unread count never resets.
2. **`firstUnseenId` is never populated** — only ever set to `null` in `useMessaging.ts` / `useDmMessaging.ts`. Divider markup exists but has no anchor.
3. **`markDisplayed()` (XEP-0333) and `markRead()` (Waddle inbox IQ) are completely decoupled.** ContentArea's `@displayed` emit fires regardless of viewport visibility or window focus.

### Confirmed semantics

A conversation's unread should clear when ALL of: user has it open, the latest message is in the viewport (pinned to bottom), and the tab/window is focused.

### Approach

Centralize read-state dispatch in a single composable (`useReadReceipts`) that gates both `markDisplayed` and `markRead` on `(active conversation && pinned-bottom && window-focused)`. Add a viewport sensor to the existing scroll plumbing and a tiny visibility composable. Remove the three scattered ad-hoc mark-read call sites. Populate `firstUnseenId` from the captured-at-load unread count.

### Files

1. `chat/src/lib/pinned-edge-scroll.ts` — expose `isPinnedAtBottom: Readonly<Ref<boolean>>` (64 px tolerance).
2. `chat/src/composables/useWindowVisibility.ts` (new) — `isWindowFocused` from visibility + focus events.
3. `chat/src/composables/useReadReceipts.ts` (new) — single watchEffect dispatching `markDisplayed` + `markRead` when all gates are true.
4. `chat/src/composables/useMessaging.ts` — expose `isPinnedAtBottom`, `latestRemoteMessageId`; add `unreadAtLoad` to `loadMessages`; populate `firstUnseenId`.
5. `chat/src/composables/useDmMessaging.ts` — mirror channel-side changes.
6. `chat/src/composables/useDmConversations.ts` — remove `markRead` calls in `openDm` and `receiveIncomingDm`.
7. `chat/src/components/ChatApp.vue` — drop `markActiveDisplayed` + `channelUnread.markRead` in `selectChannel`; pass `unreadAtLoad`; instantiate `useWindowVisibility` + `useReadReceipts`.
8. `chat/src/components/chat/ContentArea.vue` — drop the `displayed` emit and its watch (moved to composables); keep the divider rendering.

### XEP conformance

XEP-0333 `<displayed/>` semantics ("all messages up to this point, monotonic forward only") are preserved — `markDisplayed` still fires once per advancing `latestRemoteMessageId`, just gated on focus + viewport. The inbox `urn:waddle:inbox:0` IQ stays Waddle-internal.

## Test plan

- [ ] `cd chat && bun run lint` clean (knip).
- [ ] `cd chat && bun run build` clean (Astro typecheck).
- [ ] `cd chat && bun test` clean.
- [ ] Manual: receive 5 messages in a non-active channel → sidebar chip shows 5; tab title shows `*`.
- [ ] Manual: open that channel → "new messages" divider visible above the 5 unread; chip clears within ~one tick.
- [ ] Manual: scroll up; receive a new message → chip reappears.
- [ ] Manual: scroll back to bottom → chip clears.
- [ ] Manual: Cmd-Tab away while at bottom; receive a message → chip appears. Refocus → chip clears.
- [ ] DM equivalents.
- [ ] Open a channel with 0 unread → no divider, no spurious `<mark-read>` IQ on the wire.

## Risks

- **Behavioral break**: pre-fix, opening any channel marked it read. Post-fix, opening a channel where you don't reach the bottom won't auto-clear. This matches the confirmed semantics but is a perceived behavior change.
- **Stale `unreadAtLoad` heuristic**: if the inbox `unread` count exceeds the loaded MAM page (>100 back), the divider falls back to no-render. Acceptable.
- **Virtual timeline scroll accuracy**: 64 px tolerance + post-pin recompute should absorb virtualization swap noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)