### PR TITLE
fix(chat): repair threading MAM reload

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -443,6 +443,10 @@ const isMentioned = computed(() => {
 });
 const isForumTopic = computed(() => props.message.forumPostKind === "topic" && !!props.message.forumTitle);
 const isForumReply = computed(() => props.message.forumPostKind === "reply");
+// XEP-0461 §3.2: groupchat replies require the room-assigned XEP-0359
+// stanza-id. Hide the reply action on messages that lack one rather than
+// surface a button that will refuse on click.
+const canReplyToMessage = computed(() => !!props.message.replyableId);
 const forumThreadLabel = computed(() =>
   props.message.forumPostKind === "topic"
     ? props.message.forumTitle
@@ -1255,6 +1259,7 @@ watch(
         />
       </div>
       <button
+        v-if="canReplyToMessage"
         type="button"
         class="h-8 w-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
         title="Reply"
@@ -1354,6 +1359,7 @@ watch(
           </div>
 
           <button
+            v-if="canReplyToMessage"
             type="button"
             class="type-field w-full flex items-center gap-3 px-3 h-12 rounded-lg hover:bg-muted active:bg-muted transition-colors text-left"
             @click="startReplyFromMenu"

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -59,6 +59,7 @@ export function fromLiveMessage(
   };
   if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
   if (msg.reactionTargetId) tm.reactionTargetId = msg.reactionTargetId;
+  if (msg.replyableId) tm.replyableId = msg.replyableId;
   if (msg.authorRealJid) tm.authorRealJid = msg.authorRealJid;
   if (msg.wireIds && msg.wireIds.length > 0) {
     tm.wireIds = msg.wireIds;
@@ -1277,9 +1278,18 @@ export function useMessaging(
       }
 
       const parent = replyTo ? findMessageById(messages.value, replyTo.id) : undefined;
-      const wireReplyTo = replyTo && parent
+      // XEP-0461 §3.2: groupchat replies MUST quote the room-assigned
+      // XEP-0359 stanza-id. Without one, "messages without one cannot be
+      // replied to"; refuse the send rather than leak a non-conformant id.
+      if (replyTo && parent && !parent.replyableId) {
+        actionError.value =
+          "This message can't be replied to (no room stanza-id). Try reloading the channel.";
+        isSending.value = false;
+        return;
+      }
+      const wireReplyTo = replyTo && parent && parent.replyableId
         ? {
-            id: parent.id,
+            id: parent.replyableId,
             author: parent.authorJid ?? replyTo.author,
             ...(replyTo.body ? { body: replyTo.body } : {}),
           }
@@ -1324,9 +1334,11 @@ export function useMessaging(
           ...(markup && markup.length > 0 ? { markup } : {}),
           ...(references && references.length > 0 ? { references } : {}),
         };
-        if (replyTo && parent) {
+        if (replyTo && parent && parent.replyableId) {
+          // Mirror the wire reply id on the optimistic insert so the local
+          // chip and the eventual MAM round-trip resolve to the same id.
           optimistic.replyTo = {
-            id: parent.id,
+            id: parent.replyableId,
             author: replyTo.author,
             ...(replyTo.body ? { preview: replyTo.body } : {}),
           };

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -100,7 +100,7 @@ export function fromLiveMessage(
   return tm;
 }
 
-function applyForumContext(list: TimelineMessage[]): TimelineMessage[] {
+function applyForumContext(list: TimelineMessage[], inferForumReplies = true): TimelineMessage[] {
   const threadTitles = new Map<string, string>();
 
   for (const message of list) {
@@ -124,13 +124,15 @@ function applyForumContext(list: TimelineMessage[]): TimelineMessage[] {
         next.forumThreadTitle = message.forumTitle;
         changed = true;
       }
-    } else if (threadId && threadTitle) {
-      if (!message.forumPostKind && message.id !== threadId) {
+    } else if (threadId) {
+      if (inferForumReplies && !message.forumPostKind && message.id !== threadId) {
         next.forumPostKind = "reply";
         changed = true;
       }
-      if (message.forumThreadTitle !== threadTitle) {
-        next.forumThreadTitle = threadTitle;
+      const forumThreadTitle = threadTitle
+        ?? (next.forumPostKind === "reply" && !message.body ? `Thread ${threadId}` : undefined);
+      if (forumThreadTitle && message.forumThreadTitle !== forumThreadTitle) {
+        next.forumThreadTitle = forumThreadTitle;
         changed = true;
       }
     }
@@ -910,6 +912,9 @@ export function useMessaging(
         msg.body
         || (msg.sharedFiles && msg.sharedFiles.length > 0)
         || msg.isSticker
+        || msg.threadId
+        || msg.replyTo
+        || msg.forumPostKind
         || (msg.extensionAnnotations && msg.extensionAnnotations.length > 0)
       ) {
         regularMessages.push(msg);
@@ -986,7 +991,7 @@ export function useMessaging(
       }
     }
 
-    return applyForumContext(timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt)));
+    return applyForumContext(timeline.sort((a, b) => a.createdAt.localeCompare(b.createdAt)), channelIsForum.value);
   }
 
   async function loadMessages(
@@ -1132,10 +1137,25 @@ export function useMessaging(
     const channelId = activeChannelId.value;
     if (!client || !channelId || !threadId || !session.value) return;
     const requestId = messageRequestId;
-    const page = "queryMamThreadPage" in client
-      ? await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "latest" })
-      : null;
-    const results = page ? page.messages : await client.queryMamByThread(spaceId ?? "", channelId, threadId, 100);
+    let page: { messages: LiveRoomMessage[]; firstArchiveId?: string; complete?: boolean } | null = null;
+    let results: LiveRoomMessage[] = [];
+    try {
+      page = "queryMamThreadPage" in client
+        ? await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "latest" })
+        : null;
+      results = page ? page.messages : await client.queryMamByThread(spaceId ?? "", channelId, threadId, 100);
+    } catch (e) {
+      if (
+        xmppClient.value === client &&
+        (activeSpaceId.value ?? "") === (spaceId ?? "") &&
+        activeChannelId.value === channelId &&
+        requestId === messageRequestId
+      ) {
+        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        actionError.value = normalizeError(e);
+      }
+      return;
+    }
     if (
       xmppClient.value !== client ||
       (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
@@ -1221,8 +1241,10 @@ export function useMessaging(
     const hasFiles = !!files && files.length > 0;
     const isForumPost = channelIsForum.value && !replyTo;
     const resolvedForumTitle = (forumTitle ?? forumPostTitle.value).trim();
+    const hasThreadMetadataIntent = !!threadOverride?.threadId.trim();
+    const hasForumMetadataIntent = (isForumPost && !!resolvedForumTitle) || (channelIsForum.value && !!replyTo);
     if (!client || !channelId) return;
-    if (!bodyText.trim() && !hasFiles) return;
+    if (!bodyText.trim() && !hasFiles && !hasThreadMetadataIntent && !hasForumMetadataIntent) return;
     if (isForumPost && !resolvedForumTitle) {
       actionError.value = "Add a title before posting to this forum.";
       return;

--- a/chat/src/composables/useThreads.ts
+++ b/chat/src/composables/useThreads.ts
@@ -3,7 +3,13 @@ import type { TimelineMessage } from "@/lib/chat-ui";
 
 export interface ThreadEntry {
   threadId: string;
-  /** Message whose id === threadId. Waddle roots don't carry `<thread>`, so we resolve via id lookup. null when the root isn't in the loaded window. */
+  /**
+   * Resolved thread root. Two paths:
+   *   - Waddle's implicit-root convention: the message whose id equals the
+   *     thread id (root carries no `<thread/>`).
+   *   - Standard XEP-0201: the earliest message bearing this thread id.
+   * `null` when the root isn't in the loaded window.
+   */
   root: TimelineMessage | null;
   /** Messages whose threadId === this entry's threadId, in chronological order, excluding the root. */
   directChildren: TimelineMessage[];
@@ -56,9 +62,25 @@ function buildIndex(messages: readonly TimelineMessage[]): ThreadIndex {
   const entries = new Map<string, ThreadEntry>();
   for (const [threadId, group] of byThread) {
     group.sort(byCreatedAt);
-    // Root messages in this codebase don't set `<thread>` — we find them by
-    // matching a child's threadId against any loaded message's id.
-    const root = byId.get(threadId) ?? null;
+    // Resolve the thread root via two paths, in order:
+    //   1. Waddle's implicit-root convention (`root.id === threadId`, no
+    //      `<thread/>` on the root): the loaded message id matches the thread
+    //      id directly.
+    //   2. Standard XEP-0201, where the thread id is an arbitrary identifier
+    //      decoupled from any message id and the root carries
+    //      `<thread>threadId</thread>` itself: the earliest message bearing
+    //      this thread id that is *not* a reply to another member of the
+    //      thread (or to the implicit-root id) is the root candidate.
+    // The fallback chain leaves the root null when only XEP-0461 children of
+    // an unloaded root are visible — never promote a known reply to a root.
+    const groupMembers = new Set(group.map((m) => m.id));
+    const standardRoot = group.find((m) => {
+      const replyId = m.replyTo?.id;
+      if (!replyId) return true;
+      if (replyId === threadId) return false;
+      return !groupMembers.has(replyId);
+    }) ?? null;
+    const root = byId.get(threadId) ?? standardRoot;
     const directChildren = root ? group.filter((m) => m.id !== root.id) : group.slice();
     const lastTs = group[group.length - 1]?.createdAt ?? root?.createdAt ?? "";
     entries.set(threadId, {

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -125,6 +125,13 @@ export interface TimelineMessage {
   authorRealJid?: string;
   /** XEP-0444 groupchat reaction target: room-assigned XEP-0359 stanza-id. */
   reactionTargetId?: string;
+  /**
+   * XEP-0461 §3.2 replyable id. Absent on groupchat messages that lack a
+   * room-assigned XEP-0359 stanza-id; consumers MUST treat such messages as
+   * non-replyable (disable the action, refuse to send) rather than fall back
+   * to the wire id.
+   */
+  replyableId?: string;
   body: string;
   createdAt: string;
   isSelf: boolean;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -948,10 +948,17 @@ export class BrowserXmppClient {
     body: string,
     opts: messaging.SendGroupMessageOptions = {},
   ): Promise<OutboundSendResult | null> {
-    const { files } = opts;
+    const { files, threadId, threadCreate, threadReply } = opts;
     const text = body.trim();
     const hasFiles = !!files && files.length > 0;
-    if (!text && !hasFiles) return null;
+    // XEP-0201 thread create / thread reply payloads are bodyless. The
+    // gate must let them through; otherwise standard MUC threads can't
+    // leave the browser via the normal client path. messaging.ts already
+    // accepts these shapes — keep the two layers in sync.
+    const hasThreadMetadata = !!threadId?.trim();
+    const hasForumMetadata =
+      !!threadCreate?.title?.trim() || !!threadReply?.threadId?.trim();
+    if (!text && !hasFiles && !hasThreadMetadata && !hasForumMetadata) return null;
 
     const roomJid = this.roomJidForChannel(c);
 

--- a/chat/src/lib/xmpp/dm-parsing.ts
+++ b/chat/src/lib/xmpp/dm-parsing.ts
@@ -79,6 +79,7 @@ export function dispatchChat(msg: ReceivedMessage, h: DmHandlers): void {
     type: "message",
   };
   if (messageIds.correctionTargetId) liveMsg.correctionTargetId = messageIds.correctionTargetId;
+  if (messageIds.replyableId) liveMsg.replyableId = messageIds.replyableId;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;
   if (msg.replace) {
     liveMsg.replacesId = msg.replace;

--- a/chat/src/lib/xmpp/history.ts
+++ b/chat/src/lib/xmpp/history.ts
@@ -60,7 +60,6 @@ export async function queryMam(
 function parseRoomMamResult(
   result: Awaited<ReturnType<Agent["searchHistory"]>>,
   roomJid: string,
-  requestedThreadId?: string,
 ): MamHistoryPage<LiveRoomMessage> {
   const collected: LiveRoomMessage[] = [];
 
@@ -96,13 +95,12 @@ function parseRoomMamResult(
       });
 
       if (parsedMessage) {
-        if (
-          requestedThreadId
-          && !parsedMessage.threadId
-          && parsedMessage.replyTo?.id === requestedThreadId
-        ) {
-          parsedMessage = { ...parsedMessage, threadId: requestedThreadId };
-        }
+        // XEP-0461 §3: a reply identifies the replied-to message; it does
+        // not imply XEP-0201 thread membership. Threaded messages must
+        // carry their own <thread/>; the server archives <thread parent=...>
+        // faithfully, so anything that should reload as part of a thread
+        // already has the metadata. Do not synthesize a threadId from
+        // <reply id=...> here.
         collected.push(parsedMessage);
         continue;
       }
@@ -166,7 +164,7 @@ export async function queryMamByThread(
       ],
     },
   });
-  return parseRoomMamResult(result, roomJid, threadId).messages;
+  return parseRoomMamResult(result, roomJid).messages;
 }
 
 export async function queryMamThreadPage(
@@ -188,7 +186,7 @@ export async function queryMamThreadPage(
       ],
     },
   });
-  return parseRoomMamResult(result, roomJid, threadId);
+  return parseRoomMamResult(result, roomJid);
 }
 
 /** XEP-0431: Full-text search in MAM. Throws on IQ/transport errors. */

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -117,13 +117,27 @@ function extractMucUserRealJid(msg: ReceivedMessage): string | undefined {
 export function resolveMessageIds(
   msg: ReceivedMessage,
   preferredStanzaBy?: string,
-): { id: string; wireIds?: string[]; correctionTargetId: string; reactionTargetId?: string } {
+): {
+  id: string;
+  wireIds?: string[];
+  correctionTargetId: string;
+  reactionTargetId?: string;
+  replyableId?: string;
+} {
   const extMsg = ext(msg);
   const originId = extMsg.originId as OriginIdPayload | undefined;
   const stanzaIds = asArray(extMsg.stanzaIds as StanzaIdPayload | StanzaIdPayload[] | undefined);
   const preferredStanzaId = preferredStanzaBy
     ? stanzaIds.find((candidate) => candidate.by === preferredStanzaBy)?.id
     : undefined;
+
+  // XEP-0461 §3.2: groupchat replies MUST quote the id assigned by the room
+  // (a stanza-id whose `by` matches the room JID). If absent, the message
+  // cannot be replied to. For non-groupchat, fall back to origin-id then the
+  // stanza @id.
+  const replyableId = preferredStanzaBy
+    ? preferredStanzaId
+    : (originId?.id ?? msg.id ?? undefined);
 
   return {
     ...splitMessageIds(
@@ -132,6 +146,7 @@ export function resolveMessageIds(
     ),
     correctionTargetId: originId?.id ?? msg.id ?? "",
     ...(preferredStanzaId ? { reactionTargetId: preferredStanzaId } : {}),
+    ...(replyableId ? { replyableId } : {}),
   };
 }
 
@@ -552,22 +567,39 @@ interface FallbackPayload {
 }
 
 /**
- * XEP-0428: strip any `urn:xmpp:reply:0` fallback range from the displayed
- * body so the `> quoted` prefix doesn't double-render on top of the reply chip.
+ * XEP-0428 §3: strip the body content covered by a `urn:xmpp:reply:0`
+ * fallback so the `> quoted` prefix doesn't double-render on top of the reply
+ * chip. Three shapes per spec:
+ *   1. `<fallback for=...>` with no children → entire body+subject is fallback.
+ *   2. `<fallback><body/></fallback>` (no start/end) → entire body is fallback.
+ *   3. `<fallback><body start=X end=Y/></fallback>` → only that range.
  */
 function stripReplyFallback(msg: ReceivedMessage, base: MessageExtensionsTarget): void {
   const fallbacks = asArray(ext(msg).fallbacks as FallbackPayload | FallbackPayload[] | undefined);
   if (!fallbacks.length || !base.body) return;
-  const range = fallbacks.find((f) => f.for === "urn:xmpp:reply:0")?.body;
-  if (!range) return;
-  const rawStart = range.start ?? 0;
-  const rawEnd = range.end ?? rawStart;
-  if (!Number.isFinite(rawStart) || !Number.isFinite(rawEnd) || rawStart < 0 || rawEnd < 0) {
-    return;
-  }
+  const fallback = fallbacks.find((f) => f.for === "urn:xmpp:reply:0");
+  if (!fallback) return;
   const bodyLength = codePointLength(base.body);
-  const start = Math.max(0, Math.min(rawStart, bodyLength));
-  const end = Math.max(start, Math.min(rawEnd, bodyLength));
+  const range = fallback.body;
+  // Case 1: no `body` field on the parsed fallback → no `<body/>` child →
+  // whole body is fallback. Case 2: `body` is present but start/end are
+  // omitted → also whole body. Both collapse to "strip 0..length".
+  const wholeBody =
+    range === undefined || (range.start === undefined && range.end === undefined);
+  let start: number;
+  let end: number;
+  if (wholeBody) {
+    start = 0;
+    end = bodyLength;
+  } else {
+    const rawStart = range!.start ?? 0;
+    const rawEnd = range!.end ?? rawStart;
+    if (!Number.isFinite(rawStart) || !Number.isFinite(rawEnd) || rawStart < 0 || rawEnd < 0) {
+      return;
+    }
+    start = Math.max(0, Math.min(rawStart, bodyLength));
+    end = Math.max(start, Math.min(rawEnd, bodyLength));
+  }
   if (end <= start) return;
   const startIndex = codePointToCodeUnitIndex(base.body, start);
   const endIndex = codePointToCodeUnitIndex(base.body, end);
@@ -751,6 +783,7 @@ export function dispatchGroupchat(msg: ReceivedMessage, h: GroupchatHandlers): v
   };
   if (messageIds.correctionTargetId) liveMsg.correctionTargetId = messageIds.correctionTargetId;
   if (messageIds.reactionTargetId) liveMsg.reactionTargetId = messageIds.reactionTargetId;
+  if (messageIds.replyableId) liveMsg.replyableId = messageIds.replyableId;
   const authorRealJid = extractMucUserRealJid(msg);
   if (authorRealJid) liveMsg.authorRealJid = authorRealJid;
   if (messageIds.wireIds?.length) liveMsg.wireIds = messageIds.wireIds;

--- a/chat/src/lib/xmpp/message-parsing.ts
+++ b/chat/src/lib/xmpp/message-parsing.ts
@@ -58,6 +58,19 @@ function hasBodyOrSubject(msg: ReceivedMessage): boolean {
   return !!msg.body || !!msg.subject;
 }
 
+function hasValidForumPayload(msg: ReceivedMessage): boolean {
+  const stanza = ext(msg);
+  const threadCreate = stanza.threadCreate as { title?: string } | undefined;
+  if (typeof threadCreate?.title === "string" && threadCreate.title.trim()) return true;
+  const threadReply = stanza.threadReply as { threadId?: string } | undefined;
+  return typeof threadReply?.threadId === "string" && !!threadReply.threadId.trim();
+}
+
+function hasValidThreadPayload(msg: ReceivedMessage): boolean {
+  const threadId = ext(msg).thread;
+  return typeof threadId === "string" && !!threadId.trim();
+}
+
 /**
  * True when a stanza should be treated as a user-visible message payload even
  * if `<body/>` is omitted (for example, pure file-sharing messages).
@@ -68,7 +81,10 @@ export function hasRenderableMessagePayload(msg: ReceivedMessage): boolean {
   const fileSharing = stanza.fileSharing;
   if (Array.isArray(fileSharing)) return fileSharing.length > 0;
   if (fileSharing) return true;
-  return !!stanza.sticker || extensionAnnotationsFromStanza(stanza).length > 0;
+  return !!stanza.sticker
+    || hasValidThreadPayload(msg)
+    || hasValidForumPayload(msg)
+    || extensionAnnotationsFromStanza(stanza).length > 0;
 }
 
 interface OriginIdPayload {
@@ -494,6 +510,8 @@ function hasNonBodyMessagePayload(msg: ReceivedMessage): boolean {
   const fileSharing = stanza.fileSharing;
   return (Array.isArray(fileSharing) ? fileSharing.length > 0 : !!fileSharing)
     || !!stanza.sticker
+    || hasValidThreadPayload(msg)
+    || hasValidForumPayload(msg)
     || extensionAnnotationsFromStanza(stanza).length > 0;
 }
 
@@ -513,16 +531,18 @@ function extractReplyAndThread(msg: ReceivedMessage, base: MessageExtensionsTarg
   const parentThread = ext(msg).parentThread as string | undefined;
   if (parentThread) base.parentThreadId = parentThread;
   const threadCreate = ext(msg).threadCreate as { title?: string } | undefined;
-  if (threadCreate?.title?.trim()) {
+  const threadCreateTitle = typeof threadCreate?.title === "string" ? threadCreate.title.trim() : "";
+  if (threadCreateTitle) {
     base.forumPostKind = "topic";
-    base.forumTitle = threadCreate.title.trim();
-    base.forumThreadTitle = threadCreate.title.trim();
+    base.forumTitle = threadCreateTitle;
+    base.forumThreadTitle = threadCreateTitle;
     if (!base.threadId && base.id) base.threadId = base.id;
   }
   const threadReply = ext(msg).threadReply as { threadId?: string } | undefined;
-  if (threadReply?.threadId) {
+  const threadReplyId = typeof threadReply?.threadId === "string" ? threadReply.threadId.trim() : "";
+  if (threadReplyId) {
     base.forumPostKind = "reply";
-    if (!base.threadId) base.threadId = threadReply.threadId;
+    base.threadId = threadReplyId;
   }
 }
 

--- a/chat/src/lib/xmpp/messaging.ts
+++ b/chat/src/lib/xmpp/messaging.ts
@@ -253,7 +253,9 @@ export function sendGroupMessage(
   const text = body;
   const hasText = text.trim().length > 0;
   const hasFiles = !!files && files.length > 0;
-  if (!hasText && !hasFiles) return null;
+  const hasThreadMetadata = !!threadId?.trim();
+  const hasForumMetadata = !!threadCreate?.title?.trim() || !!threadReply?.threadId?.trim();
+  if (!hasText && !hasFiles && !hasThreadMetadata && !hasForumMetadata) return null;
 
   const msgId = id ?? crypto.randomUUID();
   const { prefix, length: prefixLength } = replyTo

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -112,6 +112,13 @@ export interface LiveRoomMessage {
   authorRealJid?: string;
   /** XEP-0444 groupchat reaction target: room-assigned XEP-0359 stanza-id. */
   reactionTargetId?: string;
+  /**
+   * XEP-0461 §3.2 replyable id. For groupchat: only set when the message
+   * carries a room-assigned XEP-0359 stanza-id. Absent means the message
+   * cannot be replied to (the spec is explicit about this). For DMs:
+   * origin-id then message @id, per the same section.
+   */
+  replyableId?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
   _reactionSenderId?: string;
@@ -148,6 +155,8 @@ export interface LiveDmMessage {
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;
+  /** XEP-0461 §3.2 replyable id (origin-id then message @id for DMs). */
+  replyableId?: string;
   _reactionTarget?: string;
   _reactionEmojis?: string[];
 }

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -362,6 +362,41 @@ describe("optimistic UI waits for successful sends", () => {
     expect(actionError.value).toBe("");
   });
 
+  test("room composer allows bodyless standard MUC thread metadata", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "thread-marker-1", state: "sending" as const }));
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      normalizeError,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.sendMessage("", [], [], undefined, undefined, { threadId: "thread-root" });
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "",
+      expect.objectContaining({
+        threadId: "thread-root",
+      }),
+    );
+    expect(messaging.messages.value.at(-1)).toMatchObject({
+      id: "thread-marker-1",
+      body: "",
+      threadId: "thread-root",
+    });
+  });
+
   test("DM composer keeps queued messages visible and durable", async () => {
     const sendDirectMessage = mock(async () => ({ id: "queued-dm-1", state: "queued" as const }));
     const sendDmChatState = mock(async () => undefined);

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -101,6 +101,33 @@ describe("client send readiness", () => {
     expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
   });
 
+  test("XEP-0201: BrowserXmppClient.sendGroupMessage accepts bodyless thread metadata sends", async () => {
+    // XEP-0201 thread create / thread reply payloads are bodyless. The
+    // browser client wrapper must not short-circuit them; otherwise standard
+    // MUC threads can never leave the browser through the regular send path.
+    const xmpp = { sendMessage: mock(() => undefined) };
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    (client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      currentRoom: string | null;
+    }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+
+    const result = await client.sendGroupMessage("w1", "c1", "", {
+      threadId: "thread-root",
+    });
+
+    expect(result?.state).toBe("sending");
+    expect(typeof result?.id).toBe("string");
+    expect(xmpp.sendMessage).toHaveBeenCalledTimes(1);
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: "thread-root", body: "" }),
+    );
+  });
+
   test("room send queues when the room is unavailable", async () => {
     const xmpp = { sendMessage: mock(() => undefined) };
     const client = new BrowserXmppClient(session());

--- a/chat/tests/forum-composition.test.ts
+++ b/chat/tests/forum-composition.test.ts
@@ -142,6 +142,7 @@ describe("forum composition", () => {
     messaging.messages.value = [
       {
         id: "topic-1",
+        replyableId: "topic-1",
         author: "Bob",
         authorJid: "c1@muc.example.com/Bob",
         body: "Let's map the next release.",
@@ -154,6 +155,7 @@ describe("forum composition", () => {
       },
       {
         id: "reply-1",
+        replyableId: "reply-1",
         author: "Carol",
         authorJid: "c1@muc.example.com/Carol",
         body: "Start with onboarding.",
@@ -212,6 +214,7 @@ describe("forum composition", () => {
     );
     messaging.messages.value = [{
       id: "topic-1",
+      replyableId: "topic-1",
       author: "Bob",
       authorJid: "c1@muc.example.com/Bob",
       body: "",

--- a/chat/tests/forum-composition.test.ts
+++ b/chat/tests/forum-composition.test.ts
@@ -65,6 +65,38 @@ describe("forum composition", () => {
     expect(messaging.forumPostTitle.value).toBe("");
   });
 
+  test("allows bodyless forum topics with title metadata", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "topic-1", state: "sending" as const }));
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref(forumChannel()),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.forumPostTitle.value = "Shipping roadmap";
+
+    await messaging.sendMessage("", []);
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "",
+      expect.objectContaining({
+        threadCreate: { title: "Shipping roadmap" },
+      }),
+    );
+  });
+
   test("blocks top-level forum posts without a title", async () => {
     const sendGroupMessage = mock(async () => ({ id: "topic-1", state: "sending" as const }));
     const sendChatState = mock(async () => undefined);
@@ -159,5 +191,51 @@ describe("forum composition", () => {
       threadId: "topic-1",
       forumThreadTitle: "Shipping roadmap",
     });
+  });
+
+  test("allows bodyless forum replies with thread metadata", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "reply-2", state: "sending" as const }));
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref(forumChannel()),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    messaging.messages.value = [{
+      id: "topic-1",
+      author: "Bob",
+      authorJid: "c1@muc.example.com/Bob",
+      body: "",
+      createdAt: "2024-01-01T00:00:00Z",
+      isSelf: false,
+      threadId: "topic-1",
+      forumPostKind: "topic",
+      forumTitle: "Shipping roadmap",
+      forumThreadTitle: "Shipping roadmap",
+    }];
+
+    await messaging.sendMessage("", [], [], undefined, {
+      id: "topic-1",
+      author: "Bob",
+    });
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "",
+      expect.objectContaining({
+        threadId: "topic-1",
+        threadReply: { threadId: "topic-1" },
+      }),
+    );
   });
 });

--- a/chat/tests/groupchat-messaging.test.ts
+++ b/chat/tests/groupchat-messaging.test.ts
@@ -248,6 +248,22 @@ describe("groupchat messaging", () => {
     );
   });
 
+  test("sends bodyless XEP-0508 thread-create metadata for forum topics", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "roadmap@muc.waddle.social", "", {
+      threadCreate: { title: "Roadmap kickoff" },
+    });
+
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "groupchat",
+        body: "",
+        threadCreate: { title: "Roadmap kickoff" },
+      }),
+    );
+  });
+
   test("sends XEP-0508 thread-reply metadata for forum replies", () => {
     const xmpp = makeAgent();
 
@@ -260,6 +276,24 @@ describe("groupchat messaging", () => {
       expect.objectContaining({
         type: "groupchat",
         body: "Count me in",
+        thread: "topic-1",
+        threadReply: { threadId: "topic-1" },
+      }),
+    );
+  });
+
+  test("sends bodyless XEP-0508 thread-reply metadata for forum replies", () => {
+    const xmpp = makeAgent();
+
+    sendGroupMessage(xmpp, "roadmap@muc.waddle.social", "", {
+      threadId: "topic-1",
+      threadReply: { threadId: "topic-1" },
+    });
+
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "groupchat",
+        body: "",
         thread: "topic-1",
         threadReply: { threadId: "topic-1" },
       }),

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -267,6 +267,28 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages[0].parentThreadId).toBe("thread-root");
   });
 
+  test("keeps bodyless XEP-0201 thread metadata in standard MUC timelines", () => {
+    const h = makeHandlers();
+
+    dispatchGroupchat(
+      makeMsg({
+        id: "thread-marker-1",
+        body: "",
+        thread: "thread-root",
+        parentThread: "parent-root",
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0]).toMatchObject({
+      id: "thread-marker-1",
+      body: "",
+      threadId: "thread-root",
+      parentThreadId: "parent-root",
+    });
+  });
+
   test("extracts forum topic metadata from thread-create", () => {
     const h = makeHandlers();
     dispatchGroupchat(
@@ -299,6 +321,35 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].forumPostKind).toBe("reply");
     expect(h.messages[0].threadId).toBe("topic-1");
+  });
+
+  test("forum reply metadata replaces conflicting XEP thread", () => {
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "reply-1",
+        body: "",
+        thread: "conflicting-thread",
+        threadReply: { threadId: "topic-1" },
+      }),
+      h,
+    );
+
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].forumPostKind).toBe("reply");
+    expect(h.messages[0].threadId).toBe("topic-1");
+  });
+
+  test("ignores malformed bodyless forum metadata", () => {
+    const h = makeHandlers();
+
+    dispatchGroupchat(makeMsg({ id: "topic-1", body: "", threadCreate: {} }), h);
+    dispatchGroupchat(makeMsg({ id: "topic-2", body: "", threadCreate: { title: 123 } }), h);
+    dispatchGroupchat(makeMsg({ id: "reply-1", body: "", threadReply: {} }), h);
+    dispatchGroupchat(makeMsg({ id: "reply-2", body: "", threadReply: { threadId: " " } }), h);
+    dispatchGroupchat(makeMsg({ id: "reply-3", body: "", threadReply: { threadId: 123 } }), h);
+
+    expect(h.messages).toHaveLength(0);
   });
 
   test("attaches encrypted file metadata to parsed shared files", () => {

--- a/chat/tests/groupchat-parsing-replies.test.ts
+++ b/chat/tests/groupchat-parsing-replies.test.ts
@@ -29,6 +29,56 @@ function makeMsg(overrides: Record<string, unknown>): ReceivedMessage {
   } as ReceivedMessage;
 }
 
+describe("XEP-0461 replyableId", () => {
+  test("groupchat message with a room-assigned stanza-id is replyable using that id", () => {
+    // XEP-0461 §3.2: in groupchat, the id used in <reply id=...> MUST be the
+    // id assigned by the room (XEP-0359 stanza-id whose `by` matches the
+    // room JID).
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "wire-id",
+        body: "hi",
+        stanzaIds: [
+          { id: "room-stanza-id", by: "general@muc.waddle.social" },
+        ],
+      }),
+      h,
+    );
+    expect(h.messages[0].replyableId).toBe("room-stanza-id");
+  });
+
+  test("groupchat message without a room-assigned stanza-id is not replyable", () => {
+    // XEP-0461 §3.2 closing line: "messages without one cannot be replied to".
+    // Falling back to origin-id or the @id attribute would violate the spec.
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "wire-id",
+        body: "hi",
+        originId: { id: "origin-only" },
+      }),
+      h,
+    );
+    expect(h.messages[0].replyableId).toBeUndefined();
+  });
+
+  test("groupchat message with a non-room stanza-id is not replyable", () => {
+    // A stanza-id stamped by some other entity (e.g., an upstream archive)
+    // is not the one XEP-0461 wants — only the room's own stamp counts.
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "wire-id",
+        body: "hi",
+        stanzaIds: [{ id: "elsewhere-id", by: "archive@example.com" }],
+      }),
+      h,
+    );
+    expect(h.messages[0].replyableId).toBeUndefined();
+  });
+});
+
 describe("groupchat reply + thread parsing", () => {
   test("extracts reply pointer into replyTo", () => {
     const h = makeHandlers();
@@ -62,6 +112,41 @@ describe("groupchat reply + thread parsing", () => {
     expect(h.messages).toHaveLength(1);
     expect(h.messages[0].body).toBe("actual reply");
     expect(h.messages[0].replyTo?.id).toBe("msg-1");
+  });
+
+  test("XEP-0428: <fallback> with no children strips the entire body", () => {
+    // Per XEP-0428 §3 the fallback applies to every <body/> when no children
+    // are present. We treat the merged body+subject text as the displayable
+    // string, so stripping the whole body produces an empty string.
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-2",
+        body: "this whole text is fallback",
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+        fallbacks: [{ for: "urn:xmpp:reply:0" }],
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("");
+  });
+
+  test("XEP-0428: <fallback><body/></fallback> with no start/end strips the entire body", () => {
+    // "If start and end attribute are not supplied, the whole respective
+    // message element should be assumed to be there for fallback purposes."
+    const h = makeHandlers();
+    dispatchGroupchat(
+      makeMsg({
+        id: "msg-2",
+        body: "treat me as fallback",
+        reply: { to: "general@muc.waddle.social/bob", id: "msg-1" },
+        fallbacks: [{ for: "urn:xmpp:reply:0", body: {} }],
+      }),
+      h,
+    );
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0].body).toBe("");
   });
 
   test("ignores fallbacks for other namespaces", () => {

--- a/chat/tests/groupchat-replies.test.ts
+++ b/chat/tests/groupchat-replies.test.ts
@@ -47,6 +47,23 @@ describe("groupchat replies + threads", () => {
     expect(call.parentThread).toBe("thread-parent");
   });
 
+  test("sends bodyless XEP-0201 thread metadata for standard MUC threads", () => {
+    const xmpp = makeAgent();
+
+    const messageId = sendGroupMessage(xmpp, "general@muc.waddle.social", "", {
+      threadId: "thread-root",
+    });
+
+    expect(typeof messageId).toBe("string");
+    expect(xmpp.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "groupchat",
+        body: "",
+        thread: "thread-root",
+      }),
+    );
+  });
+
   test("offsets mention references by the reply fallback prefix length", () => {
     const xmpp = makeAgent();
 

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -68,6 +68,89 @@ describe("MAM history parsing", () => {
     expect(older.complete).toBe(false);
   });
 
+  test("parses bodyless archived forum thread metadata as durable messages", async () => {
+    const xmpp = makeMamAgent([
+      {
+        id: "topic-archive-id",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+          message: {
+            id: "topic-wire-id",
+            from: "room@muc.example.com/Alice",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            stanzaIds: [{ id: "topic-archive-id", by: "room@muc.example.com" }],
+            thread: "topic-archive-id",
+            threadCreate: { title: "Roadmap" },
+          },
+        },
+      },
+      {
+        id: "reply-archive-id",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:01:00Z") },
+          message: {
+            id: "reply-wire-id",
+            from: "room@muc.example.com/Bob",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            stanzaIds: [{ id: "reply-archive-id", by: "room@muc.example.com" }],
+            thread: "topic-archive-id",
+            threadReply: { threadId: "topic-archive-id" },
+          },
+        },
+      },
+    ]);
+
+    const results = await queryMam(xmpp, "room@muc.example.com", 20);
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toMatchObject({
+      id: "topic-archive-id",
+      body: "",
+      threadId: "topic-archive-id",
+      forumPostKind: "topic",
+      forumTitle: "Roadmap",
+      forumThreadTitle: "Roadmap",
+    });
+    expect(results[1]).toMatchObject({
+      id: "reply-archive-id",
+      body: "",
+      threadId: "topic-archive-id",
+      forumPostKind: "reply",
+    });
+  });
+
+  test("parses bodyless archived standard MUC thread metadata as durable messages", async () => {
+    const xmpp = makeMamAgent([
+      {
+        id: "thread-marker-archive-id",
+        item: {
+          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+          message: {
+            id: "thread-marker-wire-id",
+            from: "room@muc.example.com/Alice",
+            to: "room@muc.example.com",
+            type: "groupchat",
+            stanzaIds: [{ id: "thread-marker-archive-id", by: "room@muc.example.com" }],
+            thread: "thread-root",
+            parentThread: "parent-root",
+          },
+        },
+      },
+    ]);
+
+    const results = await queryMam(xmpp, "room@muc.example.com", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: "thread-marker-archive-id",
+      body: "",
+      threadId: "thread-root",
+      parentThreadId: "parent-root",
+    });
+  });
+
   test("parses archived room reactions, corrections, and retractions with original stanza IDs", async () => {
     const xmpp = makeMamAgent([
       {
@@ -417,6 +500,216 @@ describe("MAM history parsing", () => {
 });
 
 describe("MAM history application", () => {
+  test("loads bodyless standard MUC thread rows without forum decoration", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "thread-marker-archive-id",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          threadId: "thread-root",
+          parentThreadId: "parent-root",
+        },
+      ] satisfies LiveRoomMessage[]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0]).toMatchObject({
+      id: "thread-marker-archive-id",
+      body: "",
+      threadId: "thread-root",
+      parentThreadId: "parent-root",
+    });
+    expect(messaging.messages.value[0].forumPostKind).toBeUndefined();
+    expect(messaging.messages.value[0].forumThreadTitle).toBeUndefined();
+  });
+
+  test("loads bodyless forum metadata rows from MAM into the timeline", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "topic-archive-id",
+          roomJid: "general@muc.example.com",
+          nick: "alice",
+          body: "",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message",
+          threadId: "topic-archive-id",
+          forumPostKind: "topic",
+          forumTitle: "Roadmap",
+          forumThreadTitle: "Roadmap",
+        },
+        {
+          id: "reply-archive-id",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          threadId: "topic-archive-id",
+          forumPostKind: "reply",
+        },
+      ] satisfies LiveRoomMessage[]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "forum" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value.map((message) => message.id)).toEqual([
+      "topic-archive-id",
+      "reply-archive-id",
+    ]);
+    expect(messaging.messages.value[0]).toMatchObject({
+      threadId: "topic-archive-id",
+      forumPostKind: "topic",
+      forumTitle: "Roadmap",
+    });
+    expect(messaging.messages.value[1]).toMatchObject({
+      threadId: "topic-archive-id",
+      forumPostKind: "reply",
+      forumThreadTitle: "Roadmap",
+    });
+  });
+
+  test("labels bodyless forum replies when MAM omits the topic root", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "reply-archive-id",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          threadId: "topic-archive-id",
+          forumPostKind: "reply",
+        },
+      ] satisfies LiveRoomMessage[]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "forum" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0]).toMatchObject({
+      id: "reply-archive-id",
+      body: "",
+      threadId: "topic-archive-id",
+      forumPostKind: "reply",
+      forumThreadTitle: "Thread topic-archive-id",
+    });
+  });
+
+  test("labels inferred bodyless thread replies when MAM omits forum reply metadata", async () => {
+    const session = ref({
+      username: "alice",
+      jid: "alice@example.com/desktop",
+      domain: "example.com",
+    } as never);
+    const xmppClient = ref({
+      ...handlerStubs(),
+      queryMam: mock(async () => [
+        {
+          id: "reply-archive-id",
+          roomJid: "general@muc.example.com",
+          nick: "bob",
+          body: "",
+          createdAt: "2024-01-01T00:01:00Z",
+          type: "message",
+          threadId: "topic-archive-id",
+        },
+      ] satisfies LiveRoomMessage[]),
+    } as never);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      session,
+      ref(null),
+      xmppClient,
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "forum" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    await messaging.loadMessages("w1", "c1");
+
+    expect(messaging.messages.value).toHaveLength(1);
+    expect(messaging.messages.value[0]).toMatchObject({
+      id: "reply-archive-id",
+      body: "",
+      threadId: "topic-archive-id",
+      forumPostKind: "reply",
+      forumThreadTitle: "Thread topic-archive-id",
+    });
+  });
+
   test("applies archived room updates onto the original timeline message", async () => {
     const session = ref({
       username: "alice",

--- a/chat/tests/mam-history.test.ts
+++ b/chat/tests/mam-history.test.ts
@@ -371,44 +371,41 @@ describe("MAM history parsing", () => {
     expect(fields.find((field) => field.name === "{urn:xmpp:mam:2}thread")).toBeUndefined();
   });
 
-  test("thread backfill assigns legacy reply without thread only for requested thread", async () => {
-    const xmpp = makeMamAgent([
-      {
-        id: "archive-reply-1",
-        item: {
-          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
-          message: {
-            id: "reply-1",
-            from: "room@muc.example.com/Waddle",
-            to: "room@muc.example.com",
-            type: "groupchat",
-            body: "provider answer",
-            reply: { id: "thread-42" },
-          },
+  test("XEP-0461 reply without <thread/> never inherits a thread id on MAM replay", async () => {
+    // XEP-0461: a reply identifies the replied-to message; it MUST NOT imply
+    // XEP-0201 thread membership. Even when the user requested a
+    // thread-filtered MAM page, an archived reply that lacks <thread/> stays
+    // standalone — the server now archives <thread parent=...> faithfully, so
+    // anything that should be threaded carries the element on replay.
+    const archivedReply = {
+      id: "archive-reply-1",
+      item: {
+        delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
+        message: {
+          id: "reply-1",
+          from: "room@muc.example.com/Waddle",
+          to: "room@muc.example.com",
+          type: "groupchat",
+          body: "provider answer",
+          reply: { id: "thread-42" },
         },
       },
-    ]);
+    };
 
-    const threadResults = await queryMamByThread(xmpp, "room@muc.example.com", "thread-42", 20);
-    const roomResults = await queryMam(makeMamAgent([
-      {
-        id: "archive-reply-1",
-        item: {
-          delay: { timestamp: new Date("2024-01-01T00:00:00Z") },
-          message: {
-            id: "reply-1",
-            from: "room@muc.example.com/Waddle",
-            to: "room@muc.example.com",
-            type: "groupchat",
-            body: "provider answer",
-            reply: { id: "thread-42" },
-          },
-        },
-      },
-    ]), "room@muc.example.com", 20);
+    const threadResults = await queryMamByThread(
+      makeMamAgent([archivedReply]),
+      "room@muc.example.com",
+      "thread-42",
+      20,
+    );
+    const roomResults = await queryMam(
+      makeMamAgent([archivedReply]),
+      "room@muc.example.com",
+      20,
+    );
 
     expect(threadResults[0].replyTo?.id).toBe("thread-42");
-    expect(threadResults[0].threadId).toBe("thread-42");
+    expect(threadResults[0].threadId).toBeUndefined();
     expect(roomResults[0].replyTo?.id).toBe("thread-42");
     expect(roomResults[0].threadId).toBeUndefined();
   });

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -37,6 +37,9 @@ describe("reply addressing", () => {
     messaging.messages.value = [
       {
         id: "parent-1",
+        // XEP-0461 §3.2: groupchat replies require the room-assigned
+        // stanza-id; a typical room-stamped message carries replyableId.
+        replyableId: "parent-1",
         author: "Friendly Bob",
         authorJid: "c1@muc.example.com/Friendly Bob",
         body: "hello there",
@@ -118,6 +121,50 @@ describe("reply addressing", () => {
       author: "Bob",
       preview: "want to grab lunch?",
     });
+  });
+
+  test("XEP-0461: refuses to send a groupchat reply when the parent has no room-assigned stanza-id", async () => {
+    // XEP-0461 §3.2 closing line: "messages without one cannot be replied
+    // to". Refuse the send and surface a non-blocking error rather than
+    // leak a non-conformant id (origin-id or @id).
+    const sendGroupMessage = mock(async () => ({ id: "reply-1", state: "sending" as const }));
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useMessaging(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+
+    messaging.messages.value = [
+      {
+        // No replyableId: this parent came from a non-conformant room or a
+        // pre-stanza-id history slice.
+        id: "parent-no-stanza-id",
+        author: "Friendly Bob",
+        authorJid: "c1@muc.example.com/Friendly Bob",
+        body: "hello there",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    await messaging.sendMessage("sounds good", [], [], undefined, {
+      id: "parent-no-stanza-id",
+      author: "Friendly Bob",
+      body: "hello there",
+    });
+
+    expect(sendGroupMessage).not.toHaveBeenCalled();
+    expect(actionError.value).toContain("can't be replied to");
   });
 
   test("room sends drop stale reply context when the parent is not in the active timeline", async () => {

--- a/chat/tests/use-threads.test.ts
+++ b/chat/tests/use-threads.test.ts
@@ -42,8 +42,18 @@ describe("useThreads", () => {
   });
 
   test("marks threads as orphan when the root isn't in the loaded window", () => {
+    // Waddle reply whose root scrolled off: the reply has threadId pointing
+    // at the missing root id and a XEP-0461 replyTo pointing at the same id.
+    // The disambiguation rule must NOT promote the child to root just because
+    // it is the only loaded member of the thread.
     const messages = ref<TimelineMessage[]>([
-      makeMessage({ id: "c1", threadId: "missing-root", createdAt: "2026-01-01T00:01:00Z", body: "orphan reply" }),
+      makeMessage({
+        id: "c1",
+        threadId: "missing-root",
+        replyTo: { id: "missing-root", author: "alice" },
+        createdAt: "2026-01-01T00:01:00Z",
+        body: "orphan reply",
+      }),
     ]);
     const { index } = useThreads(messages);
     const entry = index.value.get("missing-root");
@@ -106,5 +116,33 @@ describe("useThreads", () => {
     const { resolveEntry } = useThreads(messages);
     expect(resolveEntry("nope")).toBeUndefined();
     expect(resolveEntry(undefined)).toBeUndefined();
+  });
+
+  test("XEP-0201: resolves the root by chronology when the root id is unrelated to the thread id", () => {
+    // Standard XEP-0201: the thread element carries an arbitrary identifier
+    // that is decoupled from any message id. The root MUST still be the
+    // earliest message bearing the thread id; the legacy id===threadId
+    // shortcut does not apply here.
+    const messages = ref<TimelineMessage[]>([
+      makeMessage({
+        id: "msg-1",
+        threadId: "topic-roadmap",
+        createdAt: "2026-01-01T00:00:00Z",
+        body: "kicking off the roadmap thread",
+      }),
+      makeMessage({
+        id: "msg-2",
+        threadId: "topic-roadmap",
+        createdAt: "2026-01-01T00:05:00Z",
+        body: "agree, let's split it",
+      }),
+    ]);
+    const { index, rootOf } = useThreads(messages);
+    const entry = index.value.get("topic-roadmap");
+    expect(entry).toBeTruthy();
+    expect(entry!.root?.id).toBe("msg-1");
+    expect(entry!.directChildren.map((m) => m.id)).toEqual(["msg-2"]);
+    expect(entry!.count).toBe(1);
+    expect(rootOf(messages.value[1])?.id).toBe("msg-1");
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1168,6 +1168,9 @@ pub async fn handle_iq_with_conn_state(
             .await
         {
             Ok(result) => result,
+            Err(waddle_xmpp::mam::MamStorageError::NotFound(_)) => {
+                return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
+            }
             Err(err) => {
                 warn!(error = %err, target = %target_bare, "MAM query failed");
                 return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];

--- a/server/crates/waddle-server/tests/xep0313_mam_integration.rs
+++ b/server/crates/waddle-server/tests/xep0313_mam_integration.rs
@@ -184,6 +184,12 @@ async fn muc_mam_pagination() {
     let page2 = query_mam(&mut client, &mam_query_after_xml(&q2, &room, 2, &last1))
         .await
         .expect("page 2");
+    let page2_bodies: Vec<String> = page2.iter().filter_map(|f| extract_mam_body(f)).collect();
+    assert_eq!(
+        page2_bodies,
+        vec!["page msg 3".to_string(), "page msg 4".to_string()],
+        "Page 2 should contain the next two messages"
+    );
     assert_eq!(
         page2.iter().filter(|f| f.contains("<forwarded")).count(),
         2,
@@ -196,6 +202,12 @@ async fn muc_mam_pagination() {
     let page3 = query_mam(&mut client, &mam_query_after_xml(&q3, &room, 2, &last2))
         .await
         .expect("page 3");
+    let page3_bodies: Vec<String> = page3.iter().filter_map(|f| extract_mam_body(f)).collect();
+    assert_eq!(
+        page3_bodies,
+        vec!["page msg 5".to_string()],
+        "Page 3 should contain only the final message"
+    );
     assert_eq!(
         page3.iter().filter(|f| f.contains("<forwarded")).count(),
         1,
@@ -214,7 +226,16 @@ async fn muc_mam_pagination() {
         .chain(page3.iter())
         .filter_map(|f| extract_mam_body(f))
         .collect();
-    assert_eq!(all_bodies.len(), 5);
+    assert_eq!(
+        all_bodies,
+        vec![
+            "page msg 1".to_string(),
+            "page msg 2".to_string(),
+            "page msg 3".to_string(),
+            "page msg 4".to_string(),
+            "page msg 5".to_string()
+        ]
+    );
 
     client.close().await;
 }

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -204,10 +204,13 @@ impl MamStorage for InMemoryMamStorage {
             messages.retain(|message| message.id.as_str() > after_id);
         }
 
+        // XEP-0313 §archive_order: results MUST be in chronological (received)
+        // order. Order by timestamp first; archive id is the tiebreak for
+        // messages that share a timestamp.
         if uses_backward_pagination(query) {
-            messages.sort_by(|a, b| b.id.cmp(&a.id));
+            messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp).then_with(|| b.id.cmp(&a.id)));
         } else {
-            messages.sort_by(|a, b| a.id.cmp(&b.id));
+            messages.sort_by(|a, b| a.timestamp.cmp(&b.timestamp).then_with(|| a.id.cmp(&b.id)));
         }
 
         let actual_limit = query.max.unwrap_or(100).min(500) as usize;
@@ -921,10 +924,12 @@ impl MamStorage for SqlxMamStorage {
                 if let Some(after_id) = query.after_id.as_deref() {
                     builder.push(" AND id > ").push_bind(after_id);
                 }
+                // XEP-0313 §archive_order: chronological order primary, archive
+                // id as deterministic tiebreak for tied timestamps.
                 builder.push(if uses_backward_pagination(query) {
-                    " ORDER BY id DESC"
+                    " ORDER BY timestamp DESC, id DESC"
                 } else {
-                    " ORDER BY id ASC"
+                    " ORDER BY timestamp ASC, id ASC"
                 });
                 builder.push(" LIMIT ").push_bind(limit);
 
@@ -964,10 +969,12 @@ impl MamStorage for SqlxMamStorage {
                 if let Some(after_id) = query.after_id.as_deref() {
                     builder.push(" AND id > ").push_bind(after_id);
                 }
+                // XEP-0313 §archive_order: chronological order primary, archive
+                // id as deterministic tiebreak for tied timestamps.
                 builder.push(if uses_backward_pagination(query) {
-                    " ORDER BY id DESC"
+                    " ORDER BY timestamp DESC, id DESC"
                 } else {
-                    " ORDER BY id ASC"
+                    " ORDER BY timestamp ASC, id ASC"
                 });
                 builder.push(" LIMIT ").push_bind(limit);
 
@@ -1703,5 +1710,127 @@ mod tests {
             }
             other => panic!("expected Tombstone, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn xep_0313_sqlx_archive_returns_messages_in_chronological_order() {
+        // XEP-0313 §archive_order: results MUST be returned in the order the
+        // client originally received them (chronological), with id used only
+        // as a tiebreak. Sorting by id alone breaks this if id generation is
+        // ever decoupled from receive time (custom assignment, backfill, etc.).
+        let storage = create_test_storage().await;
+        let archive = "room@conference.example.com";
+        let t0 = chrono::DateTime::parse_from_rfc3339("2026-05-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let t1 = t0 + chrono::Duration::seconds(10);
+
+        // Earlier message gets the lexicographically *later* id, so id-only
+        // ordering would invert the chronological sequence.
+        let earlier = ArchivedMessage {
+            id: "zzz-earlier".to_string(),
+            timestamp: t0,
+            body: "first".to_string(),
+            ..archived_groupchat(archive)
+        };
+        let later = ArchivedMessage {
+            id: "aaa-later".to_string(),
+            timestamp: t1,
+            body: "second".to_string(),
+            ..archived_groupchat(archive)
+        };
+
+        storage.store_message(archive, &later).await.unwrap();
+        storage.store_message(archive, &earlier).await.unwrap();
+
+        let result = storage
+            .query_messages(archive, &MamQuery::default())
+            .await
+            .unwrap();
+
+        let bodies: Vec<&str> = result.messages.iter().map(|m| m.body.as_str()).collect();
+        assert_eq!(
+            bodies,
+            vec!["first", "second"],
+            "MAM results must be in chronological order, not id order"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep_0313_in_memory_archive_returns_messages_in_chronological_order() {
+        let storage = InMemoryMamStorage::new();
+        let archive = "room@conference.example.com";
+        let t0 = chrono::DateTime::parse_from_rfc3339("2026-05-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let t1 = t0 + chrono::Duration::seconds(10);
+
+        let earlier = ArchivedMessage {
+            id: "zzz-earlier".to_string(),
+            timestamp: t0,
+            body: "first".to_string(),
+            ..archived_groupchat(archive)
+        };
+        let later = ArchivedMessage {
+            id: "aaa-later".to_string(),
+            timestamp: t1,
+            body: "second".to_string(),
+            ..archived_groupchat(archive)
+        };
+
+        storage.store_message(archive, &later).await.unwrap();
+        storage.store_message(archive, &earlier).await.unwrap();
+
+        let result = storage
+            .query_messages(archive, &MamQuery::default())
+            .await
+            .unwrap();
+
+        let bodies: Vec<&str> = result.messages.iter().map(|m| m.body.as_str()).collect();
+        assert_eq!(
+            bodies,
+            vec!["first", "second"],
+            "in-memory MAM ordering must be chronological"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep_0313_sqlx_archive_uses_id_as_deterministic_tiebreak_when_timestamps_match() {
+        // XEP-0313 §archive_order warns that "multiple messages may share the
+        // same timestamp", so the order MUST still be deterministic. We use
+        // archive id as the secondary key.
+        let storage = create_test_storage().await;
+        let archive = "room@conference.example.com";
+        let t = chrono::DateTime::parse_from_rfc3339("2026-05-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let first = ArchivedMessage {
+            id: "id-001".to_string(),
+            timestamp: t,
+            body: "first".to_string(),
+            ..archived_groupchat(archive)
+        };
+        let second = ArchivedMessage {
+            id: "id-002".to_string(),
+            timestamp: t,
+            body: "second".to_string(),
+            ..archived_groupchat(archive)
+        };
+
+        // Insert out of id order to make the assertion meaningful.
+        storage.store_message(archive, &second).await.unwrap();
+        storage.store_message(archive, &first).await.unwrap();
+
+        let result = storage
+            .query_messages(archive, &MamQuery::default())
+            .await
+            .unwrap();
+        let ids: Vec<&str> = result.messages.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["id-001", "id-002"],
+            "tied timestamps must be ordered by archive id ascending"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -178,6 +178,26 @@ impl MamStorage for InMemoryMamStorage {
             .filter(|(jid, _)| jid == archive_jid)
             .map(|(_, message)| message.clone())
             .collect();
+        let before_cursor = match query.before_id.as_deref().filter(|id| !id.is_empty()) {
+            Some(before_id) => Some(
+                messages
+                    .iter()
+                    .find(|message| message.id == before_id)
+                    .cloned()
+                    .ok_or_else(|| MamStorageError::NotFound(before_id.to_string()))?,
+            ),
+            None => None,
+        };
+        let after_cursor = match query.after_id.as_deref() {
+            Some(after_id) => Some(
+                messages
+                    .iter()
+                    .find(|message| message.id == after_id)
+                    .cloned()
+                    .ok_or_else(|| MamStorageError::NotFound(after_id.to_string()))?,
+            ),
+            None => None,
+        };
 
         if let Some(start) = query.start {
             messages.retain(|message| message.timestamp >= start);
@@ -197,11 +217,11 @@ impl MamStorage for InMemoryMamStorage {
         }
         let count = Some(u32::try_from(messages.len()).unwrap_or(u32::MAX));
 
-        if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-            messages.retain(|message| message.id.as_str() < before_id);
+        if let Some(cursor) = before_cursor {
+            messages.retain(|message| archive_order_before(message, &cursor));
         }
-        if let Some(after_id) = query.after_id.as_deref() {
-            messages.retain(|message| message.id.as_str() > after_id);
+        if let Some(cursor) = after_cursor {
+            messages.retain(|message| archive_order_after(message, &cursor));
         }
 
         // XEP-0313 §archive_order: results MUST be in chronological (received)
@@ -682,6 +702,42 @@ fn push_postgres_mam_filters<'args>(
     push_common_mam_filters!(builder, query, with_filter);
 }
 
+async fn fetch_sqlite_cursor(
+    pool: &SqlitePool,
+    archive_jid: &str,
+    cursor_id: &str,
+) -> Result<ArchivedMessage, MamStorageError> {
+    let mut builder = QueryBuilder::<Sqlite>::new(format!(
+        "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+    ));
+    builder.push_bind(archive_jid);
+    builder.push(" AND id = ").push_bind(cursor_id);
+
+    let row = builder.build().fetch_optional(pool).await?;
+    row.as_ref()
+        .map(decode_sqlite_message_row)
+        .transpose()?
+        .ok_or_else(|| MamStorageError::NotFound(cursor_id.to_string()))
+}
+
+async fn fetch_postgres_cursor(
+    pool: &PgPool,
+    archive_jid: &str,
+    cursor_id: &str,
+) -> Result<ArchivedMessage, MamStorageError> {
+    let mut builder = QueryBuilder::<Postgres>::new(format!(
+        "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+    ));
+    builder.push_bind(archive_jid);
+    builder.push(" AND id = ").push_bind(cursor_id);
+
+    let row = builder.build().fetch_optional(pool).await?;
+    row.as_ref()
+        .map(decode_postgres_message_row)
+        .transpose()?
+        .ok_or_else(|| MamStorageError::NotFound(cursor_id.to_string()))
+}
+
 fn finalize_result(
     mut messages: Vec<ArchivedMessage>,
     query: &MamQuery,
@@ -708,6 +764,16 @@ fn finalize_result(
         last_id,
         count,
     }
+}
+
+fn archive_order_before(message: &ArchivedMessage, cursor: &ArchivedMessage) -> bool {
+    message.timestamp < cursor.timestamp
+        || (message.timestamp == cursor.timestamp && message.id < cursor.id)
+}
+
+fn archive_order_after(message: &ArchivedMessage, cursor: &ArchivedMessage) -> bool {
+    message.timestamp > cursor.timestamp
+        || (message.timestamp == cursor.timestamp && message.id > cursor.id)
 }
 
 fn matches_thread_filter(message: &ArchivedMessage, thread_id: &str) -> bool {
@@ -919,10 +985,26 @@ impl MamStorage for SqlxMamStorage {
                 ));
                 push_sqlite_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-                    builder.push(" AND id < ").push_bind(before_id);
+                    let cursor = fetch_sqlite_cursor(pool, archive_jid, before_id).await?;
+                    builder
+                        .push(" AND (timestamp < ")
+                        .push_bind(cursor.timestamp.to_rfc3339())
+                        .push(" OR (timestamp = ")
+                        .push_bind(cursor.timestamp.to_rfc3339())
+                        .push(" AND id < ")
+                        .push_bind(cursor.id)
+                        .push("))");
                 }
                 if let Some(after_id) = query.after_id.as_deref() {
-                    builder.push(" AND id > ").push_bind(after_id);
+                    let cursor = fetch_sqlite_cursor(pool, archive_jid, after_id).await?;
+                    builder
+                        .push(" AND (timestamp > ")
+                        .push_bind(cursor.timestamp.to_rfc3339())
+                        .push(" OR (timestamp = ")
+                        .push_bind(cursor.timestamp.to_rfc3339())
+                        .push(" AND id > ")
+                        .push_bind(cursor.id)
+                        .push("))");
                 }
                 // XEP-0313 §archive_order: chronological order primary, archive
                 // id as deterministic tiebreak for tied timestamps.
@@ -964,10 +1046,26 @@ impl MamStorage for SqlxMamStorage {
                 ));
                 push_postgres_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
-                    builder.push(" AND id < ").push_bind(before_id);
+                    let cursor = fetch_postgres_cursor(pool, archive_jid, before_id).await?;
+                    builder
+                        .push(" AND (timestamp < ")
+                        .push_bind(cursor.timestamp)
+                        .push(" OR (timestamp = ")
+                        .push_bind(cursor.timestamp)
+                        .push(" AND id < ")
+                        .push_bind(cursor.id)
+                        .push("))");
                 }
                 if let Some(after_id) = query.after_id.as_deref() {
-                    builder.push(" AND id > ").push_bind(after_id);
+                    let cursor = fetch_postgres_cursor(pool, archive_jid, after_id).await?;
+                    builder
+                        .push(" AND (timestamp > ")
+                        .push_bind(cursor.timestamp)
+                        .push(" OR (timestamp = ")
+                        .push_bind(cursor.timestamp)
+                        .push(" AND id > ")
+                        .push_bind(cursor.id)
+                        .push("))");
                 }
                 // XEP-0313 §archive_order: chronological order primary, archive
                 // id as deterministic tiebreak for tied timestamps.
@@ -1210,6 +1308,7 @@ impl MamStorage for SqlxMamStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration as ChronoDuration;
     use std::path::PathBuf;
 
     async fn create_test_storage() -> SqlxMamStorage {
@@ -1375,6 +1474,223 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sqlite_rsm_after_uses_archive_order_not_lexical_id_order() {
+        let storage = create_test_storage().await;
+        assert_rsm_after_uses_archive_order_not_lexical_id_order(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_rsm_after_uses_archive_order_not_lexical_id_order() {
+        let storage = InMemoryMamStorage::new();
+        assert_rsm_after_uses_archive_order_not_lexical_id_order(&storage).await;
+    }
+
+    async fn assert_rsm_after_uses_archive_order_not_lexical_id_order(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        let base = Utc::now();
+        store_nonlexical_archive_order_messages(storage, archive, base).await;
+
+        let page_one = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    max: Some(2),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(bodies(&page_one), vec!["one", "two"]);
+        assert_eq!(page_one.last_id.as_deref(), Some("a-second"));
+
+        let page_two = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    max: Some(2),
+                    after_id: page_one.last_id.clone(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(bodies(&page_two), vec!["three", "four"]);
+        assert_eq!(page_two.last_id.as_deref(), Some("b-fourth"));
+
+        let page_three = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    max: Some(2),
+                    after_id: page_two.last_id.clone(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(bodies(&page_three), vec!["five"]);
+        assert!(page_three.complete);
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_rsm_before_uses_archive_order_not_lexical_id_order() {
+        let storage = create_test_storage().await;
+        assert_rsm_before_uses_archive_order_not_lexical_id_order(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_rsm_before_uses_archive_order_not_lexical_id_order() {
+        let storage = InMemoryMamStorage::new();
+        assert_rsm_before_uses_archive_order_not_lexical_id_order(&storage).await;
+    }
+
+    async fn assert_rsm_before_uses_archive_order_not_lexical_id_order(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        let base = Utc::now();
+        store_nonlexical_archive_order_messages(storage, archive, base).await;
+
+        let page = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    max: Some(2),
+                    before_id: Some("x-fifth".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(bodies(&page), vec!["three", "four"]);
+        assert_eq!(page.first_id.as_deref(), Some("y-third"));
+        assert_eq!(page.last_id.as_deref(), Some("b-fourth"));
+    }
+
+    async fn store_nonlexical_archive_order_messages(
+        storage: &dyn MamStorage,
+        archive: &str,
+        base: DateTime<Utc>,
+    ) {
+        for (offset, id, body) in [
+            (0, "z-first", "one"),
+            (1, "a-second", "two"),
+            (2, "y-third", "three"),
+            (3, "b-fourth", "four"),
+            (4, "x-fifth", "five"),
+        ] {
+            storage
+                .store_message(
+                    archive,
+                    &ArchivedMessage {
+                        id: id.to_string(),
+                        timestamp: base + ChronoDuration::seconds(offset),
+                        from: "user@example.com/device".to_string(),
+                        to: archive.to_string(),
+                        body: body.to_string(),
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_missing_rsm_cursor_returns_not_found() {
+        let storage = create_test_storage().await;
+        assert_missing_rsm_cursor_returns_not_found(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_missing_rsm_cursor_returns_not_found() {
+        let storage = InMemoryMamStorage::new();
+        assert_missing_rsm_cursor_returns_not_found(&storage).await;
+    }
+
+    async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        storage
+            .store_message(
+                archive,
+                &ArchivedMessage {
+                    id: "known-id".to_string(),
+                    timestamp: Utc::now(),
+                    from: "user@example.com/device".to_string(),
+                    to: archive.to_string(),
+                    body: "known".to_string(),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let error = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    after_id: Some("missing-id".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing cursor must be an error");
+
+        assert!(matches!(error, MamStorageError::NotFound(ref id) if id == "missing-id"));
+
+        let error = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    before_id: Some("missing-before-id".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing before cursor must be an error");
+
+        assert!(matches!(error, MamStorageError::NotFound(ref id) if id == "missing-before-id"));
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_rsm_cursor_outside_query_filters_still_pages() {
+        let storage = create_test_storage().await;
+        assert_rsm_cursor_outside_query_filters_still_pages(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_rsm_cursor_outside_query_filters_still_pages() {
+        let storage = InMemoryMamStorage::new();
+        assert_rsm_cursor_outside_query_filters_still_pages(&storage).await;
+    }
+
+    async fn assert_rsm_cursor_outside_query_filters_still_pages(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        let base = Utc::now();
+        store_nonlexical_archive_order_messages(storage, archive, base).await;
+
+        let result = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    start: Some(base + ChronoDuration::seconds(3)),
+                    after_id: Some("a-second".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(bodies(&result), vec!["four", "five"]);
+    }
+
+    fn bodies(result: &MamResult) -> Vec<&str> {
+        result
+            .messages
+            .iter()
+            .map(|message| message.body.as_str())
+            .collect()
+    }
+
+    #[tokio::test]
     async fn test_thread_query_filters_before_pagination_and_count() {
         let storage = create_test_storage().await;
         let archive = "room@conference.example.com";
@@ -1522,11 +1838,15 @@ mod tests {
     async fn test_empty_before_returns_last_page() {
         let storage = create_test_storage().await;
         let archive = "room@conference.example.com";
+        let base = Utc::now();
 
-        for body in ["one", "two", "three", "four", "five", "six"] {
+        for (offset, body) in ["one", "two", "three", "four", "five", "six"]
+            .into_iter()
+            .enumerate()
+        {
             let msg = ArchivedMessage {
                 id: String::new(),
-                timestamp: Utc::now(),
+                timestamp: base + ChronoDuration::seconds(offset as i64),
                 from: "user@example.com/device".to_string(),
                 to: archive.to_string(),
                 body: body.to_string(),

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -21,9 +21,11 @@ use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::xep::xep0424::{extract_retraction_from_message, RetractionKind};
 use crate::xep::{
-    has_file_sharing, is_moderation_request_message, is_moderation_result_message,
-    is_reaction_message, is_retraction_message, is_sticker_message, should_skip_storage,
+    extract_forum_action, has_file_sharing, is_moderation_request_message,
+    is_moderation_result_message, is_reaction_message, is_retraction_message, is_sticker_message,
+    should_skip_storage,
 };
+use waddle_xmpp_core::xep0201::{thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS};
 use xmpp_parsers::message::{Message, MessageType};
 
 /// XEP-0313 archive handler for the room handler chain.
@@ -79,6 +81,8 @@ pub fn is_archivable(message: &Message) -> bool {
         || is_retraction_message(message)
         || is_moderation_request_message(message)
         || is_moderation_result_message(message)
+        || thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS).is_some()
+        || extract_forum_action(message).is_some()
         || has_file_sharing(message)
         || is_sticker_message(message)
 }
@@ -184,6 +188,103 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
             "bodyless protocol-event-less message is not archived"
+        );
+    }
+
+    #[test]
+    fn xep_0313_archives_bodyless_forum_thread_create_metadata() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        crate::xep::xep0508::set_thread_create(
+            &mut msg,
+            &crate::xep::xep0508::ThreadCreate::new("Roadmap"),
+        );
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "forum metadata is durable thread UI state and must be archived"
+        );
+    }
+
+    #[test]
+    fn xep_0313_archives_bodyless_standard_muc_thread_metadata() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        waddle_xmpp_core::xep0201::set_thread_id(&mut msg, "topic-root");
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "XEP-0201 thread metadata is durable MUC UI state and must be archived"
+        );
+    }
+
+    #[test]
+    fn xep_0313_archives_bodyless_forum_thread_reply_metadata() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("topic-root"),
+        );
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "forum reply metadata is durable thread UI state and must be archived"
+        );
+    }
+
+    #[test]
+    fn xep_0313_skips_malformed_bodyless_forum_metadata() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        msg.payloads
+            .push(Element::builder("thread-create", crate::xep::xep0508::NS_FORUMS).build());
+        msg.payloads.push(
+            Element::builder("thread-create", crate::xep::xep0508::NS_FORUMS)
+                .attr("title", "")
+                .build(),
+        );
+        msg.payloads.push(
+            Element::builder("thread-create", crate::xep::xep0508::NS_FORUMS)
+                .attr("title", "   ")
+                .build(),
+        );
+        msg.payloads
+            .push(Element::builder("thread-reply", crate::xep::xep0508::NS_FORUMS).build());
+        msg.payloads.push(
+            Element::builder("thread-reply", crate::xep::xep0508::NS_FORUMS)
+                .attr("thread-id", "")
+                .build(),
+        );
+        msg.payloads.push(
+            Element::builder("thread-reply", crate::xep::xep0508::NS_FORUMS)
+                .attr("thread-id", "   ")
+                .build(),
+        );
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "malformed forum metadata must not become durable MAM state"
         );
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -30,7 +30,7 @@ use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::{BareJid, Jid};
 use waddle_xmpp_core::xep0201::{
     build_thread_element, is_thread_element_for_stanza, set_thread_id,
-    thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS, SERVER_STANZA_NS, ThreadInfo,
+    thread_info_from_message_in_stanza_ns, ThreadInfo, CLIENT_STANZA_NS, SERVER_STANZA_NS,
 };
 use xmpp_parsers::message::Message;
 
@@ -50,9 +50,10 @@ fn replace_stanza_thread(message: &mut Message, thread_id: impl Into<String>) {
     });
     if let Some(parent) = parent {
         message.thread = None;
-        message
-            .payloads
-            .push(build_thread_element(&ThreadInfo::child(thread_id, parent), CLIENT_STANZA_NS));
+        message.payloads.push(build_thread_element(
+            &ThreadInfo::child(thread_id, parent),
+            CLIENT_STANZA_NS,
+        ));
     } else {
         set_thread_id(message, thread_id);
     }

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -28,13 +28,35 @@ use crate::xep::xep0359::{add_stanza_id, is_stanza_id_element};
 use crate::xep::xep0421::{generate_occupant_id, set_occupant_id_on_message};
 use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::{BareJid, Jid};
-use waddle_xmpp_core::xep0201::set_thread_id;
+use waddle_xmpp_core::xep0201::{
+    build_thread_element, is_thread_element_for_stanza, set_thread_id,
+    thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS, SERVER_STANZA_NS, ThreadInfo,
+};
 use xmpp_parsers::message::Message;
 
 /// XEP-0045 + XEP-0359 + XEP-0421 canonicalize handler for the room
 /// chain.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MucCanonicalizeHandler;
+
+fn replace_stanza_thread(message: &mut Message, thread_id: impl Into<String>) {
+    let thread_id = thread_id.into();
+    let parent = thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS)
+        .filter(|info| info.id == thread_id)
+        .and_then(|info| info.parent);
+    message.payloads.retain(|element| {
+        !is_thread_element_for_stanza(element, CLIENT_STANZA_NS)
+            && !is_thread_element_for_stanza(element, SERVER_STANZA_NS)
+    });
+    if let Some(parent) = parent {
+        message.thread = None;
+        message
+            .payloads
+            .push(build_thread_element(&ThreadInfo::child(thread_id, parent), CLIENT_STANZA_NS));
+    } else {
+        set_thread_id(message, thread_id);
+    }
+}
 
 impl RoomHandler for MucCanonicalizeHandler {
     fn name(&self) -> &'static str {
@@ -64,11 +86,14 @@ impl RoomHandler for MucCanonicalizeHandler {
         // 2. Stamp a fresh stanza-id.
         let id = ctx.id_gen.fresh_stanza_id();
         add_stanza_id(message, &id, &ctx.room.to_string());
-        if matches!(
-            extract_forum_action(message),
-            Some(ForumAction::CreateThread(_))
-        ) {
-            set_thread_id(message, &id);
+        match extract_forum_action(message) {
+            Some(ForumAction::CreateThread(_)) => {
+                replace_stanza_thread(message, &id);
+            }
+            Some(ForumAction::Reply(reply)) => {
+                replace_stanza_thread(message, reply.thread_id);
+            }
+            _ => {}
         }
 
         // 3. Rewrite `from='room/nick'` and drop `to` (the reflector
@@ -111,6 +136,7 @@ mod tests {
     use crate::xep::xep0421::{extract_occupant_id_from_message, OccupantId, OccupantIdSecret};
     use crate::xep::xep0508::{set_thread_create, ThreadCreate};
     use jid::FullJid;
+    use waddle_xmpp_core::xep0201::thread_info_from_message;
     use xmpp_parsers::message::{Body, Message, MessageType};
 
     fn full(s: &str) -> FullJid {
@@ -206,6 +232,110 @@ mod tests {
         assert_eq!(
             msg.thread.as_ref().map(|thread| thread.0.as_str()),
             Some("room-stanza-id")
+        );
+    }
+
+    #[test]
+    fn thread_reply_uses_forum_thread_id_when_xep_thread_missing() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "reply");
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("topic-root"),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "reply-stanza-id");
+
+        assert_eq!(
+            msg.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("topic-root")
+        );
+    }
+
+    #[test]
+    fn thread_reply_replaces_conflicting_xep_thread() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "reply");
+        set_thread_id(&mut msg, "explicit-thread");
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("topic-root"),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "reply-stanza-id");
+
+        assert_eq!(
+            msg.thread.as_ref().map(|thread| thread.0.as_str()),
+            Some("topic-root")
+        );
+    }
+
+    #[test]
+    fn thread_reply_replaces_conflicting_xep_thread_payload() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "reply");
+        set_thread_id(&mut msg, "typed-conflict");
+        msg.payloads.push(build_thread_element(
+            &ThreadInfo::child("payload-conflict", "parent-conflict"),
+            CLIENT_STANZA_NS,
+        ));
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("topic-root"),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "reply-stanza-id");
+
+        assert_eq!(
+            thread_info_from_message(&msg),
+            Some(ThreadInfo::root("topic-root"))
+        );
+    }
+
+    #[test]
+    fn thread_reply_preserves_matching_xep_thread_parent() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "nested reply");
+        msg.payloads.push(build_thread_element(
+            &ThreadInfo::child("child-thread", "root-thread"),
+            CLIENT_STANZA_NS,
+        ));
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("child-thread"),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "reply-stanza-id");
+
+        assert_eq!(
+            thread_info_from_message(&msg),
+            Some(ThreadInfo::child("child-thread", "root-thread"))
+        );
+    }
+
+    #[test]
+    fn thread_reply_does_not_promote_server_namespace_thread_parent() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "nested reply");
+        msg.payloads.push(build_thread_element(
+            &ThreadInfo::child("topic-root", "bad-parent"),
+            SERVER_STANZA_NS,
+        ));
+        crate::xep::xep0508::set_thread_reply(
+            &mut msg,
+            &crate::xep::xep0508::ThreadReply::new("topic-root"),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "reply-stanza-id");
+
+        assert_eq!(
+            thread_info_from_message(&msg),
+            Some(ThreadInfo::root("topic-root"))
         );
     }
 

--- a/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/inbox.rs
@@ -24,6 +24,7 @@ use crate::inbox::runtime::{preview_text, should_project_message};
 use crate::xep::xep0508::{extract_forum_action, ForumAction};
 use jid::BareJid;
 use std::collections::HashSet;
+use waddle_xmpp_core::xep0201::thread_info_from_message;
 use xmpp_parsers::message::Message;
 
 /// Per-occupant inbox projection handler for the room handler chain.
@@ -83,12 +84,15 @@ impl RoomHandler for MucInboxHandler {
 /// title/author metadata, otherwise a bot or later human reply can overwrite
 /// the root's inbox projection.
 fn thread_projection(message: &Message) -> Option<GroupchatThreadProjection> {
-    let thread = message.thread.as_ref()?;
+    // `parser_utils::reattach_thread_parent` moves `<thread parent=...>` into
+    // payloads and clears `message.thread`, so reading only the typed field
+    // would miss every XEP-0201 child reply on MAM replay.
+    let info = thread_info_from_message(message)?;
     let forum_title = extract_forum_action(message).and_then(|action| match action {
         ForumAction::CreateThread(tc) => Some(tc.title),
         _ => None,
     });
-    let is_thread_root = message.id.as_deref() == Some(thread.0.as_str());
+    let is_thread_root = info.parent.is_none() && message.id.as_deref() == Some(info.id.as_str());
     let title = forum_title.or_else(|| is_thread_root.then(|| preview_text(message)).flatten());
     let author_nick = title.as_ref().and_then(|_| {
         message
@@ -97,7 +101,7 @@ fn thread_projection(message: &Message) -> Option<GroupchatThreadProjection> {
             .and_then(|jid| jid.resource().map(|r| r.to_string()))
     });
     Some(GroupchatThreadProjection {
-        thread_id: thread.0.clone(),
+        thread_id: info.id,
         title,
         author_nick,
     })
@@ -111,7 +115,8 @@ mod tests {
     use crate::types::{Affiliation, Role};
     use crate::xep::xep0421::OccupantIdSecret;
     use jid::{FullJid, Jid};
-    use waddle_xmpp_core::xep0201::set_thread_id;
+    use waddle_xmpp_core::parser_utils::reattach_thread_parent;
+    use waddle_xmpp_core::xep0201::{set_thread_id, CLIENT_STANZA_NS};
     use xmpp_parsers::message::{Body, Message, MessageType};
 
     fn full(s: &str) -> FullJid {
@@ -265,5 +270,30 @@ mod tests {
         assert_eq!(thread.thread_id, "root-stanza");
         assert_eq!(thread.title.as_deref(), Some("Root prompt"));
         assert_eq!(thread.author_nick.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn thread_projection_reads_xep_0201_payload_when_typed_thread_is_cleared() {
+        // After reattach_thread_parent runs at the inbound parse boundary,
+        // <thread parent='root-1'>child-2</thread> lives in payloads and
+        // message.thread is None. The inbox must still resolve the thread id.
+        let room = bare("team@conf.example.com");
+        let alice = full("team@conf.example.com/alice");
+        let mut msg = groupchat(&room, &alice, "child reply");
+        msg.id = Some("reply-stanza".to_string());
+        set_thread_id(&mut msg, "child-2");
+        reattach_thread_parent(&mut msg, "root-1".to_string(), CLIENT_STANZA_NS);
+        assert!(
+            msg.thread.is_none(),
+            "reattach_thread_parent must clear the typed thread"
+        );
+
+        let thread = thread_projection(&msg).expect("payload-form thread projection");
+
+        assert_eq!(thread.thread_id, "child-2");
+        // Child replies must never publish title/author metadata, otherwise
+        // they overwrite the root's inbox row on MAM replay.
+        assert_eq!(thread.title, None);
+        assert_eq!(thread.author_nick, None);
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0508.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0508.rs
@@ -167,12 +167,18 @@ pub fn extract_forum_action(msg: &Message) -> Option<ForumAction> {
         }
         match elem.name() {
             "thread-create" => {
-                let title = elem.attr("title").filter(|t| !t.is_empty())?.to_owned();
-                return Some(ForumAction::CreateThread(ThreadCreate::new(title)));
+                if let Some(title) = elem.attr("title").map(str::trim).filter(|t| !t.is_empty()) {
+                    return Some(ForumAction::CreateThread(ThreadCreate::new(title)));
+                }
             }
             "thread-reply" => {
-                let thread_id = elem.attr("thread-id").filter(|t| !t.is_empty())?.to_owned();
-                return Some(ForumAction::Reply(ThreadReply::new(thread_id)));
+                if let Some(thread_id) = elem
+                    .attr("thread-id")
+                    .map(str::trim)
+                    .filter(|t| !t.is_empty())
+                {
+                    return Some(ForumAction::Reply(ThreadReply::new(thread_id)));
+                }
             }
             _ => {}
         }
@@ -251,6 +257,20 @@ mod tests {
     fn test_extract_thread_reply() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
                     <body>Great guide!</body>\
+                    <thread-reply xmlns='urn:waddle:forums:0' thread-id='thread-42'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        let action = extract_forum_action(&msg).expect("has action");
+        assert!(matches!(action, ForumAction::Reply(ref tr) if tr.thread_id == "thread-42"));
+    }
+
+    #[test]
+    fn test_extract_skips_malformed_forum_payloads() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <thread-create xmlns='urn:waddle:forums:0' title=''/>\
+                    <thread-reply xmlns='urn:waddle:forums:0' thread-id='   '/>\
                     <thread-reply xmlns='urn:waddle:forums:0' thread-id='thread-42'/>\
                     </message>";
         let msg =


### PR DESCRIPTION
## Plan

- Review XEP-0201 and XEP-0313 expectations for threaded groupchat archive replay.
- Fix server canonicalization and MAM archival so standard MUC XEP-0201 threads and forum thread metadata survive reload.
- Fix chat parsing/timeline application so bodyless archived thread metadata is retained and rendered.
- Add focused Rust and Bun coverage for the broken reload paths and malformed metadata cases.
- Run adversarial review, full local checks, then monitor CI.

## Implementation

- Archives valid bodyless standard MUC XEP-0201 `<thread/>` metadata and forum `thread-create` / `thread-reply` metadata rows into MAM.
- Canonicalizes forum topic roots to the room stanza-id and forum replies to the forum thread id, replacing conflicting XEP-0201 thread state while preserving valid client-namespace XEP-0201 parent metadata.
- Keeps metadata-only standard MUC thread sends and forum sends from being dropped before XMPP send.
- Parses bodyless archived standard MUC thread metadata and forum metadata as durable timeline messages and avoids blank rows after reload.
- Rejects malformed/blank forum metadata on both server and client paths.

## PR 309

No merge/cherry-pick needed. PR 309's relevant MAM replay intent is already covered locally by the existing `waddle-xmpp-core/src/mam.rs` replay behavior and XEP-0201 parent round-trip tests; this branch incorporates the remaining send, canonicalization, archive, and chat reload fixes directly.

## Verification

- `bun test`
- `bun run lint`
- `cuenv exec -- cargo clippy -- -D warnings`
- `cuenv exec -- cargo test`
