### PR TITLE
feat(chat): add keyboard reaction mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "astro": "^6.1.8",
         "emojilib": "^4.0.3",
         "events": "^3.3.0",
+        "keystrok": "^0.1.1",
         "lucide-vue-next": "^1.0.0",
         "nanostores": "^1.3.0",
         "shiki": "^4.0.2",
@@ -1035,6 +1036,8 @@
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
+
+    "keystrok": ["keystrok@0.1.1", "", {}, "sha512-B9hOlvVsSZxYZAjJSLcq4MM3ZJ1qWvkaL1VsONpPS+SsreB0np7DOShipft9j0H3oT1GD7VdseaTS9I8k8X+lg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -38,6 +38,7 @@
     "astro": "^6.1.8",
     "emojilib": "^4.0.3",
     "events": "^3.3.0",
+    "keystrok": "^0.1.1",
     "lucide-vue-next": "^1.0.0",
     "nanostores": "^1.3.0",
     "shiki": "^4.0.2",

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { type ComponentPublicInstance, computed, onMounted, onUnmounted, ref, watch, watchEffect } from "vue";
+import { createKeystrok, type Keystrok } from "keystrok";
 import { useWaddles } from "@/composables/useWaddles";
 import { useMembers } from "@/composables/useMembers";
 import { useDmConversations } from "@/composables/useDmConversations";
@@ -27,7 +28,8 @@ import HomeDashboard from "@/components/chat/HomeDashboard.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import ContentArea from "@/components/chat/ContentArea.vue";
 import ThreadPanel from "@/components/chat/ThreadPanel.vue";
-import type { ScrollDirectionMode } from "@/lib/scroll-direction";
+import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
+import { useScrollDirection } from "@/composables/useScrollDirection";
 import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
@@ -39,8 +41,15 @@ import NewDmDialog from "@/components/modals/NewDmDialog.vue";
 import MemberManagement from "@/components/modals/MemberManagement.vue";
 import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
 import type { MemberSummary } from "@/lib/chat-types";
-import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
+import type { MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import { avatarLookupCandidates, mentionAutocompleteCandidates, mentionMatchesUsername, mergeMentionMembers } from "@/lib/mentions";
+import {
+  moveReactionSelection,
+  preserveReactionSelection,
+  quickReactionForKey,
+  selectInitialReactionMessage,
+  type ReactionModeScope,
+} from "@/lib/reaction-mode";
 
 const props = defineProps<{
   tenorApiKey?: string;
@@ -49,6 +58,7 @@ const props = defineProps<{
 const tenorApiKey = props.tenorApiKey ?? "";
 
 const ui = useUiState();
+const { mode: scrollDirectionMode } = useScrollDirection();
 
 const xmppClient = computed(() => connectionStore.client);
 const session = computed(() => connectionStore.session);
@@ -135,11 +145,173 @@ const activeFirstUnseenId = computed(() =>
 // don't use XEP-0201 threads yet.
 const activeThreadStack = ref<string[]>([]);
 const threads = useThreads(activeMessages);
+type ReactionModeTarget = "main" | "thread";
+const reactionModeTarget = ref<ReactionModeTarget | null>(null);
+const reactionModeSelectedMessageId = ref<string | null>(null);
+const CHAT_KEYSTROK_SCOPE = "chat";
+const REACTION_MODE_KEYSTROK_SCOPE = "chat-reaction-mode";
+let chatKeystrok: Keystrok | null = null;
 
 function getThreadLabel(threadId: string): string {
   const entry = threads.resolveEntry(threadId);
   const body = entry?.root?.body?.trim() ?? "";
   return body.length > 0 ? body.slice(0, 40) : threadId.slice(0, 8);
+}
+
+const orderedMainReactionMessages = computed(() =>
+  orderTimelineForScrollDirection(
+    reactionModeMessageCandidates(activeMessages.value.filter((message) => !message.threadId || message.id === message.threadId)),
+    scrollDirectionMode.value,
+  ),
+);
+
+const activeThreadReactionMessages = computed<TimelineMessage[]>(() => {
+  if (ui.sidebarMode.value !== "channels") return [];
+  const threadId = activeThreadStack.value[activeThreadStack.value.length - 1];
+  if (!threadId) return [];
+  const entry = threads.resolveEntry(threadId);
+  if (!entry) return [];
+  const orderedChildren = orderTimelineForScrollDirection(reactionModeMessageCandidates(entry.directChildren), scrollDirectionMode.value);
+  return entry.root ? reactionModeMessageCandidates([entry.root, ...orderedChildren]) : orderedChildren;
+});
+
+const reactionModeMessages = computed(() =>
+  reactionModeTarget.value === "thread"
+    ? activeThreadReactionMessages.value
+    : orderedMainReactionMessages.value,
+);
+
+const reactionModeScope = computed<ReactionModeScope>(() =>
+  reactionModeTarget.value === "thread" ? "thread" : "feed",
+);
+
+const reactionModeState = computed(() =>
+  reactionModeTarget.value
+    ? {
+        selectedMessageId: reactionModeSelectedMessageId.value,
+      }
+    : null,
+);
+
+function activeReactionTarget(): ReactionModeTarget | null {
+  if (ui.activePage.value !== "chat") return null;
+  if (ui.sidebarMode.value === "channels" && activeThreadStack.value.length > 0) return "thread";
+  if (ui.sidebarMode.value === "dms" && activeDmPeer.value) return "main";
+  if (ui.sidebarMode.value === "channels" && waddles.currentChannel.value) return "main";
+  return null;
+}
+
+function reactionModeMessageCandidates(messages: readonly TimelineMessage[]): TimelineMessage[] {
+  return messages.map((message) => ({
+    ...message,
+    canReact: ui.sidebarMode.value === "dms" || !!message.reactionTargetId,
+  }));
+}
+
+function exitReactionMode() {
+  reactionModeTarget.value = null;
+  reactionModeSelectedMessageId.value = null;
+  chatKeystrok?.scope(REACTION_MODE_KEYSTROK_SCOPE).deactivate();
+}
+
+function startReactionMode(target = activeReactionTarget()): boolean {
+  if (!target) return false;
+  const messages = target === "thread" ? activeThreadReactionMessages.value : orderedMainReactionMessages.value;
+  const scope = target === "thread" ? "thread" : "feed";
+  const selected = selectInitialReactionMessage(messages, scope);
+  if (!selected) return false;
+  reactionModeTarget.value = target;
+  reactionModeSelectedMessageId.value = selected;
+  chatKeystrok?.scope(REACTION_MODE_KEYSTROK_SCOPE).override();
+  return true;
+}
+
+function reactToSelectedMessage(emoji: string) {
+  const messageId = reactionModeSelectedMessageId.value;
+  if (!messageId) return;
+  reactActiveMessage(messageId, emoji);
+  exitReactionMode();
+}
+
+function isEditableKeyTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.closest("[contenteditable='true']")) return true;
+  return !!target.closest("input, textarea, select");
+}
+
+function isComposerEditorTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && !!target.closest(".chat-composer .ProseMirror");
+}
+
+function isComposerEditorEmpty(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const editor = target.closest(".chat-composer .ProseMirror");
+  if (!(editor instanceof HTMLElement)) return false;
+  return (editor.textContent ?? "").length === 0;
+}
+
+function canStartReactionModeFromEvent(event: KeyboardEvent): boolean {
+  if (anyModalOpen()) return false;
+  if (!isEditableKeyTarget(event.target)) return true;
+  if (!isComposerEditorTarget(event.target)) return false;
+  return isComposerEditorEmpty(event.target);
+}
+
+function consumeKeystrokEvent(event: KeyboardEvent) {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+function handleStartReactionModeShortcut(event: KeyboardEvent) {
+  if (!canStartReactionModeFromEvent(event)) return;
+  if (startReactionMode()) {
+    consumeKeystrokEvent(event);
+  }
+}
+
+function handleLiteralPlusKeyDown(event: KeyboardEvent) {
+  if (event.key !== "+" || event.ctrlKey || event.metaKey || event.altKey) return;
+  if (reactionModeTarget.value) {
+    if (!ensureReactionModeOwnsEvent(event)) return;
+    consumeKeystrokEvent(event);
+    return;
+  }
+  handleStartReactionModeShortcut(event);
+}
+
+function shouldYieldReactionModeForEvent(event: KeyboardEvent): boolean {
+  if (anyModalOpen()) return true;
+  return isEditableKeyTarget(event.target);
+}
+
+function ensureReactionModeOwnsEvent(event: KeyboardEvent): boolean {
+  if (!shouldYieldReactionModeForEvent(event)) return true;
+  exitReactionMode();
+  return false;
+}
+
+function handleReactionModeMove(event: KeyboardEvent, direction: "previous" | "next") {
+  if (!ensureReactionModeOwnsEvent(event)) return;
+  reactionModeSelectedMessageId.value = moveReactionSelection(
+    reactionModeSelectedMessageId.value,
+    reactionModeMessages.value,
+    reactionModeScope.value,
+    direction,
+  );
+  consumeKeystrokEvent(event);
+}
+
+function handleReactionModeQuickReaction(event: KeyboardEvent) {
+  if (!ensureReactionModeOwnsEvent(event)) return;
+  const emoji = quickReactionForKey(event.key);
+  if (emoji) reactToSelectedMessage(emoji);
+  consumeKeystrokEvent(event);
+}
+
+function handleReactionModeEscape(event: KeyboardEvent) {
+  const shouldYield = shouldYieldReactionModeForEvent(event);
+  exitReactionMode();
+  if (!shouldYield) consumeKeystrokEvent(event);
 }
 const activeDraft = computed({
   get: () => (ui.sidebarMode.value === "dms" ? dmMessaging.draft.value : messaging.draft.value),
@@ -656,6 +828,46 @@ function loadOlderThreadMessages(threadId: string) {
   void messaging.loadOlderThreadMessages(threadId);
 }
 
+function anyModalOpen(): boolean {
+  const domModalOpen = typeof document !== "undefined" && !!document.querySelector("[aria-modal='true']");
+  return ui.showCreateChannel.value ||
+    ui.showEditChannel.value ||
+    ui.showWaddleSettings.value ||
+    ui.showMembers.value ||
+    ui.confirmDeleteWaddle.value ||
+    ui.confirmDeleteChannel.value ||
+    ui.showNewDm.value ||
+    ui.confirmRemoveMember.value !== null ||
+    ui.showMobileNav.value ||
+    ui.showMobileDetails.value ||
+    domModalOpen;
+}
+
+function handleChatEscape(event: KeyboardEvent) {
+  if (activeThreadStack.value.length === 0) return;
+  // Don't intercept Escape when any dialog/drawer is open so they can close first.
+  if (anyModalOpen()) return;
+  activeThreadStack.value = activeThreadStack.value.slice(0, -1);
+  consumeKeystrokEvent(event);
+}
+
+function bindChatKeystrokShortcuts() {
+  chatKeystrok = createKeystrok();
+  chatKeystrok
+    .bind("escape", handleChatEscape, { scope: CHAT_KEYSTROK_SCOPE })
+    .bind("escape", handleReactionModeEscape, { scope: REACTION_MODE_KEYSTROK_SCOPE })
+    .bind("up", (event) => handleReactionModeMove(event, "previous"), { scope: REACTION_MODE_KEYSTROK_SCOPE })
+    .bind("down", (event) => handleReactionModeMove(event, "next"), { scope: REACTION_MODE_KEYSTROK_SCOPE })
+    .bind("backspace", handleReactionModeEscape, { scope: REACTION_MODE_KEYSTROK_SCOPE })
+    .bind("delete", handleReactionModeEscape, { scope: REACTION_MODE_KEYSTROK_SCOPE });
+
+  for (const key of ["1", "2", "3", "4", "5"]) {
+    chatKeystrok.bind(key, handleReactionModeQuickReaction, { scope: REACTION_MODE_KEYSTROK_SCOPE });
+  }
+
+  chatKeystrok.scope(CHAT_KEYSTROK_SCOPE).activate();
+}
+
 // --- Deep linking ---
 
 function updateUrl() {
@@ -681,12 +893,37 @@ watch(
     // Channel / DM / mode changes close any open thread panel — the ids inside
     // the stack belong to the channel we just left.
     activeThreadStack.value = [];
+    exitReactionMode();
     updateUrl();
   },
 );
 
-watch(activeThreadStack, updateUrl, { deep: true });
-watch(() => ui.activePage.value, updateUrl);
+watch(activeThreadStack, () => {
+  exitReactionMode();
+  updateUrl();
+}, { deep: true });
+watch(() => ui.activePage.value, () => {
+  exitReactionMode();
+  updateUrl();
+});
+
+watch(
+  [reactionModeMessages, reactionModeScope],
+  () => {
+    if (!reactionModeTarget.value) return;
+    const selected = preserveReactionSelection(
+      reactionModeSelectedMessageId.value,
+      reactionModeMessages.value,
+      reactionModeScope.value,
+    );
+    if (!selected) {
+      exitReactionMode();
+      return;
+    }
+    reactionModeSelectedMessageId.value = selected;
+  },
+  { flush: "post" },
+);
 
 function openUserSettings() {
   ui.showMobileNav.value = false;
@@ -992,34 +1229,19 @@ watch(
   { immediate: true },
 );
 
-function handleKeyDown(e: KeyboardEvent) {
-  if (e.key !== "Escape") return;
-  if (activeThreadStack.value.length === 0) return;
-  // Don't intercept Escape when any dialog/drawer is open so they can close first.
-  const anyModalOpen =
-    ui.showCreateChannel.value ||
-    ui.showEditChannel.value ||
-    ui.showWaddleSettings.value ||
-    ui.showMembers.value ||
-    ui.confirmDeleteWaddle.value ||
-    ui.confirmDeleteChannel.value ||
-    ui.showNewDm.value ||
-    ui.confirmRemoveMember.value !== null ||
-    ui.showMobileNav.value ||
-    ui.showMobileDetails.value;
-  if (anyModalOpen) return;
-  activeThreadStack.value = activeThreadStack.value.slice(0, -1);
-  e.preventDefault();
-}
-
 onMounted(() => {
   window.addEventListener("popstate", onPopState);
-  window.addEventListener("keydown", handleKeyDown);
+  // keystrok uses "+" as its shortcut separator, so the literal plus key is
+  // handled directly while the rest of reaction mode remains scoped there.
+  window.addEventListener("keydown", handleLiteralPlusKeyDown, true);
+  bindChatKeystrokShortcuts();
 });
 
 onUnmounted(() => {
   window.removeEventListener("popstate", onPopState);
-  window.removeEventListener("keydown", handleKeyDown);
+  window.removeEventListener("keydown", handleLiteralPlusKeyDown, true);
+  chatKeystrok?.destroy();
+  chatKeystrok = null;
   appUpdate.stop();
   messaging.disconnect();
   dmMessaging.disconnect();
@@ -1292,6 +1514,7 @@ onUnmounted(() => {
               :upload-progress="activeUploadProgress"
               :thread-index="threads.index.value"
               :xmpp-client="xmppClient"
+              :reaction-mode="reactionModeTarget === 'main' ? reactionModeState : null"
               @send="sendActiveMessage"
               @typing="notifyActiveComposing"
               @edit-message="editActiveMessage"
@@ -1365,6 +1588,7 @@ onUnmounted(() => {
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
               :hide-composer="true"
+              :reaction-mode="null"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
               @push-thread="pushThread"
@@ -1400,6 +1624,7 @@ onUnmounted(() => {
               :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false"
               :upload-progress="messaging.uploadProgress.value"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"
               @push-thread="pushThread"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -61,6 +61,7 @@ const props = defineProps<{
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   threadIndex: ThreadIndex;
   xmppClient?: BrowserXmppClient | null;
+  reactionMode?: { selectedMessageId: string | null } | null;
 }>();
 
 const emit = defineEmits<{
@@ -849,6 +850,7 @@ function dayDividerLabel(createdAt: string): string {
             :author-jid="authorJidByNick?.[msg.author]"
             :thread-reply-count="threadIndex.get(msg.id)?.count ?? 0"
             :grouped="isGroupedFollowUp(msg.id)"
+            :reaction-mode-selected="reactionMode?.selectedMessageId === msg.id"
             @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
             @retract="(id) => emit('retractMessage', id)"
             @react="(id, emoji) => emit('reactMessage', id, emoji)"

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -44,6 +44,7 @@ import type { OccupantHat, OccupantPresence } from "@/lib/xmpp-client";
 import { formatTimeOfDay } from "@/composables/useMessaging";
 import { useLongPress } from "@/composables/useLongPress";
 import { $desktopToolbarOwnerId } from "@/stores/message-toolbar";
+import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
 
 const HAT_LABELS: Record<string, string> = {
   "urn:xmpp:hats:owner": "OWNER",
@@ -84,6 +85,7 @@ const props = defineProps<{
   threadReplyCount?: number;
   hideThreadChip?: boolean;
   grouped?: boolean;
+  reactionModeSelected?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -96,7 +98,7 @@ const emit = defineEmits<{
   openThread: [threadId: string];
 }>();
 
-const quickEmojis = ["👍", "❤️", "😂", "🎉", "👀"];
+const quickEmojis = QUICK_REACTION_EMOJIS;
 
 const seniorHat = computed<OccupantHat | null>(() => {
   if (!props.hats || props.hats.length === 0) return null;
@@ -468,7 +470,7 @@ const desktopToolbarLockedByAnother = computed(() =>
   desktopToolbarOwnerId.value !== null && desktopToolbarOwnerId.value !== props.message.id,
 );
 const desktopToolbarVisibilityClass = computed(() => (
-  ownsDesktopToolbarLock.value
+  ownsDesktopToolbarLock.value || props.reactionModeSelected
     ? "opacity-100 pointer-events-auto z-floating"
     : "opacity-0 group-hover:opacity-100 focus-within:opacity-100 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto z-sticky"
 ));
@@ -660,6 +662,7 @@ watch(
       message.deliveryStatus === 'sending' || message.deliveryStatus === 'queued' ? 'opacity-50' : '',
       longPress.isPressing.value ? 'no-callout' : '',
       grouped ? 'chat-message-grouped' : '',
+      reactionModeSelected ? 'chat-message-grid--reaction-selected' : '',
     ]"
     @pointerdown="longPress.handlers.onPointerdown"
     @pointermove="longPress.handlers.onPointermove"
@@ -1083,19 +1086,29 @@ watch(
     <div
       v-if="!isEditing && !desktopToolbarLockedByAnother"
       :class="[
-        'absolute -top-4 right-3 flex items-center gap-1 transition-opacity duration-150 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1 [@media(pointer:coarse)]:hidden',
+        'chat-hover-action-toolbar absolute -top-4 right-3 flex items-center gap-1 transition-opacity duration-150 bg-card/95 backdrop-blur border border-border rounded-lg shadow-lg p-1 [@media(pointer:coarse)]:hidden',
         desktopToolbarVisibilityClass,
+        reactionModeSelected ? 'chat-hover-action-toolbar--reaction-mode' : '',
       ]"
+      :role="reactionModeSelected ? 'status' : undefined"
+      :aria-live="reactionModeSelected ? 'polite' : undefined"
     >
       <button
-        v-for="e in quickEmojis"
+        v-for="(e, index) in quickEmojis"
         :key="e"
         type="button"
-        class="type-emoji-button h-8 w-8 flex items-center justify-center rounded-md hover:bg-muted hover:scale-105 transition-all duration-150"
+        class="type-emoji-button relative h-8 w-8 flex items-center justify-center rounded-md hover:bg-muted hover:scale-105 transition-all duration-150"
         :title="`React with ${e}`"
         :aria-label="`React to message with ${e}`"
         @click="react(e)"
-      >{{ e }}</button>
+      >
+        <span
+          v-if="reactionModeSelected"
+          class="chat-reaction-mode-keycap type-meta type-numeric"
+          aria-hidden="true"
+        >{{ index + 1 }}</span>
+        {{ e }}
+      </button>
       <div class="relative">
         <button
           ref="pickerButtonEl"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -40,6 +40,7 @@ const props = defineProps<{
   hasOlderReplies?: boolean;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   channelName: string;
+  reactionMode?: { selectedMessageId: string | null } | null;
   /**
    * When true, the composer is hidden but sub-thread navigation stays active.
    * Used to render the parent context pane in the accordion layout.
@@ -481,6 +482,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
           :author-jid="authorJidByNick?.[message.author]"
           :thread-reply-count="activeEntry.count"
           hide-thread-chip
+          :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
           @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
           @retract="(id) => emit('retractMessage', id)"
           @react="(id, emoji) => emit('reactMessage', id, emoji)"
@@ -511,6 +513,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
               :thread-reply-count="threadIndex.get(message.id)?.count ?? 0"
               :grouped="isGroupedFollowUp(message.id)"
               hide-thread-chip
+              :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
               @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
               @retract="(id) => emit('retractMessage', id)"
               @react="(id, emoji) => emit('reactMessage', id, emoji)"

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -57,6 +57,7 @@ export function fromLiveMessage(
     isSelf: msg.nick === session.username,
   };
   if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
+  if (msg.reactionTargetId) tm.reactionTargetId = msg.reactionTargetId;
   if (msg.authorRealJid) tm.authorRealJid = msg.authorRealJid;
   if (msg.wireIds && msg.wireIds.length > 0) {
     tm.wireIds = msg.wireIds;
@@ -548,7 +549,7 @@ export function useMessaging(
 
   function applyReaction(messageId: string, nick: string, emojis: string[]) {
     messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
+      if (m.reactionTargetId !== messageId) return m;
       const existing: Record<string, string[]> = m.reactions ? { ...m.reactions } : {};
       // Remove this nick from all existing emoji lists
       for (const key of Object.keys(existing)) {
@@ -853,7 +854,7 @@ export function useMessaging(
     }
 
     for (const update of reactionUpdates) {
-      const target = findMessageById(timeline, update.targetId);
+      const target = timeline.find((message) => message.reactionTargetId === update.targetId);
       if (!target) continue;
       const reactions: Record<string, string[]> = target.reactions ? { ...target.reactions } : {};
       for (const emoji of update.emojis) {
@@ -1230,7 +1231,8 @@ export function useMessaging(
 
     // Compute the new reaction set for this user
     const msg = findMessageById(messages.value, messageId);
-    const targetId = msg?.id ?? messageId;
+    const targetId = msg?.reactionTargetId;
+    if (!targetId) return;
     const myNick = session.value.username;
     const currentReactions = msg?.reactions ?? {};
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -48,6 +48,8 @@ export interface TimelineMessage {
   authorOccupantJid?: string;
   /** XEP-0313 MUC archive real JID from muc#user item@jid, when present. */
   authorRealJid?: string;
+  /** XEP-0444 groupchat reaction target: room-assigned XEP-0359 stanza-id. */
+  reactionTargetId?: string;
   body: string;
   createdAt: string;
   isSelf: boolean;

--- a/chat/src/lib/reaction-mode.ts
+++ b/chat/src/lib/reaction-mode.ts
@@ -1,0 +1,80 @@
+export const QUICK_REACTION_EMOJIS: readonly string[] = ["👍", "❤️", "😂", "🎉", "👀"];
+
+export type ReactionModeScope = "feed" | "thread";
+export type ReactionModeMessage = {
+  id: string;
+  createdAt: string;
+  threadId?: string;
+  isRetracted?: boolean;
+  deliveryStatus?: "queued" | "sending" | "delivered" | "failed";
+  canReact?: boolean;
+};
+
+function isReactionModeMessageEligible(message: ReactionModeMessage, scope: ReactionModeScope): boolean {
+  if (message.isRetracted) return false;
+  if (message.canReact === false) return false;
+  if (message.deliveryStatus === "queued" || message.deliveryStatus === "sending" || message.deliveryStatus === "failed") {
+    return false;
+  }
+  return scope === "thread" || !message.threadId || message.threadId === message.id;
+}
+
+export function reactionModeMessages(
+  messages: readonly ReactionModeMessage[],
+  scope: ReactionModeScope,
+): ReactionModeMessage[] {
+  return messages.filter((message) => isReactionModeMessageEligible(message, scope));
+}
+
+export function selectInitialReactionMessage(
+  messages: readonly ReactionModeMessage[],
+  scope: ReactionModeScope,
+): string | null {
+  const eligible = reactionModeMessages(messages, scope);
+  if (eligible.length === 0) return null;
+
+  return eligible.reduce((selected, candidate) => {
+    return createdAtTime(candidate) >= createdAtTime(selected) ? candidate : selected;
+  }).id;
+}
+
+export function preserveReactionSelection(
+  previousId: string | null,
+  messages: readonly ReactionModeMessage[],
+  scope: ReactionModeScope,
+): string | null {
+  const eligible = reactionModeMessages(messages, scope);
+  if (eligible.length === 0) return null;
+  if (previousId && eligible.some((message) => message.id === previousId)) return previousId;
+  return selectInitialReactionMessage(eligible, scope);
+}
+
+export function moveReactionSelection(
+  currentId: string | null,
+  messages: readonly ReactionModeMessage[],
+  scope: ReactionModeScope,
+  direction: "previous" | "next",
+): string | null {
+  const eligible = reactionModeMessages(messages, scope);
+  if (eligible.length === 0) return null;
+  if (!currentId) return selectInitialReactionMessage(eligible, scope);
+
+  const selectedIndex = eligible.findIndex((message) => message.id === currentId);
+  if (selectedIndex === -1) return selectInitialReactionMessage(eligible, scope);
+
+  const nextIndex = direction === "previous"
+    ? Math.max(0, selectedIndex - 1)
+    : Math.min(eligible.length - 1, selectedIndex + 1);
+
+  return eligible[nextIndex]?.id ?? null;
+}
+
+export function quickReactionForKey(key: string): string | null {
+  if (!/^[1-5]$/.test(key)) return null;
+  return QUICK_REACTION_EMOJIS[Number(key) - 1] ?? null;
+}
+
+function createdAtTime(message: ReactionModeMessage): number {
+  const time = Date.parse(message.createdAt);
+  return Number.isNaN(time) ? 0 : time;
+}

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -91,7 +91,7 @@ function extractMucUserRealJid(msg: ReceivedMessage): string | undefined {
 export function resolveMessageIds(
   msg: ReceivedMessage,
   preferredStanzaBy?: string,
-): { id: string; wireIds?: string[]; correctionTargetId: string } {
+): { id: string; wireIds?: string[]; correctionTargetId: string; reactionTargetId?: string } {
   const extMsg = ext(msg);
   const originId = extMsg.originId as OriginIdPayload | undefined;
   const stanzaIds = asArray(extMsg.stanzaIds as StanzaIdPayload | StanzaIdPayload[] | undefined);
@@ -105,6 +105,7 @@ export function resolveMessageIds(
       [msg.id, originId?.id, ...stanzaIds.map((candidate) => candidate.id)],
     ),
     correctionTargetId: originId?.id ?? msg.id ?? "",
+    ...(preferredStanzaId ? { reactionTargetId: preferredStanzaId } : {}),
   };
 }
 
@@ -417,6 +418,7 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
     type: msg.body || hasNonBodyMessagePayload(msg) ? "message" : "subject",
   };
   if (messageIds.correctionTargetId) liveMsg.correctionTargetId = messageIds.correctionTargetId;
+  if (messageIds.reactionTargetId) liveMsg.reactionTargetId = messageIds.reactionTargetId;
   const authorRealJid = extractMucUserRealJid(msg);
   if (authorRealJid) liveMsg.authorRealJid = authorRealJid;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -110,6 +110,8 @@ export interface LiveRoomMessage {
   forumThreadTitle?: string;
   /** XEP-0313 MUC archive real JID from muc#user item@jid, when present. */
   authorRealJid?: string;
+  /** XEP-0444 groupchat reaction target: room-assigned XEP-0359 stanza-id. */
+  reactionTargetId?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -985,6 +985,18 @@
   background: color-mix(in oklab, var(--muted) 38%, transparent);
 }
 
+.chat-message-grid--reaction-selected::before {
+  opacity: 1;
+  border-color: color-mix(in oklab, var(--primary) 16%, transparent);
+  background: linear-gradient(
+    90deg,
+    color-mix(in oklab, var(--primary) 7%, transparent),
+    color-mix(in oklab, var(--primary) 3%, transparent) 16rem,
+    transparent
+  );
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--primary) 7%, transparent);
+}
+
 .chat-message-avatar-cell {
   width: var(--chat-message-avatar-size);
   height: var(--chat-message-avatar-size);
@@ -1052,6 +1064,30 @@
 
 .chat-message-reactions {
   width: 100%;
+}
+
+.chat-hover-action-toolbar--reaction-mode {
+  border-color: color-mix(in oklab, var(--primary) 28%, var(--border));
+  background: color-mix(in oklab, var(--card) 88%, var(--primary) 12%);
+  box-shadow:
+    0 14px 36px color-mix(in oklab, var(--primary) 18%, transparent),
+    var(--shadow-floating);
+}
+
+.chat-reaction-mode-keycap {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.25rem;
+  display: grid;
+  width: 1rem;
+  height: 1rem;
+  place-items: center;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--primary) 35%, var(--border));
+  background: var(--popover);
+  color: var(--primary);
+  line-height: 1;
+  box-shadow: 0 4px 10px color-mix(in oklab, var(--primary) 16%, transparent);
 }
 
 .chat-message-meta-row {

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -308,6 +308,7 @@ describe("groupchat reply + thread parsing", () => {
 
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].id).toBe("stable-1");
+    expect(h.messages[0].reactionTargetId).toBe("stable-1");
     expect(h.messages[0].wireIds).toEqual(["echo-1", "client-1", "server-1"]);
     expect(h.messages[0].correctionTargetId).toBe("client-1");
   });

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -375,6 +375,7 @@ describe("MAM history application", () => {
           body: "hello",
           createdAt: "2024-01-01T00:00:00Z",
           type: "message",
+          reactionTargetId: "msg-1",
         },
         {
           id: "edit-1",
@@ -431,7 +432,7 @@ describe("MAM history application", () => {
     expect(messaging.messages.value[0].reactions).toEqual({ "👍": ["alice"] });
   });
 
-  test("applies archived room updates when reactions target an alternate wire id", async () => {
+  test("ignores archived room reactions that target an alternate wire id", async () => {
     const session = ref({
       username: "alice",
       jid: "alice@example.com/desktop",
@@ -443,6 +444,7 @@ describe("MAM history application", () => {
         {
           id: "stable-msg-1",
           wireIds: ["echo-msg-1", "client-msg-1"],
+          reactionTargetId: "stable-msg-1",
           roomJid: "general@muc.example.com",
           nick: "bob",
           body: "hello",
@@ -480,7 +482,7 @@ describe("MAM history application", () => {
 
     expect(messaging.messages.value).toHaveLength(1);
     expect(messaging.messages.value[0].id).toBe("stable-msg-1");
-    expect(messaging.messages.value[0].reactions).toEqual({ "👍": ["alice"] });
+    expect(messaging.messages.value[0].reactions).toBeUndefined();
   });
 
   test("applies archived DM updates onto the original timeline message", async () => {

--- a/chat/tests/reaction-mode.test.ts
+++ b/chat/tests/reaction-mode.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import {
+  moveReactionSelection,
+  preserveReactionSelection,
+  QUICK_REACTION_EMOJIS,
+  quickReactionForKey,
+  reactionModeMessages,
+  selectInitialReactionMessage,
+  type ReactionModeMessage,
+} from "../src/lib/reaction-mode";
+
+const messages: ReactionModeMessage[] = [
+  { id: "oldest", createdAt: "2026-04-29T10:00:00Z" },
+  { id: "thread-root", createdAt: "2026-04-29T10:00:30Z", threadId: "thread-root" },
+  { id: "thread-child", createdAt: "2026-04-29T10:01:00Z", threadId: "oldest" },
+  { id: "retracted", createdAt: "2026-04-29T10:02:00Z", isRetracted: true },
+  { id: "queued", createdAt: "2026-04-29T10:02:30Z", deliveryStatus: "queued" },
+  { id: "newest-feed", createdAt: "2026-04-29T10:03:00Z" },
+];
+
+describe("reaction mode helpers", () => {
+  test("exports the quick reaction emoji palette", () => {
+    expect(QUICK_REACTION_EMOJIS).toEqual(["👍", "❤️", "😂", "🎉", "👀"]);
+  });
+
+  test("selects the most recent eligible feed message initially", () => {
+    expect(selectInitialReactionMessage(messages, "feed")).toBe("newest-feed");
+  });
+
+  test("filters main feed eligibility separately from thread eligibility", () => {
+    expect(reactionModeMessages(messages, "feed").map((message) => message.id)).toEqual([
+      "oldest",
+      "thread-root",
+      "newest-feed",
+    ]);
+
+    expect(reactionModeMessages(messages, "thread").map((message) => message.id)).toEqual([
+      "oldest",
+      "thread-root",
+      "thread-child",
+      "newest-feed",
+    ]);
+  });
+
+  test("excludes local-only undelivered messages from reaction mode", () => {
+    expect(
+      reactionModeMessages([
+        { id: "queued", createdAt: "2026-04-29T10:00:00Z", deliveryStatus: "queued" },
+        { id: "sending", createdAt: "2026-04-29T10:01:00Z", deliveryStatus: "sending" },
+        { id: "failed", createdAt: "2026-04-29T10:02:00Z", deliveryStatus: "failed" },
+        { id: "delivered", createdAt: "2026-04-29T10:03:00Z", deliveryStatus: "delivered" },
+      ], "feed").map((message) => message.id),
+    ).toEqual(["delivered"]);
+  });
+
+  test("excludes messages without a conformant reaction target signal", () => {
+    expect(
+      reactionModeMessages([
+        { id: "no-target", createdAt: "2026-04-29T10:00:00Z", canReact: false },
+        { id: "target", createdAt: "2026-04-29T10:01:00Z", canReact: true },
+      ], "feed").map((message) => message.id),
+    ).toEqual(["target"]);
+  });
+
+  test("moves selection with arrows over the rendered order", () => {
+    const renderedOrder: ReactionModeMessage[] = [
+      { id: "first-rendered", createdAt: "2026-04-29T10:03:00Z" },
+      { id: "thread-child", createdAt: "2026-04-29T10:04:00Z", threadId: "first-rendered" },
+      { id: "second-rendered", createdAt: "2026-04-29T10:01:00Z" },
+      { id: "retracted", createdAt: "2026-04-29T10:05:00Z", isRetracted: true },
+      { id: "third-rendered", createdAt: "2026-04-29T10:02:00Z" },
+    ];
+
+    expect(moveReactionSelection("second-rendered", renderedOrder, "feed", "previous")).toBe("first-rendered");
+    expect(moveReactionSelection("second-rendered", renderedOrder, "feed", "next")).toBe("third-rendered");
+    expect(moveReactionSelection("first-rendered", renderedOrder, "feed", "previous")).toBe("first-rendered");
+    expect(moveReactionSelection("third-rendered", renderedOrder, "feed", "next")).toBe("third-rendered");
+    expect(moveReactionSelection("first-rendered", renderedOrder, "thread", "next")).toBe("thread-child");
+  });
+
+  test("preserves a still-eligible selection and falls back to the initial selection", () => {
+    expect(preserveReactionSelection("oldest", messages, "feed")).toBe("oldest");
+    expect(preserveReactionSelection("thread-child", messages, "feed")).toBe("newest-feed");
+    expect(preserveReactionSelection(null, messages, "feed")).toBe("newest-feed");
+  });
+
+  test("maps number keys 1-5 to quick reactions", () => {
+    expect(["1", "2", "3", "4", "5"].map((key) => quickReactionForKey(key))).toEqual([
+      "👍",
+      "❤️",
+      "😂",
+      "🎉",
+      "👀",
+    ]);
+    expect(quickReactionForKey("0")).toBeNull();
+    expect(quickReactionForKey("6")).toBeNull();
+  });
+
+});


### PR DESCRIPTION
## Plan

Add a chat-only keyboard reaction mode that reuses the existing XEP-0444 reaction path.

- Use `keystrok` for scoped reaction-mode keys: Escape/Backspace/Delete exit, Up/Down move selection, and 1-5 apply common reactions.
- Handle literal `+` directly because `keystrok` treats `+` as a shortcut separator; the handler runs only on chat pages, respects modal/drawer state, and only works in a composer when `+` is the first character.
- Keep the active message visible by promoting the existing hover reaction toolbar on the selected row, with number badges for the quick reactions.
- Select the active thread pane when a thread is open; otherwise select the main channel or DM timeline.
- Carry explicit `reactionTargetId` values for groupchat messages and require them for channel/thread reactions.
- Cover helper and XEP target behavior with focused Bun tests, then run chat tests, lint, and build.

## XEP review

XEP-0444 Message Reactions requires groupchat reactions to target the MUC-assigned XEP-0359 stanza-id. This PR keeps the existing `urn:xmpp:reactions:0` sender, but tightens channel/thread reaction eligibility and application so groupchat reactions only use explicit room stanza ids. DM reaction matching remains separate.
