### PR TITLE
fix(chat): make extensions usable

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance } from "vue";
-import { AlertCircle, CheckCircle2, Hash, LoaderCircle, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
+import { AlertCircle, CheckCircle2, Hash, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
 import { findMessageElementById } from "@/lib/message-targeting";
@@ -21,12 +21,15 @@ import {
   parseExtensionCommandLaunches,
   parseExtensionCommandForm,
   type DiscoveredExtensionCommand,
+  type ExtensionCommandAction,
   type ExtensionCommandFormField,
+  type ExtensionCommandResult,
 } from "@/lib/xmpp/extension-commands";
 import { useScrollDirection } from "@/composables/useScrollDirection";
 import type { ThreadIndex } from "@/composables/useThreads";
 import { formatStamp, formatDayDivider, isSameDay } from "@/composables/useMessaging";
 import ChatHeader from "@/components/chat/ChatHeader.vue";
+import ExtensionPalette from "@/components/chat/ExtensionPalette.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
 import UserProfileDrawer from "@/components/chat/UserProfileDrawer.vue";
@@ -116,11 +119,15 @@ const extensionCommands = ref<DiscoveredExtensionCommand[]>([]);
 const extensionLauncherState = ref<"idle" | "loading" | "error">("idle");
 const extensionLauncherDetail = ref("");
 const extensionCommandStates = ref<Record<string, { state: "loading" | "success" | "warning" | "error"; detail?: string }>>({});
-const extensionCommandForms = ref<Record<string, { sessionId: string; fields: ExtensionCommandFormField[] }>>({});
+const extensionCommandForms = ref<Record<string, { sessionId: string; fields: ExtensionCommandFormField[]; actions?: ExtensionCommandAction[] }>>({});
 const extensionCommandActions = ref<Record<string, ExtensionAnnotationAction[]>>({});
 
 type MessageComposerHandle = {
   addAttachments: (files: Array<File | Blob>) => void;
+  focus: () => void;
+  focusExtensions: () => void;
+};
+type ExtensionPaletteHandle = {
   focus: () => void;
 };
 
@@ -130,8 +137,59 @@ function focusComposer() {
   void nextTick(() => composerRef.value?.focus());
 }
 
+function closeExtensionLauncher() {
+  extensionLauncherOpen.value = false;
+  void nextTick(() => composerRef.value?.focusExtensions());
+}
+
+function clearExtensionCommandSurfaces(key: string) {
+  const nextForms = { ...extensionCommandForms.value };
+  delete nextForms[key];
+  extensionCommandForms.value = nextForms;
+  const nextActions = { ...extensionCommandActions.value };
+  delete nextActions[key];
+  extensionCommandActions.value = nextActions;
+}
+
+function storeExtensionResultSurfaces(key: string, result: ExtensionCommandResult) {
+  let foundActions = false;
+  if (result.form) {
+    const actions = parseExtensionCommandLaunches(result.form);
+    if (actions.length > 0) {
+      foundActions = true;
+      extensionCommandActions.value = { ...extensionCommandActions.value, [key]: actions };
+    }
+  }
+  if (!foundActions) {
+    const nextActions = { ...extensionCommandActions.value };
+    delete nextActions[key];
+    extensionCommandActions.value = nextActions;
+  }
+
+  if (result.sessionId && result.form && result.status === "executing") {
+    const fields = parseExtensionCommandForm(result.form);
+    if (fields.length > 0) {
+      extensionCommandForms.value = {
+        ...extensionCommandForms.value,
+        [key]: {
+          sessionId: result.sessionId,
+          fields,
+          ...(result.actions?.allowed.length ? { actions: result.actions.allowed } : {}),
+        },
+      };
+      return;
+    }
+  }
+  const nextForms = { ...extensionCommandForms.value };
+  delete nextForms[key];
+  extensionCommandForms.value = nextForms;
+}
+
 async function openExtensionLauncher() {
   extensionLauncherOpen.value = !extensionLauncherOpen.value;
+  if (extensionLauncherOpen.value) {
+    void nextTick(() => extensionPaletteRef.value?.focus());
+  }
   if (!extensionLauncherOpen.value || extensionCommands.value.length > 0) return;
   if (!props.xmppClient) {
     extensionLauncherState.value = "error";
@@ -155,25 +213,12 @@ async function openExtensionLauncher() {
 async function invokeExtensionCommand(command: DiscoveredExtensionCommand) {
   if (!props.xmppClient) return;
   const key = command.node;
+  clearExtensionCommandSurfaces(key);
   extensionCommandStates.value = { ...extensionCommandStates.value, [key]: { state: "loading" } };
   try {
     const result = await props.xmppClient.invokeExtensionCommand(command);
     const outcome = extensionCommandOutcome(result);
-    if (result.sessionId && result.form) {
-      const fields = parseExtensionCommandForm(result.form);
-      if (fields.length > 0) {
-        extensionCommandForms.value = {
-          ...extensionCommandForms.value,
-          [key]: { sessionId: result.sessionId, fields },
-        };
-      }
-    }
-    if (result.form) {
-      const actions = parseExtensionCommandLaunches(result.form);
-      if (actions.length > 0) {
-        extensionCommandActions.value = { ...extensionCommandActions.value, [key]: actions };
-      }
-    }
+    storeExtensionResultSurfaces(key, result);
     extensionCommandStates.value = { ...extensionCommandStates.value, [key]: outcome };
   } catch (error) {
     extensionCommandStates.value = {
@@ -183,24 +228,42 @@ async function invokeExtensionCommand(command: DiscoveredExtensionCommand) {
   }
 }
 
-async function submitExtensionCommandForm(command: DiscoveredExtensionCommand) {
+function updateExtensionCommandField(commandNode: string, fieldName: string, values: string[]) {
+  const form = extensionCommandForms.value[commandNode];
+  if (!form) return;
+  extensionCommandForms.value = {
+    ...extensionCommandForms.value,
+    [commandNode]: {
+      ...form,
+      fields: form.fields.map((field) =>
+        field.name === fieldName
+          ? { ...field, values, value: values[0] ?? "" }
+          : field,
+      ),
+    },
+  };
+}
+
+function resetExtensionLauncherState() {
+  extensionLauncherOpen.value = false;
+  extensionCommands.value = [];
+  extensionLauncherState.value = "idle";
+  extensionLauncherDetail.value = "";
+  extensionCommandStates.value = {};
+  extensionCommandForms.value = {};
+  extensionCommandActions.value = {};
+}
+
+async function submitExtensionCommandForm(command: DiscoveredExtensionCommand, action: ExtensionCommandAction = "complete") {
   if (!props.xmppClient) return;
   const key = command.node;
   const form = extensionCommandForms.value[key];
   if (!form) return;
   extensionCommandStates.value = { ...extensionCommandStates.value, [key]: { state: "loading" } };
   try {
-    const result = await props.xmppClient.submitExtensionCommandForm(command, form.sessionId, form.fields);
+    const result = await props.xmppClient.submitExtensionCommandForm(command, form.sessionId, form.fields, action);
     const outcome = extensionCommandOutcome(result);
-    if (result.form) {
-      const actions = parseExtensionCommandLaunches(result.form);
-      if (actions.length > 0) {
-        extensionCommandActions.value = { ...extensionCommandActions.value, [key]: actions };
-      }
-    }
-    const nextForms = { ...extensionCommandForms.value };
-    delete nextForms[key];
-    extensionCommandForms.value = nextForms;
+    storeExtensionResultSurfaces(key, result);
     extensionCommandStates.value = { ...extensionCommandStates.value, [key]: outcome };
   } catch (error) {
     extensionCommandStates.value = {
@@ -217,6 +280,7 @@ async function invokeCommandResultAction(command: DiscoveredExtensionCommand, ac
   try {
     const result = await props.invokeExtensionAction(action);
     const outcome = extensionCommandOutcome(result);
+    storeExtensionResultSurfaces(key, result);
     extensionCommandStates.value = { ...extensionCommandStates.value, [key]: outcome };
   } catch (error) {
     extensionCommandStates.value = {
@@ -350,6 +414,10 @@ const currentDayMarkerLabel = ref("");
 const composerRef = ref<MessageComposerHandle | null>(null);
 const setComposerRef = (instance: MessageComposerHandle | null) => {
   composerRef.value = instance;
+};
+const extensionPaletteRef = ref<ExtensionPaletteHandle | null>(null);
+const setExtensionPaletteRef = (instance: ExtensionPaletteHandle | null) => {
+  extensionPaletteRef.value = instance;
 };
 const showSearch = ref(false);
 const searchInput = ref("");
@@ -541,6 +609,7 @@ watch(conversationScope, () => {
   cancelReply();
   clearReplyJumpNotice();
   clearReconnectedNotice();
+  resetExtensionLauncherState();
   forumTitle.value = "";
 });
 
@@ -836,6 +905,7 @@ function dayDividerLabel(createdAt: string): string {
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
       :is-top-pinned="true"
+      :extensions-open="extensionLauncherOpen"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
@@ -843,93 +913,22 @@ function dayDividerLabel(createdAt: string): string {
       @open-extensions="openExtensionLauncher"
     />
 
-    <div
+    <ExtensionPalette
       v-if="extensionLauncherOpen && isTopPinned"
-      class="chat-message-lane border-b border-border bg-background/95 px-[var(--chat-content-inline)] py-3"
-    >
-      <div class="flex flex-wrap items-center gap-2">
-        <span v-if="extensionLauncherState === 'loading'" class="type-caption inline-flex items-center gap-2 text-muted-foreground">
-          <LoaderCircle class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-          Loading extensions
-        </span>
-        <button
-          v-for="command in extensionCommands"
-          :key="command.node"
-          type="button"
-          class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 py-1.5 text-foreground hover:bg-muted/70 disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="invokeExtensionCommand(command)"
-        >
-          <LoaderCircle
-            v-if="extensionCommandStates[command.node]?.state === 'loading'"
-            class="h-3.5 w-3.5 animate-spin"
-            aria-hidden="true"
-          />
-          <CheckCircle2
-            v-else-if="extensionCommandStates[command.node]?.state === 'success'"
-            class="h-3.5 w-3.5 text-success"
-            aria-hidden="true"
-          />
-          <AlertCircle
-            v-else-if="extensionCommandStates[command.node]?.state === 'warning' || extensionCommandStates[command.node]?.state === 'error'"
-            class="h-3.5 w-3.5"
-            :class="extensionCommandStates[command.node]?.state === 'error' ? 'text-destructive' : 'text-warning'"
-            aria-hidden="true"
-          />
-          {{ command.name }}
-        </button>
-      </div>
-      <p
-        v-if="extensionLauncherDetail || Object.values(extensionCommandStates).some((state) => state.detail)"
-        class="type-caption mt-2 text-muted-foreground"
-      >
-        {{ extensionLauncherDetail || Object.values(extensionCommandStates).find((state) => state.detail)?.detail }}
-      </p>
-      <div
-        v-for="command in extensionCommands.filter((item) => extensionCommandForms[item.node])"
-        :key="`form:${command.node}`"
-        class="mt-3 grid gap-2 rounded-md border border-border bg-muted/30 p-3"
-      >
-        <label
-          v-for="field in extensionCommandForms[command.node].fields"
-          :key="`${command.node}:${field.name}`"
-          class="type-caption grid gap-1 text-muted-foreground"
-        >
-          <span>{{ field.label }}</span>
-          <input
-            v-model="field.value"
-            class="min-h-8 rounded-md border border-border bg-background px-2 text-foreground"
-            :type="field.type === 'text-private' ? 'password' : 'text'"
-            :required="field.required"
-            @input="field.values = [field.value]"
-          />
-        </label>
-        <button
-          type="button"
-          class="type-caption justify-self-start rounded-md bg-primary px-3 py-1.5 text-primary-foreground disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="submitExtensionCommandForm(command)"
-        >
-          Submit
-        </button>
-      </div>
-      <div
-        v-for="command in extensionCommands.filter((item) => extensionCommandActions[item.node]?.length)"
-        :key="`actions:${command.node}`"
-        class="mt-3 flex flex-wrap gap-2"
-      >
-        <button
-          v-for="action in extensionCommandActions[command.node]"
-          :key="`${command.node}:${action.route}`"
-          type="button"
-          class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground hover:bg-muted disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="invokeCommandResultAction(command, action)"
-        >
-          {{ action.label }}
-        </button>
-      </div>
-    </div>
+      :ref="setExtensionPaletteRef"
+      :state="extensionLauncherState"
+      :detail="extensionLauncherDetail"
+      :commands="extensionCommands"
+      :command-states="extensionCommandStates"
+      :command-forms="extensionCommandForms"
+      :command-actions="extensionCommandActions"
+      :is-top-pinned="true"
+      @close="closeExtensionLauncher"
+      @invoke-command="invokeExtensionCommand"
+      @submit-form="submitExtensionCommandForm"
+      @invoke-action="invokeCommandResultAction"
+      @update-field="updateExtensionCommandField"
+    />
 
     <!-- Typing indicator (social / top-pinned mode) -->
     <div
@@ -1106,99 +1105,28 @@ function dayDividerLabel(createdAt: string): string {
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
+      :extensions-open="extensionLauncherOpen"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="onSelectGif"
       @open-extensions="openExtensionLauncher"
     />
-    <div
+    <ExtensionPalette
       v-if="extensionLauncherOpen && !isTopPinned"
-      class="border-t border-border bg-background/95 px-[var(--chat-content-inline)] py-3"
-    >
-      <div class="flex flex-wrap items-center gap-2">
-        <span v-if="extensionLauncherState === 'loading'" class="type-caption inline-flex items-center gap-2 text-muted-foreground">
-          <LoaderCircle class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-          Loading extensions
-        </span>
-        <button
-          v-for="command in extensionCommands"
-          :key="command.node"
-          type="button"
-          class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 py-1.5 text-foreground hover:bg-muted/70 disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="invokeExtensionCommand(command)"
-        >
-          <LoaderCircle
-            v-if="extensionCommandStates[command.node]?.state === 'loading'"
-            class="h-3.5 w-3.5 animate-spin"
-            aria-hidden="true"
-          />
-          <CheckCircle2
-            v-else-if="extensionCommandStates[command.node]?.state === 'success'"
-            class="h-3.5 w-3.5 text-success"
-            aria-hidden="true"
-          />
-          <AlertCircle
-            v-else-if="extensionCommandStates[command.node]?.state === 'warning' || extensionCommandStates[command.node]?.state === 'error'"
-            class="h-3.5 w-3.5"
-            :class="extensionCommandStates[command.node]?.state === 'error' ? 'text-destructive' : 'text-warning'"
-            aria-hidden="true"
-          />
-          {{ command.name }}
-        </button>
-      </div>
-      <p
-        v-if="extensionLauncherDetail || Object.values(extensionCommandStates).some((state) => state.detail)"
-        class="type-caption mt-2 text-muted-foreground"
-      >
-        {{ extensionLauncherDetail || Object.values(extensionCommandStates).find((state) => state.detail)?.detail }}
-      </p>
-      <div
-        v-for="command in extensionCommands.filter((item) => extensionCommandForms[item.node])"
-        :key="`form:${command.node}`"
-        class="mt-3 grid gap-2 rounded-md border border-border bg-muted/30 p-3"
-      >
-        <label
-          v-for="field in extensionCommandForms[command.node].fields"
-          :key="`${command.node}:${field.name}`"
-          class="type-caption grid gap-1 text-muted-foreground"
-        >
-          <span>{{ field.label }}</span>
-          <input
-            v-model="field.value"
-            class="min-h-8 rounded-md border border-border bg-background px-2 text-foreground"
-            :type="field.type === 'text-private' ? 'password' : 'text'"
-            :required="field.required"
-            @input="field.values = [field.value]"
-          />
-        </label>
-        <button
-          type="button"
-          class="type-caption justify-self-start rounded-md bg-primary px-3 py-1.5 text-primary-foreground disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="submitExtensionCommandForm(command)"
-        >
-          Submit
-        </button>
-      </div>
-      <div
-        v-for="command in extensionCommands.filter((item) => extensionCommandActions[item.node]?.length)"
-        :key="`actions:${command.node}`"
-        class="mt-3 flex flex-wrap gap-2"
-      >
-        <button
-          v-for="action in extensionCommandActions[command.node]"
-          :key="`${command.node}:${action.route}`"
-          type="button"
-          class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground hover:bg-muted disabled:opacity-60"
-          :disabled="extensionCommandStates[command.node]?.state === 'loading'"
-          @click="invokeCommandResultAction(command, action)"
-        >
-          {{ action.label }}
-        </button>
-      </div>
-    </div>
+      :ref="setExtensionPaletteRef"
+      :state="extensionLauncherState"
+      :detail="extensionLauncherDetail"
+      :commands="extensionCommands"
+      :command-states="extensionCommandStates"
+      :command-forms="extensionCommandForms"
+      :command-actions="extensionCommandActions"
+      @close="closeExtensionLauncher"
+      @invoke-command="invokeExtensionCommand"
+      @submit-form="submitExtensionCommandForm"
+      @invoke-action="invokeCommandResultAction"
+      @update-field="updateExtensionCommandField"
+    />
     <UserProfileDrawer
       v-model:open="profileDrawerOpen"
       :username="popoverAuthor?.username ?? ''"

--- a/chat/src/components/chat/ExtensionPalette.vue
+++ b/chat/src/components/chat/ExtensionPalette.vue
@@ -1,0 +1,398 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  AlertCircle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  LoaderCircle,
+  Play,
+  ShieldCheck,
+  Square,
+  X,
+} from "lucide-vue-next";
+import {
+  extensionCommandFormBlockedReason,
+  visibleExtensionCommandFields,
+  type DiscoveredExtensionCommand,
+  type ExtensionCommandAction,
+  type ExtensionCommandFormField,
+} from "@/lib/xmpp/extension-commands";
+import type { ExtensionAnnotationAction } from "@/lib/chat-ui";
+
+const props = defineProps<{
+  state: "idle" | "loading" | "error";
+  detail: string;
+  commands: DiscoveredExtensionCommand[];
+  commandStates: Record<string, { state: "loading" | "success" | "warning" | "error"; detail?: string }>;
+  commandForms: Record<string, { sessionId: string; fields: ExtensionCommandFormField[]; actions?: ExtensionCommandAction[] }>;
+  commandActions: Record<string, ExtensionAnnotationAction[]>;
+  isTopPinned?: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  invokeCommand: [command: DiscoveredExtensionCommand];
+  submitForm: [command: DiscoveredExtensionCommand, action: ExtensionCommandAction];
+  invokeAction: [command: DiscoveredExtensionCommand, action: ExtensionAnnotationAction];
+  updateField: [commandNode: string, fieldName: string, values: string[]];
+}>();
+
+const adminCommands = computed(() =>
+  props.commands.filter((command) => command.node.includes(":admin:")),
+);
+const memberCommands = computed(() =>
+  props.commands.filter((command) => !command.node.includes(":admin:")),
+);
+const closeButtonRef = ref<HTMLButtonElement | null>(null);
+
+function setCloseButtonRef(el: HTMLButtonElement | null) {
+  closeButtonRef.value = el;
+}
+
+function focus() {
+  closeButtonRef.value?.focus();
+}
+
+defineExpose({ focus });
+
+function visibleFields(command: DiscoveredExtensionCommand): ExtensionCommandFormField[] {
+  return visibleExtensionCommandFields(props.commandForms[command.node]?.fields ?? []);
+}
+
+function blockedReason(command: DiscoveredExtensionCommand): string | undefined {
+  return extensionCommandFormBlockedReason(props.commandForms[command.node]?.fields ?? []);
+}
+
+function allowedActions(command: DiscoveredExtensionCommand): ExtensionCommandAction[] {
+  const configured = props.commandForms[command.node]?.actions ?? [];
+  const actions = configured.length > 0 ? configured : ["complete", "cancel"];
+  return actions.includes("cancel") ? actions : [...actions, "cancel"];
+}
+
+function stateDetail(command: DiscoveredExtensionCommand): string {
+  return props.commandStates[command.node]?.detail ?? "";
+}
+
+function hasRequiredValue(field: ExtensionCommandFormField): boolean {
+  if (field.type === "fixed") return true;
+  if (field.type === "boolean") return field.value.trim().length > 0;
+  if (field.type === "list-multi" || field.type === "text-multi" || field.type === "jid-multi") {
+    return field.values.some((value) => value.trim().length > 0);
+  }
+  return field.value.trim().length > 0;
+}
+
+function missingRequiredFields(command: DiscoveredExtensionCommand): ExtensionCommandFormField[] {
+  return visibleFields(command).filter((field) => field.required && !hasRequiredValue(field));
+}
+
+function canSubmitAction(command: DiscoveredExtensionCommand, action: ExtensionCommandAction): boolean {
+  if (props.commandStates[command.node]?.state === "loading") return false;
+  if (action === "cancel" || action === "prev") return true;
+  return !blockedReason(command) && missingRequiredFields(command).length === 0;
+}
+
+function setSingleValue(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, value: string) {
+  emit("updateField", command.node, field.name, [value]);
+}
+
+function setSingleValueFromEvent(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, event: Event) {
+  setSingleValue(command, field, (event.target as HTMLInputElement | HTMLSelectElement).value);
+}
+
+function setBooleanValue(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, checked: boolean) {
+  emit("updateField", command.node, field.name, [checked ? "1" : "0"]);
+}
+
+function setBooleanValueFromEvent(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, event: Event) {
+  setBooleanValue(command, field, (event.target as HTMLInputElement).checked);
+}
+
+function toggleMultiValue(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, value: string, checked: boolean) {
+  const values = new Set(field.values);
+  if (checked) values.add(value);
+  else values.delete(value);
+  const orderedValues = field.options.length > 0
+    ? field.options.map((option) => option.value).filter((optionValue) => values.has(optionValue))
+    : field.values.filter((fieldValue) => values.has(fieldValue));
+  emit("updateField", command.node, field.name, orderedValues);
+}
+
+function toggleMultiValueFromEvent(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, value: string, event: Event) {
+  toggleMultiValue(command, field, value, (event.target as HTMLInputElement).checked);
+}
+
+function setMultiLineValueFromEvent(command: DiscoveredExtensionCommand, field: ExtensionCommandFormField, event: Event) {
+  emit("updateField", command.node, field.name, (event.target as HTMLTextAreaElement).value.split("\n"));
+}
+
+function actionLabel(action: ExtensionCommandAction): string {
+  switch (action) {
+    case "prev":
+      return "Back";
+    case "next":
+      return "Next";
+    case "cancel":
+      return "Cancel";
+    default:
+      return "Complete";
+  }
+}
+</script>
+
+<template>
+  <section
+    class="chat-extension-palette max-h-[min(72dvh,44rem)] overflow-y-auto overscroll-contain border-border bg-background/95 px-[var(--chat-content-inline)] py-3"
+    :class="isTopPinned ? 'border-b' : 'border-t'"
+    role="region"
+    aria-label="Extensions"
+  >
+    <div class="chat-message-lane grid gap-3">
+      <header class="flex items-center justify-between gap-3">
+        <div class="min-w-0">
+          <h2 class="type-card-title text-foreground">Extensions</h2>
+          <p class="type-caption text-muted-foreground">
+            Waddle-native actions available in this conversation.
+          </p>
+        </div>
+        <button
+          :ref="setCloseButtonRef"
+          type="button"
+          class="chat-icon-button h-9 w-9"
+          title="Close extensions"
+          aria-label="Close extensions"
+          @click="emit('close')"
+        >
+          <X class="h-4 w-4" aria-hidden="true" />
+        </button>
+      </header>
+
+      <div v-if="state === 'loading'" class="type-caption inline-flex items-center gap-2 text-muted-foreground" role="status">
+        <LoaderCircle class="h-4 w-4 animate-spin" aria-hidden="true" />
+        Loading extensions
+      </div>
+
+      <p v-else-if="state === 'error'" class="type-caption text-destructive" role="alert">
+        {{ detail || "Could not load extensions." }}
+      </p>
+
+      <p v-else-if="commands.length === 0" class="type-caption text-muted-foreground">
+        {{ detail || "No extensions are available here." }}
+      </p>
+
+      <div v-else class="grid gap-3">
+        <div v-if="memberCommands.length > 0" class="grid gap-2">
+          <h3 class="type-section-label text-muted-foreground">Available here</h3>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="command in memberCommands"
+              :key="command.node"
+              type="button"
+              class="type-control inline-flex min-h-10 max-w-full items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 text-foreground transition-colors hover:bg-muted/70 disabled:opacity-60"
+              :disabled="commandStates[command.node]?.state === 'loading'"
+              @click="emit('invokeCommand', command)"
+            >
+              <LoaderCircle
+                v-if="commandStates[command.node]?.state === 'loading'"
+                class="h-4 w-4 animate-spin"
+                aria-hidden="true"
+              />
+              <CheckCircle2
+                v-else-if="commandStates[command.node]?.state === 'success'"
+                class="h-4 w-4 text-success"
+                aria-hidden="true"
+              />
+              <AlertCircle
+                v-else-if="commandStates[command.node]?.state === 'warning' || commandStates[command.node]?.state === 'error'"
+                class="h-4 w-4"
+                :class="commandStates[command.node]?.state === 'error' ? 'text-destructive' : 'text-warning'"
+                aria-hidden="true"
+              />
+              <Play v-else class="h-4 w-4 text-primary" aria-hidden="true" />
+              <span class="min-w-0 break-words text-left">{{ command.name }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div v-if="adminCommands.length > 0" class="grid gap-2">
+          <h3 class="type-section-label text-muted-foreground">Admin</h3>
+          <div class="flex flex-wrap gap-2">
+            <button
+              v-for="command in adminCommands"
+              :key="command.node"
+              type="button"
+              class="type-control inline-flex min-h-10 max-w-full items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-foreground transition-colors hover:bg-muted disabled:opacity-60"
+              :disabled="commandStates[command.node]?.state === 'loading'"
+              @click="emit('invokeCommand', command)"
+            >
+              <ShieldCheck class="h-4 w-4 text-primary" aria-hidden="true" />
+              <span class="min-w-0 break-words text-left">{{ command.name }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <p
+        v-if="detail || Object.values(commandStates).some((commandState) => commandState.detail)"
+        class="type-caption text-muted-foreground"
+        role="status"
+      >
+        {{ detail || Object.values(commandStates).find((commandState) => commandState.detail)?.detail }}
+      </p>
+
+      <article
+        v-for="command in commands.filter((item) => commandForms[item.node])"
+        :key="`form:${command.node}`"
+        class="grid gap-3 rounded-lg border border-border bg-muted/30 p-3"
+      >
+        <div class="min-w-0">
+          <h3 class="type-control break-words text-foreground">{{ command.name }}</h3>
+          <p v-if="stateDetail(command)" class="type-caption break-words text-muted-foreground">{{ stateDetail(command) }}</p>
+        </div>
+
+        <p v-if="blockedReason(command)" class="type-caption text-destructive" role="alert">
+          {{ blockedReason(command) }}
+        </p>
+        <p v-else-if="missingRequiredFields(command).length > 0" class="type-caption text-muted-foreground">
+          Complete required fields to continue.
+        </p>
+
+        <div class="grid gap-3">
+          <template
+            v-for="field in visibleFields(command)"
+            :key="`${command.node}:${field.name}`"
+          >
+            <p v-if="field.type === 'fixed'" class="type-caption text-muted-foreground">
+              {{ field.value || field.label }}
+            </p>
+
+            <label
+              v-else-if="field.type === 'boolean'"
+              class="type-control flex min-h-10 items-center gap-2 text-foreground"
+            >
+              <input
+                type="checkbox"
+                class="h-4 w-4 accent-primary"
+                :checked="field.value === '1' || field.value === 'true'"
+                :disabled="!!blockedReason(command)"
+                @change="setBooleanValueFromEvent(command, field, $event)"
+              />
+              <span>{{ field.label }}</span>
+            </label>
+
+            <label
+              v-else-if="field.type === 'list-single'"
+              class="type-caption grid gap-1 text-muted-foreground"
+            >
+              <span>{{ field.label }}<span v-if="field.required" aria-hidden="true"> *</span></span>
+              <select
+                class="min-h-10 rounded-md border border-border bg-background px-2 text-foreground"
+                :value="field.value"
+                :required="field.required"
+                :disabled="!!blockedReason(command)"
+                @change="setSingleValueFromEvent(command, field, $event)"
+              >
+                <option value="">Select</option>
+                <option v-for="option in field.options" :key="option.value" :value="option.value">
+                  {{ option.label }}
+                </option>
+              </select>
+              <span v-if="field.description" class="text-muted-foreground/75">{{ field.description }}</span>
+            </label>
+
+            <fieldset
+              v-else-if="field.type === 'list-multi'"
+              class="grid gap-2"
+            >
+              <legend class="type-caption text-muted-foreground">
+                {{ field.label }}<span v-if="field.required"> (required)</span>
+              </legend>
+              <label
+                v-for="option in field.options"
+                :key="option.value"
+                class="type-control flex min-h-9 items-center gap-2 text-foreground"
+              >
+                <input
+                  type="checkbox"
+                  class="h-4 w-4 accent-primary"
+                  :checked="field.values.includes(option.value)"
+                  :disabled="!!blockedReason(command)"
+                  @change="toggleMultiValueFromEvent(command, field, option.value, $event)"
+                />
+                <span>{{ option.label }}</span>
+              </label>
+              <p v-if="field.description" class="type-caption text-muted-foreground/75">{{ field.description }}</p>
+            </fieldset>
+
+            <label
+              v-else-if="field.type === 'text-multi' || field.type === 'jid-multi'"
+              class="type-caption grid gap-1 text-muted-foreground"
+            >
+              <span>{{ field.label }}<span v-if="field.required" aria-hidden="true"> *</span></span>
+              <textarea
+                class="min-h-24 rounded-md border border-border bg-background px-2 py-2 text-foreground"
+                :value="field.values.join('\n')"
+                :required="field.required"
+                :disabled="!!blockedReason(command)"
+                @input="setMultiLineValueFromEvent(command, field, $event)"
+              />
+              <span v-if="field.description" class="text-muted-foreground/75">{{ field.description }}</span>
+            </label>
+
+            <label
+              v-else
+              class="type-caption grid gap-1 text-muted-foreground"
+            >
+              <span>{{ field.label }}<span v-if="field.required" aria-hidden="true"> *</span></span>
+              <input
+                class="min-h-10 rounded-md border border-border bg-background px-2 text-foreground"
+                :type="field.type === 'text-private' ? 'password' : 'text'"
+                :value="field.value"
+                :required="field.required"
+                :disabled="field.blocked || !!blockedReason(command)"
+                @input="setSingleValueFromEvent(command, field, $event)"
+              />
+              <span v-if="field.description" class="text-muted-foreground/75">{{ field.description }}</span>
+            </label>
+          </template>
+        </div>
+
+        <div class="flex flex-wrap gap-2">
+          <button
+            v-for="action in allowedActions(command)"
+            :key="`${command.node}:${action}`"
+            type="button"
+            class="type-control inline-flex min-h-10 items-center gap-2 rounded-md px-3 py-2 disabled:opacity-60"
+            :class="action === 'cancel' || action === 'prev' ? 'border border-border bg-background text-foreground hover:bg-muted' : 'bg-primary text-primary-foreground'"
+            :disabled="!canSubmitAction(command, action)"
+            @click="emit('submitForm', command, action)"
+          >
+            <ArrowLeft v-if="action === 'prev'" class="h-4 w-4" aria-hidden="true" />
+            <Square v-else-if="action === 'cancel'" class="h-4 w-4" aria-hidden="true" />
+            <ArrowRight v-else-if="action === 'next'" class="h-4 w-4" aria-hidden="true" />
+            <CheckCircle2 v-else class="h-4 w-4" aria-hidden="true" />
+            {{ actionLabel(action) }}
+          </button>
+        </div>
+      </article>
+
+      <div
+        v-for="command in commands.filter((item) => commandActions[item.node]?.length)"
+        :key="`actions:${command.node}`"
+        class="flex flex-wrap gap-2"
+      >
+        <button
+          v-for="action in commandActions[command.node]"
+          :key="`${command.node}:${action.route}`"
+          type="button"
+          class="type-control inline-flex min-h-10 max-w-full min-w-0 items-center gap-2 rounded-md border border-border bg-background px-3 py-2 text-foreground hover:bg-muted disabled:opacity-60"
+          :disabled="commandStates[command.node]?.state === 'loading'"
+          @click="emit('invokeAction', command, action)"
+        >
+          <span class="min-w-0 break-words text-left">{{ action.label }}</span>
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -28,6 +28,8 @@ import EmojiPicker from "@/components/chat/EmojiPicker.vue";
 import ImageLightbox from "@/components/ui/ImageLightbox.vue";
 import {
   extensionCardDetails,
+  extensionActionStatusLabel,
+  extensionPresentation,
   renderStyledBody,
   extensionSurfaceLabel,
   isAudioFile,
@@ -162,17 +164,16 @@ async function invokeExtension(annotationId: string, action: ExtensionAnnotation
     const result = await props.invokeExtensionAction(action);
     const outcome = extensionCommandOutcome(result);
     setExtensionActionState(annotationId, action, outcome);
-    setTimeout(() => {
-      if (extensionActionState(annotationId, action)?.state === "success") {
-        setExtensionActionState(annotationId, action);
-      }
-    }, 2500);
   } catch (error) {
     setExtensionActionState(annotationId, action, {
       state: "error",
       detail: error instanceof Error ? error.message : "Action failed.",
     });
   }
+}
+
+function actionStatusLabel(annotationId: string, action: ExtensionAnnotationAction): string {
+  return extensionActionStatusLabel(extensionActionState(annotationId, action)?.state);
 }
 
 const imageAttachments = computed(() =>
@@ -875,24 +876,37 @@ watch(
           class="chat-extension-card flex min-w-0 items-start gap-3 rounded-lg border border-border bg-muted/25 p-3 text-left"
         >
           <span class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-background text-foreground ring-1 ring-border">
-            <ClipboardList v-if="annotation.surfaceKind === 'board'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
-            <Gamepad2 v-else-if="annotation.surfaceKind === 'game'" class="h-4 w-4 text-success" aria-hidden="true" />
-            <Bot v-else-if="annotation.surfaceKind === 'chat-bot'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
-            <Sparkles v-else-if="annotation.surfaceKind === 'dynamic-canvas'" class="h-4 w-4 text-warning" aria-hidden="true" />
+            <ClipboardList v-if="extensionPresentation(annotation).kind === 'links-task-board' || annotation.surfaceKind === 'board'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
+            <Gamepad2 v-else-if="extensionPresentation(annotation).kind === 'pub-quiz' || annotation.surfaceKind === 'game'" class="h-4 w-4 text-success" aria-hidden="true" />
+            <Bot v-else-if="extensionPresentation(annotation).kind === 'ai-chatbot' || annotation.surfaceKind === 'chat-bot'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
+            <Sparkles v-else-if="extensionPresentation(annotation).kind === 'ai-assistant-canvas' || annotation.surfaceKind === 'dynamic-canvas'" class="h-4 w-4 text-warning" aria-hidden="true" />
             <LayoutDashboard v-else class="h-4 w-4" aria-hidden="true" />
           </span>
           <span class="min-w-0 flex-1">
             <span class="type-section-label block text-muted-foreground">
-              {{ extensionSurfaceLabel(annotation.surfaceKind) }}
+              {{ extensionPresentation(annotation).label || extensionSurfaceLabel(annotation.surfaceKind) }}
             </span>
-            <span class="type-control block truncate text-foreground">
-              {{ annotation.title }}
+            <span class="type-control block break-words text-foreground">
+              {{ extensionPresentation(annotation).title }}
             </span>
-            <span v-if="annotation.summary" class="type-caption mt-1 block text-muted-foreground">
-              {{ annotation.summary }}
+            <span v-if="extensionPresentation(annotation).summary" class="type-caption mt-1 block break-words text-muted-foreground">
+              {{ extensionPresentation(annotation).summary }}
+            </span>
+            <span
+              v-if="extensionPresentation(annotation).options.length > 0"
+              class="mt-2 grid gap-1"
+            >
+              <span
+                v-for="option in extensionPresentation(annotation).options"
+                :key="`${annotation.annotationId}:option:${option.id}`"
+                class="type-caption flex min-w-0 items-center justify-between gap-3 rounded-md bg-background/70 px-2 py-1.5 text-foreground ring-1 ring-border/70"
+              >
+                <span class="min-w-0 break-words">{{ option.label }}</span>
+                <span v-if="option.value !== undefined" class="type-numeric text-muted-foreground">{{ option.value }}</span>
+              </span>
             </span>
             <dl
-              v-if="extensionCardDetails(annotation).length > 0"
+              v-if="extensionPresentation(annotation).kind === 'generic' && extensionCardDetails(annotation).length > 0"
               class="mt-2 grid min-w-0 grid-cols-[max-content_minmax(0,1fr)] gap-x-2 gap-y-1"
             >
               <template
@@ -900,7 +914,7 @@ watch(
                 :key="`${annotation.annotationId}:${detail.label}:${detail.value}`"
               >
                 <dt class="type-meta text-muted-foreground/70">{{ detail.label }}</dt>
-                <dd class="type-caption min-w-0 truncate text-foreground/85" :title="detail.value">{{ detail.value }}</dd>
+                <dd class="type-caption min-w-0 break-words text-foreground/85" :title="detail.value">{{ detail.value }}</dd>
               </template>
             </dl>
             <span v-if="annotation.actions.length > 0" class="mt-2 flex flex-wrap gap-2">
@@ -908,7 +922,7 @@ watch(
                 v-for="action in annotation.actions"
                 :key="`${annotation.annotationId}:${action.route}:${action.label}`"
                 type="button"
-                class="type-caption inline-flex min-h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
                 :disabled="extensionActionState(annotation.annotationId, action)?.state === 'loading' || !action.launch"
                 :title="extensionActionState(annotation.annotationId, action)?.detail ?? action.launch?.commandNode ?? action.label"
                 @click.stop="invokeExtension(annotation.annotationId, action)"
@@ -934,6 +948,9 @@ watch(
                   aria-hidden="true"
                 />
                 {{ action.label }}
+                <span v-if="actionStatusLabel(annotation.annotationId, action)" class="text-muted-foreground">
+                  {{ actionStatusLabel(annotation.annotationId, action) }}
+                </span>
               </button>
             </span>
             <span

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -45,6 +45,7 @@ const props = defineProps<{
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   replyingTo?: { id: string; author: string; preview?: string } | null;
   isTopPinned?: boolean;
+  extensionsOpen?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -74,6 +75,10 @@ const setEditorRef = (instance: InstanceType<typeof ChatEditor> | null) => {
 const fileInputRef = ref<HTMLInputElement | null>(null);
 const setFileInputRef = (el: HTMLInputElement | null) => {
   fileInputRef.value = el;
+};
+const extensionButtonRef = ref<HTMLButtonElement | null>(null);
+const setExtensionButtonRef = (el: HTMLButtonElement | null) => {
+  extensionButtonRef.value = el;
 };
 
 const tiptapEditor = computed(() => {
@@ -331,7 +336,11 @@ function focus() {
   editorRef.value?.focus();
 }
 
-defineExpose({ addAttachments, focus });
+function focusExtensions() {
+  extensionButtonRef.value?.focus();
+}
+
+defineExpose({ addAttachments, focus, focusExtensions });
 
 function openFilePicker() {
   fileInputRef.value?.click();
@@ -643,10 +652,12 @@ watch(
         <Paperclip class="w-4 h-4" aria-hidden="true" />
       </button>
       <button
+        :ref="setExtensionButtonRef"
         type="button"
         class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary disabled:opacity-40 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
         title="Extensions"
         aria-label="Extensions"
+        :aria-expanded="extensionsOpen"
         :disabled="disabled"
         @click="emit('openExtensions')"
       >

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -49,6 +49,27 @@ export interface ExtensionPayloadElement {
   children: ExtensionPayloadElement[];
 }
 
+export type ExtensionUiBlockKind = "text" | "image" | "action" | "form" | "list" | "unknown";
+
+export interface ExtensionUiBlock {
+  kind: ExtensionUiBlockKind;
+  id?: string;
+  title?: string;
+  text?: string;
+  label?: string;
+  description?: string;
+  style?: string;
+  launchId?: string;
+  attributes: Record<string, string>;
+  children: ExtensionUiBlock[];
+}
+
+export interface ExtensionUiView {
+  id: string;
+  title?: string;
+  blocks: ExtensionUiBlock[];
+}
+
 export interface ExtensionLaunchContext {
   waddleId?: string;
   roomJid?: string;
@@ -83,6 +104,7 @@ export interface ExtensionAnnotation {
   imageUrl?: string;
   source?: ExtensionEnvelopeSource;
   payloadNamespace?: string;
+  views?: ExtensionUiView[];
   payloads?: ExtensionPayloadElement[];
   fields: Record<string, string>;
   actions: ExtensionAnnotationAction[];
@@ -413,4 +435,176 @@ export function extensionCardDetails(annotation: ExtensionAnnotation, limit = 6)
   }
 
   return details.slice(0, limit);
+}
+
+type ExtensionPresentationKind =
+  | "links-task-board"
+  | "pub-quiz"
+  | "ai-chatbot"
+  | "ai-assistant-canvas"
+  | "decision-polls"
+  | "generic";
+
+interface ExtensionPresentationOption {
+  id: string;
+  label: string;
+  value?: number;
+}
+
+interface ExtensionPresentation {
+  kind: ExtensionPresentationKind;
+  label: string;
+  title: string;
+  summary?: string;
+  primaryValue?: string;
+  secondaryValue?: string;
+  options: ExtensionPresentationOption[];
+  details: ExtensionCardDetail[];
+}
+
+export function extensionPresentation(annotation: ExtensionAnnotation): ExtensionPresentation {
+  const payload = annotation.payloads?.[0];
+  const plugin = annotation.extensionId;
+  if (plugin === "decision-polls" || payload?.namespace === "urn:waddle:decision-polls:1") {
+    return decisionPollPresentation(annotation, payload);
+  }
+  if (plugin === "pub-quiz" || payload?.namespace === "urn:waddle:pub-quiz:1") {
+    return pubQuizPresentation(annotation, payload);
+  }
+  if (plugin === "links-task-board" || payload?.namespace === "urn:waddle:links-task-board:1") {
+    return linksTaskBoardPresentation(annotation, payload);
+  }
+  if (plugin === "ai-chatbot" || payload?.namespace === "urn:waddle:ai-chatbot:1") {
+    return aiChatbotPresentation(annotation, payload);
+  }
+  if (plugin === "ai-assistant-canvas" || payload?.namespace === "urn:waddle:ai-assistant-canvas:1") {
+    return canvasPresentation(annotation, payload);
+  }
+  return {
+    kind: "generic",
+    label: extensionSurfaceLabel(annotation.surfaceKind),
+    title: annotation.title,
+    ...(annotation.summary ? { summary: annotation.summary } : {}),
+    options: [],
+    details: extensionCardDetails(annotation),
+  };
+}
+
+export function extensionActionStatusLabel(state?: "loading" | "success" | "warning" | "error"): string {
+  switch (state) {
+    case "loading":
+      return "Working";
+    case "success":
+      return "Done";
+    case "warning":
+      return "Needs attention";
+    case "error":
+      return "Failed";
+    default:
+      return "";
+  }
+}
+
+function childText(payload: ExtensionPayloadElement | undefined, name: string): string | undefined {
+  const text = payload?.children.find((child) => child.name === name)?.text?.trim();
+  return text || undefined;
+}
+
+function payloadAttr(payload: ExtensionPayloadElement | undefined, ...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = payload?.attributes[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function payloadOptions(payload: ExtensionPayloadElement | undefined): ExtensionPresentationOption[] {
+  return payload?.children
+    .filter((child) => child.name === "option" || child.name === "answer")
+    .map((child, index) => ({
+      id: child.attributes.id ?? child.attributes["option-id"] ?? String(index),
+      label: child.text?.trim() || child.attributes.label || child.attributes.title || `Option ${index + 1}`,
+      ...(Number.isFinite(Number(child.attributes.votes)) ? { value: Number(child.attributes.votes) } : {}),
+    })) ?? [];
+}
+
+function decisionPollPresentation(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): ExtensionPresentation {
+  const question = childText(payload, "question") ?? payloadAttr(payload, "question") ?? annotation.title;
+  const status = payloadAttr(payload, "status", "state") ?? payloadAttr(payload, "closes-at");
+  return {
+    kind: "decision-polls",
+    label: "Poll",
+    title: question,
+    ...(status ? { summary: status } : annotation.summary ? { summary: annotation.summary } : {}),
+    options: payloadOptions(payload),
+    details: extensionCardDetails(annotation, 3),
+  };
+}
+
+function pubQuizPresentation(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): ExtensionPresentation {
+  const question = childText(payload, "question") ?? payloadAttr(payload, "question") ?? annotation.title;
+  const round = payloadAttr(payload, "round", "round-id");
+  return {
+    kind: "pub-quiz",
+    label: "Quiz",
+    title: question,
+    ...(round ? { summary: `Round ${round}` } : annotation.summary ? { summary: annotation.summary } : {}),
+    options: payloadOptions(payload),
+    details: extensionCardDetails(annotation, 3),
+  };
+}
+
+function linksTaskBoardPresentation(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): ExtensionPresentation {
+  const title = payloadAttr(payload, "title", "name") ?? childText(payload, "title") ?? annotation.title;
+  const url = payloadAttr(payload, "url", "href");
+  const site = payloadAttr(payload, "site", "host");
+  return {
+    kind: "links-task-board",
+    label: payload?.name === "task" ? "Task" : "Link",
+    title,
+    ...(site || url ? { summary: site ?? url } : annotation.summary ? { summary: annotation.summary } : {}),
+    ...(url ? { primaryValue: url } : {}),
+    options: [],
+    details: extensionCardDetails(annotation, 4),
+  };
+}
+
+function aiChatbotPresentation(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): ExtensionPresentation {
+  const answer = childText(payload, "answer") ?? childText(payload, "response") ?? payload?.text?.trim();
+  return {
+    kind: "ai-chatbot",
+    label: "AI answer",
+    title: annotation.title,
+    ...(answer ? { summary: answer } : annotation.summary ? { summary: annotation.summary } : {}),
+    options: [],
+    details: extensionCardDetails(annotation, 3),
+  };
+}
+
+function canvasPresentation(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): ExtensionPresentation {
+  const prompt = childText(payload, "prompt") ?? payloadAttr(payload, "prompt") ?? annotation.title;
+  const render = payloadAttr(payload, "render-id", "artifact-digest", "artifact");
+  return {
+    kind: "ai-assistant-canvas",
+    label: "Canvas",
+    title: prompt,
+    ...(render ? { summary: render } : annotation.summary ? { summary: annotation.summary } : {}),
+    options: [],
+    details: extensionCardDetails(annotation, 3),
+  };
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -50,6 +50,7 @@ import {
   invokeExtensionLaunch,
   submitExtensionCommandForm,
   type DiscoveredExtensionCommand,
+  type ExtensionCommandAction,
   type ExtensionCommandFormField,
   type ExtensionCommandResult,
 } from "./extension-commands";
@@ -1103,9 +1104,10 @@ export class BrowserXmppClient {
     command: DiscoveredExtensionCommand,
     sessionId: string,
     fields: ExtensionCommandFormField[],
+    action?: ExtensionCommandAction,
   ): Promise<ExtensionCommandResult> {
     const xmpp = await this.requireConnectedXmpp();
-    return submitExtensionCommandForm(xmpp, command, sessionId, fields);
+    return submitExtensionCommandForm(xmpp, command, sessionId, fields, action);
   }
 
   async enablePushNotifications(opts: {

--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -14,17 +14,34 @@ export interface ExtensionCommandNote {
 export interface ExtensionCommandResult {
   status?: string;
   sessionId?: string;
+  actions?: ExtensionCommandActions;
   notes: ExtensionCommandNote[];
   form?: unknown;
+}
+
+export type ExtensionCommandAction = "next" | "prev" | "complete" | "cancel";
+
+export interface ExtensionCommandActions {
+  execute?: ExtensionCommandAction;
+  allowed: ExtensionCommandAction[];
+}
+
+export interface ExtensionCommandFormOption {
+  label: string;
+  value: string;
 }
 
 export interface ExtensionCommandFormField {
   name: string;
   label: string;
   type: string;
+  description?: string;
   value: string;
   values: string[];
+  options: ExtensionCommandFormOption[];
   required: boolean;
+  blocked: boolean;
+  hidden: boolean;
 }
 
 export interface DiscoveredExtensionCommand {
@@ -43,7 +60,7 @@ interface ExtensionCommandOutcome {
 interface DataFormField {
   name: string;
   type?: string;
-  value: string;
+  value: string | string[] | boolean;
 }
 
 interface ExtensionInvokeIq {
@@ -51,8 +68,8 @@ interface ExtensionInvokeIq {
   to: string;
   command: {
     node: string;
-    action: "execute";
-    form: {
+    action: "execute" | ExtensionCommandAction;
+    form?: {
       type: "submit";
       fields: DataFormField[];
     };
@@ -132,23 +149,25 @@ function buildExtensionCommandExecuteIq(serviceJid: string, node: string): Exten
     command: {
       node,
       action: "execute",
-      form: {
-        type: "submit",
-        fields: [
-          { name: "FORM_TYPE", type: "hidden", value: NS_ADHOC_COMMANDS },
-        ],
-      },
     },
   };
 }
 
 export function parseExtensionCommandResult(response: unknown): ExtensionCommandResult {
-  const command = (response as { command?: { status?: unknown; sessionid?: unknown; sessionId?: unknown; notes?: Array<{ type?: unknown; value?: unknown }>; form?: unknown } } | undefined)?.command;
+  const command = (response as { command?: { status?: unknown; sid?: unknown; sessionid?: unknown; sessionId?: unknown; availableActions?: unknown; actions?: unknown; notes?: Array<{ type?: unknown; value?: unknown }>; form?: unknown } } | undefined)?.command;
   const notes = Array.isArray(command?.notes) ? command.notes : [];
+  const rawActions = command?.availableActions ?? command?.actions;
+  const actions = parseCommandActions(
+    rawActions,
+    typeof command?.status === "string" ? command.status : undefined,
+    rawActions !== undefined,
+  );
   return {
     ...(typeof command?.status === "string" && command.status ? { status: command.status } : {}),
+    ...(typeof command?.sid === "string" && command.sid ? { sessionId: command.sid } : {}),
     ...(typeof command?.sessionid === "string" && command.sessionid ? { sessionId: command.sessionid } : {}),
     ...(typeof command?.sessionId === "string" && command.sessionId ? { sessionId: command.sessionId } : {}),
+    ...(actions ? { actions } : {}),
     ...(command?.form ? { form: command.form } : {}),
     notes: notes
       .map((note) => ({
@@ -163,22 +182,60 @@ export function parseExtensionCommandForm(form: unknown): ExtensionCommandFormFi
   const fields = (form as { fields?: unknown[] } | undefined)?.fields;
   if (!Array.isArray(fields)) return [];
   return fields.flatMap((field) => {
-    const item = field as { name?: unknown; var?: unknown; label?: unknown; type?: unknown; value?: unknown; values?: unknown[]; required?: unknown };
+    const item = field as {
+      name?: unknown;
+      var?: unknown;
+      label?: unknown;
+      type?: unknown;
+      desc?: unknown;
+      description?: unknown;
+      value?: unknown;
+      values?: unknown[];
+      rawValues?: unknown[];
+      required?: unknown;
+      options?: unknown[];
+    };
     const name = typeof item.name === "string" ? item.name : typeof item.var === "string" ? item.var : "";
-    if (!name) return [];
-    const values = Array.isArray(item.values) ? item.values : item.value !== undefined ? [item.value] : [];
+    const type = typeof item.type === "string" ? item.type : "text-single";
+    if (!name && type !== "fixed") return [];
+    const values = Array.isArray(item.value)
+      ? item.value
+      : Array.isArray(item.values)
+        ? item.values
+        : Array.isArray(item.rawValues)
+          ? item.rawValues
+          : item.value !== undefined
+            ? [item.value]
+            : [];
     const stringValues = values
       .filter((value) => typeof value === "string" || typeof value === "number" || typeof value === "boolean")
       .map((value) => String(value));
+    const fieldValues = type === "boolean" && stringValues.length === 0 ? ["0"] : stringValues;
+    const fieldName = name || `fixed:${fieldValues.join("\n")}`;
     return [{
-      name,
-      label: typeof item.label === "string" && item.label ? item.label : name,
-      type: typeof item.type === "string" ? item.type : "text-single",
-      value: stringValues[0] ?? "",
-      values: stringValues,
+      name: fieldName,
+      label: typeof item.label === "string" && item.label ? item.label : fieldName,
+      type,
+      ...(typeof item.desc === "string" && item.desc ? { description: item.desc } : {}),
+      ...(typeof item.description === "string" && item.description ? { description: item.description } : {}),
+      value: fieldValues[0] ?? "",
+      values: fieldValues,
+      options: parseFieldOptions(item.options),
       required: item.required === true,
+      blocked: isForbiddenExtensionCommandField(name, type),
+      hidden: type === "hidden",
     }];
   });
+}
+
+export function visibleExtensionCommandFields(fields: ExtensionCommandFormField[]): ExtensionCommandFormField[] {
+  return fields.filter((field) => !field.hidden);
+}
+
+export function extensionCommandFormBlockedReason(fields: ExtensionCommandFormField[]): string | undefined {
+  const blocked = fields.find((field) => field.blocked);
+  if (!blocked) return undefined;
+  return `Extension command form contains a forbidden field: ${blocked.label}.`;
 }
 
 export function parseExtensionCommandLaunches(form: unknown): ExtensionAnnotationAction[] {
@@ -255,6 +312,9 @@ export function extensionCommandOutcome(result: unknown): ExtensionCommandOutcom
 
   const status = parsed.status?.trim().toLowerCase();
   if (status === "executing") {
+    if (parsed.form && parseExtensionCommandForm(parsed.form).length > 0) {
+      return { state: "warning" };
+    }
     return { state: "warning", detail: "Extension returned a form that this client cannot complete yet." };
   }
   if (status && status !== "completed" && status !== "complete") {
@@ -314,23 +374,27 @@ export async function submitExtensionCommandForm(
   command: DiscoveredExtensionCommand,
   sessionId: string,
   fields: ExtensionCommandFormField[],
+  action: ExtensionCommandAction = "complete",
 ): Promise<ExtensionCommandResult> {
   const response = await xmpp.sendIQ({
     type: "set",
     to: command.serviceJid,
     command: {
       node: command.node,
-      sessionid: sessionId,
-      action: "complete",
-        form: {
-          type: "submit",
-          fields: fields.map((field) => ({
-            name: field.name,
-            type: field.type,
-            value: field.value,
-            values: field.values.length > 0 ? field.values : [field.value],
-          })),
-        },
+      sid: sessionId,
+      action,
+      ...(action === "cancel" || action === "prev" ? {} : {
+          form: {
+            type: "submit",
+            fields: fields
+              .filter((field) => field.type !== "fixed")
+              .map((field) => ({
+                name: field.name,
+                type: field.type,
+                value: dataFormFieldValue(field),
+              })),
+          },
+        }),
     },
   } as unknown as Parameters<Agent["sendIQ"]>[0]);
   return parseExtensionCommandResult(response);
@@ -353,6 +417,68 @@ export async function discoverExtensionCommands(
       node: item.node!,
       name: item.name || item.node!,
     }));
+}
+
+function parseFieldOptions(options: unknown): ExtensionCommandFormOption[] {
+  if (!Array.isArray(options)) return [];
+  return options.flatMap((option) => {
+    const item = option as { label?: unknown; value?: unknown; values?: unknown[] };
+    const rawValue = item.value ?? item.values?.[0];
+    if (typeof rawValue !== "string" && typeof rawValue !== "number" && typeof rawValue !== "boolean") return [];
+    const value = String(rawValue);
+    return [{
+      label: typeof item.label === "string" && item.label ? item.label : value,
+      value,
+    }];
+  });
+}
+
+function dataFormFieldValue(field: ExtensionCommandFormField): string | string[] | boolean {
+  if (field.type === "boolean") return field.value === "1" || field.value === "true";
+  if (field.type === "hidden" && field.values.length > 1) return field.values;
+  if (field.type === "list-multi" || field.type === "text-multi" || field.type === "jid-multi") {
+    return field.values.length > 0 ? field.values : [];
+  }
+  return field.value;
+}
+
+function parseCommandActions(actions: unknown, status?: string, actionsProvided = false): ExtensionCommandActions | undefined {
+  const value = (actions && typeof actions === "object" ? actions : {}) as {
+    execute?: unknown;
+    next?: unknown;
+    prev?: unknown;
+    previous?: unknown;
+    complete?: unknown;
+    cancel?: unknown;
+    allowed?: unknown[];
+  };
+  const allowed = new Set<ExtensionCommandAction>();
+  if (actions && typeof actions === "object") {
+    if (Array.isArray(value.allowed)) {
+      for (const action of value.allowed) {
+        if (isExtensionCommandAction(action)) allowed.add(action);
+      }
+    }
+    if (value.next !== undefined) allowed.add("next");
+    if (value.prev !== undefined || value.previous !== undefined) allowed.add("prev");
+    if (value.complete !== undefined) allowed.add("complete");
+    if (value.cancel !== undefined) allowed.add("cancel");
+  }
+  const execute = isExtensionCommandAction(value.execute) ? value.execute : undefined;
+  if (execute) allowed.add(execute);
+  if (status === "executing" && !actionsProvided) allowed.add("complete");
+  if (status === "executing") allowed.add("cancel");
+  const allowedList = [...allowed];
+  return allowedList.length > 0 || execute ? { ...(execute ? { execute } : {}), allowed: allowedList } : undefined;
+}
+
+function isExtensionCommandAction(value: unknown): value is ExtensionCommandAction {
+  return value === "next" || value === "prev" || value === "complete" || value === "cancel";
+}
+
+function isForbiddenExtensionCommandField(name: string, type: string): boolean {
+  if (type === "text-private") return true;
+  return /(?:^|[#:_-])(secret|token|password|api[_-]?key|apikey|credential)(?:$|[#:_-])/i.test(name);
 }
 
 async function discoverExtensionCommandService(xmpp: Agent, userJid: string): Promise<string> {

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -10,6 +10,9 @@ import type {
   ExtensionLaunchDescriptor,
   ExtensionPayloadElement,
   ExtensionSurfaceKind,
+  ExtensionUiBlock,
+  ExtensionUiBlockKind,
+  ExtensionUiView,
   MessageReference,
 } from "@/lib/chat-ui";
 import type {
@@ -277,9 +280,11 @@ function extensionAnnotationsFromStanza(stanza: Record<string, unknown>): Extens
 function parseExtensionEnrichment(payload: ExtensionEnrichmentPayload): ExtensionAnnotation | null {
   if (!payload.id || !payload.plugin) return null;
   const plugin = payload.plugin;
-  const payloads = parsePayloadElements(payload.payload, payload.payloadNamespace);
+  const elements = parsePayloadElements(payload.payload, payload.payloadNamespace);
+  const views = parseExtensionUiViews(elements);
+  const payloads = elements.filter((element) => element.namespace !== FRAMEWORK_NAMESPACE);
   const source = parseExtensionSource(payload.source);
-  const surfaceKind = inferSurfaceKind(payload, payloads);
+  const surfaceKind = inferSurfaceKind(payload, elements);
   if (!surfaceKind) return null;
   const launches = asArray(payload.launches).flatMap((launch) =>
     parseExtensionLaunch(launch, plugin, source) ?? [],
@@ -298,6 +303,7 @@ function parseExtensionEnrichment(payload: ExtensionEnrichmentPayload): Extensio
     ...(payload.payloadNamespace ? { summary: payload.payloadNamespace } : {}),
     ...(source ? { source } : {}),
     ...(payload.payloadNamespace ? { payloadNamespace: payload.payloadNamespace } : {}),
+    ...(views.length > 0 ? { views } : {}),
     ...(payloads.length > 0 ? { payloads } : {}),
     fields: {
       ...(payload.capability ? { capability: payload.capability } : {}),
@@ -401,8 +407,7 @@ function parsePayloadElements(
   fallbackNamespace?: string,
 ): ExtensionPayloadElement[] {
   return asArray(payload?.elements)
-    .flatMap((element) => normalizePayloadElement(element, fallbackNamespace) ?? [])
-    .filter((element) => element.namespace !== FRAMEWORK_NAMESPACE);
+    .flatMap((element) => normalizePayloadElement(element, fallbackNamespace) ?? []);
 }
 
 function normalizePayloadElement(
@@ -430,6 +435,37 @@ function normalizePayloadElement(
     ...(text ? { text } : {}),
     children,
   };
+}
+
+function parseExtensionUiViews(elements: ExtensionPayloadElement[]): ExtensionUiView[] {
+  return elements
+    .filter((element) => element.namespace === FRAMEWORK_NAMESPACE && element.name === "view")
+    .map((element, index) => ({
+      id: element.attributes.id || `view-${index + 1}`,
+      ...(element.attributes.title ? { title: element.attributes.title } : {}),
+      blocks: element.children.map(parseExtensionUiBlock),
+    }));
+}
+
+function parseExtensionUiBlock(element: ExtensionPayloadElement): ExtensionUiBlock {
+  const kind = parseExtensionUiBlockKind(element.name);
+  return {
+    kind,
+    ...(element.attributes.id ? { id: element.attributes.id } : {}),
+    ...(element.attributes.title ? { title: element.attributes.title } : {}),
+    ...(element.attributes.label ? { label: element.attributes.label } : {}),
+    ...(element.attributes.description ? { description: element.attributes.description } : {}),
+    ...(element.attributes.style ? { style: element.attributes.style } : {}),
+    ...(element.attributes["launch-id"] ? { launchId: element.attributes["launch-id"] } : {}),
+    ...(element.text ? { text: element.text } : {}),
+    attributes: element.attributes,
+    children: element.children.map(parseExtensionUiBlock),
+  };
+}
+
+function parseExtensionUiBlockKind(name: string): ExtensionUiBlockKind {
+  if (name === "text" || name === "image" || name === "action" || name === "form" || name === "list") return name;
+  return "unknown";
 }
 
 function readablePayloadTitle(element: ExtensionPayloadElement): string {

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   extensionCardDetails,
+  extensionPresentation,
   inferredFileDisposition,
   isAudioFile,
   isImageFile,
@@ -145,5 +146,62 @@ describe("renderStyledBody", () => {
       { label: "Question", value: "Ship the extension framework this week?" },
       { label: "Option", value: "Yes" },
     ]);
+  });
+
+  test("renders decision poll extensions as member-facing poll presentations", () => {
+    const annotation: ExtensionAnnotation = {
+      extensionId: "decision-polls",
+      annotationId: "poll-1",
+      surfaceKind: "utility-panel",
+      title: "Ship it?",
+      summary: "urn:waddle:decision-polls:1",
+      payloadNamespace: "urn:waddle:decision-polls:1",
+      fields: {
+        payloadNamespace: "urn:waddle:decision-polls:1",
+      },
+      payloads: [{
+        namespace: "urn:waddle:decision-polls:1",
+        name: "poll",
+        attributes: {
+          xmlns: "urn:waddle:decision-polls:1",
+          status: "open",
+        },
+        children: [
+          {
+            namespace: "urn:waddle:decision-polls:1",
+            name: "question",
+            attributes: {},
+            text: "Ship it?",
+            children: [],
+          },
+          {
+            namespace: "urn:waddle:decision-polls:1",
+            name: "option",
+            attributes: { id: "yes", votes: "2" },
+            text: "Yes",
+            children: [],
+          },
+          {
+            namespace: "urn:waddle:decision-polls:1",
+            name: "option",
+            attributes: { id: "no", votes: "1" },
+            text: "No",
+            children: [],
+          },
+        ],
+      }],
+      actions: [],
+    };
+
+    expect(extensionPresentation(annotation)).toMatchObject({
+      kind: "decision-polls",
+      label: "Poll",
+      title: "Ship it?",
+      summary: "open",
+      options: [
+        { id: "yes", label: "Yes", value: 2 },
+        { id: "no", label: "No", value: 1 },
+      ],
+    });
   });
 });

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -3,8 +3,13 @@ import type { ExtensionLaunchDescriptor } from "../src/lib/chat-ui";
 import {
   buildExtensionLaunchInvokeIq,
   extensionCommandOutcome,
+  extensionCommandFormBlockedReason,
   extensionServiceJidForUserJid,
+  invokeExtensionCommand,
+  parseExtensionCommandForm,
   parseExtensionCommandResult,
+  submitExtensionCommandForm,
+  visibleExtensionCommandFields,
 } from "../src/lib/xmpp/extension-commands";
 
 const launch: ExtensionLaunchDescriptor = {
@@ -65,6 +70,32 @@ describe("extension command invocation", () => {
     ]);
   });
 
+  test("builds plain XEP-0050 execute requests for discovered commands", async () => {
+    let sent: unknown;
+    const xmpp = {
+      async sendIQ(iq: unknown) {
+        sent = iq;
+        return { command: { status: "completed", notes: [] } };
+      },
+    };
+
+    await invokeExtensionCommand(
+      xmpp as any,
+      "alice@example.com/web",
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:noop", name: "Noop" },
+    );
+
+    expect(sent).toMatchObject({
+      type: "set",
+      to: "extensions.example.com",
+      command: {
+        node: "urn:waddle:extension:noop",
+        action: "execute",
+      },
+    });
+    expect((sent as { command?: { form?: unknown } }).command?.form).toBeUndefined();
+  });
+
   test("uses source stanza metadata when context only carries the waddle id", () => {
     const iq = buildExtensionLaunchInvokeIq("alice@example.com/web", {
       ...launch,
@@ -108,6 +139,186 @@ describe("extension command invocation", () => {
     expect(extensionCommandOutcome({ status: "executing", notes: [] })).toEqual({
       state: "warning",
       detail: "Extension returned a form that this client cannot complete yet.",
+    });
+    expect(extensionCommandOutcome({
+      status: "executing",
+      form: { fields: [{ name: "payload#question", type: "text-single", value: "" }] },
+      notes: [],
+    })).toEqual({ state: "warning" });
+  });
+
+  test("parses XEP-0004 form fields, options, visibility, and forbidden fields", () => {
+    const fields = parseExtensionCommandForm({
+      fields: [
+        { type: "fixed", value: "Section heading" },
+        { name: "FORM_TYPE", type: "hidden", value: "urn:waddle:extension:1" },
+        { name: "hidden#multi", type: "hidden", value: ["a", "b"] },
+        { name: "payload#question", type: "text-single", label: "Question", required: true, desc: "Ask the room." },
+        {
+          name: "payload#mode",
+          type: "list-single",
+          label: "Mode",
+          value: "single",
+          options: [
+            { label: "Single choice", value: "single" },
+            { label: "Multiple choice", value: "multi" },
+          ],
+        },
+        { name: "payload#notify", type: "boolean", value: true },
+        { name: "waddle#api_key", type: "text-private", label: "API key" },
+      ],
+    });
+
+    expect(visibleExtensionCommandFields(fields).map((field) => field.name)).toEqual([
+      "fixed:Section heading",
+      "payload#question",
+      "payload#mode",
+      "payload#notify",
+      "waddle#api_key",
+    ]);
+    expect(fields[0]).toMatchObject({
+      label: "fixed:Section heading",
+      type: "fixed",
+      value: "Section heading",
+    });
+    expect(fields[3]).toMatchObject({
+      label: "Question",
+      required: true,
+      description: "Ask the room.",
+      value: "",
+      blocked: false,
+    });
+    expect(fields[4]?.options).toEqual([
+      { label: "Single choice", value: "single" },
+      { label: "Multiple choice", value: "multi" },
+    ]);
+    expect(fields[5]?.value).toBe("true");
+    expect(extensionCommandFormBlockedReason(fields)).toBe("Extension command form contains a forbidden field: API key.");
+  });
+
+  test("parses allowed XEP-0050 stage actions", () => {
+    const result = parseExtensionCommandResult({
+      command: {
+        status: "executing",
+        sid: "session-1",
+        availableActions: { execute: "next", next: true },
+        notes: [],
+      },
+    });
+
+    expect(result.sessionId).toBe("session-1");
+    expect(result.actions).toEqual({
+      execute: "next",
+      allowed: ["next", "cancel"],
+    });
+  });
+
+  test("defaults executing commands without actions to complete plus cancel", () => {
+    const result = parseExtensionCommandResult({
+      command: {
+        status: "executing",
+        sid: "session-1",
+        notes: [],
+      },
+    });
+
+    expect(result.actions).toEqual({
+      allowed: ["complete", "cancel"],
+    });
+  });
+
+  test("preserves XEP-0004 multi-value fields from Stanza form values", () => {
+    const fields = parseExtensionCommandForm({
+      fields: [
+        { name: "payload#choices", type: "list-multi", value: ["yes", "maybe"] },
+        { name: "payload#notes", type: "text-multi", value: ["first", "second"] },
+        { name: "payload#notify", type: "boolean" },
+      ],
+    });
+
+    expect(fields[0]?.values).toEqual(["yes", "maybe"]);
+    expect(fields[1]?.values).toEqual(["first", "second"]);
+    expect(fields[2]).toMatchObject({ value: "0", values: ["0"] });
+  });
+
+  test("submits XEP-0050 session id and XEP-0004 multi values using Stanza names", async () => {
+    let sent: unknown;
+    const xmpp = {
+      async sendIQ(iq: unknown) {
+        sent = iq;
+        return { command: { status: "completed", notes: [] } };
+      },
+    };
+
+    await submitExtensionCommandForm(
+      xmpp as any,
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:poll", name: "Poll" },
+      "session-1",
+      [
+        {
+          name: "fixed:Do not send me",
+          label: "Do not send me",
+          type: "fixed",
+          value: "Do not send me",
+          values: ["Do not send me"],
+          options: [],
+          required: false,
+          blocked: false,
+          hidden: false,
+        },
+        {
+          name: "payload#choices",
+          label: "Choices",
+          type: "list-multi",
+          value: "yes",
+          values: ["yes", "maybe"],
+          options: [],
+          required: true,
+          blocked: false,
+          hidden: false,
+        },
+        {
+          name: "payload#notify",
+          label: "Notify",
+          type: "boolean",
+          value: "0",
+          values: ["0"],
+          options: [],
+          required: true,
+          blocked: false,
+          hidden: false,
+        },
+        {
+          name: "hidden#multi",
+          label: "Hidden",
+          type: "hidden",
+          value: "alpha",
+          values: ["alpha", "beta"],
+          options: [],
+          required: false,
+          blocked: false,
+          hidden: true,
+        },
+      ],
+      "next",
+    );
+
+    expect(sent).toMatchObject({
+      type: "set",
+      to: "extensions.example.com",
+      command: {
+        node: "urn:waddle:extension:poll",
+        sid: "session-1",
+        action: "next",
+        form: {
+          type: "submit",
+          fields: [
+            { name: "payload#choices", type: "list-multi", value: ["yes", "maybe"] },
+            { name: "payload#notify", type: "boolean", value: false },
+            { name: "hidden#multi", type: "hidden", value: ["alpha", "beta"] },
+          ],
+        },
+      },
     });
   });
 });


### PR DESCRIPTION
## Plan

Implement the Waddle extension UX recovery plan for the chat web client.

### Summary

- Replace the current protocol-debug extension launcher with a usable Waddle-native extension palette.
- Add a real XEP-0050 command runner and XEP-0004 form renderer.
- Render production extension enrichments as typed Waddle-native cards instead of generic key/value metadata.
- Keep everything XMPP-native: no plugin DOM, iframe, JS, CSS, client WASM, REST, webhooks, or mutable extension HTTP APIs.

### Key Changes

- Add an extension palette opened from the composer, grouped by available, recent, and admin commands.
- Preserve XEP-0050 sessions and support next, previous, complete, and cancel actions.
- Parse and render XEP-0004 field types, options, descriptions, required fields, and hidden values.
- Reject forbidden secret/private command fields according to the extension protocol plan.
- Add typed renderers for links/task board, pub quiz, AI chatbot, dynamic canvas, and decision polls message enrichments.
- Add durable action feedback states and reset stale extension command state on room/DM changes.

### Test Plan

- Run `bun test` in `chat/`.
- Run `bun run lint` in `chat/`.
- Run `bun run build` in `chat/`.
- Add or update targeted tests for extension commands, XEP-0004 forms, typed enrichment rendering, and stale state reset.

### Assumptions

- First implementation scope is `chat/` because that is where the current extension launcher, command runner, and message enrichment UI exist.
- Persistent PubSub route surfaces may need a follow-up if server-side route discovery or PubSub read helpers are missing, but the web client should establish the native UI model now.
