### PR TITLE
chore(chat): clean up extension rendering

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -12,13 +12,11 @@ import {
   MessageSquare,
   Lock,
   AlertCircle,
-  Bot,
   CheckCircle2,
   ClipboardList,
   Gamepad2,
   LayoutDashboard,
   LoaderCircle,
-  Sparkles,
 } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
@@ -878,8 +876,7 @@ watch(
           <span class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-md bg-background text-foreground ring-1 ring-border">
             <ClipboardList v-if="extensionPresentation(annotation).kind === 'links-task-board' || annotation.surfaceKind === 'board'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
             <Gamepad2 v-else-if="extensionPresentation(annotation).kind === 'pub-quiz' || annotation.surfaceKind === 'game'" class="h-4 w-4 text-success" aria-hidden="true" />
-            <Bot v-else-if="extensionPresentation(annotation).kind === 'ai-chatbot' || annotation.surfaceKind === 'chat-bot'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
-            <Sparkles v-else-if="extensionPresentation(annotation).kind === 'ai-assistant-canvas' || annotation.surfaceKind === 'dynamic-canvas'" class="h-4 w-4 text-warning" aria-hidden="true" />
+            <MessageSquare v-else-if="annotation.surfaceKind === 'chat-bot'" class="h-4 w-4 text-primary/80" aria-hidden="true" />
             <LayoutDashboard v-else class="h-4 w-4" aria-hidden="true" />
           </span>
           <span class="min-w-0 flex-1">

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -367,7 +367,7 @@ export function extensionSurfaceLabel(kind: ExtensionSurfaceKind): string {
     case "game":
       return "Game";
     case "chat-bot":
-      return "AI bot";
+      return "Chat bot";
     case "dynamic-canvas":
       return "Dynamic canvas";
     case "utility-panel":
@@ -440,8 +440,6 @@ export function extensionCardDetails(annotation: ExtensionAnnotation, limit = 6)
 type ExtensionPresentationKind =
   | "links-task-board"
   | "pub-quiz"
-  | "ai-chatbot"
-  | "ai-assistant-canvas"
   | "decision-polls"
   | "generic";
 
@@ -474,17 +472,12 @@ export function extensionPresentation(annotation: ExtensionAnnotation): Extensio
   if (plugin === "links-task-board" || payload?.namespace === "urn:waddle:links-task-board:1") {
     return linksTaskBoardPresentation(annotation, payload);
   }
-  if (plugin === "ai-chatbot" || payload?.namespace === "urn:waddle:ai-chatbot:1") {
-    return aiChatbotPresentation(annotation, payload);
-  }
-  if (plugin === "ai-assistant-canvas" || payload?.namespace === "urn:waddle:ai-assistant-canvas:1") {
-    return canvasPresentation(annotation, payload);
-  }
+  const summary = genericExtensionSummary(annotation, payload);
   return {
     kind: "generic",
     label: extensionSurfaceLabel(annotation.surfaceKind),
     title: annotation.title,
-    ...(annotation.summary ? { summary: annotation.summary } : {}),
+    ...(summary ? { summary } : {}),
     options: [],
     details: extensionCardDetails(annotation),
   };
@@ -516,6 +509,17 @@ function payloadAttr(payload: ExtensionPayloadElement | undefined, ...names: str
     if (value) return value;
   }
   return undefined;
+}
+
+function genericExtensionSummary(
+  annotation: ExtensionAnnotation,
+  payload: ExtensionPayloadElement | undefined,
+): string | undefined {
+  const summary = annotation.summary?.trim();
+  if (summary && summary !== annotation.payloadNamespace) return summary;
+  const text = payload ? payloadText(payload) : null;
+  if (text && text !== annotation.title) return text;
+  return summary || undefined;
 }
 
 function payloadOptions(payload: ExtensionPayloadElement | undefined): ExtensionPresentationOption[] {
@@ -575,36 +579,5 @@ function linksTaskBoardPresentation(
     ...(url ? { primaryValue: url } : {}),
     options: [],
     details: extensionCardDetails(annotation, 4),
-  };
-}
-
-function aiChatbotPresentation(
-  annotation: ExtensionAnnotation,
-  payload: ExtensionPayloadElement | undefined,
-): ExtensionPresentation {
-  const answer = childText(payload, "answer") ?? childText(payload, "response") ?? payload?.text?.trim();
-  return {
-    kind: "ai-chatbot",
-    label: "AI answer",
-    title: annotation.title,
-    ...(answer ? { summary: answer } : annotation.summary ? { summary: annotation.summary } : {}),
-    options: [],
-    details: extensionCardDetails(annotation, 3),
-  };
-}
-
-function canvasPresentation(
-  annotation: ExtensionAnnotation,
-  payload: ExtensionPayloadElement | undefined,
-): ExtensionPresentation {
-  const prompt = childText(payload, "prompt") ?? payloadAttr(payload, "prompt") ?? annotation.title;
-  const render = payloadAttr(payload, "render-id", "artifact-digest", "artifact");
-  return {
-    kind: "ai-assistant-canvas",
-    label: "Canvas",
-    title: prompt,
-    ...(render ? { summary: render } : annotation.summary ? { summary: annotation.summary } : {}),
-    options: [],
-    details: extensionCardDetails(annotation, 3),
   };
 }

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -204,4 +204,74 @@ describe("renderStyledBody", () => {
       ],
     });
   });
+
+  test("renders former assistant extension payloads through generic surface presentations", () => {
+    const chatbotAnnotation: ExtensionAnnotation = {
+      extensionId: "ai-chatbot",
+      annotationId: "chatbot-1",
+      surfaceKind: "chat-bot",
+      title: "Answer card",
+      summary: "urn:waddle:ai-chatbot:1",
+      payloadNamespace: "urn:waddle:ai-chatbot:1",
+      fields: {
+        payloadNamespace: "urn:waddle:ai-chatbot:1",
+      },
+      payloads: [{
+        namespace: "urn:waddle:ai-chatbot:1",
+        name: "assistant-answer",
+        attributes: {
+          xmlns: "urn:waddle:ai-chatbot:1",
+        },
+        children: [{
+          namespace: "urn:waddle:ai-chatbot:1",
+          name: "answer",
+          attributes: {},
+          text: "Use the generic card renderer.",
+          children: [],
+        }],
+      }],
+      actions: [],
+    };
+    const canvasAnnotation: ExtensionAnnotation = {
+      extensionId: "ai-assistant-canvas",
+      annotationId: "canvas-1",
+      surfaceKind: "dynamic-canvas",
+      title: "Canvas card",
+      summary: "urn:waddle:ai-assistant-canvas:1",
+      payloadNamespace: "urn:waddle:ai-assistant-canvas:1",
+      fields: {
+        payloadNamespace: "urn:waddle:ai-assistant-canvas:1",
+      },
+      payloads: [{
+        namespace: "urn:waddle:ai-assistant-canvas:1",
+        name: "canvas",
+        attributes: {
+          xmlns: "urn:waddle:ai-assistant-canvas:1",
+        },
+        children: [{
+          namespace: "urn:waddle:ai-assistant-canvas:1",
+          name: "prompt",
+          attributes: {},
+          text: "Sketch a task board.",
+          children: [],
+        }],
+      }],
+      actions: [],
+    };
+
+    expect(extensionPresentation(chatbotAnnotation)).toMatchObject({
+      kind: "generic",
+      label: "Chat bot",
+      title: "Answer card",
+      summary: "Use the generic card renderer.",
+      details: [{ label: "Answer", value: "Use the generic card renderer." }],
+    });
+    expect(extensionPresentation(canvasAnnotation)).toMatchObject({
+      kind: "generic",
+      label: "Dynamic canvas",
+      title: "Canvas card",
+      summary: "Sketch a task board.",
+      details: [{ label: "Prompt", value: "Sketch a task board." }],
+    });
+  });
 });


### PR DESCRIPTION
## Plan

- Review chat rendering and extension metadata paths against relevant XEP files under ./xeps.
- Remove AI-specific presentation branches and icon checks from chat rendering.
- Preserve generic extension/card rendering using existing generic metadata and surface kind information.
- Add or update focused chat tests where current assertions depend on AI-specific rendering.
- Run focused chat checks for the changed surface.
