### PR TITLE
fix(chat): left-align message lane to channel sidebar

### DIFF
--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -41,95 +41,93 @@ function presenceText(show?: string): string {
 </script>
 
 <template>
-  <div class="chat-pane-header border-b border-border px-[var(--chat-content-inline)] py-0 flex flex-shrink-0 items-center glass-surface">
-    <div class="chat-message-lane chat-pane-header-row">
-      <div class="flex min-w-0 flex-1 items-center gap-2">
-        <button
-          class="chat-icon-button chat-icon-button--md text-muted-foreground hover:bg-muted hover:text-foreground lg:hidden"
-          type="button"
-          aria-label="Open navigation"
-          @click="emit('openNav')"
-        >
-          <Menu class="w-4 h-4" />
-        </button>
-        <div class="chat-pane-title-group">
-          <span class="chat-pane-title-icon rounded-lg bg-primary/8">
-            <component :is="dmPeer ? MessageCircle : isForumChannel ? MessagesSquare : Hash" class="w-4 h-4 text-primary/70" />
-          </span>
-          <div class="min-w-0">
-            <div class="flex min-w-0 items-center gap-2">
-              <h1 class="type-chat-title truncate">
-                {{ dmPeer ? dmPeer.peerUsername : channel?.name ?? "…" }}
-              </h1>
-              <span
-                v-if="isForumChannel"
-                class="type-badge rounded-full border border-primary/15 bg-primary/8 px-2 py-0.5 text-primary/80"
-              >
-                Forum
-              </span>
-              <span v-if="dmPeer" class="hidden lg:inline type-meta text-muted-foreground">
-                · {{ presenceText(dmPeer.presenceShow) }}
-              </span>
-            </div>
-            <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">
-              {{ presenceText(dmPeer.presenceShow) }}
-            </div>
-            <div v-else-if="channel && waddle" class="lg:hidden type-caption text-muted-foreground truncate">
-              {{ waddle.name }}
-            </div>
+  <div class="chat-pane-header border-b border-border px-[var(--chat-content-inline)] py-0 flex flex-shrink-0 items-center justify-between gap-[var(--space-md)] glass-surface">
+    <div class="chat-message-lane flex min-w-0 items-center gap-2">
+      <button
+        class="chat-icon-button chat-icon-button--md text-muted-foreground hover:bg-muted hover:text-foreground lg:hidden"
+        type="button"
+        aria-label="Open navigation"
+        @click="emit('openNav')"
+      >
+        <Menu class="w-4 h-4" />
+      </button>
+      <div class="chat-pane-title-group">
+        <span class="chat-pane-title-icon rounded-lg bg-primary/8">
+          <component :is="dmPeer ? MessageCircle : isForumChannel ? MessagesSquare : Hash" class="w-4 h-4 text-primary/70" />
+        </span>
+        <div class="min-w-0">
+          <div class="flex min-w-0 items-center gap-2">
+            <h1 class="type-chat-title truncate">
+              {{ dmPeer ? dmPeer.peerUsername : channel?.name ?? "…" }}
+            </h1>
+            <span
+              v-if="isForumChannel"
+              class="type-badge rounded-full border border-primary/15 bg-primary/8 px-2 py-0.5 text-primary/80"
+            >
+              Forum
+            </span>
+            <span v-if="dmPeer" class="hidden lg:inline type-meta text-muted-foreground">
+              · {{ presenceText(dmPeer.presenceShow) }}
+            </span>
+          </div>
+          <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">
+            {{ presenceText(dmPeer.presenceShow) }}
+          </div>
+          <div v-else-if="channel && waddle" class="lg:hidden type-caption text-muted-foreground truncate">
+            {{ waddle.name }}
           </div>
         </div>
       </div>
-      <div class="flex shrink-0 items-center gap-3">
-        <div
-          v-if="connectionNotice && connectionStatusClasses"
-          class="type-caption type-emphasis hidden md:inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1"
-          :class="connectionStatusClasses.chip"
+    </div>
+    <div class="flex shrink-0 items-center gap-3">
+      <div
+        v-if="connectionNotice && connectionStatusClasses"
+        class="type-caption type-emphasis hidden md:inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1"
+        :class="connectionStatusClasses.chip"
+      >
+        <component
+          :is="connectionStatusIcon"
+          class="w-3.5 h-3.5"
+          :class="{ 'motion-safe:animate-spin': connectionNotice.tone === 'reconnecting' }"
+        />
+        <span>{{ connectionNotice.shortLabel }}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <button
+          v-if="channel || dmPeer"
+          class="chat-icon-button chat-icon-button--md transition-all duration-200"
+          :class="showSearch ? 'bg-muted text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
+          title="Search messages"
+          aria-label="Search messages"
+          :aria-pressed="showSearch"
+          type="button"
+          @click="showSearch = !showSearch"
         >
-          <component
-            :is="connectionStatusIcon"
-            class="w-3.5 h-3.5"
-            :class="{ 'motion-safe:animate-spin': connectionNotice.tone === 'reconnecting' }"
-          />
-          <span>{{ connectionNotice.shortLabel }}</span>
-        </div>
-        <div class="flex items-center gap-1.5">
-          <button
-            v-if="channel || dmPeer"
-            class="chat-icon-button chat-icon-button--md transition-all duration-200"
-            :class="showSearch ? 'bg-muted text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
-            title="Search messages"
-            aria-label="Search messages"
-            :aria-pressed="showSearch"
-            type="button"
-            @click="showSearch = !showSearch"
-          >
-            <Search class="w-3.5 h-3.5" />
-          </button>
-          <button
-            v-if="canManageChannels && channel"
-            class="chat-icon-button chat-icon-button--md text-muted-foreground hover:bg-muted hover:text-foreground"
-            title="Channel settings"
-            aria-label="Channel settings"
-            type="button"
-            @click="emit('editChannel')"
-          >
-            <Settings class="w-3.5 h-3.5" />
-          </button>
-          <button
-            v-if="channel"
-            class="chat-action-button chat-action-button--secondary text-muted-foreground hover:text-foreground"
-            type="button"
-            :title="`${memberCount} ${memberCount === 1 ? 'member' : 'members'}`"
-            :aria-label="`Open details (${memberCount} ${memberCount === 1 ? 'member' : 'members'})`"
-            @click="emit('openDetails')"
-          >
-            <Users class="w-3.5 h-3.5" />
-            <span class="type-control">{{ memberCount }}</span>
-            <span class="hidden lg:inline type-control">{{ memberCount === 1 ? "member" : "members" }}</span>
-            <ChevronRight class="w-3.5 h-3.5 opacity-60" />
-          </button>
-        </div>
+          <Search class="w-3.5 h-3.5" />
+        </button>
+        <button
+          v-if="canManageChannels && channel"
+          class="chat-icon-button chat-icon-button--md text-muted-foreground hover:bg-muted hover:text-foreground"
+          title="Channel settings"
+          aria-label="Channel settings"
+          type="button"
+          @click="emit('editChannel')"
+        >
+          <Settings class="w-3.5 h-3.5" />
+        </button>
+        <button
+          v-if="channel"
+          class="chat-action-button chat-action-button--secondary text-muted-foreground hover:text-foreground"
+          type="button"
+          :title="`${memberCount} ${memberCount === 1 ? 'member' : 'members'}`"
+          :aria-label="`Open details (${memberCount} ${memberCount === 1 ? 'member' : 'members'})`"
+          @click="emit('openDetails')"
+        >
+          <Users class="w-3.5 h-3.5" />
+          <span class="type-control">{{ memberCount }}</span>
+          <span class="hidden lg:inline type-control">{{ memberCount === 1 ? "member" : "members" }}</span>
+          <ChevronRight class="w-3.5 h-3.5 opacity-60" />
+        </button>
       </div>
     </div>
   </div>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -847,38 +847,36 @@ function dayDividerLabel(createdAt: string): string {
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      class="border-b border-primary/12 bg-primary/8 text-foreground"
+      class="border-b border-primary/12 bg-primary/8 text-foreground flex flex-col gap-3 px-[var(--chat-content-inline)] py-3.5 sm:flex-row sm:items-center sm:justify-between"
     >
-      <div class="chat-message-lane flex flex-col gap-3 px-[var(--chat-content-inline)] py-3.5 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex min-w-0 items-start gap-3">
-          <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/15 bg-background/75 text-primary">
-            <RefreshCw
-              class="h-4 w-4"
-              :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
-            />
-          </div>
-          <div class="flex min-w-0 flex-col gap-0.5">
-            <p class="type-control">
-              Update ready
-            </p>
-            <p class="type-caption chat-copy-measure text-foreground/75">
-              {{ updateNoticeBody }}
-            </p>
-          </div>
-        </div>
-        <button
-          type="button"
-          class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-primary px-3.5 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-wait disabled:opacity-75"
-          :disabled="isApplyingUpdate"
-          @click="emit('refreshUpdate')"
-        >
+      <div class="chat-message-lane flex min-w-0 items-start gap-3">
+        <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/15 bg-background/75 text-primary">
           <RefreshCw
-            class="h-3.5 w-3.5"
+            class="h-4 w-4"
             :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
           />
-          <span>{{ isApplyingUpdate ? "Refreshing…" : "Refresh" }}</span>
-        </button>
+        </div>
+        <div class="flex min-w-0 flex-col gap-0.5">
+          <p class="type-control">
+            Update ready
+          </p>
+          <p class="type-caption chat-copy-measure text-foreground/75">
+            {{ updateNoticeBody }}
+          </p>
+        </div>
       </div>
+      <button
+        type="button"
+        class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-primary px-3.5 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-wait disabled:opacity-75"
+        :disabled="isApplyingUpdate"
+        @click="emit('refreshUpdate')"
+      >
+        <RefreshCw
+          class="h-3.5 w-3.5"
+          :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
+        />
+        <span>{{ isApplyingUpdate ? "Refreshing…" : "Refresh" }}</span>
+      </button>
     </div>
 
     <!-- Search bar -->

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -847,36 +847,38 @@ function dayDividerLabel(createdAt: string): string {
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      class="border-b border-primary/12 bg-primary/8 text-foreground flex flex-col gap-3 px-[var(--chat-content-inline)] py-3.5 sm:flex-row sm:items-center sm:justify-between"
+      class="border-b border-primary/12 bg-primary/8 text-foreground"
     >
-      <div class="chat-message-lane flex min-w-0 items-start gap-3">
-        <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/15 bg-background/75 text-primary">
+      <div class="chat-message-lane flex flex-col gap-3 px-[var(--chat-content-inline)] py-3.5 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 items-start gap-3">
+          <div class="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full border border-primary/15 bg-background/75 text-primary">
+            <RefreshCw
+              class="h-4 w-4"
+              :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
+            />
+          </div>
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <p class="type-control">
+              Update ready
+            </p>
+            <p class="type-caption chat-copy-measure text-foreground/75">
+              {{ updateNoticeBody }}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-primary px-3.5 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-wait disabled:opacity-75"
+          :disabled="isApplyingUpdate"
+          @click="emit('refreshUpdate')"
+        >
           <RefreshCw
-            class="h-4 w-4"
+            class="h-3.5 w-3.5"
             :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
           />
-        </div>
-        <div class="flex min-w-0 flex-col gap-0.5">
-          <p class="type-control">
-            Update ready
-          </p>
-          <p class="type-caption chat-copy-measure text-foreground/75">
-            {{ updateNoticeBody }}
-          </p>
-        </div>
+          <span>{{ isApplyingUpdate ? "Refreshing…" : "Refresh" }}</span>
+        </button>
       </div>
-      <button
-        type="button"
-        class="type-control inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-full bg-primary px-3.5 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35 disabled:cursor-wait disabled:opacity-75"
-        :disabled="isApplyingUpdate"
-        @click="emit('refreshUpdate')"
-      >
-        <RefreshCw
-          class="h-3.5 w-3.5"
-          :class="{ 'motion-safe:animate-spin': isApplyingUpdate }"
-        />
-        <span>{{ isApplyingUpdate ? "Refreshing…" : "Refresh" }}</span>
-      </button>
     </div>
 
     <!-- Search bar -->

--- a/chat/src/components/chat/GifPicker.vue
+++ b/chat/src/components/chat/GifPicker.vue
@@ -57,7 +57,7 @@ function selectGif(gif: GiphyGif) {
 
 <template>
   <div
-    class="z-popover absolute left-0 right-0 glass-panel border border-border rounded-lg max-h-96 flex flex-col shadow-2xl animate-fade-in overflow-hidden"
+    class="chat-composer-popover z-popover absolute glass-panel border border-border rounded-lg max-h-96 flex flex-col shadow-2xl animate-fade-in overflow-hidden"
     :class="isTopPinned ? 'top-full mt-2' : 'bottom-full mb-2'"
   >
     <!-- Header -->

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -101,7 +101,7 @@
   --chat-sidebar-width: clamp(16.5rem, 18vw, 19rem);
   --chat-header-height: 3.5rem;
   --chat-content-inline: clamp(1rem, 2vw, 2rem);
-  --chat-message-lane: clamp(42rem, 68vw, 70rem);
+  --chat-message-lane: clamp(42rem, 68vw, 60rem);
   --chat-copy-measure: 68ch;
   --chat-readable-measure: 72ch;
   --chat-thread-width: clamp(22rem, 32vw, 30rem);
@@ -582,7 +582,8 @@
 
 .chat-message-lane {
   width: min(100%, var(--chat-message-lane));
-  margin-inline: auto;
+  margin-inline-start: 0;
+  margin-inline-end: auto;
 }
 
 .chat-copy-measure {
@@ -802,7 +803,8 @@
 
 .chat-composer > :not(.chat-composer-popover) {
   width: min(100%, var(--chat-message-lane));
-  margin-inline: auto;
+  margin-inline-start: 0;
+  margin-inline-end: auto;
 }
 
 .chat-composer {
@@ -821,8 +823,7 @@
 
 .chat-composer-popover {
   width: min(calc(100% - var(--chat-content-inline) - var(--chat-content-inline)), var(--chat-message-lane));
-  left: 50%;
-  transform: translateX(-50%);
+  left: var(--chat-content-inline);
 }
 
 .chat-pane-header {
@@ -1124,7 +1125,8 @@
 .chat-current-day-marker__lane {
   display: flex;
   width: min(100%, var(--chat-message-lane));
-  margin-inline: auto;
+  margin-inline-start: 0;
+  margin-inline-end: auto;
   align-items: center;
   gap: var(--space-sm);
   justify-content: center;

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -831,14 +831,6 @@
   min-height: var(--chat-header-height);
 }
 
-.chat-pane-header-row {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-md);
-}
-
 .chat-pane-title-group {
   display: grid;
   min-width: 0;

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -904,7 +904,6 @@
   flex-direction: column;
   gap: var(--space-xs);
   align-items: flex-start;
-  max-width: var(--chat-readable-measure);
 }
 
 .chat-message-list {

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -1512,7 +1512,6 @@
 }
 
 .type-message-body {
-  max-width: var(--chat-readable-measure);
   font-size: var(--text-message);
   line-height: var(--leading-message);
   letter-spacing: 0;

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -801,12 +801,6 @@
   }
 }
 
-.chat-composer > :not(.chat-composer-popover) {
-  width: min(100%, var(--chat-message-lane));
-  margin-inline-start: 0;
-  margin-inline-end: auto;
-}
-
 .chat-composer {
   padding: var(--chat-composer-block) var(--chat-content-inline);
   box-shadow: var(--shadow-pane);
@@ -822,8 +816,8 @@
 }
 
 .chat-composer-popover {
-  width: min(calc(100% - var(--chat-content-inline) - var(--chat-content-inline)), var(--chat-message-lane));
   left: var(--chat-content-inline);
+  right: var(--chat-content-inline);
 }
 
 .chat-pane-header {
@@ -834,7 +828,6 @@
 .chat-pane-title-group {
   display: grid;
   min-width: 0;
-  flex: 1 1 auto;
   grid-template-columns: var(--control-md) minmax(0, 1fr);
   column-gap: var(--space-sm);
   align-items: center;
@@ -1116,9 +1109,6 @@
 
 .chat-current-day-marker__lane {
   display: flex;
-  width: min(100%, var(--chat-message-lane));
-  margin-inline-start: 0;
-  margin-inline-end: auto;
   align-items: center;
   gap: var(--space-sm);
   justify-content: center;


### PR DESCRIPTION
## Summary

Replace the centered chat-message-lane with a left-aligned lane that hugs the channels sidebar. Tighten the lane width cap so dead space doesn't accumulate to its right on wide displays. Lift channel-header chrome out of the lane and pin it to the pane's right edge so it stops floating with the lane. Composer (message bar) spans the full pane width and naturally shrinks when a thread panel opens.

## Design (decided in /grill-me + an adjustment)

- **Strategy:** tighten lane cap and left-align (vs. fill-pane which would over-stretch lines on ultrawide)
- **Lane width cap:** 70rem → 60rem (Slack/Discord band; code blocks still readable)
- **Margin:** ``margin-inline: auto`` → ``margin-inline-start: 0; margin-inline-end: auto`` (RTL-safe; dead space lands on the logical end)
- **Header pattern:** title group stays in the lane, action icons (search/settings/members/etc.) lift out and pin to the pane's right edge via ``justify-between``
- **Banners (update / connection / error / reply-jump / search):** stay fully in the lane — including their CTAs — so prose and action read together
- **Composer (message bar):** spans the full pane width (NOT lane-capped). When a thread panel opens, ContentArea shrinks and the composer shrinks with it
- **Composer autocomplete popover:** anchored via ``left: var(--chat-content-inline); right: var(--chat-content-inline)`` so it tracks the input width edge-to-edge
- **Day marker (floating "Today" pill):** centers within the pane, not within the lane
- **Thread state:** lane cap stays fixed regardless of thread state — opening a thread doesn't reflow messages

## Files changed

- ``chat/src/styles/global.css`` — lane cap, lane margin flip, composer pane-wide, popover anchor, day marker centering, drop unused ``.chat-pane-header-row`` and dead ``flex: 1 1 auto``
- ``chat/src/components/chat/ChatHeader.vue`` — lift action icons out of lane to the pane's right edge
- ``chat/src/components/chat/ContentArea.vue`` — (initially split, then reverted) update-banner stays fully in the lane

## Test plan

- [ ] Wide desktop, channel timeline: messages hug sidebar, header icons sit at pane right, composer spans full pane
- [ ] Thread open at depth 1: composer shrinks to ContentArea width; messages do not reflow
- [ ] Search bar / pinned bar: text and chrome stay in the lane
- [ ] Day marker pill: centered in the visible pane, not in the lane
- [ ] DM view: same alignment as channel view
- [ ] Mobile / narrow viewport: lane fills 100%, header icons remain right-aligned without wrapping
- [ ] ``bun run lint`` (knip) clean in ``chat/``
- [ ] ``bun test`` clean in ``chat/``