### PR TITLE
fix(chat): preserve threaded replies across MAM reloads

### DIFF
--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -139,6 +139,57 @@ function applyForumContext(list: TimelineMessage[]): TimelineMessage[] {
   });
 }
 
+function mergeReplyToMetadata(
+  existing: TimelineMessage["replyTo"],
+  incoming: TimelineMessage["replyTo"],
+): TimelineMessage["replyTo"] {
+  if (!incoming) return existing;
+  if (!existing) return { ...incoming };
+  if (existing.id !== incoming.id) return existing;
+
+  let next = existing;
+  if (!next.author && incoming.author) next = { ...next, author: incoming.author };
+  if (!next.preview && incoming.preview) next = { ...next, preview: incoming.preview };
+  return next;
+}
+
+function sameStringList(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function mergeMissingThreadMetadata(
+  existing: TimelineMessage,
+  incoming: TimelineMessage,
+): TimelineMessage {
+  let next = existing;
+  const assign = (patch: Partial<TimelineMessage>) => {
+    next = next === existing ? { ...existing, ...patch } : { ...next, ...patch };
+  };
+
+  const ids = mergeMessageIds(next, next.id, [incoming.id, ...(incoming.wireIds ?? [])]);
+  if (ids.id !== next.id || !sameStringList(ids.wireIds, next.wireIds)) next = ids;
+
+  if (!next.threadId && incoming.threadId) assign({ threadId: incoming.threadId });
+  if (!next.parentThreadId && incoming.parentThreadId) assign({ parentThreadId: incoming.parentThreadId });
+  if (!next.correctionTargetId && incoming.correctionTargetId) {
+    assign({ correctionTargetId: incoming.correctionTargetId });
+  }
+  if (!next.reactionTargetId && incoming.reactionTargetId) {
+    assign({ reactionTargetId: incoming.reactionTargetId });
+  }
+
+  const replyTo = mergeReplyToMetadata(next.replyTo, incoming.replyTo);
+  if (replyTo !== next.replyTo) assign({ replyTo });
+
+  return next;
+}
+
+interface TimelineBuildOptions {
+  seedExistingOnly?: boolean;
+}
+
 function queuedRoomMessageToTimeline(
   session: WaddleSession,
   roomJid: string,
@@ -790,6 +841,7 @@ export function useMessaging(
     // Only catch up if we had already loaded this channel; otherwise the
     // standard loadMessages call on channel-select handles it.
     if (messages.value.length === 0) return;
+    const metadataSeed = messages.value;
     const preserved = messages.value.filter(
       (m) =>
         m.isSelf && (
@@ -799,7 +851,7 @@ export function useMessaging(
         ),
     );
     void (async () => {
-      await loadMessages(spaceId ?? "", channelId);
+      await loadMessages(spaceId ?? "", channelId, 0, metadataSeed);
       if (
         preserved.length === 0 ||
         (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
@@ -821,6 +873,7 @@ export function useMessaging(
   function buildTimelineFromMamResults(
     mamResults: LiveRoomMessage[],
     existing: TimelineMessage[] = [],
+    options: TimelineBuildOptions = {},
   ): TimelineMessage[] {
     const regularMessages: LiveRoomMessage[] = [];
     const reactionUpdates: { targetId: string; nick: string; senderId: string; emojis: string[] }[] = [];
@@ -867,10 +920,26 @@ export function useMessaging(
     for (const message of existing) {
       indexMessageByIds(byId, message);
     }
-    const timeline = [...existing];
+    const timeline = options.seedExistingOnly ? [] : [...existing];
     for (const raw of regularMessages) {
-      if (findMessageById(timeline, raw.id)) continue;
       const tm = fromLiveMessage(session.value!, raw, (id) => byId.get(id));
+      const existingMessage = [tm.id, ...(tm.wireIds ?? [])]
+        .map((id) => byId.get(id))
+        .find((message): message is TimelineMessage => !!message);
+      if (existingMessage) {
+        const merged = options.seedExistingOnly
+          ? mergeMissingThreadMetadata(tm, existingMessage)
+          : mergeMissingThreadMetadata(existingMessage, tm);
+        if (options.seedExistingOnly) {
+          indexMessageByIds(byId, merged);
+          timeline.push(merged);
+        } else if (merged !== existingMessage) {
+          const index = timeline.indexOf(existingMessage);
+          if (index !== -1) timeline[index] = merged;
+          indexMessageByIds(byId, merged);
+        }
+        continue;
+      }
       indexMessageByIds(byId, tm);
       timeline.push(tm);
     }
@@ -920,7 +989,12 @@ export function useMessaging(
     return applyForumContext(timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt)));
   }
 
-  async function loadMessages(spaceId: string, channelId: string, unreadAtLoad = 0) {
+  async function loadMessages(
+    spaceId: string,
+    channelId: string,
+    unreadAtLoad = 0,
+    metadataSeed: TimelineMessage[] = [],
+  ) {
     if (!session.value) return;
 
     const requestId = ++messageRequestId;
@@ -963,7 +1037,12 @@ export function useMessaging(
 
       oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
       hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
-      const timelineWithQueue = appendQueuedMessages(buildTimelineFromMamResults(mamResults), roomJid);
+      const timelineWithQueue = appendQueuedMessages(
+        buildTimelineFromMamResults(mamResults, metadataSeed, {
+          seedExistingOnly: metadataSeed.length > 0,
+        }),
+        roomJid,
+      );
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) {
         isLoadingMessages.value = false;
@@ -1071,7 +1150,12 @@ export function useMessaging(
       [threadId]: page ? !page.complete && !!page.firstArchiveId : results.length >= 100,
     };
     const next = buildTimelineFromMamResults(results, messages.value);
-    if (next.length === messages.value.length) return;
+    if (
+      next.length === messages.value.length &&
+      next.every((message, index) => message === messages.value[index])
+    ) {
+      return;
+    }
     messages.value = next;
   }
 

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -493,6 +493,113 @@ describe("MAM history application", () => {
     expect(messaging.messages.value[0].extensionAnnotations).toBeUndefined();
   });
 
+  test("thread backfill merges missing metadata into an existing room MAM reply", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "thread-42",
+          reactionTargetId: "thread-42",
+          roomJid: "general@muc.example.com",
+          nick: "alice",
+          body: "topic root",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message",
+        },
+        {
+          id: "stable-reply-1",
+          wireIds: ["reply-1"],
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "room copy",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          replyTo: { id: "thread-42" },
+        },
+        {
+          id: "edit-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "room copy, edited",
+          createdAt: "2024-01-01T00:02:00Z",
+          type: "message",
+          replacesId: "stable-reply-1",
+        },
+      ]),
+      queryMamByThread: mock(async () => [
+        {
+          id: "reply-1",
+          wireIds: ["stable-reply-1"],
+          reactionTargetId: "reply-1",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "thread copy should not replace existing body",
+          createdAt: "2024-01-01T00:09:00Z",
+          type: "message",
+          replyTo: { id: "thread-42", author: "alice" },
+          threadId: "thread-42",
+          parentThreadId: "parent-thread",
+        },
+        {
+          id: "reaction-1",
+          roomJid: "general@muc.example.com",
+          nick: "dave",
+          body: "",
+          createdAt: "2024-01-01T00:10:00Z",
+          type: "subject",
+          _reactionTarget: "reply-1",
+          _reactionEmojis: ["🔥"],
+          _reactionSenderId: "dave@example.com",
+        },
+      ]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+    const loadedReply = messaging.messages.value.find((message) => message.id === "stable-reply-1");
+
+    expect(messaging.messages.value).toHaveLength(2);
+    expect(loadedReply?.threadId).toBeUndefined();
+    expect(loadedReply?.body).toBe("room copy, edited");
+    expect(loadedReply?.isEdited).toBe(true);
+    expect(loadedReply?.reactions).toBeUndefined();
+
+    await messaging.backfillThread("thread-42");
+    const mergedReply = messaging.messages.value.find((message) => message.id === "stable-reply-1");
+
+    expect(messaging.messages.value).toHaveLength(2);
+    expect(mergedReply?.threadId).toBe("thread-42");
+    expect(mergedReply?.parentThreadId).toBe("parent-thread");
+    expect(mergedReply?.wireIds).toContain("reply-1");
+    expect(mergedReply?.replyTo).toEqual({
+      id: "thread-42",
+      author: "alice",
+      preview: "topic root",
+    });
+    expect(mergedReply?.body).toBe("room copy, edited");
+    expect(mergedReply?.createdAt).toBe("2024-01-01T00:01:00Z");
+    expect(mergedReply?.isEdited).toBe(true);
+    expect(mergedReply?.reactions).toEqual({ "🔥": ["dave"] });
+  });
+
   test("ignores archived room reactions that target an alternate wire id", async () => {
     const session = ref({
       username: "alice",

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -165,6 +165,86 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
     expect(clientAny.value.queryMam).toHaveBeenCalledWith("w1", "c1", 100);
   });
 
+  test("fresh session preserves learned thread metadata for matching MAM messages", async () => {
+    const client = makeRoomClient([
+      {
+        id: "thread-42",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "alice",
+        body: "topic root",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message",
+      },
+      {
+        id: "reply-archive",
+        wireIds: ["reply-live"],
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "bob",
+        body: "reply from fresh MAM",
+        createdAt: "2024-01-01T00:01:00Z",
+        type: "message",
+        replyTo: { id: "thread-42" },
+      },
+      {
+        id: "reaction-archive",
+        roomJid: "w1-c1@rooms.example.com",
+        nick: "carol",
+        body: "",
+        createdAt: "2024-01-01T00:02:00Z",
+        type: "subject",
+        _reactionTarget: "reply-live",
+        _reactionEmojis: ["🔥"],
+        _reactionSenderId: "carol@example.com",
+      },
+    ]);
+    const { messaging } = makeRoomMessaging(client);
+
+    messaging.messages.value = [
+      {
+        id: "thread-42",
+        author: "alice",
+        body: "topic root",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: true,
+      },
+      {
+        id: "reply-live",
+        wireIds: ["reply-archive"],
+        reactionTargetId: "reply-live",
+        author: "bob",
+        body: "live reply",
+        createdAt: "2024-01-01T00:01:00Z",
+        isSelf: false,
+        replyTo: {
+          id: "thread-42",
+          author: "alice",
+          preview: "topic root",
+        },
+        threadId: "thread-42",
+        parentThreadId: "parent-thread",
+      },
+    ];
+
+    messaging.onSessionLifecycle({ type: "fresh" });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await nextTick();
+
+    expect(messaging.messages.value).toHaveLength(2);
+    const reply = messaging.messages.value.find((message) => message.id === "reply-archive");
+    expect(reply?.wireIds).toContain("reply-live");
+    expect(reply?.body).toBe("reply from fresh MAM");
+    expect(reply?.threadId).toBe("thread-42");
+    expect(reply?.parentThreadId).toBe("parent-thread");
+    expect(reply?.reactionTargetId).toBe("reply-live");
+    expect(reply?.replyTo).toEqual({
+      id: "thread-42",
+      author: "alice",
+      preview: "topic root",
+    });
+    expect(reply?.reactions).toEqual({ "🔥": ["carol"] });
+  });
+
   test("fresh session is a no-op when no messages are loaded yet", async () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -2219,7 +2219,7 @@ impl ToElementString for waddle_xmpp::Stanza {
         use waddle_xmpp::Stanza;
         match self {
             Stanza::Iq(iq) => stanza_to_string(iq.clone()),
-            Stanza::Message(msg) => stanza_to_string(msg.clone()),
+            Stanza::Message(msg) => message_to_string(msg),
             Stanza::Presence(p) => stanza_to_string(p.clone()),
         }
     }
@@ -2540,7 +2540,10 @@ async fn finish_archive_groupchat_message(
     // `reattach_thread_parent` at the inbound boundary so the parent
     // attribute survives `Message::try_from` here.
     let (thread_id, parent_thread_id) =
-        match waddle_xmpp::xep0201::thread_info_from_message(&archive_clone) {
+        match waddle_xmpp::xep0201::thread_info_from_message_in_stanza_ns(
+            &archive_clone,
+            waddle_xmpp::xep0201::CLIENT_STANZA_NS,
+        ) {
             Some(info) => (
                 Some(info.id),
                 info.parent.and_then(waddle_xmpp::mam::ThreadId::new),
@@ -4219,6 +4222,22 @@ mod tests {
         assert_eq!(outcome.frames.len(), 2);
         assert!(outcome.frames[0].contains("id=\"a\""));
         assert!(outcome.frames[1].contains("id=\"b\""));
+    }
+
+    #[tokio::test]
+    async fn send_stanza_preserves_xep_0201_thread_on_wire() {
+        let mut msg = chat_msg("alice@example.com/web", "bob@example.com", "threaded hi");
+        msg.thread = Some(xmpp_parsers::message::Thread("root-thread".to_string()));
+
+        let events = vec![OutboundEvent::SendStanza(Box::new(Stanza::Message(msg)))];
+        let outcome = interpret(events, &Deps::registry_only(&test_registry())).await;
+
+        assert_eq!(outcome.frames.len(), 1);
+        assert!(
+            outcome.frames[0].contains("<thread>root-thread</thread>"),
+            "SendStanza must preserve RFC 6121/XEP-0201 thread on the wire: {}",
+            outcome.frames[0]
+        );
     }
 
     // -----------------------------------------------------------------

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -53,6 +53,7 @@ pub use stanza::Stanza;
 pub use types::{Affiliation, ConnectionState, Role, StanzaType, Transport};
 pub use xep0201::{
     build_thread_element, install_thread_element, parse_thread_info, set_thread_id,
-    thread_id_from_message, thread_info_from_message, ThreadInfo, NS_THREAD_FEATURE,
-    THREAD_ELEMENT,
+    thread_id_from_message, thread_id_from_message_in_stanza_ns, thread_info_from_message,
+    thread_info_from_message_in_stanza_ns, ThreadInfo, CLIENT_STANZA_NS, NS_THREAD_FEATURE,
+    SERVER_STANZA_NS, THREAD_ELEMENT,
 };

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -574,27 +574,35 @@ fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage
         return element;
     }
 
-    if let Ok(mut message) = Message::try_from(element.clone()) {
-        message.to = None;
-        return Element::from(message);
-    }
-
-    if element.attr("to").is_none() {
-        return element;
-    }
-
-    let ns = element.ns().to_string();
-    let name = element.name().to_string();
-    let mut builder = Element::builder(name, &ns);
-    for (key, value) in element.attrs() {
-        if key != "to" {
-            builder = builder.attr(key, value);
+    let mut normalized = if element.attr("to").is_none() {
+        element
+    } else {
+        let ns = element.ns().to_string();
+        let name = element.name().to_string();
+        let mut builder = Element::builder(name, &ns);
+        for (key, value) in element.attrs() {
+            if key != "to" {
+                builder = builder.attr(key, value);
+            }
         }
+        for child in element.children().cloned() {
+            builder = builder.append(child);
+        }
+        builder.build()
+    };
+
+    if let Some(thread_id) = archived.thread_id.as_deref() {
+        let info = crate::xep0201::ThreadInfo {
+            id: thread_id.to_owned(),
+            parent: archived
+                .parent_thread_id
+                .as_ref()
+                .map(|parent| parent.as_str().to_owned()),
+        };
+        crate::xep0201::install_thread_element(&mut normalized, &info);
     }
-    for child in element.children().cloned() {
-        builder = builder.append(child);
-    }
-    builder.build()
+
+    normalized
 }
 
 fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMessage) -> Element {
@@ -1200,6 +1208,52 @@ mod tests {
         let thread = replay_inner_thread(&msgs[0]);
         assert_eq!(thread.text().trim(), "child-thread");
         assert_eq!(thread.attr("parent"), Some("root-thread"));
+    }
+
+    #[test]
+    fn xep_0201_groupchat_stanza_xml_replay_reinstalls_thread_and_strips_to() {
+        let archived = ArchivedMessage {
+            id: "archive-threaded-reply".to_string(),
+            timestamp: Utc::now(),
+            from: "room@conference.example.com/alice".to_string(),
+            to: "room@conference.example.com".to_string(),
+            body: "threaded reply".to_string(),
+            stanza_id: Some("wire-id-2".to_string()),
+            thread_id: Some("root-thread".to_string()),
+            parent_thread_id: ThreadId::new("parent-thread"),
+            message_type: "groupchat".to_string(),
+            stanza_xml: Some(
+                "<message xmlns='jabber:client' from='room@conference.example.com/alice' to='bob@example.com/web' type='groupchat' id='wire-id-2'><body>threaded reply</body><thread>stale-thread</thread><reply xmlns='urn:xmpp:reply:0' id='root-thread'/></message>"
+                    .to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let msgs = build_result_messages("q-stanza-xml", "bob@example.com/web", &[archived]);
+        let result = msgs[0]
+            .payloads
+            .iter()
+            .find(|p| p.name() == "result" && p.ns() == MAM_NS)
+            .expect("result payload");
+        let forwarded = result
+            .children()
+            .find(|c| c.name() == "forwarded" && c.ns() == FORWARD_NS)
+            .expect("forwarded element");
+        let inner_msg = forwarded
+            .children()
+            .find(|c| c.name() == "message" && c.ns() == CLIENT_NS)
+            .expect("inner message");
+        let thread = inner_msg
+            .children()
+            .find(|c| c.name() == "thread")
+            .expect("thread child on replay");
+
+        assert_eq!(inner_msg.attr("to"), None);
+        assert_eq!(thread.text().trim(), "root-thread");
+        assert_eq!(thread.attr("parent"), Some("parent-thread"));
+        assert!(inner_msg
+            .children()
+            .any(|c| c.name() == "reply" && c.ns() == REPLY_NS));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/parser_utils.rs
+++ b/server/crates/waddle-xmpp-core/src/parser_utils.rs
@@ -19,12 +19,19 @@ pub fn ensure_thread_element(element: &mut Element, thread_id: Option<&str>) {
         let trimmed = id.trim();
         if trimmed.is_empty() {
             // skip empty thread
-        } else if !element.children().any(|child| child.name() == "thread") {
+        } else {
+            let stanza_ns = element.ns();
+            if element
+                .children()
+                .any(|child| crate::xep0201::is_thread_element_for_stanza(child, &stanza_ns))
+            {
+                return;
+            }
             let info = crate::xep0201::ThreadInfo {
                 id: trimmed.to_owned(),
                 parent: None,
             };
-            element.append_child(crate::xep0201::build_thread_element(&info, element.ns()));
+            element.append_child(crate::xep0201::build_thread_element(&info, &stanza_ns));
         }
     }
 }
@@ -40,9 +47,10 @@ pub fn ensure_thread_element(element: &mut Element, thread_id: Option<&str>) {
 /// ## Returns
 /// The parent attribute value if present and non-empty, None otherwise.
 pub fn extract_thread_parent(element: &Element) -> Option<String> {
+    let stanza_ns = element.ns();
     element
         .children()
-        .find(|child| child.name() == "thread")
+        .find(|child| crate::xep0201::is_thread_element_for_stanza(child, &stanza_ns))
         .and_then(|child| {
             child
                 .attr("parent")
@@ -117,6 +125,50 @@ mod tests {
     }
 
     #[test]
+    fn test_ensure_thread_element_ignores_unrelated_namespaced_thread() {
+        let mut element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "urn:example:other:0")
+                    .attr("kind", "extension")
+                    .append("not-xep-0201")
+                    .build(),
+            )
+            .build();
+
+        ensure_thread_element(&mut element, Some("thread-123"));
+
+        assert_eq!(
+            element.get_child("thread", "jabber:client").unwrap().text(),
+            "thread-123"
+        );
+        assert!(element
+            .children()
+            .any(|child| child.name() == "thread" && child.ns() == "urn:example:other:0"));
+    }
+
+    #[test]
+    fn test_ensure_thread_element_ignores_explicit_empty_namespace_thread() {
+        let mut element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "")
+                    .attr("kind", "extension")
+                    .append("not-xep-0201")
+                    .build(),
+            )
+            .build();
+
+        ensure_thread_element(&mut element, Some("thread-123"));
+
+        assert_eq!(
+            element.get_child("thread", "jabber:client").unwrap().text(),
+            "thread-123"
+        );
+        assert!(element
+            .children()
+            .any(|child| child.name() == "thread" && child.ns().is_empty()));
+    }
+
+    #[test]
     fn test_extract_thread_parent() {
         let element = Element::builder("message", "jabber:client")
             .append(
@@ -136,6 +188,21 @@ mod tests {
         let element = Element::builder("message", "jabber:client")
             .append(
                 Element::builder("thread", "jabber:client")
+                    .append("thread-456")
+                    .build(),
+            )
+            .build();
+
+        let parent = extract_thread_parent(&element);
+        assert_eq!(parent, None);
+    }
+
+    #[test]
+    fn test_extract_thread_parent_ignores_explicit_empty_namespace_thread() {
+        let element = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder("thread", "")
+                    .attr("parent", "not-a-stanza-parent")
                     .append("thread-456")
                     .build(),
             )

--- a/server/crates/waddle-xmpp-core/src/stanza.rs
+++ b/server/crates/waddle-xmpp-core/src/stanza.rs
@@ -21,7 +21,14 @@ impl Stanza {
     /// Convert the stanza to a minidom Element.
     pub fn to_element(&self) -> minidom::Element {
         match self {
-            Stanza::Message(message) => message.clone().into(),
+            Stanza::Message(message) => {
+                let mut element = message.clone().into();
+                crate::parser_utils::ensure_thread_element(
+                    &mut element,
+                    message.thread.as_ref().map(|thread| thread.0.as_str()),
+                );
+                element
+            }
             Stanza::Presence(presence) => presence.clone().into(),
             Stanza::Iq(iq) => iq.clone().into(),
         }

--- a/server/crates/waddle-xmpp-core/src/xep0201.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0201.rs
@@ -1,8 +1,9 @@
 //! XEP-0201: Best Practices for Message Threads
 //!
-//! The `<thread/>` element is defined by RFC 6121 (no namespace). XEP-0201 is
-//! an Informational XEP that standardises how clients and servers should
-//! generate, propagate, and optionally nest threads via the `parent` attribute.
+//! The `<thread/>` element is defined by RFC 6121 as a child of the message
+//! stanza. XEP-0201 is an Informational XEP that standardises how clients and
+//! servers should generate, propagate, and optionally nest threads via the
+//! `parent` attribute.
 //!
 //! Wire shape:
 //!
@@ -25,6 +26,24 @@ pub const NS_THREAD_FEATURE: &str = "urn:xmpp:threads:0";
 
 /// The RFC 6121 thread element name.
 pub const THREAD_ELEMENT: &str = "thread";
+
+/// Client-to-server stanza namespace for message payloads.
+pub const CLIENT_STANZA_NS: &str = "jabber:client";
+
+/// Server-to-server stanza namespace for message payloads.
+pub const SERVER_STANZA_NS: &str = "jabber:server";
+
+/// Return true for the RFC 6121 `<thread/>` child belonging to `stanza_ns`.
+///
+/// Same-local-name extension payloads in another namespace are not message
+/// thread metadata and must be preserved.
+pub fn is_thread_element_for_stanza(element: &Element, stanza_ns: &str) -> bool {
+    element.name() == THREAD_ELEMENT && element.ns() == stanza_ns
+}
+
+fn is_message_thread_payload_for_stanza(element: &Element, stanza_ns: &str) -> bool {
+    element.name() == THREAD_ELEMENT && element.ns() == stanza_ns
+}
 
 /// Thread identifier plus an optional parent (XEP-0201 nesting).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -54,9 +73,10 @@ impl ThreadInfo {
 }
 
 fn find_thread_element(msg_xml: &Element) -> Option<&Element> {
+    let stanza_ns = msg_xml.ns();
     msg_xml
         .children()
-        .find(|child| child.name() == THREAD_ELEMENT)
+        .find(|child| is_thread_element_for_stanza(child, &stanza_ns))
 }
 
 /// Parse thread info from a raw message element.
@@ -97,11 +117,15 @@ pub fn parse_thread_info(msg_xml: &Element) -> Option<ThreadInfo> {
 /// field (parent unrecoverable) when no payload thread exists. Callers that
 /// need parent on archive write should ensure `reattach_thread_parent` runs
 /// upstream of this call.
-pub fn thread_info_from_message(msg: &Message) -> Option<ThreadInfo> {
+pub fn thread_info_from_message_in_stanza_ns(
+    msg: &Message,
+    stanza_ns: impl AsRef<str>,
+) -> Option<ThreadInfo> {
+    let stanza_ns = stanza_ns.as_ref();
     if let Some(thread_elem) = msg
         .payloads
         .iter()
-        .find(|elem| elem.name() == THREAD_ELEMENT)
+        .find(|elem| is_message_thread_payload_for_stanza(elem, stanza_ns))
     {
         let text = thread_elem.text();
         let id = text.trim();
@@ -124,6 +148,11 @@ pub fn thread_info_from_message(msg: &Message) -> Option<ThreadInfo> {
     })
 }
 
+/// Read XEP-0201 thread info from a client-stanza parsed `Message`.
+pub fn thread_info_from_message(msg: &Message) -> Option<ThreadInfo> {
+    thread_info_from_message_in_stanza_ns(msg, CLIENT_STANZA_NS)
+}
+
 /// Build a `<thread/>` element with optional `parent` attribute in the given
 /// stanza namespace.
 ///
@@ -141,16 +170,16 @@ pub fn build_thread_element(info: &ThreadInfo, ns: impl AsRef<str>) -> Element {
 /// Replace any `<thread/>` children on a raw message element with one built
 /// from `info`, inheriting the message's namespace.
 pub fn install_thread_element(msg_xml: &mut Element, info: &ThreadInfo) {
-    let stanza_ns = msg_xml.ns();
+    let stanza_ns = msg_xml.ns().to_string();
     let to_remove: Vec<(String, String)> = msg_xml
         .children()
-        .filter(|c| c.name() == THREAD_ELEMENT)
+        .filter(|c| is_thread_element_for_stanza(c, &stanza_ns))
         .map(|c| (c.name().to_owned(), c.ns()))
         .collect();
     for (name, ns) in to_remove {
         msg_xml.remove_child(&name, ns.as_str());
     }
-    msg_xml.append_child(build_thread_element(info, stanza_ns));
+    msg_xml.append_child(build_thread_element(info, &stanza_ns));
 }
 
 /// Read RFC 6121 `<thread/>` identifier from a message.
@@ -160,12 +189,21 @@ pub fn install_thread_element(msg_xml: &mut Element, info: &ThreadInfo) {
 /// callers that constructed messages by appending an element rather than
 /// setting the typed field.
 pub fn thread_id_from_message(msg: &Message) -> Option<String> {
+    thread_id_from_message_in_stanza_ns(msg, CLIENT_STANZA_NS)
+}
+
+/// Read RFC 6121 `<thread/>` identifier from a message in `stanza_ns`.
+pub fn thread_id_from_message_in_stanza_ns(
+    msg: &Message,
+    stanza_ns: impl AsRef<str>,
+) -> Option<String> {
     if let Some(thread) = msg.thread.as_ref() {
         return Some(thread.0.clone());
     }
+    let stanza_ns = stanza_ns.as_ref();
     msg.payloads
         .iter()
-        .find(|elem| elem.name() == THREAD_ELEMENT)
+        .find(|elem| is_message_thread_payload_for_stanza(elem, stanza_ns))
         .map(|elem| elem.text())
         .map(|text| text.trim().to_owned())
         .filter(|text| !text.is_empty())
@@ -214,6 +252,20 @@ mod tests {
         let xml = "<message xmlns='jabber:client'/>"
             .parse::<Element>()
             .expect("valid xml");
+        assert_eq!(parse_thread_info(&xml), None);
+    }
+
+    #[test]
+    fn explicit_empty_namespace_thread_is_not_stanza_thread() {
+        let xml = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder(THREAD_ELEMENT, "")
+                    .attr("parent", "root-1")
+                    .append("not-stanza-thread")
+                    .build(),
+            )
+            .build();
+
         assert_eq!(parse_thread_info(&xml), None);
     }
 
@@ -269,6 +321,57 @@ mod tests {
         let count = xml
             .children()
             .filter(|c| c.name() == THREAD_ELEMENT)
+            .count();
+        assert_eq!(count, 1);
+        let info = parse_thread_info(&xml).expect("thread after install");
+        assert_eq!(info.id, "new");
+        assert_eq!(info.parent.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn install_thread_element_preserves_unrelated_namespaced_thread_payload() {
+        let mut xml = "<message xmlns='jabber:client'><thread xmlns='urn:example:other:0' kind='extension'>keep me</thread><thread>old</thread></message>"
+            .parse::<Element>()
+            .expect("valid xml");
+        install_thread_element(&mut xml, &ThreadInfo::child("new", "root"));
+
+        assert!(xml.children().any(|c| {
+            c.name() == THREAD_ELEMENT && c.ns() == "urn:example:other:0" && c.text() == "keep me"
+        }));
+        let count = xml
+            .children()
+            .filter(|c| is_thread_element_for_stanza(c, "jabber:client"))
+            .count();
+        assert_eq!(count, 1);
+        let info = parse_thread_info(&xml).expect("thread after install");
+        assert_eq!(info.id, "new");
+        assert_eq!(info.parent.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn install_thread_element_preserves_explicit_empty_namespace_thread_payload() {
+        let mut xml = Element::builder("message", "jabber:client")
+            .append(
+                Element::builder(THREAD_ELEMENT, "")
+                    .attr("kind", "extension")
+                    .append("keep me")
+                    .build(),
+            )
+            .append(
+                Element::builder(THREAD_ELEMENT, "jabber:client")
+                    .append("old")
+                    .build(),
+            )
+            .build();
+
+        install_thread_element(&mut xml, &ThreadInfo::child("new", "root"));
+
+        assert!(xml
+            .children()
+            .any(|c| c.name() == THREAD_ELEMENT && c.ns().is_empty() && c.text() == "keep me"));
+        let count = xml
+            .children()
+            .filter(|c| is_thread_element_for_stanza(c, "jabber:client"))
             .count();
         assert_eq!(count, 1);
         let info = parse_thread_info(&xml).expect("thread after install");
@@ -344,6 +447,67 @@ mod tests {
         let info = thread_info_from_message(&msg).expect("thread info");
         assert_eq!(info.id, "authoritative-id");
         assert_eq!(info.parent.as_deref(), Some("root-1"));
+    }
+
+    #[test]
+    fn thread_info_from_message_ignores_empty_namespace_payload() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        set_thread_id(&mut msg, "typed-thread");
+        msg.payloads.push(
+            Element::builder(THREAD_ELEMENT, "")
+                .attr("parent", "foreign-root")
+                .append("foreign-thread")
+                .build(),
+        );
+
+        let info = thread_info_from_message(&msg).expect("typed thread");
+        assert_eq!(info.id, "typed-thread");
+        assert_eq!(info.parent, None);
+    }
+
+    #[test]
+    fn thread_info_from_message_ignores_wrong_stanza_namespace_payload() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        set_thread_id(&mut msg, "typed-thread");
+        msg.payloads.push(
+            Element::builder(THREAD_ELEMENT, SERVER_STANZA_NS)
+                .attr("parent", "foreign-root")
+                .append("foreign-thread")
+                .build(),
+        );
+
+        let info = thread_info_from_message(&msg).expect("typed thread");
+        assert_eq!(info.id, "typed-thread");
+        assert_eq!(info.parent, None);
+    }
+
+    #[test]
+    fn thread_info_from_message_can_read_server_stanza_namespace() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        msg.payloads.push(
+            Element::builder(THREAD_ELEMENT, SERVER_STANZA_NS)
+                .attr("parent", "server-root")
+                .append("server-child")
+                .build(),
+        );
+
+        assert_eq!(thread_info_from_message(&msg), None);
+        let info =
+            thread_info_from_message_in_stanza_ns(&msg, SERVER_STANZA_NS).expect("server thread");
+        assert_eq!(info.id, "server-child");
+        assert_eq!(info.parent.as_deref(), Some("server-root"));
+    }
+
+    #[test]
+    fn thread_id_from_message_ignores_empty_namespace_payload() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        msg.payloads.push(
+            Element::builder(THREAD_ELEMENT, "")
+                .append("foreign-thread")
+                .build(),
+        );
+
+        assert_eq!(thread_id_from_message(&msg), None);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -31,7 +31,7 @@ use crate::xep::{
     extract_references_from_message, extract_retraction_from_message, parse_reply_from_message,
     RetractionKind, NS_REPLY,
 };
-use waddle_xmpp_core::xep0201::thread_info_from_message;
+use waddle_xmpp_core::xep0201::{thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS};
 
 /// Build the [`ArchivedMessage`] persisted form of a one-to-one
 /// (chat / normal) `<message/>` for direct MAM storage.
@@ -92,13 +92,14 @@ pub fn build_direct_archived_message(
     // post-reattach payload form. The inbound parse boundary in
     // `protocol::frame::parse_stanza` calls `reattach_thread_parent` so the
     // parent attribute survives `Message::try_from`'s typed lossy parse.
-    let (thread_id, parent_thread_id) = match thread_info_from_message(message) {
-        Some(info) => (
-            Some(info.id),
-            info.parent.and_then(waddle_xmpp_core::mam::ThreadId::new),
-        ),
-        None => (None, None),
-    };
+    let (thread_id, parent_thread_id) =
+        match thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS) {
+            Some(info) => (
+                Some(info.id),
+                info.parent.and_then(waddle_xmpp_core::mam::ThreadId::new),
+            ),
+            None => (None, None),
+        };
 
     ArchivedMessage {
         id,
@@ -440,6 +441,28 @@ mod tests {
             archived.parent_thread_id.as_ref().map(|t| t.as_str()),
             Some("root-1")
         );
+    }
+
+    #[test]
+    fn xep_0201_direct_chat_ignores_wrong_stanza_namespace_payload() {
+        use minidom::Element;
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        waddle_xmpp_core::xep0201::set_thread_id(&mut msg, "typed-thread");
+        msg.payloads.push(
+            Element::builder("thread", waddle_xmpp_core::xep0201::SERVER_STANZA_NS)
+                .attr("parent", "foreign-root")
+                .append("foreign-thread")
+                .build(),
+        );
+
+        let archived = build_direct_archived_message(
+            "alice@example.com",
+            "alice@example.com",
+            "bob@example.com",
+            &msg,
+        );
+        assert_eq!(archived.thread_id.as_deref(), Some("typed-thread"));
+        assert!(archived.parent_thread_id.is_none());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -1198,6 +1198,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn xep_0198_detached_replay_preserves_xep_0201_thread_metadata() {
+        use xmpp_parsers::message::{Body, Message, MessageType, Thread};
+
+        let registry = InMemorySmSessionRegistry::new();
+        let jid = make_test_jid();
+        let session = make_test_session_for_jid("stream-threaded-replay", jid.clone());
+        registry.store_session(session).await.unwrap();
+
+        let mut msg = Message::new(Some(jid::Jid::from(jid.clone())));
+        msg.from = Some(jid::Jid::from(
+            "sender@example.com/web".parse::<FullJid>().expect("jid"),
+        ));
+        msg.id = Some("detached-threaded-message".to_string());
+        msg.type_ = MessageType::Chat;
+        msg.bodies
+            .insert(String::new(), Body("threaded".to_string()));
+        msg.thread = Some(Thread("conversation-thread".to_string()));
+        msg.payloads.push(
+            minidom::Element::builder("thread", "urn:example:other:0")
+                .attr("kind", "extension")
+                .append("not-xep-0201")
+                .build(),
+        );
+
+        assert!(registry
+            .record_stanza_for_detached_bound_resource(&jid, &Stanza::Message(msg))
+            .await
+            .unwrap());
+        let stored = registry
+            .peek_session("stream-threaded-replay")
+            .await
+            .unwrap()
+            .expect("detached session remains");
+        let replay = stored
+            .unacked_stanzas
+            .last()
+            .map(|(_, xml)| xml)
+            .expect("recorded replay stanza");
+        let element = replay
+            .parse::<minidom::Element>()
+            .expect("valid stanza xml");
+
+        assert!(element.children().any(|child| {
+            child.name() == "thread"
+                && child.ns() == "jabber:client"
+                && child.text() == "conversation-thread"
+        }));
+        assert!(element.children().any(|child| {
+            child.name() == "thread"
+                && child.ns() == "urn:example:other:0"
+                && child.text() == "not-xep-0201"
+        }));
+    }
+
+    #[tokio::test]
     async fn xep_0198_scrub_for_tombstone_matches_groupchat_stanza_id() {
         // Groupchat retractions key off the room's XEP-0359 stanza-id
         // per the "archive id == wire stanza-id" invariant

--- a/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
@@ -52,6 +52,12 @@ fn nested_thread_groupchat_row(
     }
 }
 
+fn element_xml(element: &Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize element");
+    String::from_utf8(bytes).expect("element xml is utf-8")
+}
+
 #[tokio::test]
 async fn xep_0201_nested_thread_round_trips_through_mam() {
     // L4 promise: write a row with `<thread parent='root-thread'>child-thread</thread>`
@@ -102,7 +108,7 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
         .expect("inner message");
     let thread_elem = inner_msg
         .children()
-        .find(|c| c.name() == "thread")
+        .find(|c| c.name() == "thread" && c.ns() == "jabber:client")
         .expect("thread element on replay");
     assert_eq!(thread_elem.text().trim(), "child-thread");
     assert_eq!(thread_elem.attr("parent"), Some("root-thread"));
@@ -110,6 +116,88 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
     // Sanity: assert the same archive id was assigned (groupchat
     // canonical-id invariant).
     assert_eq!(retrieved.id, archive_id);
+}
+
+#[test]
+fn xep_0201_groupchat_stanza_xml_replay_preserves_thread_metadata() {
+    // Regression for archived `stanza_xml` replay: normalization must
+    // remove only the per-recipient `to` and keep/reinstall the
+    // XEP-0201 `<thread/>` element.
+    let archived_stanza = Element::builder("message", "jabber:client")
+        .attr("from", "team@conference.example.com/alice")
+        .attr("to", "bob@example.com/web")
+        .attr("type", "groupchat")
+        .attr("id", "wire-archive-xml")
+        .append(
+            Element::builder("body", "jabber:client")
+                .append("threaded reply")
+                .build(),
+        )
+        .append(build_thread_element(
+            &ThreadInfo {
+                id: "stale-thread".to_string(),
+                parent: None,
+            },
+            "jabber:client",
+        ))
+        .append(
+            Element::builder("reply", "urn:xmpp:reply:0")
+                .attr("id", "root-thread")
+                .build(),
+        )
+        .append(
+            Element::builder("thread", "urn:example:other:0")
+                .attr("kind", "extension")
+                .append("not-xep-0201")
+                .build(),
+        )
+        .build();
+    let row = ArchivedMessage {
+        id: "archive-xml".to_string(),
+        timestamp: Utc::now(),
+        from: "team@conference.example.com/alice".to_string(),
+        to: ROOM.to_string(),
+        body: "threaded reply".to_string(),
+        stanza_id: Some("wire-archive-xml".to_string()),
+        thread_id: Some("root-thread".to_string()),
+        parent_thread_id: waddle_xmpp::mam::ThreadId::new("parent-thread"),
+        reply_to_id: Some("root-thread".to_string()),
+        reply_to_jid: None,
+        origin_id: None,
+        message_type: "groupchat".to_string(),
+        stanza_xml: Some(element_xml(&archived_stanza)),
+        rich: None,
+        nickname_generation: Some(0),
+    };
+
+    let envelopes =
+        waddle_xmpp_core::mam::build_result_messages("q-xml", "bob@example.com", &[row]);
+    let result_payload = envelopes[0]
+        .payloads
+        .iter()
+        .find(|p| p.name() == "result" && p.ns() == waddle_xmpp_core::mam::MAM_NS)
+        .expect("result payload");
+    let forwarded = result_payload
+        .children()
+        .find(|c| c.name() == "forwarded" && c.ns() == waddle_xmpp_core::mam::FORWARD_NS)
+        .expect("forwarded");
+    let inner_msg = forwarded
+        .children()
+        .find(|c| c.name() == "message")
+        .expect("inner message");
+    let thread_elem = inner_msg
+        .children()
+        .find(|c| c.name() == "thread" && c.ns() == "jabber:client")
+        .expect("thread element on replay");
+
+    assert_eq!(inner_msg.attr("to"), None);
+    assert_eq!(thread_elem.text().trim(), "root-thread");
+    assert_eq!(thread_elem.attr("parent"), Some("parent-thread"));
+    assert!(inner_msg.children().any(|child| {
+        child.name() == "thread"
+            && child.ns() == "urn:example:other:0"
+            && child.text() == "not-xep-0201"
+    }));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Preserve XEP-0201 thread metadata through MAM replay, typed stanza serialization, and XEP-0198 detached replay.
- Normalize archived groupchat stanza XML by stripping stale per-recipient `to` attributes and reinstalling the canonical `<thread parent="...">...</thread>` child while preserving unrelated payloads.
- Make thread parsing namespace-strict so only the enclosing stanza namespace is treated as RFC 6121/XEP-0201 thread metadata.
- Merge missing thread, reply, correction, reaction, and wire-id aliases into chat timeline rows when MAM/backfill returns a sparse copy of an already-seen message.
- Seed fresh-session MAM reloads with prior timeline metadata only, so live-learned thread state survives reload without retaining stale message content.

## Root Cause

Threaded replies worked live because the client had the in-memory message and reply metadata. After reload, the room history path could return archived messages without the same thread metadata attached to the replayed stanza, and the chat timeline merge path dropped metadata when the same logical message arrived under a different archive/wire id.

## XEP Review

- Reviewed `./xeps` before implementation.
- RFC 6121 / XEP-0201: standard message threads are represented as a stanza-namespace `<thread>` child with optional `parent`; unrelated same-name payloads in other namespaces are preserved.
- XEP-0313: MAM replay now preserves the archived message payload shape while normalizing stale groupchat delivery addressing.
- XEP-0198: detached replay now serializes typed `Message.thread` metadata back onto the wire.
- XEP-0359, XEP-0308, XEP-0444, and XEP-0461: existing stanza ids, corrections, reactions, and replies are preserved while thread metadata is repaired.
- The existing Waddle MAM thread query field remains the current custom filter; this PR does not introduce a new custom wire shape.

## Validation

- `bun run lint` in `chat/`
- `bun test` in `chat/`
- `cargo fmt --check`
- `git diff --check`
- `cuenv exec -- cargo clippy -p waddle-xmpp-core -p waddle-xmpp -p waddle-server -- -D warnings`
- `cuenv exec -- cargo test -p waddle-xmpp-core thread_info_from_message --lib`
- `cuenv exec -- cargo test -p waddle-xmpp xep_0201_direct_chat_ignores_wrong_stanza_namespace_payload --lib`
- `cuenv exec -- cargo test -p waddle-xmpp-core -p waddle-xmpp -p waddle-server`

## Review Notes

Adversarial review found and this PR fixed gaps in duplicate wire-id merging, fresh-session metadata seeding, namespace-sensitive thread parsing, and XEP-0198 replay serialization. Final adversarial pass found no actionable issues.
