### PR TITLE
fix(chat): run ai chatbot in muc threads

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -5,6 +5,7 @@ import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
+import { filterV1ExtensionPaletteCommands, isAiThreadPromptBody, nextAiThreadRootToOpen } from "@/lib/ai-thread-ux";
 import {
   getPinnedScrollTop,
   getNewMessagesDividerPlacement,
@@ -121,6 +122,8 @@ const extensionLauncherDetail = ref("");
 const extensionCommandStates = ref<Record<string, { state: "loading" | "success" | "warning" | "error"; detail?: string }>>({});
 const extensionCommandForms = ref<Record<string, { sessionId: string; fields: ExtensionCommandFormField[]; actions?: ExtensionCommandAction[] }>>({});
 const extensionCommandActions = ref<Record<string, ExtensionAnnotationAction[]>>({});
+const pendingAiThreadPromptBodies: string[] = [];
+let seenMessageIdsForAiThread = new Set(props.messages.map((message) => message.id));
 
 type MessageComposerHandle = {
   addAttachments: (files: Array<File | Blob>) => void;
@@ -199,7 +202,7 @@ async function openExtensionLauncher() {
   extensionLauncherState.value = "loading";
   extensionLauncherDetail.value = "";
   try {
-    extensionCommands.value = await props.xmppClient.discoverExtensionCommands();
+    extensionCommands.value = filterV1ExtensionPaletteCommands(await props.xmppClient.discoverExtensionCommands());
     extensionLauncherState.value = "idle";
     if (extensionCommands.value.length === 0) {
       extensionLauncherDetail.value = "No extension commands discovered.";
@@ -377,6 +380,9 @@ async function scrollToMessage(messageId: string) {
 
 function onSend(body: string, markup: MarkupSpan[], references: MessageReference[], files?: Array<File | Blob>) {
   const pending = replyingTo.value;
+  if (!pending && props.channel && !props.dmPeer && isAiThreadPromptBody(body)) {
+    pendingAiThreadPromptBodies.push(body);
+  }
   emit(
     "send",
     body,
@@ -440,6 +446,22 @@ const conversationScope = computed(() => [
   props.channel?.id ?? "",
   props.dmPeer?.peerJid ?? "",
 ].join(":"));
+
+watch(conversationScope, () => {
+  pendingAiThreadPromptBodies.length = 0;
+  seenMessageIdsForAiThread = new Set(props.messages.map((message) => message.id));
+});
+
+watch(() => props.messages, (messages) => {
+  if (pendingAiThreadPromptBodies.length > 0) {
+    const match = nextAiThreadRootToOpen(messages, pendingAiThreadPromptBodies, seenMessageIdsForAiThread);
+    if (match) {
+      pendingAiThreadPromptBodies.splice(match.promptIndex, 1);
+      emit("openThread", match.messageId);
+    }
+  }
+  seenMessageIdsForAiThread = new Set(messages.map((message) => message.id));
+});
 const hasSeenOnline = ref(props.xmppStatus.state === "online");
 const showReconnectedNotice = ref(false);
 let reconnectedNoticeTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/chat/src/lib/ai-thread-ux.ts
+++ b/chat/src/lib/ai-thread-ux.ts
@@ -1,0 +1,48 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+
+const AI_CHATBOT_COMMAND_PATTERNS = [
+  /(?:^|[:/#-])ai-chatbot(?:$|[:/#-])/i,
+  /\bai\s+chatbot\b/i,
+  /\bask\s+ai\b/i,
+];
+
+export function isAiThreadPromptBody(body: string): boolean {
+  return /^\s*\/ai(?:\s|$)/i.test(body) || /@waddle\b/i.test(body);
+}
+
+function isAiThreadRootCandidate(message: TimelineMessage, promptBody: string): boolean {
+  return message.isSelf
+    && message.body === promptBody
+    && !message.replyTo
+    && message.deliveryStatus === "delivered"
+    && (!message.threadId || message.threadId === message.id);
+}
+
+export function nextAiThreadRootToOpen(
+  messages: readonly TimelineMessage[],
+  pendingPromptBodies: readonly string[],
+  seenMessageIds: ReadonlySet<string>,
+): { messageId: string; promptIndex: number } | undefined {
+  for (const message of messages) {
+    if (seenMessageIds.has(message.id)) continue;
+    const promptIndex = pendingPromptBodies.findIndex((body) => isAiThreadRootCandidate(message, body));
+    if (promptIndex >= 0) return { messageId: message.id, promptIndex };
+  }
+  return undefined;
+}
+
+interface ExtensionPaletteCommand {
+  node: string;
+  name: string;
+}
+
+function isV1HiddenExtensionCommand(command: ExtensionPaletteCommand): boolean {
+  const haystack = `${command.node} ${command.name}`;
+  return AI_CHATBOT_COMMAND_PATTERNS.some((pattern) => pattern.test(haystack));
+}
+
+export function filterV1ExtensionPaletteCommands<T extends ExtensionPaletteCommand>(
+  commands: readonly T[],
+): T[] {
+  return commands.filter((command) => !isV1HiddenExtensionCommand(command));
+}

--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -1,5 +1,6 @@
 import type { Agent } from "stanza";
 import type { ExtensionAnnotationAction, ExtensionLaunchDescriptor } from "@/lib/chat-ui";
+import { filterV1ExtensionPaletteCommands } from "@/lib/ai-thread-ux";
 import { jidDomain } from "./jid";
 
 const NS_WADDLE_EXTENSION_1 = "urn:waddle:extension:1";
@@ -410,13 +411,13 @@ export async function discoverExtensionCommands(
   };
   const response = await disco.getDiscoItems?.(serviceJid, NS_ADHOC_COMMANDS);
   const items = response?.items ?? [];
-  return items
+  return filterV1ExtensionPaletteCommands(items
     .filter((item) => item.node && item.node !== INVOKE_COMMAND_NODE)
     .map((item) => ({
       serviceJid: item.jid ?? serviceJid,
       node: item.node!,
       name: item.name || item.node!,
-    }));
+    })));
 }
 
 function parseFieldOptions(options: unknown): ExtensionCommandFormOption[] {

--- a/chat/tests/ai-thread-ux.test.ts
+++ b/chat/tests/ai-thread-ux.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import {
+  filterV1ExtensionPaletteCommands,
+  isAiThreadPromptBody,
+  nextAiThreadRootToOpen,
+} from "../src/lib/ai-thread-ux";
+
+function message(overrides: Partial<TimelineMessage>): TimelineMessage {
+  return {
+    id: "msg-1",
+    author: "alice",
+    body: "hello",
+    createdAt: "2026-05-01T10:00:00.000Z",
+    isSelf: true,
+    ...overrides,
+  };
+}
+
+describe("AI thread UX", () => {
+  test("detects /ai prompts and @waddle mentions", () => {
+    expect(isAiThreadPromptBody("/ai summarize this")).toBe(true);
+    expect(isAiThreadPromptBody("  /ai")).toBe(true);
+    expect(isAiThreadPromptBody("can @waddle help?")).toBe(true);
+    expect(isAiThreadPromptBody("plain message")).toBe(false);
+    expect(isAiThreadPromptBody("prefix /ai in the middle")).toBe(false);
+  });
+
+  test("opens the new self-authored main-feed root for a pending AI prompt", () => {
+    const seen = new Set(["old-ai"]);
+    const result = nextAiThreadRootToOpen(
+      [
+        message({ id: "old-ai", body: "/ai old", deliveryStatus: "delivered" }),
+        message({ id: "new-ai", body: "/ai summarize this", deliveryStatus: "delivered" }),
+      ],
+      ["/ai summarize this"],
+      seen,
+    );
+
+    expect(result).toEqual({ messageId: "new-ai", promptIndex: 0 });
+  });
+
+  test("does not open threads for replies, thread children, other users, or already-seen messages", () => {
+    const pending = ["@waddle summarize"];
+    const seen = new Set(["seen-root"]);
+
+    expect(nextAiThreadRootToOpen([
+      message({ id: "seen-root", body: "@waddle summarize" }),
+      message({ id: "reply", body: "@waddle summarize", deliveryStatus: "delivered", replyTo: { id: "root" } }),
+      message({ id: "child", body: "@waddle summarize", deliveryStatus: "delivered", threadId: "root" }),
+      message({ id: "other-user", body: "@waddle summarize", deliveryStatus: "delivered", isSelf: false }),
+    ], pending, seen)).toBeUndefined();
+  });
+
+  test("waits for the canonical delivered self-echo before opening", () => {
+    const pending = ["/ai summarize this"];
+
+    expect(nextAiThreadRootToOpen([
+      message({ id: "client-id", body: "/ai summarize this", deliveryStatus: "sending" }),
+    ], pending, new Set())).toBeUndefined();
+
+    expect(nextAiThreadRootToOpen([
+      message({ id: "canonical-room-id", body: "/ai summarize this", deliveryStatus: "delivered" }),
+    ], pending, new Set(["client-id"]))).toEqual({ messageId: "canonical-room-id", promptIndex: 0 });
+  });
+
+  test("hides the AI chatbot command from v1 extension palette discovery", () => {
+    expect(filterV1ExtensionPaletteCommands([
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:poll", name: "Poll" },
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:1:ai-chatbot", name: "Ask AI Chatbot" },
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:notes", name: "Notes" },
+    ])).toEqual([
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:poll", name: "Poll" },
+      { serviceJid: "extensions.example.com", node: "urn:waddle:extension:notes", name: "Notes" },
+    ]);
+  });
+});

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ExtensionLaunchDescriptor } from "../src/lib/chat-ui";
 import {
   buildExtensionLaunchInvokeIq,
+  discoverExtensionCommands,
   extensionCommandOutcome,
   extensionCommandFormBlockedReason,
   extensionServiceJidForUserJid,
@@ -94,6 +95,29 @@ describe("extension command invocation", () => {
       },
     });
     expect((sent as { command?: { form?: unknown } }).command?.form).toBeUndefined();
+  });
+
+  test("hides the AI chatbot command from discovered extension commands for v1", async () => {
+    const xmpp = {
+      async getDiscoItems(jid: string, node?: string) {
+        if (!node) return { items: [{ jid: "extensions.example.com" }] };
+        return {
+          items: [
+            { jid, node: "urn:waddle:extension:poll", name: "Poll" },
+            { jid, node: "urn:waddle:extension:1:ai-chatbot", name: "Ask AI Chatbot" },
+            { jid, node: "urn:waddle:extension:notes", name: "Notes" },
+          ],
+        };
+      },
+      async getDiscoInfo() {
+        return { features: ["http://jabber.org/protocol/commands"] };
+      },
+    };
+
+    expect(await discoverExtensionCommands(xmpp as any, "alice@example.com/web")).toEqual([
+      { serviceJid: "example.com", node: "urn:waddle:extension:poll", name: "Poll" },
+      { serviceJid: "example.com", node: "urn:waddle:extension:notes", name: "Notes" },
+    ]);
   });
 
   test("uses source stanza metadata when context only carries the waddle id", () => {

--- a/server/crates/waddle-extensions/src/lib.rs
+++ b/server/crates/waddle-extensions/src/lib.rs
@@ -6,14 +6,14 @@ pub mod runtime;
 pub mod types;
 
 pub use config::{ExtensionConfig, ExtensionModuleConfig};
-pub use manager::ExtensionManager;
+pub use manager::{ExtensionManager, MessageExtensionOutcome};
 pub use types::{
-    message_has_framework_envelope, ArtifactReference, CommandAction, CommandDescriptor,
-    CommandInvocation, CommandSessionId, DataForm, DataFormField, DataFormType, DataFormValue,
-    DetectedLink, DisplayText, ExtensionCapability, ExtensionEffect, ExtensionEnvelope,
-    ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse, FormFieldOption,
-    FormFieldType, FormFieldValue, FrameworkTypeError, LaunchContext, LaunchDescriptor, LaunchId,
-    LaunchToken, MessageEnrichment, PayloadRoot, PayloadRule, PayloadSurface, PluginId,
-    PubSubPublish, StanzaId, Timestamp, UiActionId, WaddleId, XmlAttribute, XmlElement, XmlNode,
-    INVOKE_COMMAND_NODE,
+    message_has_framework_envelope, ArtifactReference, BotGroupchatResponse, CommandAction,
+    CommandDescriptor, CommandInvocation, CommandSessionId, DataForm, DataFormField, DataFormType,
+    DataFormValue, DetectedLink, DisplayText, ExtensionCapability, ExtensionEffect,
+    ExtensionEnvelope, ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse,
+    FormFieldOption, FormFieldType, FormFieldValue, FrameworkTypeError, FullJidValue,
+    LaunchContext, LaunchDescriptor, LaunchId, LaunchToken, MessageEnrichment, PayloadRoot,
+    PayloadRule, PayloadSurface, PluginId, PubSubPublish, ReplyTarget, RoomJid, StanzaId, ThreadId,
+    Timestamp, UiActionId, WaddleId, XmlAttribute, XmlElement, XmlNode, INVOKE_COMMAND_NODE,
 };

--- a/server/crates/waddle-extensions/src/manager.rs
+++ b/server/crates/waddle-extensions/src/manager.rs
@@ -22,12 +22,19 @@ use crate::runtime::{LoadedExtension, WasmRuntime};
 use crate::types::{
     is_official_namespace, message_has_framework_envelope, CommandAction, CommandInvocation,
     CommandNode, CommandSessionId, DetectedLink, DisplayText, ExtensionEffect, ExtensionEnvelope,
-    ExtensionEvent, LaunchContext, LaunchId, LaunchInvocation, LinkTarget, MessageContext,
-    MessageHook, PayloadNamespace, PluginId, StanzaId, WaddleId, FRAMEWORK_NAMESPACE,
+    ExtensionEvent, FullJidValue, LaunchContext, LaunchId, LaunchInvocation, LinkTarget,
+    MessageContext, MessageHook, PayloadNamespace, PluginId, ReplyTarget, RoomJid, StanzaId,
+    ThreadId, WaddleId, FRAMEWORK_NAMESPACE,
 };
 
 const MAX_DETECTED_LINKS: usize = 3;
 const EXTENSION_ENRICH_TIMEOUT: Duration = Duration::from_millis(750);
+
+#[derive(Debug, Clone, Default)]
+pub struct MessageExtensionOutcome {
+    pub enrichments_added: usize,
+    pub effects: Vec<ExtensionEffect>,
+}
 
 pub struct LaunchInvocationRequest<'a> {
     pub plugin_name: &'a str,
@@ -330,8 +337,18 @@ impl ExtensionManager {
     }
 
     pub async fn enrich_message_for_waddle(&self, msg: &mut Message, waddle_id: WaddleId) -> usize {
+        self.process_message_for_waddle(msg, waddle_id)
+            .await
+            .enrichments_added
+    }
+
+    pub async fn process_message_for_waddle(
+        &self,
+        msg: &mut Message,
+        waddle_id: WaddleId,
+    ) -> MessageExtensionOutcome {
         if message_has_framework_envelope(msg) {
-            return 0;
+            return MessageExtensionOutcome::default();
         }
 
         let Some(body) = msg
@@ -340,25 +357,40 @@ impl ExtensionManager {
             .or_else(|| msg.bodies.values().next())
             .map(|body| body.0.clone())
         else {
-            return 0;
+            return MessageExtensionOutcome::default();
         };
         let Ok(body_text) = DisplayText::new(body.clone()) else {
-            return 0;
+            return MessageExtensionOutcome::default();
         };
 
         let links = detect_links(&body);
 
-        let mut count = 0usize;
+        let mut outcome = MessageExtensionOutcome::default();
         if !self.actors.is_empty() {
             let hook_links: Vec<LinkTarget> = links
                 .into_iter()
                 .filter_map(|link| LinkTarget::try_from(link).ok())
                 .collect();
             let source_stanza_id = msg.id.clone().and_then(|id| StanzaId::new(id).ok());
+            let room = msg
+                .to
+                .as_ref()
+                .and_then(|jid| RoomJid::new(jid.to_bare().to_string()).ok());
+            let sender = if room.is_some() {
+                None
+            } else {
+                msg.from
+                    .as_ref()
+                    .and_then(|jid| FullJidValue::new(jid.to_string()).ok())
+            };
             let event = ExtensionEvent::MessageHook(MessageHook {
                 context: MessageContext {
                     waddle_id,
                     stanza_id: source_stanza_id.clone(),
+                    room,
+                    sender,
+                    thread_id: thread_id_from_message(msg),
+                    reply_to: reply_target_from_payloads(&msg.payloads),
                 },
                 body: body_text,
                 links: hook_links,
@@ -372,18 +404,19 @@ impl ExtensionManager {
                     return None;
                 }
                 let actor_name = actor.manifest().id.to_string();
+                let manifest = actor.manifest();
                 let actor = Arc::clone(actor);
                 let event = event.clone();
                 Some(async move {
                     match timeout(EXTENSION_ENRICH_TIMEOUT, actor.handle_event(event)).await {
-                        Ok(effects) => (actor_name, effects),
+                        Ok(effects) => (actor_name, manifest, effects),
                         Err(_) => {
                             warn!(
                                 extension = %actor_name,
                                 timeout_secs = EXTENSION_ENRICH_TIMEOUT.as_secs(),
                                 "extension enrichment timed out; continuing fail-open"
                             );
-                            (actor_name, Vec::new())
+                            (actor_name, manifest, Vec::new())
                         }
                     }
                 })
@@ -391,11 +424,22 @@ impl ExtensionManager {
             let results = join_all(enrich_futures).await;
 
             let mut enrichments = Vec::new();
-            for (_actor_name, effects) in results {
+            let mut emitted_effects = Vec::new();
+            for (actor_name, manifest, effects) in results {
                 for effect in self.sign_effects(effects) {
+                    if !effect.validate_for_manifest(&manifest) {
+                        warn!(
+                            extension = %actor_name,
+                            "extension emitted undeclared or invalid message effect; dropping"
+                        );
+                        continue;
+                    }
                     match effect {
                         ExtensionEffect::EnrichMessage(envelope) => {
                             enrichments.extend(envelope.enrichments);
+                        }
+                        ExtensionEffect::BotGroupchatResponse(response) => {
+                            emitted_effects.push(ExtensionEffect::BotGroupchatResponse(response));
                         }
                         ExtensionEffect::PublishPubSub(_)
                         | ExtensionEffect::ReferenceArtifact(_)
@@ -404,16 +448,21 @@ impl ExtensionManager {
                     }
                 }
             }
-            count = enrichments.len();
+            let count = enrichments.len();
             if !enrichments.is_empty() {
                 msg.payloads
                     .push(ExtensionEnvelope::new(enrichments).to_minidom());
             }
-            if count > 0 {
-                debug!(embeds_added = count, "message enriched by extensions");
+            outcome.enrichments_added = count;
+            outcome.effects = emitted_effects;
+            if outcome.enrichments_added > 0 {
+                debug!(
+                    embeds_added = outcome.enrichments_added,
+                    "message enriched by extensions"
+                );
             }
         }
-        count
+        outcome
     }
 
     fn sign_effects(&self, mut effects: Vec<ExtensionEffect>) -> Vec<ExtensionEffect> {
@@ -427,6 +476,7 @@ impl ExtensionManager {
                     }
                 }
                 ExtensionEffect::PublishPubSub(_)
+                | ExtensionEffect::BotGroupchatResponse(_)
                 | ExtensionEffect::ReferenceArtifact(_)
                 | ExtensionEffect::HostWarning(_)
                 | ExtensionEffect::Noop => {}
@@ -667,6 +717,32 @@ where
     }
 
     Ok(Value::Object(config))
+}
+
+fn reply_target_from_payloads(payloads: &[minidom::Element]) -> Option<ReplyTarget> {
+    payloads
+        .iter()
+        .find(|payload| payload.name() == "reply" && payload.ns() == "urn:xmpp:reply:0")
+        .and_then(|payload| {
+            let id = payload.attr("id").and_then(|id| StanzaId::new(id).ok())?;
+            let to = payload.attr("to").and_then(|to| FullJidValue::new(to).ok());
+            Some(ReplyTarget { id, to })
+        })
+}
+
+fn thread_id_from_message(msg: &Message) -> Option<ThreadId> {
+    msg.thread
+        .as_ref()
+        .and_then(|thread| ThreadId::new(thread.0.clone()).ok())
+        .or_else(|| {
+            msg.payloads
+                .iter()
+                .find(|payload| {
+                    payload.name() == "thread-reply" && payload.ns() == "urn:waddle:forums:0"
+                })
+                .and_then(|payload| payload.attr("thread-id"))
+                .and_then(|thread_id| ThreadId::new(thread_id).ok())
+        })
 }
 
 fn detect_links(body: &str) -> Vec<DetectedLink> {

--- a/server/crates/waddle-extensions/src/runtime.rs
+++ b/server/crates/waddle-extensions/src/runtime.rs
@@ -7,16 +7,17 @@ use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::types::{
-    ActionBlock, ActionId, ArtifactReference, BodyRange, CommandAction, CommandDescriptor,
-    CommandInvocation, CommandNode, CommandSessionId, DataForm, DataFormField, DataFormType,
-    DataFormValue, DisplayText, EnrichmentId, ExtensionCapability, ExtensionEffect,
+    ActionBlock, ActionId, ArtifactReference, BodyRange, BotGroupchatResponse, CommandAction,
+    CommandDescriptor, CommandInvocation, CommandNode, CommandSessionId, DataForm, DataFormField,
+    DataFormType, DataFormValue, DisplayText, EnrichmentId, ExtensionCapability, ExtensionEffect,
     ExtensionEnvelope, ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse,
-    FormFieldOption, FormFieldType, FormFieldValue, ImageBlock, LaunchContext, LaunchDescriptor,
-    LaunchId, LaunchInvocation, LinkTarget, ListId, ListItem, ListItemId, ListView, MediaType,
-    MessageContext, MessageEnrichment, MessageHook, MessageSource, PayloadNamespace, PayloadRoot,
-    PayloadRule, PayloadSurface, PluginId, PluginVersion, PubSubItemId, PubSubNode, PubSubPublish,
-    Sha256Digest, StanzaId, TextBlock, TextStyle, Timestamp, UiActionId, UiBlock, UiView, UiViewId,
-    Url, WaddleId, XmlAttribute, XmlElement, XmlNode,
+    FormFieldOption, FormFieldType, FormFieldValue, FullJidValue, ImageBlock, LaunchContext,
+    LaunchDescriptor, LaunchId, LaunchInvocation, LinkTarget, ListId, ListItem, ListItemId,
+    ListView, MediaType, MessageContext, MessageEnrichment, MessageHook, MessageSource,
+    PayloadNamespace, PayloadRoot, PayloadRule, PayloadSurface, PluginId, PluginVersion,
+    PubSubItemId, PubSubNode, PubSubPublish, ReplyTarget, RoomJid, Sha256Digest, StanzaId,
+    TextBlock, TextStyle, ThreadId, Timestamp, UiActionId, UiBlock, UiView, UiViewId, Url,
+    WaddleId, XmlAttribute, XmlElement, XmlNode,
 };
 
 wasmtime::component::bindgen!({
@@ -301,6 +302,19 @@ impl From<MessageContext> for wit_types::MessageContext {
         Self {
             waddle_id: value.waddle_id.into(),
             stanza_id: value.stanza_id.map(Into::into),
+            room: value.room.map(Into::into),
+            sender: value.sender.map(Into::into),
+            thread_id: value.thread_id.map(Into::into),
+            reply_to: value.reply_to.map(Into::into),
+        }
+    }
+}
+
+impl From<ReplyTarget> for wit_types::ReplyTarget {
+    fn from(value: ReplyTarget) -> Self {
+        Self {
+            id: value.id.into(),
+            to: value.to.map(Into::into),
         }
     }
 }
@@ -535,6 +549,7 @@ impl_domain_newtype_to_wit!(CommandNode, CommandNode);
 impl_domain_newtype_to_wit!(CommandSessionId, CommandSessionId);
 impl_domain_newtype_to_wit!(DisplayText, DisplayText);
 impl_domain_newtype_to_wit!(EnrichmentId, EnrichmentId);
+impl_domain_newtype_to_wit!(FullJidValue, FullJid);
 impl_domain_newtype_to_wit!(LaunchId, LaunchId);
 impl_domain_newtype_to_wit!(ListId, ListId);
 impl_domain_newtype_to_wit!(ListItemId, ListItemId);
@@ -543,8 +558,10 @@ impl_domain_newtype_to_wit!(PayloadNamespace, PayloadNamespace);
 impl_domain_newtype_to_wit!(PluginId, PluginId);
 impl_domain_newtype_to_wit!(PubSubItemId, PubsubItemId);
 impl_domain_newtype_to_wit!(PubSubNode, PubsubNode);
+impl_domain_newtype_to_wit!(RoomJid, RoomJid);
 impl_domain_newtype_to_wit!(Sha256Digest, Sha256Digest);
 impl_domain_newtype_to_wit!(StanzaId, StanzaId);
+impl_domain_newtype_to_wit!(ThreadId, ThreadId);
 impl_domain_newtype_to_wit!(Timestamp, Timestamp);
 impl_domain_newtype_to_wit!(UiActionId, UiActionId);
 impl_domain_newtype_to_wit!(UiViewId, UiViewId);
@@ -573,6 +590,9 @@ impl TryFrom<wit_types::ExtensionEffect> for ExtensionEffect {
             wit_types::ExtensionEffect::EnrichMessage(envelope) => {
                 Self::EnrichMessage(envelope.try_into()?)
             }
+            wit_types::ExtensionEffect::BotGroupchatResponse(response) => {
+                Self::BotGroupchatResponse(response.try_into()?)
+            }
             wit_types::ExtensionEffect::PublishPubsub(publish) => {
                 Self::PublishPubSub(publish.try_into()?)
             }
@@ -580,6 +600,36 @@ impl TryFrom<wit_types::ExtensionEffect> for ExtensionEffect {
                 Self::ReferenceArtifact(artifact.try_into()?)
             }
             wit_types::ExtensionEffect::Noop => Self::Noop,
+        })
+    }
+}
+
+impl TryFrom<wit_types::BotGroupchatResponse> for BotGroupchatResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(value: wit_types::BotGroupchatResponse) -> Result<Self> {
+        Ok(Self {
+            body: wit_newtype_to_domain!(value.body, DisplayText)?,
+            room: wit_newtype_to_domain!(value.room, RoomJid)?,
+            thread_id: value
+                .thread_id
+                .map(|thread_id| wit_newtype_to_domain!(thread_id, ThreadId))
+                .transpose()?,
+            reply_to: value.reply_to.map(TryInto::try_into).transpose()?,
+        })
+    }
+}
+
+impl TryFrom<wit_types::ReplyTarget> for ReplyTarget {
+    type Error = anyhow::Error;
+
+    fn try_from(value: wit_types::ReplyTarget) -> Result<Self> {
+        Ok(Self {
+            id: wit_newtype_to_domain!(value.id, StanzaId)?,
+            to: value
+                .to
+                .map(|to| wit_newtype_to_domain!(to, FullJidValue))
+                .transpose()?,
         })
     }
 }
@@ -634,6 +684,7 @@ impl From<wit_types::ExtensionCapability> for ExtensionCapability {
         match value {
             wit_types::ExtensionCapability::MessageEnrich => Self::MessageEnrich,
             wit_types::ExtensionCapability::MessageObserve => Self::MessageObserve,
+            wit_types::ExtensionCapability::BotGroupchatSend => Self::BotGroupchatSend,
             wit_types::ExtensionCapability::Commands => Self::Commands,
             wit_types::ExtensionCapability::Launch => Self::Launch,
             wit_types::ExtensionCapability::PubsubPublish => Self::PubSubPublish,

--- a/server/crates/waddle-extensions/src/types.rs
+++ b/server/crates/waddle-extensions/src/types.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use minidom::Element;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use xmpp_parsers::jid::{BareJid, FullJid};
 use xmpp_parsers::message::Message;
 
 pub const FRAMEWORK_NAMESPACE: &str = "urn:waddle:extension:1";
@@ -32,6 +33,10 @@ pub enum FrameworkTypeError {
     InvalidSha256Digest(String),
     #[error("artifact URI {0:?} must be immutable HTTP(S) and include /sha256/")]
     InvalidArtifactUri(String),
+    #[error("bare JID {0:?} is invalid")]
+    InvalidBareJid(String),
+    #[error("full JID {0:?} is invalid")]
+    InvalidFullJid(String),
     #[error("artifact URI {uri:?} must include digest {sha256:?}")]
     ArtifactDigestMismatch { uri: String, sha256: String },
     #[error("body range end {end} must be greater than start {start}")]
@@ -101,10 +106,77 @@ typed_non_empty_string!(PubSubItemId, "pubsub item id");
 typed_non_empty_string!(PubSubNode, "pubsub node");
 typed_non_empty_string!(StanzaId, "stanza id");
 typed_non_empty_string!(Timestamp, "timestamp");
+typed_non_empty_string!(ThreadId, "thread id");
 typed_non_empty_string!(UiActionId, "ui action id");
 typed_non_empty_string!(UiViewId, "ui view id");
 typed_non_empty_string!(Url, "url");
 typed_non_empty_string!(WaddleId, "waddle id");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RoomJid(String);
+
+impl RoomJid {
+    pub fn new(value: impl Into<String>) -> Result<Self, FrameworkTypeError> {
+        let value = value.into();
+        value
+            .parse::<BareJid>()
+            .map_err(|_| FrameworkTypeError::InvalidBareJid(value.clone()))?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for RoomJid {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for RoomJid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FullJidValue(String);
+
+impl FullJidValue {
+    pub fn new(value: impl Into<String>) -> Result<Self, FrameworkTypeError> {
+        let value = value.into();
+        value
+            .parse::<FullJid>()
+            .map_err(|_| FrameworkTypeError::InvalidFullJid(value.clone()))?;
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for FullJidValue {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for FullJidValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PluginId(String);
@@ -345,6 +417,8 @@ pub enum ExtensionCapability {
     MessageEnrich,
     #[serde(rename = "message.observe")]
     MessageObserve,
+    #[serde(rename = "bot.groupchat.send")]
+    BotGroupchatSend,
     #[serde(rename = "commands")]
     Commands,
     #[serde(rename = "launch")]
@@ -362,6 +436,7 @@ impl ExtensionCapability {
         match self {
             Self::MessageEnrich => "message.enrich",
             Self::MessageObserve => "message.observe",
+            Self::BotGroupchatSend => "bot.groupchat.send",
             Self::Commands => "commands",
             Self::Launch => "launch",
             Self::PubSubPublish => "pubsub.publish",
@@ -1101,12 +1176,22 @@ pub struct MessageHook {
 pub struct MessageContext {
     pub waddle_id: WaddleId,
     pub stanza_id: Option<StanzaId>,
+    pub room: Option<RoomJid>,
+    pub sender: Option<FullJidValue>,
+    pub thread_id: Option<ThreadId>,
+    pub reply_to: Option<ReplyTarget>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LinkTarget {
     pub url: Url,
     pub range: BodyRange,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReplyTarget {
+    pub id: StanzaId,
+    pub to: Option<FullJidValue>,
 }
 
 impl TryFrom<DetectedLink> for LinkTarget {
@@ -1177,6 +1262,7 @@ pub struct ExtensionResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ExtensionEffect {
     EnrichMessage(ExtensionEnvelope),
+    BotGroupchatResponse(BotGroupchatResponse),
     PublishPubSub(PubSubPublish),
     ReferenceArtifact(ArtifactReference),
     HostWarning(DisplayText),
@@ -1212,6 +1298,9 @@ impl ExtensionEffect {
                     && publish.payload.namespace == publish.payload.root.namespace
                     && manifest.declares_payload(PayloadSurface::PubSubItem, &publish.payload)
             }
+            Self::BotGroupchatResponse(_) => {
+                manifest.declares_capability(ExtensionCapability::BotGroupchatSend)
+            }
             Self::ReferenceArtifact(_) => {
                 manifest.declares_capability(ExtensionCapability::ArtifactReference)
             }
@@ -1226,6 +1315,14 @@ pub struct PubSubPublish {
     pub node: PubSubNode,
     pub item_id: Option<PubSubItemId>,
     pub payload: ExtensionPayload,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BotGroupchatResponse {
+    pub body: DisplayText,
+    pub room: RoomJid,
+    pub thread_id: Option<ThreadId>,
+    pub reply_to: Option<ReplyTarget>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -873,7 +873,9 @@ fn build_cors(origins: Option<&str>) -> CorsLayer {
                 .filter_map(|o| o.trim().parse().ok())
                 .collect();
             if allowed.is_empty() {
-                warn!("WADDLE_CORS_ORIGINS set but no valid origins parsed, falling back to permissive CORS");
+                warn!(
+                    "WADDLE_CORS_ORIGINS set but no valid origins parsed, falling back to permissive CORS"
+                );
                 CorsLayer::permissive()
             } else {
                 info!(origins = ?allowed, "Configured CORS with explicit allowed origins");
@@ -1444,6 +1446,7 @@ async fn extension_command_result(
                     if count == 1 { "" } else { "s" }
                 )));
             }
+            ExtensionEffect::BotGroupchatResponse(_) => {}
             ExtensionEffect::Noop => {}
         }
     }

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -74,7 +74,11 @@ use kameo::actor::ActorRef;
 use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
-use waddle_extensions::{message_has_framework_envelope, ExtensionManager, WaddleId};
+use waddle_extensions::{
+    message_has_framework_envelope, BotGroupchatResponse, ExtensionEffect, ExtensionManager,
+    FullJidValue, ReplyTarget as ExtensionReplyTarget, StanzaId as ExtensionStanzaId,
+    ThreadId as ExtensionThreadId, WaddleId,
+};
 use waddle_xmpp::carbons::{build_received_carbon, build_sent_carbon};
 use waddle_xmpp::inbox::runtime::{direct_message_entry, groupchat_entry, groupchat_thread_entry};
 use waddle_xmpp::inbox::storage::InboxStorage;
@@ -107,10 +111,12 @@ use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::xep::xep0191::BlockingStorage;
 use waddle_xmpp::xep::xep0430::build_inbox_push;
 use waddle_xmpp::xep::{
-    extract_correction_from_message, extract_explicit_mentions, extract_reactions_from_message,
-    extract_references_from_message, extract_retraction_from_message, parse_reply_from_message,
-    remove_stanza_ids_by, RetractionKind, NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT,
-    NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE, NS_REPLY,
+    extract_correction_from_message, extract_explicit_mentions, extract_forum_action,
+    extract_reactions_from_message, extract_references_from_message,
+    extract_retraction_from_message, parse_reply_from_message, remove_stanza_ids_by,
+    set_reply_payload, set_thread_id, ForumAction, ReplyReference, RetractionKind,
+    NS_EXPLICIT_MENTIONS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS, NS_REFERENCE,
+    NS_REPLY,
 };
 use waddle_xmpp::Stanza;
 use xmpp_parsers::message::{Message, MessageType as XmppMessageType};
@@ -1437,6 +1443,7 @@ async fn dispatch_to_room(
     // value (Copilot review on PR #279). Avoids per-occupant
     // `Utc::now()` drift across a second-boundary.
     let dispatch_timestamp = chrono::Utc::now().timestamp();
+    normalize_thread_create_source(&mut prototype);
     let gate_ctx = RoomContext {
         room: &room_jid,
         sender_full: &sender_full,
@@ -1446,6 +1453,7 @@ async fn dispatch_to_room(
         id_gen: &id_gen,
         occupant_id_secret: OCCUPANT_ID_SECRET,
         sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
+        project_sender_inbox: true,
         dispatch_timestamp,
     };
     let mut gate_working = prototype.clone();
@@ -1496,12 +1504,18 @@ async fn dispatch_to_room(
     //    enrichment payloads. Fail-open: extension errors leave the
     //    message unchanged.
     let waddle_id = waddle_id_for_room_jid(&room_jid);
-    let _embeds_added = state
+    let extension_outcome = state
         .deps
         .protocol
         .extension_manager
-        .enrich_message_for_waddle(&mut prototype, waddle_id)
+        .process_message_for_waddle(&mut prototype, waddle_id)
         .await;
+    let bot_response_requested = extension_outcome
+        .effects
+        .iter()
+        .any(|effect| matches!(effect, ExtensionEffect::BotGroupchatResponse(_)));
+    let source_thread_id_before_dispatch =
+        bot_response_source_thread_id(&mut prototype, bot_response_requested);
 
     // 6. Rich-target validation against the room archive. Runs only
     //    after the gate has admitted the sender, so non-occupants /
@@ -1561,6 +1575,7 @@ async fn dispatch_to_room(
         // `RoomActor::GetRoomSnapshot` round-trip per groupchat
         // archive write (Copilot review on PR #279).
         sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
+        project_sender_inbox: true,
         dispatch_timestamp,
     };
     let mut working = prototype;
@@ -1589,7 +1604,250 @@ async fn dispatch_to_room(
         outcome.close = true;
     }
     outcome.feedback.extend(nested.feedback);
+
+    let canonical_source_reply = canonical_reply_target_for_room_message(&working, &room_jid);
+    let canonical_source_thread_id = message_thread_id(&working)
+        .or(source_thread_id_before_dispatch)
+        .or_else(|| {
+            canonical_source_reply
+                .as_ref()
+                .map(|reply| reply.id.as_str().to_string())
+        });
+
+    for effect in extension_outcome.effects {
+        if let ExtensionEffect::BotGroupchatResponse(response) = effect {
+            let Some(response) = canonicalize_bot_response_target(
+                response,
+                canonical_source_thread_id.as_deref(),
+                canonical_source_reply.clone(),
+            ) else {
+                warn!(
+                    room = %room_jid,
+                    "DispatchToRoom: bot response requested but canonical source target was unavailable; dropping"
+                );
+                continue;
+            };
+            let nested = Box::pin(dispatch_bot_groupchat_response(
+                deps,
+                BotGroupchatDispatch {
+                    room_jid: &room_jid,
+                    occupants: &occupants,
+                    room_actor: Some(&room_actor),
+                    room_moderated: snapshot.config.moderated,
+                    dispatch_timestamp,
+                    recursion_depth,
+                },
+                response,
+            ))
+            .await;
+            outcome.frames.extend(nested.frames);
+            outcome.close = outcome.close || nested.close;
+            outcome.feedback.extend(nested.feedback);
+        }
+    }
     outcome
+}
+
+struct BotGroupchatDispatch<'a> {
+    room_jid: &'a BareJid,
+    occupants: &'a [OccupantSnapshot],
+    room_actor: Option<&'a ActorRef<RoomActor>>,
+    room_moderated: bool,
+    dispatch_timestamp: i64,
+    recursion_depth: u8,
+}
+
+async fn dispatch_bot_groupchat_response(
+    deps: &Deps<'_>,
+    bot_ctx: BotGroupchatDispatch<'_>,
+    response: BotGroupchatResponse,
+) -> InterpretOutcome {
+    let mut outcome = InterpretOutcome::default();
+    if response.room.as_str() != bot_ctx.room_jid.to_string() {
+        warn!(
+            room = %bot_ctx.room_jid,
+            response_room = response.room.as_str(),
+            "BotGroupchatResponse room did not match dispatch room; dropping"
+        );
+        return outcome;
+    }
+
+    let Some(bot_full) = bot_full_jid(bot_ctx.room_jid) else {
+        warn!(room = %bot_ctx.room_jid, "BotGroupchatResponse could not build bot sender JID; dropping");
+        return outcome;
+    };
+
+    let mut working = Message::new(Some(Jid::from(bot_ctx.room_jid.clone())));
+    working.id = Some(uuid::Uuid::new_v4().to_string());
+    working.from = Some(Jid::from(bot_full.clone()));
+    working.type_ = XmppMessageType::Groupchat;
+    working.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body(response.body.as_str().to_string()),
+    );
+
+    if let Some(thread_id) = response.thread_id.as_ref() {
+        set_thread_id(&mut working, thread_id.as_str());
+    }
+    if let Some(reply_to) = response.reply_to.as_ref() {
+        let mut reply = ReplyReference::new(reply_to.id.as_str());
+        if let Some(to) = reply_to.to.as_ref() {
+            reply = reply.with_to(to.as_str());
+        }
+        set_reply_payload(&mut working, &reply);
+    }
+
+    if let Some(room_actor) = bot_ctx.room_actor {
+        if let Err(stanza_error) = validate_groupchat_rich_targets(
+            deps,
+            bot_ctx.room_jid,
+            &working,
+            None,
+            room_actor,
+            Some(0),
+        )
+        .await
+        {
+            warn!(
+                room = %bot_ctx.room_jid,
+                error = ?stanza_error,
+                "BotGroupchatResponse failed rich-target validation; dropping"
+            );
+            return outcome;
+        }
+    }
+
+    let bot_nick = available_bot_nick(bot_ctx.occupants);
+    let mut bot_occupants = bot_ctx.occupants.to_vec();
+    bot_occupants.push(OccupantSnapshot {
+        full_jid: bot_full.clone(),
+        nick: bot_nick,
+        affiliation: waddle_xmpp::Affiliation::Member,
+        role: waddle_xmpp::Role::Participant,
+    });
+
+    let id_gen = UuidV4Generator;
+    let ctx = RoomContext {
+        room: bot_ctx.room_jid,
+        sender_full: &bot_full,
+        occupants: &bot_occupants,
+        managed_room_forbidden: false,
+        room_moderated: bot_ctx.room_moderated,
+        id_gen: &id_gen,
+        occupant_id_secret: OCCUPANT_ID_SECRET,
+        sender_nickname_generation: 0,
+        project_sender_inbox: false,
+        dispatch_timestamp: bot_ctx.dispatch_timestamp,
+    };
+
+    let dispatch_outcome = default_room_pipeline_dispatcher().dispatch(&mut working, &ctx);
+    let nested = Box::pin(interpret_with_depth(
+        dispatch_outcome.events,
+        deps,
+        bot_ctx.recursion_depth,
+    ))
+    .await;
+    outcome.frames.extend(nested.frames);
+    outcome.close = nested.close;
+    outcome.feedback.extend(nested.feedback);
+    outcome
+}
+
+fn bot_full_jid(room_jid: &BareJid) -> Option<FullJid> {
+    let domain = room_jid.domain();
+    format!("waddle@{domain}/bot").parse::<FullJid>().ok()
+}
+
+fn available_bot_nick(occupants: &[OccupantSnapshot]) -> String {
+    const BASE: &str = "waddle";
+    if !occupants.iter().any(|occupant| occupant.nick == BASE) {
+        return BASE.to_string();
+    }
+    for suffix in 2.. {
+        let candidate = format!("{BASE}-{suffix}");
+        if !occupants.iter().any(|occupant| occupant.nick == candidate) {
+            return candidate;
+        }
+    }
+    unreachable!("unbounded suffix search always returns")
+}
+
+fn normalize_thread_create_source(message: &mut Message) -> Option<String> {
+    let Some(ForumAction::CreateThread(_)) = extract_forum_action(message) else {
+        return None;
+    };
+    let thread_id = message
+        .thread
+        .as_ref()
+        .map(|thread| thread.0.clone())
+        .or_else(|| message.id.clone())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    if message.id.is_none() {
+        message.id = Some(thread_id.clone());
+    }
+    if message.thread.is_none() {
+        set_thread_id(message, &thread_id);
+    }
+    Some(thread_id)
+}
+
+fn bot_response_source_thread_id(
+    prototype: &mut Message,
+    bot_response_requested: bool,
+) -> Option<String> {
+    let source_thread_id = message_thread_id(prototype);
+    if !bot_response_requested {
+        return source_thread_id;
+    }
+
+    if let Some(thread_id) = source_thread_id {
+        if prototype.thread.is_none() {
+            set_thread_id(prototype, &thread_id);
+        }
+        return Some(thread_id);
+    }
+
+    None
+}
+
+fn canonicalize_bot_response_target(
+    mut response: BotGroupchatResponse,
+    source_thread_id: Option<&str>,
+    source_reply: Option<ExtensionReplyTarget>,
+) -> Option<BotGroupchatResponse> {
+    response.thread_id =
+        source_thread_id.and_then(|thread_id| ExtensionThreadId::new(thread_id.to_string()).ok());
+    response.reply_to = source_reply;
+    if response.thread_id.is_some() && response.reply_to.is_some() {
+        Some(response)
+    } else {
+        None
+    }
+}
+
+fn canonical_reply_target_for_room_message(
+    message: &Message,
+    room: &BareJid,
+) -> Option<ExtensionReplyTarget> {
+    let id = ExtensionStanzaId::new(extract_room_stanza_id(message, room)?).ok()?;
+    let to = message
+        .from
+        .as_ref()
+        .and_then(|from| FullJidValue::new(from.to_string()).ok());
+    Some(ExtensionReplyTarget { id, to })
+}
+
+fn message_thread_id(message: &Message) -> Option<String> {
+    message
+        .thread
+        .as_ref()
+        .map(|thread| thread.0.clone())
+        .or_else(|| {
+            extract_forum_action(message).and_then(|action| match action {
+                ForumAction::Reply(reply) => Some(reply.thread_id),
+                ForumAction::CreateThread(_) => message.id.clone(),
+            })
+        })
 }
 
 /// Resolve the managed-room owner override against the deployment
@@ -2498,6 +2756,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use waddle_xmpp::xep::{set_thread_create, ThreadCreate};
     use waddle_xmpp::Stanza;
     use xmpp_parsers::iq::{Iq, IqType};
     use xmpp_parsers::minidom::Element;
@@ -3821,6 +4080,192 @@ mod tests {
         let outcome = interpret(events, &Deps::registry_only(&registry)).await;
         assert!(outcome.frames.is_empty());
         assert!(!outcome.close);
+    }
+
+    #[tokio::test]
+    async fn bot_groupchat_response_dispatches_threaded_muc_message() {
+        use waddle_extensions::{
+            BotGroupchatResponse, DisplayText, FullJidValue, ReplyTarget, RoomJid, StanzaId,
+            ThreadId,
+        };
+
+        let registry = ConnectionRegistry::new();
+        let room_jid: jid::BareJid = "chat@muc.example.com".parse().expect("room jid");
+        let alice: jid::FullJid = "alice@example.com/web".parse().expect("alice jid");
+        let bob: jid::FullJid = "bob@example.com/web".parse().expect("bob jid");
+        let (alice_tx, mut alice_rx) = tokio::sync::mpsc::channel(8);
+        let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+        registry.register(alice.clone(), alice_tx);
+        registry.register(bob.clone(), bob_tx);
+
+        let occupants = vec![
+            OccupantSnapshot {
+                full_jid: alice.clone(),
+                nick: "alice".to_string(),
+                affiliation: waddle_xmpp::Affiliation::Member,
+                role: waddle_xmpp::Role::Participant,
+            },
+            OccupantSnapshot {
+                full_jid: bob.clone(),
+                nick: "bob".to_string(),
+                affiliation: waddle_xmpp::Affiliation::Member,
+                role: waddle_xmpp::Role::Participant,
+            },
+        ];
+        let response = BotGroupchatResponse {
+            body: DisplayText::new("AI answer").expect("body"),
+            room: RoomJid::new(room_jid.to_string()).expect("room"),
+            thread_id: Some(ThreadId::new("root-msg").expect("thread")),
+            reply_to: Some(ReplyTarget {
+                id: StanzaId::new("root-msg").expect("reply id"),
+                to: Some(FullJidValue::new(alice.to_string()).expect("reply to")),
+            }),
+        };
+
+        let outcome = dispatch_bot_groupchat_response(
+            &Deps::registry_only(&registry),
+            BotGroupchatDispatch {
+                room_jid: &room_jid,
+                occupants: &occupants,
+                room_actor: None,
+                room_moderated: false,
+                dispatch_timestamp: 1777629203,
+                recursion_depth: 0,
+            },
+            response,
+        )
+        .await;
+
+        assert!(outcome.frames.is_empty());
+        assert!(!outcome.close);
+
+        let alice_delivered = drain_inbound(&mut alice_rx);
+        let bob_delivered = drain_inbound(&mut bob_rx);
+        assert_eq!(alice_delivered.len(), 1);
+        assert_eq!(bob_delivered.len(), 1);
+
+        let Stanza::Message(message) = &alice_delivered[0].stanza else {
+            panic!("expected bot groupchat message");
+        };
+        assert_eq!(message.type_, xmpp_parsers::message::MessageType::Groupchat);
+        assert_eq!(
+            message.from.as_ref().map(ToString::to_string),
+            Some(format!("{room_jid}/waddle"))
+        );
+        assert_eq!(
+            message.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("root-msg")
+        );
+        assert_eq!(
+            message.bodies.get("").map(|body| body.0.as_str()),
+            Some("AI answer")
+        );
+        let reply = parse_reply_from_message(message).expect("reply payload");
+        assert_eq!(reply.id, "root-msg");
+        assert_eq!(reply.to, Some(alice.to_string()));
+        assert!(
+            !message
+                .payloads
+                .iter()
+                .any(|payload| payload.ns() == "urn:waddle:forums:0"),
+            "plain MUC bot responses must not reuse forum metadata"
+        );
+    }
+
+    #[test]
+    fn message_thread_id_reads_existing_forum_reply_without_rfc_thread() {
+        let xml = r#"<message xmlns='jabber:client' id='child'>
+            <thread-reply xmlns='urn:waddle:forums:0' thread-id='root-msg'/>
+        </message>"#;
+        let element: Element = xml.parse().expect("element");
+        let message = Message::try_from(element).expect("message");
+        assert_eq!(message_thread_id(&message).as_deref(), Some("root-msg"));
+    }
+
+    #[test]
+    fn bot_response_source_thread_leaves_plain_root_unthreaded() {
+        let mut message = Message::new(Some(Jid::from(
+            "chat@muc.example.com"
+                .parse::<jid::BareJid>()
+                .expect("room jid"),
+        )));
+        message.id = Some("client-root-id".to_string());
+        message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+        message.bodies.insert(
+            String::new(),
+            xmpp_parsers::message::Body("/ai explain this".to_string()),
+        );
+
+        let thread_id = bot_response_source_thread_id(&mut message, true);
+
+        assert_eq!(thread_id, None);
+        assert_eq!(message.id.as_deref(), Some("client-root-id"));
+        assert!(message.thread.is_none());
+        assert!(extract_forum_action(&message).is_none());
+    }
+
+    #[test]
+    fn bot_response_source_thread_stamps_existing_forum_root() {
+        let mut message = Message::new(Some(Jid::from(
+            "chat@muc.example.com"
+                .parse::<jid::BareJid>()
+                .expect("room jid"),
+        )));
+        message.id = Some("forum-root-id".to_string());
+        message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+        set_thread_create(&mut message, &ThreadCreate::new("Forum root"));
+
+        let thread_id = bot_response_source_thread_id(&mut message, true);
+
+        assert_eq!(thread_id.as_deref(), Some("forum-root-id"));
+        assert_eq!(
+            message.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("forum-root-id")
+        );
+    }
+
+    #[test]
+    fn thread_create_source_is_normalized_for_inbox_projection() {
+        let mut message = Message::new(Some(Jid::from(
+            "chat@muc.example.com"
+                .parse::<jid::BareJid>()
+                .expect("room jid"),
+        )));
+        message.id = Some("live-forum-root".to_string());
+        message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+        set_thread_create(&mut message, &ThreadCreate::new("Live forum root"));
+
+        let thread_id = normalize_thread_create_source(&mut message);
+
+        assert_eq!(thread_id.as_deref(), Some("live-forum-root"));
+        assert_eq!(
+            message.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("live-forum-root")
+        );
+        assert!(matches!(
+            extract_forum_action(&message),
+            Some(ForumAction::CreateThread(_))
+        ));
+    }
+
+    #[test]
+    fn bot_nick_avoids_existing_occupant_collision() {
+        let occupants = vec![
+            OccupantSnapshot {
+                full_jid: "alice@example.com/web".parse().expect("alice jid"),
+                nick: "waddle".to_string(),
+                affiliation: waddle_xmpp::Affiliation::Member,
+                role: waddle_xmpp::Role::Participant,
+            },
+            OccupantSnapshot {
+                full_jid: "bob@example.com/web".parse().expect("bob jid"),
+                nick: "waddle-2".to_string(),
+                affiliation: waddle_xmpp::Affiliation::Member,
+                role: waddle_xmpp::Role::Participant,
+            },
+        ];
+
+        assert_eq!(available_bot_nick(&occupants), "waddle-3");
     }
 
     // -----------------------------------------------------------------

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -128,6 +128,7 @@ mod tests {
             id_gen: &id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         };
         match MucArchiveHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -26,6 +26,8 @@ use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::xep::xep0359::{add_stanza_id, is_stanza_id_element};
 use crate::xep::xep0421::{generate_occupant_id, set_occupant_id_on_message};
+use crate::xep::xep0461::set_thread_id;
+use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::{BareJid, Jid};
 use xmpp_parsers::message::Message;
 
@@ -62,6 +64,12 @@ impl RoomHandler for MucCanonicalizeHandler {
         // 2. Stamp a fresh stanza-id.
         let id = ctx.id_gen.fresh_stanza_id();
         add_stanza_id(message, &id, &ctx.room.to_string());
+        if matches!(
+            extract_forum_action(message),
+            Some(ForumAction::CreateThread(_))
+        ) {
+            set_thread_id(message, &id);
+        }
 
         // 3. Rewrite `from='room/nick'` and drop `to` (the reflector
         //    fills `to` per occupant). If the sender nick is somehow
@@ -101,6 +109,7 @@ mod tests {
     use crate::types::{Affiliation, Role};
     use crate::xep::xep0359::{build_stanza_id_element, extract_stanza_ids};
     use crate::xep::xep0421::{extract_occupant_id_from_message, OccupantId};
+    use crate::xep::xep0508::{set_thread_create, ThreadCreate};
     use jid::FullJid;
     use xmpp_parsers::message::{Body, Message, MessageType};
 
@@ -142,6 +151,7 @@ mod tests {
             id_gen: &id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         };
         match MucCanonicalizeHandler.handle(msg, &ctx) {
@@ -179,6 +189,23 @@ mod tests {
         assert!(stamps
             .iter()
             .any(|s| s.by == "team@conf.example.com" && s.id == "stamp-1"));
+    }
+
+    #[test]
+    fn thread_create_root_uses_room_stanza_id_as_thread_id() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "new topic");
+        msg.id = Some("client-id".to_string());
+        set_thread_id(&mut msg, "spoofed-thread");
+        set_thread_create(&mut msg, &ThreadCreate::new("Topic"));
+
+        run(&room, &sender, "alice-nick", &mut msg, "room-stanza-id");
+
+        assert_eq!(
+            msg.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("room-stanza-id")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/room/context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/context.rs
@@ -103,6 +103,11 @@ pub struct RoomContext<'a> {
     /// `RoomActor::GetRoomSnapshot` query at archive time (Copilot
     /// review on PR #279).
     pub sender_nickname_generation: u64,
+    /// Whether the sender should receive the sender-owned inbox
+    /// projection. Real occupant sends do; synthetic server-authored
+    /// sends can disable this while still using the sender snapshot
+    /// for MUC canonicalization.
+    pub project_sender_inbox: bool,
     /// Single dispatch timestamp (Unix epoch seconds) shared across
     /// every per-occupant
     /// [`super::super::event::OutboundEvent::ProjectGroupchatInbox`]
@@ -124,5 +129,23 @@ impl<'a> RoomContext<'a> {
         self.occupants
             .iter()
             .find(|o| &o.full_jid == self.sender_full)
+    }
+
+    /// Occupants that should receive delivery and recipient-owned inbox projection.
+    ///
+    /// Normal user-originated dispatches use the full occupant set.
+    /// Server-authored synthetic dispatches may include a sender-only
+    /// snapshot so canonicalization can produce `room/nick` without
+    /// treating that synthetic sender as a real recipient.
+    pub fn recipient_occupants(&'a self) -> Box<dyn Iterator<Item = &'a OccupantSnapshot> + 'a> {
+        if self.project_sender_inbox {
+            Box::new(self.occupants.iter())
+        } else {
+            Box::new(
+                self.occupants
+                    .iter()
+                    .filter(|occupant| &occupant.full_jid != self.sender_full),
+            )
+        }
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
@@ -105,7 +105,7 @@ mod tests {
         room: &'a BareJid,
         sender_full: &'a FullJid,
         occupants: &'a [OccupantSnapshot],
-        gen: &'a FixedIdGenerator,
+        id_gen: &'a FixedIdGenerator,
     ) -> RoomContext<'a> {
         RoomContext {
             room,
@@ -113,9 +113,10 @@ mod tests {
             occupants,
             managed_room_forbidden: false,
             room_moderated: false,
-            id_gen: gen,
+            id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         }
     }

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -48,7 +48,10 @@ impl RoomHandler for MucInboxHandler {
         // also enumerated as an occupant, and this matches RFC
         // expectations for "your own outgoing copy" surfacing in your
         // inbox.
-        if seen.insert(sender_bare.clone()) {
+        if ctx.project_sender_inbox
+            && ctx.sender_snapshot().is_some()
+            && seen.insert(sender_bare.clone())
+        {
             events.push(OutboundEvent::ProjectGroupchatInbox {
                 owner: sender_bare,
                 room: ctx.room.clone(),
@@ -58,7 +61,7 @@ impl RoomHandler for MucInboxHandler {
                 dispatch_timestamp: ctx.dispatch_timestamp,
             });
         }
-        for occupant in ctx.occupants {
+        for occupant in ctx.recipient_occupants() {
             let bare = occupant.bare_jid();
             if !seen.insert(bare.clone()) {
                 continue;
@@ -76,23 +79,23 @@ impl RoomHandler for MucInboxHandler {
     }
 }
 
-/// Resolve the thread metadata for a groupchat message, mirroring the
-/// legacy
-/// `deliver_groupchat_via_room_actor::groupchat_thread_entry(...)`
-/// title-resolution logic: prefer a Waddle `CreateThread` action's
-/// title, fall back to the message preview, and capture the resource
-/// component of `from` as the author nick.
+/// Resolve thread metadata for actual roots. Replies must not publish
+/// title/author metadata, otherwise a bot or later human reply can overwrite
+/// the root's inbox projection.
 fn thread_projection(message: &Message) -> Option<GroupchatThreadProjection> {
     let thread = message.thread.as_ref()?;
     let forum_title = extract_forum_action(message).and_then(|action| match action {
         ForumAction::CreateThread(tc) => Some(tc.title),
         _ => None,
     });
-    let title = forum_title.or_else(|| preview_text(message));
-    let author_nick = message
-        .from
-        .as_ref()
-        .and_then(|jid| jid.resource().map(|r| r.to_string()));
+    let is_thread_root = message.id.as_deref() == Some(thread.0.as_str());
+    let title = forum_title.or_else(|| is_thread_root.then(|| preview_text(message)).flatten());
+    let author_nick = title.as_ref().and_then(|_| {
+        message
+            .from
+            .as_ref()
+            .and_then(|jid| jid.resource().map(|r| r.to_string()))
+    });
     Some(GroupchatThreadProjection {
         thread_id: thread.0.clone(),
         title,
@@ -106,6 +109,7 @@ mod tests {
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
+    use crate::xep::xep0461::set_thread_id;
     use jid::{FullJid, Jid};
     use xmpp_parsers::message::{Body, Message, MessageType};
 
@@ -152,6 +156,7 @@ mod tests {
             id_gen: &id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         };
         match MucInboxHandler.handle(msg, &ctx) {
@@ -228,5 +233,35 @@ mod tests {
         let proj = projections(&events);
         // Sender + one bob row (the second bob session collapsed).
         assert_eq!(proj.len(), 2);
+    }
+
+    #[test]
+    fn thread_projection_does_not_publish_reply_metadata() {
+        let room = bare("team@conf.example.com");
+        let bot = full("team@conf.example.com/waddle");
+        let mut msg = groupchat(&room, &bot, "AI answer");
+        msg.id = Some("reply-stanza".to_string());
+        set_thread_id(&mut msg, "root-stanza");
+
+        let thread = thread_projection(&msg).expect("thread projection");
+
+        assert_eq!(thread.thread_id, "root-stanza");
+        assert_eq!(thread.title, None);
+        assert_eq!(thread.author_nick, None);
+    }
+
+    #[test]
+    fn thread_projection_publishes_root_metadata() {
+        let room = bare("team@conf.example.com");
+        let alice = full("team@conf.example.com/alice");
+        let mut msg = groupchat(&room, &alice, "Root prompt");
+        msg.id = Some("root-stanza".to_string());
+        set_thread_id(&mut msg, "root-stanza");
+
+        let thread = thread_projection(&msg).expect("thread projection");
+
+        assert_eq!(thread.thread_id, "root-stanza");
+        assert_eq!(thread.title.as_deref(), Some("Root prompt"));
+        assert_eq!(thread.author_nick.as_deref(), Some("alice"));
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
@@ -178,6 +178,7 @@ mod tests {
             id_gen: &id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         };
         OccupancyValidationHandler.handle(msg, &ctx)

--- a/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
@@ -32,7 +32,7 @@ impl RoomHandler for ReflectorHandler {
 
     fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
         let mut events = Vec::with_capacity(ctx.occupants.len());
-        for occupant in ctx.occupants {
+        for occupant in ctx.recipient_occupants() {
             let mut copy = message.clone();
             copy.to = Some(Jid::from(occupant.full_jid.clone()));
             events.push(OutboundEvent::RouteToConnection {
@@ -76,6 +76,7 @@ mod tests {
             id_gen: &id_gen,
             occupant_id_secret: b"test-secret",
             sender_nickname_generation: 0,
+            project_sender_inbox: true,
             dispatch_timestamp: 0,
         };
         match ReflectorHandler.handle(msg, &ctx) {

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
@@ -84,6 +84,7 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
         id_gen: &id_gen,
         occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
         sender_nickname_generation: 0,
+        project_sender_inbox: true,
         dispatch_timestamp: 0,
     };
 
@@ -165,6 +166,7 @@ fn xep_0045_non_occupant_halts_chain_with_typed_not_acceptable() {
         id_gen: &id_gen,
         occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
         sender_nickname_generation: 0,
+        project_sender_inbox: true,
         dispatch_timestamp: 0,
     };
 
@@ -226,6 +228,7 @@ fn xep_0359_room_chain_strips_client_spoofed_room_stanza_id() {
         id_gen: &id_gen,
         occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
         sender_nickname_generation: 0,
+        project_sender_inbox: true,
         dispatch_timestamp: 0,
     };
 
@@ -282,6 +285,7 @@ fn xep_0424_groupchat_retraction_emits_archive_and_tombstone_events() {
         id_gen: &id_gen,
         occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
         sender_nickname_generation: 0,
+        project_sender_inbox: true,
         dispatch_timestamp: 0,
     };
 
@@ -349,6 +353,7 @@ fn xep_0430_groupchat_message_emits_per_occupant_inbox_projection() {
         id_gen: &id_gen,
         occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
         sender_nickname_generation: 0,
+        project_sender_inbox: true,
         dispatch_timestamp: 0,
     };
     let mut msg = groupchat(&room, &alice, "hello inbox");

--- a/server/extensions/ai-chatbot/src/lib.rs
+++ b/server/extensions/ai-chatbot/src/lib.rs
@@ -35,14 +35,8 @@ impl exports::waddle::extension::framework::Guest for AiChatbot {
         event: types::ExtensionEvent,
     ) -> Result<types::ExtensionResponse, types::ExtensionError> {
         let effects = match event {
-            types::ExtensionEvent::MessageHook(hook)
-                if hook.body.value.contains("@waddle") || hook.body.value.contains("/ai") =>
-            {
-                vec![visible_message(answer(
-                    &hook.body.value,
-                    hook.context.waddle_id,
-                    hook.context.stanza_id,
-                ))]
+            types::ExtensionEvent::MessageHook(hook) => {
+                message_hook_response(hook).into_iter().collect()
             }
             types::ExtensionEvent::Command(command) => {
                 let prompt = command
@@ -64,10 +58,70 @@ impl exports::waddle::extension::framework::Guest for AiChatbot {
                     launch.context.source_stanza_id,
                 ))]
             }
-            _ => vec![],
         };
         Ok(types::ExtensionResponse { effects })
     }
+}
+
+fn message_hook_response(hook: types::MessageHook) -> Option<types::ExtensionEffect> {
+    let body = hook.body.value;
+    let explicit_mention = contains_waddle_mention(&body);
+    let slash_trigger = starts_with_ai_command(&body);
+    let types::MessageContext {
+        room,
+        sender,
+        thread_id,
+        stanza_id,
+        reply_to,
+        ..
+    } = hook.context;
+    let in_thread = thread_id.is_some();
+    let is_reply = reply_to.is_some();
+    if !explicit_mention && (!slash_trigger || in_thread) {
+        return None;
+    }
+    if is_reply && !in_thread {
+        return None;
+    }
+
+    let room = room?;
+    let root_thread_id = thread_id.or_else(|| {
+        stanza_id
+            .clone()
+            .map(|id| types::ThreadId { value: id.value })
+    });
+    let reply_to = stanza_id
+        .map(|id| types::ReplyTarget { id, to: sender })
+        .or(reply_to);
+    Some(types::ExtensionEffect::BotGroupchatResponse(
+        types::BotGroupchatResponse {
+            body: display(&answer_body(&body)),
+            room,
+            thread_id: root_thread_id,
+            reply_to,
+        },
+    ))
+}
+
+fn contains_waddle_mention(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower
+        .match_indices("@waddle")
+        .any(|(start, mention)| is_word_boundary(lower.as_bytes().get(start + mention.len())))
+}
+
+fn starts_with_ai_command(body: &str) -> bool {
+    let trimmed = body.trim_start();
+    let lower = trimmed.to_ascii_lowercase();
+    lower.starts_with("/ai") && is_command_boundary(lower.as_bytes().get(3))
+}
+
+fn is_command_boundary(next: Option<&u8>) -> bool {
+    matches!(next, None | Some(b' ' | b'\t' | b'\r' | b'\n'))
+}
+
+fn is_word_boundary(next: Option<&u8>) -> bool {
+    !matches!(next, Some(b'a'..=b'z' | b'0'..=b'9' | b'_'))
 }
 
 fn manifest() -> types::ExtensionManifest {
@@ -86,6 +140,7 @@ fn manifest() -> types::ExtensionManifest {
             types::ExtensionCapability::Commands,
             types::ExtensionCapability::Launch,
             types::ExtensionCapability::MessageObserve,
+            types::ExtensionCapability::BotGroupchatSend,
         ],
         commands: vec![
             command_descriptor(COMMAND_NODE, "Ask AI Chatbot"),
@@ -136,7 +191,9 @@ fn answer(
             title: Some(display(PLUGIN_NAME)),
             blocks: vec![
                 types::UiBlock::Text(types::TextBlock {
-                    text: display("I can help summarize the recent thread, draft replies, or turn this into an action list."),
+                    text: display(
+                        "I can help summarize the recent thread, draft replies, or turn this into an action list.",
+                    ),
                     style: types::TextStyle::Body,
                 }),
                 types::UiBlock::Text(types::TextBlock {
@@ -181,6 +238,13 @@ fn answer(
             expires_at: None,
         }],
     }
+}
+
+fn answer_body(prompt: &str) -> String {
+    format!(
+        "I can help summarize the recent thread, draft replies, or turn this into an action list.\n\n{}",
+        prompt
+    )
 }
 
 fn payload(root: &str, attrs: Vec<(&str, String)>, text: &str) -> types::ExtensionPayload {
@@ -257,5 +321,76 @@ fn payload_namespace() -> types::PayloadNamespace {
 fn display(value: &str) -> types::DisplayText {
     types::DisplayText {
         value: value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{contains_waddle_mention, message_hook_response, starts_with_ai_command, types};
+
+    #[test]
+    fn detects_ai_root_command_case_insensitively_with_boundary() {
+        assert!(starts_with_ai_command("/ai summarize"));
+        assert!(starts_with_ai_command("  /AI"));
+        assert!(starts_with_ai_command("/Ai\tthread"));
+        assert!(!starts_with_ai_command("prefix /ai"));
+        assert!(!starts_with_ai_command("/airship"));
+    }
+
+    #[test]
+    fn detects_waddle_mention_case_insensitively_with_boundary() {
+        assert!(contains_waddle_mention("@waddle summarize"));
+        assert!(contains_waddle_mention("can @Waddle help?"));
+        assert!(contains_waddle_mention("@WADDLE"));
+        assert!(!contains_waddle_mention("@waddled"));
+        assert!(!contains_waddle_mention("@waddle_bot"));
+    }
+
+    #[test]
+    fn ignores_root_feed_replies_even_when_they_mention_ai() {
+        let hook = message_hook("/ai summarize this reply", None, Some("parent-msg"));
+        assert!(message_hook_response(hook).is_none());
+    }
+
+    #[test]
+    fn allows_threaded_followups_that_mention_waddle() {
+        let hook = message_hook("@Waddle continue", Some("thread-root"), Some("parent-msg"));
+        assert!(message_hook_response(hook).is_some());
+    }
+
+    fn message_hook(
+        body: &str,
+        thread_id: Option<&str>,
+        reply_to: Option<&str>,
+    ) -> types::MessageHook {
+        types::MessageHook {
+            context: types::MessageContext {
+                waddle_id: types::WaddleId {
+                    value: "space".to_string(),
+                },
+                stanza_id: Some(types::StanzaId {
+                    value: "source-msg".to_string(),
+                }),
+                room: Some(types::RoomJid {
+                    value: "chat@muc.example.com".to_string(),
+                }),
+                sender: Some(types::FullJid {
+                    value: "alice@example.com/web".to_string(),
+                }),
+                thread_id: thread_id.map(|value| types::ThreadId {
+                    value: value.to_string(),
+                }),
+                reply_to: reply_to.map(|id| types::ReplyTarget {
+                    id: types::StanzaId {
+                        value: id.to_string(),
+                    },
+                    to: None,
+                }),
+            },
+            body: types::DisplayText {
+                value: body.to_string(),
+            },
+            links: vec![],
+        }
     }
 }

--- a/server/wit/waddle-extension.wit
+++ b/server/wit/waddle-extension.wit
@@ -27,6 +27,10 @@ interface types {
         value: string,
     }
 
+    record full-jid {
+        value: string,
+    }
+
     record enrichment-id {
         value: string,
     }
@@ -67,6 +71,10 @@ interface types {
         value: string,
     }
 
+    record room-jid {
+        value: string,
+    }
+
     record sha256-digest {
         value: string,
     }
@@ -76,6 +84,10 @@ interface types {
     }
 
     record timestamp {
+        value: string,
+    }
+
+    record thread-id {
         value: string,
     }
 
@@ -109,6 +121,7 @@ interface types {
     enum extension-capability {
         message-enrich,
         message-observe,
+        bot-groupchat-send,
         commands,
         launch,
         pubsub-publish,
@@ -306,9 +319,18 @@ interface types {
         enrichments: list<message-enrichment>,
     }
 
+    record reply-target {
+        id: stanza-id,
+        to: option<full-jid>,
+    }
+
     record message-context {
         waddle-id: waddle-id,
         stanza-id: option<stanza-id>,
+        room: option<room-jid>,
+        sender: option<full-jid>,
+        thread-id: option<thread-id>,
+        reply-to: option<reply-target>,
     }
 
     record link-target {
@@ -366,8 +388,16 @@ interface types {
         payload: extension-payload,
     }
 
+    record bot-groupchat-response {
+        body: display-text,
+        room: room-jid,
+        thread-id: option<thread-id>,
+        reply-to: option<reply-target>,
+    }
+
     variant extension-effect {
         enrich-message(extension-envelope),
+        bot-groupchat-response(bot-groupchat-response),
         publish-pubsub(pubsub-publish),
         reference-artifact(artifact-reference),
         noop,


### PR DESCRIPTION
## Plan

- Move AI chatbot use out of the generic extension palette and into normal MUC conversation flow.
- Treat `/ai ...` and `@waddle ...` root messages as prompts that open a dedicated thread.
- Let the server produce a synthetic bot groupchat reply in that thread using XMPP-native room dispatch.
- Preserve constrained context for follow-ups by requiring threaded follow-ups to mention `@waddle`.
- Keep room routing, archive, inbox, replies, and thread metadata conformant with existing XEP/Waddle typed payload paths.

## Implemented

- Added client-side AI thread UX detection and tests.
- Hidden the AI chatbot XEP-0050 command from the v1 extension palette while leaving other extension commands available.
- Added typed extension ABI support for bot-authored groupchat responses, including room, sender, thread id, and reply target context.
- Updated the AI chatbot extension to trigger on `/ai` or `@waddle` roots, ignore main-feed replies, and allow threaded `@waddle` follow-ups.
- Server now creates a thread on the user root when needed, dispatches the bot answer as a synthetic MUC message, and canonicalizes the reply target to the room-assigned stanza id.
- Synthetic bot dispatch uses the normal room pipeline for canonicalization, archive, inbox, and fan-out, while avoiding treating the bot as a real recipient or sender inbox owner.
- Message context extraction now understands both RFC/XEP thread payloads and Waddle forum thread replies.
- Room canonicalization now normalizes every `thread-create` root so its XMPP `<thread/>` id is the room-stamped stanza id, fixing refresh/archive reconstruction of newly created threads.
- Synthetic bot nick selection avoids collisions with existing room occupants.

## Verification

- `bun test tests/ai-thread-ux.test.ts tests/extension-command.test.ts`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check5 cargo check -p waddle-server --message-format=short`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check5 cargo test -p waddle-server bot_groupchat_response -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check5 cargo test -p waddle-server message_thread_id_reads_existing_forum_reply_without_rfc_thread -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check5 cargo test -p ai-chatbot -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check15 cargo test -p waddle-xmpp thread_create_root_uses_room_stanza_id_as_thread_id -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check15 cargo test -p waddle-server thread_create_source_is_normalized_for_inbox_projection -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check15 cargo test -p waddle-server bot_response_source_thread_stamps_existing_forum_root -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/waddle-cargo-check15 cargo test -p waddle-server bot_nick_avoids_existing_occupant_collision -- --nocapture`

## Notes

- The shell environment prints `(eval):5: parse error near 'end'` before some Bun/Cargo commands, but the commands above completed successfully.
- Two earlier fresh-target Cargo attempts hung silently in the sandbox; the same checks were rerun successfully against the warmed target directory above.
