### PR TITLE
fix(server): require WADDLE_OCCUPANT_ID_SECRET, remove hardcoded XEP-0421 key

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -96,8 +96,16 @@ docker run --rm \
   -e WADDLE_DATABASE_URL=sqlite:///var/lib/waddle/waddle.db \
   -e WADDLE_XMPP_MAM_DATABASE_URL=sqlite:///var/lib/waddle/mam.db \
   -e WADDLE_XMPP_INBOX_DATABASE_URL=sqlite:///var/lib/waddle/inbox.db \
+  -e WADDLE_OCCUPANT_ID_SECRET="$(openssl rand -base64 48)" \
   waddle-server:local
 ```
+
+`WADDLE_OCCUPANT_ID_SECRET` is the per-deployment HMAC key used to derive
+XEP-0421 occupant identifiers. It must be at least 32 bytes and stay
+stable across restarts; rotating it severs occupant-id continuity for
+clients tracking users across nick changes. The Helm chart auto-generates
+and persists this secret on first install; bare-metal/docker deployments
+must supply it themselves.
 
 GitHub Actions publishes container images to GHCR on every push to `main` and on semver tags (`vX.Y.Z`).
 Release tags publish semver image tags (for example `v0.2.1` -> `0.2.1`, `0.2`, `0`).

--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -87,6 +87,7 @@ helm upgrade --install waddle ./charts/waddle-server \
 The chart supports an app secret containing:
 
 - `WADDLE_SESSION_KEY` (required by server features relying on encrypted session data)
+- `WADDLE_OCCUPANT_ID_SECRET` (**required**; per-deployment HMAC key for XEP-0421 occupant identifiers; ≥32 bytes)
 - `WADDLE_AUTH_PROVIDERS_JSON` (optional; required to enable `/api/auth/*` broker flows)
 - `WADDLE_DATABASE_URL` (optional; preferred location for DB DSN with credentials)
 - `WADDLE_XMPP_MAM_DATABASE_URL` (optional MAM DSN override)
@@ -95,19 +96,42 @@ The chart supports an app secret containing:
 Provider JSON may also be set in `config.authProvidersJson`, but `secret.authProvidersJson`
 is recommended because provider definitions usually include client secrets.
 
-Default behavior:
+### Required keys when bringing your own Secret
+
+Setting `secret.create=false` and providing `secret.existingSecret=<name>` skips
+chart templating entirely. The externally-managed Secret **must** contain at
+minimum:
+
+- `WADDLE_SESSION_KEY`
+- `WADDLE_OCCUPANT_ID_SECRET`
+
+…plus any other keys this chart documents (database DSNs, auth providers,
+SpiceDB preshared key) that your deployment relies on. If
+`WADDLE_OCCUPANT_ID_SECRET` is missing, the server hard-fails at startup with
+a clear error.
+
+### Default behavior
 
 - `secret.create=true` creates a chart-managed secret
-- If `secret.sessionKey` is empty:
-  - on first install, a random key is generated
-  - on upgrades, the existing `WADDLE_SESSION_KEY` is preserved (via `lookup`) when present
+- If `secret.sessionKey` / `secret.occupantIdSecret` is empty:
+  - on first install, a random 64-character alphanumeric value is generated
+  - on upgrades, the existing in-cluster value is preserved (via `lookup`)
+
+> ⚠️ **Do not rotate `WADDLE_OCCUPANT_ID_SECRET` without an explicit migration plan.**
+> The XEP-0421 occupant identifier is the only stable per-(room, user) handle for
+> client-side identity continuity (recognising users across nick changes). Rotating
+> the secret invalidates every previously-issued occupant-id, severing that continuity.
+> The chart auto-generates the secret once on first install; back up the resulting
+> Kubernetes Secret externally (Velero, sealed-secrets export, password manager) so a
+> namespace deletion or etcd loss does not silently rotate the key.
 
 Recommended for stable upgrades:
 
 ```bash
 helm upgrade --install waddle ./charts/waddle-server \
   --namespace waddle \
-  --set secret.sessionKey="$(openssl rand -hex 32)"
+  --set secret.sessionKey="$(openssl rand -hex 32)" \
+  --set secret.occupantIdSecret="$(openssl rand -base64 48)"
 ```
 
 Or use an existing secret:

--- a/server/charts/waddle-server/templates/secret.yaml
+++ b/server/charts/waddle-server/templates/secret.yaml
@@ -8,6 +8,7 @@
 {{- $existingXmppInboxDatabaseUrl := "" -}}
 {{- $existingXmppPubsubDatabaseUrl := "" -}}
 {{- $existingSpiceDbPresharedKey := "" -}}
+{{- $existingOccupantIdSecret := "" -}}
 {{- if and $existing $existing.data (hasKey $existing.data "WADDLE_SESSION_KEY") -}}
 {{- $existingSessionKey = (index $existing.data "WADDLE_SESSION_KEY" | b64dec) -}}
 {{- end -}}
@@ -29,6 +30,9 @@
 {{- if and $existing $existing.data (hasKey $existing.data "WADDLE_SPICEDB_PRESHARED_KEY") -}}
 {{- $existingSpiceDbPresharedKey = (index $existing.data "WADDLE_SPICEDB_PRESHARED_KEY" | b64dec) -}}
 {{- end -}}
+{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_OCCUPANT_ID_SECRET") -}}
+{{- $existingOccupantIdSecret = (index $existing.data "WADDLE_OCCUPANT_ID_SECRET" | b64dec) -}}
+{{- end -}}
 {{- $sessionKey := default "" (coalesce .Values.secret.sessionKey $existingSessionKey) -}}
 {{- $authProvidersJson := coalesce .Values.secret.authProvidersJson $existingAuthProvidersJson -}}
 {{- $databaseUrl := coalesce .Values.secret.databaseUrl $existingDatabaseUrl -}}
@@ -36,8 +40,12 @@
 {{- $xmppInboxDatabaseUrl := coalesce .Values.secret.xmppInboxDatabaseUrl $existingXmppInboxDatabaseUrl -}}
 {{- $xmppPubsubDatabaseUrl := coalesce .Values.secret.xmppPubsubDatabaseUrl $existingXmppPubsubDatabaseUrl -}}
 {{- $spicedbPresharedKey := coalesce .Values.secret.spicedbPresharedKey $existingSpiceDbPresharedKey -}}
+{{- $occupantIdSecret := default "" (coalesce .Values.secret.occupantIdSecret $existingOccupantIdSecret) -}}
 {{- if empty $sessionKey -}}
 {{- $sessionKey = randAlphaNum 64 -}}
+{{- end -}}
+{{- if empty $occupantIdSecret -}}
+{{- $occupantIdSecret = randAlphaNum 64 -}}
 {{- end -}}
 apiVersion: v1
 kind: Secret
@@ -48,6 +56,7 @@ metadata:
 type: Opaque
 data:
   WADDLE_SESSION_KEY: {{ $sessionKey | toString | b64enc }}
+  WADDLE_OCCUPANT_ID_SECRET: {{ $occupantIdSecret | toString | b64enc }}
   {{- if $authProvidersJson }}
   WADDLE_AUTH_PROVIDERS_JSON: {{ $authProvidersJson | toString | b64enc }}
   {{- end }}

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -141,6 +141,13 @@ secret:
   create: true
   existingSecret: ""
   sessionKey: ""
+  # Per-deployment HMAC key used to derive XEP-0421 occupant identifiers.
+  # Required (≥32 bytes). When `secret.create` is true and this value is
+  # empty the chart auto-generates a 64-character alphanumeric secret on
+  # first install and preserves it across upgrades via `lookup`.
+  # **Do not rotate** without an explicit migration plan — rotation breaks
+  # XEP-0421 occupant-id continuity for every existing room/user pair.
+  occupantIdSecret: ""
   # JSON object/array for WADDLE_AUTH_PROVIDERS_JSON.
   # This usually contains provider client secrets and should stay in Secret data.
   # Example:

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 use tracing::info;
 use waddle_extensions::ExtensionConfig;
+use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
@@ -133,6 +134,41 @@ pub struct ServerConfig {
     /// SpiceDB backend configuration.
     /// Runtime startup requires this to be set.
     pub spicedb: Option<SpiceDbConfig>,
+    /// Per-deployment HMAC key used to derive XEP-0421 occupant
+    /// identifiers. Loaded from `WADDLE_OCCUPANT_ID_SECRET` and shared
+    /// across the WebSocket dependencies and `RoomRegistryActor` so
+    /// every stamping site reads the same key. Required at startup;
+    /// see [`parse_occupant_id_secret`] for the validation rules.
+    pub occupant_id_secret: OccupantIdSecret,
+}
+
+/// Validate the `WADDLE_OCCUPANT_ID_SECRET` env var into a typed secret.
+///
+/// Pure function so the validation logic is unit-testable without
+/// mutating process-global env state. Called by [`ServerConfig::from_env`]
+/// with the result of `std::env::var(...).ok().as_deref()`.
+fn parse_occupant_id_secret(raw: Option<&str>) -> Result<OccupantIdSecret, String> {
+    let value = raw.ok_or_else(|| {
+        format!(
+            "WADDLE_OCCUPANT_ID_SECRET is required (≥{OCCUPANT_ID_SECRET_MIN_BYTES} bytes; \
+             generate with: openssl rand -base64 48)"
+        )
+    })?;
+    OccupantIdSecret::new(value.as_bytes().to_vec()).map_err(|e| {
+        format!(
+            "WADDLE_OCCUPANT_ID_SECRET invalid: {e} \
+             (generate with: openssl rand -base64 48)"
+        )
+    })
+}
+
+#[cfg(test)]
+const TEST_OCCUPANT_ID_SECRET: &str = "test-occupant-id-secret-32-bytes-long";
+
+#[cfg(test)]
+fn test_occupant_id_secret() -> OccupantIdSecret {
+    OccupantIdSecret::new(TEST_OCCUPANT_ID_SECRET.as_bytes().to_vec())
+        .expect("test secret meets length floor")
 }
 
 impl Default for ServerConfig {
@@ -144,6 +180,19 @@ impl Default for ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             spicedb: None,
+            // The Default impl is only used in tests / scaffolding paths
+            // that don't go through `from_env`. Production startup must
+            // call `ServerConfig::from_env` which enforces the env var.
+            #[cfg(test)]
+            occupant_id_secret: test_occupant_id_secret(),
+            // In non-test builds the Default impl is unused for production
+            // bootstrap; supply a placeholder that meets the length floor
+            // so any incidental `Default::default()` still type-checks.
+            #[cfg(not(test))]
+            occupant_id_secret: OccupantIdSecret::new(
+                b"PLACEHOLDER-default-impl-do-not-use-32b".to_vec(),
+            )
+            .expect("placeholder meets length floor"),
         }
     }
 }
@@ -163,6 +212,9 @@ impl ServerConfig {
             ExtensionConfig::from_env().map_err(|e| format!("invalid extension config: {e}"))?;
         let spicedb = SpiceDbConfig::from_env()?;
 
+        let occupant_id_secret =
+            parse_occupant_id_secret(std::env::var("WADDLE_OCCUPANT_ID_SECRET").ok().as_deref())?;
+
         Ok(Self {
             mode,
             base_url,
@@ -170,6 +222,7 @@ impl ServerConfig {
             auth,
             extensions,
             spicedb,
+            occupant_id_secret,
         })
     }
 
@@ -200,6 +253,7 @@ impl ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             spicedb: None,
+            occupant_id_secret: test_occupant_id_secret(),
         }
     }
 
@@ -212,7 +266,47 @@ impl ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             spicedb: None,
+            occupant_id_secret: test_occupant_id_secret(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_occupant_id_secret_rejects_unset() {
+        let err = parse_occupant_id_secret(None).unwrap_err();
+        assert!(
+            err.contains("WADDLE_OCCUPANT_ID_SECRET is required"),
+            "error must name the env var; got: {err}"
+        );
+        assert!(
+            err.contains("openssl rand"),
+            "error must include the generation recipe; got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_occupant_id_secret_rejects_short_value() {
+        let err = parse_occupant_id_secret(Some("short")).unwrap_err();
+        assert!(
+            err.contains("at least"),
+            "error must mention the length floor; got: {err}"
+        );
+        assert!(
+            err.contains("openssl rand"),
+            "error must include the generation recipe; got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_occupant_id_secret_accepts_minimum_length() {
+        // Exactly the floor — must succeed.
+        let value: String = "x".repeat(OCCUPANT_ID_SECRET_MIN_BYTES);
+        let secret = parse_occupant_id_secret(Some(&value)).expect("32 bytes is accepted");
+        assert_eq!(secret.key().len(), OCCUPANT_ID_SECRET_MIN_BYTES);
     }
 }
 

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -171,6 +171,12 @@ fn test_occupant_id_secret() -> OccupantIdSecret {
         .expect("test secret meets length floor")
 }
 
+// `Default` is gated to `#[cfg(test)]`. Production startup MUST go
+// through `ServerConfig::from_env`, which enforces the deployment-keyed
+// `WADDLE_OCCUPANT_ID_SECRET`; a non-test `Default` impl could be
+// silently used (e.g. via `..Default::default()` in scaffolding) and
+// reintroduce the cross-deployment linkability that #283 closes.
+#[cfg(test)]
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
@@ -180,19 +186,7 @@ impl Default for ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             spicedb: None,
-            // The Default impl is only used in tests / scaffolding paths
-            // that don't go through `from_env`. Production startup must
-            // call `ServerConfig::from_env` which enforces the env var.
-            #[cfg(test)]
             occupant_id_secret: test_occupant_id_secret(),
-            // In non-test builds the Default impl is unused for production
-            // bootstrap; supply a placeholder that meets the length floor
-            // so any incidental `Default::default()` still type-checks.
-            #[cfg(not(test))]
-            occupant_id_secret: OccupantIdSecret::new(
-                b"PLACEHOLDER-default-impl-do-not-use-32b".to_vec(),
-            )
-            .expect("placeholder meets length floor"),
         }
     }
 }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -932,7 +932,10 @@ async fn create_router(
     // Create MUC room registry with the XMPP domain (not the HTTP base_url host)
     let xmpp_domain = auth_state.xmpp_domain.clone();
     let service_domains = XmppServiceDomains::new(&xmpp_domain, &xmpp_config.component_domain);
-    let room_registry = kameo::spawn(RoomRegistryActor::new(service_domains.muc.clone()));
+    let room_registry = kameo::spawn(RoomRegistryActor::new(
+        service_domains.muc.clone(),
+        server_config.occupant_id_secret.clone(),
+    ));
 
     let extension_launch_key = server_config
         .session_key
@@ -1026,6 +1029,7 @@ async fn create_router(
                 sm_session_registry,
                 resumable_sessions,
             },
+            occupant_id_secret: server_config.occupant_id_secret.clone(),
         },
     });
     // XEP-0198 expired-session janitor. Without this, detached SM sessions

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -90,7 +90,6 @@ use waddle_xmpp::mam::{
     ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
     RichMessageId, RichText, STANZA_ID_NS,
 };
-use waddle_xmpp::muc::presence::OCCUPANT_ID_SECRET;
 use waddle_xmpp::muc::room_actor::{GetNicknameGeneration, GetRoomSnapshot, RoomActor};
 use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parse_managed_room_jid;
@@ -1451,7 +1450,7 @@ async fn dispatch_to_room(
         managed_room_forbidden,
         room_moderated: snapshot.config.moderated,
         id_gen: &id_gen,
-        occupant_id_secret: OCCUPANT_ID_SECRET,
+        occupant_id_secret: &state.deps.occupant_id_secret,
         sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
         project_sender_inbox: true,
         dispatch_timestamp,
@@ -1568,7 +1567,7 @@ async fn dispatch_to_room(
         // previously emitted `RoomActorError::VisitorMayNotSpeak`.
         room_moderated: snapshot.config.moderated,
         id_gen: &id_gen,
-        occupant_id_secret: OCCUPANT_ID_SECRET,
+        occupant_id_secret: &state.deps.occupant_id_secret,
         // Carry the sender's nickname-generation through the chain
         // so `MucArchiveHandler` can stamp it directly on
         // `OutboundEvent::ArchiveGroupchat`. Avoids a second
@@ -1636,6 +1635,7 @@ async fn dispatch_to_room(
                     room_moderated: snapshot.config.moderated,
                     dispatch_timestamp,
                     recursion_depth,
+                    occupant_id_secret: &state.deps.occupant_id_secret,
                 },
                 response,
             ))
@@ -1655,6 +1655,7 @@ struct BotGroupchatDispatch<'a> {
     room_moderated: bool,
     dispatch_timestamp: i64,
     recursion_depth: u8,
+    occupant_id_secret: &'a waddle_xmpp::xep::xep0421::OccupantIdSecret,
 }
 
 async fn dispatch_bot_groupchat_response(
@@ -1734,7 +1735,7 @@ async fn dispatch_bot_groupchat_response(
         managed_room_forbidden: false,
         room_moderated: bot_ctx.room_moderated,
         id_gen: &id_gen,
-        occupant_id_secret: OCCUPANT_ID_SECRET,
+        occupant_id_secret: bot_ctx.occupant_id_secret,
         sender_nickname_generation: 0,
         project_sender_inbox: false,
         dispatch_timestamp: bot_ctx.dispatch_timestamp,
@@ -4123,6 +4124,10 @@ mod tests {
             }),
         };
 
+        let test_secret = waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("test secret meets length floor");
         let outcome = dispatch_bot_groupchat_response(
             &Deps::registry_only(&registry),
             BotGroupchatDispatch {
@@ -4132,6 +4137,7 @@ mod tests {
                 room_moderated: false,
                 dispatch_timestamp: 1777629203,
                 recursion_depth: 0,
+                occupant_id_secret: &test_secret,
             },
             response,
         )

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -1689,6 +1689,7 @@ pub async fn handle_muc_join(
     if !join_outcome.is_same_bare_multi_session_join {
         for existing in &join_outcome.existing_occupants {
             let presence_stanza = create_presence_stanza(
+                state,
                 room_jid,
                 nick,
                 sender_jid,
@@ -1807,7 +1808,9 @@ pub async fn handle_muc_leave(
 
     let Some(room_actor) = get_room_actor(state, room_jid).await else {
         debug!(room = %room_jid, "Room not found for leave");
-        return vec![build_muc_self_unavailable_xml(room_jid, nick, sender_jid)];
+        return vec![build_muc_self_unavailable_xml(
+            state, room_jid, nick, sender_jid,
+        )];
     };
 
     let outcome = match room_actor
@@ -1819,11 +1822,15 @@ pub async fn handle_muc_leave(
         Ok(Some(outcome)) => outcome,
         Ok(None) => {
             debug!(room = %room_jid, nick = %nick, sender = %sender_jid, "MUC leave for absent occupant");
-            return vec![build_muc_self_unavailable_xml(room_jid, nick, sender_jid)];
+            return vec![build_muc_self_unavailable_xml(
+                state, room_jid, nick, sender_jid,
+            )];
         }
         Err(error) => {
             warn!(room = %room_jid, nick = %nick, sender = %sender_jid, error = ?error, "Failed to leave MUC room");
-            return vec![build_muc_self_unavailable_xml(room_jid, nick, sender_jid)];
+            return vec![build_muc_self_unavailable_xml(
+                state, room_jid, nick, sender_jid,
+            )];
         }
     };
 
@@ -1841,6 +1848,7 @@ pub async fn handle_muc_leave(
                 Affiliation::Member,
                 false,
                 Some(sender_jid),
+                &state.deps.occupant_id_secret,
             );
             let stanza = Stanza::Presence(presence);
             let _outcome = state
@@ -1852,6 +1860,7 @@ pub async fn handle_muc_leave(
     }
 
     vec![build_muc_self_unavailable_xml(
+        state,
         room_jid,
         &outcome.nick,
         sender_jid,
@@ -1977,7 +1986,12 @@ fn build_muc_subject_message_xml(room_jid: &BareJid, to_jid: &FullJid, room_name
     )
 }
 
-fn build_muc_self_unavailable_xml(room_jid: &BareJid, nick: &str, sender_jid: &FullJid) -> String {
+fn build_muc_self_unavailable_xml(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    nick: &str,
+    sender_jid: &FullJid,
+) -> String {
     let from_jid = room_jid
         .clone()
         .with_resource_str(nick)
@@ -1989,6 +2003,7 @@ fn build_muc_self_unavailable_xml(room_jid: &BareJid, nick: &str, sender_jid: &F
         Affiliation::Member,
         true,
         Some(sender_jid),
+        &state.deps.occupant_id_secret,
     );
     stanza_to_xml(&Stanza::Presence(presence))
 }
@@ -2019,6 +2034,7 @@ async fn server_permission_allowed(
 
 /// Create a presence stanza for MUC
 fn create_presence_stanza(
+    state: &WebSocketState,
     room_jid: &BareJid,
     nick: &str,
     real_jid: &FullJid,
@@ -2038,6 +2054,7 @@ fn create_presence_stanza(
         role,
         false,
         Some(real_jid),
+        &state.deps.occupant_id_secret,
     )
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -1842,13 +1842,17 @@ pub async fn handle_muc_leave(
                 .clone()
                 .with_resource_str(&outcome.nick)
                 .unwrap_or_else(|_| sender_jid.clone());
+            let sender_bare = sender_jid.to_bare();
             let presence = waddle_xmpp::muc::build_leave_presence(
                 &from_jid,
                 occupant_jid,
                 Affiliation::Member,
                 false,
-                Some(sender_jid),
-                &state.deps.occupant_id_secret,
+                &waddle_xmpp::xep::xep0421::OccupantIdentity {
+                    bare_jid: &sender_bare,
+                    real_jid: Some(sender_jid),
+                    secret: &state.deps.occupant_id_secret,
+                },
             );
             let stanza = Stanza::Presence(presence);
             let _outcome = state
@@ -1997,13 +2001,17 @@ fn build_muc_self_unavailable_xml(
         .with_resource_str(nick)
         .unwrap_or_else(|_| sender_jid.clone());
 
+    let sender_bare = sender_jid.to_bare();
     let presence = waddle_xmpp::muc::build_leave_presence(
         &from_jid,
         sender_jid,
         Affiliation::Member,
         true,
-        Some(sender_jid),
-        &state.deps.occupant_id_secret,
+        &waddle_xmpp::xep::xep0421::OccupantIdentity {
+            bare_jid: &sender_bare,
+            real_jid: Some(sender_jid),
+            secret: &state.deps.occupant_id_secret,
+        },
     );
     stanza_to_xml(&Stanza::Presence(presence))
 }
@@ -2047,14 +2055,18 @@ fn create_presence_stanza(
         .with_resource_str(nick)
         .unwrap_or_else(|_| real_jid.clone());
 
+    let real_bare = real_jid.to_bare();
     waddle_xmpp::muc::build_occupant_presence(
         &from_jid,
         to_jid,
         affiliation,
         role,
         false,
-        Some(real_jid),
-        &state.deps.occupant_id_secret,
+        &waddle_xmpp::xep::xep0421::OccupantIdentity {
+            bare_jid: &real_bare,
+            real_jid: Some(real_jid),
+            secret: &state.deps.occupant_id_secret,
+        },
     )
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -49,6 +49,7 @@ use waddle_xmpp::{
         InMemorySmSessionRegistry, SmClaimCompletion, SmEnable, SmResume, SmSessionRegistry,
         SmStanza, StreamManagementState, SM_NS,
     },
+    xep::xep0421::OccupantIdSecret,
     Stanza,
 };
 use xmpp_parsers::minidom::Element;
@@ -97,6 +98,10 @@ pub struct WebSocketDeps {
     pub service_domains: XmppServiceDomains,
     /// Protocol/runtime services used by the WebSocket C2S path.
     pub protocol: ProtocolServices,
+    /// Per-deployment XEP-0421 occupant-id HMAC key. Cheap-clone via the
+    /// inner `Arc<[u8]>`; shared with `RoomRegistryActor` so every
+    /// stamping site uses the same key.
+    pub occupant_id_secret: OccupantIdSecret,
 }
 
 pub struct ProtocolServices {
@@ -2685,6 +2690,8 @@ mod tests {
                     connection_registry: Arc::new(ConnectionRegistry::new()),
                     room_registry: kameo::spawn(RoomRegistryActor::new(
                         "muc.example.com".to_string(),
+                        OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
+                            .expect("test secret meets length floor"),
                     )),
                     mam_storage,
                     inbox_storage: Arc::new(
@@ -2702,6 +2709,10 @@ mod tests {
                     sm_session_registry: Arc::new(InMemorySmSessionRegistry::new()),
                     resumable_sessions: Arc::new(dashmap::DashMap::new()),
                 },
+                occupant_id_secret: OccupantIdSecret::new(
+                    b"test-occupant-id-secret-32-bytes-long".to_vec(),
+                )
+                .expect("test secret meets length floor"),
             },
         })
     }

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -80,6 +80,10 @@ impl TestServer {
             .env("WADDLE_XMPP_MAM_DATABASE_URL", "sqlite::memory:")
             .env("WADDLE_XMPP_INBOX_DATABASE_URL", "sqlite::memory:")
             .env("WADDLE_XMPP_PUBSUB_DATABASE_URL", "sqlite::memory:")
+            .env(
+                "WADDLE_OCCUPANT_ID_SECRET",
+                "integration-test-occupant-id-secret-32-bytes-long",
+            )
             .env("WADDLE_HTTP_PORT_FILE", &port_file)
             .stdout(Stdio::null())
             .stderr(Stdio::null())

--- a/server/crates/waddle-server/tests/xep0421_occupant_id_ws.rs
+++ b/server/crates/waddle-server/tests/xep0421_occupant_id_ws.rs
@@ -1,0 +1,102 @@
+//! XEP-0421 occupant-id wiring integration test over WebSocket.
+//!
+//! End-to-end coverage that the deployment-config secret loaded from
+//! `WADDLE_OCCUPANT_ID_SECRET` (set by the test harness in
+//! `ws_common/mod.rs`) reaches the actual stamping site, and that the
+//! resulting `<occupant-id/>` matches the documented derivation
+//! `HMAC_SHA256(secret, room_bare || 0x00 || user_bare)`.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use waddle_xmpp::xep::xep0421::{generate_occupant_id, OccupantIdSecret};
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+/// Must match `WADDLE_OCCUPANT_ID_SECRET` set by `ws_common/mod.rs`.
+/// Co-locating it here ensures the assertion fails loudly if the harness
+/// ever changes the secret without updating this test.
+const HARNESS_SECRET: &str = "integration-test-occupant-id-secret-32-bytes-long";
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0421-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn extract_occupant_id_attr(frame: &str) -> Option<String> {
+    // Stanzas come over the wire as text; cheap substring extraction
+    // is sufficient for this assertion-only test.
+    let needle = "<occupant-id";
+    let start = frame.find(needle)?;
+    let tail = &frame[start..];
+    let id_attr = tail.find("id=")?;
+    let after = &tail[id_attr + 3..];
+    let quote = after.chars().next()?;
+    let inner = &after[1..];
+    let end = inner.find(quote)?;
+    Some(inner[..end].to_string())
+}
+
+#[tokio::test]
+async fn xep_0421_groupchat_reflection_carries_occupant_id_keyed_by_env_secret() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("oid-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="client-msg-1">
+                <body>occupant-id wiring check</body>
+            </message>"#
+        ))
+        .await
+        .expect("send message");
+
+    let echo = client
+        .recv_matching(|frame| frame.contains("occupant-id wiring check"))
+        .await
+        .expect("echo");
+
+    let stamped = extract_occupant_id_attr(&echo)
+        .unwrap_or_else(|| panic!("reflected message must carry <occupant-id/>; got: {echo}"));
+
+    let secret = OccupantIdSecret::new(HARNESS_SECRET.as_bytes().to_vec())
+        .expect("harness secret meets length floor");
+    let room_bare: jid::BareJid = room.parse().expect("room bare jid");
+    let user_bare: jid::BareJid = format!("{USERNAME}@{DOMAIN}")
+        .parse()
+        .expect("user bare jid");
+    let expected = generate_occupant_id(&user_bare, &room_bare, &secret);
+
+    assert_eq!(
+        stamped,
+        expected.as_str(),
+        "stamped occupant-id must match HMAC(env-secret, room || 0x00 || user); \
+         echo={echo}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -12,7 +12,7 @@ use xmpp_parsers::muc::user::{
 use xmpp_parsers::presence::{Presence, Type as PresenceType};
 
 use crate::types::{Affiliation, Role};
-use crate::xep::xep0421::OccupantIdSecret;
+use crate::xep::xep0421::OccupantIdentity;
 use crate::XmppError;
 
 /// Namespace for MUC user protocol.
@@ -267,34 +267,19 @@ pub fn build_occupant_presence(
     affiliation: Affiliation,
     role: Role,
     is_self: bool, // true if this is the joining user's own presence
-    occupant_real_jid: Option<&FullJid>, // real JID to include (semi-anonymous rooms)
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
-    add_muc_user_payload(&mut presence, affiliation, role, is_self, occupant_real_jid);
-    add_presence_identity_payloads(
-        &mut presence,
-        from_room_jid,
-        affiliation,
-        role,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
-    );
+    add_muc_user_payload(&mut presence, affiliation, role, is_self, identity.real_jid);
+    add_presence_identity_payloads(&mut presence, from_room_jid, affiliation, role, identity);
 
     presence
 }
 
 /// Build a rebroadcast in-room presence update with server-trusted MUC identity.
-///
-/// `clippy::too_many_arguments` is suppressed: the parameter list mirrors
-/// the XEP-0045 §7.x identity tuple for an occupant presence update, plus
-/// the per-deployment XEP-0421 key threaded in by #283. Bundling them
-/// into a sub-struct would obscure the spec mapping; the existing
-/// `interpret.rs::project_groupchat_inbox` follows the same pattern.
-#[allow(clippy::too_many_arguments)]
 pub fn build_occupant_presence_update(
     incoming_presence: &Presence,
     from_room_jid: &FullJid,
@@ -302,22 +287,14 @@ pub fn build_occupant_presence_update(
     affiliation: Affiliation,
     role: Role,
     is_self: bool,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = incoming_presence.clone();
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
     strip_server_controlled_presence_payloads(&mut presence);
-    add_muc_user_payload(&mut presence, affiliation, role, is_self, occupant_real_jid);
-    add_presence_identity_payloads(
-        &mut presence,
-        from_room_jid,
-        affiliation,
-        role,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
-    );
+    add_muc_user_payload(&mut presence, affiliation, role, is_self, identity.real_jid);
+    add_presence_identity_payloads(&mut presence, from_room_jid, affiliation, role, identity);
 
     presence
 }
@@ -377,8 +354,7 @@ pub fn build_leave_presence(
     to_jid: &FullJid,        // recipient's real JID
     affiliation: Affiliation,
     is_self: bool,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -387,7 +363,7 @@ pub fn build_leave_presence(
     // Build the MUC user element
     let mut statuses = Vec::new();
 
-    if occupant_real_jid.is_some() {
+    if identity.real_jid.is_some() {
         statuses.push(Status::NonAnonymousRoom);
     }
 
@@ -399,7 +375,7 @@ pub fn build_leave_presence(
     let item = Item {
         affiliation: affiliation_to_muc(affiliation),
         role: MucRole::None,
-        jid: occupant_real_jid.cloned(),
+        jid: identity.real_jid.cloned(),
         nick: None,
         actor: None,
         continue_: None,
@@ -418,8 +394,7 @@ pub fn build_leave_presence(
         from_room_jid,
         affiliation,
         Role::None,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
+        identity,
     );
 
     presence
@@ -430,8 +405,7 @@ fn add_presence_identity_payloads(
     from_room_jid: &FullJid,
     affiliation: Affiliation,
     role: Role,
-    occupant_bare_jid: Option<BareJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) {
     let affiliation_name = match affiliation {
         Affiliation::Owner => "owner",
@@ -446,14 +420,16 @@ fn add_presence_identity_payloads(
     }
     crate::xep::xep0317::set_hats(presence, &hats);
 
-    if let Some(occupant_bare_jid) = occupant_bare_jid {
-        let occupant_id = crate::xep::xep0421::generate_occupant_id(
-            &occupant_bare_jid,
-            &from_room_jid.to_bare(),
-            occupant_id_secret,
-        );
-        crate::xep::xep0421::set_occupant_id_on_presence(presence, &occupant_id);
-    }
+    // XEP-0421 §"Business Rules": occupant-id MUST be on every emitted
+    // MUC presence regardless of whether the real JID is disclosed.
+    // The room service knows `bare_jid` even in fully-anonymous rooms;
+    // disclosure is governed independently by `identity.real_jid`.
+    let occupant_id = crate::xep::xep0421::generate_occupant_id(
+        identity.bare_jid,
+        &from_room_jid.to_bare(),
+        identity.secret,
+    );
+    crate::xep::xep0421::set_occupant_id_on_presence(presence, &occupant_id);
 }
 
 /// Convert internal Affiliation to xmpp_parsers MUC Affiliation.
@@ -490,11 +466,6 @@ fn role_to_muc(role: Role) -> MucRole {
 /// * `is_self` - True if this presence is going to the kicked user
 /// * `reason` - Optional reason for the kick
 /// * `actor` - Optional JID of who performed the kick
-///
-/// `clippy::too_many_arguments` is suppressed for the same reason as
-/// `build_occupant_presence_update`: the parameter list maps directly to
-/// the XEP-0045 §8.2 kick stanza shape.
-#[allow(clippy::too_many_arguments)]
 pub fn build_kick_presence(
     from_room_jid: &FullJid,
     to_jid: &FullJid,
@@ -502,15 +473,14 @@ pub fn build_kick_presence(
     is_self: bool,
     reason: Option<&str>,
     actor: Option<&BareJid>,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
     let mut statuses = vec![Status::Kicked];
-    if occupant_real_jid.is_some() {
+    if identity.real_jid.is_some() {
         statuses.push(Status::NonAnonymousRoom);
     }
     if is_self {
@@ -529,7 +499,7 @@ pub fn build_kick_presence(
     let item = Item {
         affiliation: affiliation_to_muc(affiliation),
         role: MucRole::None, // Kicked = role none
-        jid: occupant_real_jid.cloned(),
+        jid: identity.real_jid.cloned(),
         nick: None,
         actor: actor_elem,
         continue_: None,
@@ -548,8 +518,7 @@ pub fn build_kick_presence(
         from_room_jid,
         affiliation,
         Role::None,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
+        identity,
     );
 
     presence
@@ -573,15 +542,14 @@ pub fn build_ban_presence(
     is_self: bool,
     reason: Option<&str>,
     actor: Option<&BareJid>,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
     let mut statuses = vec![Status::Banned];
-    if occupant_real_jid.is_some() {
+    if identity.real_jid.is_some() {
         statuses.push(Status::NonAnonymousRoom);
     }
     if is_self {
@@ -600,7 +568,7 @@ pub fn build_ban_presence(
     let item = Item {
         affiliation: MucAffiliation::Outcast, // Banned = outcast
         role: MucRole::None,                  // Banned = role none
-        jid: occupant_real_jid.cloned(),
+        jid: identity.real_jid.cloned(),
         nick: None,
         actor: actor_elem,
         continue_: None,
@@ -619,8 +587,7 @@ pub fn build_ban_presence(
         from_room_jid,
         Affiliation::Outcast,
         Role::None,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
+        identity,
     );
 
     presence
@@ -644,15 +611,14 @@ pub fn build_affiliation_change_presence(
     new_affiliation: Affiliation,
     role: Role,
     is_self: bool,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
     let mut statuses = Vec::new();
-    if occupant_real_jid.is_some() {
+    if identity.real_jid.is_some() {
         statuses.push(Status::NonAnonymousRoom);
     }
     if is_self {
@@ -662,7 +628,7 @@ pub fn build_affiliation_change_presence(
     let item = Item {
         affiliation: affiliation_to_muc(new_affiliation),
         role: role_to_muc(role),
-        jid: occupant_real_jid.cloned(),
+        jid: identity.real_jid.cloned(),
         nick: None,
         actor: None,
         continue_: None,
@@ -681,8 +647,7 @@ pub fn build_affiliation_change_presence(
         from_room_jid,
         new_affiliation,
         role,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
+        identity,
     );
 
     presence
@@ -706,15 +671,14 @@ pub fn build_role_change_presence(
     affiliation: Affiliation,
     new_role: Role,
     is_self: bool,
-    occupant_real_jid: Option<&FullJid>,
-    occupant_id_secret: &OccupantIdSecret,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
     let mut statuses = Vec::new();
-    if occupant_real_jid.is_some() {
+    if identity.real_jid.is_some() {
         statuses.push(Status::NonAnonymousRoom);
     }
     if is_self {
@@ -724,7 +688,7 @@ pub fn build_role_change_presence(
     let item = Item {
         affiliation: affiliation_to_muc(affiliation),
         role: role_to_muc(new_role),
-        jid: occupant_real_jid.cloned(),
+        jid: identity.real_jid.cloned(),
         nick: None,
         actor: None,
         continue_: None,
@@ -743,8 +707,7 @@ pub fn build_role_change_presence(
         from_room_jid,
         affiliation,
         new_role,
-        occupant_real_jid.map(|jid| jid.to_bare()),
-        occupant_id_secret,
+        identity,
     );
 
     presence
@@ -754,8 +717,8 @@ pub fn build_role_change_presence(
 mod tests {
     use super::*;
 
-    fn test_secret() -> OccupantIdSecret {
-        OccupantIdSecret::for_testing(b"presence-test-secret".to_vec())
+    fn test_secret() -> crate::xep::xep0421::OccupantIdSecret {
+        crate::xep::xep0421::OccupantIdSecret::for_testing(b"presence-test-secret".to_vec())
     }
 
     fn make_sender_jid() -> FullJid {
@@ -859,14 +822,18 @@ mod tests {
         let occupant_jid: FullJid = "joiner@example.com/desktop".parse().unwrap();
 
         let secret = test_secret();
+        let occupant_bare = occupant_jid.to_bare();
         let presence = build_occupant_presence(
             &from,
             &to,
             Affiliation::Member,
             Role::Participant,
             true, // is_self
-            Some(&occupant_jid),
-            &secret,
+            &OccupantIdentity {
+                bare_jid: &occupant_bare,
+                real_jid: Some(&occupant_jid),
+                secret: &secret,
+            },
         );
 
         assert_eq!(presence.from, Some(Jid::from(from)));
@@ -897,13 +864,17 @@ mod tests {
         let occupant_jid: FullJid = "leaver@example.com/phone".parse().unwrap();
 
         let secret = test_secret();
+        let occupant_bare = occupant_jid.to_bare();
         let presence = build_leave_presence(
             &from,
             &to,
             Affiliation::Member,
             true,
-            Some(&occupant_jid),
-            &secret,
+            &OccupantIdentity {
+                bare_jid: &occupant_bare,
+                real_jid: Some(&occupant_jid),
+                secret: &secret,
+            },
         );
 
         assert_eq!(presence.type_, PresenceType::Unavailable);
@@ -938,6 +909,7 @@ mod tests {
             .insert(String::new(), "coding".to_string());
 
         let secret = test_secret();
+        let occupant_bare = occupant_jid.to_bare();
         let presence = build_occupant_presence_update(
             &incoming,
             &from,
@@ -945,8 +917,11 @@ mod tests {
             Affiliation::Member,
             Role::Participant,
             false,
-            Some(&occupant_jid),
-            &secret,
+            &OccupantIdentity {
+                bare_jid: &occupant_bare,
+                real_jid: Some(&occupant_jid),
+                secret: &secret,
+            },
         );
 
         assert_eq!(presence.statuses.get(""), Some(&"coding".to_string()));

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -12,25 +12,8 @@ use xmpp_parsers::muc::user::{
 use xmpp_parsers::presence::{Presence, Type as PresenceType};
 
 use crate::types::{Affiliation, Role};
+use crate::xep::xep0421::OccupantIdSecret;
 use crate::XmppError;
-
-/// Server-side secret used to derive the XEP-0421 stable occupant-id
-/// HMAC. Shared between the presence-side stamping (this module) and
-/// the message-side groupchat reflection stamping (#229 PR17 room
-/// chain) so the same user resolves to the same occupant-id across
-/// presence joins/leaves AND outgoing groupchat messages.
-///
-/// **Deployment-config gap (Copilot review on PR #277, post-#229
-/// follow-up):** XEP-0421 §3 recommends the occupant-id derivation be
-/// keyed by a per-deployment secret so occupant-ids are unlinkable
-/// across deployments. Today this is a process-wide compiled-in
-/// constant. The new room handler chain takes the secret via
-/// [`crate::protocol::room::context::RoomContext::occupant_id_secret`]
-/// so a follow-up PR can thread a configured, rotatable secret from
-/// `WebSocketState` (or equivalent app state) through the production
-/// `presence.rs` and `message.rs` call sites and demote this constant
-/// to a `#[cfg(test)]` default.
-pub const OCCUPANT_ID_SECRET: &[u8] = b"waddle-xmpp-occupant-id-v1";
 
 /// Namespace for MUC user protocol.
 pub const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
@@ -285,6 +268,7 @@ pub fn build_occupant_presence(
     role: Role,
     is_self: bool, // true if this is the joining user's own presence
     occupant_real_jid: Option<&FullJid>, // real JID to include (semi-anonymous rooms)
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -297,12 +281,20 @@ pub fn build_occupant_presence(
         affiliation,
         role,
         occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
     );
 
     presence
 }
 
 /// Build a rebroadcast in-room presence update with server-trusted MUC identity.
+///
+/// `clippy::too_many_arguments` is suppressed: the parameter list mirrors
+/// the XEP-0045 §7.x identity tuple for an occupant presence update, plus
+/// the per-deployment XEP-0421 key threaded in by #283. Bundling them
+/// into a sub-struct would obscure the spec mapping; the existing
+/// `interpret.rs::project_groupchat_inbox` follows the same pattern.
+#[allow(clippy::too_many_arguments)]
 pub fn build_occupant_presence_update(
     incoming_presence: &Presence,
     from_room_jid: &FullJid,
@@ -311,6 +303,7 @@ pub fn build_occupant_presence_update(
     role: Role,
     is_self: bool,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = incoming_presence.clone();
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -323,6 +316,7 @@ pub fn build_occupant_presence_update(
         affiliation,
         role,
         occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
     );
 
     presence
@@ -384,6 +378,7 @@ pub fn build_leave_presence(
     affiliation: Affiliation,
     is_self: bool,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -418,7 +413,14 @@ pub fn build_leave_presence(
 
     let muc_element: Element = muc_user.into();
     presence.payloads.push(muc_element);
-    add_presence_identity_payloads(&mut presence, from_room_jid, affiliation, Role::None, None);
+    add_presence_identity_payloads(
+        &mut presence,
+        from_room_jid,
+        affiliation,
+        Role::None,
+        occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
+    );
 
     presence
 }
@@ -429,6 +431,7 @@ fn add_presence_identity_payloads(
     affiliation: Affiliation,
     role: Role,
     occupant_bare_jid: Option<BareJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) {
     let affiliation_name = match affiliation {
         Affiliation::Owner => "owner",
@@ -447,7 +450,7 @@ fn add_presence_identity_payloads(
         let occupant_id = crate::xep::xep0421::generate_occupant_id(
             &occupant_bare_jid,
             &from_room_jid.to_bare(),
-            OCCUPANT_ID_SECRET,
+            occupant_id_secret,
         );
         crate::xep::xep0421::set_occupant_id_on_presence(presence, &occupant_id);
     }
@@ -487,6 +490,11 @@ fn role_to_muc(role: Role) -> MucRole {
 /// * `is_self` - True if this presence is going to the kicked user
 /// * `reason` - Optional reason for the kick
 /// * `actor` - Optional JID of who performed the kick
+///
+/// `clippy::too_many_arguments` is suppressed for the same reason as
+/// `build_occupant_presence_update`: the parameter list maps directly to
+/// the XEP-0045 §8.2 kick stanza shape.
+#[allow(clippy::too_many_arguments)]
 pub fn build_kick_presence(
     from_room_jid: &FullJid,
     to_jid: &FullJid,
@@ -495,6 +503,7 @@ pub fn build_kick_presence(
     reason: Option<&str>,
     actor: Option<&BareJid>,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -534,6 +543,14 @@ pub fn build_kick_presence(
 
     let muc_element: Element = muc_user.into();
     presence.payloads.push(muc_element);
+    add_presence_identity_payloads(
+        &mut presence,
+        from_room_jid,
+        affiliation,
+        Role::None,
+        occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
+    );
 
     presence
 }
@@ -557,6 +574,7 @@ pub fn build_ban_presence(
     reason: Option<&str>,
     actor: Option<&BareJid>,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::Unavailable);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -596,6 +614,14 @@ pub fn build_ban_presence(
 
     let muc_element: Element = muc_user.into();
     presence.payloads.push(muc_element);
+    add_presence_identity_payloads(
+        &mut presence,
+        from_room_jid,
+        Affiliation::Outcast,
+        Role::None,
+        occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
+    );
 
     presence
 }
@@ -619,6 +645,7 @@ pub fn build_affiliation_change_presence(
     role: Role,
     is_self: bool,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -655,6 +682,7 @@ pub fn build_affiliation_change_presence(
         new_affiliation,
         role,
         occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
     );
 
     presence
@@ -679,6 +707,7 @@ pub fn build_role_change_presence(
     new_role: Role,
     is_self: bool,
     occupant_real_jid: Option<&FullJid>,
+    occupant_id_secret: &OccupantIdSecret,
 ) -> Presence {
     let mut presence = Presence::new(PresenceType::None);
     presence.from = Some(Jid::from(from_room_jid.clone()));
@@ -715,6 +744,7 @@ pub fn build_role_change_presence(
         affiliation,
         new_role,
         occupant_real_jid.map(|jid| jid.to_bare()),
+        occupant_id_secret,
     );
 
     presence
@@ -723,6 +753,10 @@ pub fn build_role_change_presence(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_secret() -> OccupantIdSecret {
+        OccupantIdSecret::for_testing(b"presence-test-secret".to_vec())
+    }
 
     fn make_sender_jid() -> FullJid {
         "user@example.com/resource".parse().unwrap()
@@ -824,6 +858,7 @@ mod tests {
         let to: FullJid = "user@example.com/resource".parse().unwrap();
         let occupant_jid: FullJid = "joiner@example.com/desktop".parse().unwrap();
 
+        let secret = test_secret();
         let presence = build_occupant_presence(
             &from,
             &to,
@@ -831,6 +866,7 @@ mod tests {
             Role::Participant,
             true, // is_self
             Some(&occupant_jid),
+            &secret,
         );
 
         assert_eq!(presence.from, Some(Jid::from(from)));
@@ -860,8 +896,15 @@ mod tests {
         let to: FullJid = "user@example.com/resource".parse().unwrap();
         let occupant_jid: FullJid = "leaver@example.com/phone".parse().unwrap();
 
-        let presence =
-            build_leave_presence(&from, &to, Affiliation::Member, true, Some(&occupant_jid));
+        let secret = test_secret();
+        let presence = build_leave_presence(
+            &from,
+            &to,
+            Affiliation::Member,
+            true,
+            Some(&occupant_jid),
+            &secret,
+        );
 
         assert_eq!(presence.type_, PresenceType::Unavailable);
         assert!(!presence.payloads.is_empty());
@@ -894,6 +937,7 @@ mod tests {
             .statuses
             .insert(String::new(), "coding".to_string());
 
+        let secret = test_secret();
         let presence = build_occupant_presence_update(
             &incoming,
             &from,
@@ -902,6 +946,7 @@ mod tests {
             Role::Participant,
             false,
             Some(&occupant_jid),
+            &secret,
         );
 
         assert_eq!(presence.statuses.get(""), Some(&"coding".to_string()));

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -20,6 +20,7 @@ use super::{
     build_role_change_presence, MucRoom, OutboundMucMessage, RoomConfig,
 };
 use crate::types::{Affiliation, Role};
+use crate::xep::xep0421::OccupantIdentity;
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -912,6 +913,12 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     .room_jid
                     .with_resource_str(&target_nick)
                     .expect("nick was previously accepted as resource");
+                let target_bare = target_occupant.real_jid.to_bare();
+                let target_identity = OccupantIdentity {
+                    bare_jid: &target_bare,
+                    real_jid: Some(&target_occupant.real_jid),
+                    secret: &self.occupant_id_secret,
+                };
                 if new_role == Role::None {
                     for (nick, occupant) in self.room.occupants.iter() {
                         let is_self = nick == &target_nick;
@@ -922,8 +929,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                             is_self,
                             item.reason.as_deref(),
                             Some(&msg.sender_jid.to_bare()),
-                            Some(&target_occupant.real_jid),
-                            &self.occupant_id_secret,
+                            &target_identity,
                         );
                         presence_updates.push((occupant.real_jid.clone(), presence));
                     }
@@ -940,8 +946,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                             target_occupant.affiliation,
                             new_role,
                             is_self,
-                            Some(&target_occupant.real_jid),
-                            &self.occupant_id_secret,
+                            &target_identity,
                         );
                         presence_updates.push((occupant.real_jid.clone(), presence));
                     }
@@ -1000,6 +1005,12 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                         .room_jid
                         .with_resource_str(&occupant.nick)
                         .expect("nick was previously accepted as resource");
+                    let occupant_bare = occupant.real_jid.to_bare();
+                    let occupant_identity = OccupantIdentity {
+                        bare_jid: &occupant_bare,
+                        real_jid: Some(&occupant.real_jid),
+                        secret: &self.occupant_id_secret,
+                    };
                     if new_affiliation == Affiliation::Outcast {
                         for (nick, occ) in self.room.occupants.iter() {
                             let is_self = nick == &occupant.nick;
@@ -1009,8 +1020,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                                 is_self,
                                 item.reason.as_deref(),
                                 Some(&msg.sender_jid.to_bare()),
-                                Some(&occupant.real_jid),
-                                &self.occupant_id_secret,
+                                &occupant_identity,
                             );
                             presence_updates.push((occ.real_jid.clone(), presence));
                         }
@@ -1024,8 +1034,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                                 new_affiliation,
                                 occupant.role,
                                 is_self,
-                                Some(&occupant.real_jid),
-                                &self.occupant_id_secret,
+                                &occupant_identity,
                             );
                             presence_updates.push((occ.real_jid.clone(), presence));
                         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -130,6 +130,7 @@ impl OccupantInfo {
 #[actor(mailbox = bounded(2048))]
 pub struct RoomActor {
     room: MucRoom,
+    occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
 }
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -161,8 +162,11 @@ pub enum RoomActorError {
 
 impl RoomActor {
     /// Create a new `RoomActor` wrapping the given room.
-    pub fn new(room: MucRoom) -> Self {
-        Self { room }
+    pub fn new(room: MucRoom, occupant_id_secret: crate::xep::xep0421::OccupantIdSecret) -> Self {
+        Self {
+            room,
+            occupant_id_secret,
+        }
     }
 }
 
@@ -919,6 +923,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                             item.reason.as_deref(),
                             Some(&msg.sender_jid.to_bare()),
                             Some(&target_occupant.real_jid),
+                            &self.occupant_id_secret,
                         );
                         presence_updates.push((occupant.real_jid.clone(), presence));
                     }
@@ -936,6 +941,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                             new_role,
                             is_self,
                             Some(&target_occupant.real_jid),
+                            &self.occupant_id_secret,
                         );
                         presence_updates.push((occupant.real_jid.clone(), presence));
                     }
@@ -1004,6 +1010,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                                 item.reason.as_deref(),
                                 Some(&msg.sender_jid.to_bare()),
                                 Some(&occupant.real_jid),
+                                &self.occupant_id_secret,
                             );
                             presence_updates.push((occ.real_jid.clone(), presence));
                         }
@@ -1018,6 +1025,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                                 occupant.role,
                                 is_self,
                                 Some(&occupant.real_jid),
+                                &self.occupant_id_secret,
                             );
                             presence_updates.push((occ.real_jid.clone(), presence));
                         }
@@ -1097,8 +1105,13 @@ impl kameo::message::Message<DestroyWithNotifications> for RoomActor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::xep::xep0421::OccupantIdSecret;
     use kameo::actor::ActorRef;
     use kameo::error::SendError;
+
+    fn test_secret() -> OccupantIdSecret {
+        OccupantIdSecret::for_testing(b"test-secret".to_vec())
+    }
 
     fn test_room() -> MucRoom {
         let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
@@ -1117,18 +1130,21 @@ mod tests {
     }
 
     async fn spawn_room_actor() -> ActorRef<RoomActor> {
-        kameo::spawn(RoomActor::new(test_room()))
+        kameo::spawn(RoomActor::new(test_room(), test_secret()))
     }
 
     async fn spawn_room_actor_with_config(mut config: RoomConfig) -> ActorRef<RoomActor> {
         let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
         config.name = "Test Room".to_string();
-        kameo::spawn(RoomActor::new(MucRoom::new(
-            room_jid,
-            "waddle-1".to_string(),
-            "channel-1".to_string(),
-            config,
-        )))
+        kameo::spawn(RoomActor::new(
+            MucRoom::new(
+                room_jid,
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                config,
+            ),
+            test_secret(),
+        ))
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -16,6 +16,7 @@ use tracing::{debug, info, warn};
 use super::room_actor::RoomActor;
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
+use crate::xep::xep0421::OccupantIdSecret;
 
 /// Actor that owns the mapping from room JIDs to per-room actors.
 ///
@@ -27,6 +28,10 @@ pub struct RoomRegistryActor {
     rooms: HashMap<BareJid, ActorRef<RoomActor>>,
     poisoned_rooms: HashSet<BareJid>,
     muc_domain: String,
+    /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
+    /// `RoomActor` at spawn so all rooms in this deployment share the
+    /// same keying material.
+    occupant_id_secret: OccupantIdSecret,
 }
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -39,12 +44,13 @@ pub enum RoomRegistryError {
 
 impl RoomRegistryActor {
     /// Create a new registry for the given MUC service domain.
-    pub fn new(muc_domain: String) -> Self {
+    pub fn new(muc_domain: String, occupant_id_secret: OccupantIdSecret) -> Self {
         info!(domain = %muc_domain, "Creating RoomRegistryActor");
         Self {
             rooms: HashMap::new(),
             poisoned_rooms: HashSet::new(),
             muc_domain,
+            occupant_id_secret,
         }
     }
 
@@ -59,7 +65,7 @@ impl RoomRegistryActor {
         config: RoomConfig,
     ) -> ActorRef<RoomActor> {
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
-        let actor_ref = kameo::spawn(RoomActor::new(room));
+        let actor_ref = kameo::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
         self.rooms.insert(room_jid, actor_ref.clone());
         actor_ref
     }
@@ -314,7 +320,10 @@ mod tests {
     }
 
     async fn spawn_registry() -> ActorRef<RoomRegistryActor> {
-        kameo::spawn(RoomRegistryActor::new("muc.example.com".to_string()))
+        kameo::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        ))
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -90,6 +90,7 @@ mod tests {
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
     use crate::xep::xep0334::Hint;
+    use crate::xep::xep0421::OccupantIdSecret;
     use jid::{BareJid, FullJid, Jid};
     use minidom::Element;
     use xmpp_parsers::message::{Body, Message, MessageType};
@@ -119,6 +120,7 @@ mod tests {
             role: Role::Participant,
         }];
         let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
         let ctx = RoomContext {
             room,
             sender_full: sender,
@@ -126,7 +128,7 @@ mod tests {
             managed_room_forbidden: false,
             room_moderated: false,
             id_gen: &id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -108,7 +108,7 @@ mod tests {
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
     use crate::xep::xep0359::{build_stanza_id_element, extract_stanza_ids};
-    use crate::xep::xep0421::{extract_occupant_id_from_message, OccupantId};
+    use crate::xep::xep0421::{extract_occupant_id_from_message, OccupantId, OccupantIdSecret};
     use crate::xep::xep0508::{set_thread_create, ThreadCreate};
     use jid::FullJid;
     use xmpp_parsers::message::{Body, Message, MessageType};
@@ -142,6 +142,7 @@ mod tests {
             role: Role::Participant,
         }];
         let id_gen = FixedIdGenerator(fresh.to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
         let ctx = RoomContext {
             room,
             sender_full: sender,
@@ -149,7 +150,7 @@ mod tests {
             managed_room_forbidden: false,
             room_moderated: false,
             id_gen: &id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,
@@ -235,7 +236,8 @@ mod tests {
         let id = extract_occupant_id_from_message(&msg).expect("occupant-id stamped");
 
         // Stable: same (user, room) yields same id with the same secret.
-        let expected = generate_occupant_id(&sender.to_bare(), &room, b"test-secret");
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let expected = generate_occupant_id(&sender.to_bare(), &room, &secret);
         assert_eq!(id, expected);
         // Non-empty.
         assert!(!id.as_str().is_empty());

--- a/server/crates/waddle-xmpp/src/protocol/room/context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/context.rs
@@ -16,6 +16,7 @@
 
 use super::super::id_gen::IdGenerator;
 use crate::types::{Affiliation, Role};
+use crate::xep::xep0421::OccupantIdSecret;
 use jid::{BareJid, FullJid};
 
 /// Snapshot of one occupant of the room, frozen at dispatch start.
@@ -94,7 +95,7 @@ pub struct RoomContext<'a> {
     /// Server-side secret used to derive the XEP-0421 stable occupant-id
     /// (per-(room, bare-jid) HMAC). Borrowed from the deployment config
     /// so tests can substitute a fixture without mutating global state.
-    pub occupant_id_secret: &'a [u8],
+    pub occupant_id_secret: &'a OccupantIdSecret,
     /// Sender's per-room nickname generation (XEP-0308 §3 correction
     /// window). Provided here so the
     /// [`super::archive::MucArchiveHandler`] can include it directly

--- a/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
@@ -80,6 +80,7 @@ mod tests {
     use super::*;
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::types::{Affiliation, Role};
+    use crate::xep::xep0421::OccupantIdSecret;
     use jid::{BareJid, FullJid};
     use xmpp_parsers::message::{Message, MessageType};
 
@@ -106,6 +107,7 @@ mod tests {
         sender_full: &'a FullJid,
         occupants: &'a [OccupantSnapshot],
         id_gen: &'a FixedIdGenerator,
+        occupant_id_secret: &'a OccupantIdSecret,
     ) -> RoomContext<'a> {
         RoomContext {
             room,
@@ -114,7 +116,7 @@ mod tests {
             managed_room_forbidden: false,
             room_moderated: false,
             id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,
@@ -139,7 +141,8 @@ mod tests {
             role: Role::Participant,
         }];
         let id_gen = FixedIdGenerator("fresh-id".to_string());
-        let ctx = fixture_ctx(&room, &sender, &occupants, &id_gen);
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let ctx = fixture_ctx(&room, &sender, &occupants, &id_gen, &secret);
 
         let mut chain = RoomDispatcher::new();
         chain.register(Arc::new(CountHandler {

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -109,6 +109,7 @@ mod tests {
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
+    use crate::xep::xep0421::OccupantIdSecret;
     use crate::xep::xep0461::set_thread_id;
     use jid::{FullJid, Jid};
     use xmpp_parsers::message::{Body, Message, MessageType};
@@ -147,6 +148,7 @@ mod tests {
         msg: &mut Message,
     ) -> Vec<OutboundEvent> {
         let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
         let ctx = RoomContext {
             room,
             sender_full,
@@ -154,7 +156,7 @@ mod tests {
             managed_room_forbidden: false,
             room_moderated: false,
             id_gen: &id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,

--- a/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/occupancy_validation.rs
@@ -131,6 +131,7 @@ mod tests {
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
+    use crate::xep::xep0421::OccupantIdSecret;
     use crate::Stanza;
     use jid::{BareJid, FullJid};
 
@@ -169,6 +170,7 @@ mod tests {
         msg: &mut Message,
     ) -> RoomHandlerOutcome {
         let id_gen = FixedIdGenerator("fresh".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
         let ctx = RoomContext {
             room,
             sender_full: sender,
@@ -176,7 +178,7 @@ mod tests {
             managed_room_forbidden: managed_forbidden,
             room_moderated: moderated,
             id_gen: &id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,

--- a/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/reflector.rs
@@ -50,6 +50,7 @@ mod tests {
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
+    use crate::xep::xep0421::OccupantIdSecret;
     use jid::{BareJid, FullJid};
     use xmpp_parsers::message::{Body, Message, MessageType};
 
@@ -67,6 +68,7 @@ mod tests {
         msg: &mut Message,
     ) -> Vec<OutboundEvent> {
         let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
         let ctx = RoomContext {
             room,
             sender_full: sender,
@@ -74,7 +76,7 @@ mod tests {
             managed_room_forbidden: false,
             room_moderated: false,
             id_gen: &id_gen,
-            occupant_id_secret: b"test-secret",
+            occupant_id_secret: &secret,
             sender_nickname_generation: 0,
             project_sender_inbox: true,
             dispatch_timestamp: 0,

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs
@@ -18,13 +18,20 @@ use super::id_gen::FixedIdGenerator;
 use super::room::{default_room_dispatcher, OccupantSnapshot, RoomContext};
 use crate::types::{Affiliation, Role};
 use crate::xep::xep0359::{extract_stanza_ids, NS_SID};
-use crate::xep::xep0421::{extract_occupant_id_from_message, generate_occupant_id};
+use crate::xep::xep0421::{
+    extract_occupant_id_from_message, generate_occupant_id, OccupantIdSecret,
+};
 use crate::Stanza;
 use jid::{BareJid, FullJid, Jid};
 use xmpp_parsers::message::{Body, Message, MessageType};
 use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
-const TEST_OCCUPANT_ID_SECRET: &[u8] = b"l4-test-occupant-id-secret";
+fn test_occupant_id_secret() -> OccupantIdSecret {
+    // ≥32 bytes so the value also passes the production length floor;
+    // the L4 wire-trace fixture mirrors what a real deployment would carry.
+    OccupantIdSecret::new(b"l4-wire-trace-occupant-id-secret-32b".to_vec())
+        .expect("test secret meets length floor")
+}
 
 fn full(s: &str) -> FullJid {
     s.parse().expect("valid full jid")
@@ -75,6 +82,7 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
         occ(bob.clone(), "bob-nick"),
     ];
     let id_gen = FixedIdGenerator("room-archive-id-1".to_string());
+    let secret = test_occupant_id_secret();
     let ctx = RoomContext {
         room: &room,
         sender_full: &alice,
@@ -82,7 +90,7 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
         managed_room_forbidden: false,
         room_moderated: false,
         id_gen: &id_gen,
-        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+        occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
         dispatch_timestamp: 0,
@@ -124,8 +132,7 @@ fn xep_0045_groupchat_dispatches_through_handler_chain_with_canonical_stamps() {
     assert_eq!(routes.len(), 2, "fan-out to both occupants");
 
     // Every reflected copy carries the canonical stamps.
-    let expected_occupant_id =
-        generate_occupant_id(&alice.to_bare(), &room, TEST_OCCUPANT_ID_SECRET);
+    let expected_occupant_id = generate_occupant_id(&alice.to_bare(), &room, &secret);
     for route in &routes {
         // from='room/alice-nick'
         assert_eq!(
@@ -157,6 +164,7 @@ fn xep_0045_non_occupant_halts_chain_with_typed_not_acceptable() {
     let alice = full("alice@example.com/web");
 
     let id_gen = FixedIdGenerator("ignored".to_string());
+    let secret = test_occupant_id_secret();
     let ctx = RoomContext {
         room: &room,
         sender_full: &alice,
@@ -164,7 +172,7 @@ fn xep_0045_non_occupant_halts_chain_with_typed_not_acceptable() {
         managed_room_forbidden: false,
         room_moderated: false,
         id_gen: &id_gen,
-        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+        occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
         dispatch_timestamp: 0,
@@ -219,6 +227,7 @@ fn xep_0359_room_chain_strips_client_spoofed_room_stanza_id() {
     let alice = full("alice@example.com/web");
     let occupants = vec![occ(alice.clone(), "alice-nick")];
     let id_gen = FixedIdGenerator("genuine-room-id".to_string());
+    let secret = test_occupant_id_secret();
     let ctx = RoomContext {
         room: &room,
         sender_full: &alice,
@@ -226,7 +235,7 @@ fn xep_0359_room_chain_strips_client_spoofed_room_stanza_id() {
         managed_room_forbidden: false,
         room_moderated: false,
         id_gen: &id_gen,
-        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+        occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
         dispatch_timestamp: 0,
@@ -276,6 +285,7 @@ fn xep_0424_groupchat_retraction_emits_archive_and_tombstone_events() {
     let alice = full("alice@example.com/web");
     let occupants = vec![occ(alice.clone(), "alice-nick")];
     let id_gen = FixedIdGenerator("retraction-archive".to_string());
+    let secret = test_occupant_id_secret();
     let ctx = RoomContext {
         room: &room,
         sender_full: &alice,
@@ -283,7 +293,7 @@ fn xep_0424_groupchat_retraction_emits_archive_and_tombstone_events() {
         managed_room_forbidden: false,
         room_moderated: false,
         id_gen: &id_gen,
-        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+        occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
         dispatch_timestamp: 0,
@@ -344,6 +354,7 @@ fn xep_0430_groupchat_message_emits_per_occupant_inbox_projection() {
         occ(charlie_b.clone(), "charlie"),
     ];
     let id_gen = FixedIdGenerator("inbox-archive".to_string());
+    let secret = test_occupant_id_secret();
     let ctx = RoomContext {
         room: &room,
         sender_full: &alice,
@@ -351,7 +362,7 @@ fn xep_0430_groupchat_message_emits_per_occupant_inbox_projection() {
         managed_room_forbidden: false,
         room_moderated: false,
         id_gen: &id_gen,
-        occupant_id_secret: TEST_OCCUPANT_ID_SECRET,
+        occupant_id_secret: &secret,
         sender_nickname_generation: 0,
         project_sender_inbox: true,
         dispatch_timestamp: 0,

--- a/server/crates/waddle-xmpp/src/xep/xep0421.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0421.rs
@@ -32,13 +32,78 @@
 use hmac::{Hmac, Mac};
 use minidom::Element;
 use sha2::Sha256;
+use std::sync::Arc;
 use xmpp_parsers::message::Message;
 use xmpp_parsers::presence::Presence;
 
 /// Namespace for XEP-0421 Occupant Identifiers.
 pub const NS_OCCUPANT_ID: &str = "urn:xmpp:occupant-id:0";
 
+/// Minimum byte length of the deployment-keyed occupant-id secret.
+///
+/// XEP-0421 §3 specifies that the derivation be keyed by a per-deployment
+/// secret to avoid cross-deployment linkability. The 32-byte floor is the
+/// project's chosen entropy minimum; values below this are rejected at
+/// `OccupantIdSecret` construction.
+pub const OCCUPANT_ID_SECRET_MIN_BYTES: usize = 32;
+
 type HmacSha256 = Hmac<Sha256>;
+
+/// Per-deployment HMAC key used to derive XEP-0421 occupant identifiers.
+///
+/// The inner allocation is shared via `Arc<[u8]>` so the same secret can
+/// flow through `WebSocketDeps`, `RoomRegistryActor`, every spawned
+/// `RoomActor`, and `RoomContext` without copying the bytes.
+///
+/// `Debug` is hand-implemented to redact the value — never print, log, or
+/// derive trace fields from this type. The bytes are accessible only via
+/// `key()` for HMAC consumption.
+#[derive(Clone)]
+pub struct OccupantIdSecret(Arc<[u8]>);
+
+impl OccupantIdSecret {
+    /// Validate and wrap a deployment secret. Rejects values shorter than
+    /// `OCCUPANT_ID_SECRET_MIN_BYTES`.
+    pub fn new(bytes: impl Into<Arc<[u8]>>) -> Result<Self, OccupantIdSecretError> {
+        let bytes: Arc<[u8]> = bytes.into();
+        if bytes.len() < OCCUPANT_ID_SECRET_MIN_BYTES {
+            return Err(OccupantIdSecretError::TooShort {
+                got: bytes.len(),
+                min: OCCUPANT_ID_SECRET_MIN_BYTES,
+            });
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Borrow the raw HMAC key bytes. The only legitimate consumer is
+    /// `generate_occupant_id` (or its kameo/test equivalents).
+    pub fn key(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Test-only constructor that bypasses length validation. Lets unit
+    /// tests use short labels like `b"test-secret"` without coupling them
+    /// to the production length floor.
+    #[cfg(test)]
+    pub(crate) fn for_testing(bytes: impl Into<Arc<[u8]>>) -> Self {
+        Self(bytes.into())
+    }
+}
+
+impl std::fmt::Debug for OccupantIdSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("OccupantIdSecret")
+            .field(&format_args!("<redacted, {} bytes>", self.0.len()))
+            .finish()
+    }
+}
+
+/// Failure reasons for `OccupantIdSecret::new`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum OccupantIdSecretError {
+    #[error("occupant-id secret must be at least {min} bytes, got {got}")]
+    TooShort { got: usize, min: usize },
+}
 
 /// An opaque occupant identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -96,16 +161,23 @@ impl OccupantIdCarrier for Presence {
 /// Takes typed JIDs (typed-payloads hard rule) — the canonical JID
 /// string form is generated at the HMAC boundary only, never carried
 /// across function boundaries as `String`.
+///
+/// Inputs are joined with a `0x00` byte (per XEP-0421 §3 example) which
+/// cannot appear in a bare JID per RFC 7622 / PRECIS, so the boundary is
+/// unambiguous. Earlier revisions used `:` as a separator, which is a
+/// valid JID-localpart character and produced collisions like
+/// `room=a@x` + `user=b:c@y` ↔ `room=a@x:b` + `user=c@y`.
 pub fn generate_occupant_id(
     user_bare_jid: &jid::BareJid,
     room_jid: &jid::BareJid,
-    server_secret: &[u8],
+    server_secret: &OccupantIdSecret,
 ) -> OccupantId {
-    let mut mac = HmacSha256::new_from_slice(server_secret).expect("HMAC accepts any key length");
+    let mut mac =
+        HmacSha256::new_from_slice(server_secret.key()).expect("HMAC accepts any key length");
     // `BareJid::as_str` returns the canonical string form; we hash
     // bytes at the I/O boundary only.
     mac.update(room_jid.as_str().as_bytes());
-    mac.update(b":");
+    mac.update(&[0u8]);
     mac.update(user_bare_jid.as_str().as_bytes());
     let result = mac.finalize().into_bytes();
 
@@ -182,7 +254,10 @@ mod tests {
     use super::*;
     use xmpp_parsers::message::MessageType;
 
-    const TEST_SECRET: &[u8] = b"waddle-test-secret-key-for-occupant-ids";
+    fn test_secret() -> OccupantIdSecret {
+        OccupantIdSecret::new(b"waddle-test-secret-key-for-occupant-ids".to_vec())
+            .expect("test secret meets length floor")
+    }
 
     fn alice() -> jid::BareJid {
         "alice@example.com".parse().expect("bare")
@@ -202,30 +277,80 @@ mod tests {
 
     #[test]
     fn test_generate_occupant_id_deterministic() {
-        let id1 = generate_occupant_id(&alice(), &room(), TEST_SECRET);
-        let id2 = generate_occupant_id(&alice(), &room(), TEST_SECRET);
+        let secret = test_secret();
+        let id1 = generate_occupant_id(&alice(), &room(), &secret);
+        let id2 = generate_occupant_id(&alice(), &room(), &secret);
         assert_eq!(id1, id2);
     }
 
     #[test]
     fn test_generate_different_users() {
-        let alice_id = generate_occupant_id(&alice(), &room(), TEST_SECRET);
-        let bob_id = generate_occupant_id(&bob(), &room(), TEST_SECRET);
+        let secret = test_secret();
+        let alice_id = generate_occupant_id(&alice(), &room(), &secret);
+        let bob_id = generate_occupant_id(&bob(), &room(), &secret);
         assert_ne!(alice_id, bob_id);
     }
 
     #[test]
     fn test_generate_different_rooms() {
-        let r1 = generate_occupant_id(&alice(), &room1(), TEST_SECRET);
-        let r2 = generate_occupant_id(&alice(), &room2(), TEST_SECRET);
+        let secret = test_secret();
+        let r1 = generate_occupant_id(&alice(), &room1(), &secret);
+        let r2 = generate_occupant_id(&alice(), &room2(), &secret);
         assert_ne!(r1, r2);
     }
 
     #[test]
+    fn test_generate_different_secrets_produce_different_ids() {
+        // XEP-0421 §3: the deployment-keyed derivation MUST make occupant-ids
+        // unlinkable across deployments using different secrets. Same (user,
+        // room) inputs with different keys must yield different ids.
+        let secret_a = OccupantIdSecret::new(b"deployment-a-secret-32-bytes-long".to_vec())
+            .expect("≥32 bytes");
+        let secret_b = OccupantIdSecret::new(b"deployment-b-secret-32-bytes-long".to_vec())
+            .expect("≥32 bytes");
+        let id_a = generate_occupant_id(&alice(), &room(), &secret_a);
+        let id_b = generate_occupant_id(&alice(), &room(), &secret_b);
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
     fn test_generate_id_length() {
-        let id = generate_occupant_id(&alice(), &room(), TEST_SECRET);
+        let secret = test_secret();
+        let id = generate_occupant_id(&alice(), &room(), &secret);
         // 16 bytes = 32 hex chars
         assert_eq!(id.0.len(), 32);
+    }
+
+    #[test]
+    fn test_secret_rejects_short_input() {
+        let result = OccupantIdSecret::new(b"too-short".to_vec());
+        assert_eq!(
+            result.unwrap_err(),
+            OccupantIdSecretError::TooShort {
+                got: 9,
+                min: OCCUPANT_ID_SECRET_MIN_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn test_secret_accepts_minimum_length() {
+        let bytes = vec![0x42u8; OCCUPANT_ID_SECRET_MIN_BYTES];
+        OccupantIdSecret::new(bytes).expect("32 bytes meets floor");
+    }
+
+    #[test]
+    fn test_secret_debug_redacts_bytes() {
+        let secret = test_secret();
+        let rendered = format!("{secret:?}");
+        assert!(
+            rendered.contains("redacted"),
+            "Debug output should redact the secret bytes; got: {rendered}"
+        );
+        assert!(
+            !rendered.contains("waddle-test-secret"),
+            "Debug must not leak secret bytes; got: {rendered}"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0421.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0421.rs
@@ -105,6 +105,33 @@ pub enum OccupantIdSecretError {
     TooShort { got: usize, min: usize },
 }
 
+/// Bundled occupant-identity inputs for XEP-0045/0421 presence stamping.
+///
+/// Three fields that always travel together when a presence-builder needs
+/// to stamp an `<occupant-id/>`:
+///
+/// - `bare_jid` — the user's bare JID. **Always required.** The room
+///   service knows who the occupant is regardless of whether the real
+///   JID is disclosed in the MUC `<item jid='…'>`. Used as the HMAC
+///   message input.
+/// - `real_jid` — whether to disclose the user's full JID in
+///   `<item jid='…'>`. `Some` for non-anonymous and semi-anonymous
+///   rooms; `None` for fully-anonymous rooms (XEP-0045 §15.6.4). The
+///   choice is independent of `bare_jid` — a fully-anonymous room
+///   still stamps occupant-id (XEP-0421 §"Business Rules"), it just
+///   doesn't expose the real JID.
+/// - `secret` — the per-deployment HMAC key.
+///
+/// Bundling these three drops public `build_*_presence` argument counts
+/// below clippy's `too_many_arguments` threshold without an `#[allow]`,
+/// and is the typed-payloads-rule-conformant shape for "occupant
+/// identity context" crossing the legacy presence builders' boundary.
+pub struct OccupantIdentity<'a> {
+    pub bare_jid: &'a jid::BareJid,
+    pub real_jid: Option<&'a jid::FullJid>,
+    pub secret: &'a OccupantIdSecret,
+}
+
 /// An opaque occupant identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OccupantId(pub String);
@@ -341,16 +368,22 @@ mod tests {
 
     #[test]
     fn test_secret_debug_redacts_bytes() {
-        let secret = test_secret();
+        // Build the secret from a known marker substring. The `Debug`
+        // impl MUST redact the bytes; we then check the rendered form
+        // contains "redacted" and does NOT contain the marker. We
+        // deliberately do NOT interpolate the rendered string into any
+        // panic / assertion message — doing so would taint-flow the
+        // secret-derived value into a panic-log sink (false-positive
+        // for CodeQL `rust/cleartext-logging`, but also pointless: if
+        // redaction failed, the panic message would itself leak the
+        // bytes during test failure).
+        const MARKER: &str = "do-not-leak-this-byte-string-32b!!!!!";
+        let secret = OccupantIdSecret::new(MARKER.as_bytes().to_vec()).expect("≥32 bytes");
         let rendered = format!("{secret:?}");
-        assert!(
-            rendered.contains("redacted"),
-            "Debug output should redact the secret bytes; got: {rendered}"
-        );
-        assert!(
-            !rendered.contains("waddle-test-secret"),
-            "Debug must not leak secret bytes; got: {rendered}"
-        );
+        let redacted = rendered.contains("redacted");
+        let leaked = rendered.contains(MARKER);
+        assert!(redacted, "Debug output should contain 'redacted'");
+        assert!(!leaked, "Debug must not leak secret bytes");
     }
 
     #[test]

--- a/server/env.cue
+++ b/server/env.cue
@@ -599,6 +599,9 @@ schema.#Project & {
 			WADDLE_TEST_FIXED_ACCOUNT_ENABLED:  "true"
 			WADDLE_TEST_FIXED_ACCOUNT_PASSWORD: "cuenv-test-password"
 			WADDLE_UPLOAD_DIR:                  "./uploads"
+			// XEP-0421 occupant-id HMAC key. Test/CI value only — production
+			// must set its own via the Helm chart or secret manager.
+			WADDLE_OCCUPANT_ID_SECRET: "cuenv-test-occupant-id-secret-32-bytes-long"
 		}
 	}
 


### PR DESCRIPTION
Closes #283. Follow-up structural cleanup tracked in #300; pre-existing conformance gap on subject messages tracked in #304.

## Summary

XEP-0421 occupant-id is currently keyed by a hardcoded compile-time constant `b"waddle-xmpp-occupant-id-v1"` in `server/crates/waddle-xmpp/src/muc/presence.rs:33`. Every Waddle deployment uses the same key, so an adversary running their own instance can pre-compute occupant-ids for any `(user, room)` pair and de-anonymize occupants in any other deployment that reuses the same room name. This violates the privacy/unlinkability intent of XEP-0421 §3.

This PR replaces the constant with a per-deployment secret loaded from `WADDLE_OCCUPANT_ID_SECRET`. Server startup hard-fails if unset or below the 32-byte minimum. The Helm chart auto-generates the secret on first install and preserves it across upgrades, mirroring the `WADDLE_SESSION_KEY` pattern. The PR also fixes a pre-existing collision-vulnerability in the HMAC input encoding (separator `:` is a valid JID-localpart character; switching to `0x00` per the XEP-0421 §3 example).

A pre-implementation stamping-site audit found two additional pre-existing XEP-0421 conformance gaps that are 1:1 with the builders being modified — `build_kick_presence` and `build_ban_presence` currently emit `from='room@…/nick'` presences with no `<occupant-id/>` payload at all. Both are fixed in this PR. A third gap on subject messages (`build_subject_message`) lives on a different code path and is tracked separately as #304.

## Plan

### Resolved design decisions

| # | Decision | Choice |
|---|---|---|
| Q1  | Source                  | Env var only — `WADDLE_OCCUPANT_ID_SECRET`. |
| Q2  | Encoding                | Raw UTF-8, byte-length ≥ 32. Matches `WADDLE_SESSION_KEY`. |
| Q3  | Fail-closed scope       | Always required. No production/dev split. Error message includes generation recipe. |
| Q4  | Type                    | `pub struct OccupantIdSecret(Arc<[u8]>)` newtype with redacted `Debug`, `key(&self) -> &[u8]` accessor, validated constructor. (Reverses initial "plain `String`" decision after adversarial review flagged a typed-payloads-rule violation: the secret crosses internal handler/actor boundaries, not just the env-parsing boundary.) |
| Q5  | Layout                  | Flat field on `ServerConfig`, loaded inline in `from_env`. |
| Q6  | Threading legacy presence | `&OccupantIdSecret` parameter on the legacy `build_*_presence` functions and their private helper. **Originally 5 builders; expanded to 7** after audit (kick + ban added). Short-term divergence from `RoomContext`-borne threading is resolved by follow-up #300. |
| Q7  | Reaching `room_actor.rs` | Constructor arg on `RoomRegistryActor` → forwarded to each `RoomActor` at spawn. |
| Q8  | WebSocket layer         | Flat `pub occupant_id_secret: OccupantIdSecret` on `WebSocketDeps`. Same value shared with `RoomRegistryActor`. |
| Q9  | Test default            | `#[cfg(test)] const TEST_OCCUPANT_ID_SECRET` in `waddle-server::config` (≥32 bytes). |
| Q10 | Tests                   | (a) Extract `parse_occupant_id_secret(Option<&str>) -> Result<OccupantIdSecret, String>` helper; +3 unit tests. (b) +1 protocol test in `xep0421.rs` for differing secrets producing different IDs. (c) +1 end-to-end integration test through the websocket harness asserting the env-supplied secret reaches the stamping site. |
| Q11 | Old constant            | Delete `OCCUPANT_ID_SECRET` outright. |
| Q12 | Startup logging         | Nothing logged. Hard-fail is the only operator signal. |
| Q13 | Docs                    | Helm `templates/secret.yaml` + `values.yaml` + chart `README.md` mirror `WADDLE_SESSION_KEY` pattern. Chart README adds rotation warning, external-Secret-required-keys subsection, and "back up this Secret externally" note. |
| Q14 | PR scope                | Single PR. |

### Adversarial-review amendments (applied)

1. **Fix `:` → `0x00` separator bug in `xep0421.rs::generate_occupant_id`.** `:` is valid in JID localparts (RFC 7622), creating room/user collisions. XEP-0421 §3 example uses `0x00`. Pre-existing bug; included since we're touching this code path.
2. **Stamping-site audit before code.** Completed. Confirmed: live groupchat messages, MAM result wrapping, history-on-join replay, corrections, retractions all stamp correctly via `MucCanonicalizeHandler`. Push/inbox don't mint new stanzas. **Found three pre-existing gaps**: `build_kick_presence` and `build_ban_presence` (folded into this PR) and `build_subject_message` (filed as #304).
3. **End-to-end wiring integration test.** The 4 originally-planned tests prove HMAC math and config parsing; none prove the env-loaded secret reaches the stamping site. Added one integration test through the websocket harness.
4. **`OccupantIdSecret` newtype with redacted `Debug`** (replaces "plain `String`"; see Q4).
5. **Bump `wire_trace_l4_room_tests.rs:27` fixture** from 26 bytes to ≥32 to remove the inconsistency with the config-layer floor.
6. **Enumerate dev/CI surfaces** that need the env injected: `cuenv` env files, integration-test setup, GitHub Actions workflows, docker-run example in `server/README.md`. Error message includes copy-pasteable `openssl rand -base64 48` recipe.
7. **Chart README "required keys for externally-managed Secret" subsection.** When operators set `secret.existingSecret`, the chart skips templating; they need to know the new key is required. Without this, upgrade → CrashLoopBackOff.
8. **Filed two follow-up issues**: #302 (project-wide secret zeroization) and #303 (Helm `lookup`-empty-on-`helm template` GitOps gotcha).

### Out of scope (per resolved design)

- No newtype-borne `Zeroize` (deferred to #302).
- No per-room key derivation / no rotation overlap window (issue's "Optional, follow-up").
- No fingerprint / startup-confirmation logging.
- Migration of legacy presence callers off the bare `&OccupantIdSecret` parameter onto a presence-side room handler chain — tracked in #300, sequenced after #282.
- Subject-message stamping conformance gap — tracked in #304.

## Acceptance criteria mapping (issue #283)

- [ ] `OCCUPANT_ID_SECRET` removed as a compile-time constant.
- [ ] Loaded from `WADDLE_OCCUPANT_ID_SECRET`, required, no fallback.
- [ ] Server startup hard-fails on unset / weak secret with a clear error message and generation recipe.
- [ ] Test: occupant-id derivation is byte-identical across server restarts when the secret is unchanged. (Existing `xep0421.rs::test_generate_occupant_id_deterministic` covers this.)
- [ ] Test: occupant-id derivation differs when the secret differs. (New test in `xep0421.rs`.)
- [ ] Deployment docs updated (Helm chart README).

## Test plan

- [ ] `cargo test -p waddle-server config::tests` (3 new unit tests on `parse_occupant_id_secret`).
- [ ] `cargo test -p waddle-xmpp xep::xep0421` (1 new protocol test, existing tests still pass; separator changed from `:` to `0x00`).
- [ ] `cargo test --workspace` (touches the 7 legacy builder signatures + their callers; mechanical compile-error-driven update).
- [ ] New integration test through the WebSocket harness: set `WADDLE_OCCUPANT_ID_SECRET`, drive a MUC join, assert outgoing presence's `<occupant-id>` matches `HMAC(secret, room || 0x00 || user)` for known inputs.
- [ ] `cargo fmt && cargo clippy -- -D warnings` clean.
- [ ] `helm lint server/charts/waddle-server` clean.
- [ ] `helm template` smoke: render the chart with no values and confirm `WADDLE_OCCUPANT_ID_SECRET` is emitted; render again with `secret.occupantIdSecret=…` and confirm the override wins.
- [ ] First-run UX check: `unset WADDLE_OCCUPANT_ID_SECRET && cargo run --bin waddle-server` produces an error message that names the env var and includes the generation recipe.

## Implementation file list (touched)

**Rust — server crate:**
- `server/crates/waddle-server/src/config.rs` (new field, parser helper, tests, test constructors)
- `server/crates/waddle-server/src/server/mod.rs` (bootstrap: construct `OccupantIdSecret`, plumb into `WebSocketDeps` + `RoomRegistryActor::new`)
- `server/crates/waddle-server/src/server/routes/websocket/mod.rs` (`WebSocketDeps` field)
- `server/crates/waddle-server/src/server/routes/interpret.rs:1454,1571,1737` (3 `RoomContext` wirings)
- `server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs:1838,1986,2034` (3 builder call sites)

**Rust — xmpp crate:**
- `server/crates/waddle-xmpp/src/xep/xep0421.rs` (separator fix `:` → `0x00`, new test, `OccupantIdSecret` newtype lives here)
- `server/crates/waddle-xmpp/src/muc/presence.rs` (delete constant, thread `&OccupantIdSecret` through 7 builders + private helper; add stamping calls in `build_kick_presence` and `build_ban_presence`)
- `server/crates/waddle-xmpp/src/muc/room_actor.rs` (kick/ban/role/affiliation builder call sites + actor field)
- `server/crates/waddle-xmpp/src/muc/mod.rs` (re-exports if signatures change)
- `server/crates/waddle-xmpp/src/protocol/room/context.rs:97` (`RoomContext::occupant_id_secret` switches from `&'a [u8]` to `&'a OccupantIdSecret`)
- `server/crates/waddle-xmpp/src/protocol/wire_trace_l4_room_tests.rs:27` (bump to ≥32 bytes)

**Helm chart:**
- `server/charts/waddle-server/templates/secret.yaml` (mirror `WADDLE_SESSION_KEY` block)
- `server/charts/waddle-server/values.yaml:143` (add `secret.occupantIdSecret: ""`)
- `server/charts/waddle-server/README.md` (env-var entry + rotation warning + external-Secret-required-keys subsection + backup note)

**Dev/CI:**
- Whichever `cuenv` `env.cue` files seed the local dev shell.
- Whichever GH Actions workflows set env for integration tests.

## Notes for reviewers

- The two-conventions transitional state (`RoomContext` vs bare-parameter) is documented and tracked in #300; do not block on consolidation.
- The `:` → `0x00` separator change is in scope because we're already touching `generate_occupant_id`. CLAUDE.md "breaking changes by default" + "no production servers" makes this safe to bundle.
- `OccupantIdSecret` is project-novel infrastructure (no other config secret has a newtype today) — the typed-payloads hard rule justifies it because the secret crosses handler/actor boundaries, not just the config-parse boundary. Other config secrets (`WADDLE_SESSION_KEY`, etc.) are consumed inside `AuthState::new` without crossing handler boundaries; if they grow such uses, they should follow the same pattern.
- Kick + ban occupant-id stamping is folded in because the audit found those builders silently violating XEP-0421 §"Business Rules" (occupant-id required on every emitted message AND presence). Subject-message stamping has the same gap but lives on a different code path (legacy actor's `broadcast_subject_change`); tracked in #304 to keep this PR's scope coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)