### PR TITLE
Fix AI thread MAM backfill and provider responses

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -43,7 +43,7 @@ import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
 import type { MemberSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import { avatarLookupCandidates, mentionAutocompleteCandidates, mentionMatchesUsername, mergeMentionMembers } from "@/lib/mentions";
-import { withAiAssistantMentionCandidate } from "@/lib/ai-thread-ux";
+import { AI_CHATBOT_FEATURE, withAiAssistantMentionCandidate } from "@/lib/ai-thread-ux";
 import {
   moveReactionSelection,
   preserveReactionSelection,
@@ -378,8 +378,14 @@ watch(authorJidByNick, (value) => {
 }, { immediate: true });
 const fetchedAvatarUrlByJid = ref<Record<string, string | null>>({});
 const avatarFetchStateByJid = ref<Record<string, "pending" | "done">>({});
+const aiAssistantEnabled = computed(() =>
+  waddles.currentChannel.value?.features?.includes(AI_CHATBOT_FEATURE) === true,
+);
 const mentionCandidates = computed(() =>
-  withAiAssistantMentionCandidate(mentionAutocompleteCandidates(mergedMentionMembers.value.members)).map((candidate) => {
+  withAiAssistantMentionCandidate(
+    mentionAutocompleteCandidates(mergedMentionMembers.value.members),
+    aiAssistantEnabled.value,
+  ).map((candidate) => {
     if (candidate.kind === "broadcast" || !candidate.jid) return candidate;
     return {
       ...candidate,
@@ -1536,6 +1542,7 @@ onUnmounted(() => {
               :thread-index="threads.index.value"
               :xmpp-client="xmppClient"
               :reaction-mode="reactionModeTarget === 'main' ? reactionModeState : null"
+              :ai-assistant-enabled="aiAssistantEnabled"
               @send="sendActiveMessage"
               @typing="notifyActiveComposing"
               @edit-message="editActiveMessage"
@@ -1609,6 +1616,7 @@ onUnmounted(() => {
               :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 2] ?? ''] ?? false"
               :upload-progress="{ uploading: false, progress: 0, filename: '' }"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :ai-assistant-enabled="aiAssistantEnabled"
               :hide-composer="true"
               :reaction-mode="null"
               @close="closeThreadPanel"
@@ -1647,6 +1655,7 @@ onUnmounted(() => {
               :has-older-replies="messaging.threadHasOlder.value[activeThreadStack[activeThreadStack.length - 1] ?? ''] ?? false"
               :upload-progress="messaging.uploadProgress.value"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
+              :ai-assistant-enabled="aiAssistantEnabled"
               :reaction-mode="reactionModeTarget === 'thread' ? reactionModeState : null"
               @close="closeThreadPanel"
               @pop-to="popThreadTo"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -73,6 +73,7 @@ const props = defineProps<{
   threadIndex: ThreadIndex;
   xmppClient?: BrowserXmppClient | null;
   reactionMode?: { selectedMessageId: string | null } | null;
+  aiAssistantEnabled?: boolean;
   invokeExtensionAction?: (action: ExtensionAnnotationAction) => Promise<unknown>;
 }>();
 
@@ -926,6 +927,7 @@ function dayDividerLabel(createdAt: string): string {
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
+      :ai-assistant-enabled="aiAssistantEnabled === true"
       :is-top-pinned="true"
       :extensions-open="extensionLauncherOpen"
       @send="onSend"
@@ -1127,6 +1129,7 @@ function dayDividerLabel(createdAt: string): string {
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
+      :ai-assistant-enabled="aiAssistantEnabled === true"
       :extensions-open="extensionLauncherOpen"
       @send="onSend"
       @cancel-reply="cancelReply"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -45,6 +45,7 @@ const props = defineProps<{
   slowModeCooldown: number;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   replyingTo?: { id: string; author: string; preview?: string } | null;
+  aiAssistantEnabled?: boolean;
   isTopPinned?: boolean;
   extensionsOpen?: boolean;
 }>();
@@ -164,7 +165,7 @@ const mentionResults = computed(() => {
 });
 
 const emojiResults = computed(() => searchEmoji(emojiQuery.value));
-const commandResults = computed(() => aiComposerCommandResults(commandQuery.value).slice(0, 8));
+const commandResults = computed(() => aiComposerCommandResults(commandQuery.value, props.aiAssistantEnabled === true).slice(0, 8));
 const showForumTitleInput = computed(() => props.isForumChannel && !props.replyingTo);
 
 const activeResults = computed(() => {
@@ -240,7 +241,7 @@ function checkAutocompleteFromEditor() {
   const textBefore = doc.textBetween(0, pos, "\n", "\uFFFC");
 
   const commandMatch = textBefore.match(/^\/([a-z]*)$/i);
-  if (commandMatch) {
+  if (commandMatch && props.aiAssistantEnabled === true) {
     commandQuery.value = commandMatch[1];
     selectedIndex.value = 0;
     showCommands.value = true;

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -40,6 +40,7 @@ const props = defineProps<{
   hasOlderReplies?: boolean;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
   channelName: string;
+  aiAssistantEnabled?: boolean;
   reactionMode?: { selectedMessageId: string | null } | null;
   /**
    * When true, the composer is hidden but sub-thread navigation stays active.
@@ -432,6 +433,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"
         :replying-to="replyingTo"
+        :ai-assistant-enabled="aiAssistantEnabled === true"
         :is-top-pinned="true"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"
@@ -580,6 +582,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"
         :replying-to="replyingTo"
+        :ai-assistant-enabled="aiAssistantEnabled === true"
         :is-top-pinned="false"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"

--- a/chat/src/composables/useWaddles.ts
+++ b/chat/src/composables/useWaddles.ts
@@ -181,6 +181,7 @@ export function useWaddles(
         spaceId: c.spaceId,
         channel_type: c.channelType,
         position: c.position,
+        features: c.features,
       }));
 
       channels.value = channelList;

--- a/chat/src/lib/ai-thread-ux.ts
+++ b/chat/src/lib/ai-thread-ux.ts
@@ -2,6 +2,7 @@ import type { TimelineMessage } from "@/lib/chat-ui";
 import type { MentionCandidate } from "@/lib/mentions";
 
 const AI_ASSISTANT_MENTION = "waddle";
+export const AI_CHATBOT_FEATURE = "urn:waddle:ai-chatbot:1";
 
 const AI_CHATBOT_COMMAND_PATTERNS = [
   /(?:^|[:/#-])ai-chatbot(?:$|[:/#-])/i,
@@ -27,7 +28,8 @@ export function isAiThreadPromptBody(body: string): boolean {
   return /^\s*\/ai(?:\s|$)/i.test(body) || /@waddle\b/i.test(body);
 }
 
-export function aiComposerCommandResults(query: string): AiComposerCommand[] {
+export function aiComposerCommandResults(query: string, enabled = true): AiComposerCommand[] {
+  if (!enabled) return [];
   const normalized = query.trim().replace(/^\/+/, "").toLowerCase();
   return AI_COMPOSER_COMMANDS.filter((candidate) =>
     candidate.command.slice(1).startsWith(normalized)
@@ -37,7 +39,9 @@ export function aiComposerCommandResults(query: string): AiComposerCommand[] {
 
 export function withAiAssistantMentionCandidate(
   candidates: readonly MentionCandidate[],
+  enabled = true,
 ): MentionCandidate[] {
+  if (!enabled) return [...candidates];
   if (candidates.some((candidate) => candidate.username.toLowerCase() === AI_ASSISTANT_MENTION)) {
     return [...candidates];
   }

--- a/chat/src/lib/chat-types.ts
+++ b/chat/src/lib/chat-types.ts
@@ -17,6 +17,7 @@ export interface ChannelSummary {
   description?: string | null;
   channel_type?: string;
   position?: number;
+  features?: string[];
   is_default?: boolean;
   created_at?: string;
   updated_at?: string | null;

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -187,6 +187,7 @@ async function hydrateChannelType(
       channelType: parseChannelType(info),
       spaceId: channel.spaceId ?? parentSpaceId ?? undefined,
       standalone: channel.spaceId || parentSpaceId ? false : channel.standalone,
+      ...(info.features?.length ? { features: info.features } : {}),
     };
   } catch {
     return channel;

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -4,6 +4,8 @@ import type { ReceivedMessage } from "stanza/protocol";
 import type { LiveRoomMessage, MamHistoryPage, MamPageParam } from "./types";
 import { dispatchGroupchat } from "./message-parsing";
 
+const WADDLE_MAM_THREAD_FIELD = "{urn:waddle:mam-thread:0}thread";
+
 function pagingForPageParam(max: number, pageParam: MamPageParam) {
   return pageParam.type === "latest"
     ? { max, before: "" }
@@ -58,6 +60,7 @@ export async function queryMam(
 function parseRoomMamResult(
   result: Awaited<ReturnType<Agent["searchHistory"]>>,
   roomJid: string,
+  requestedThreadId?: string,
 ): MamHistoryPage<LiveRoomMessage> {
   const collected: LiveRoomMessage[] = [];
 
@@ -93,6 +96,13 @@ function parseRoomMamResult(
       });
 
       if (parsedMessage) {
+        if (
+          requestedThreadId
+          && !parsedMessage.threadId
+          && parsedMessage.replyTo?.id === requestedThreadId
+        ) {
+          parsedMessage = { ...parsedMessage, threadId: requestedThreadId };
+        }
         collected.push(parsedMessage);
         continue;
       }
@@ -152,11 +162,11 @@ export async function queryMamByThread(
       type: "submit",
       fields: [
         { name: "FORM_TYPE", type: "hidden", value: "urn:xmpp:mam:2" },
-        { name: "{urn:xmpp:mam:2}thread", value: threadId },
+        { name: WADDLE_MAM_THREAD_FIELD, value: threadId },
       ],
     },
   });
-  return parseRoomMamResult(result, roomJid).messages;
+  return parseRoomMamResult(result, roomJid, threadId).messages;
 }
 
 export async function queryMamThreadPage(
@@ -174,11 +184,11 @@ export async function queryMamThreadPage(
       type: "submit",
       fields: [
         { name: "FORM_TYPE", type: "hidden", value: "urn:xmpp:mam:2" },
-        { name: "{urn:xmpp:mam:2}thread", value: threadId },
+        { name: WADDLE_MAM_THREAD_FIELD, value: threadId },
       ],
     },
   });
-  return parseRoomMamResult(result, roomJid);
+  return parseRoomMamResult(result, roomJid, threadId);
 }
 
 /** XEP-0431: Full-text search in MAM. Throws on IQ/transport errors. */

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -73,7 +73,7 @@ function parseRoomMamResult(
         ? mamResult.item.delay.timestamp.toISOString()
         : new Date().toISOString();
       const archivedMsg = withArchivedMessageId(mamResult.id, innerMsg as ReceivedMessage);
-      let parsedMessage: LiveRoomMessage | null = null;
+      let parsedMessage: LiveRoomMessage | undefined;
       let reactionUpdate: { targetId: string; emojis: string[]; nick: string; senderId: string } | null = null;
 
       dispatchGroupchat(archivedMsg, {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -245,6 +245,7 @@ export interface DiscoveredChannel {
   position: number;
   spaceId?: string;
   standalone?: boolean;
+  features?: string[];
 }
 
 export interface DiscoveredSpace {

--- a/chat/tests/ai-thread-ux.test.ts
+++ b/chat/tests/ai-thread-ux.test.ts
@@ -78,13 +78,14 @@ describe("AI thread UX", () => {
   });
 
   test("offers the AI slash command for composer autocomplete", () => {
-    expect(aiComposerCommandResults("").map((command) => command.command)).toEqual(["/ai"]);
-    expect(aiComposerCommandResults("a").map((command) => command.command)).toEqual(["/ai"]);
-    expect(aiComposerCommandResults("poll")).toEqual([]);
+    expect(aiComposerCommandResults("", true).map((command) => command.command)).toEqual(["/ai"]);
+    expect(aiComposerCommandResults("a", true).map((command) => command.command)).toEqual(["/ai"]);
+    expect(aiComposerCommandResults("poll", true)).toEqual([]);
+    expect(aiComposerCommandResults("", false)).toEqual([]);
   });
 
   test("adds the Waddle assistant to mention autocomplete once", () => {
-    expect(withAiAssistantMentionCandidate([])).toEqual([
+    expect(withAiAssistantMentionCandidate([], true)).toEqual([
       {
         username: "waddle",
         jid: null,
@@ -92,6 +93,7 @@ describe("AI thread UX", () => {
         kind: "member",
       },
     ]);
+    expect(withAiAssistantMentionCandidate([], false)).toEqual([]);
 
     expect(withAiAssistantMentionCandidate([
       {
@@ -100,6 +102,6 @@ describe("AI thread UX", () => {
         avatar_url: null,
         kind: "member",
       },
-    ])).toHaveLength(1);
+    ], true)).toHaveLength(1);
   });
 });

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -3,7 +3,7 @@ import { nextTick, ref } from "vue";
 import type { Agent } from "stanza";
 import type { ExtensionAnnotation } from "../src/lib/chat-ui";
 import { queryPersonalMam, queryPersonalMamPage } from "../src/lib/xmpp/dm-history";
-import { queryMam, queryMamPage, queryMamThreadPage } from "../src/lib/xmpp/history";
+import { queryMam, queryMamByThread, queryMamPage, queryMamThreadPage } from "../src/lib/xmpp/history";
 import { useDmMessaging } from "../src/composables/useDmMessaging";
 import { useMessaging } from "../src/composables/useMessaging";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
@@ -269,7 +269,7 @@ describe("MAM history parsing", () => {
     expect(page.complete).toBe(true);
   });
 
-  test("paged thread history uses the XEP-0313 thread form field and RSM before cursor", async () => {
+  test("paged thread history uses the Waddle MAM thread form field and RSM before cursor", async () => {
     const xmpp = makeMamPageAgent({ results: [], paging: { first: "thread-1" }, complete: false });
 
     await queryMamThreadPage(
@@ -284,7 +284,50 @@ describe("MAM history parsing", () => {
     expect((callArgs?.[1] as { paging?: unknown })?.paging).toEqual({ max: 20, before: "thread-1" });
     const fields =
       ((callArgs?.[1] as { form?: { fields?: { name: string; value?: string }[] } })?.form?.fields) ?? [];
-    expect(fields.find((field) => field.name === "{urn:xmpp:mam:2}thread")?.value).toBe("thread-42");
+    expect(fields.find((field) => field.name === "{urn:waddle:mam-thread:0}thread")?.value).toBe("thread-42");
+    expect(fields.find((field) => field.name === "{urn:xmpp:mam:2}thread")).toBeUndefined();
+  });
+
+  test("thread backfill assigns legacy reply without thread only for requested thread", async () => {
+    const xmpp = makeMamAgent([
+      {
+        id: "archive-reply-1",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+          message: {
+            id: "reply-1",
+            from: "room@muc.example.com/Waddle",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            body: "provider answer",
+            reply: { id: "thread-42" },
+          },
+        },
+      },
+    ]);
+
+    const threadResults = await queryMamByThread(xmpp, "room@muc.example.com", "thread-42", 20);
+    const roomResults = await queryMam(makeMamAgent([
+      {
+        id: "archive-reply-1",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+          message: {
+            id: "reply-1",
+            from: "room@muc.example.com/Waddle",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            body: "provider answer",
+            reply: { id: "thread-42" },
+          },
+        },
+      },
+    ]), "room@muc.example.com", 20);
+
+    expect(threadResults[0].replyTo?.id).toBe("thread-42");
+    expect(threadResults[0].threadId).toBe("thread-42");
+    expect(roomResults[0].replyTo?.id).toBe("thread-42");
+    expect(roomResults[0].threadId).toBeUndefined();
   });
 
   // Reconnect catch-up: an iPhone/Safari session that drops its websocket

--- a/server/crates/waddle-extensions/src/lib.rs
+++ b/server/crates/waddle-extensions/src/lib.rs
@@ -8,12 +8,14 @@ pub mod types;
 pub use config::{ExtensionConfig, ExtensionModuleConfig};
 pub use manager::{ExtensionManager, MessageExtensionOutcome};
 pub use types::{
-    message_has_framework_envelope, ArtifactReference, BotGroupchatResponse, CommandAction,
-    CommandDescriptor, CommandInvocation, CommandSessionId, DataForm, DataFormField, DataFormType,
-    DataFormValue, DetectedLink, DisplayText, ExtensionCapability, ExtensionEffect,
-    ExtensionEnvelope, ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse,
-    FormFieldOption, FormFieldType, FormFieldValue, FrameworkTypeError, FullJidValue,
-    LaunchContext, LaunchDescriptor, LaunchId, LaunchToken, MessageEnrichment, PayloadRoot,
-    PayloadRule, PayloadSurface, PluginId, PubSubPublish, ReplyTarget, RoomJid, StanzaId, ThreadId,
-    Timestamp, UiActionId, WaddleId, XmlAttribute, XmlElement, XmlNode, INVOKE_COMMAND_NODE,
+    message_has_framework_envelope, ArtifactReference, BotGroupchatResponse,
+    BotGroupchatResponsePurpose, CommandAction, CommandDescriptor, CommandInvocation,
+    CommandSessionId, DataForm, DataFormField, DataFormType, DataFormValue, DetectedLink,
+    DisplayText, ExtensionCapability, ExtensionEffect, ExtensionEnvelope, ExtensionEvent,
+    ExtensionManifest, ExtensionPayload, ExtensionResponse, FormFieldOption, FormFieldType,
+    FormFieldValue, FrameworkTypeError, FullJidValue, LaunchContext, LaunchDescriptor, LaunchId,
+    LaunchToken, MessageEnrichment, PayloadRoot, PayloadRule, PayloadSurface, PluginId,
+    PubSubPublish, ReplyTarget, RoomJid, StanzaId, ThreadId, Timestamp, UiActionId, WaddleId,
+    XmlAttribute, XmlElement, XmlNode, AI_CHATBOT_NAMESPACE, AI_CHATBOT_PLUGIN_ID,
+    INVOKE_COMMAND_NODE,
 };

--- a/server/crates/waddle-extensions/src/manager.rs
+++ b/server/crates/waddle-extensions/src/manager.rs
@@ -20,11 +20,12 @@ use crate::config::{ExtensionConfig, ExtensionModuleConfig};
 use crate::oci::OciExtensionPuller;
 use crate::runtime::{LoadedExtension, WasmRuntime};
 use crate::types::{
-    is_official_namespace, message_has_framework_envelope, CommandAction, CommandInvocation,
-    CommandNode, CommandSessionId, DetectedLink, DisplayText, ExtensionEffect, ExtensionEnvelope,
-    ExtensionEvent, FullJidValue, LaunchContext, LaunchId, LaunchInvocation, LinkTarget,
-    MessageContext, MessageHook, PayloadNamespace, PluginId, ReplyTarget, RoomJid, StanzaId,
-    ThreadId, WaddleId, FRAMEWORK_NAMESPACE,
+    is_official_namespace, message_has_framework_envelope, BotGroupchatResponsePurpose,
+    CommandAction, CommandInvocation, CommandNode, CommandSessionId, DetectedLink, DisplayText,
+    ExtensionEffect, ExtensionEnvelope, ExtensionEvent, ExtensionManifest, FullJidValue,
+    LaunchContext, LaunchId, LaunchInvocation, LinkTarget, MessageContext, MessageHook,
+    PayloadNamespace, PluginId, ReplyTarget, RoomJid, StanzaId, ThreadId, WaddleId,
+    AI_CHATBOT_NAMESPACE, AI_CHATBOT_PLUGIN_ID, FRAMEWORK_NAMESPACE,
 };
 
 const MAX_DETECTED_LINKS: usize = 3;
@@ -438,7 +439,9 @@ impl ExtensionManager {
                         ExtensionEffect::EnrichMessage(envelope) => {
                             enrichments.extend(envelope.enrichments);
                         }
-                        ExtensionEffect::BotGroupchatResponse(response) => {
+                        ExtensionEffect::BotGroupchatResponse(mut response) => {
+                            response.purpose =
+                                bot_groupchat_response_purpose_for_manifest(&manifest);
                             emitted_effects.push(ExtensionEffect::BotGroupchatResponse(response));
                         }
                         ExtensionEffect::PublishPubSub(_)
@@ -568,6 +571,21 @@ fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
         .zip(right)
         .fold(0u8, |diff, (left, right)| diff | (left ^ right))
         == 0
+}
+
+fn bot_groupchat_response_purpose_for_manifest(
+    manifest: &ExtensionManifest,
+) -> BotGroupchatResponsePurpose {
+    let is_ai_chatbot = manifest.id.as_str() == AI_CHATBOT_PLUGIN_ID
+        && manifest
+            .payloads
+            .iter()
+            .any(|rule| rule.root.namespace.as_str() == AI_CHATBOT_NAMESPACE);
+    if is_ai_chatbot {
+        BotGroupchatResponsePurpose::AiProviderFallback
+    } else {
+        BotGroupchatResponsePurpose::Message
+    }
 }
 
 fn validate_manifest_against_module(
@@ -806,10 +824,16 @@ mod tests {
     use xmpp_parsers::message::{Body, Message};
 
     use super::{
-        detect_links, effective_module_config_json, effective_module_config_with_reader,
-        EffectiveModuleConfigError, ExtensionManager, MAX_DETECTED_LINKS,
+        bot_groupchat_response_purpose_for_manifest, detect_links, effective_module_config_json,
+        effective_module_config_with_reader, EffectiveModuleConfigError, ExtensionManager,
+        MAX_DETECTED_LINKS,
     };
     use crate::config::{ExtensionConfig, ExtensionModuleConfig};
+    use crate::types::{
+        BotGroupchatResponsePurpose, DisplayText, ExtensionCapability, ExtensionManifest,
+        PayloadNamespace, PayloadRoot, PayloadRule, PayloadSurface, PluginId, PluginVersion,
+        AI_CHATBOT_NAMESPACE, AI_CHATBOT_PLUGIN_ID,
+    };
 
     #[test]
     fn detects_urls() {
@@ -1015,6 +1039,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn ai_provider_fallback_purpose_is_scoped_to_ai_chatbot_manifest() {
+        let ai_chatbot = bot_manifest(AI_CHATBOT_PLUGIN_ID, AI_CHATBOT_NAMESPACE);
+        assert_eq!(
+            bot_groupchat_response_purpose_for_manifest(&ai_chatbot),
+            BotGroupchatResponsePurpose::AiProviderFallback
+        );
+
+        let wrong_id = bot_manifest("other-chatbot", AI_CHATBOT_NAMESPACE);
+        assert_eq!(
+            bot_groupchat_response_purpose_for_manifest(&wrong_id),
+            BotGroupchatResponsePurpose::Message
+        );
+
+        let wrong_namespace = bot_manifest(AI_CHATBOT_PLUGIN_ID, "urn:waddle:other-chatbot:1");
+        assert_eq!(
+            bot_groupchat_response_purpose_for_manifest(&wrong_namespace),
+            BotGroupchatResponsePurpose::Message
+        );
+    }
+
     #[tokio::test]
     async fn enrich_message_does_not_fallback_without_loaded_actor() {
         let manager = ExtensionManager {
@@ -1031,6 +1076,29 @@ mod tests {
 
         assert_eq!(manager.enrich_message(&mut msg).await, 0);
         assert!(msg.payloads.is_empty());
+    }
+
+    fn bot_manifest(id: &str, namespace: &str) -> ExtensionManifest {
+        ExtensionManifest {
+            id: PluginId::new(id.to_string()).expect("plugin id"),
+            name: DisplayText::new("test bot").expect("name"),
+            version: PluginVersion::new("0.1.0").expect("version"),
+            payloads: vec![PayloadRule {
+                surface: PayloadSurface::MessageEnrichment,
+                root: PayloadRoot::new(
+                    PayloadNamespace::new(namespace.to_string()).expect("namespace"),
+                    "assistant-answer",
+                )
+                .expect("payload root"),
+            }],
+            capabilities: vec![
+                ExtensionCapability::MessageObserve,
+                ExtensionCapability::BotGroupchatSend,
+            ],
+            commands: Vec::new(),
+            pubsub_nodes: Vec::new(),
+            artifact: None,
+        }
     }
 
     struct TestArtifacts {

--- a/server/crates/waddle-extensions/src/runtime.rs
+++ b/server/crates/waddle-extensions/src/runtime.rs
@@ -7,17 +7,17 @@ use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{WasiCtx, WasiCtxBuilder, WasiCtxView, WasiView};
 
 use crate::types::{
-    ActionBlock, ActionId, ArtifactReference, BodyRange, BotGroupchatResponse, CommandAction,
-    CommandDescriptor, CommandInvocation, CommandNode, CommandSessionId, DataForm, DataFormField,
-    DataFormType, DataFormValue, DisplayText, EnrichmentId, ExtensionCapability, ExtensionEffect,
-    ExtensionEnvelope, ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse,
-    FormFieldOption, FormFieldType, FormFieldValue, FullJidValue, ImageBlock, LaunchContext,
-    LaunchDescriptor, LaunchId, LaunchInvocation, LinkTarget, ListId, ListItem, ListItemId,
-    ListView, MediaType, MessageContext, MessageEnrichment, MessageHook, MessageSource,
-    PayloadNamespace, PayloadRoot, PayloadRule, PayloadSurface, PluginId, PluginVersion,
-    PubSubItemId, PubSubNode, PubSubPublish, ReplyTarget, RoomJid, Sha256Digest, StanzaId,
-    TextBlock, TextStyle, ThreadId, Timestamp, UiActionId, UiBlock, UiView, UiViewId, Url,
-    WaddleId, XmlAttribute, XmlElement, XmlNode,
+    ActionBlock, ActionId, ArtifactReference, BodyRange, BotGroupchatResponse,
+    BotGroupchatResponsePurpose, CommandAction, CommandDescriptor, CommandInvocation, CommandNode,
+    CommandSessionId, DataForm, DataFormField, DataFormType, DataFormValue, DisplayText,
+    EnrichmentId, ExtensionCapability, ExtensionEffect, ExtensionEnvelope, ExtensionEvent,
+    ExtensionManifest, ExtensionPayload, ExtensionResponse, FormFieldOption, FormFieldType,
+    FormFieldValue, FullJidValue, ImageBlock, LaunchContext, LaunchDescriptor, LaunchId,
+    LaunchInvocation, LinkTarget, ListId, ListItem, ListItemId, ListView, MediaType,
+    MessageContext, MessageEnrichment, MessageHook, MessageSource, PayloadNamespace, PayloadRoot,
+    PayloadRule, PayloadSurface, PluginId, PluginVersion, PubSubItemId, PubSubNode, PubSubPublish,
+    ReplyTarget, RoomJid, Sha256Digest, StanzaId, TextBlock, TextStyle, ThreadId, Timestamp,
+    UiActionId, UiBlock, UiView, UiViewId, Url, WaddleId, XmlAttribute, XmlElement, XmlNode,
 };
 
 wasmtime::component::bindgen!({
@@ -609,6 +609,7 @@ impl TryFrom<wit_types::BotGroupchatResponse> for BotGroupchatResponse {
 
     fn try_from(value: wit_types::BotGroupchatResponse) -> Result<Self> {
         Ok(Self {
+            purpose: BotGroupchatResponsePurpose::Message,
             body: wit_newtype_to_domain!(value.body, DisplayText)?,
             room: wit_newtype_to_domain!(value.room, RoomJid)?,
             thread_id: value

--- a/server/crates/waddle-extensions/src/types.rs
+++ b/server/crates/waddle-extensions/src/types.rs
@@ -8,6 +8,8 @@ use xmpp_parsers::message::Message;
 
 pub const FRAMEWORK_NAMESPACE: &str = "urn:waddle:extension:1";
 pub const INVOKE_COMMAND_NODE: &str = "urn:waddle:extension:1:invoke";
+pub const AI_CHATBOT_PLUGIN_ID: &str = "ai-chatbot";
+pub const AI_CHATBOT_NAMESPACE: &str = "urn:waddle:ai-chatbot:1";
 
 const MAX_XML_DEPTH: usize = 16;
 const MAX_XML_ATTRIBUTES: usize = 64;
@@ -1317,8 +1319,17 @@ pub struct PubSubPublish {
     pub payload: ExtensionPayload,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum BotGroupchatResponsePurpose {
+    #[serde(rename = "message")]
+    Message,
+    #[serde(rename = "ai-provider-fallback")]
+    AiProviderFallback,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BotGroupchatResponse {
+    pub purpose: BotGroupchatResponsePurpose,
     pub body: DisplayText,
     pub room: RoomJid,
     pub thread_id: Option<ThreadId>,

--- a/server/crates/waddle-server/src/ai_provider.rs
+++ b/server/crates/waddle-server/src/ai_provider.rs
@@ -1,5 +1,13 @@
+use std::sync::OnceLock;
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+const AI_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const AI_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const AI_COMMAND: &str = "/ai";
+const WADDLE_MENTION: &str = "@waddle";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AiProviderKind {
@@ -22,6 +30,8 @@ pub enum AiProviderError {
     UnsupportedProvider(String),
     #[error("AI provider request failed: {0}")]
     Http(#[from] reqwest::Error),
+    #[error("AI provider HTTP client initialization failed: {0}")]
+    HttpClient(String),
     #[error("AI provider returned no answer")]
     EmptyResponse,
 }
@@ -78,7 +88,7 @@ struct OpenAiResponseMessage {
 
 pub async fn generate_ai_response(prompt: &str) -> Result<String, AiProviderError> {
     let config = AiProviderConfig::from_env()?;
-    generate_ai_response_with_config(&reqwest::Client::new(), &config, prompt).await
+    generate_ai_response_with_config(ai_http_client()?, &config, prompt).await
 }
 
 pub fn is_ai_provider_configured() -> bool {
@@ -93,6 +103,20 @@ pub async fn generate_ai_response_with_config(
     match config.kind {
         AiProviderKind::OpenAi => generate_openai_response(client, config, prompt).await,
     }
+}
+
+fn ai_http_client() -> Result<&'static reqwest::Client, AiProviderError> {
+    static CLIENT: OnceLock<Result<reqwest::Client, String>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .connect_timeout(AI_HTTP_CONNECT_TIMEOUT)
+                .timeout(AI_HTTP_REQUEST_TIMEOUT)
+                .build()
+                .map_err(|error| error.to_string())
+        })
+        .as_ref()
+        .map_err(|error| AiProviderError::HttpClient(error.clone()))
 }
 
 async fn generate_openai_response(
@@ -140,36 +164,76 @@ async fn generate_openai_response(
 
 pub fn clean_ai_prompt(body: &str) -> String {
     let trimmed = body.trim();
-    let without_command = if trimmed.len() >= 3 && trimmed[..3].eq_ignore_ascii_case("/ai") {
-        &trimmed[3..]
-    } else {
-        trimmed
-    };
-    without_command
-        .replace("@waddle", "")
-        .replace("@Waddle", "")
-        .trim()
-        .to_string()
+    let without_command = strip_ai_command(trimmed).unwrap_or(trimmed);
+    remove_waddle_mentions(without_command).trim().to_string()
 }
 
 pub fn is_ai_prompt_body(body: &str) -> bool {
     let trimmed = body.trim_start();
-    let slash = trimmed.len() >= 3
-        && trimmed[..3].eq_ignore_ascii_case("/ai")
-        && trimmed
-            .as_bytes()
-            .get(3)
-            .is_none_or(|ch| matches!(ch, b' ' | b'\t' | b'\r' | b'\n'));
-    slash || body.to_ascii_lowercase().contains("@waddle")
+    strip_ai_command(trimmed).is_some() || contains_waddle_mention(body)
+}
+
+fn strip_ai_command(trimmed: &str) -> Option<&str> {
+    (has_ai_command_prefix(trimmed)
+        && is_command_boundary(trimmed.as_bytes().get(AI_COMMAND.len())))
+    .then(|| trimmed.get(AI_COMMAND.len()..).unwrap_or(""))
+}
+
+fn has_ai_command_prefix(trimmed: &str) -> bool {
+    trimmed
+        .get(..AI_COMMAND.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(AI_COMMAND))
+}
+
+fn remove_waddle_mentions(value: &str) -> String {
+    let mut cleaned = String::with_capacity(value.len());
+    let mut cursor = 0;
+    while cursor < value.len() {
+        let remaining = &value[cursor..];
+        if remaining
+            .get(..WADDLE_MENTION.len())
+            .is_some_and(|mention| mention.eq_ignore_ascii_case(WADDLE_MENTION))
+            && is_word_boundary(remaining.as_bytes().get(WADDLE_MENTION.len()))
+        {
+            cursor += WADDLE_MENTION.len();
+        } else {
+            let Some(ch) = remaining.chars().next() else {
+                break;
+            };
+            cleaned.push(ch);
+            cursor += ch.len_utf8();
+        }
+    }
+    cleaned
+}
+
+fn contains_waddle_mention(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower
+        .match_indices(WADDLE_MENTION)
+        .any(|(start, mention)| is_word_boundary(lower.as_bytes().get(start + mention.len())))
+}
+
+fn is_word_boundary(next: Option<&u8>) -> bool {
+    !matches!(next, Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'))
+}
+
+fn is_command_boundary(next: Option<&u8>) -> bool {
+    matches!(next, None | Some(b' ' | b'\t' | b'\r' | b'\n'))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        generate_ai_response_with_config, AiProviderConfig, AiProviderError, AiProviderKind,
+        clean_ai_prompt, generate_ai_response_with_config, is_ai_prompt_body, AiProviderConfig,
+        AiProviderError, AiProviderKind,
     };
     use wiremock::matchers::{body_string_contains, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    mod shared_ai_prompt_cases {
+        include!("../../../test-fixtures/ai_prompt_cases.rs");
+    }
 
     #[tokio::test]
     async fn mocked_openai_response_becomes_answer() {
@@ -226,7 +290,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn empty_provider_response_is_unavailable_error() {
+    async fn empty_provider_response_is_empty_response_error() {
         let server = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/chat/completions"))
@@ -250,5 +314,40 @@ mod tests {
         .expect_err("empty response");
 
         assert!(matches!(err, AiProviderError::EmptyResponse));
+    }
+
+    #[test]
+    fn ai_prompt_helpers_do_not_panic_on_multibyte_prefixes() {
+        assert!(!is_ai_prompt_body("☃ /ai later"));
+        assert_eq!(clean_ai_prompt("☃ /ai later"), "☃ /ai later");
+    }
+
+    #[test]
+    fn clean_ai_prompt_strips_command_and_mentions_case_insensitively() {
+        assert_eq!(
+            clean_ai_prompt("  /AI @WADDLE explain this  "),
+            "explain this"
+        );
+        assert_eq!(clean_ai_prompt("@wAdDlE continue"), "continue");
+        assert_eq!(
+            clean_ai_prompt("@waddle_bot continue"),
+            "@waddle_bot continue"
+        );
+        assert_eq!(
+            clean_ai_prompt("@waddleBot continue"),
+            "@waddleBot continue"
+        );
+        assert_eq!(clean_ai_prompt("/airship @WADDLE"), "/airship");
+        assert!(is_ai_prompt_body("@WADDLE continue"));
+        assert!(!is_ai_prompt_body("@waddle_bot continue"));
+        assert!(!is_ai_prompt_body("@waddleBot continue"));
+    }
+
+    #[test]
+    fn shared_ai_prompt_cases_match_host_parser() {
+        for &(body, is_prompt, cleaned) in shared_ai_prompt_cases::AI_PROMPT_CASES {
+            assert_eq!(is_ai_prompt_body(body), is_prompt, "{body}");
+            assert_eq!(clean_ai_prompt(body), cleaned, "{body}");
+        }
     }
 }

--- a/server/crates/waddle-server/src/ai_provider.rs
+++ b/server/crates/waddle-server/src/ai_provider.rs
@@ -1,0 +1,254 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AiProviderKind {
+    OpenAi,
+}
+
+#[derive(Debug, Clone)]
+pub struct AiProviderConfig {
+    pub kind: AiProviderKind,
+    pub api_key: String,
+    pub model: String,
+    pub base_url: String,
+}
+
+#[derive(Debug, Error)]
+pub enum AiProviderError {
+    #[error("AI provider unavailable: set WADDLE_AI_PROVIDER=openai, OPENAI_API_KEY, and WADDLE_AI_MODEL")]
+    Unavailable,
+    #[error("unsupported AI provider {0:?}")]
+    UnsupportedProvider(String),
+    #[error("AI provider request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("AI provider returned no answer")]
+    EmptyResponse,
+}
+
+impl AiProviderConfig {
+    pub fn from_env() -> Result<Self, AiProviderError> {
+        let provider =
+            std::env::var("WADDLE_AI_PROVIDER").map_err(|_| AiProviderError::Unavailable)?;
+        let kind = match provider.as_str() {
+            "openai" => AiProviderKind::OpenAi,
+            other => return Err(AiProviderError::UnsupportedProvider(other.to_string())),
+        };
+        let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| AiProviderError::Unavailable)?;
+        let model = std::env::var("WADDLE_AI_MODEL").map_err(|_| AiProviderError::Unavailable)?;
+        if api_key.trim().is_empty() || model.trim().is_empty() {
+            return Err(AiProviderError::Unavailable);
+        }
+        Ok(Self {
+            kind,
+            api_key,
+            model,
+            base_url: std::env::var("WADDLE_OPENAI_BASE_URL")
+                .unwrap_or_else(|_| "https://api.openai.com".to_string()),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<OpenAiMessage<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct OpenAiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChatResponse {
+    choices: Vec<OpenAiChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiResponseMessage {
+    content: String,
+}
+
+pub async fn generate_ai_response(prompt: &str) -> Result<String, AiProviderError> {
+    let config = AiProviderConfig::from_env()?;
+    generate_ai_response_with_config(&reqwest::Client::new(), &config, prompt).await
+}
+
+pub fn is_ai_provider_configured() -> bool {
+    AiProviderConfig::from_env().is_ok()
+}
+
+pub async fn generate_ai_response_with_config(
+    client: &reqwest::Client,
+    config: &AiProviderConfig,
+    prompt: &str,
+) -> Result<String, AiProviderError> {
+    match config.kind {
+        AiProviderKind::OpenAi => generate_openai_response(client, config, prompt).await,
+    }
+}
+
+async fn generate_openai_response(
+    client: &reqwest::Client,
+    config: &AiProviderConfig,
+    prompt: &str,
+) -> Result<String, AiProviderError> {
+    let url = format!(
+        "{}/v1/chat/completions",
+        config.base_url.trim_end_matches('/')
+    );
+    let request = OpenAiChatRequest {
+        model: config.model.as_str(),
+        messages: vec![
+            OpenAiMessage {
+                role: "system",
+                content: "You are Waddle's XMPP-native room assistant. Answer concisely.",
+            },
+            OpenAiMessage {
+                role: "user",
+                content: prompt,
+            },
+        ],
+    };
+
+    let response = client
+        .post(url)
+        .bearer_auth(config.api_key.as_str())
+        .json(&request)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<OpenAiChatResponse>()
+        .await?;
+
+    response
+        .choices
+        .into_iter()
+        .find_map(|choice| {
+            let content = choice.message.content.trim().to_string();
+            (!content.is_empty()).then_some(content)
+        })
+        .ok_or(AiProviderError::EmptyResponse)
+}
+
+pub fn clean_ai_prompt(body: &str) -> String {
+    let trimmed = body.trim();
+    let without_command = if trimmed.len() >= 3 && trimmed[..3].eq_ignore_ascii_case("/ai") {
+        &trimmed[3..]
+    } else {
+        trimmed
+    };
+    without_command
+        .replace("@waddle", "")
+        .replace("@Waddle", "")
+        .trim()
+        .to_string()
+}
+
+pub fn is_ai_prompt_body(body: &str) -> bool {
+    let trimmed = body.trim_start();
+    let slash = trimmed.len() >= 3
+        && trimmed[..3].eq_ignore_ascii_case("/ai")
+        && trimmed
+            .as_bytes()
+            .get(3)
+            .is_none_or(|ch| matches!(ch, b' ' | b'\t' | b'\r' | b'\n'));
+    slash || body.to_ascii_lowercase().contains("@waddle")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        generate_ai_response_with_config, AiProviderConfig, AiProviderError, AiProviderKind,
+    };
+    use wiremock::matchers::{body_string_contains, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn mocked_openai_response_becomes_answer() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header("authorization", "Bearer test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "Rawkode is David Flanagan." } }]
+            })))
+            .mount(&server)
+            .await;
+
+        let answer = generate_ai_response_with_config(
+            &reqwest::Client::new(),
+            &AiProviderConfig {
+                kind: AiProviderKind::OpenAi,
+                api_key: "test-key".to_string(),
+                model: "gpt-test".to_string(),
+                base_url: server.uri(),
+            },
+            "/ai Who is Rawkode?",
+        )
+        .await
+        .expect("mocked response");
+
+        assert_eq!(answer, "Rawkode is David Flanagan.");
+    }
+
+    #[tokio::test]
+    async fn prompt_is_sent_to_provider() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(body_string_contains("/ai Who is Rawkode?"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .mount(&server)
+            .await;
+
+        generate_ai_response_with_config(
+            &reqwest::Client::new(),
+            &AiProviderConfig {
+                kind: AiProviderKind::OpenAi,
+                api_key: "test-key".to_string(),
+                model: "gpt-test".to_string(),
+                base_url: server.uri(),
+            },
+            "/ai Who is Rawkode?",
+        )
+        .await
+        .expect("provider response");
+    }
+
+    #[tokio::test]
+    async fn empty_provider_response_is_unavailable_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": []
+            })))
+            .mount(&server)
+            .await;
+
+        let err = generate_ai_response_with_config(
+            &reqwest::Client::new(),
+            &AiProviderConfig {
+                kind: AiProviderKind::OpenAi,
+                api_key: "test-key".to_string(),
+                model: "gpt-test".to_string(),
+                base_url: server.uri(),
+            },
+            "/ai no fake answers",
+        )
+        .await
+        .expect_err("empty response");
+
+        assert!(matches!(err, AiProviderError::EmptyResponse));
+    }
+}

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 
+pub mod ai_provider;
 pub mod auth;
 pub mod config;
 pub mod db;

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -66,6 +66,7 @@
 //!   `ValidateOAuthBearer`, `SetTimer`, `CancelTimer`,
 //!   `RegisterConnection` — wired in later migration steps.
 
+use crate::ai_provider::{generate_ai_response, is_ai_prompt_body};
 use crate::auth::Session;
 use crate::permissions::{CheckPermission, Object, ObjectType, Permission, Subject};
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
@@ -75,9 +76,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use waddle_extensions::{
-    message_has_framework_envelope, BotGroupchatResponse, ExtensionEffect, ExtensionManager,
-    FullJidValue, ReplyTarget as ExtensionReplyTarget, StanzaId as ExtensionStanzaId,
-    ThreadId as ExtensionThreadId, WaddleId,
+    message_has_framework_envelope, BotGroupchatResponse, DisplayText, ExtensionEffect,
+    ExtensionManager, FullJidValue, ReplyTarget as ExtensionReplyTarget,
+    StanzaId as ExtensionStanzaId, ThreadId as ExtensionThreadId, WaddleId,
 };
 use waddle_xmpp::carbons::{build_received_carbon, build_sent_carbon};
 use waddle_xmpp::inbox::runtime::{direct_message_entry, groupchat_entry, groupchat_thread_entry};
@@ -1605,6 +1606,7 @@ async fn dispatch_to_room(
     }
     outcome.feedback.extend(nested.feedback);
 
+    let source_prompt_body = prototype_body(&working);
     let canonical_source_reply = canonical_reply_target_for_room_message(&working, &room_jid);
     let canonical_source_thread_id = message_thread_id(&working)
         .or(source_thread_id_before_dispatch)
@@ -1616,7 +1618,7 @@ async fn dispatch_to_room(
 
     for effect in extension_outcome.effects {
         if let ExtensionEffect::BotGroupchatResponse(response) = effect {
-            let Some(response) = canonicalize_bot_response_target(
+            let Some(mut response) = canonicalize_bot_response_target(
                 response,
                 canonical_source_thread_id.as_deref(),
                 canonical_source_reply.clone(),
@@ -1627,6 +1629,32 @@ async fn dispatch_to_room(
                 );
                 continue;
             };
+            if let Some(prompt) = source_prompt_body
+                .as_deref()
+                .filter(|body| is_ai_prompt_body(body) && is_ai_provider_fallback(&response))
+            {
+                match generate_ai_response(prompt).await {
+                    Ok(answer) => match DisplayText::new(answer) {
+                        Ok(answer) => {
+                            response.body = answer;
+                        }
+                        Err(error) => {
+                            warn!(
+                                room = %room_jid,
+                                %error,
+                                "AI provider returned an invalid display body; keeping fallback response"
+                            );
+                        }
+                    },
+                    Err(error) => {
+                        warn!(
+                            room = %room_jid,
+                            %error,
+                            "AI provider unavailable; keeping explicit fallback response"
+                        );
+                    }
+                }
+            }
             let nested = Box::pin(dispatch_bot_groupchat_response(
                 deps,
                 BotGroupchatDispatch {
@@ -1646,6 +1674,13 @@ async fn dispatch_to_room(
         }
     }
     outcome
+}
+
+fn is_ai_provider_fallback(response: &BotGroupchatResponse) -> bool {
+    response
+        .body
+        .as_str()
+        .starts_with("AI provider unavailable. Configure WADDLE_AI_PROVIDER=openai")
 }
 
 struct BotGroupchatDispatch<'a> {

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -76,8 +76,8 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use waddle_extensions::{
-    message_has_framework_envelope, BotGroupchatResponse, DisplayText, ExtensionEffect,
-    ExtensionManager, FullJidValue, ReplyTarget as ExtensionReplyTarget,
+    message_has_framework_envelope, BotGroupchatResponse, BotGroupchatResponsePurpose, DisplayText,
+    ExtensionEffect, ExtensionManager, FullJidValue, ReplyTarget as ExtensionReplyTarget,
     StanzaId as ExtensionStanzaId, ThreadId as ExtensionThreadId, WaddleId,
 };
 use waddle_xmpp::carbons::{build_received_carbon, build_sent_carbon};
@@ -1637,6 +1637,7 @@ async fn dispatch_to_room(
                     Ok(answer) => match DisplayText::new(answer) {
                         Ok(answer) => {
                             response.body = answer;
+                            response.purpose = BotGroupchatResponsePurpose::Message;
                         }
                         Err(error) => {
                             warn!(
@@ -1650,7 +1651,7 @@ async fn dispatch_to_room(
                         warn!(
                             room = %room_jid,
                             %error,
-                            "AI provider unavailable; keeping explicit fallback response"
+                            "AI provider request failed; keeping explicit fallback response"
                         );
                     }
                 }
@@ -1677,10 +1678,7 @@ async fn dispatch_to_room(
 }
 
 fn is_ai_provider_fallback(response: &BotGroupchatResponse) -> bool {
-    response
-        .body
-        .as_str()
-        .starts_with("AI provider unavailable. Configure WADDLE_AI_PROVIDER=openai")
+    response.purpose == BotGroupchatResponsePurpose::AiProviderFallback
 }
 
 struct BotGroupchatDispatch<'a> {
@@ -4121,8 +4119,8 @@ mod tests {
     #[tokio::test]
     async fn bot_groupchat_response_dispatches_threaded_muc_message() {
         use waddle_extensions::{
-            BotGroupchatResponse, DisplayText, FullJidValue, ReplyTarget, RoomJid, StanzaId,
-            ThreadId,
+            BotGroupchatResponse, BotGroupchatResponsePurpose, DisplayText, FullJidValue,
+            ReplyTarget, RoomJid, StanzaId, ThreadId,
         };
 
         let registry = ConnectionRegistry::new();
@@ -4149,6 +4147,7 @@ mod tests {
             },
         ];
         let response = BotGroupchatResponse {
+            purpose: BotGroupchatResponsePurpose::Message,
             body: DisplayText::new("AI answer").expect("body"),
             room: RoomJid::new(room_jid.to_string()).expect("room"),
             thread_id: Some(ThreadId::new("root-msg").expect("thread")),
@@ -4209,6 +4208,32 @@ mod tests {
     }
 
     #[test]
+    fn ai_provider_fallback_detection_uses_typed_purpose() {
+        use waddle_extensions::{
+            BotGroupchatResponse, BotGroupchatResponsePurpose, DisplayText, RoomJid,
+        };
+
+        let response = BotGroupchatResponse {
+            purpose: BotGroupchatResponsePurpose::Message,
+            body: DisplayText::new("AI provider unavailable. Configure WADDLE_AI_PROVIDER=openai")
+                .expect("body"),
+            room: RoomJid::new("chat@muc.example.com").expect("room"),
+            thread_id: None,
+            reply_to: None,
+        };
+        assert!(!is_ai_provider_fallback(&response));
+
+        let fallback = BotGroupchatResponse {
+            purpose: BotGroupchatResponsePurpose::AiProviderFallback,
+            body: DisplayText::new("fallback copy can change").expect("body"),
+            room: RoomJid::new("chat@muc.example.com").expect("room"),
+            thread_id: None,
+            reply_to: None,
+        };
+        assert!(is_ai_provider_fallback(&fallback));
+    }
+
+    #[test]
     fn message_thread_id_reads_existing_forum_reply_without_rfc_thread() {
         let xml = r#"<message xmlns='jabber:client' id='child'>
             <thread-reply xmlns='urn:waddle:forums:0' thread-id='root-msg'/>
@@ -4243,10 +4268,12 @@ mod tests {
     #[test]
     fn bot_response_target_uses_canonical_reply_id_as_thread_for_plain_roots() {
         use waddle_extensions::{
-            BotGroupchatResponse, DisplayText, FullJidValue, RoomJid, StanzaId, ThreadId,
+            BotGroupchatResponse, BotGroupchatResponsePurpose, DisplayText, FullJidValue, RoomJid,
+            StanzaId, ThreadId,
         };
 
         let response = BotGroupchatResponse {
+            purpose: BotGroupchatResponsePurpose::Message,
             body: DisplayText::new("AI answer").expect("body"),
             room: RoomJid::new("chat@muc.example.com").expect("room"),
             thread_id: Some(ThreadId::new("client-origin-id").expect("thread")),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -4,6 +4,7 @@ use jid::{BareJid, FullJid, Jid};
 use std::sync::Arc;
 use tracing::{debug, warn};
 use url::{Host, Url};
+use waddle_extensions::AI_CHATBOT_NAMESPACE;
 use waddle_xmpp::{
     carbons::CARBONS_NS,
     commands::{CommandContext, CommandResult},
@@ -91,8 +92,6 @@ use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::xmpp_state::{get_xmpp_channel, list_xmpp_channels, XmppChannelRecord};
 use crate::vcard::VCardStore;
 
-const AI_CHATBOT_FEATURE: &str = "urn:waddle:ai-chatbot:1";
-
 fn extension_features_for_disco(state: &WebSocketState) -> Vec<Feature> {
     let ai_provider_configured = is_ai_provider_configured();
     state
@@ -101,7 +100,7 @@ fn extension_features_for_disco(state: &WebSocketState) -> Vec<Feature> {
         .extension_manager
         .extension_features()
         .into_iter()
-        .filter(|ns| ai_provider_configured || ns != AI_CHATBOT_FEATURE)
+        .filter(|ns| ai_provider_configured || ns != AI_CHATBOT_NAMESPACE)
         .map(|ns| Feature::new(&ns))
         .collect()
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1,3 +1,4 @@
+use crate::ai_provider::is_ai_provider_configured;
 use chrono;
 use jid::{BareJid, FullJid, Jid};
 use std::sync::Arc;
@@ -15,9 +16,10 @@ use waddle_xmpp::{
     inbox::runtime::filter_query,
     isr::{build_isr_token_error, build_isr_token_result, is_isr_token_request, IsrToken, ISR_NS},
     mam::{
-        add_stanza_id as add_mam_stanza_id, build_fin_iq, build_result_messages, is_mam_query,
-        parse_mam_query, ArchivedMessage, ArchivedModeration, ArchivedRichMessage,
-        ArchivedRichPayload, RichMessageId, RichText,
+        add_stanza_id as add_mam_stanza_id, build_fin_iq, build_query_form_iq,
+        build_result_messages, is_mam_query, is_mam_query_form_request, parse_mam_query,
+        ArchivedMessage, ArchivedModeration, ArchivedRichMessage, ArchivedRichPayload,
+        RichMessageId, RichText,
     },
     muc::{
         admin::{
@@ -88,6 +90,21 @@ use crate::permissions::{
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
 use crate::server::xmpp_state::{get_xmpp_channel, list_xmpp_channels, XmppChannelRecord};
 use crate::vcard::VCardStore;
+
+const AI_CHATBOT_FEATURE: &str = "urn:waddle:ai-chatbot:1";
+
+fn extension_features_for_disco(state: &WebSocketState) -> Vec<Feature> {
+    let ai_provider_configured = is_ai_provider_configured();
+    state
+        .deps
+        .protocol
+        .extension_manager
+        .extension_features()
+        .into_iter()
+        .filter(|ns| ai_provider_configured || ns != AI_CHATBOT_FEATURE)
+        .map(|ns| Feature::new(&ns))
+        .collect()
+}
 
 /// Only called from test helpers.
 #[cfg(test)]
@@ -402,15 +419,7 @@ pub async fn handle_iq_with_conn_state(
                 Feature::muc_self_ping_optimization(),
                 Feature::new(NS_CHANNEL_SEARCH),
             ];
-            features.extend(
-                state
-                    .deps
-                    .protocol
-                    .extension_manager
-                    .extension_features()
-                    .into_iter()
-                    .map(|ns| Feature::new(&ns)),
-            );
+            features.extend(extension_features_for_disco(state));
             let response = build_disco_info_response(request_iq, &identities, &features, None);
             return vec![iq_to_xml(response)];
         }
@@ -444,15 +453,7 @@ pub async fn handle_iq_with_conn_state(
                         snapshot.config.moderated,
                         snapshot.config.forum,
                     );
-                    features.extend(
-                        state
-                            .deps
-                            .protocol
-                            .extension_manager
-                            .extension_features()
-                            .into_iter()
-                            .map(|ns| Feature::new(&ns)),
-                    );
+                    features.extend(extension_features_for_disco(state));
                     let extensions = room_space_metadata_extensions(state, &room_jid, domain).await;
                     if !extensions.is_empty() {
                         features.push(Feature::spaces());
@@ -481,15 +482,7 @@ pub async fn handle_iq_with_conn_state(
                             channel.channel_type == "announcement",
                             channel.channel_type == "forum",
                         );
-                        features.extend(
-                            state
-                                .deps
-                                .protocol
-                                .extension_manager
-                                .extension_features()
-                                .into_iter()
-                                .map(|ns| Feature::new(&ns)),
-                        );
+                        features.extend(extension_features_for_disco(state));
                         let extensions =
                             room_space_metadata_extensions(state, &room_jid, domain).await;
                         if !extensions.is_empty() {
@@ -515,15 +508,7 @@ pub async fn handle_iq_with_conn_state(
                         .unwrap_or_else(|| "Room".to_string());
                     let identities = vec![Identity::muc_room(Some(&room_name))];
                     let mut features = muc_room_features(false, false, false, false);
-                    features.extend(
-                        state
-                            .deps
-                            .protocol
-                            .extension_manager
-                            .extension_features()
-                            .into_iter()
-                            .map(|ns| Feature::new(&ns)),
-                    );
+                    features.extend(extension_features_for_disco(state));
                     let response =
                         build_disco_info_response(request_iq, &identities, &features, None);
                     return vec![iq_to_xml(response)];
@@ -615,15 +600,7 @@ pub async fn handle_iq_with_conn_state(
             Feature::new("jabber:iq:search"),
             Feature::new(ISR_NS),
         ]);
-        features.extend(
-            state
-                .deps
-                .protocol
-                .extension_manager
-                .extension_features()
-                .into_iter()
-                .map(|ns| Feature::new(&ns)),
-        );
+        features.extend(extension_features_for_disco(state));
         let response =
             match server_affiliation_for_requester(state, authenticated_session.as_ref()).await {
                 Some(role) => build_disco_info_response_with_extensions(
@@ -1129,10 +1106,17 @@ pub async fn handle_iq_with_conn_state(
             return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
         }
 
+        if is_mam_query_form_request(request_iq) {
+            return vec![iq_to_xml(build_query_form_iq(request_iq))];
+        }
+
         let (query_id, query) = match parse_mam_query(request_iq) {
             Ok(parsed) => parsed,
             Err(err) => {
                 warn!(error = %err, target = %target_bare, "Invalid MAM query");
+                if matches!(err, waddle_xmpp::CoreError::NotImplemented) {
+                    return vec![build_iq_error_xml(&id, "cancel", "feature-not-implemented")];
+                }
                 return vec![build_iq_error_xml(&id, "modify", "bad-request")];
             }
         };
@@ -1152,13 +1136,15 @@ pub async fn handle_iq_with_conn_state(
             }
         };
 
-        result.count = state
-            .deps
-            .protocol
-            .mam_storage
-            .count_messages(archive_jid.as_str())
-            .await
-            .ok();
+        if result.count.is_none() {
+            result.count = state
+                .deps
+                .protocol
+                .mam_storage
+                .count_messages(archive_jid.as_str())
+                .await
+                .ok();
+        }
 
         let recipient_jid = request_iq
             .from

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -4,7 +4,7 @@ use minidom::Element;
 use tracing::debug;
 use xmpp_parsers::iq::Iq;
 
-use crate::CoreError;
+use crate::{mam::WADDLE_MAM_THREAD_NS, CoreError};
 
 const DATA_FORMS_NS: &str = "jabber:x:data";
 const SERVER_INFO_FORM_TYPE: &str = "urn:xmpp:serverinfo:0";
@@ -94,6 +94,10 @@ impl Feature {
 
     pub fn mam() -> Self {
         Self::new("urn:xmpp:mam:2")
+    }
+
+    pub fn waddle_mam_thread() -> Self {
+        Self::new(WADDLE_MAM_THREAD_NS)
     }
 
     pub fn replies() -> Self {
@@ -465,6 +469,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::caps(),
         Feature::roster_versioning(),
         Feature::mam(),
+        Feature::waddle_mam_thread(),
         Feature::stanza_ids(),
         Feature::replies(),
         Feature::message_correction(),
@@ -564,6 +569,7 @@ pub fn muc_room_features(
         Feature::disco_info(),
         Feature::muc(),
         Feature::mam(),
+        Feature::waddle_mam_thread(),
         Feature::stanza_ids(),
         Feature::replies(),
         Feature::message_correction(),

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -16,6 +16,14 @@ use crate::{CoreError, CoreResult};
 /// MAM XML namespace (XEP-0313 v2).
 pub const MAM_NS: &str = "urn:xmpp:mam:2";
 
+/// Waddle MAM thread filter namespace.
+///
+/// XEP-0313 permits extension data form fields, but `{urn:xmpp:mam:2}thread`
+/// is not a standard MAM field. Keep Waddle-specific filtering in a Waddle
+/// namespace so official MAM semantics stay conformant.
+pub const WADDLE_MAM_THREAD_NS: &str = "urn:waddle:mam-thread:0";
+pub const WADDLE_MAM_THREAD_FIELD: &str = "{urn:waddle:mam-thread:0}thread";
+
 /// Result Set Management namespace (XEP-0059).
 pub const RSM_NS: &str = "http://jabber.org/protocol/rsm";
 
@@ -161,6 +169,20 @@ pub struct ArchivedRichMessage {
     pub mentions: Vec<ArchivedMention>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ThreadId(String);
+
+impl ThreadId {
+    pub fn new(value: impl Into<String>) -> Option<Self> {
+        let value = value.into();
+        (!value.trim().is_empty()).then_some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 /// Archived message metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArchivedMessage {
@@ -234,6 +256,10 @@ pub struct MamQuery {
     pub end: Option<DateTime<Utc>>,
     /// Filter by sender.
     pub with: Option<String>,
+    /// Filter by Waddle thread root id.
+    pub thread_id: Option<ThreadId>,
+    /// XEP-0431 full-text search terms.
+    pub fulltext: Option<RichText>,
     /// Maximum results to return.
     pub max: Option<u32>,
     /// Pagination: before this ID.
@@ -260,9 +286,7 @@ pub struct MamResult {
 /// Parse a MAM query from an IQ stanza.
 pub fn parse_mam_query(iq: &Iq) -> CoreResult<(String, MamQuery)> {
     let query_elem = match &iq.payload {
-        IqType::Set(elem) | IqType::Get(elem) if elem.name() == "query" && elem.ns() == MAM_NS => {
-            elem
-        }
+        IqType::Set(elem) if elem.name() == "query" && elem.ns() == MAM_NS => elem,
         IqType::Set(_) | IqType::Get(_) => {
             return Err(CoreError::bad_request(Some(
                 "Missing MAM query element".to_string(),
@@ -295,6 +319,14 @@ pub fn parse_mam_query(iq: &Iq) -> CoreResult<(String, MamQuery)> {
     Ok((query_id, mam_query))
 }
 
+/// Check if an IQ asks for the XEP-0313 supported query fields form.
+pub fn is_mam_query_form_request(iq: &Iq) -> bool {
+    matches!(
+        &iq.payload,
+        IqType::Get(elem) if elem.name() == "query" && elem.ns() == MAM_NS
+    )
+}
+
 /// Check if an IQ is a MAM query.
 pub fn is_mam_query(iq: &Iq) -> bool {
     matches!(
@@ -302,6 +334,61 @@ pub fn is_mam_query(iq: &Iq) -> bool {
         IqType::Set(elem) | IqType::Get(elem)
             if elem.name() == "query" && elem.ns() == MAM_NS
     )
+}
+
+/// Build the XEP-0313 supported query fields response.
+pub fn build_query_form_iq(original_iq: &Iq) -> Iq {
+    let form = Element::builder("x", DATA_FORMS_NS)
+        .attr("type", "form")
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "FORM_TYPE")
+                .attr("type", "hidden")
+                .append(
+                    Element::builder("value", DATA_FORMS_NS)
+                        .append(MAM_NS)
+                        .build(),
+                )
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "with")
+                .attr("type", "jid-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "start")
+                .attr("type", "text-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "end")
+                .attr("type", "text-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", WADDLE_MAM_THREAD_FIELD)
+                .attr("type", "text-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "fulltext")
+                .attr("type", "text-single")
+                .build(),
+        )
+        .build();
+    let query = Element::builder("query", MAM_NS).append(form).build();
+    Iq {
+        from: original_iq.to.clone(),
+        to: original_iq.from.clone(),
+        id: original_iq.id.clone(),
+        payload: IqType::Result(Some(query)),
+    }
 }
 
 /// Build MAM result messages for each archived message.
@@ -353,6 +440,7 @@ fn parse_data_form(form: &Element, query: &mut MamQuery) -> CoreResult<()> {
             .map(|value| value.text());
 
         match var {
+            "" | "FORM_TYPE" => {}
             "start" => {
                 if let Some(value) = value.filter(|value| !value.is_empty()) {
                     query.start = Some(parse_datetime(&value)?);
@@ -366,7 +454,15 @@ fn parse_data_form(form: &Element, query: &mut MamQuery) -> CoreResult<()> {
             "with" => {
                 query.with = value.filter(|value| !value.is_empty());
             }
-            _ => {}
+            WADDLE_MAM_THREAD_FIELD => {
+                query.thread_id = value.and_then(ThreadId::new);
+            }
+            "fulltext" => {
+                query.fulltext = value.and_then(RichText::new);
+            }
+            _ => {
+                return Err(CoreError::NotImplemented);
+            }
         }
     }
 
@@ -765,6 +861,16 @@ mod tests {
                                     )
                                     .build(),
                             )
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "fulltext")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("release notes")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
                             .build(),
                     )
                     .append(
@@ -783,10 +889,118 @@ mod tests {
         assert_eq!(query.max, Some(10));
         assert_eq!(query.after_id.as_deref(), Some("msg-9"));
         assert_eq!(query.with.as_deref(), Some("juliet@example.com"));
+        assert_eq!(
+            query.fulltext.as_ref().map(RichText::as_str),
+            Some("release notes")
+        );
         let start = query.start.expect("start filter");
         assert_eq!(start.year(), 2024);
         assert_eq!(start.month(), 1);
         assert_eq!(start.day(), 15);
+    }
+
+    #[test]
+    fn parses_waddle_mam_thread_field() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "mam-thread".to_string(),
+            payload: IqType::Set(
+                Element::builder("query", MAM_NS)
+                    .append(
+                        Element::builder("x", DATA_FORMS_NS)
+                            .attr("type", "submit")
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", WADDLE_MAM_THREAD_FIELD)
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("thread-root")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "FORM_TYPE")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append(MAM_NS)
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            ),
+        };
+
+        let (_, query) = parse_mam_query(&iq).expect("valid MAM query");
+
+        assert_eq!(
+            query.thread_id.as_ref().map(ThreadId::as_str),
+            Some("thread-root")
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_mam_form_fields() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "mam-thread".to_string(),
+            payload: IqType::Set(
+                Element::builder("query", MAM_NS)
+                    .append(
+                        Element::builder("x", DATA_FORMS_NS)
+                            .attr("type", "submit")
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "{urn:xmpp:mam:2}thread")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("wrong-thread")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .build(),
+                    )
+                    .build(),
+            ),
+        };
+
+        let err = parse_mam_query(&iq).expect_err("unsupported MAM field");
+        assert!(matches!(err, CoreError::NotImplemented));
+    }
+
+    #[test]
+    fn builds_mam_query_form_with_waddle_thread_field() {
+        let iq = Iq {
+            from: Some("juliet@example.com/chamber".parse().expect("from jid")),
+            to: Some("room@muc.example.com".parse().expect("to jid")),
+            id: "mam-form".to_string(),
+            payload: IqType::Get(Element::builder("query", MAM_NS).build()),
+        };
+
+        assert!(is_mam_query_form_request(&iq));
+        let result = build_query_form_iq(&iq);
+        let IqType::Result(Some(query)) = result.payload else {
+            panic!("expected query form result");
+        };
+        let form = query.get_child("x", DATA_FORMS_NS).expect("form");
+        let fields = form
+            .children()
+            .filter_map(|field| field.attr("var"))
+            .collect::<Vec<_>>();
+
+        assert!(fields.contains(&"FORM_TYPE"));
+        assert!(fields.contains(&"with"));
+        assert!(fields.contains(&"start"));
+        assert!(fields.contains(&"end"));
+        assert!(fields.contains(&WADDLE_MAM_THREAD_FIELD));
+        assert!(fields.contains(&"fulltext"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -55,11 +55,11 @@ pub use error::{
 pub use parser::{ns, StreamHeader};
 pub use routing::{RouterConfig, RoutingDestination, RoutingResult, StanzaRouter};
 pub use types::*;
-pub use waddle_xmpp_core::Stanza;
 pub use waddle_xmpp_core::{
     managed_room_jid, managed_room_localpart, parse_managed_room_jid, parse_managed_room_localpart,
     ChannelInfo, ChannelRoomInfo, ChannelType, UploadSlotInfo,
 };
+pub use waddle_xmpp_core::{CoreError, Stanza};
 pub use xep::xep0077::{RegistrationError, RegistrationRequest};
 
 use jid::BareJid;

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -18,8 +18,9 @@ pub mod storage;
 
 pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
 pub use waddle_xmpp_core::mam::{
-    add_stanza_id, build_fin_iq, build_result_messages, is_mam_query, parse_mam_query,
-    ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference,
-    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
-    MamQuery, MamResult, RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
+    add_stanza_id, build_fin_iq, build_query_form_iq, build_result_messages, is_mam_query,
+    is_mam_query_form_request, parse_mam_query, ArchivedMention, ArchivedMessage,
+    ArchivedModeration, ArchivedReactionSet, ArchivedReference, ArchivedReply, ArchivedRetraction,
+    ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone, MamQuery, MamResult,
+    RichMessageId, RichText, MAM_NS, RSM_NS, STANZA_ID_NS,
 };

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -593,6 +593,74 @@ fn uses_backward_pagination(query: &MamQuery) -> bool {
     query.before_id.is_some()
 }
 
+macro_rules! push_common_mam_filters {
+    ($builder:expr, $query:expr, $with_filter:expr) => {{
+        if let Some(with) = $with_filter {
+            $builder
+                .push(" AND (from_jid LIKE ")
+                .push_bind(with)
+                .push(" OR to_jid LIKE ")
+                .push_bind(with)
+                .push(")");
+        }
+        if let Some(thread_id) = $query.thread_id.as_ref() {
+            $builder
+                .push(" AND (id = ")
+                .push_bind(thread_id.as_str())
+                .push(" OR stanza_id = ")
+                .push_bind(thread_id.as_str())
+                .push(" OR thread_id = ")
+                .push_bind(thread_id.as_str())
+                .push(" OR (thread_id IS NULL AND reply_to_id = ")
+                .push_bind(thread_id.as_str())
+                .push("))");
+        }
+        if let Some(fulltext) = $query.fulltext.as_ref() {
+            for term in fulltext.as_str().split_whitespace() {
+                $builder
+                    .push(" AND LOWER(body) LIKE ")
+                    .push_bind(format!("%{}%", term.to_lowercase()));
+            }
+        }
+    }};
+}
+
+fn push_sqlite_mam_filters<'args>(
+    builder: &mut QueryBuilder<'args, Sqlite>,
+    archive_jid: &'args str,
+    query: &'args MamQuery,
+    with_filter: Option<&'args str>,
+) {
+    builder.push_bind(archive_jid);
+    if let Some(start) = query.start {
+        builder
+            .push(" AND timestamp >= ")
+            .push_bind(start.to_rfc3339());
+    }
+    if let Some(end) = query.end {
+        builder
+            .push(" AND timestamp <= ")
+            .push_bind(end.to_rfc3339());
+    }
+    push_common_mam_filters!(builder, query, with_filter);
+}
+
+fn push_postgres_mam_filters<'args>(
+    builder: &mut QueryBuilder<'args, Postgres>,
+    archive_jid: &'args str,
+    query: &'args MamQuery,
+    with_filter: Option<&'args str>,
+) {
+    builder.push_bind(archive_jid);
+    if let Some(start) = query.start {
+        builder.push(" AND timestamp >= ").push_bind(start);
+    }
+    if let Some(end) = query.end {
+        builder.push(" AND timestamp <= ").push_bind(end);
+    }
+    push_common_mam_filters!(builder, query, with_filter);
+}
+
 fn finalize_result(
     mut messages: Vec<ArchivedMessage>,
     query: &MamQuery,
@@ -806,44 +874,12 @@ impl MamStorage for SqlxMamStorage {
                 let mut count_builder = QueryBuilder::<Sqlite>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
-                count_builder.push_bind(archive_jid);
-                if let Some(start) = query.start {
-                    count_builder
-                        .push(" AND timestamp >= ")
-                        .push_bind(start.to_rfc3339());
-                }
-                if let Some(end) = query.end {
-                    count_builder
-                        .push(" AND timestamp <= ")
-                        .push_bind(end.to_rfc3339());
-                }
-                if let Some(with) = with_filter.as_deref() {
-                    count_builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
-                }
-                if let Some(thread_id) = query.thread_id.as_ref() {
-                    count_builder
-                        .push(" AND (id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR stanza_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR thread_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push("))");
-                }
-                if let Some(fulltext) = query.fulltext.as_ref() {
-                    for term in fulltext.as_str().split_whitespace() {
-                        count_builder
-                            .push(" AND LOWER(body) LIKE ")
-                            .push_bind(format!("%{}%", term.to_lowercase()));
-                    }
-                }
+                push_sqlite_mam_filters(
+                    &mut count_builder,
+                    archive_jid,
+                    query,
+                    with_filter.as_deref(),
+                );
                 let count = count_builder
                     .build_query_scalar::<i64>()
                     .fetch_one(pool)
@@ -852,44 +888,7 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Sqlite>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                builder.push_bind(archive_jid);
-                if let Some(start) = query.start {
-                    builder
-                        .push(" AND timestamp >= ")
-                        .push_bind(start.to_rfc3339());
-                }
-                if let Some(end) = query.end {
-                    builder
-                        .push(" AND timestamp <= ")
-                        .push_bind(end.to_rfc3339());
-                }
-                if let Some(with) = with_filter.as_deref() {
-                    builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
-                }
-                if let Some(thread_id) = query.thread_id.as_ref() {
-                    builder
-                        .push(" AND (id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR stanza_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR thread_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push("))");
-                }
-                if let Some(fulltext) = query.fulltext.as_ref() {
-                    for term in fulltext.as_str().split_whitespace() {
-                        builder
-                            .push(" AND LOWER(body) LIKE ")
-                            .push_bind(format!("%{}%", term.to_lowercase()));
-                    }
-                }
+                push_sqlite_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     builder.push(" AND id < ").push_bind(before_id);
                 }
@@ -918,40 +917,12 @@ impl MamStorage for SqlxMamStorage {
                 let mut count_builder = QueryBuilder::<Postgres>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
-                count_builder.push_bind(archive_jid);
-                if let Some(start) = query.start {
-                    count_builder.push(" AND timestamp >= ").push_bind(start);
-                }
-                if let Some(end) = query.end {
-                    count_builder.push(" AND timestamp <= ").push_bind(end);
-                }
-                if let Some(with) = with_filter.as_deref() {
-                    count_builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
-                }
-                if let Some(thread_id) = query.thread_id.as_ref() {
-                    count_builder
-                        .push(" AND (id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR stanza_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR thread_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push("))");
-                }
-                if let Some(fulltext) = query.fulltext.as_ref() {
-                    for term in fulltext.as_str().split_whitespace() {
-                        count_builder
-                            .push(" AND LOWER(body) LIKE ")
-                            .push_bind(format!("%{}%", term.to_lowercase()));
-                    }
-                }
+                push_postgres_mam_filters(
+                    &mut count_builder,
+                    archive_jid,
+                    query,
+                    with_filter.as_deref(),
+                );
                 let count = count_builder
                     .build_query_scalar::<i64>()
                     .fetch_one(pool)
@@ -960,40 +931,7 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Postgres>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                builder.push_bind(archive_jid);
-                if let Some(start) = query.start {
-                    builder.push(" AND timestamp >= ").push_bind(start);
-                }
-                if let Some(end) = query.end {
-                    builder.push(" AND timestamp <= ").push_bind(end);
-                }
-                if let Some(with) = with_filter.as_deref() {
-                    builder
-                        .push(" AND (from_jid LIKE ")
-                        .push_bind(with)
-                        .push(" OR to_jid LIKE ")
-                        .push_bind(with)
-                        .push(")");
-                }
-                if let Some(thread_id) = query.thread_id.as_ref() {
-                    builder
-                        .push(" AND (id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR stanza_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR thread_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
-                        .push_bind(thread_id.as_str())
-                        .push("))");
-                }
-                if let Some(fulltext) = query.fulltext.as_ref() {
-                    for term in fulltext.as_str().split_whitespace() {
-                        builder
-                            .push(" AND LOWER(body) LIKE ")
-                            .push_bind(format!("%{}%", term.to_lowercase()));
-                    }
-                }
+                push_postgres_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     builder.push(" AND id < ").push_bind(before_id);
                 }

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -22,6 +22,7 @@ use tracing::{debug, info, instrument};
 use uuid::Uuid;
 
 use super::{ArchivedMessage, MamQuery, MamResult};
+use crate::xep::matches_fulltext;
 
 /// Errors that can occur during MAM storage operations.
 #[derive(Error, Debug)]
@@ -186,6 +187,14 @@ impl MamStorage for InMemoryMamStorage {
             messages
                 .retain(|message| message.from.starts_with(with) || message.to.starts_with(with));
         }
+        if let Some(thread_id) = query.thread_id.as_ref() {
+            messages.retain(|message| matches_thread_filter(message, thread_id.as_str()));
+        }
+        if let Some(fulltext) = query.fulltext.as_ref() {
+            messages.retain(|message| matches_fulltext(message.body.as_str(), fulltext.as_str()));
+        }
+        let count = Some(u32::try_from(messages.len()).unwrap_or(u32::MAX));
+
         if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
             messages.retain(|message| message.id.as_str() < before_id);
         }
@@ -217,7 +226,7 @@ impl MamStorage for InMemoryMamStorage {
             complete,
             first_id,
             last_id,
-            count: None,
+            count,
         })
     }
 
@@ -584,7 +593,11 @@ fn uses_backward_pagination(query: &MamQuery) -> bool {
     query.before_id.is_some()
 }
 
-fn finalize_result(mut messages: Vec<ArchivedMessage>, query: &MamQuery) -> MamResult {
+fn finalize_result(
+    mut messages: Vec<ArchivedMessage>,
+    query: &MamQuery,
+    count: Option<u32>,
+) -> MamResult {
     let actual_limit = query.max.unwrap_or(100).min(500) as usize;
     let complete = messages.len() <= actual_limit;
 
@@ -604,8 +617,15 @@ fn finalize_result(mut messages: Vec<ArchivedMessage>, query: &MamQuery) -> MamR
         complete,
         first_id,
         last_id,
-        count: None,
+        count,
     }
+}
+
+fn matches_thread_filter(message: &ArchivedMessage, thread_id: &str) -> bool {
+    message.id == thread_id
+        || message.stanza_id.as_deref() == Some(thread_id)
+        || message.thread_id.as_deref() == Some(thread_id)
+        || (message.thread_id.is_none() && message.reply_to_id.as_deref() == Some(thread_id))
 }
 
 fn decode_sqlite_message_row(row: &SqliteRow) -> Result<ArchivedMessage, MamStorageError> {
@@ -783,6 +803,52 @@ impl MamStorage for SqlxMamStorage {
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
+                let mut count_builder = QueryBuilder::<Sqlite>::new(
+                    "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
+                );
+                count_builder.push_bind(archive_jid);
+                if let Some(start) = query.start {
+                    count_builder
+                        .push(" AND timestamp >= ")
+                        .push_bind(start.to_rfc3339());
+                }
+                if let Some(end) = query.end {
+                    count_builder
+                        .push(" AND timestamp <= ")
+                        .push_bind(end.to_rfc3339());
+                }
+                if let Some(with) = with_filter.as_deref() {
+                    count_builder
+                        .push(" AND (from_jid LIKE ")
+                        .push_bind(with)
+                        .push(" OR to_jid LIKE ")
+                        .push_bind(with)
+                        .push(")");
+                }
+                if let Some(thread_id) = query.thread_id.as_ref() {
+                    count_builder
+                        .push(" AND (id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR stanza_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR thread_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push("))");
+                }
+                if let Some(fulltext) = query.fulltext.as_ref() {
+                    for term in fulltext.as_str().split_whitespace() {
+                        count_builder
+                            .push(" AND LOWER(body) LIKE ")
+                            .push_bind(format!("%{}%", term.to_lowercase()));
+                    }
+                }
+                let count = count_builder
+                    .build_query_scalar::<i64>()
+                    .fetch_one(pool)
+                    .await?;
+
                 let mut builder = QueryBuilder::<Sqlite>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
@@ -805,6 +871,25 @@ impl MamStorage for SqlxMamStorage {
                         .push_bind(with)
                         .push(")");
                 }
+                if let Some(thread_id) = query.thread_id.as_ref() {
+                    builder
+                        .push(" AND (id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR stanza_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR thread_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push("))");
+                }
+                if let Some(fulltext) = query.fulltext.as_ref() {
+                    for term in fulltext.as_str().split_whitespace() {
+                        builder
+                            .push(" AND LOWER(body) LIKE ")
+                            .push_bind(format!("%{}%", term.to_lowercase()));
+                    }
+                }
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     builder.push(" AND id < ").push_bind(before_id);
                 }
@@ -823,9 +908,55 @@ impl MamStorage for SqlxMamStorage {
                     .iter()
                     .map(decode_sqlite_message_row)
                     .collect::<Result<Vec<_>, _>>()?;
-                Ok(finalize_result(messages, query))
+                Ok(finalize_result(
+                    messages,
+                    query,
+                    Some(u32::try_from(count).unwrap_or(u32::MAX)),
+                ))
             }
             MamDatabaseBackend::Postgres(pool) => {
+                let mut count_builder = QueryBuilder::<Postgres>::new(
+                    "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
+                );
+                count_builder.push_bind(archive_jid);
+                if let Some(start) = query.start {
+                    count_builder.push(" AND timestamp >= ").push_bind(start);
+                }
+                if let Some(end) = query.end {
+                    count_builder.push(" AND timestamp <= ").push_bind(end);
+                }
+                if let Some(with) = with_filter.as_deref() {
+                    count_builder
+                        .push(" AND (from_jid LIKE ")
+                        .push_bind(with)
+                        .push(" OR to_jid LIKE ")
+                        .push_bind(with)
+                        .push(")");
+                }
+                if let Some(thread_id) = query.thread_id.as_ref() {
+                    count_builder
+                        .push(" AND (id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR stanza_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR thread_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push("))");
+                }
+                if let Some(fulltext) = query.fulltext.as_ref() {
+                    for term in fulltext.as_str().split_whitespace() {
+                        count_builder
+                            .push(" AND LOWER(body) LIKE ")
+                            .push_bind(format!("%{}%", term.to_lowercase()));
+                    }
+                }
+                let count = count_builder
+                    .build_query_scalar::<i64>()
+                    .fetch_one(pool)
+                    .await?;
+
                 let mut builder = QueryBuilder::<Postgres>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
@@ -843,6 +974,25 @@ impl MamStorage for SqlxMamStorage {
                         .push(" OR to_jid LIKE ")
                         .push_bind(with)
                         .push(")");
+                }
+                if let Some(thread_id) = query.thread_id.as_ref() {
+                    builder
+                        .push(" AND (id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR stanza_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR thread_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push(" OR (thread_id IS NULL AND reply_to_id = ")
+                        .push_bind(thread_id.as_str())
+                        .push("))");
+                }
+                if let Some(fulltext) = query.fulltext.as_ref() {
+                    for term in fulltext.as_str().split_whitespace() {
+                        builder
+                            .push(" AND LOWER(body) LIKE ")
+                            .push_bind(format!("%{}%", term.to_lowercase()));
+                    }
                 }
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     builder.push(" AND id < ").push_bind(before_id);
@@ -862,7 +1012,11 @@ impl MamStorage for SqlxMamStorage {
                     .iter()
                     .map(decode_postgres_message_row)
                     .collect::<Result<Vec<_>, _>>()?;
-                Ok(finalize_result(messages, query))
+                Ok(finalize_result(
+                    messages,
+                    query,
+                    Some(u32::try_from(count).unwrap_or(u32::MAX)),
+                ))
             }
         }
     }
@@ -1206,6 +1360,108 @@ mod tests {
         assert_eq!(page_two.messages[0].body, "three");
     }
 
+    #[tokio::test]
+    async fn test_thread_query_filters_before_pagination_and_count() {
+        let storage = create_test_storage().await;
+        let archive = "room@conference.example.com";
+
+        for msg in [
+            ArchivedMessage {
+                id: "a-thread-root".to_string(),
+                body: "root".to_string(),
+                ..archived_groupchat(archive)
+            },
+            ArchivedMessage {
+                id: "b-thread-reply".to_string(),
+                thread_id: Some("a-thread-root".to_string()),
+                body: "reply".to_string(),
+                ..archived_groupchat(archive)
+            },
+            ArchivedMessage {
+                id: "c-legacy-reply".to_string(),
+                reply_to_id: Some("a-thread-root".to_string()),
+                body: "legacy".to_string(),
+                ..archived_groupchat(archive)
+            },
+            ArchivedMessage {
+                id: "unrelated".to_string(),
+                thread_id: Some("other-thread".to_string()),
+                body: "unrelated".to_string(),
+                ..archived_groupchat(archive)
+            },
+        ] {
+            storage.store_message(archive, &msg).await.unwrap();
+        }
+
+        let result = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    thread_id: waddle_xmpp_core::mam::ThreadId::new("a-thread-root"),
+                    max: Some(2),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = result
+            .messages
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a-thread-root", "b-thread-reply"]);
+        assert_eq!(result.count, Some(3));
+        assert!(!result.complete);
+    }
+
+    #[tokio::test]
+    async fn test_fulltext_query_filters_before_pagination_and_count() {
+        let storage = create_test_storage().await;
+        let archive = "room@conference.example.com";
+
+        for msg in [
+            ArchivedMessage {
+                id: "a-alpha".to_string(),
+                body: "release notes alpha".to_string(),
+                ..archived_groupchat(archive)
+            },
+            ArchivedMessage {
+                id: "b-beta".to_string(),
+                body: "release notes beta".to_string(),
+                ..archived_groupchat(archive)
+            },
+            ArchivedMessage {
+                id: "c-other".to_string(),
+                body: "standup notes".to_string(),
+                ..archived_groupchat(archive)
+            },
+        ] {
+            storage.store_message(archive, &msg).await.unwrap();
+        }
+
+        let result = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    fulltext: waddle_xmpp_core::mam::RichText::new("release notes"),
+                    max: Some(1),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = result
+            .messages
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a-alpha"]);
+        assert_eq!(result.count, Some(2));
+        assert!(!result.complete);
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sqlite_file_backing_persists() {
         let artifacts = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/test-artifacts");
@@ -1280,5 +1536,15 @@ mod tests {
         let bodies: Vec<&str> = last_page.messages.iter().map(|m| m.body.as_str()).collect();
         assert_eq!(bodies, vec!["four", "five", "six"]);
         assert!(!last_page.complete);
+    }
+
+    fn archived_groupchat(archive: &str) -> ArchivedMessage {
+        ArchivedMessage {
+            timestamp: Utc::now(),
+            from: format!("{archive}/alice"),
+            to: archive.to_string(),
+            message_type: "groupchat".to_string(),
+            ..Default::default()
+        }
     }
 }

--- a/server/extensions/ai-chatbot/src/lib.rs
+++ b/server/extensions/ai-chatbot/src/lib.rs
@@ -20,8 +20,6 @@ bindings::export!(AiChatbot with_types_in bindings);
 const PLUGIN_ID: &str = "ai-chatbot";
 const PLUGIN_NAME: &str = "AI Chatbot";
 const PLUGIN_NS: &str = "urn:waddle:ai-chatbot:1";
-const INVOKE_NODE: &str = "urn:waddle:extension:1:invoke";
-const COMMAND_NODE: &str = "urn:waddle:extension:1:ai-chatbot";
 const VERSION: &str = "0.1.0";
 
 impl exports::waddle::extension::lifecycle::Guest for AiChatbot {
@@ -38,25 +36,8 @@ impl exports::waddle::extension::framework::Guest for AiChatbot {
             types::ExtensionEvent::MessageHook(hook) => {
                 message_hook_response(hook).into_iter().collect()
             }
-            types::ExtensionEvent::Command(command) => {
-                let prompt = command
-                    .fields
-                    .first()
-                    .and_then(|field| field.values.first())
-                    .map(|value| value.value.as_str())
-                    .unwrap_or("Ask me from chat with /ask.");
-                vec![visible_message(answer(prompt, command.waddle_id, None))]
-            }
-            types::ExtensionEvent::Launch(launch) => {
-                let prompt = field_value(&launch.fields, "payload#assistant-followup#question")
-                    .or_else(|| field_value(&launch.fields, "payload#assistant-followup"))
-                    .or_else(|| field_value(&launch.fields, "payload#question"))
-                    .unwrap_or("Continue the previous answer.");
-                vec![visible_message(answer(
-                    prompt,
-                    launch.context.waddle_id,
-                    launch.context.source_stanza_id,
-                ))]
+            types::ExtensionEvent::Command(_) | types::ExtensionEvent::Launch(_) => {
+                vec![types::ExtensionEffect::Noop]
             }
         };
         Ok(types::ExtensionResponse { effects })
@@ -77,7 +58,7 @@ fn message_hook_response(hook: types::MessageHook) -> Option<types::ExtensionEff
     } = hook.context;
     let in_thread = thread_id.is_some();
     let is_reply = reply_to.is_some();
-    if !explicit_mention && (!slash_trigger || in_thread) {
+    if !explicit_mention && !slash_trigger {
         return None;
     }
     if is_reply && !in_thread {
@@ -131,124 +112,24 @@ fn manifest() -> types::ExtensionManifest {
         version: types::PluginVersion {
             value: VERSION.to_string(),
         },
-        payloads: vec![
-            payload_rule(types::PayloadSurface::MessageEnrichment, "assistant-answer"),
-            payload_rule(types::PayloadSurface::LaunchPayload, "assistant-followup"),
-        ],
+        payloads: vec![payload_rule(
+            types::PayloadSurface::MessageEnrichment,
+            "assistant-answer",
+        )],
         capabilities: vec![
-            types::ExtensionCapability::MessageEnrich,
-            types::ExtensionCapability::Commands,
-            types::ExtensionCapability::Launch,
             types::ExtensionCapability::MessageObserve,
             types::ExtensionCapability::BotGroupchatSend,
         ],
-        commands: vec![
-            command_descriptor(COMMAND_NODE, "Ask AI Chatbot"),
-            command_descriptor(INVOKE_NODE, "Run AI Chatbot action"),
-        ],
+        commands: vec![],
         pubsub_nodes: vec![],
         artifact: None,
     }
 }
 
-struct VisibleMessage {
-    ui: Vec<types::UiView>,
-    payloads: Vec<types::ExtensionPayload>,
-    launches: Vec<types::LaunchDescriptor>,
-}
-
-fn visible_message(message: VisibleMessage) -> types::ExtensionEffect {
-    types::ExtensionEffect::EnrichMessage(types::ExtensionEnvelope {
-        version: 1,
-        enrichments: vec![types::MessageEnrichment {
-            id: types::EnrichmentId {
-                value: "assistant-message".to_string(),
-            },
-            plugin: plugin_id(),
-            capability: types::ExtensionCapability::MessageEnrich,
-            payload_namespace: payload_namespace(),
-            created_at: types::Timestamp {
-                value: "2026-04-27T00:00:00Z".to_string(),
-            },
-            source: None,
-            ui: message.ui,
-            payloads: message.payloads,
-            launches: message.launches,
-        }],
-    })
-}
-
-fn answer(
-    prompt: &str,
-    waddle_id: types::WaddleId,
-    source_stanza_id: Option<types::StanzaId>,
-) -> VisibleMessage {
-    let answer = answer_body(prompt);
-    VisibleMessage {
-        ui: vec![types::UiView {
-            id: types::UiViewId {
-                value: "ai-answer".to_string(),
-            },
-            title: Some(display(PLUGIN_NAME)),
-            blocks: vec![
-                types::UiBlock::Text(types::TextBlock {
-                    text: display(&answer),
-                    style: types::TextStyle::Body,
-                }),
-                types::UiBlock::Text(types::TextBlock {
-                    text: display(prompt),
-                    style: types::TextStyle::Muted,
-                }),
-                types::UiBlock::Action(types::ActionBlock {
-                    launch_id: launch_id("ask-followup"),
-                    label: display("Ask follow-up"),
-                }),
-            ],
-        }],
-        payloads: vec![payload(
-            "assistant-answer",
-            vec![
-                ("run-id", "run-ai-chatbot-1".to_string()),
-                ("profile", "default".to_string()),
-                ("context-source", "mam".to_string()),
-            ],
-            "Assistant response generated",
-        )],
-        launches: vec![types::LaunchDescriptor {
-            id: launch_id("ask-followup"),
-            plugin: plugin_id(),
-            action: types::ActionId {
-                value: "ask-followup".to_string(),
-            },
-            command_node: types::CommandNode {
-                value: INVOKE_NODE.to_string(),
-            },
-            label: display("Ask follow-up"),
-            context: types::LaunchContext {
-                waddle_id,
-                source_stanza_id,
-            },
-            payloads: vec![payload(
-                "assistant-followup",
-                vec![("question", prompt.to_string())],
-                prompt,
-            )],
-            fallback: None,
-            expires_at: None,
-        }],
-    }
-}
-
 fn answer_body(prompt: &str) -> String {
     let prompt = clean_prompt(prompt);
-    if let Some(answer) = answer_letter_count(&prompt) {
-        return answer;
-    }
-    if let Some(answer) = answer_arithmetic(&prompt) {
-        return answer;
-    }
     format!(
-        "I received: {prompt}\n\nI can answer simple arithmetic and letter-count questions here. A real AI provider is not wired into this extension yet."
+        "AI provider unavailable. Configure WADDLE_AI_PROVIDER=openai, OPENAI_API_KEY, and WADDLE_AI_MODEL on the server to answer: {prompt}"
     )
 }
 
@@ -266,121 +147,9 @@ fn clean_prompt(prompt: &str) -> String {
         .to_string()
 }
 
-fn answer_letter_count(prompt: &str) -> Option<String> {
-    let lower = prompt.to_ascii_lowercase();
-    if !lower.contains("how many") || !lower.contains(" in ") {
-        return None;
-    }
-    let needle = extract_quoted_letter(prompt).or_else(|| extract_letter_before_in(prompt))?;
-    let word = prompt
-        .rsplit_once(" in ")
-        .map(|(_, word)| word)
-        .unwrap_or(prompt)
-        .trim_matches(|ch: char| !ch.is_alphanumeric());
-    if word.is_empty() {
-        return None;
-    }
-    let count = word
-        .chars()
-        .filter(|ch| ch.eq_ignore_ascii_case(&needle))
-        .count();
-    Some(format!(
-        "\"{word}\" contains {count} '{}'{}.",
-        needle,
-        if count == 1 { "" } else { "s" }
-    ))
-}
-
-fn extract_quoted_letter(prompt: &str) -> Option<char> {
-    let mut chars = prompt.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '\'' || ch == '"' || ch == '`' {
-            let letter = chars.next()?;
-            let closing = chars.next()?;
-            if closing == ch && letter.is_alphabetic() {
-                return Some(letter);
-            }
-        }
-    }
-    None
-}
-
-fn extract_letter_before_in(prompt: &str) -> Option<char> {
-    let before_in = prompt.rsplit_once(" in ")?.0;
-    before_in.split_whitespace().rev().find_map(|token| {
-        let token = token
-            .trim_matches(|ch: char| !ch.is_alphabetic())
-            .trim_end_matches("'s");
-        (token.chars().count() == 1)
-            .then(|| token.chars().next())
-            .flatten()
-    })
-}
-
-fn answer_arithmetic(prompt: &str) -> Option<String> {
-    let expression = prompt.trim().trim_end_matches('?').trim();
-    let expression = if expression.len() >= 8 && expression[..8].eq_ignore_ascii_case("what is ") {
-        &expression[8..]
-    } else {
-        expression
-    }
-    .trim();
-    let mut parts = expression.split_whitespace();
-    let left = parts.next()?.parse::<i64>().ok()?;
-    let op = parts.next()?;
-    let right = parts.next()?.parse::<i64>().ok()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    let value = match op {
-        "+" => left.checked_add(right)?,
-        "-" => left.checked_sub(right)?,
-        "*" | "x" | "X" => left.checked_mul(right)?,
-        "/" => {
-            if right == 0 {
-                return Some("Division by zero is undefined.".to_string());
-            }
-            if left % right == 0 {
-                left / right
-            } else {
-                return Some(format!("{left} / {right} = {}", left as f64 / right as f64));
-            }
-        }
-        "%" => {
-            if right == 0 {
-                return Some("Modulo by zero is undefined.".to_string());
-            }
-            left % right
-        }
-        _ => return None,
-    };
-    Some(format!("{left} {op} {right} = {value}."))
-}
-
-fn payload(root: &str, attrs: Vec<(&str, String)>, text: &str) -> types::ExtensionPayload {
-    let namespace = payload_namespace();
-    types::ExtensionPayload {
-        namespace: namespace.clone(),
-        root: types::PayloadRoot {
-            namespace: namespace.clone(),
-            local_name: root.to_string(),
-        },
-        tokens: vec![
-            types::XmlToken::StartElement(types::XmlElement {
-                namespace,
-                local_name: root.to_string(),
-                attributes: attrs
-                    .into_iter()
-                    .map(|(name, value)| types::XmlAttribute {
-                        namespace: None,
-                        local_name: name.to_string(),
-                        value,
-                    })
-                    .collect(),
-            }),
-            types::XmlToken::Text(text.to_string()),
-            types::XmlToken::EndElement,
-        ],
+fn plugin_id() -> types::PluginId {
+    types::PluginId {
+        value: PLUGIN_ID.to_string(),
     }
 }
 
@@ -394,40 +163,12 @@ fn payload_rule(surface: types::PayloadSurface, root: &str) -> types::PayloadRul
     }
 }
 
-fn command_descriptor(node: &str, name: &str) -> types::CommandDescriptor {
-    types::CommandDescriptor {
-        node: types::CommandNode {
-            value: node.to_string(),
-        },
-        name: display(name),
-    }
-}
-
-fn field_value<'a>(fields: &'a [types::FormFieldValue], name: &str) -> Option<&'a str> {
-    fields
-        .iter()
-        .find(|field| field.name.value == name)
-        .and_then(|field| field.values.first())
-        .map(|value| value.value.as_str())
-}
-
-fn launch_id(value: &str) -> types::LaunchId {
-    types::LaunchId {
-        value: value.to_string(),
-    }
-}
-
-fn plugin_id() -> types::PluginId {
-    types::PluginId {
-        value: PLUGIN_ID.to_string(),
-    }
-}
-
 fn payload_namespace() -> types::PayloadNamespace {
     types::PayloadNamespace {
         value: PLUGIN_NS.to_string(),
     }
 }
+
 fn display(value: &str) -> types::DisplayText {
     types::DisplayText {
         value: value.to_string(),
@@ -471,24 +212,18 @@ mod tests {
     }
 
     #[test]
-    fn answers_basic_arithmetic_without_canned_text() {
-        assert_eq!(answer_body("/ai what is 10 % 5?"), "10 % 5 = 0.");
-        assert_eq!(answer_body("/ai what is 5 * 5?"), "5 * 5 = 25.");
-    }
-
-    #[test]
-    fn answers_letter_count_questions_without_canned_text() {
-        assert_eq!(
-            answer_body("/ai How many r's in Strawberry?"),
-            "\"Strawberry\" contains 3 'r's."
-        );
-    }
-
-    #[test]
-    fn falls_back_honestly_when_no_local_answer_exists() {
+    fn reports_provider_unavailable_without_fake_local_answer() {
         let answer = answer_body("/ai summarize the release notes");
-        assert!(answer.contains("A real AI provider is not wired"));
-        assert!(!answer.contains("I can help summarize the recent thread"));
+        assert!(answer.contains("AI provider unavailable"));
+        assert!(answer.contains("WADDLE_AI_MODEL"));
+        assert!(!answer.contains("simple arithmetic"));
+        assert!(!answer.contains("letter-count"));
+    }
+
+    #[test]
+    fn allows_threaded_followups_with_slash_ai() {
+        let hook = message_hook("/ai continue", Some("thread-root"), Some("parent-msg"));
+        assert!(message_hook_response(hook).is_some());
     }
 
     fn message_hook(

--- a/server/extensions/ai-chatbot/src/lib.rs
+++ b/server/extensions/ai-chatbot/src/lib.rs
@@ -21,6 +21,8 @@ const PLUGIN_ID: &str = "ai-chatbot";
 const PLUGIN_NAME: &str = "AI Chatbot";
 const PLUGIN_NS: &str = "urn:waddle:ai-chatbot:1";
 const VERSION: &str = "0.1.0";
+const AI_COMMAND: &str = "/ai";
+const WADDLE_MENTION: &str = "@waddle";
 
 impl exports::waddle::extension::lifecycle::Guest for AiChatbot {
     fn init(_config: String) -> Result<types::ExtensionManifest, String> {
@@ -93,8 +95,7 @@ fn contains_waddle_mention(body: &str) -> bool {
 
 fn starts_with_ai_command(body: &str) -> bool {
     let trimmed = body.trim_start();
-    let lower = trimmed.to_ascii_lowercase();
-    lower.starts_with("/ai") && is_command_boundary(lower.as_bytes().get(3))
+    has_ai_command_prefix(trimmed) && is_command_boundary(trimmed.as_bytes().get(AI_COMMAND.len()))
 }
 
 fn is_command_boundary(next: Option<&u8>) -> bool {
@@ -102,7 +103,7 @@ fn is_command_boundary(next: Option<&u8>) -> bool {
 }
 
 fn is_word_boundary(next: Option<&u8>) -> bool {
-    !matches!(next, Some(b'a'..=b'z' | b'0'..=b'9' | b'_'))
+    !matches!(next, Some(b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_'))
 }
 
 fn manifest() -> types::ExtensionManifest {
@@ -135,16 +136,42 @@ fn answer_body(prompt: &str) -> String {
 
 fn clean_prompt(prompt: &str) -> String {
     let trimmed = prompt.trim();
-    let without_command = if trimmed.len() >= 3 && trimmed[..3].eq_ignore_ascii_case("/ai") {
-        &trimmed[3..]
-    } else {
-        trimmed
-    };
-    without_command
-        .replace("@waddle", "")
-        .replace("@Waddle", "")
-        .trim()
-        .to_string()
+    let without_command = strip_ai_command(trimmed).unwrap_or(trimmed);
+    remove_waddle_mentions(without_command).trim().to_string()
+}
+
+fn strip_ai_command(trimmed: &str) -> Option<&str> {
+    (has_ai_command_prefix(trimmed)
+        && is_command_boundary(trimmed.as_bytes().get(AI_COMMAND.len())))
+    .then(|| trimmed.get(AI_COMMAND.len()..).unwrap_or(""))
+}
+
+fn has_ai_command_prefix(trimmed: &str) -> bool {
+    trimmed
+        .get(..AI_COMMAND.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(AI_COMMAND))
+}
+
+fn remove_waddle_mentions(value: &str) -> String {
+    let mut cleaned = String::with_capacity(value.len());
+    let mut cursor = 0;
+    while cursor < value.len() {
+        let remaining = &value[cursor..];
+        if remaining
+            .get(..WADDLE_MENTION.len())
+            .is_some_and(|mention| mention.eq_ignore_ascii_case(WADDLE_MENTION))
+            && is_word_boundary(remaining.as_bytes().get(WADDLE_MENTION.len()))
+        {
+            cursor += WADDLE_MENTION.len();
+        } else {
+            let Some(ch) = remaining.chars().next() else {
+                break;
+            };
+            cleaned.push(ch);
+            cursor += ch.len_utf8();
+        }
+    }
+    cleaned
 }
 
 fn plugin_id() -> types::PluginId {
@@ -178,8 +205,13 @@ fn display(value: &str) -> types::DisplayText {
 #[cfg(test)]
 mod tests {
     use super::{
-        answer_body, contains_waddle_mention, message_hook_response, starts_with_ai_command, types,
+        answer_body, clean_prompt, contains_waddle_mention, message_hook_response,
+        starts_with_ai_command, types,
     };
+
+    mod shared_ai_prompt_cases {
+        include!("../../../test-fixtures/ai_prompt_cases.rs");
+    }
 
     #[test]
     fn detects_ai_root_command_case_insensitively_with_boundary() {
@@ -188,6 +220,7 @@ mod tests {
         assert!(starts_with_ai_command("/Ai\tthread"));
         assert!(!starts_with_ai_command("prefix /ai"));
         assert!(!starts_with_ai_command("/airship"));
+        assert!(!starts_with_ai_command("☃ /ai later"));
     }
 
     #[test]
@@ -218,6 +251,28 @@ mod tests {
         assert!(answer.contains("WADDLE_AI_MODEL"));
         assert!(!answer.contains("simple arithmetic"));
         assert!(!answer.contains("letter-count"));
+    }
+
+    #[test]
+    fn clean_prompt_strips_ai_command_and_mentions_case_insensitively() {
+        assert_eq!(clean_prompt(" /AI @WADDLE summarize "), "summarize");
+        assert_eq!(clean_prompt("@wAdDlE continue"), "continue");
+        assert_eq!(clean_prompt("@waddle_bot continue"), "@waddle_bot continue");
+        assert_eq!(clean_prompt("@waddleBot continue"), "@waddleBot continue");
+        assert_eq!(clean_prompt("☃ /ai later"), "☃ /ai later");
+        assert_eq!(clean_prompt("/airship @WADDLE"), "/airship");
+    }
+
+    #[test]
+    fn shared_ai_prompt_cases_match_extension_parser() {
+        for &(body, is_prompt, cleaned) in shared_ai_prompt_cases::AI_PROMPT_CASES {
+            assert_eq!(
+                starts_with_ai_command(body) || contains_waddle_mention(body),
+                is_prompt,
+                "{body}"
+            );
+            assert_eq!(clean_prompt(body), cleaned, "{body}");
+        }
     }
 
     #[test]

--- a/server/test-fixtures/ai_prompt_cases.rs
+++ b/server/test-fixtures/ai_prompt_cases.rs
@@ -1,0 +1,10 @@
+pub const AI_PROMPT_CASES: &[(&str, bool, &str)] = &[
+    ("/ai summarize", true, "summarize"),
+    ("/AI @WADDLE summarize", true, "summarize"),
+    ("@wAdDlE continue", true, "continue"),
+    ("@waddle_bot continue", false, "@waddle_bot continue"),
+    ("@waddleBot continue", false, "@waddleBot continue"),
+    ("prefix /ai", false, "prefix /ai"),
+    ("☃ /ai later", false, "☃ /ai later"),
+    ("/airship @WADDLE", true, "/airship"),
+];


### PR DESCRIPTION
## Problem

The HAR showed two related server-side failures:

- Thread MAM queries were sent by the client, but the server ignored the thread filter and returned unrelated room history.
- AI bot replies carried `<reply/>` but did not reliably carry the canonical `<thread/>`, so a direct refresh of a thread could not rebuild the root/reply relationship.

This PR makes thread identity canonical on the server, makes thread backfill filter in MAM, and removes the fake local AI answer logic.

## What Changed

### MAM and Thread Backfill

- Adds typed `ThreadId` support to `MamQuery`.
- Replaces the non-conformant `{urn:xmpp:mam:2}thread` field with Waddle-owned `{urn:waddle:mam-thread:0}thread`.
- Applies the thread filter before pagination and before RSM count calculation.
- Matches thread queries against:
  - archive id / room stanza-id, so the root message is included;
  - stored `thread_id`, so normal descendants are included;
  - legacy rows with no `thread_id` but `reply_to_id == requested thread`, so existing broken bot replies can recover.
- Implements the same behavior for in-memory, SQLite, and Postgres MAM storage.
- Adds XEP-0313 query form discovery for supported fields.
- Fails closed on unsupported MAM form fields with `feature-not-implemented`.
- Keeps XEP-0431 `fulltext` explicitly supported so existing search keeps working.

### Bot Threading

- Canonicalizes bot response targets after MUC room processing has assigned the real room stanza-id.
- Root `/ai` and `@waddle` prompts now produce bot replies threaded to the prompt stanza-id.
- Thread follow-ups preserve the existing root thread id and reply to the canonical prompt stanza-id.
- Bot replies use the normal room dispatch pipeline, so archive/inbox projections see the same typed stanza shape as other room messages.

### AI Provider Boundary

- Removes arithmetic, letter-count, and canned response behavior from `ai-chatbot`.
- Adds server-owned OpenAI provider config:
  - `WADDLE_AI_PROVIDER=openai`
  - `OPENAI_API_KEY`
  - `WADDLE_AI_MODEL`
  - optional `WADDLE_OPENAI_BASE_URL` for tests
- Provider/config failures keep an explicit unavailable message instead of falling back to a fake answer.
- Provider calls are scoped to AI chatbot fallback bot responses, so other future bot effects will not be overwritten just because a source message mentions `/ai` or `@waddle`.
- Command/launch AI extension paths are currently disabled/no-op rather than emitting fake provider-unavailable cards.

### Client

- Thread MAM backfill now sends `{urn:waddle:mam-thread:0}thread`.
- Thread backfill only repairs legacy returned replies that lack `<thread/>` when `replyTo.id` matches the requested thread id.
- Discovered channel features are preserved through topology hydration.
- `/ai` slash autocomplete and `@waddle` mention autocomplete are gated on the room advertising `urn:waddle:ai-chatbot:1`.
- The server only advertises that AI feature when provider config is valid.
- Fixes the chat-side MAM history parser type narrowing that caused the first PR CI run to fail during `astro check`.

## Protocol Notes

- Official `urn:xmpp:threads:0` remains limited to conformant XEP-0201 `<thread/>` behavior.
- Waddle-specific MAM thread filtering uses `urn:waddle:mam-thread:0`, not an official XMPP namespace.
- Unsupported MAM form fields no longer fail open to unfiltered history.
- XEP-0431 `fulltext` is explicitly parsed as a typed query value and applied before pagination/count.

## Remaining TODO

- [ ] Build bounded AI provider context from the thread root plus recent thread messages instead of sending only the current prompt.
- [ ] Add end-to-end WebSocket coverage proving the provider response becomes the bot body for `/ai` and `@waddle` room prompts.
- [ ] Add explicit WebSocket coverage for MAM query form discovery and unsupported MAM form fields.
- [ ] Decide whether command/launch AI surfaces should be rebuilt on the server provider path or remain disabled/no-op.
- [ ] Verify provider-config-gated AI feature advertisement in CI or an integration environment with env vars set/unset.

## Verification

- `cargo test -p waddle-xmpp-core mam::tests -- --nocapture`: passed.
- `cargo test -p waddle-xmpp mam::storage::tests -- --nocapture`: passed.
- `cargo test -p waddle-server ai_provider -- --nocapture`: passed.
- `cargo test -p waddle-server bot_response -- --nocapture`: passed.
- `cargo clippy -p waddle-server --all-targets -- -D warnings`: passed.
- `bun test`: passed, 470 tests.
- `bun test tests/mam-history.test.ts`: passed, 25 tests.
- `bun run lint`: passed.
- `bun run build`: passed.
- `git diff --check`: passed.
- PR CI at `4f4a1b0` is green:
  - `waddle-chat-pullRequest`: passed.
  - `waddle-server-pullRequest`: passed.
  - `waddle-server-xmppCompliance`: passed.
  - CodeQL actions/go/javascript-typescript/rust: passed.

## Review Notes

- Two adversarial review passes were run on the main PR changes.
- First pass found unsupported MAM fields failing open and missing MAM form discovery; both were fixed.
- Second pass found that failing unknown fields broke existing XEP-0431 `fulltext`; explicit typed fulltext support was added.
- A final adversarial review pass was run for the chat CI fix and protocol impact; no actionable issues were found.
