### PR TITLE
fix(ci): restore server publish oidc permission

### DIFF
--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -15,6 +15,7 @@ permissions:
   checks: write
   pull-requests: none
   packages: write
+  id-token: write
 jobs:
   build-cuenv:
     name: build.cuenv

--- a/server/env.cue
+++ b/server/env.cue
@@ -133,6 +133,7 @@ schema.#Project & {
 			derivePaths: false
 			provider: github: {
 				permissions: {
+					"id-token":      "write"
 					packages:        "write"
 					"pull-requests": "none"
 				}


### PR DESCRIPTION
## Plan

- Restore id-token: write to the default server CI pipeline so Determinate/FlakeHub setup is no longer reported as misconfigured.
- Regenerate the generated GitHub workflow with cuenv sync ci.
- Verify the generated workflow includes id-token: write alongside packages: write.
- Rerun the failed server publish workflow and monitor the publishContainerImage job.

## Verification

- cuenv sync ci --check -A

## Notes

This is a CI-only change. It does not alter XMPP wire behavior or any XEP namespace usage.