### PR TITLE
fix(chat): open ai prompt threads from feed

### DIFF
--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -87,6 +87,10 @@ function requiredLaunchValue(value: string | undefined, label: string): string {
   throw new Error(`Launch is missing ${label}.`);
 }
 
+function optionalDataFormField(name: string, value: string | undefined): DataFormField[] {
+  return value?.trim() ? [{ name, value }] : [];
+}
+
 export function buildExtensionLaunchInvokeIq(
   userJid: string,
   launch: ExtensionLaunchDescriptor,
@@ -99,12 +103,12 @@ export function buildExtensionLaunchInvokeIq(
     { name: "plugin", value: requiredLaunchValue(launch.pluginId, "plugin id") },
     { name: "action", value: requiredLaunchValue(launch.actionId, "action id") },
     { name: "waddle-id", value: requiredLaunchValue(launch.context.waddleId, "waddle id") },
-    { name: "source-stanza-id", value: requiredLaunchValue(messageStanzaId, "source stanza id") },
+    ...optionalDataFormField("source-stanza-id", messageStanzaId),
     { name: "launch-id", value: requiredLaunchValue(launch.id, "launch id") },
     { name: "launch-token", value: requiredLaunchValue(launch.launchToken, "launch token") },
     { name: "expires-at", value: requiredLaunchValue(launch.expiresAt, "expiry") },
     { name: "waddle#waddle_id", value: requiredLaunchValue(launch.context.waddleId, "waddle id") },
-    { name: "waddle#message_stanza_id", value: requiredLaunchValue(messageStanzaId, "source stanza id") },
+    ...optionalDataFormField("waddle#message_stanza_id", messageStanzaId),
     { name: "waddle#launch_id", value: requiredLaunchValue(launch.id, "launch id") },
     { name: "waddle#launch_token", value: requiredLaunchValue(launch.launchToken, "launch token") },
     { name: "waddle#expires_at", value: requiredLaunchValue(launch.expiresAt, "expiry") },
@@ -241,6 +245,9 @@ export function extensionCommandFormBlockedReason(fields: ExtensionCommandFormFi
 export function parseExtensionCommandLaunches(form: unknown): ExtensionAnnotationAction[] {
   const fields = parseExtensionCommandForm(form);
   const byName = new Map(fields.map((field) => [field.name, field.value]));
+  if (byName.get("FORM_TYPE") !== `${NS_WADDLE_EXTENSION_1}:result`) {
+    return [];
+  }
   const count = Number.parseInt(byName.get("launch-count") ?? "0", 10);
   const actions: ExtensionAnnotationAction[] = [];
   for (let index = 0; index < count; index += 1) {
@@ -322,6 +329,9 @@ export function extensionCommandOutcome(result: unknown): ExtensionCommandOutcom
     return { state: "warning", detail: `Command returned status: ${parsed.status}.` };
   }
 
+  const formDetail = extensionResultFormDetail(parsed.form);
+  if (formDetail) return { state: "success", detail: formDetail };
+
   const infoDetail = commandNotesDetail(parsed.notes, ["info"]);
   return infoDetail ? { state: "success", detail: infoDetail } : { state: "success" };
 }
@@ -343,6 +353,18 @@ function commandNotesDetail(notes: ExtensionCommandNote[], types: string[]): str
     .map((note) => note.value.trim())
     .filter((value) => value.length > 0);
   return values.length > 0 ? values.join(" ") : undefined;
+}
+
+function extensionResultFormDetail(form: unknown): string | undefined {
+  const fields = parseExtensionCommandForm(form);
+  const byName = new Map(fields.map((field) => [field.name, field.value.trim()]));
+  if (byName.get("FORM_TYPE") !== `${NS_WADDLE_EXTENSION_1}:result`) return undefined;
+  const body = byName.get("extension#body");
+  const prompt = byName.get("extension#prompt");
+  return [body, prompt]
+    .filter((value): value is string => !!value)
+    .join(" ")
+    .trim() || undefined;
 }
 
 export async function invokeExtensionLaunch(

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -7,6 +7,7 @@ import {
   extensionServiceJidForUserJid,
   invokeExtensionCommand,
   parseExtensionCommandForm,
+  parseExtensionCommandLaunches,
   parseExtensionCommandResult,
   submitExtensionCommandForm,
   visibleExtensionCommandFields,
@@ -106,11 +107,114 @@ describe("extension command invocation", () => {
       .toBe("archive-id-from-source");
   });
 
-  test("requires launch tokens before invoking action buttons", () => {
+  test("requires core launch identity before invoking action buttons", () => {
+    expect(() => buildExtensionLaunchInvokeIq("alice@example.com/web", {
+      ...launch,
+      pluginId: " ",
+    })).toThrow("Launch is missing plugin id.");
+  });
+
+  test("requires signed launch proof before invoking action buttons", () => {
     expect(() => buildExtensionLaunchInvokeIq("alice@example.com/web", {
       ...launch,
       launchToken: undefined,
     })).toThrow("Launch is missing launch token.");
+  });
+
+  test("builds launch invoke requests without source stanza metadata", () => {
+    const iq = buildExtensionLaunchInvokeIq("alice@example.com/web", {
+      id: "ask-followup",
+      pluginId: "ai-chatbot",
+      actionId: "ask-followup",
+      commandNode: "urn:waddle:extension:1:invoke",
+      launchToken: "signed-followup-token",
+      expiresAt: "2026-05-01T10:53:23Z",
+      label: "Ask follow-up",
+      context: {
+        waddleId: "alice@example.com/web",
+      },
+      payloads: [{
+        namespace: "urn:waddle:ai-chatbot:1",
+        name: "assistant-followup",
+        attributes: {
+          xmlns: "urn:waddle:ai-chatbot:1",
+          question: "Ask me from chat with /ask.",
+        },
+        text: "Ask me from chat with /ask.",
+        children: [],
+      }],
+    });
+
+    expect(iq.command.form.fields).toContainEqual({ name: "launch-token", value: "signed-followup-token" });
+    expect(iq.command.form.fields).toContainEqual({ name: "expires-at", value: "2026-05-01T10:53:23Z" });
+    expect(iq.command.form.fields).toContainEqual({ name: "payload#assistant-followup#question", value: "Ask me from chat with /ask." });
+    expect(iq.command.form.fields).not.toContainEqual(expect.objectContaining({ name: "source-stanza-id" }));
+    expect(iq.command.form.fields).not.toContainEqual(expect.objectContaining({ name: "waddle#message_stanza_id" }));
+  });
+
+  test("parses AI chatbot result launches without source stanza metadata", () => {
+    const actions = parseExtensionCommandLaunches({
+      fields: [
+        { name: "FORM_TYPE", type: "hidden", value: "urn:waddle:extension:1:result" },
+        { name: "launch-count", value: "1" },
+        { name: "launch#0#id", value: "ask-followup" },
+        { name: "launch#0#plugin", value: "ai-chatbot" },
+        { name: "launch#0#action", value: "ask-followup" },
+        { name: "launch#0#command-node", value: "urn:waddle:extension:1:invoke" },
+        { name: "launch#0#label", value: "Ask follow-up" },
+        { name: "launch#0#waddle-id", value: "alice@example.com/web" },
+        { name: "launch#0#token", value: "signed-followup-token" },
+        { name: "launch#0#expires-at", value: "2026-05-01T10:53:23Z" },
+        { name: "launch#0#payload#0#namespace", value: "urn:waddle:ai-chatbot:1" },
+        { name: "launch#0#payload#0#name", value: "assistant-followup" },
+        { name: "launch#0#payload#0#text", value: "Ask me from chat with /ask." },
+        { name: "launch#0#payload#0#attr#question", value: "Ask me from chat with /ask." },
+      ],
+    });
+
+    expect(actions).toEqual([{
+      label: "Ask follow-up",
+      route: "ask-followup",
+      launch: {
+        id: "ask-followup",
+        pluginId: "ai-chatbot",
+        actionId: "ask-followup",
+        commandNode: "urn:waddle:extension:1:invoke",
+        launchToken: "signed-followup-token",
+        expiresAt: "2026-05-01T10:53:23Z",
+        label: "Ask follow-up",
+        context: {
+          waddleId: "alice@example.com/web",
+        },
+        payloads: [{
+          namespace: "urn:waddle:ai-chatbot:1",
+          name: "assistant-followup",
+          attributes: {
+            xmlns: "urn:waddle:ai-chatbot:1",
+            question: "Ask me from chat with /ask.",
+          },
+          text: "Ask me from chat with /ask.",
+          children: [],
+        }],
+      },
+    }]);
+  });
+
+  test("does not parse launch actions from unrelated data forms", () => {
+    expect(parseExtensionCommandLaunches({
+      fields: [
+        { name: "FORM_TYPE", type: "hidden", value: "urn:example:other:result" },
+        { name: "launch-count", value: "1" },
+        { name: "launch#0#id", value: "ask-followup" },
+        { name: "launch#0#plugin", value: "ai-chatbot" },
+        { name: "launch#0#action", value: "ask-followup" },
+        { name: "launch#0#command-node", value: "urn:waddle:extension:1:invoke" },
+        { name: "launch#0#label", value: "Ask follow-up" },
+        { name: "launch#0#waddle-id", value: "alice@example.com/web" },
+        { name: "launch#0#token", value: "signed-followup-token" },
+        { name: "launch#0#expires-at", value: "2026-05-01T10:53:23Z" },
+      ],
+    })).toEqual([]);
   });
 
   test("classifies command notes and non-completed statuses for button state", () => {
@@ -145,6 +249,21 @@ describe("extension command invocation", () => {
       form: { fields: [{ name: "payload#question", type: "text-single", value: "" }] },
       notes: [],
     })).toEqual({ state: "warning" });
+
+    expect(extensionCommandOutcome({
+      status: "completed",
+      form: {
+        fields: [
+          { name: "FORM_TYPE", type: "hidden", value: "urn:waddle:extension:1:result" },
+          { name: "extension#body", value: "I can help summarize the recent thread." },
+          { name: "extension#prompt", value: "Morning" },
+        ],
+      },
+      notes: [{ type: "info", value: "Produced 1 message enrichment" }],
+    })).toEqual({
+      state: "success",
+      detail: "I can help summarize the recent thread. Morning",
+    });
   });
 
   test("parses XEP-0004 form fields, options, visibility, and forbidden fields", () => {

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -41,6 +41,7 @@ use waddle_extensions::{
     FormFieldType as ExtensionFormFieldType, FormFieldValue, LaunchContext, LaunchId,
     PubSubPublish, StanzaId, UiActionId, WaddleId, INVOKE_COMMAND_NODE,
 };
+use waddle_extensions::types::UiBlock;
 use waddle_xmpp::inbox::storage::InboxStorage;
 use waddle_xmpp::mam::{MamStorage, SqlxMamStorage};
 use waddle_xmpp::pubsub::{NodeConfig, PubSubItem, PubSubStorage};
@@ -935,6 +936,7 @@ async fn create_router(
     let extension_launch_key = server_config
         .session_key
         .clone()
+        .filter(|key| !key.is_empty())
         .unwrap_or_else(|| format!("development-extension-launch-key:{xmpp_domain}"));
     let extension_manager = Arc::new(
         match ExtensionManager::from_config(server_config.extensions.clone()).await {
@@ -1193,9 +1195,12 @@ async fn register_extension_commands(
                 let source_stanza_id = extension_field_value(&fields, "source-stanza-id")
                     .or_else(|| extension_field_value(&fields, "waddle#message_stanza_id"))
                     .and_then(|value| StanzaId::new(value).ok());
-                let expires_at = extension_field_value(&fields, "expires-at")
+                let Some(expires_at) = extension_field_value(&fields, "expires-at")
                     .or_else(|| extension_field_value(&fields, "waddle#expires_at"))
-                    .and_then(|value| waddle_extensions::Timestamp::new(value).ok());
+                    .and_then(|value| waddle_extensions::Timestamp::new(value).ok())
+                else {
+                    return extension_warning_result("Extension launch expiry is missing or invalid");
+                };
                 let context = LaunchContext {
                     waddle_id,
                     source_stanza_id,
@@ -1205,7 +1210,7 @@ async fn register_extension_commands(
                     &action_id,
                     &launch_id,
                     &context,
-                    expires_at.as_ref(),
+                    Some(&expires_at),
                     &launch_token,
                 ) {
                     return extension_warning_result(
@@ -1224,7 +1229,7 @@ async fn register_extension_commands(
                         action: ctx.command.action.map(extension_command_action),
                         fields,
                         form: submitted_form.and_then(extension_data_form),
-                        expires_at,
+                        expires_at: Some(expires_at),
                         launch_token: &launch_token,
                     })
                     .await;
@@ -1488,11 +1493,33 @@ fn extension_enrichment_result_form(
         .add_field(Field::text_single(
             "extension#summary",
             enrichment.payload_namespace.as_str(),
-        ))
-        .add_field(Field::text_single(
-            "launch-count",
-            enrichment.launches.len().to_string(),
         ));
+    let text_blocks: Vec<_> = enrichment
+        .ui
+        .first()
+        .map(|view| {
+            view.blocks
+                .iter()
+                .filter_map(|block| match block {
+                    UiBlock::Text(text) => Some(text.text.as_str()),
+                    UiBlock::Image(_)
+                    | UiBlock::Action(_)
+                    | UiBlock::Form(_)
+                    | UiBlock::List(_) => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Some(body) = text_blocks.first() {
+        form = form.add_field(Field::text_single("extension#body", *body));
+    }
+    if let Some(prompt) = text_blocks.get(1) {
+        form = form.add_field(Field::text_single("extension#prompt", *prompt));
+    }
+    form = form.add_field(Field::text_single(
+        "launch-count",
+        enrichment.launches.len().to_string(),
+    ));
     for (index, launch) in enrichment.launches.iter().enumerate() {
         let prefix = format!("launch#{index}");
         form = form


### PR DESCRIPTION
## Plan

- Review XEP-0369, XEP-0461, and related local thread/message handling before changing client behavior.
- Keep the implementation scoped to chat/src plus focused chat tests; do not touch server files.
- Remove or hide the AI chatbot command from the Extensions palette discovery/render path for v1.
- Detect current-user main-feed messages that start with /ai or contain @waddle, then open that message's thread after the optimistic/reflected root exists.
- Rely on existing thread rendering so AI replies remain visible only inside the thread panel.
- Run focused chat tests and lint/type checks covering the touched code.

## Notes

- Client-only v1 UX change.
- Existing unrelated server edits are intentionally left untouched.