### PR TITLE
fix(chat): make spaces collapsible in sidebar

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -698,6 +698,7 @@ function showFirstRunSetupIfNeeded() {
   }
 
   setupPromptShown = true;
+  ui.createChannelContextSpaceId.value = null;
   waddles.createChannelForm.value = {
     intent: "space-with-muc",
     space_name: "",
@@ -706,6 +707,12 @@ function showFirstRunSetupIfNeeded() {
     muc_description: "",
     muc_type: "text",
   };
+  ui.showCreateChannel.value = true;
+}
+
+function openCreateChannelDialog(spaceId: string | null = null) {
+  ui.createChannelContextSpaceId.value = spaceId;
+  waddles.prepareCreateChannelForContext(spaceId);
   ui.showCreateChannel.value = true;
 }
 
@@ -1133,6 +1140,7 @@ async function handleCreateChannel() {
   const created = await waddles.createChannel();
   if (!created) return;
   ui.showCreateChannel.value = false;
+  ui.createChannelContextSpaceId.value = null;
   if (created.intent === "space") {
     // Space-only: topology reloaded, no room to load — leave channel unselected.
     return;
@@ -1297,6 +1305,7 @@ onUnmounted(() => {
             :has-unread-dms="dmConversations.hasUnread.value"
             :session="null"
             horizontal
+            @toggle-channels="ui.sidebarMode.value = 'channels'"
             @toggle-dms="ui.sidebarMode.value = 'dms'"
           />
         </div>
@@ -1311,14 +1320,17 @@ onUnmounted(() => {
           :is-loading="waddles.isLoadingStructure.value"
           :member-count="waddles.members.value.length"
           :active-channel-jids="messaging.activeChannels.value"
+          :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           class="!w-full !border-r-0 !flex-1"
           @select-channel="selectChannel"
           @select-thread="onSelectThread"
-          @create-channel="ui.showCreateChannel.value = true"
+          @create-channel="openCreateChannelDialog()"
+          @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"
           @open-members="ui.showMembers.value = true"
+          @update-collapsed-group-ids="ui.collapsedSpaceGroupIds.value = $event"
         />
         <DmPanel
           v-else
@@ -1395,6 +1407,7 @@ onUnmounted(() => {
           :web-commit-sha="version.webCommitSha.value"
           :server-version="version.serverVersion.value"
           @open-settings="openUserSettings"
+          @toggle-channels="ui.sidebarMode.value = 'channels'"
           @toggle-dms="ui.sidebarMode.value = 'dms'"
           @logout="handleLogout"
           @request-notifications="handleRequestNotifications"
@@ -1415,13 +1428,16 @@ onUnmounted(() => {
           :is-loading="waddles.isLoadingStructure.value"
           :member-count="waddles.members.value.length"
           :active-channel-jids="messaging.activeChannels.value"
+          :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
           @select-channel="selectChannel"
           @select-thread="onSelectThread"
-          @create-channel="ui.showCreateChannel.value = true"
+          @create-channel="openCreateChannelDialog()"
+          @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"
           @open-members="ui.showMembers.value = true"
+          @update-collapsed-group-ids="ui.collapsedSpaceGroupIds.value = $event"
         />
         <DmPanel
           v-else
@@ -1652,6 +1668,7 @@ onUnmounted(() => {
       :form="waddles.createChannelForm.value"
       :is-submitting="waddles.isSubmitting.value"
       :spaces="waddles.sortedSpaces.value.map((space) => ({ node: space.id, name: space.name }))"
+      :default-space-node="ui.createChannelContextSpaceId.value"
       @update:form="waddles.createChannelForm.value = $event"
       @submit="handleCreateChannel"
     />

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { Hash, MessagesSquare, Plus, Settings, Users, ChevronDown, MessageCircle } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
@@ -16,6 +16,7 @@ const props = defineProps<{
   isLoading: boolean;
   memberCount: number;
   activeChannelJids: Set<string>;
+  collapsedGroupIds: Set<string>;
   channelUnreadMap?: Record<string, { unread: number; mentions: number }>;
   threadEntriesFn?: (roomJid: string) => ThreadInboxEntry[];
   roomAvatarHashes?: Record<string, string>;
@@ -40,15 +41,69 @@ const channelGroups = computed(() =>
   })),
 );
 
+function groupUnreadSummary(group: (typeof channelGroups.value)[number]) {
+  return group.channels.reduce(
+    (summary, { channel, unread }) => ({
+      unread: summary.unread + unread.unread,
+      mentions: summary.mentions + unread.mentions,
+      hasActivity: summary.hasActivity || hasActivity(channel.id),
+    }),
+    { unread: 0, mentions: 0, hasActivity: false },
+  );
+}
+
+function groupToggleLabel(group: (typeof channelGroups.value)[number]) {
+  const state = isGroupCollapsed(group.id) ? "collapsed" : "expanded";
+  const channelCount = `${group.channels.length} ${group.channels.length === 1 ? "channel" : "channels"}`;
+  const summary = groupUnreadSummary(group);
+  const activity = activityLabel(summary);
+
+  return `${group.name}, ${state}, ${channelCount}, ${activity}`;
+}
+
+function activityLabel(summary: { unread: number; mentions: number; hasActivity: boolean }) {
+  const parts: string[] = [];
+  if (summary.mentions > 0) {
+    parts.push(`${summary.mentions} ${summary.mentions === 1 ? "mention" : "mentions"}`);
+  }
+  if (summary.unread > 0) {
+    parts.push(`${summary.unread} unread`);
+  }
+  if (summary.hasActivity) {
+    parts.push("active");
+  }
+  return parts.length > 0 ? parts.join(", ") : "no unread activity";
+}
+
+function channelRowLabel(
+  channel: ChannelSummary,
+  unread: { unread: number; mentions: number },
+  isActive: boolean,
+) {
+  return `${channel.name}, ${isActive ? "selected" : "not selected"}, ${activityLabel({
+    unread: unread.unread,
+    mentions: unread.mentions,
+    hasActivity: hasActivity(channel.id),
+  })}`;
+}
+
+function threadRowLabel(thread: ThreadInboxEntry) {
+  const summary = thread.unread > 0 ? `${thread.unread} unread` : "no unread activity";
+  const replies = `${thread.replyCount} ${thread.replyCount === 1 ? "reply" : "replies"}`;
+  return `${truncateTitle(thread.title)}, thread, ${replies}, ${summary}`;
+}
+
 function channelIcon(channel: ChannelSummary) {
   return detectForumChannel(channel) ? MessagesSquare : Hash;
 }
 
-function channelThreads(channelId: string): ThreadInboxEntry[] {
+function channelThreads(channel: ChannelSummary): ThreadInboxEntry[] {
   if (!props.threadEntriesFn) return [];
+  if (channel.jid) return props.threadEntriesFn(channel.jid);
+
   // Find the room JID from the active channel JIDs
   for (const jid of props.activeChannelJids) {
-    if (jid.startsWith(channelId + "@") || jid.includes(channelId)) {
+    if (jid.startsWith(channel.id + "@") || jid.includes(channel.id)) {
       return props.threadEntriesFn(jid);
     }
   }
@@ -64,25 +119,51 @@ const emit = defineEmits<{
   selectChannel: [id: string];
   selectThread: [channelId: string, threadId: string];
   createChannel: [];
+  createChannelInSpace: [spaceId: string | null];
   openSettings: [];
   openMembers: [];
+  updateCollapsedGroupIds: [groupIds: Set<string>];
 }>();
+
+function isGroupCollapsed(groupId: string): boolean {
+  return props.collapsedGroupIds.has(groupId);
+}
+
+function toggleGroup(groupId: string) {
+  const next = new Set(props.collapsedGroupIds);
+  if (next.has(groupId)) {
+    next.delete(groupId);
+  } else {
+    next.add(groupId);
+  }
+  emit("updateCollapsedGroupIds", next);
+}
+
+watch(
+  () => props.activeChannelId,
+  (activeChannelId) => {
+    if (!activeChannelId) return;
+    const activeGroup = channelGroups.value.find((group) =>
+      group.channels.some(({ channel }) => channel.id === activeChannelId),
+    );
+    if (!activeGroup || !props.collapsedGroupIds.has(activeGroup.id)) return;
+    const next = new Set(props.collapsedGroupIds);
+    next.delete(activeGroup.id);
+    emit("updateCollapsedGroupIds", next);
+  },
+);
 </script>
 
 <template>
   <div class="chat-sidebar-pane glass-panel">
     <!-- Waddle header -->
     <div class="chat-sidebar-header">
-      <button
-        class="flex items-center gap-1.5 min-w-0 hover:text-primary transition-colors duration-200 group"
-        type="button"
-      >
-        <span class="type-pane-title truncate text-sidebar-foreground">{{ waddle?.name ?? "Channels" }}</span>
-        <ChevronDown class="w-3 h-3 text-sidebar-muted flex-shrink-0 group-hover:text-primary transition-colors" />
-      </button>
+      <div class="min-w-0 flex-1">
+        <span class="type-pane-title truncate text-sidebar-foreground">Spaces</span>
+      </div>
       <div class="flex gap-0.5 flex-shrink-0">
         <button
-          v-if="canManageCommunity"
+          v-if="waddle && canManageCommunity"
           class="chat-icon-button chat-icon-button--sm hover:bg-sidebar-accent"
           title="Settings"
           aria-label="Waddle settings"
@@ -115,7 +196,7 @@ const emit = defineEmits<{
           </div>
         </div>
 
-        <div v-else-if="channels.length === 0" class="type-caption text-center py-10 text-sidebar-muted">
+        <div v-else-if="channels.length === 0 && spaces.length === 0" class="type-caption text-center py-10 text-sidebar-muted">
           <div class="flex flex-col items-center gap-3 px-4">
             <span>There are no channels or spaces configured yet.</span>
             <button
@@ -132,16 +213,72 @@ const emit = defineEmits<{
 
         <div v-else class="chat-list-stack">
           <section v-for="group in channelGroups" :key="group.id" class="grid gap-1">
-            <span class="type-section-label px-2 pt-2 text-sidebar-muted">
-              {{ group.name }}
-            </span>
-            <template v-for="{ channel, unread } in group.channels" :key="channel.id">
+            <div class="flex items-center gap-1 rounded-md hover:bg-sidebar-accent/35">
+              <button
+                class="type-section-label flex min-w-0 flex-1 items-center gap-1.5 px-2 pt-2 pb-1 text-left text-sidebar-muted hover:text-sidebar-foreground"
+                type="button"
+                :aria-expanded="!isGroupCollapsed(group.id)"
+                :aria-label="groupToggleLabel(group)"
+                @click="toggleGroup(group.id)"
+              >
+                <ChevronDown
+                  class="h-3 w-3 flex-shrink-0 transition-transform"
+                  :class="isGroupCollapsed(group.id) ? '-rotate-90' : ''"
+                />
+                <span class="flex-1 truncate">{{ group.name }}</span>
+                <template v-if="isGroupCollapsed(group.id)">
+                  <span
+                    v-if="groupUnreadSummary(group).mentions > 0"
+                    class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+                    aria-hidden="true"
+                  >{{ groupUnreadSummary(group).mentions }}</span>
+                  <span
+                    v-else-if="groupUnreadSummary(group).unread > 0"
+                    class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                    aria-hidden="true"
+                  >{{ groupUnreadSummary(group).unread }}</span>
+                  <span
+                    v-else-if="groupUnreadSummary(group).hasActivity"
+                    class="w-2 h-2 rounded-full bg-primary shadow-[0_0_6px_var(--glow-strong)]"
+                    aria-hidden="true"
+                  />
+                </template>
+                <span class="type-meta type-numeric text-sidebar-muted">{{ group.channels.length }}</span>
+              </button>
+              <button
+                v-if="canManageChannels"
+                class="chat-icon-button chat-icon-button--sm mr-1 mt-1"
+                type="button"
+                :aria-label="group.space ? `Create channel in ${group.name}` : 'Create standalone channel'"
+                @click="emit('createChannelInSpace', group.space?.id ?? null)"
+              >
+                <Plus class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <template v-if="!isGroupCollapsed(group.id)">
+              <div
+                v-if="group.channels.length === 0"
+                class="type-caption flex items-center justify-between gap-2 px-6 py-2 text-sidebar-muted"
+              >
+                <span>No channels yet.</span>
+                <button
+                  v-if="canManageChannels"
+                  class="type-control rounded-md border border-border px-2 py-1 text-sidebar-foreground hover:bg-sidebar-accent"
+                  type="button"
+                  :aria-label="group.space ? `Create channel in ${group.name}` : 'Create standalone channel'"
+                  @click="emit('createChannelInSpace', group.space?.id ?? null)"
+                >
+                  Create
+                </button>
+              </div>
+              <template v-for="{ channel, unread } in group.channels" :key="channel.id">
               <button
                 class="chat-list-row w-full min-h-10 flex items-center gap-2.5 px-3 py-2 text-left group"
                 :class="activeChannelId === channel.id
                   ? 'bg-sidebar-accent text-sidebar-foreground'
                   : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'"
                 :aria-current="activeChannelId === channel.id ? 'page' : undefined"
+                :aria-label="channelRowLabel(channel, unread, activeChannelId === channel.id)"
                 type="button"
                 @click="emit('selectChannel', channel.id)"
               >
@@ -182,10 +319,11 @@ const emit = defineEmits<{
 
               <!-- Active threads for this channel -->
               <button
-                v-for="thread in channelThreads(channel.id)"
+                v-for="thread in channelThreads(channel)"
                 :key="thread.threadId"
                 class="chat-channel-thread-row chat-list-row flex items-center gap-2 px-2.5 py-2 text-left text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group"
                 type="button"
+                :aria-label="threadRowLabel(thread)"
                 @click="emit('selectThread', channel.id, thread.threadId)"
               >
                 <MessageCircle class="w-3 h-3 flex-shrink-0 opacity-40 group-hover:opacity-70" />
@@ -203,6 +341,7 @@ const emit = defineEmits<{
                   aria-hidden="true"
                 >{{ thread.unread }}</span>
               </button>
+              </template>
             </template>
           </section>
         </div>

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { MessageCircle } from "lucide-vue-next";
+import { Layers, MessageCircle } from "lucide-vue-next";
 import type { SpaceSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { ServerVersion } from "@/composables/useVersion";
@@ -21,6 +21,7 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
+  toggleChannels: [];
   toggleDms: [];
   openSettings: [];
   logout: [];
@@ -60,6 +61,19 @@ const emit = defineEmits<{
 
     <!-- Bottom actions -->
     <div class="chat-rail-actions" :class="horizontal ? 'chat-rail-actions-horizontal' : 'chat-rail-actions-vertical'">
+      <button
+        class="relative w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-200 hover:scale-105"
+        :class="activeSidebarMode === 'channels'
+          ? 'bg-rail-hover text-primary'
+          : 'text-rail-foreground hover:bg-rail-hover hover:text-primary'"
+        title="Spaces"
+        aria-label="Spaces"
+        :aria-pressed="activeSidebarMode === 'channels'"
+        type="button"
+        @click="emit('toggleChannels')"
+      >
+        <Layers class="w-4 h-4" />
+      </button>
       <button
         class="relative w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-200 hover:scale-105"
         :class="activeSidebarMode === 'dms'

--- a/chat/src/components/modals/CreateChannelDialog.vue
+++ b/chat/src/components/modals/CreateChannelDialog.vue
@@ -19,6 +19,7 @@ const props = defineProps<{
   isSubmitting: boolean;
   /** Available spaces for the "MUC in existing Space" intent (node id → display name). */
   spaces?: { node: string; name: string }[];
+  defaultSpaceNode?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -37,8 +38,8 @@ const INTENTS: { value: CreateIntent; label: string; caption: string; icon: unkn
   },
   {
     value: "muc",
-    label: "Channel",
-    caption: "A standalone real-time channel.",
+    label: "Standalone channel",
+    caption: "A real-time channel outside any Space.",
     icon: Hash,
   },
   {
@@ -64,7 +65,7 @@ function selectIntent(intent: CreateIntent) {
       emit("update:form", { intent: "muc", name: "", description: "", muc_type: "text" } satisfies CreateMucFormData);
       break;
     case "space-muc":
-      emit("update:form", { intent: "space-muc", space_node: "", name: "", description: "", muc_type: "text" } satisfies CreateSpaceMucFormData);
+      emit("update:form", { intent: "space-muc", space_node: props.defaultSpaceNode ?? "", name: "", description: "", muc_type: "text" } satisfies CreateSpaceMucFormData);
       break;
     case "space-with-muc":
       emit("update:form", { intent: "space-with-muc", space_name: "", space_description: "", muc_name: "", muc_description: "", muc_type: "text" } satisfies CreateSpaceWithMucFormData);
@@ -106,7 +107,7 @@ const isSubmitDisabled = computed(() => {
 const dialogTitle = computed(() => {
   switch (props.form.intent) {
     case "space": return "New Space";
-    case "muc": return "New Channel";
+    case "muc": return "New Standalone Channel";
     case "space-muc": return "New Channel in Space";
     case "space-with-muc": return "New Space + Channel";
   }

--- a/chat/src/composables/useUiState.ts
+++ b/chat/src/composables/useUiState.ts
@@ -5,6 +5,8 @@ export function useUiState() {
   const activePage = ref<"dashboard" | "chat" | "settings">("dashboard");
   const adminTab = ref<AdminTab>("rooms");
   const sidebarMode = ref<"channels" | "dms">("channels");
+  const collapsedSpaceGroupIds = ref<Set<string>>(new Set());
+  const createChannelContextSpaceId = ref<string | null>(null);
   const showMobileNav = ref(false);
   const showMobileDetails = ref(false);
   const showCreateChannel = ref(false);
@@ -29,6 +31,8 @@ export function useUiState() {
     activePage,
     adminTab,
     sidebarMode,
+    collapsedSpaceGroupIds,
+    createChannelContextSpaceId,
     showMobileNav,
     showMobileDetails,
     showCreateChannel,

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -3,7 +3,7 @@ import type { SpaceSummary, ChannelSummary, MemberSummary } from "@/lib/chat-typ
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { CommunityFormData, CreateFormData, ChannelEditFormData, CreateChannelResult } from "@/lib/chat-ui";
-import { defaultCreateForm } from "@/lib/chat-ui";
+import { defaultCreateForm, defaultCreateFormForContext } from "@/lib/chat-ui";
 import {
   createMucRoom,
   createSpaceNode,
@@ -37,6 +37,7 @@ export function useWaddles(
   const spacesServiceJid = ref<string | null>(null);
 
   const activeChannelId: Ref<string | null> = ref(null);
+  const selectedSpaceId: Ref<string | null> = ref(null);
 
   const isLoadingStructure = ref(false);
   const isSubmitting = ref(false);
@@ -62,7 +63,7 @@ export function useWaddles(
   const currentChannel = computed(
     () => channels.value.find((c) => c.id === activeChannelId.value) ?? null,
   );
-  const activeSpaceId = computed(() => currentChannel.value?.spaceId ?? null);
+  const activeSpaceId = computed(() => currentChannel.value?.spaceId ?? selectedSpaceId.value);
   const currentSpace = computed(() =>
     activeSpaceId.value
       ? waddles.value.find((w) => w.id === activeSpaceId.value) ?? null
@@ -132,6 +133,7 @@ export function useWaddles(
 
   watch(currentChannel, (c) => {
     if (c) {
+      selectedSpaceId.value = c.spaceId ?? null;
       editChannelForm.value = {
         name: c.name,
         description: c.description ?? "",
@@ -142,6 +144,10 @@ export function useWaddles(
 
   function resetForms() {
     createChannelForm.value = defaultCreateForm();
+  }
+
+  function prepareCreateChannelForContext(spaceId: string | null = currentSpace.value?.id ?? null) {
+    createChannelForm.value = defaultCreateFormForContext(spaceId);
   }
 
   async function loadStructure(preferredChannelId?: string | null, opts?: LoadStructureOptions): Promise<string | null> {
@@ -182,6 +188,7 @@ export function useWaddles(
 
       if (opts?.noChannelSelect) {
         activeChannelId.value = null;
+        selectedSpaceId.value = null;
         resetForms();
         return null;
       }
@@ -195,6 +202,7 @@ export function useWaddles(
 
       activeChannelId.value = nextChannelId;
       const nextChannel = channelList.find((channel) => channel.id === nextChannelId);
+      selectedSpaceId.value = nextChannel ? nextChannel.spaceId ?? null : selectedSpaceId.value;
       if (nextChannelId && xmppClient.value) {
         const memberReqId = ++memberRequestId;
         try {
@@ -257,14 +265,6 @@ export function useWaddles(
     }
   }
 
-  function selectDiscoveredSpace(spaceId: string): string | null {
-    if (!waddles.value.some((space) => space.id === spaceId)) return null;
-    const nextChannelId = channels.value.find((channel) => channel.spaceId === spaceId)?.id ?? null;
-    activeChannelId.value = nextChannelId;
-    members.value = [];
-    return nextChannelId;
-  }
-
   async function updateWaddle() {
     actionError.value = "Space settings are managed by the server configuration.";
   }
@@ -324,6 +324,7 @@ export function useWaddles(
 
         createChannelForm.value = defaultCreateForm();
         await loadStructure(null, { noChannelSelect: true });
+        selectedSpaceId.value = node;
         return {
           intent: "space",
           spaceId: node,
@@ -414,6 +415,7 @@ export function useWaddles(
     members.value = [];
     serverRole.value = null;
     activeChannelId.value = null;
+    selectedSpaceId.value = null;
   }
 
   return {
@@ -441,7 +443,7 @@ export function useWaddles(
     loadSpace,
     loadStructure,
     reloadChannelMembers,
-    selectDiscoveredSpace,
+    prepareCreateChannelForContext,
     updateWaddle,
     deleteWaddle,
     createChannel,

--- a/chat/src/lib/channel-grouping.ts
+++ b/chat/src/lib/channel-grouping.ts
@@ -7,6 +7,17 @@ interface ChannelGroup {
   channels: ChannelSummary[];
 }
 
+export const STANDALONE_CHANNEL_GROUP_ID = "synthetic:standalone";
+export const STANDALONE_CHANNEL_GROUP_NAME = "Standalone channels";
+
+function sortChannels(items: ChannelSummary[]) {
+  return [...items].sort(
+    (a, b) =>
+      (a.position ?? 0) - (b.position ?? 0) ||
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
+  );
+}
+
 export function groupChannelsBySpace(
   spaces: SpaceSummary[],
   channels: ChannelSummary[],
@@ -25,30 +36,33 @@ export function groupChannelsBySpace(
     }
   }
 
-  const sortChannels = (items: ChannelSummary[]) =>
-    [...items].sort(
-      (a, b) =>
-        (a.position ?? 0) - (b.position ?? 0) ||
-        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
-    );
-
   const groups: ChannelGroup[] = spaces
     .map((space) => ({
-      id: space.id,
+      id: `space:${space.id}`,
       name: space.name,
       space,
       channels: sortChannels(grouped.get(space.id) ?? []),
-    }))
-    .filter((group) => group.channels.length > 0);
+    }));
 
   if (standalone.length > 0) {
     groups.push({
-      id: "standalone",
-      name: "Channels",
+      id: STANDALONE_CHANNEL_GROUP_ID,
+      name: STANDALONE_CHANNEL_GROUP_NAME,
       space: null,
       channels: sortChannels(standalone),
     });
   }
 
   return groups;
+}
+
+export function firstChannelIdForSpace(
+  channels: ChannelSummary[],
+  spaceId: string,
+): string | null {
+  return sortChannels(channels.filter((channel) => channel.spaceId === spaceId))[0]?.id ?? null;
+}
+
+export function firstStandaloneChannelId(channels: ChannelSummary[]): string | null {
+  return sortChannels(channels.filter((channel) => !channel.spaceId))[0]?.id ?? null;
 }

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -150,6 +150,21 @@ export function defaultCreateForm(): CreateMucFormData {
   return { intent: "muc", name: "", description: "", muc_type: "text" };
 }
 
+/** Returns the best create form for the current navigation container. */
+export function defaultCreateFormForContext(spaceNode?: string | null): CreateMucFormData | CreateSpaceMucFormData {
+  if (spaceNode) {
+    return {
+      intent: "space-muc",
+      space_node: spaceNode,
+      name: "",
+      description: "",
+      muc_type: "text",
+    };
+  }
+
+  return defaultCreateForm();
+}
+
 // ── Create result typed model ────────────────────────────────────────
 
 /** Returned by createChannel() for a Space-only creation — no room was created. */

--- a/chat/tests/channel-grouping.test.ts
+++ b/chat/tests/channel-grouping.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { groupChannelsBySpace } from "../src/lib/channel-grouping";
+import {
+  firstChannelIdForSpace,
+  firstStandaloneChannelId,
+  groupChannelsBySpace,
+  STANDALONE_CHANNEL_GROUP_ID,
+  STANDALONE_CHANNEL_GROUP_NAME,
+} from "../src/lib/channel-grouping";
+import type { ChannelSummary } from "../src/lib/chat-types";
 
 describe("groupChannelsBySpace", () => {
   test("groups rooms under spaces and keeps standalone rooms separate", () => {
@@ -13,17 +20,77 @@ describe("groupChannelsBySpace", () => {
 
     expect(groups).toEqual([
       {
-        id: "general",
+        id: "space:general",
         name: "General",
         space: { id: "general", name: "General" },
         channels: [{ id: "chat", name: "Chat", spaceId: "general", position: 0 }],
       },
       {
-        id: "standalone",
-        name: "Channels",
+        id: STANDALONE_CHANNEL_GROUP_ID,
+        name: STANDALONE_CHANNEL_GROUP_NAME,
         space: null,
         channels: [{ id: "random", name: "Random", position: 1 }],
       },
     ]);
+  });
+
+  test("keeps empty spaces visible as collapsible groups", () => {
+    const groups = groupChannelsBySpace(
+      [
+        { id: "empty", name: "Empty" },
+        { id: "general", name: "General" },
+      ],
+      [{ id: "chat", name: "Chat", spaceId: "general", position: 0 }],
+    );
+
+    expect(groups).toEqual([
+      {
+        id: "space:empty",
+        name: "Empty",
+        space: { id: "empty", name: "Empty" },
+        channels: [],
+      },
+      {
+        id: "space:general",
+        name: "General",
+        space: { id: "general", name: "General" },
+        channels: [{ id: "chat", name: "Chat", spaceId: "general", position: 0 }],
+      },
+    ]);
+  });
+
+  test("labels standalone groups as standalone channels", () => {
+    const groups = groupChannelsBySpace(
+      [],
+      [{ id: "random", name: "Random", position: 0 }],
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.id).toBe(STANDALONE_CHANNEL_GROUP_ID);
+    expect(groups[0]?.name).toBe("Standalone channels");
+    expect(groups[0]?.space).toBeNull();
+  });
+});
+
+describe("channel container routing helpers", () => {
+  const channels: ChannelSummary[] = [
+    { id: "standalone-late", name: "Standalone Late", position: 20 },
+    { id: "space-late", name: "Space Late", spaceId: "space-a", position: 20 },
+    { id: "standalone-first", name: "Standalone First", position: 1 },
+    { id: "space-first", name: "Space First", spaceId: "space-a", position: 1 },
+    { id: "other-space", name: "Other Space", spaceId: "space-b", position: 0 },
+  ];
+
+  test("choosing a Space maps to the first channel in that Space", () => {
+    expect(firstChannelIdForSpace(channels, "space-a")).toBe("space-first");
+  });
+
+  test("choosing the standalone container maps to the first standalone channel", () => {
+    expect(firstStandaloneChannelId(channels)).toBe("standalone-first");
+  });
+
+  test("container helpers return null when there is no matching channel", () => {
+    expect(firstChannelIdForSpace(channels, "missing-space")).toBeNull();
+    expect(firstStandaloneChannelId([{ id: "space-only", name: "Space Only", spaceId: "space-a" }])).toBeNull();
   });
 });

--- a/chat/tests/create-intent.test.ts
+++ b/chat/tests/create-intent.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   defaultCreateForm,
+  defaultCreateFormForContext,
   type CreateFormData,
   type CreateSpaceFormData,
   type CreateMucFormData,
@@ -16,6 +17,30 @@ describe("create intent form model", () => {
       expect(form.name).toBe("");
       expect(form.description).toBe("");
       expect(form.muc_type).toBe("text");
+    });
+
+    it("keeps the default muc intent explicitly standalone", () => {
+      const form = defaultCreateForm();
+      expect(form.intent).toBe("muc");
+      expect("space_node" in form).toBe(false);
+    });
+  });
+
+  describe("defaultCreateFormForContext", () => {
+    it("prefers a space-muc intent when an active Space exists", () => {
+      const form = defaultCreateFormForContext("team-space");
+      expect(form).toEqual({
+        intent: "space-muc",
+        space_node: "team-space",
+        name: "",
+        description: "",
+        muc_type: "text",
+      });
+    });
+
+    it("uses a standalone muc intent when no active Space exists", () => {
+      expect(defaultCreateFormForContext(null)).toEqual(defaultCreateForm());
+      expect(defaultCreateFormForContext(undefined)).toEqual(defaultCreateForm());
     });
   });
 


### PR DESCRIPTION
## Summary

Make Spaces the primary channel sidebar structure: each Space renders as a Discord-style collapsible section, with standalone MUCs grouped separately as "Standalone channels".

## Plan

- Replace the header dropdown idea with inline collapsible Space groups in the sidebar.
- Keep empty Spaces visible, with an inline create-channel affordance.
- Preserve standalone MUC support while labeling it explicitly as standalone.
- Share collapse state across desktop/mobile sidebar instances and show unread/mention state on collapsed groups.
- Preserve the clicked Space context when creating a channel from a Space section.
- Keep all behavior on existing XMPP MUC, PubSub, Bookmarks, and Spaces flows.

## Verification

- `cd chat && bun test`
- `cd chat && bun run lint`
- `cd chat && bun run build`
- Adversarial UX, Vue/TypeScript, and XMPP/XEP review passes repeated until no actionable issues remained.
