### PR TITLE
fix(server): improve XEP-0313 compliance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -287,7 +287,6 @@
               cargoExtraArgs = "--locked --package ai-assistant-canvas --package ai-chatbot --package decision-polls --package links-task-board --package pub-quiz";
               cargoCheckExtraArgs = "";
               cargoBuildExtraArgs = "";
-              doCheck = false;
               cargoTestExtraArgs = "";
               doCheck = false;
             }

--- a/flake.nix
+++ b/flake.nix
@@ -289,6 +289,7 @@
               cargoBuildExtraArgs = "";
               doCheck = false;
               cargoTestExtraArgs = "";
+              doCheck = false;
             }
           );
         in

--- a/server/crates/waddle-server/src/server/extension_host_adapter.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter.rs
@@ -452,8 +452,12 @@ impl ExtensionHostAdapter {
         }
         if let Some(reply_to) = reply_to.as_ref() {
             let mut reply = waddle_xmpp::xep::ReplyReference::new(reply_to.id.as_str());
-            if let Some(to) = reply_to.to.as_ref() {
-                reply = reply.with_to(to.as_str());
+            if let Some(to) = reply_to
+                .to
+                .as_ref()
+                .and_then(|to| to.as_str().parse::<Jid>().ok())
+            {
+                reply = reply.with_to(to);
             }
             waddle_xmpp::xep::set_reply_payload(&mut message, &reply);
         }

--- a/server/crates/waddle-server/src/server/extension_host_adapter.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter.rs
@@ -851,6 +851,9 @@ impl ext_host::ExtensionHostTools for ExtensionHostAdapter {
                 .text
                 .and_then(|text| waddle_xmpp::mam::RichText::new(text.into_string())),
             max: Some(query.max_results),
+            filter_before_id: None,
+            filter_after_id: None,
+            ids: Vec::new(),
             before_id: Some(String::new()),
             after_id: None,
         };

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -1106,8 +1106,9 @@ async fn interpret_with_depth(
 /// incoming-block enforcement and risk persisting blocked messages
 /// into the recipient's MAM / inbox.
 ///
-/// The synthetic full-JID resource is a static literal
-/// (`"offline-recipient-pass"`) because the recipient-pass
+/// The synthetic full-JID resource is the shared
+/// [`waddle_xmpp::protocol::HEADLESS_RECIPIENT_RESOURCE`] constant because
+/// the recipient-pass
 /// [`waddle_xmpp::protocol::session_state::Locality`] derivation
 /// matches `to` against the bound bare JID — the resource value is
 /// irrelevant for locality, and the synthetic resource never reaches
@@ -1130,18 +1131,19 @@ async fn run_headless_recipient_pass(
     // Synthetic FullJid for `transition_to_ready`. The resource value
     // is irrelevant — the recipient pass derives `Locality::Recipient`
     // from bare-as-bare matching when `to` is bare.
-    let synthetic_resource = match jid::ResourcePart::new("offline-recipient-pass") {
-        Ok(rp) => rp,
-        Err(error) => {
-            warn!(
-                bare_jid = %recipient_bare,
-                %error,
-                "headless recipient-pass: synthetic resource part rejected; \
-                 skipping (should not happen — static literal)"
-            );
-            return;
-        }
-    };
+    let synthetic_resource =
+        match jid::ResourcePart::new(waddle_xmpp::protocol::HEADLESS_RECIPIENT_RESOURCE) {
+            Ok(rp) => rp,
+            Err(error) => {
+                warn!(
+                    bare_jid = %recipient_bare,
+                    %error,
+                    "headless recipient-pass: synthetic resource part rejected; \
+                     skipping (should not happen — static literal)"
+                );
+                return;
+            }
+        };
     let synthetic_full = recipient_bare.with_resource(&synthetic_resource);
 
     // Fail-closed on blocklist load error (Copilot review on PR #275).
@@ -1170,6 +1172,7 @@ async fn run_headless_recipient_pass(
     };
 
     let mut transient = XmppStateMachine::new(deps.local_domain, (**dispatcher).clone());
+    transient.set_has_live_transport(false);
     transient.transition_to_ready(synthetic_full, false);
     transient.set_blocklist(blocklist);
 

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -1241,11 +1241,20 @@ async fn apply_retraction_tombstone(
             return;
         }
     };
+    let Some(retraction_id) = retraction_message
+        .id
+        .clone()
+        .and_then(waddle_xmpp::mam::RichMessageId::new)
+    else {
+        warn!(
+            archive = %archive,
+            target = target_wire_id,
+            "ApplyRetractionTombstone: retraction stanza missing valid message id; skipping"
+        );
+        return;
+    };
     let tombstone = waddle_xmpp::mam::ArchivedTombstone {
-        retraction_id: retraction_message
-            .id
-            .clone()
-            .and_then(waddle_xmpp::mam::RichMessageId::new),
+        retraction_id: Some(retraction_id),
         stamp: chrono::Utc::now(),
         moderation: None,
     };
@@ -2795,8 +2804,16 @@ async fn apply_groupchat_retraction_tombstone(
             return;
         }
     };
+    let Some(retraction_id) = retraction_message.id.clone().and_then(RichMessageId::new) else {
+        warn!(
+            archive = %room,
+            target = target_message_id,
+            "ApplyGroupchatRetractionTombstone: retraction stanza missing valid message id; skipping"
+        );
+        return;
+    };
     let tombstone = ArchivedTombstone {
-        retraction_id: retraction_message.id.clone().and_then(RichMessageId::new),
+        retraction_id: Some(retraction_id),
         stamp: chrono::Utc::now(),
         moderation: None,
     };
@@ -3041,10 +3058,12 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
                     RichMessageId::new(id).map(|target_id| {
                         ArchivedRichPayload::Retraction(ArchivedRetraction {
                             target_id,
-                            stamp: chrono::DateTime::parse_from_rfc3339(&retracted.stamp)
-                                .ok()
+                            stamp: retracted
+                                .stamp
+                                .as_deref()
+                                .and_then(|stamp| chrono::DateTime::parse_from_rfc3339(stamp).ok())
                                 .map(|stamp| stamp.with_timezone(&chrono::Utc)),
-                            retraction_id: None,
+                            retraction_id: RichMessageId::new(retracted.retraction_id),
                         })
                     })
                 }),

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -3094,7 +3094,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
                 ref_type,
                 begin: reference.begin.and_then(|value| value.try_into().ok()),
                 end: reference.end.and_then(|value| value.try_into().ok()),
-                uri: reference.uri.and_then(RichText::new),
+                uri: RichText::new(reference.uri),
                 anchor: reference.anchor.and_then(RichText::new),
             })
         })

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -1967,7 +1967,7 @@ async fn dispatch_bot_groupchat_response(
             .as_ref()
             .and_then(|to| room_scoped_reply_to_attr(to.as_str(), bot_ctx.room_jid))
         {
-            reply = reply.with_to(&to);
+            reply = reply.with_to(to);
         }
         set_reply_payload(&mut working, &reply);
     }
@@ -2413,7 +2413,7 @@ async fn validate_groupchat_rich_targets(
     }
     if has_malformed_rich_payload(message) {
         return Err(bad_request_error(
-            "Rich-message payload is missing required identifier.",
+            "Rich-message payload is missing a required identifier or contains an invalid JID.",
         ));
     }
     let Some(mam_storage) = deps.mam_storage else {
@@ -2561,7 +2561,10 @@ fn has_malformed_rich_payload(message: &Message) -> bool {
                 && payload.attr("id").is_none_or(str::is_empty))
             || (payload.ns() == NS_REPLY
                 && payload.name() == "reply"
-                && payload.attr("id").is_none_or(str::is_empty))
+                && (payload.attr("id").is_none_or(str::is_empty)
+                    || payload.attr("to").is_some_and(|to| {
+                        to.trim().is_empty() || to.trim().parse::<Jid>().is_err()
+                    })))
             || (payload.ns() == NS_REFERENCE
                 && payload.name() == "reference"
                 && (payload.attr("type").is_none_or(str::is_empty)
@@ -2975,16 +2978,16 @@ fn extract_groupchat_reply_reference(
     };
     let reply_to_jid = reply
         .attr("to")
-        .and_then(|value| room_scoped_reply_to_attr(value, room));
+        .and_then(|value| room_scoped_reply_to_attr(value, room))
+        .map(|jid| jid.to_string());
     (reply.attr("id").map(ToOwned::to_owned), reply_to_jid)
 }
 
-pub(crate) fn room_scoped_reply_to_attr(value: &str, room: &BareJid) -> Option<String> {
+pub(crate) fn room_scoped_reply_to_attr(value: &str, room: &BareJid) -> Option<Jid> {
     value
         .parse::<Jid>()
         .ok()
         .filter(|jid| jid.to_bare() == *room)
-        .map(|jid| jid.to_string())
 }
 
 fn extract_origin_id(message: &Message) -> Option<String> {
@@ -3059,10 +3062,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
             })
         });
     let reply = parse_reply_from_message(message).and_then(|reply| {
-        RichMessageId::new(reply.id).map(|id| ArchivedReply {
-            id,
-            to: reply.to.and_then(|to| to.parse().ok()),
-        })
+        RichMessageId::new(reply.id).map(|id| ArchivedReply { id, to: reply.to })
     });
     let references = extract_references_from_message(message)
         .into_iter()
@@ -4568,7 +4568,11 @@ mod tests {
 
         assert_eq!(
             room_scoped_reply_to_attr("chat@muc.example.com/alice", &room),
-            Some("chat@muc.example.com/alice".to_string())
+            Some(
+                "chat@muc.example.com/alice"
+                    .parse::<Jid>()
+                    .expect("occupant jid")
+            )
         );
         assert_eq!(
             room_scoped_reply_to_attr("alice@example.com/web", &room),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -411,7 +411,6 @@ pub async fn handle_iq_with_conn_state(
             let mut features = vec![
                 Feature::muc(),
                 Feature::replies(),
-                Feature::muc_self_ping_optimization(),
                 Feature::new(NS_CHANNEL_SEARCH),
             ];
             features.extend(extension_features_for_disco(state));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -587,6 +587,7 @@ pub async fn handle_iq_with_conn_state(
                     let features = vec![
                         Feature::disco_info(),
                         Feature::mam(),
+                        Feature::mam_extended(),
                         Feature::fulltext_mam(),
                     ];
                     let response =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -1,6 +1,6 @@
 use chrono;
 use jid::{BareJid, FullJid, Jid};
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use tracing::{debug, warn};
 use url::{Host, Url};
 use waddle_xmpp::{
@@ -76,7 +76,10 @@ use super::super::{
     build_iq_error_xml, build_iq_error_xml_with_addresses, build_iq_result_xml, destroy_room_actor,
     get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml, WebSocketState,
 };
-use super::presence::get_managed_channel_for_room;
+use super::presence::{
+    get_managed_channel_for_room, send_current_presence_from_user_to_user,
+    send_unavailable_presence_from_user_to_user,
+};
 use crate::auth::{NativeUserStore, Session};
 use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};
 use crate::db::blocking::DatabaseBlockingStorage;
@@ -3780,6 +3783,7 @@ async fn handle_blocking_iq(
                     "internal-server-error",
                 )];
             }
+            send_blocking_presence_side_effects(state, &user_bare, &jids, true).await;
             send_blocking_pushes(state, &user_bare, true, &jids).await;
             vec![iq_to_xml(
                 waddle_xmpp::xep::xep0191::build_blocking_success(iq),
@@ -3824,6 +3828,7 @@ async fn handle_blocking_iq(
                 }
                 jids
             };
+            send_blocking_presence_side_effects(state, &user_bare, &unblocked_jids, false).await;
             send_blocking_pushes(state, &user_bare, false, &unblocked_jids).await;
             vec![iq_to_xml(
                 waddle_xmpp::xep::xep0191::build_blocking_success(iq),
@@ -3859,6 +3864,63 @@ async fn handle_blocking_iq(
     }
 
     response
+}
+
+async fn send_blocking_presence_side_effects(
+    state: &WebSocketState,
+    user_bare: &BareJid,
+    jids: &[String],
+    blocked: bool,
+) {
+    let storage = match roster_storage_for_state(state).await {
+        Ok(storage) => storage,
+        Err(error) => {
+            warn!(jid = %user_bare, error = %error, "Failed to access roster storage for XEP-0191 presence side effects");
+            return;
+        }
+    };
+    let subscribers = match storage.get_presence_subscribers(user_bare).await {
+        Ok(subscribers) => subscribers,
+        Err(error) => {
+            warn!(jid = %user_bare, error = %error, "Failed to load presence subscribers for XEP-0191 presence side effects");
+            return;
+        }
+    };
+
+    let subscriber_bares: HashSet<BareJid> = subscribers
+        .into_iter()
+        .filter_map(|jid| match jid.parse::<Jid>() {
+            Ok(jid) => Some(jid.to_bare()),
+            Err(error) => {
+                warn!(jid, %error, "Skipping invalid stored roster subscriber JID");
+                None
+            }
+        })
+        .collect();
+
+    let mut targets = Vec::new();
+    let mut seen = HashSet::new();
+    for jid in jids {
+        let Ok(target) = jid.parse::<Jid>() else {
+            warn!(
+                jid,
+                "Skipping invalid XEP-0191 target JID for presence side effects"
+            );
+            continue;
+        };
+        let target_bare = target.to_bare();
+        if subscriber_bares.contains(&target_bare) && seen.insert(target_bare.clone()) {
+            targets.push(target_bare);
+        }
+    }
+
+    for target in targets {
+        if blocked {
+            send_unavailable_presence_from_user_to_user(state, user_bare, &target).await;
+        } else {
+            send_current_presence_from_user_to_user(state, user_bare, &target).await;
+        }
+    }
 }
 
 async fn send_blocking_pushes(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -3,6 +3,7 @@ use waddle_xmpp::{
     parser::stanza_to_string,
     protocol::handlers::errors::bad_request_reply,
     protocol::{frame::InboundFrame, InboundEvent, XmppStateMachine},
+    xep::NS_DELAY,
     Stanza,
 };
 
@@ -39,7 +40,7 @@ use waddle_xmpp::protocol::ConnectionPhase;
 ///
 /// [`OutboundEvent::DispatchToRoom`]: waddle_xmpp::protocol::OutboundEvent::DispatchToRoom
 pub async fn handle_message(
-    incoming: xmpp_parsers::message::Message,
+    mut incoming: xmpp_parsers::message::Message,
     state: &WebSocketState,
     phase: &ConnectionPhase,
     state_machine: Option<&mut XmppStateMachine>,
@@ -56,6 +57,8 @@ pub async fn handle_message(
         );
         return vec![];
     };
+
+    strip_client_authored_delay(&mut incoming);
 
     if incoming.type_ != xmpp_parsers::message::MessageType::Groupchat
         && incoming.type_ != xmpp_parsers::message::MessageType::Error
@@ -85,8 +88,40 @@ pub async fn handle_message(
     frames
 }
 
+fn strip_client_authored_delay(message: &mut xmpp_parsers::message::Message) {
+    message
+        .payloads
+        .retain(|payload| !(payload.name() == "delay" && payload.ns() == NS_DELAY));
+}
+
 fn remove_framework_envelopes(message: &mut xmpp_parsers::message::Message) {
     message
         .payloads
         .retain(|payload| !payload.ns().starts_with("urn:waddle:"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::message::Message;
+    use xmpp_parsers::minidom::Element;
+
+    #[test]
+    fn strips_client_supplied_delay_without_touching_other_payloads() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <body>Hello</body>\
+                    <delay xmlns='urn:xmpp:delay' from='evil.example' stamp='2024-06-01T09:30:00Z'>forged</delay>\
+                    <envelope xmlns='urn:waddle:test'/>\
+                    </message>";
+        let mut message =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("message");
+
+        strip_client_authored_delay(&mut message);
+
+        assert!(message.payloads.iter().all(|payload| payload.ns() != NS_DELAY));
+        assert!(message
+            .payloads
+            .iter()
+            .any(|payload| payload.ns().starts_with("urn:waddle:")));
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -118,7 +118,10 @@ mod tests {
 
         strip_client_authored_delay(&mut message);
 
-        assert!(message.payloads.iter().all(|payload| payload.ns() != NS_DELAY));
+        assert!(message
+            .payloads
+            .iter()
+            .all(|payload| payload.ns() != NS_DELAY));
         assert!(message
             .payloads
             .iter()

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -386,7 +386,7 @@ async fn send_existing_subscription_ack(
     }
 }
 
-async fn send_current_presence_from_user_to_user(
+pub(super) async fn send_current_presence_from_user_to_user(
     state: &WebSocketState,
     from: &BareJid,
     to: &BareJid,
@@ -418,7 +418,7 @@ async fn send_current_presence_from_user_to_user(
     }
 }
 
-async fn send_unavailable_presence_from_user_to_user(
+pub(super) async fn send_unavailable_presence_from_user_to_user(
     state: &WebSocketState,
     from: &BareJid,
     to: &BareJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -12,6 +12,7 @@ use waddle_xmpp::{
     },
     registry::BroadcastOutcome,
     roster::{build_roster_push, AskType, RosterItem, Subscription},
+    xep::NS_DELAY,
     Affiliation, Role, Stanza,
 };
 use xmpp_parsers::minidom::Element;
@@ -29,13 +30,14 @@ use crate::server::xmpp_state::{get_xmpp_channel, XmppChannelRecord};
 use waddle_xmpp::protocol::ConnectionPhase;
 
 pub async fn handle_presence(
-    presence: xmpp_parsers::presence::Presence,
+    mut presence: xmpp_parsers::presence::Presence,
     domain: &str,
     muc_domain: &str,
     state: &WebSocketState,
     phase: &ConnectionPhase,
     _authenticated_session: &Option<Session>,
 ) -> Vec<String> {
+    strip_client_authored_delay(&mut presence);
     let is_unavailable = presence.type_ == xmpp_parsers::presence::Type::Unavailable;
 
     // Check if this is a MUC presence (to room@muc.domain/nick)
@@ -109,6 +111,12 @@ pub async fn handle_presence(
     vec![]
 }
 
+fn strip_client_authored_delay(presence: &mut xmpp_parsers::presence::Presence) {
+    presence
+        .payloads
+        .retain(|payload| !(payload.name() == "delay" && payload.ns() == NS_DELAY));
+}
+
 fn is_directed_presence_update(presence: &xmpp_parsers::presence::Presence) -> bool {
     presence.to.is_some()
         && !matches!(
@@ -119,6 +127,29 @@ fn is_directed_presence_update(presence: &xmpp_parsers::presence::Presence) -> b
                 | xmpp_parsers::presence::Type::Unsubscribed
                 | xmpp_parsers::presence::Type::Probe
         )
+}
+
+#[cfg(test)]
+mod delay_strip_tests {
+    use super::*;
+
+    #[test]
+    fn strips_client_supplied_delay_payload() {
+        let xml = "<presence xmlns='jabber:client' from='alice@example.com/web'>\
+                    <delay xmlns='urn:xmpp:delay' from='evil.example' stamp='2024-06-01T09:30:00Z'/>\
+                    <status>ready</status>\
+                    </presence>";
+        let mut presence =
+            xmpp_parsers::presence::Presence::try_from(xml.parse::<Element>().expect("valid xml"))
+                .expect("presence");
+
+        strip_client_authored_delay(&mut presence);
+
+        assert!(presence
+            .payloads
+            .iter()
+            .all(|payload| !(payload.name() == "delay" && payload.ns() == NS_DELAY)));
+    }
 }
 
 async fn roster_storage(state: &WebSocketState) -> Option<DatabaseRosterStorage> {

--- a/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
+++ b/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
@@ -3,7 +3,7 @@
 mod ws_common;
 
 use std::time::Duration;
-use ws_common::{TestServer, WsXmppClient};
+use ws_common::{disco_info_query, TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
@@ -862,6 +862,43 @@ async fn websocket_muc_self_ping_succeeds_for_joined_occupant() {
     assert!(
         response.contains("type=\"result\"") || response.contains("type='result'"),
         "expected MUC self-ping result, got: {response}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn websocket_muc_room_disco_advertises_self_ping_optimization_only_on_rooms() {
+    let (_server, mut client) = setup().await;
+    let room = format!("self-ping-disco-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let muc_service = format!("muc.{DOMAIN}");
+    let feature = "http://jabber.org/protocol/muc#self-ping-optimization";
+
+    client
+        .send(&format!(
+            r#"<presence xmlns="jabber:client" to="{room}/admin"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+
+    let service_response = disco_info_query(&mut client, &muc_service, "ws-muc-self-ping-svc")
+        .await
+        .expect("service disco#info response");
+    assert!(
+        !service_response.contains(feature),
+        "muc service disco must not advertise XEP-0410 room feature: {service_response}"
+    );
+
+    let room_response = disco_info_query(&mut client, &room, "ws-muc-self-ping-room")
+        .await
+        .expect("room disco#info response");
+    assert!(
+        room_response.contains(feature),
+        "muc room disco missing XEP-0410 feature: {room_response}"
     );
 
     client.close().await;

--- a/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
+++ b/server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs
@@ -44,6 +44,92 @@ async fn assert_no_frame_matching<F>(
     }
 }
 
+async fn connect_alice_bob() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+
+    let alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice connection");
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connection");
+
+    (server, alice, bob)
+}
+
+async fn send_roster_get(client: &mut WsXmppClient, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="get" id="{id}"><query xmlns="jabber:iq:roster"/></iq>"#
+        ))
+        .await
+        .expect("send roster get");
+    let _ = client
+        .recv_matching(|frame| frame.contains(id))
+        .await
+        .expect("roster get result");
+}
+
+async fn establish_subscription_to_alice(alice: &mut WsXmppClient, bob: &mut WsXmppClient) {
+    send_roster_get(alice, "alice-subscription-roster").await;
+    send_roster_get(bob, "bob-subscription-roster").await;
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice available");
+    bob.send(r#"<presence xmlns="jabber:client" type="subscribe" to="alice@localhost"/>"#)
+        .await
+        .expect("bob subscribes to alice");
+    let subscribe = alice
+        .recv_matching(|frame| {
+            frame.contains("type=\"subscribe\"") || frame.contains("type='subscribe'")
+        })
+        .await
+        .expect("alice receives subscribe");
+    assert!(
+        subscribe.contains("from=\"bob@localhost\"") || subscribe.contains("from='bob@localhost'"),
+        "expected bob subscribe request, got: {subscribe}"
+    );
+
+    alice
+        .send(r#"<presence xmlns="jabber:client" type="subscribed" to="bob@localhost"/>"#)
+        .await
+        .expect("alice approves bob");
+    let subscribed = bob
+        .recv_matching(|frame| {
+            frame.contains("type=\"subscribed\"") || frame.contains("type='subscribed'")
+        })
+        .await
+        .expect("bob receives approval");
+    assert!(
+        subscribed.contains("from=\"alice@localhost\"")
+            || subscribed.contains("from='alice@localhost'"),
+        "expected alice approval, got: {subscribed}"
+    );
+
+    bob.send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob available for presence updates");
+}
+
 #[tokio::test]
 async fn websocket_vcard_set_then_get_roundtrips() {
     let (_server, mut client) = setup().await;
@@ -176,6 +262,91 @@ async fn websocket_disco_advertises_blocking() {
     );
 
     client.close().await;
+}
+
+#[tokio::test]
+async fn websocket_blocking_updates_presence_visibility_for_subscribed_contact() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    establish_subscription_to_alice(&mut alice, &mut bob).await;
+
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><show>chat</show><status>visible before block</status><priority>7</priority></presence>"#,
+        )
+        .await
+        .expect("alice sends current presence");
+    let initial_presence = bob
+        .recv_matching(|frame| frame.contains("visible before block"))
+        .await
+        .expect("bob receives initial presence");
+    assert!(
+        initial_presence.contains("from=\"alice@localhost/")
+            || initial_presence.contains("from='alice@localhost/"),
+        "expected alice presence before blocking, got: {initial_presence}"
+    );
+
+    alice
+        .send(
+            r#"<iq xmlns="jabber:client" type="set" id="ws-block-presence"><block xmlns="urn:xmpp:blocking"><item jid="bob@localhost"/></block></iq>"#,
+        )
+        .await
+        .expect("alice blocks bob");
+    let block_response = alice
+        .recv_matching(|frame| frame.contains("ws-block-presence"))
+        .await
+        .expect("blocking response");
+    assert!(
+        block_response.contains("type=\"result\"") || block_response.contains("type='result'"),
+        "expected blocking result, got: {block_response}"
+    );
+    let unavailable = bob
+        .recv_matching(|frame| {
+            (frame.contains("type=\"unavailable\"") || frame.contains("type='unavailable'"))
+                && (frame.contains("from=\"alice@localhost/")
+                    || frame.contains("from='alice@localhost/"))
+        })
+        .await
+        .expect("bob receives unavailable presence after block");
+    assert!(
+        unavailable.contains("to=\"bob@localhost\"") || unavailable.contains("to='bob@localhost'"),
+        "expected unavailable presence addressed to bob, got: {unavailable}"
+    );
+
+    alice
+        .send(
+            r#"<iq xmlns="jabber:client" type="set" id="ws-unblock-presence"><unblock xmlns="urn:xmpp:blocking"><item jid="bob@localhost"/></unblock></iq>"#,
+        )
+        .await
+        .expect("alice unblocks bob");
+    let unblock_response = alice
+        .recv_matching(|frame| frame.contains("ws-unblock-presence"))
+        .await
+        .expect("unblocking response");
+    assert!(
+        unblock_response.contains("type=\"result\"") || unblock_response.contains("type='result'"),
+        "expected unblocking result, got: {unblock_response}"
+    );
+    let restored_presence = bob
+        .recv_matching(|frame| frame.contains("visible before block"))
+        .await
+        .expect("bob receives current presence after unblock");
+    assert!(
+        restored_presence.contains("from=\"alice@localhost/")
+            || restored_presence.contains("from='alice@localhost/"),
+        "expected alice current presence after unblock, got: {restored_presence}"
+    );
+
+    assert_no_frame_matching(
+        &mut bob,
+        Duration::from_millis(250),
+        |frame| frame.contains("type=\"unavailable\"") || frame.contains("type='unavailable'"),
+        "bob should not receive extra unavailable presence after unblock",
+    )
+    .await;
+
+    bob.close().await;
+    alice.close().await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xep0092_software_version_ws.rs
+++ b/server/crates/waddle-server/tests/xep0092_software_version_ws.rs
@@ -41,7 +41,7 @@ async fn websocket_disco_advertises_software_version() {
 }
 
 #[tokio::test]
-async fn websocket_version_query_returns_name_version_and_os() {
+async fn websocket_version_query_returns_name_and_version_without_os() {
     let (_server, mut client) = setup().await;
 
     let response = version_query(&mut client, DOMAIN, "ws-version-1")
@@ -61,8 +61,8 @@ async fn websocket_version_query_returns_name_version_and_os() {
         "expected <version/> child, got: {response}"
     );
     assert!(
-        extract_element_text(&response, "os").is_some(),
-        "expected <os/> child, got: {response}"
+        extract_element_text(&response, "os").is_none(),
+        "XEP-0092 leaves <os/> optional and Waddle should not disclose it by default: {response}"
     );
     assert!(
         response.contains("ws-version-1"),

--- a/server/crates/waddle-server/tests/xep0203_delayed_delivery_ws.rs
+++ b/server/crates/waddle-server/tests/xep0203_delayed_delivery_ws.rs
@@ -1,0 +1,107 @@
+//! XEP-0203 delayed-delivery integration tests over WebSocket.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0203-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn contains_nested_message_delay(frame: &str, body_text: &str) -> bool {
+    fn find_message<'a>(element: &'a Element, body_text: &str) -> Option<&'a Element> {
+        if element.name() == "message"
+            && element.ns() == "jabber:client"
+            && element
+                .get_child("body", "jabber:client")
+                .is_some_and(|body| body.text() == body_text)
+        {
+            return Some(element);
+        }
+        for child in element.children() {
+            if let Some(found) = find_message(child, body_text) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    let element = frame.parse::<Element>().expect("valid XML frame");
+    find_message(&element, body_text)
+        .and_then(|message| message.get_child("delay", "urn:xmpp:delay"))
+        .is_some()
+}
+
+#[tokio::test]
+async fn client_spoofed_delay_is_stripped_from_groupchat_flow() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("delay-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let body = "forged delay should vanish";
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="delay-1">
+                <body>{body}</body>
+                <delay xmlns="urn:xmpp:delay" from="evil.example" stamp="2024-06-01T09:30:00Z">forged</delay>
+            </message>"#
+        ))
+        .await
+        .expect("send groupchat with forged delay");
+    let echo = client
+        .recv_matching(|frame| frame.contains(body))
+        .await
+        .expect("live reflection");
+    assert!(
+        !contains_nested_message_delay(&echo, body),
+        "live reflection leaked client-authored delay: {echo}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-delay" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-delay") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    let replay = frames
+        .iter()
+        .find(|frame| frame.contains(body))
+        .unwrap_or_else(|| panic!("MAM did not replay original message: {frames:?}"));
+    assert!(
+        !contains_nested_message_delay(replay, body),
+        "MAM replay leaked client-authored delay: {replay}"
+    );
+
+    client.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0313_mam_integration.rs
+++ b/server/crates/waddle-server/tests/xep0313_mam_integration.rs
@@ -5,7 +5,7 @@
 mod ws_common;
 
 use tokio::sync::Mutex;
-use ws_common::{TestServer, WsXmppClient};
+use ws_common::{disco_info_query, TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
@@ -38,6 +38,16 @@ fn mam_query_after_xml(id: &str, archive_jid: &str, max: u32, after: &str) -> St
     )
 }
 
+fn mam_query_ids_xml(id: &str, archive_jid: &str, ids: &[&str]) -> String {
+    let id_values = ids
+        .iter()
+        .map(|archive_id| format!(r#"<value>{archive_id}</value>"#))
+        .collect::<String>();
+    format!(
+        r#"<iq type="set" id="{id}" to="{archive_jid}"><query xmlns="urn:xmpp:mam:2"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>urn:xmpp:mam:2</value></field><field var="ids">{id_values}</field></x></query></iq>"#
+    )
+}
+
 async fn query_mam(client: &mut WsXmppClient, query_xml: &str) -> Result<Vec<String>, String> {
     client.send(query_xml).await?;
     client
@@ -49,6 +59,19 @@ fn extract_mam_body(frame: &str) -> Option<String> {
     let start = frame.find("<body>")?;
     let end = frame.find("</body>")?;
     Some(frame[start + 6..end].to_string())
+}
+
+fn extract_result_id(frame: &str) -> Option<String> {
+    let result = &frame[frame.find("<result")?..];
+    if let Some(start) = result.find(" id=\"") {
+        let value = &result[start + 5..];
+        return Some(value[..value.find('"')?].to_string());
+    }
+    if let Some(start) = result.find(" id='") {
+        let value = &result[start + 5..];
+        return Some(value[..value.find('\'')?].to_string());
+    }
+    None
 }
 
 fn extract_fin_last(frame: &str) -> Option<String> {
@@ -235,6 +258,164 @@ async fn muc_mam_pagination() {
             "page msg 4".to_string(),
             "page msg 5".to_string()
         ]
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn personal_archive_disco_advertises_extended_mam_feature() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let archive_jid = format!("{USERNAME}@{DOMAIN}");
+
+    let response = disco_info_query(&mut client, &archive_jid, "mam-disco-personal")
+        .await
+        .expect("personal archive disco#info response");
+
+    assert!(
+        response.contains("urn:xmpp:mam:2#extended"),
+        "personal archive disco missing urn:xmpp:mam:2#extended: {response}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn personal_archive_mam_form_includes_extended_fields() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let archive_jid = format!("{USERNAME}@{DOMAIN}");
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="mam-form-personal" to="{archive_jid}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send mam form request");
+    let response = client
+        .recv_matching(|frame| frame.contains("mam-form-personal"))
+        .await
+        .expect("mam form response");
+
+    for field in ["before-id", "after-id", "ids"] {
+        assert!(
+            response.contains(&format!("var=\"{field}\""))
+                || response.contains(&format!("var='{field}'")),
+            "mam form missing {field}: {response}"
+        );
+    }
+    assert!(
+        response.contains("http://jabber.org/protocol/xdata-validate"),
+        "mam form missing XEP-0122 validation namespace: {response}"
+    );
+    assert!(
+        response.contains("datatype=\"xs:string\"") || response.contains("datatype='xs:string'"),
+        "mam form missing ids datatype: {response}"
+    );
+    assert!(response.contains("<open") || response.contains("<open/>"));
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn room_disco_advertises_extended_mam_feature() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("mam-disco-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+
+    let response = disco_info_query(&mut client, &room, "mam-disco-room")
+        .await
+        .expect("room disco#info response");
+
+    assert!(
+        response.contains("urn:xmpp:mam:2#extended"),
+        "room disco missing urn:xmpp:mam:2#extended: {response}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
+async fn room_mam_ids_query_returns_only_requested_messages() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("mam-ids-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+
+    let bodies = ["ids one", "ids two", "ids three"];
+    for body in &bodies {
+        client
+            .send(&format!(
+                r#"<message type="groupchat" to="{room}"><body>{body}</body></message>"#
+            ))
+            .await
+            .expect("send message");
+        client
+            .recv_matching(|frame| frame.contains(body))
+            .await
+            .expect("echo");
+    }
+
+    let initial = query_mam(
+        &mut client,
+        &mam_query_xml(
+            &format!("ids-seed-{}", uuid::Uuid::new_v4()),
+            &room,
+            Some(10),
+        ),
+    )
+    .await
+    .expect("seed mam query");
+    let result_frames: Vec<&str> = initial
+        .iter()
+        .map(|frame| frame.as_str())
+        .filter(|frame| frame.contains("<forwarded"))
+        .collect();
+    let selected_ids = [
+        extract_result_id(result_frames[2]).expect("third archive id"),
+        extract_result_id(result_frames[0]).expect("first archive id"),
+    ];
+
+    let filtered = query_mam(
+        &mut client,
+        &mam_query_ids_xml(
+            &format!("ids-filter-{}", uuid::Uuid::new_v4()),
+            &room,
+            &[selected_ids[0].as_str(), selected_ids[1].as_str()],
+        ),
+    )
+    .await
+    .expect("ids mam query");
+    let filtered_bodies: Vec<String> = filtered
+        .iter()
+        .filter_map(|frame| extract_mam_body(frame))
+        .collect();
+
+    assert_eq!(
+        filtered_bodies,
+        vec!["ids one".to_string(), "ids three".to_string()]
     );
 
     client.close().await;

--- a/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
+++ b/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
@@ -106,6 +106,10 @@ async fn retraction_routes_and_replays_from_mam() {
         "tombstone leaked original body: {tombstone}"
     );
     assert!(
+        tombstone.contains("<retracted") && tombstone.contains("id=\"retract-1\""),
+        "tombstone must cite the retraction stanza id: {tombstone}"
+    );
+    assert!(
         frames
             .iter()
             .all(|frame| !frame.contains("<body>remove me</body>")),
@@ -186,9 +190,15 @@ async fn dm_retraction_tombstones_both_archives() {
             .all(|frame| !frame.contains("<body>retract this dm</body>")),
         "recipient archive leaked original body after retraction: {bob_frames:?}"
     );
+    let bob_tombstone = bob_frames
+        .iter()
+        .find(|frame| frame.contains("<retracted "))
+        .unwrap_or_else(|| {
+            panic!("recipient archive missing tombstone for retracted DM: {bob_frames:?}")
+        });
     assert!(
-        bob_frames.iter().any(|frame| frame.contains("<retracted ")),
-        "recipient archive missing tombstone for retracted DM: {bob_frames:?}"
+        bob_tombstone.contains("id=\"dm-retract-1\""),
+        "recipient tombstone must cite the retraction stanza id: {bob_tombstone}"
     );
 
     // Admin's MAM also tombstones.
@@ -208,11 +218,15 @@ async fn dm_retraction_tombstones_both_archives() {
             .all(|frame| !frame.contains("<body>retract this dm</body>")),
         "sender archive leaked original body after retraction: {admin_frames:?}"
     );
+    let admin_tombstone = admin_frames
+        .iter()
+        .find(|frame| frame.contains("<retracted "))
+        .unwrap_or_else(|| {
+            panic!("sender archive missing tombstone for retracted DM: {admin_frames:?}")
+        });
     assert!(
-        admin_frames
-            .iter()
-            .any(|frame| frame.contains("<retracted ")),
-        "sender archive missing tombstone for retracted DM: {admin_frames:?}"
+        admin_tombstone.contains("id=\"dm-retract-1\""),
+        "sender tombstone must cite the retraction stanza id: {admin_tombstone}"
     );
 
     bob.close().await;

--- a/server/crates/waddle-server/tests/xep0461_replies_ws.rs
+++ b/server/crates/waddle-server/tests/xep0461_replies_ws.rs
@@ -132,6 +132,36 @@ async fn reply_to_unknown_target_routes_without_error() {
 }
 
 #[tokio::test]
+async fn reply_with_empty_to_jid_returns_bad_request() {
+    // XEP-0461 §Use Cases: if the optional `to` attribute is present it
+    // names the author of the referenced message, so it must be a valid JID.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("reply-bad-to-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="reply-bad-to">
+                <body>bad reply</body>
+                <reply xmlns="urn:xmpp:reply:0" to=" " id="parent-1"/>
+            </message>"#
+        ))
+        .await
+        .expect("send malformed reply");
+    let error = client
+        .recv_matching(|frame| frame.contains("<bad-request"))
+        .await
+        .expect("bad-request error");
+    assert!(
+        error.contains("type=\"error\""),
+        "not an error stanza: {error}"
+    );
+
+    client.close().await;
+}
+
+#[tokio::test]
 async fn reply_with_fallback_replays_from_mam() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup().await;

--- a/server/crates/waddle-xmpp-core/src/carbons.rs
+++ b/server/crates/waddle-xmpp-core/src/carbons.rs
@@ -16,6 +16,23 @@ pub const FORWARDED_NS: &str = "urn:xmpp:forward:0";
 pub const DELAY_NS: &str = "urn:xmpp:delay";
 
 const HINTS_NS: &str = "urn:xmpp:hints";
+const CHAT_STATES_NS: &str = "http://jabber.org/protocol/chatstates";
+const RECEIPTS_NS: &str = "urn:xmpp:receipts";
+const CHAT_MARKERS_NS: &str = "urn:xmpp:chat-markers:0";
+
+fn is_instant_messaging_payload(payload: &Element) -> bool {
+    matches!(
+        (payload.ns().as_str(), payload.name()),
+        (
+            CHAT_STATES_NS,
+            "active" | "composing" | "paused" | "inactive" | "gone"
+        ) | (RECEIPTS_NS, "request" | "received")
+            | (
+                CHAT_MARKERS_NS,
+                "markable" | "received" | "displayed" | "acknowledged"
+            )
+    )
+}
 
 /// Check if an IQ is a carbons enable request.
 pub fn is_carbons_enable(iq: &Iq) -> bool {
@@ -43,14 +60,9 @@ pub fn build_carbons_result(original_iq: &Iq) -> Iq {
     }
 }
 
-/// Check if a message should be excluded from carbon copying.
+/// Check whether a message is eligible for XEP-0280 carbon copying.
 pub fn should_copy_message(msg: &Message) -> bool {
     use xmpp_parsers::message::MessageType;
-
-    match msg.type_ {
-        MessageType::Groupchat | MessageType::Error => return false,
-        _ => {}
-    }
 
     if msg
         .payloads
@@ -70,12 +82,25 @@ pub fn should_copy_message(msg: &Message) -> bool {
         return false;
     }
 
-    if msg.bodies.is_empty() {
-        debug!("Message has no body, skipping carbon");
+    if matches!(msg.type_, MessageType::Groupchat | MessageType::Error) {
+        debug!("Message type is not eligible for carbons");
         return false;
     }
 
-    true
+    if matches!(msg.type_, MessageType::Chat) {
+        return true;
+    }
+
+    if matches!(msg.type_, MessageType::Normal) && !msg.bodies.is_empty() {
+        return true;
+    }
+
+    if msg.payloads.iter().any(is_instant_messaging_payload) {
+        return true;
+    }
+
+    debug!("Message is not XEP-0280 eligible, skipping carbon");
+    false
 }
 
 /// Build a "sent" carbon message wrapper.
@@ -211,9 +236,47 @@ mod tests {
     }
 
     #[test]
-    fn test_should_not_copy_no_body() {
-        let msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+    fn test_should_copy_bodyless_chat() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Chat;
+        assert!(should_copy_message(&msg));
+    }
+
+    #[test]
+    fn test_should_not_copy_bodyless_normal_without_im_payload() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Normal;
         assert!(!should_copy_message(&msg));
+    }
+
+    #[test]
+    fn test_should_copy_bodyless_with_chat_state_payload() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Normal;
+        msg.payloads
+            .push(Element::builder("composing", CHAT_STATES_NS).build());
+        assert!(should_copy_message(&msg));
+    }
+
+    #[test]
+    fn test_should_copy_bodyless_with_receipt_payload() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Normal;
+        msg.payloads
+            .push(Element::builder("request", RECEIPTS_NS).build());
+        assert!(should_copy_message(&msg));
+    }
+
+    #[test]
+    fn test_should_copy_bodyless_with_chat_marker_payload() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Normal;
+        msg.payloads.push(
+            Element::builder("displayed", CHAT_MARKERS_NS)
+                .attr("id", "msg-1")
+                .build(),
+        );
+        assert!(should_copy_message(&msg));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/carbons.rs
+++ b/server/crates/waddle-xmpp-core/src/carbons.rs
@@ -34,6 +34,16 @@ fn is_instant_messaging_payload(payload: &Element) -> bool {
     )
 }
 
+fn has_no_copy_hint(msg: &Message) -> bool {
+    msg.payloads
+        .iter()
+        .any(|payload| payload.name() == "no-copy" && payload.ns() == HINTS_NS)
+}
+
+fn no_copy_suppresses_carbons(msg: &Message) -> bool {
+    has_no_copy_hint(msg) && msg.to.as_ref().and_then(|jid| jid.resource()).is_some()
+}
+
 /// Check if an IQ is a carbons enable request.
 pub fn is_carbons_enable(iq: &Iq) -> bool {
     match &iq.payload {
@@ -64,12 +74,8 @@ pub fn build_carbons_result(original_iq: &Iq) -> Iq {
 pub fn should_copy_message(msg: &Message) -> bool {
     use xmpp_parsers::message::MessageType;
 
-    if msg
-        .payloads
-        .iter()
-        .any(|payload| payload.name() == "no-copy" && payload.ns() == HINTS_NS)
-    {
-        debug!("Message has <no-copy/> hint, skipping carbon");
+    if no_copy_suppresses_carbons(msg) {
+        debug!("Message has <no-copy/> hint for a full-JID target, skipping carbon");
         return false;
     }
 
@@ -294,8 +300,8 @@ mod tests {
     }
 
     #[test]
-    fn test_should_not_copy_with_no_copy_hint() {
-        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+    fn test_should_not_copy_with_no_copy_hint_to_full_jid() {
+        let mut msg = Message::new(Some("recipient@example.com/phone".parse().unwrap()));
         msg.type_ = MessageType::Chat;
         msg.bodies.insert(
             String::new(),
@@ -305,6 +311,20 @@ mod tests {
             .push(Element::builder("no-copy", HINTS_NS).build());
 
         assert!(!should_copy_message(&msg));
+    }
+
+    #[test]
+    fn test_should_copy_with_no_copy_hint_to_bare_jid() {
+        let mut msg = Message::new(Some("recipient@example.com".parse().unwrap()));
+        msg.type_ = MessageType::Chat;
+        msg.bodies.insert(
+            String::new(),
+            xmpp_parsers::message::Body("Hello".to_string()),
+        );
+        msg.payloads
+            .push(Element::builder("no-copy", HINTS_NS).build());
+
+        assert!(should_copy_message(&msg));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -29,6 +29,7 @@ pub struct DiscoInfoQuery {
 pub struct Identity {
     pub category: String,
     pub type_: String,
+    pub lang: Option<String>,
     pub name: Option<String>,
 }
 
@@ -37,8 +38,14 @@ impl Identity {
         Self {
             category: category.to_string(),
             type_: type_.to_string(),
+            lang: None,
             name: name.map(str::to_string),
         }
+    }
+
+    pub fn with_lang(mut self, lang: Option<&str>) -> Self {
+        self.lang = lang.map(str::to_string);
+        self
     }
 
     pub fn server(name: Option<&str>) -> Self {
@@ -404,6 +411,10 @@ pub fn build_disco_info_response_with_extensions(
             .attr("category", &identity.category)
             .attr("type", &identity.type_);
 
+        if let Some(ref lang) = identity.lang {
+            id_builder = id_builder.attr("xml:lang", lang);
+        }
+
         if let Some(ref name) = identity.name {
             id_builder = id_builder.attr("name", name);
         }
@@ -662,16 +673,21 @@ mod tests {
 
         let response = build_disco_info_response(
             &iq,
-            &[Identity::server(Some("Waddle"))],
+            &[Identity::server(Some("Waddle")).with_lang(Some("en"))],
             &[Feature::disco_info(), Feature::disco_items()],
             None,
         );
 
         assert_eq!(response.id, "disco-1");
-        assert!(matches!(
-            response.payload,
-            xmpp_parsers::iq::IqType::Result(Some(_))
-        ));
+
+        let xmpp_parsers::iq::IqType::Result(Some(query)) = response.payload else {
+            panic!("expected disco#info result payload");
+        };
+        let identity = query
+            .children()
+            .find(|child| child.name() == "identity")
+            .expect("identity should be present");
+        assert_eq!(identity.attr("xml:lang"), Some("en"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -108,6 +108,10 @@ impl Feature {
         Self::new("urn:xmpp:mam:2")
     }
 
+    pub fn mam_extended() -> Self {
+        Self::new("urn:xmpp:mam:2#extended")
+    }
+
     pub fn fulltext_mam() -> Self {
         Self::new(FULLTEXT_MAM_NS)
     }
@@ -501,6 +505,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::caps(),
         Feature::roster_versioning(),
         Feature::mam(),
+        Feature::mam_extended(),
         Feature::waddle_mam_thread(),
         Feature::stanza_ids(),
         Feature::replies(),
@@ -603,6 +608,7 @@ pub fn muc_room_features(
         Feature::muc(),
         Feature::muc_self_ping_optimization(),
         Feature::mam(),
+        Feature::mam_extended(),
         Feature::fulltext_mam(),
         Feature::waddle_mam_thread(),
         Feature::stanza_ids(),
@@ -735,6 +741,7 @@ mod tests {
         assert!(features.contains(&Feature::disco_info()));
         assert!(features.contains(&Feature::carbons()));
         assert!(features.contains(&Feature::receipts()));
+        assert!(features.contains(&Feature::mam_extended()));
         assert!(!features.contains(&Feature::fulltext_mam()));
         assert!(features.contains(&Feature::server_info()));
     }
@@ -747,6 +754,7 @@ mod tests {
         assert!(features.contains(&Feature::muc_membersonly()));
         assert!(features.contains(&Feature::muc_unmoderated()));
         assert!(features.contains(&Feature::muc_self_ping_optimization()));
+        assert!(features.contains(&Feature::mam_extended()));
         assert!(features.contains(&Feature::fulltext_mam()));
         assert!(features.contains(&Feature::chat_states()));
         assert_eq!(Feature::chat_states().0, NS_CHATSTATES);

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -126,6 +126,10 @@ impl Feature {
         Self::new("urn:xmpp:message-correct:0")
     }
 
+    pub fn chat_markers() -> Self {
+        Self::new("urn:xmpp:chat-markers:0")
+    }
+
     pub fn message_retraction() -> Self {
         Self::new("urn:xmpp:message-retract:1")
     }
@@ -491,6 +495,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::stanza_ids(),
         Feature::replies(),
         Feature::message_correction(),
+        Feature::chat_markers(),
         Feature::message_retraction(),
         Feature::reactions(),
         Feature::references(),
@@ -592,6 +597,7 @@ pub fn muc_room_features(
         Feature::stanza_ids(),
         Feature::replies(),
         Feature::message_correction(),
+        Feature::chat_markers(),
         Feature::message_retraction(),
         Feature::message_moderation(),
         Feature::reactions(),

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -13,6 +13,7 @@ const DATA_FORMS_NS: &str = "jabber:x:data";
 const SERVER_INFO_FORM_TYPE: &str = "urn:xmpp:serverinfo:0";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_FORUMS: &str = "urn:xmpp:forums:0";
+const NS_MUC_SELF_PING_OPTIMIZATION: &str = "http://jabber.org/protocol/muc#self-ping-optimization";
 
 /// Service Discovery info namespace (XEP-0030).
 pub const DISCO_INFO_NS: &str = "http://jabber.org/protocol/disco#info";
@@ -223,7 +224,7 @@ impl Feature {
     }
 
     pub fn muc_self_ping_optimization() -> Self {
-        Self::new("urn:xmpp:muc-selfping:0")
+        Self::new(NS_MUC_SELF_PING_OPTIMIZATION)
     }
 
     pub fn pubsub() -> Self {
@@ -582,7 +583,6 @@ pub fn muc_service_features() -> Vec<Feature> {
         Feature::disco_info(),
         Feature::disco_items(),
         Feature::muc(),
-        Feature::muc_self_ping_optimization(),
     ]
 }
 
@@ -596,6 +596,7 @@ pub fn muc_room_features(
     let mut features = vec![
         Feature::disco_info(),
         Feature::muc(),
+        Feature::muc_self_ping_optimization(),
         Feature::mam(),
         Feature::fulltext_mam(),
         Feature::waddle_mam_thread(),
@@ -739,6 +740,17 @@ mod tests {
         assert!(features.contains(&Feature::muc_persistent()));
         assert!(features.contains(&Feature::muc_membersonly()));
         assert!(features.contains(&Feature::muc_unmoderated()));
+        assert!(features.contains(&Feature::muc_self_ping_optimization()));
         assert!(features.contains(&Feature::fulltext_mam()));
+    }
+
+    #[test]
+    fn test_muc_service_features_exclude_xep_0410_feature() {
+        let features = muc_service_features();
+        assert!(!features.contains(&Feature::muc_self_ping_optimization()));
+        assert_eq!(
+            Feature::muc_self_ping_optimization().0,
+            NS_MUC_SELF_PING_OPTIMIZATION
+        );
     }
 }

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -11,6 +11,7 @@ use crate::{
 
 const DATA_FORMS_NS: &str = "jabber:x:data";
 const SERVER_INFO_FORM_TYPE: &str = "urn:xmpp:serverinfo:0";
+const NS_CHATSTATES: &str = "http://jabber.org/protocol/chatstates";
 const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
 const NS_FORUMS: &str = "urn:xmpp:forums:0";
 const NS_MUC_SELF_PING_OPTIMIZATION: &str = "http://jabber.org/protocol/muc#self-ping-optimization";
@@ -129,6 +130,10 @@ impl Feature {
 
     pub fn chat_markers() -> Self {
         Self::new("urn:xmpp:chat-markers:0")
+    }
+
+    pub fn chat_states() -> Self {
+        Self::new(NS_CHATSTATES)
     }
 
     pub fn receipts() -> Self {
@@ -604,6 +609,7 @@ pub fn muc_room_features(
         Feature::replies(),
         Feature::message_correction(),
         Feature::chat_markers(),
+        Feature::chat_states(),
         Feature::message_retraction(),
         Feature::message_moderation(),
         Feature::reactions(),
@@ -742,6 +748,8 @@ mod tests {
         assert!(features.contains(&Feature::muc_unmoderated()));
         assert!(features.contains(&Feature::muc_self_ping_optimization()));
         assert!(features.contains(&Feature::fulltext_mam()));
+        assert!(features.contains(&Feature::chat_states()));
+        assert_eq!(Feature::chat_states().0, NS_CHATSTATES);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -130,6 +130,10 @@ impl Feature {
         Self::new("urn:xmpp:chat-markers:0")
     }
 
+    pub fn receipts() -> Self {
+        Self::new("urn:xmpp:receipts")
+    }
+
     pub fn message_retraction() -> Self {
         Self::new("urn:xmpp:message-retract:1")
     }
@@ -496,6 +500,7 @@ pub fn server_features() -> Vec<Feature> {
         Feature::replies(),
         Feature::message_correction(),
         Feature::chat_markers(),
+        Feature::receipts(),
         Feature::message_retraction(),
         Feature::reactions(),
         Feature::references(),
@@ -722,6 +727,7 @@ mod tests {
         let features = server_features();
         assert!(features.contains(&Feature::disco_info()));
         assert!(features.contains(&Feature::carbons()));
+        assert!(features.contains(&Feature::receipts()));
         assert!(!features.contains(&Feature::fulltext_mam()));
         assert!(features.contains(&Feature::server_info()));
     }

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -51,6 +51,7 @@ const MESSAGE_MODERATE_NS: &str = "urn:xmpp:message-moderate:1";
 const REACTIONS_NS: &str = "urn:xmpp:reactions:0";
 const REFERENCE_NS: &str = "urn:xmpp:reference:0";
 const MENTIONS_NS: &str = "urn:xmpp:mentions:0";
+const XDATA_VALIDATE_NS: &str = "http://jabber.org/protocol/xdata-validate";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RichMessageId(pub String);
@@ -284,9 +285,15 @@ pub struct MamQuery {
     pub fulltext: Option<RichText>,
     /// Maximum results to return.
     pub max: Option<u32>,
-    /// Pagination: before this ID.
+    /// Extended MAM filter: only messages before this archive ID.
+    pub filter_before_id: Option<String>,
+    /// Extended MAM filter: only messages after this archive ID.
+    pub filter_after_id: Option<String>,
+    /// Extended MAM filter: only these archive IDs.
+    pub ids: Vec<String>,
+    /// RSM pagination cursor: before this ID.
     pub before_id: Option<String>,
-    /// Pagination: after this ID.
+    /// RSM pagination cursor: after this ID.
     pub after_id: Option<String>,
 }
 
@@ -393,6 +400,30 @@ pub fn build_query_form_iq(original_iq: &Iq) -> Iq {
         )
         .append(
             Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "before-id")
+                .attr("type", "text-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "after-id")
+                .attr("type", "text-single")
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
+                .attr("var", "ids")
+                .attr("type", "list-multi")
+                .append(
+                    Element::builder("validate", XDATA_VALIDATE_NS)
+                        .attr("datatype", "xs:string")
+                        .append(Element::builder("open", XDATA_VALIDATE_NS).build())
+                        .build(),
+                )
+                .build(),
+        )
+        .append(
+            Element::builder("field", DATA_FORMS_NS)
                 .attr("var", WADDLE_MAM_THREAD_FIELD)
                 .attr("type", "text-single")
                 .build(),
@@ -456,25 +487,39 @@ fn parse_data_form(form: &Element, query: &mut MamQuery) -> CoreResult<()> {
         }
 
         let var = field.attr("var").unwrap_or("");
-        let value = field
+        let values = field
             .children()
-            .find(|c| c.name() == "value")
-            .map(|value| value.text());
+            .filter(|child| child.name() == "value")
+            .map(Element::text)
+            .collect::<Vec<_>>();
+        let value = values.iter().find(|value| !value.is_empty()).cloned();
 
         match var {
             "" | "FORM_TYPE" => {}
             "start" => {
-                if let Some(value) = value.filter(|value| !value.is_empty()) {
+                if let Some(value) = value {
                     query.start = Some(parse_datetime(&value)?);
                 }
             }
             "end" => {
-                if let Some(value) = value.filter(|value| !value.is_empty()) {
+                if let Some(value) = value {
                     query.end = Some(parse_datetime(&value)?);
                 }
             }
             "with" => {
-                query.with = value.filter(|value| !value.is_empty());
+                query.with = value;
+            }
+            "before-id" => {
+                query.filter_before_id = value;
+            }
+            "after-id" => {
+                query.filter_after_id = value;
+            }
+            "ids" => {
+                query.ids = values
+                    .into_iter()
+                    .filter(|value| !value.is_empty())
+                    .collect();
             }
             WADDLE_MAM_THREAD_FIELD => {
                 query.thread_id = value.and_then(ThreadId::new);
@@ -911,6 +956,41 @@ mod tests {
                             )
                             .append(
                                 Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "before-id")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("msg-20")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "after-id")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("msg-2")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
+                                    .attr("var", "ids")
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("msg-5")
+                                            .build(),
+                                    )
+                                    .append(
+                                        Element::builder("value", DATA_FORMS_NS)
+                                            .append("msg-7")
+                                            .build(),
+                                    )
+                                    .build(),
+                            )
+                            .append(
+                                Element::builder("field", DATA_FORMS_NS)
                                     .attr("var", FULLTEXT_MAM_FIELD)
                                     .append(
                                         Element::builder("value", DATA_FORMS_NS)
@@ -936,6 +1016,9 @@ mod tests {
         assert_eq!(query_id, "query-1");
         assert_eq!(query.max, Some(10));
         assert_eq!(query.after_id.as_deref(), Some("msg-9"));
+        assert_eq!(query.filter_before_id.as_deref(), Some("msg-20"));
+        assert_eq!(query.filter_after_id.as_deref(), Some("msg-2"));
+        assert_eq!(query.ids, vec!["msg-5", "msg-7"]);
         assert_eq!(query.with.as_deref(), Some("juliet@example.com"));
         assert_eq!(
             query.fulltext.as_ref().map(RichText::as_str),
@@ -1078,9 +1161,22 @@ mod tests {
         assert!(fields.contains(&"with"));
         assert!(fields.contains(&"start"));
         assert!(fields.contains(&"end"));
+        assert!(fields.contains(&"before-id"));
+        assert!(fields.contains(&"after-id"));
+        assert!(fields.contains(&"ids"));
         assert!(fields.contains(&WADDLE_MAM_THREAD_FIELD));
         assert!(fields.contains(&FULLTEXT_MAM_FIELD));
         assert!(!fields.contains(&"fulltext"));
+
+        let ids_field = form
+            .children()
+            .find(|field| field.attr("var") == Some("ids"))
+            .expect("ids field");
+        let validate = ids_field
+            .get_child("validate", XDATA_VALIDATE_NS)
+            .expect("ids field validate element");
+        assert_eq!(validate.attr("datatype"), Some("xs:string"));
+        assert!(validate.get_child("open", XDATA_VALIDATE_NS).is_some());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
@@ -82,7 +82,7 @@ pub fn pep_features() -> Vec<Feature> {
         Feature::pubsub_retrieve_items(),
         Feature::pubsub_subscribe(),
         Feature::mam(),
-        Feature::new("urn:xmpp:mam:2#extended"),
+        Feature::mam_extended(),
         Feature::new("urn:xmpp:push:0"),
         Feature::new("urn:xmpp:pep-vcard-conversion:0"),
         Feature::bookmarks_compat(),

--- a/server/crates/waddle-xmpp/src/inbox/runtime.rs
+++ b/server/crates/waddle-xmpp/src/inbox/runtime.rs
@@ -5,10 +5,11 @@ use xmpp_parsers::message::Message;
 
 use super::{ConversationKind, InboxEntry};
 use crate::mam::STANZA_ID_NS;
+use crate::xep::xep0424::extract_retraction_from_message;
 use crate::xep::xep0430::InboxQuery;
 use crate::xep::{
     has_file_sharing, is_moderation_request_message, is_moderation_result_message,
-    is_reaction_message, is_retraction_message, is_sticker_message, should_skip_storage,
+    is_reaction_message, is_sticker_message, should_skip_storage,
 };
 
 pub fn should_project_message(msg: &Message) -> bool {
@@ -21,7 +22,10 @@ pub fn should_project_message(msg: &Message) -> bool {
     }
 
     is_reaction_message(msg)
-        || is_retraction_message(msg)
+        || matches!(
+            extract_retraction_from_message(msg),
+            Some(crate::xep::RetractionKind::Request(_))
+        )
         || is_moderation_request_message(msg)
         || is_moderation_result_message(msg)
         || has_file_sharing(msg)
@@ -159,6 +163,19 @@ mod tests {
 
         assert!(should_project_message(&msg));
         assert!(preview_text(&msg).is_none());
+    }
+
+    #[test]
+    fn runtime_skips_inbound_tombstones() {
+        let mut msg = Message::new(Some(jid::Jid::from(jid("bob@example.com"))));
+        msg.payloads.push(
+            minidom::Element::builder("retracted", crate::xep::xep0424::NS_MESSAGE_RETRACT)
+                .attr("id", "retract-1")
+                .attr("stamp", "2024-06-01T09:00:00Z")
+                .build(),
+        );
+
+        assert!(!should_project_message(&msg));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -236,7 +236,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
                 ref_type,
                 begin: reference.begin.and_then(|value| value.try_into().ok()),
                 end: reference.end.and_then(|value| value.try_into().ok()),
-                uri: reference.uri.and_then(RichText::new),
+                uri: RichText::new(reference.uri),
                 anchor: reference.anchor.and_then(RichText::new),
             })
         })

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -198,10 +198,12 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
                     RichMessageId::new(id).map(|target_id| {
                         ArchivedRichPayload::Retraction(ArchivedRetraction {
                             target_id,
-                            stamp: chrono::DateTime::parse_from_rfc3339(&retracted.stamp)
-                                .ok()
+                            stamp: retracted
+                                .stamp
+                                .as_deref()
+                                .and_then(|stamp| chrono::DateTime::parse_from_rfc3339(stamp).ok())
                                 .map(|stamp| stamp.with_timezone(&Utc)),
-                            retraction_id: None,
+                            retraction_id: RichMessageId::new(retracted.retraction_id),
                         })
                     })
                 }),

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -223,10 +223,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
         });
 
     let reply = parse_reply_from_message(message).and_then(|reply| {
-        RichMessageId::new(reply.id).map(|id| ArchivedReply {
-            id,
-            to: reply.to.and_then(|to| to.parse().ok()),
-        })
+        RichMessageId::new(reply.id).map(|id| ArchivedReply { id, to: reply.to })
     });
 
     let references = extract_references_from_message(message)

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -13,6 +13,7 @@ use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
 };
 use sqlx::{Postgres, QueryBuilder, Row, Sqlite};
+use std::collections::HashSet;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -178,6 +179,29 @@ impl MamStorage for InMemoryMamStorage {
             .filter(|(jid, _)| jid == archive_jid)
             .map(|(_, message)| message.clone())
             .collect();
+        let filter_before_cursor = match query.filter_before_id.as_deref() {
+            Some(before_id) => Some(
+                messages
+                    .iter()
+                    .find(|message| message.id == before_id)
+                    .cloned()
+                    .ok_or_else(|| MamStorageError::NotFound(before_id.to_string()))?,
+            ),
+            None => None,
+        };
+        let filter_after_cursor = match query.filter_after_id.as_deref() {
+            Some(after_id) => Some(
+                messages
+                    .iter()
+                    .find(|message| message.id == after_id)
+                    .cloned()
+                    .ok_or_else(|| MamStorageError::NotFound(after_id.to_string()))?,
+            ),
+            None => None,
+        };
+        if let Some(missing_id) = missing_requested_id(&messages, &query.ids) {
+            return Err(MamStorageError::NotFound(missing_id));
+        }
         let before_cursor = match query.before_id.as_deref().filter(|id| !id.is_empty()) {
             Some(before_id) => Some(
                 messages
@@ -209,11 +233,21 @@ impl MamStorage for InMemoryMamStorage {
             messages
                 .retain(|message| message.from.starts_with(with) || message.to.starts_with(with));
         }
+        if !query.ids.is_empty() {
+            let requested_ids = query.ids.iter().map(String::as_str).collect::<HashSet<_>>();
+            messages.retain(|message| requested_ids.contains(message.id.as_str()));
+        }
         if let Some(thread_id) = query.thread_id.as_ref() {
             messages.retain(|message| matches_thread_filter(message, thread_id.as_str()));
         }
         if let Some(fulltext) = query.fulltext.as_ref() {
             messages.retain(|message| matches_fulltext(message.body.as_str(), fulltext.as_str()));
+        }
+        if let Some(cursor) = filter_before_cursor.as_ref() {
+            messages.retain(|message| archive_order_before(message, cursor));
+        }
+        if let Some(cursor) = filter_after_cursor.as_ref() {
+            messages.retain(|message| archive_order_after(message, cursor));
         }
         let count = Some(u32::try_from(messages.len()).unwrap_or(u32::MAX));
 
@@ -634,6 +668,28 @@ fn uses_backward_pagination(query: &MamQuery) -> bool {
     query.before_id.is_some()
 }
 
+fn missing_requested_id_in_set(
+    available_ids: &HashSet<&str>,
+    requested_ids: &[String],
+) -> Option<String> {
+    requested_ids
+        .iter()
+        .find(|id| !available_ids.contains(id.as_str()))
+        .cloned()
+}
+
+fn missing_requested_id(messages: &[ArchivedMessage], requested_ids: &[String]) -> Option<String> {
+    if requested_ids.is_empty() {
+        return None;
+    }
+
+    let available_ids = messages
+        .iter()
+        .map(|message| message.id.as_str())
+        .collect::<HashSet<_>>();
+    missing_requested_id_in_set(&available_ids, requested_ids)
+}
+
 macro_rules! push_common_mam_filters {
     ($builder:expr, $query:expr, $with_filter:expr) => {{
         if let Some(with) = $with_filter {
@@ -643,6 +699,14 @@ macro_rules! push_common_mam_filters {
                 .push(" OR to_jid LIKE ")
                 .push_bind(with)
                 .push(")");
+        }
+        if !$query.ids.is_empty() {
+            $builder.push(" AND id IN (");
+            let mut ids = $builder.separated(", ");
+            for id in &$query.ids {
+                ids.push_bind(id.as_str());
+            }
+            ids.push_unseparated(")");
         }
         if let Some(thread_id) = $query.thread_id.as_ref() {
             $builder
@@ -671,6 +735,8 @@ fn push_sqlite_mam_filters<'args>(
     archive_jid: &'args str,
     query: &'args MamQuery,
     with_filter: Option<&'args str>,
+    filter_before: Option<&'args ArchivedMessage>,
+    filter_after: Option<&'args ArchivedMessage>,
 ) {
     builder.push_bind(archive_jid);
     if let Some(start) = query.start {
@@ -683,6 +749,26 @@ fn push_sqlite_mam_filters<'args>(
             .push(" AND timestamp <= ")
             .push_bind(end.to_rfc3339());
     }
+    if let Some(cursor) = filter_before {
+        builder
+            .push(" AND (timestamp < ")
+            .push_bind(cursor.timestamp.to_rfc3339())
+            .push(" OR (timestamp = ")
+            .push_bind(cursor.timestamp.to_rfc3339())
+            .push(" AND id < ")
+            .push_bind(cursor.id.as_str())
+            .push("))");
+    }
+    if let Some(cursor) = filter_after {
+        builder
+            .push(" AND (timestamp > ")
+            .push_bind(cursor.timestamp.to_rfc3339())
+            .push(" OR (timestamp = ")
+            .push_bind(cursor.timestamp.to_rfc3339())
+            .push(" AND id > ")
+            .push_bind(cursor.id.as_str())
+            .push("))");
+    }
     push_common_mam_filters!(builder, query, with_filter);
 }
 
@@ -691,6 +777,8 @@ fn push_postgres_mam_filters<'args>(
     archive_jid: &'args str,
     query: &'args MamQuery,
     with_filter: Option<&'args str>,
+    filter_before: Option<&'args ArchivedMessage>,
+    filter_after: Option<&'args ArchivedMessage>,
 ) {
     builder.push_bind(archive_jid);
     if let Some(start) = query.start {
@@ -698,6 +786,26 @@ fn push_postgres_mam_filters<'args>(
     }
     if let Some(end) = query.end {
         builder.push(" AND timestamp <= ").push_bind(end);
+    }
+    if let Some(cursor) = filter_before {
+        builder
+            .push(" AND (timestamp < ")
+            .push_bind(cursor.timestamp)
+            .push(" OR (timestamp = ")
+            .push_bind(cursor.timestamp)
+            .push(" AND id < ")
+            .push_bind(cursor.id.as_str())
+            .push("))");
+    }
+    if let Some(cursor) = filter_after {
+        builder
+            .push(" AND (timestamp > ")
+            .push_bind(cursor.timestamp)
+            .push(" OR (timestamp = ")
+            .push_bind(cursor.timestamp)
+            .push(" AND id > ")
+            .push_bind(cursor.id.as_str())
+            .push("))");
     }
     push_common_mam_filters!(builder, query, with_filter);
 }
@@ -736,6 +844,73 @@ async fn fetch_postgres_cursor(
         .map(decode_postgres_message_row)
         .transpose()?
         .ok_or_else(|| MamStorageError::NotFound(cursor_id.to_string()))
+}
+
+async fn ensure_sqlite_requested_ids_exist(
+    pool: &SqlitePool,
+    archive_jid: &str,
+    requested_ids: &[String],
+) -> Result<(), MamStorageError> {
+    if requested_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut builder = QueryBuilder::<Sqlite>::new("SELECT id FROM mam_messages WHERE room_jid = ");
+    builder.push_bind(archive_jid);
+    builder.push(" AND id IN (");
+    let mut ids = builder.separated(", ");
+    for id in requested_ids {
+        ids.push_bind(id.as_str());
+    }
+    ids.push_unseparated(")");
+
+    let available_ids = builder
+        .build_query_scalar::<String>()
+        .fetch_all(pool)
+        .await?;
+    let available_ids = available_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    if let Some(missing_id) = missing_requested_id_in_set(&available_ids, requested_ids) {
+        return Err(MamStorageError::NotFound(missing_id));
+    }
+
+    Ok(())
+}
+
+async fn ensure_postgres_requested_ids_exist(
+    pool: &PgPool,
+    archive_jid: &str,
+    requested_ids: &[String],
+) -> Result<(), MamStorageError> {
+    if requested_ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut builder =
+        QueryBuilder::<Postgres>::new("SELECT id FROM mam_messages WHERE room_jid = ");
+    builder.push_bind(archive_jid);
+    builder.push(" AND id IN (");
+    let mut ids = builder.separated(", ");
+    for id in requested_ids {
+        ids.push_bind(id.as_str());
+    }
+    ids.push_unseparated(")");
+
+    let available_ids = builder
+        .build_query_scalar::<String>()
+        .fetch_all(pool)
+        .await?;
+    let available_ids = available_ids
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    if let Some(missing_id) = missing_requested_id_in_set(&available_ids, requested_ids) {
+        return Err(MamStorageError::NotFound(missing_id));
+    }
+
+    Ok(())
 }
 
 fn finalize_result(
@@ -966,6 +1141,18 @@ impl MamStorage for SqlxMamStorage {
 
         match &self.backend {
             MamDatabaseBackend::Sqlite(pool) => {
+                let filter_before_cursor = match query.filter_before_id.as_deref() {
+                    Some(before_id) => {
+                        Some(fetch_sqlite_cursor(pool, archive_jid, before_id).await?)
+                    }
+                    None => None,
+                };
+                let filter_after_cursor = match query.filter_after_id.as_deref() {
+                    Some(after_id) => Some(fetch_sqlite_cursor(pool, archive_jid, after_id).await?),
+                    None => None,
+                };
+                ensure_sqlite_requested_ids_exist(pool, archive_jid, &query.ids).await?;
+
                 let mut count_builder = QueryBuilder::<Sqlite>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
@@ -974,6 +1161,8 @@ impl MamStorage for SqlxMamStorage {
                     archive_jid,
                     query,
                     with_filter.as_deref(),
+                    filter_before_cursor.as_ref(),
+                    filter_after_cursor.as_ref(),
                 );
                 let count = count_builder
                     .build_query_scalar::<i64>()
@@ -983,7 +1172,14 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Sqlite>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                push_sqlite_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
+                push_sqlite_mam_filters(
+                    &mut builder,
+                    archive_jid,
+                    query,
+                    with_filter.as_deref(),
+                    filter_before_cursor.as_ref(),
+                    filter_after_cursor.as_ref(),
+                );
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     let cursor = fetch_sqlite_cursor(pool, archive_jid, before_id).await?;
                     builder
@@ -1027,6 +1223,20 @@ impl MamStorage for SqlxMamStorage {
                 ))
             }
             MamDatabaseBackend::Postgres(pool) => {
+                let filter_before_cursor = match query.filter_before_id.as_deref() {
+                    Some(before_id) => {
+                        Some(fetch_postgres_cursor(pool, archive_jid, before_id).await?)
+                    }
+                    None => None,
+                };
+                let filter_after_cursor = match query.filter_after_id.as_deref() {
+                    Some(after_id) => {
+                        Some(fetch_postgres_cursor(pool, archive_jid, after_id).await?)
+                    }
+                    None => None,
+                };
+                ensure_postgres_requested_ids_exist(pool, archive_jid, &query.ids).await?;
+
                 let mut count_builder = QueryBuilder::<Postgres>::new(
                     "SELECT COUNT(*) FROM mam_messages WHERE room_jid = ",
                 );
@@ -1035,6 +1245,8 @@ impl MamStorage for SqlxMamStorage {
                     archive_jid,
                     query,
                     with_filter.as_deref(),
+                    filter_before_cursor.as_ref(),
+                    filter_after_cursor.as_ref(),
                 );
                 let count = count_builder
                     .build_query_scalar::<i64>()
@@ -1044,7 +1256,14 @@ impl MamStorage for SqlxMamStorage {
                 let mut builder = QueryBuilder::<Postgres>::new(format!(
                     "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
                 ));
-                push_postgres_mam_filters(&mut builder, archive_jid, query, with_filter.as_deref());
+                push_postgres_mam_filters(
+                    &mut builder,
+                    archive_jid,
+                    query,
+                    with_filter.as_deref(),
+                    filter_before_cursor.as_ref(),
+                    filter_after_cursor.as_ref(),
+                );
                 if let Some(before_id) = query.before_id.as_deref().filter(|id| !id.is_empty()) {
                     let cursor = fetch_postgres_cursor(pool, archive_jid, before_id).await?;
                     builder
@@ -1565,6 +1784,78 @@ mod tests {
         assert_eq!(page.last_id.as_deref(), Some("b-fourth"));
     }
 
+    #[tokio::test]
+    async fn test_sqlite_extended_before_id_filters_without_flipping_order() {
+        let storage = create_test_storage().await;
+        assert_extended_before_id_filters_without_flipping_order(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_extended_before_id_filters_without_flipping_order() {
+        let storage = InMemoryMamStorage::new();
+        assert_extended_before_id_filters_without_flipping_order(&storage).await;
+    }
+
+    async fn assert_extended_before_id_filters_without_flipping_order(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        let base = Utc::now();
+        store_nonlexical_archive_order_messages(storage, archive, base).await;
+
+        let result = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    filter_before_id: Some("x-fifth".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(bodies(&result), vec!["one", "two", "three", "four"]);
+        assert_eq!(result.first_id.as_deref(), Some("z-first"));
+        assert_eq!(result.last_id.as_deref(), Some("b-fourth"));
+        assert_eq!(result.count, Some(4));
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_extended_ids_query_returns_specific_messages() {
+        let storage = create_test_storage().await;
+        assert_extended_ids_query_returns_specific_messages(&storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_inmemory_extended_ids_query_returns_specific_messages() {
+        let storage = InMemoryMamStorage::new();
+        assert_extended_ids_query_returns_specific_messages(&storage).await;
+    }
+
+    async fn assert_extended_ids_query_returns_specific_messages(storage: &dyn MamStorage) {
+        let archive = "room@conference.example.com";
+        let base = Utc::now();
+        store_nonlexical_archive_order_messages(storage, archive, base).await;
+
+        let result = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    ids: vec!["x-fifth".to_string(), "a-second".to_string()],
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let ids: Vec<&str> = result
+            .messages
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a-second", "x-fifth"]);
+        assert_eq!(bodies(&result), vec!["two", "five"]);
+        assert_eq!(result.count, Some(2));
+    }
+
     async fn store_nonlexical_archive_order_messages(
         storage: &dyn MamStorage,
         archive: &str,
@@ -1648,6 +1939,49 @@ mod tests {
             .expect_err("missing before cursor must be an error");
 
         assert!(matches!(error, MamStorageError::NotFound(ref id) if id == "missing-before-id"));
+
+        let error = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    filter_before_id: Some("missing-filter-before-id".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing extended before-id must be an error");
+
+        assert!(
+            matches!(error, MamStorageError::NotFound(ref id) if id == "missing-filter-before-id")
+        );
+
+        let error = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    filter_after_id: Some("missing-filter-after-id".to_string()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing extended after-id must be an error");
+
+        assert!(
+            matches!(error, MamStorageError::NotFound(ref id) if id == "missing-filter-after-id")
+        );
+
+        let error = storage
+            .query_messages(
+                archive,
+                &MamQuery {
+                    ids: vec!["known-id".to_string(), "missing-query-id".to_string()],
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing ids entry must be an error");
+
+        assert!(matches!(error, MamStorageError::NotFound(ref id) if id == "missing-query-id"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
@@ -121,6 +121,7 @@ fn build_ctx<'a>(
         blocklist: bl,
         carbons: CarbonsState::Disabled,
         muc_occupancy: occ,
+        has_live_transport: true,
         id_gen: gen,
     };
     MessageContext::derive(env, msg)

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
@@ -70,6 +70,7 @@ impl Fixture {
             blocklist: &self.blocklist,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &self.occupancy,
+            has_live_transport: true,
             id_gen: &self.id_gen,
         };
         MessageContext::derive(env, message)

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -135,8 +135,10 @@ fn has_substantive_body(message: &Message) -> bool {
 fn has_archivable_payload(message: &Message) -> bool {
     use crate::xep::{xep0308, xep0424};
     xep0308::is_correction_message(message)
-        || xep0424::is_retraction_message(message)
-        || xep0424::is_tombstone_message(message)
+        || matches!(
+            xep0424::extract_retraction_from_message(message),
+            Some(xep0424::RetractionKind::Request(_))
+        )
 }
 
 #[cfg(test)]
@@ -255,6 +257,26 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let archives = extract_archive_events(&outcome);
         assert_eq!(archives.len(), 1);
+    }
+
+    #[test]
+    fn xep_0424_tombstones_are_not_archived_as_inbound_messages() {
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some(jid::Jid::from(bare("bob@example.com"))));
+        msg.from = Some(jid::Jid::from(local.clone()));
+        msg.type_ = MessageType::Chat;
+        msg.payloads.push(
+            Element::builder("retracted", crate::xep::xep0424::NS_MESSAGE_RETRACT)
+                .attr("id", "retract-1")
+                .attr("stamp", "2024-06-01T09:00:00Z")
+                .build(),
+        );
+
+        let outcome = run(&local, &mut msg);
+        assert!(
+            extract_archive_events(&outcome).is_empty(),
+            "archive-side tombstones must not be treated as inbound archivable messages"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -176,6 +176,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/blocking_filter.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/blocking_filter.rs
@@ -132,6 +132,7 @@ mod tests {
             blocklist: bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/canonicalize.rs
@@ -124,6 +124,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
@@ -11,7 +11,8 @@
 //! - `<message type='groupchat'>` MUST NOT be carboned (§6.2).
 //! - `<private xmlns='urn:xmpp:carbons:2'/>` MUST suppress carbons (§6.1).
 //! - XEP-0334 `<no-copy xmlns='urn:xmpp:hints'/>` MUST suppress carbons.
-//! - Body-less messages SHOULD NOT be carboned (`should_copy_message`).
+//! - `type='chat'` messages remain eligible even without a `<body/>` (§6.1).
+//! - Body-less XEP-0085 / XEP-0184 / XEP-0333 payloads remain eligible (§6.1).
 //! - Error stanzas are not carboned.
 //!
 //! Locality / `kind` mapping:
@@ -227,11 +228,23 @@ mod tests {
     // -----------------------------------------------------------------
 
     #[test]
-    fn xep_0280_body_less_message_is_not_carboned() {
+    fn xep_0280_body_less_chat_message_is_carboned() {
         let local = full("alice@example.com/web");
         let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
         msg.from = Some("alice@example.com/web".parse().expect("jid"));
         msg.type_ = MessageType::Chat;
+        let outcome = run(&local, CarbonsState::Enabled, &mut msg);
+        let carbons = extract_carbons(&outcome);
+        assert_eq!(carbons.len(), 1);
+        assert_eq!(carbons[0].1, CarbonKind::Sent);
+    }
+
+    #[test]
+    fn xep_0280_body_less_normal_message_without_im_payload_is_not_carboned() {
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Normal;
         let outcome = run(&local, CarbonsState::Enabled, &mut msg);
         assert!(extract_carbons(&outcome).is_empty());
     }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
@@ -214,14 +214,27 @@ mod tests {
     // -----------------------------------------------------------------
 
     #[test]
-    fn xep_0334_no_copy_hint_suppresses_carbons() {
+    fn xep_0334_no_copy_hint_suppresses_carbons_for_full_jid_targets() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com/phone", "shh");
+        msg.payloads.push(
+            Element::builder(Hint::NoCopy.element_name(), crate::xep::xep0334::NS_HINTS).build(),
+        );
+        let outcome = run(&local, CarbonsState::Enabled, &mut msg);
+        assert!(extract_carbons(&outcome).is_empty());
+    }
+
+    #[test]
+    fn xep_0334_no_copy_hint_does_not_override_bare_jid_routing() {
         let local = full("alice@example.com/web");
         let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "shh");
         msg.payloads.push(
             Element::builder(Hint::NoCopy.element_name(), crate::xep::xep0334::NS_HINTS).build(),
         );
         let outcome = run(&local, CarbonsState::Enabled, &mut msg);
-        assert!(extract_carbons(&outcome).is_empty());
+        let carbons = extract_carbons(&outcome);
+        assert_eq!(carbons.len(), 1);
+        assert_eq!(carbons[0].1, CarbonKind::Sent);
     }
 
     // -----------------------------------------------------------------

--- a/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
@@ -116,6 +116,7 @@ mod tests {
             blocklist: &bl,
             carbons,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/enrichment_dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/enrichment_dispatch.rs
@@ -160,6 +160,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
@@ -179,6 +179,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/mod.rs
@@ -33,6 +33,7 @@ pub mod enrichment_dispatch;
 pub mod errors;
 pub mod inbox;
 pub mod ping;
+pub mod receipts;
 pub mod rich_target_validation;
 pub mod route;
 pub mod session;
@@ -80,9 +81,12 @@ pub fn register_default_handlers(dispatcher: &mut StanzaDispatcher) {
 ///    user.
 /// 7. [`inbox::InboxHandler`] — project the conversation into the
 ///    Waddle inbox.
-/// 8. [`route::RouteHandler`] — final stage: route 1:1 to the
-///    destination connection, dispatch groupchat to the room chain,
-///    or write to the local wire on the recipient pass.
+/// 8. [`route::RouteHandler`] — final stage for the content stanza:
+///    route 1:1 to the destination connection, dispatch groupchat to
+///    the room chain, or write to the local wire on the recipient pass.
+/// 9. [`receipts::ReceiptsHandler`] (XEP-0184) — after the content
+///    stanza is queued for delivery, emit a separate receipt route for
+///    eligible direct messages that requested one.
 pub fn register_default_message_handlers(dispatcher: &mut StanzaDispatcher) {
     dispatcher.register_message(Arc::new(blocking_filter::BlockingFilterHandler));
     dispatcher.register_message(Arc::new(
@@ -94,6 +98,7 @@ pub fn register_default_message_handlers(dispatcher: &mut StanzaDispatcher) {
     dispatcher.register_message(Arc::new(carbons_message::CarbonsMessageHandler));
     dispatcher.register_message(Arc::new(inbox::InboxHandler));
     dispatcher.register_message(Arc::new(route::RouteHandler));
+    dispatcher.register_message(Arc::new(receipts::ReceiptsHandler));
 }
 
 /// Build an empty `type="result"` IQ with `from`/`to` swapped relative to

--- a/server/crates/waddle-xmpp/src/protocol/handlers/ping.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/ping.rs
@@ -1,7 +1,7 @@
 //! XEP-0199 — XMPP Ping.
 //!
-//! The simplest possible handler: takes a `<ping>` IQ-get, emits the
-//! corresponding IQ-result with swapped `to`/`from` addresses.
+//! Validates incoming ping IQs and emits either a conformant pong reply
+//! or a typed `<bad-request/>` error for malformed requests.
 
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::traits::IqHandler;
@@ -18,9 +18,14 @@ impl IqHandler for PingHandler {
         xep0199::NS_PING
     }
 
-    fn handle(&self, iq: &Iq, _ctx: &StanzaContext<'_>) -> Vec<OutboundEvent> {
-        let result = xep0199::build_ping_result(iq);
-        vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(result)))]
+    fn handle(&self, iq: &Iq, ctx: &StanzaContext<'_>) -> Vec<OutboundEvent> {
+        let session_bare = ctx.full_jid.to_bare();
+        let reply = if xep0199::is_ping(iq) {
+            xep0199::build_ping_result(iq, ctx.domain, &session_bare)
+        } else {
+            xep0199::build_ping_bad_request(iq, ctx.domain, &session_bare)
+        };
+        vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(reply)))]
     }
 }
 
@@ -29,6 +34,7 @@ mod tests {
     use super::*;
     use minidom::Element;
     use xmpp_parsers::iq::{Iq, IqType};
+    use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType};
 
     fn test_ctx_jid() -> jid::FullJid {
         "alice@waddle.social/web".parse().expect("valid test JID")
@@ -70,6 +76,84 @@ mod tests {
                         reply.to.as_ref().map(|j| j.to_string()),
                         Some("alice@waddle.social/web".to_string())
                     );
+                }
+                other => panic!("expected Iq stanza, got {other:?}"),
+            },
+            other => panic!("expected SendStanza, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ping_without_to_uses_server_domain_in_result() {
+        let ping_elem = Element::builder("ping", xep0199::NS_PING).build();
+        let iq = Iq {
+            from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+            to: None,
+            id: "p2".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let jid = test_ctx_jid();
+        let ctx = StanzaContext {
+            domain: "waddle.social",
+            full_jid: &jid,
+        };
+
+        let events = PingHandler.handle(&iq, &ctx);
+
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => {
+                    assert_eq!(
+                        reply.from.as_ref().map(|j| j.to_string()),
+                        Some("waddle.social".into())
+                    );
+                    assert_eq!(
+                        reply.to.as_ref().map(|j| j.to_string()),
+                        Some("alice@waddle.social/web".into())
+                    );
+                    assert!(matches!(reply.payload, IqType::Result(_)));
+                }
+                other => panic!("expected Iq stanza, got {other:?}"),
+            },
+            other => panic!("expected SendStanza, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_ping_produces_bad_request_error() {
+        let ping_elem = Element::builder("ping", xep0199::NS_PING)
+            .append(Element::builder("extra", xep0199::NS_PING).build())
+            .build();
+        let iq = Iq {
+            from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+            to: None,
+            id: "p3".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let jid = test_ctx_jid();
+        let ctx = StanzaContext {
+            domain: "waddle.social",
+            full_jid: &jid,
+        };
+
+        let events = PingHandler.handle(&iq, &ctx);
+
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                Stanza::Iq(reply) => {
+                    assert_eq!(
+                        reply.from.as_ref().map(|j| j.to_string()),
+                        Some("waddle.social".into())
+                    );
+                    assert_eq!(
+                        reply.to.as_ref().map(|j| j.to_string()),
+                        Some("alice@waddle.social/web".into())
+                    );
+                    let IqType::Error(error) = &reply.payload else {
+                        panic!("expected error reply")
+                    };
+                    assert_eq!(error.type_, ErrorType::Modify);
+                    assert_eq!(error.defined_condition, DefinedCondition::BadRequest);
                 }
                 other => panic!("expected Iq stanza, got {other:?}"),
             },

--- a/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
@@ -1,0 +1,147 @@
+//! XEP-0184: Message Delivery Receipts — recipient-pass acknowledgements.
+//!
+//! XEP-0184 §5 says the recipient generates an ack message only for a
+//! content message that requested a receipt, and XEP-0184 §4 says entities
+//! MUST NOT include `<request/>` in an ack message. Waddle therefore emits
+//! receipts only on the live recipient pass for direct `chat`/`normal`/
+//! `headline` messages that carry `<request/>` and a non-empty `id`.
+//!
+//! The handler is deliberately registered **after** [`super::route::RouteHandler`]
+//! so the original content stanza's `SendStanza` is queued before the receipt's
+//! `RouteToConnection`, avoiding an ack being processed ahead of the content.
+//! Headless offline-recipient passes are excluded because they persist/archive
+//! on behalf of an offline user but do not represent delivery to a live client.
+
+use crate::protocol::event::OutboundEvent;
+use crate::protocol::message_context::MessageContext;
+use crate::protocol::session_state::Locality;
+use crate::protocol::traits::{HandlerOutcome, MessageHandler};
+use crate::xep::xep0184::{build_receipt_message, has_receipt_received, has_receipt_request};
+use crate::Stanza;
+use jid::Jid;
+use xmpp_parsers::message::{Message, MessageType};
+
+/// Recipient-pass XEP-0184 receipt emitter.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReceiptsHandler;
+
+impl MessageHandler for ReceiptsHandler {
+    fn name(&self) -> &'static str {
+        "xep-0184-receipts"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &MessageContext<'_>) -> HandlerOutcome {
+        if ctx.locality != Locality::Recipient
+            || !ctx.has_live_transport
+            || !is_receipt_eligible(message)
+        {
+            return HandlerOutcome::Continue(Vec::new());
+        }
+
+        let Some(original_id) = message.id.as_deref().filter(|id| !id.is_empty()) else {
+            return HandlerOutcome::Continue(Vec::new());
+        };
+        let Some(target) = message.from.clone() else {
+            return HandlerOutcome::Continue(Vec::new());
+        };
+
+        let mut receipt = build_receipt_message(
+            Some(target.clone()),
+            Some(Jid::from(ctx.full_jid.clone())),
+            original_id,
+        );
+        receipt.type_ = message.type_.clone();
+
+        HandlerOutcome::Continue(vec![OutboundEvent::RouteToConnection {
+            jid: target,
+            stanza: Box::new(Stanza::Message(receipt)),
+        }])
+    }
+}
+
+fn is_receipt_eligible(message: &Message) -> bool {
+    matches!(
+        message.type_,
+        MessageType::Chat | MessageType::Normal | MessageType::Headline
+    ) && has_receipt_request(message)
+        && !has_receipt_received(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::message_context::MessageContextEnv;
+    use crate::protocol::session_state::{Blocklist, CarbonsState, MucOccupancy};
+    use crate::xep::xep0184::extract_received_id;
+    use jid::FullJid;
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn receipt_request_message() -> Message {
+        let mut message = Message::new(Some("bob@example.com".parse().expect("jid")));
+        message.from = Some("alice@example.com/web".parse().expect("jid"));
+        message.type_ = MessageType::Chat;
+        message.id = Some("msg-1".to_string());
+        message
+            .payloads
+            .push(crate::xep::xep0184::build_receipt_request_element());
+        message
+    }
+
+    fn run(local: &FullJid, has_live_transport: bool, message: &mut Message) -> HandlerOutcome {
+        let blocklist = Blocklist::empty();
+        let occupancy = MucOccupancy::empty();
+        let id_gen = FixedIdGenerator("id".to_string());
+        let env = MessageContextEnv {
+            domain: "example.com",
+            full_jid: local,
+            blocklist: &blocklist,
+            carbons: CarbonsState::Disabled,
+            muc_occupancy: &occupancy,
+            has_live_transport,
+            id_gen: &id_gen,
+        };
+        let mut ctx = MessageContext::derive(env, message);
+        ctx.locality = Locality::Recipient;
+        ReceiptsHandler.handle(message, &ctx)
+    }
+
+    #[test]
+    fn xep_0184_live_recipient_pass_routes_receipt() {
+        let local = full("bob@example.com/desk");
+        let mut message = receipt_request_message();
+
+        let outcome = run(&local, true, &mut message);
+        let events = match outcome {
+            HandlerOutcome::Continue(events) => events,
+            other => panic!("expected Continue, got {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            OutboundEvent::RouteToConnection { jid, stanza } => {
+                assert_eq!(jid.to_string(), "alice@example.com/web");
+                let Stanza::Message(receipt) = stanza.as_ref() else {
+                    panic!("expected receipt message")
+                };
+                assert_eq!(
+                    receipt.from.as_ref().map(ToString::to_string),
+                    Some(local.to_string())
+                );
+                assert_eq!(extract_received_id(receipt), Some("msg-1".to_string()));
+            }
+            other => panic!("expected RouteToConnection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xep_0184_headless_recipient_pass_does_not_route_receipt() {
+        let local = full("bob@example.com/custom");
+        let mut message = receipt_request_message();
+
+        let outcome = run(&local, false, &mut message);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref events) if events.is_empty()));
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -416,7 +416,7 @@ mod tests {
         let local = full("alice@example.com/web");
         let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "agreed");
         msg.payloads.push(build_reply_element(
-            &ReplyReference::new("stanza-Y").with_to("bob@example.com"),
+            &ReplyReference::new("stanza-Y").with_to("bob@example.com".parse().expect("valid jid")),
         ));
 
         let outcome = run(&local, &mut msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -116,6 +116,15 @@ impl MessageHandler for RichTargetValidationHandler {
         if matches!(message.type_, MessageType::Groupchat) {
             return HandlerOutcome::Continue(Vec::new());
         }
+        if let Err(xep0308::CorrectionError::MissingId) =
+            xep0308::parse_correction_from_message(message)
+        {
+            let reply = bad_request_reply(
+                message,
+                "Message correction payload is missing the required id attribute.",
+            );
+            return HandlerOutcome::Halt(vec![send_message_error(reply)]);
+        }
         let Some(detected) = detect(message, ctx) else {
             return HandlerOutcome::Continue(Vec::new());
         };
@@ -389,6 +398,35 @@ mod tests {
             }
             other => panic!("expected OriginId ref, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn xep_0308_malformed_correction_emits_bad_request() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "fixed text");
+        msg.payloads
+            .push(xmpp_parsers::message_correct::Replace { id: String::new() }.into());
+
+        let outcome = run(&local, &mut msg);
+        let parsed = extract_error_payload(&outcome);
+        assert_eq!(parsed.type_, ErrorType::Modify);
+        assert_eq!(parsed.defined_condition, DefinedCondition::BadRequest);
+    }
+
+    #[test]
+    fn xep_0308_malformed_groupchat_correction_is_skipped_user_side() {
+        let local = full("alice@example.com/web");
+        let mut msg = chat_with_body(
+            "alice@example.com/web",
+            "room@conf.example.com",
+            "fixed text",
+        );
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads
+            .push(xmpp_parsers::message_correct::Replace { id: String::new() }.into());
+
+        let outcome = run(&local, &mut msg);
+        assert!(matches!(outcome, HandlerOutcome::Continue(ref e) if e.is_empty()));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -303,6 +303,7 @@ mod tests {
             blocklist: bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: occ,
+            has_live_transport: true,
             id_gen: gen,
         };
         MessageContext::derive(env, msg)

--- a/server/crates/waddle-xmpp/src/protocol/handlers/route.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/route.rs
@@ -142,6 +142,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Disabled,
             muc_occupancy: occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/time.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/time.rs
@@ -2,7 +2,7 @@
 
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::traits::IqHandler;
-use crate::xep::xep0202::{build_time_response_utc, NS_TIME};
+use crate::xep::xep0202::{build_current_time_response, NS_TIME};
 use crate::Stanza;
 use xmpp_parsers::iq::Iq;
 
@@ -17,7 +17,7 @@ impl IqHandler for TimeHandler {
 
     fn handle(&self, iq: &Iq, _ctx: &StanzaContext<'_>) -> Vec<OutboundEvent> {
         vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(
-            build_time_response_utc(iq),
+            build_current_time_response(iq),
         )))]
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/version.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/version.rs
@@ -1,9 +1,10 @@
 //! XEP-0092 — Software Version.
 //!
-//! Responds with the git commit SHA and optional host OS so clients can display
-//! deployment state. The SHA is read at runtime from the `WADDLE_GIT_SHA`
-//! environment variable (set by the deployment environment); local runs fall
-//! back to the Cargo package version.
+//! Responds with the git commit SHA while omitting the optional operating-system
+//! field, which keeps the server compliant with XEP-0092's OS privacy guidance.
+//! The SHA is read at runtime from the `WADDLE_GIT_SHA` environment variable
+//! (set by the deployment environment); local runs fall back to the Cargo
+//! package version.
 
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::traits::IqHandler;
@@ -46,7 +47,7 @@ impl IqHandler for VersionHandler {
         let info = SoftwareVersion {
             name: "Waddle".to_string(),
             version,
-            os: include_os_version().then(|| std::env::consts::OS.to_string()),
+            os: None,
         };
         vec![send_iq(build_version_response(iq, &info))]
     }
@@ -71,13 +72,6 @@ fn server_version() -> String {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
-}
-
-fn include_os_version() -> bool {
-    std::env::var("WADDLE_XMPP_VERSION_INCLUDE_OS")
-        .map(|value| value.trim().eq_ignore_ascii_case("false"))
-        .map(|disabled| !disabled)
-        .unwrap_or(true)
 }
 
 #[cfg(test)]
@@ -114,11 +108,8 @@ mod tests {
         }
     }
 
-    fn capture_version_env() -> (EnvGuard, EnvGuard) {
-        (
-            EnvGuard::capture("WADDLE_GIT_SHA"),
-            EnvGuard::capture("WADDLE_XMPP_VERSION_INCLUDE_OS"),
-        )
+    fn capture_version_env() -> EnvGuard {
+        EnvGuard::capture("WADDLE_GIT_SHA")
     }
 
     fn test_ctx_jid() -> jid::FullJid {
@@ -141,12 +132,10 @@ mod tests {
     }
 
     #[test]
-    fn version_query_produces_result_with_name_version_and_os() {
+    fn version_query_produces_result_without_os() {
         let _guard = ENV_LOCK.lock().unwrap();
         let _env = capture_version_env();
-        // Inject a known SHA so the assertion is precise.
         std::env::set_var("WADDLE_GIT_SHA", "  deadbeef1234567890abcdef  ");
-        std::env::remove_var("WADDLE_XMPP_VERSION_INCLUDE_OS");
 
         let query = Element::builder("query", NS_VERSION).build();
         let iq = Iq {
@@ -184,7 +173,7 @@ mod tests {
                     assert!(payload.get_child("name", NS_VERSION).is_some());
                     let version = payload.get_child("version", NS_VERSION).expect("version");
                     assert_eq!(version.text(), "deadbeef1234567890abcdef");
-                    assert!(payload.get_child("os", NS_VERSION).is_some());
+                    assert!(payload.get_child("os", NS_VERSION).is_none());
                 }
                 other => panic!("expected Iq stanza, got {other:?}"),
             },
@@ -197,7 +186,6 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         let _env = capture_version_env();
         std::env::remove_var("WADDLE_GIT_SHA");
-        std::env::remove_var("WADDLE_XMPP_VERSION_INCLUDE_OS");
 
         let query = Element::builder("query", NS_VERSION).build();
         let iq = Iq {
@@ -223,42 +211,6 @@ mod tests {
                     };
                     let version = payload.get_child("version", NS_VERSION).expect("version");
                     assert_eq!(version.text(), env!("CARGO_PKG_VERSION"));
-                }
-                other => panic!("expected Iq stanza, got {other:?}"),
-            },
-            other => panic!("expected SendStanza, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn version_query_omits_os_when_disabled() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let _env = capture_version_env();
-        std::env::set_var("WADDLE_GIT_SHA", "deadbeef1234567890abcdef");
-        std::env::set_var("WADDLE_XMPP_VERSION_INCLUDE_OS", "false");
-
-        let query = Element::builder("query", NS_VERSION).build();
-        let iq = Iq {
-            from: Some("alice@waddle.social/web".parse().expect("valid jid")),
-            to: Some("waddle.social".parse().expect("valid jid")),
-            id: "v3".to_string(),
-            payload: IqType::Get(query),
-        };
-        let jid = test_ctx_jid();
-        let ctx = StanzaContext {
-            domain: "waddle.social",
-            full_jid: &jid,
-        };
-
-        let events = VersionHandler.handle(&iq, &ctx);
-
-        match &events[0] {
-            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
-                Stanza::Iq(reply) => {
-                    let IqType::Result(Some(payload)) = &reply.payload else {
-                        panic!("expected version result payload");
-                    };
-                    assert!(payload.get_child("os", NS_VERSION).is_none());
                 }
                 other => panic!("expected Iq stanza, got {other:?}"),
             },

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -162,6 +162,10 @@ pub struct XmppStateMachine {
     /// handler; read by `RouteHandler`'s groupchat branch via
     /// [`MessageContext`].
     muc_occupancy: MucOccupancy,
+    /// Whether this state machine currently represents a live client
+    /// transport. Headless offline-recipient passes flip this to `false`
+    /// so delivery-only XEPs do not fire.
+    has_live_transport: bool,
     /// Source of fresh, opaque XEP-0359 stanza-ids stamped by message
     /// handlers. Defaults to UUIDv4; tests can override.
     id_gen: Arc<dyn IdGenerator>,
@@ -192,6 +196,7 @@ impl XmppStateMachine {
             blocklist: Blocklist::empty(),
             carbons: CarbonsState::Disabled,
             muc_occupancy: MucOccupancy::empty(),
+            has_live_transport: true,
             id_gen,
         }
     }
@@ -258,6 +263,12 @@ impl XmppStateMachine {
     pub fn transition_to_closing(&mut self) {
         let bound = self.phase.bound_jid().cloned();
         self.phase = ConnectionPhase::closing(bound);
+    }
+
+    /// Mark whether this machine currently represents a live client
+    /// transport.
+    pub fn set_has_live_transport(&mut self, has_live_transport: bool) {
+        self.has_live_transport = has_live_transport;
     }
 
     /// Replace the per-connection XEP-0191 blocklist snapshot.
@@ -583,6 +594,7 @@ impl XmppStateMachine {
                         blocklist: &self.blocklist,
                         carbons: self.carbons,
                         muc_occupancy: &self.muc_occupancy,
+                        has_live_transport: self.has_live_transport,
                         id_gen: self.id_gen.as_ref(),
                     };
                     let mctx = MessageContext::derive(env, &message);
@@ -712,6 +724,7 @@ impl XmppStateMachine {
                 blocklist: &snapshot.blocklist,
                 carbons: snapshot.carbons,
                 muc_occupancy: &snapshot.muc_occupancy,
+                has_live_transport: self.has_live_transport,
                 id_gen: self.id_gen.as_ref(),
             };
             let mctx = MessageContext::derive(env, &message);
@@ -760,6 +773,7 @@ impl XmppStateMachine {
                         blocklist: &self.blocklist,
                         carbons: self.carbons,
                         muc_occupancy: &self.muc_occupancy,
+                        has_live_transport: self.has_live_transport,
                         id_gen: self.id_gen.as_ref(),
                     };
                     // Peer stanzas are by definition recipient-pass —
@@ -856,6 +870,7 @@ fn infer_resume_kind(
                         blocklist: &blocklist,
                         carbons: CarbonsState::Disabled,
                         muc_occupancy: &muc_occupancy,
+                        has_live_transport: true,
                         id_gen: &id_gen,
                     },
                 )?;
@@ -930,6 +945,7 @@ pub(crate) mod test_support {
             blocklist: Blocklist::empty(),
             carbons: CarbonsState::Disabled,
             muc_occupancy: MucOccupancy::empty(),
+            has_live_transport: true,
             id_gen,
         }
     }

--- a/server/crates/waddle-xmpp/src/protocol/message_context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/message_context.rs
@@ -41,6 +41,8 @@ pub struct MessageContext<'a> {
     pub carbons: CarbonsState,
     /// Snapshot of the local connection's XEP-0045 occupancy.
     pub muc_occupancy: &'a MucOccupancy,
+    /// Whether this dispatch represents a live client transport.
+    pub has_live_transport: bool,
     /// Source of fresh, opaque XEP-0359 stanza-id values.
     pub id_gen: &'a dyn IdGenerator,
 }
@@ -56,6 +58,7 @@ impl<'a> MessageContext<'a> {
             blocklist: env.blocklist,
             carbons: env.carbons,
             muc_occupancy: env.muc_occupancy,
+            has_live_transport: env.has_live_transport,
             id_gen: env.id_gen,
         }
     }
@@ -79,6 +82,8 @@ pub struct MessageContextEnv<'a> {
     pub carbons: CarbonsState,
     /// Snapshot of the local connection's XEP-0045 occupancy.
     pub muc_occupancy: &'a MucOccupancy,
+    /// Whether this dispatch represents a live client transport.
+    pub has_live_transport: bool,
     /// Source of fresh, opaque XEP-0359 stanza-id values.
     pub id_gen: &'a dyn IdGenerator,
 }
@@ -106,6 +111,7 @@ mod tests {
             blocklist: &bl,
             carbons: CarbonsState::Enabled,
             muc_occupancy: &occ,
+            has_live_transport: true,
             id_gen: &gen,
         };
 

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -35,6 +35,10 @@ pub mod room;
 pub mod session_state;
 pub mod traits;
 
+/// Synthetic resource used by the offline headless recipient pass in
+/// `waddle-server`.
+pub const HEADLESS_RECIPIENT_RESOURCE: &str = "offline-recipient-pass";
+
 #[cfg(test)]
 mod dispatch_message_l2_tests;
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -22,8 +22,7 @@ use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::xep::xep0424::{extract_retraction_from_message, RetractionKind};
 use crate::xep::{
     extract_forum_action, has_file_sharing, is_moderation_request_message,
-    is_moderation_result_message, is_reaction_message, is_retraction_message, is_sticker_message,
-    should_skip_storage,
+    is_moderation_result_message, is_reaction_message, is_sticker_message, should_skip_storage,
 };
 use waddle_xmpp_core::xep0201::{thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS};
 use xmpp_parsers::message::{Message, MessageType};
@@ -78,7 +77,10 @@ pub fn is_archivable(message: &Message) -> bool {
         return true;
     }
     is_reaction_message(message)
-        || is_retraction_message(message)
+        || matches!(
+            extract_retraction_from_message(message),
+            Some(RetractionKind::Request(_))
+        )
         || is_moderation_request_message(message)
         || is_moderation_result_message(message)
         || thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS).is_some()
@@ -188,6 +190,27 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
             "bodyless protocol-event-less message is not archived"
+        );
+    }
+
+    #[test]
+    fn xep_0424_skips_inbound_groupchat_tombstones() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        msg.payloads.push(
+            Element::builder("retracted", crate::xep::xep0424::NS_MESSAGE_RETRACT)
+                .attr("id", "retract-1")
+                .attr("stamp", "2024-06-01T09:00:00Z")
+                .build(),
+        );
+
+        let events = run(&room, &sender, &mut msg);
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "archive-side tombstones must not be treated as inbound groupchat messages"
         );
     }
 

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -13,8 +13,8 @@
 //!   sets via `<set>` elements with max, after, before, index, first, last, count.
 //! - **XEP-0085**: Chat State Notifications - Typing indicators and
 //!   conversational state (active, composing, paused, inactive, gone).
-//! - **XEP-0092**: Software Version - Name, package version, and host OS
-//!   reported via `jabber:iq:version`.
+//! - **XEP-0092**: Software Version - Name and package version reported via
+//!   `jabber:iq:version`, with the optional OS field omitted by default.
 //! - **XEP-0184**: Message Delivery Receipts - Request and acknowledge
 //!   message delivery with `<request/>` and `<received/>` elements.
 //! - **XEP-0106**: JID Escaping - Escape/unescape special characters

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -336,8 +336,9 @@ pub use xep0297::{
 
 pub use xep0308::{
     build_correction_message, build_replace_element, extract_correction_from_message,
-    extract_replaces_id, is_correction_message, is_replace_element, set_correction,
-    strip_correction, Correction, CorrectionCarrier, CorrectionError, NS_MESSAGE_CORRECT,
+    extract_replaces_id, is_correction_message, is_replace_element, parse_correction_from_message,
+    set_correction, strip_correction, Correction, CorrectionCarrier, CorrectionError,
+    NS_MESSAGE_CORRECT,
 };
 
 pub use xep0317::{

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -240,7 +240,8 @@ pub use xep0077::{
 };
 
 pub use xep0115::{
-    build_caps_element, build_waddle_caps_element, compute_caps_hash, ensure_caps_payload,
+    build_caps_element, build_caps_element_with_extensions, build_waddle_caps_element,
+    compute_caps_hash, compute_caps_hash_with_extensions, ensure_caps_payload,
     extract_caps_from_presence, is_caps_node_query, parse_caps_node, CachedDiscoInfo, Caps,
     CapsCache, NS_CAPS, WADDLE_CAPS_NODE,
 };

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -37,8 +37,8 @@
 //!   MUC occupants via `<hats/>` in presence, with well-known URIs.
 //! - **XEP-0319**: Last User Interaction in Presence - Idle detection
 //!   via `<idle since='...'/>` in presence stanzas.
-//! - **XEP-0333**: Displayed Markers - Read receipts via `<markable/>`,
-//!   `<displayed/>`, `<received/>`, and `<acknowledged/>` elements.
+//! - **XEP-0333**: Displayed Markers - `<markable/>` requests and
+//!   `<displayed/>` updates for messages that have been shown.
 //! - **XEP-0372**: References - Structured @mentions and data references
 //!   via `<reference/>` elements with type, position, and URI.
 //! - **XEP-0377**: Spam Reporting - Abuse/spam reports with reasons
@@ -350,10 +350,9 @@ pub use xep0319::{
 };
 
 pub use xep0333::{
-    add_markable, build_acknowledged_element, build_displayed_element, build_displayed_message,
-    build_markable_element, build_received_element, extract_marker_from_message, extract_marker_id,
-    has_markable, has_marker, is_marker_element, is_standalone_marker, strip_markers, Marker,
-    MarkerCarrier, MarkerError, NS_CHAT_MARKERS,
+    add_markable, build_displayed_element, build_displayed_message, build_markable_element,
+    extract_marker_from_message, extract_marker_id, has_markable, has_marker, is_marker_element,
+    is_standalone_marker, strip_markers, Marker, MarkerCarrier, MarkerError, NS_CHAT_MARKERS,
 };
 
 pub use xep0334::{

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -308,7 +308,8 @@ pub use xep0172::{
 };
 
 pub use xep0202::{
-    build_time_response, build_time_response_utc, is_time_query, parse_time_response, NS_TIME,
+    build_current_time_response, build_time_response, is_time_query, parse_time_response,
+    EntityTime, NS_TIME,
 };
 
 pub use xep0203::{

--- a/server/crates/waddle-xmpp/src/xep/xep0085.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0085.rs
@@ -31,9 +31,10 @@
 //!
 //! ## Service Discovery
 //!
-//! Per the specification, entities advertise support via `http://jabber.org/protocol/chatstates`
-//! in disco#info. The *server* does not advertise this feature; it is a client-to-client
-//! negotiation. The server transparently routes chat state notifications.
+//! Per the specification, entities advertise support via
+//! `http://jabber.org/protocol/chatstates` in disco#info. Waddle does not
+//! advertise chat states as a global server feature, but MUC rooms that
+//! rebroadcast groupchat chat state notifications do advertise the feature.
 
 use minidom::Element;
 use thiserror::Error;

--- a/server/crates/waddle-xmpp/src/xep/xep0092.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0092.rs
@@ -1,8 +1,9 @@
 //! XEP-0092: Software Version
 //!
 //! Allows clients to query the server (or any entity) for its software
-//! name, version, and host operating system. Waddle reports the package version
-//! here so cache keys do not depend on per-commit build metadata.
+//! name and version, with optional operating-system disclosure. Waddle keeps
+//! the helper generic, while the server omits OS details by default so cache
+//! keys do not depend on per-commit build metadata.
 //!
 //! ## XML Format
 //!
@@ -19,7 +20,6 @@
 //!   <query xmlns='jabber:iq:version'>
 //!     <name>Waddle</name>
 //!     <version>0.1.0</version>
-//!     <os>Linux</os>
 //!   </query>
 //! </iq>
 //! ```

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -29,6 +29,9 @@ pub const NS_CAPS: &str = "http://jabber.org/protocol/caps";
 /// Default node for Waddle's capabilities.
 pub const WADDLE_CAPS_NODE: &str = "https://waddle.social/caps";
 
+const DATA_FORMS_NS: &str = "jabber:x:data";
+const FORM_TYPE_FIELD: &str = "FORM_TYPE";
+
 /// Entity Capabilities element (`<c xmlns='http://jabber.org/protocol/caps'>`).
 ///
 /// Included in presence stanzas to advertise capabilities via a hash.
@@ -164,12 +167,24 @@ impl CapsCache {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CapsDataForm {
+    form_type: String,
+    fields: Vec<CapsDataField>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CapsDataField {
+    var: String,
+    values: Vec<String>,
+}
+
 /// Compute the capabilities verification string per XEP-0115 Section 5.
 ///
 /// The verification string is computed as:
 /// 1. Sort identities by category/type/lang/name
 /// 2. Sort features alphabetically
-/// 3. Concatenate in a specific format with '<' delimiters
+/// 3. Sort XEP-0128 data forms by FORM_TYPE and append their fields/values
 /// 4. Hash with SHA-1
 /// 5. Base64 encode
 ///
@@ -185,41 +200,60 @@ impl CapsCache {
 /// ## Example
 ///
 /// ```
-/// use waddle_xmpp::disco::info::{Identity, Feature};
+/// use waddle_xmpp::disco::info::{Feature, Identity};
 /// use waddle_xmpp::xep::xep0115::compute_caps_hash;
 ///
 /// let identities = vec![Identity::server(Some("Test Server"))];
-/// let features = vec![
-///     Feature::disco_info(),
-///     Feature::disco_items(),
-/// ];
+/// let features = vec![Feature::disco_info(), Feature::disco_items()];
 /// let hash = compute_caps_hash(&identities, &features);
 /// ```
 pub fn compute_caps_hash(identities: &[Identity], features: &[Feature]) -> String {
-    let verification_string = build_verification_string(identities, features);
+    compute_caps_hash_with_extensions(identities, features, &[])
+}
+
+/// Compute the capabilities verification string including XEP-0128 disco forms.
+pub fn compute_caps_hash_with_extensions(
+    identities: &[Identity],
+    features: &[Feature],
+    extensions: &[Element],
+) -> String {
+    let verification_string =
+        build_verification_string_with_extensions(identities, features, extensions);
     hash_verification_string(&verification_string)
 }
 
-/// Build the verification string from identities and features.
-///
-/// Per XEP-0115 Section 5.1:
-/// 1. For each identity: "category/type/lang/name<"
-/// 2. For each feature: "feature<"
-/// 3. (Extensions omitted for simplicity - add when needed)
-fn build_verification_string(identities: &[Identity], features: &[Feature]) -> String {
+/// Build the verification string from identities, features, and XEP-0128 forms.
+fn build_verification_string_with_extensions(
+    identities: &[Identity],
+    features: &[Feature],
+    extensions: &[Element],
+) -> String {
     let mut s = String::new();
 
-    // Sort and add identities
-    // Format: category/type/lang/name<
     let mut sorted_identities: Vec<_> = identities.iter().collect();
-    sorted_identities
-        .sort_by(|a, b| (&a.category, &a.type_, &a.name).cmp(&(&b.category, &b.type_, &b.name)));
+    sorted_identities.sort_by(|a, b| {
+        (
+            a.category.as_str(),
+            a.type_.as_str(),
+            a.lang.as_deref().unwrap_or(""),
+            a.name.as_deref().unwrap_or(""),
+        )
+            .cmp(&(
+                b.category.as_str(),
+                b.type_.as_str(),
+                b.lang.as_deref().unwrap_or(""),
+                b.name.as_deref().unwrap_or(""),
+            ))
+    });
 
     for id in sorted_identities {
         s.push_str(&id.category);
         s.push('/');
         s.push_str(&id.type_);
-        s.push('/'); // lang (empty for now)
+        s.push('/');
+        if let Some(ref lang) = id.lang {
+            s.push_str(lang);
+        }
         s.push('/');
         if let Some(ref name) = id.name {
             s.push_str(name);
@@ -227,8 +261,7 @@ fn build_verification_string(identities: &[Identity], features: &[Feature]) -> S
         s.push('<');
     }
 
-    // Sort and add features
-    let mut sorted_features: Vec<_> = features.iter().map(|f| &f.0).collect();
+    let mut sorted_features: Vec<_> = features.iter().map(|f| f.0.as_str()).collect();
     sorted_features.sort();
 
     for feat in sorted_features {
@@ -236,7 +269,81 @@ fn build_verification_string(identities: &[Identity], features: &[Feature]) -> S
         s.push('<');
     }
 
+    let mut data_forms: Vec<_> = extensions.iter().filter_map(parse_caps_data_form).collect();
+    data_forms.sort_by(|a, b| a.form_type.cmp(&b.form_type));
+
+    for form in data_forms {
+        s.push_str(&form.form_type);
+        s.push('<');
+
+        let mut fields = form.fields;
+        fields.sort_by(|a, b| a.var.cmp(&b.var));
+
+        for field in fields {
+            s.push_str(&field.var);
+            s.push('<');
+
+            let mut values = field.values;
+            values.sort();
+            if values.is_empty() {
+                s.push('<');
+                continue;
+            }
+
+            for value in values {
+                s.push_str(&value);
+                s.push('<');
+            }
+        }
+    }
+
     s
+}
+
+fn parse_caps_data_form(extension: &Element) -> Option<CapsDataForm> {
+    if extension.name() != "x" || extension.ns() != DATA_FORMS_NS {
+        return None;
+    }
+
+    if extension.attr("type") != Some("result") {
+        return None;
+    }
+
+    let mut form_type = None;
+    let mut fields = Vec::new();
+
+    for field in extension
+        .children()
+        .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
+    {
+        let Some(var) = field.attr("var") else {
+            return None;
+        };
+
+        let values = field
+            .children()
+            .filter(|child| child.name() == "value" && child.ns() == DATA_FORMS_NS)
+            .map(Element::text)
+            .collect::<Vec<_>>();
+
+        if var == FORM_TYPE_FIELD {
+            if form_type.is_some() {
+                return None;
+            }
+
+            if field.attr("type") == Some("hidden") {
+                form_type = values.first().cloned();
+            }
+            continue;
+        }
+
+        fields.push(CapsDataField {
+            var: var.to_string(),
+            values,
+        });
+    }
+
+    form_type.map(|form_type| CapsDataForm { form_type, fields })
 }
 
 /// Hash the verification string with SHA-1 and base64 encode.
@@ -259,7 +366,17 @@ fn hash_verification_string(verification_string: &str) -> String {
 ///
 /// A minidom Element containing the `<c>` element with computed hash.
 pub fn build_caps_element(node: &str, identities: &[Identity], features: &[Feature]) -> Element {
-    let ver = compute_caps_hash(identities, features);
+    build_caps_element_with_extensions(node, identities, features, &[])
+}
+
+/// Build a `<c>` caps element whose `ver` accounts for XEP-0128 extensions.
+pub fn build_caps_element_with_extensions(
+    node: &str,
+    identities: &[Identity],
+    features: &[Feature],
+    extensions: &[Element],
+) -> Element {
+    let ver = compute_caps_hash_with_extensions(identities, features, extensions);
     Caps::new(node, &ver).build_element()
 }
 
@@ -317,6 +434,152 @@ pub fn parse_caps_node(node: &str) -> Option<(&str, &str)> {
 mod tests {
     use super::*;
     use crate::disco::info::{Feature, Identity, DISCO_INFO_NS};
+
+    fn data_form_field(var: &str, field_type: Option<&str>, values: &[&str]) -> Element {
+        let mut builder = Element::builder("field", DATA_FORMS_NS).attr("var", var);
+
+        if let Some(field_type) = field_type {
+            builder = builder.attr("type", field_type);
+        }
+
+        for value in values {
+            builder = builder.append(
+                Element::builder("value", DATA_FORMS_NS)
+                    .append(*value)
+                    .build(),
+            );
+        }
+
+        builder.build()
+    }
+
+    fn software_info_form() -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(data_form_field(
+                "ip_version",
+                Some("text-multi"),
+                &["ipv6", "ipv4"],
+            ))
+            .append(data_form_field("os", None, &["Mac"]))
+            .append(data_form_field("os_version", None, &["10.5.1"]))
+            .append(data_form_field("software", None, &["Psi"]))
+            .append(data_form_field("software_version", None, &["0.11"]))
+            .build()
+    }
+
+    fn software_info_form_with_type(form_type: &str) -> Element {
+        let mut form = software_info_form();
+        form.set_attr("type", form_type);
+        form
+    }
+
+    fn software_info_form_with_form_type_field_type(field_type: &str) -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some(field_type),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(data_form_field("software", None, &["Psi"]))
+            .build()
+    }
+
+    fn software_info_form_with_foreign_children() -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(
+                Element::builder("field", "urn:waddle:test:foreign")
+                    .attr("var", "rogue-field")
+                    .append(
+                        Element::builder("value", "urn:waddle:test:foreign")
+                            .append("rogue")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .attr("var", "software")
+                    .append(
+                        Element::builder("value", DATA_FORMS_NS)
+                            .append("Psi")
+                            .build(),
+                    )
+                    .append(
+                        Element::builder("value", "urn:waddle:test:foreign")
+                            .append("rogue")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    fn software_info_form_with_empty_value_field() -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .attr("var", "software")
+                    .build(),
+            )
+            .build()
+    }
+
+    fn software_info_form_with_duplicate_form_type() -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo:duplicate"],
+            ))
+            .append(data_form_field("software", None, &["Psi"]))
+            .build()
+    }
+
+    fn software_info_form_with_missing_var() -> Element {
+        Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(
+                Element::builder("field", DATA_FORMS_NS)
+                    .append(
+                        Element::builder("value", DATA_FORMS_NS)
+                            .append("rogue")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(data_form_field("software", None, &["Psi"]))
+            .build()
+    }
 
     #[test]
     fn test_caps_new() {
@@ -454,14 +717,14 @@ mod tests {
 
     #[test]
     fn test_build_verification_string_empty() {
-        let s = build_verification_string(&[], &[]);
+        let s = build_verification_string_with_extensions(&[], &[], &[]);
         assert_eq!(s, "");
     }
 
     #[test]
     fn test_build_verification_string_identity_only() {
         let identities = vec![Identity::server(Some("Test Server"))];
-        let s = build_verification_string(&identities, &[]);
+        let s = build_verification_string_with_extensions(&identities, &[], &[]);
         // Format: category/type/lang/name<
         assert_eq!(s, "server/im//Test Server<");
     }
@@ -469,8 +732,15 @@ mod tests {
     #[test]
     fn test_build_verification_string_identity_no_name() {
         let identities = vec![Identity::server(None)];
-        let s = build_verification_string(&identities, &[]);
+        let s = build_verification_string_with_extensions(&identities, &[], &[]);
         assert_eq!(s, "server/im//<");
+    }
+
+    #[test]
+    fn test_build_verification_string_identity_with_lang() {
+        let identities = vec![Identity::new("client", "pc", Some("Psi")).with_lang(Some("en"))];
+        let s = build_verification_string_with_extensions(&identities, &[], &[]);
+        assert_eq!(s, "client/pc/en/Psi<");
     }
 
     #[test]
@@ -479,7 +749,7 @@ mod tests {
             Feature::new("http://jabber.org/protocol/disco#info"),
             Feature::new("http://jabber.org/protocol/disco#items"),
         ];
-        let s = build_verification_string(&[], &features);
+        let s = build_verification_string_with_extensions(&[], &features, &[]);
         // Features should be sorted alphabetically
         assert_eq!(
             s,
@@ -494,7 +764,7 @@ mod tests {
             Feature::new("a-feature"),
             Feature::new("m-feature"),
         ];
-        let s = build_verification_string(&[], &features);
+        let s = build_verification_string_with_extensions(&[], &features, &[]);
         assert_eq!(s, "a-feature<m-feature<z-feature<");
     }
 
@@ -505,7 +775,7 @@ mod tests {
             Identity::new("client", "pc", Some("MyClient")),
         ];
         let features = vec![Feature::new("feature2"), Feature::new("feature1")];
-        let s = build_verification_string(&identities, &features);
+        let s = build_verification_string_with_extensions(&identities, &features, &[]);
         // Identities sorted by category/type/name, then features sorted
         assert_eq!(s, "client/pc//MyClient<server/im//Test<feature1<feature2<");
     }
@@ -521,14 +791,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_caps_hash_example() {
-        // Based on XEP-0115 Section 5.2 example (simplified)
-        // Identity: client/pc/en/Exodus 0.9.1
-        // Features sorted:
-        //   http://jabber.org/protocol/caps
-        //   http://jabber.org/protocol/disco#info
-        //   http://jabber.org/protocol/disco#items
-        //   http://jabber.org/protocol/muc
+    fn test_compute_caps_hash_simple_example() {
         let identities = vec![Identity::new("client", "pc", Some("Exodus 0.9.1"))];
         let features = vec![
             Feature::new(NS_CAPS),
@@ -538,10 +801,126 @@ mod tests {
         ];
 
         let hash = compute_caps_hash(&identities, &features);
+        assert_eq!(hash, "QgayPKawpkPSDYmwT/WM94uAlu0=");
+    }
 
-        // The hash should be a valid base64 string of 28 characters (20 bytes base64 encoded)
-        assert_eq!(hash.len(), 28);
-        assert!(BASE64.decode(&hash).is_ok());
+    #[test]
+    fn test_build_verification_string_with_extensions_complex_example() {
+        let identities = vec![
+            Identity::new("client", "pc", Some("Psi 0.11")).with_lang(Some("en")),
+            Identity::new("client", "pc", Some("\u{03A8} 0.11")).with_lang(Some("el")),
+        ];
+        let features = vec![
+            Feature::new("http://jabber.org/protocol/muc"),
+            Feature::new(DISCO_INFO_NS),
+            Feature::new(NS_CAPS),
+            Feature::new("http://jabber.org/protocol/disco#items"),
+        ];
+        let extensions = vec![software_info_form()];
+
+        let verification_string =
+            build_verification_string_with_extensions(&identities, &features, &extensions);
+
+        assert_eq!(
+            verification_string,
+            "client/pc/el/\u{03A8} 0.11<client/pc/en/Psi 0.11<http://jabber.org/protocol/caps<http://jabber.org/protocol/disco#info<http://jabber.org/protocol/disco#items<http://jabber.org/protocol/muc<urn:xmpp:dataforms:softwareinfo<ip_version<ipv4<ipv6<os<Mac<os_version<10.5.1<software<Psi<software_version<0.11<"
+        );
+    }
+
+    #[test]
+    fn test_compute_caps_hash_with_extensions_complex_example() {
+        let identities = vec![
+            Identity::new("client", "pc", Some("Psi 0.11")).with_lang(Some("en")),
+            Identity::new("client", "pc", Some("\u{03A8} 0.11")).with_lang(Some("el")),
+        ];
+        let features = vec![
+            Feature::new("http://jabber.org/protocol/muc"),
+            Feature::new(DISCO_INFO_NS),
+            Feature::new(NS_CAPS),
+            Feature::new("http://jabber.org/protocol/disco#items"),
+        ];
+        let extensions = vec![software_info_form()];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, "q07IKJEyjvHSyhy//CH0CxmKi8w=");
+    }
+
+    #[test]
+    fn test_compute_caps_hash_ignores_non_result_forms() {
+        let identities = vec![Identity::server(Some("Waddle"))];
+        let features = vec![Feature::disco_info(), Feature::disco_items()];
+        let baseline = compute_caps_hash(&identities, &features);
+        let extensions = vec![software_info_form_with_type("submit")];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, baseline);
+    }
+
+    #[test]
+    fn test_compute_caps_hash_ignores_forms_without_hidden_form_type() {
+        let identities = vec![Identity::server(Some("Waddle"))];
+        let features = vec![Feature::disco_info(), Feature::disco_items()];
+        let baseline = compute_caps_hash(&identities, &features);
+        let extensions = vec![software_info_form_with_form_type_field_type("text-single")];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, baseline);
+    }
+
+    #[test]
+    fn test_compute_caps_hash_ignores_foreign_namespaced_form_children() {
+        let identities = vec![Identity::server(Some("Waddle"))];
+        let features = vec![Feature::disco_info(), Feature::disco_items()];
+        let clean_extensions = vec![Element::builder("x", DATA_FORMS_NS)
+            .attr("type", "result")
+            .append(data_form_field(
+                FORM_TYPE_FIELD,
+                Some("hidden"),
+                &["urn:xmpp:dataforms:softwareinfo"],
+            ))
+            .append(data_form_field("software", None, &["Psi"]))
+            .build()];
+        let baseline = compute_caps_hash_with_extensions(&identities, &features, &clean_extensions);
+        let extensions = vec![software_info_form_with_foreign_children()];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, baseline);
+    }
+
+    #[test]
+    fn test_build_verification_string_treats_missing_field_values_as_empty() {
+        let verification_string = build_verification_string_with_extensions(
+            &[Identity::server(Some("Waddle"))],
+            &[Feature::disco_info()],
+            &[software_info_form_with_empty_value_field()],
+        );
+
+        assert_eq!(
+            verification_string,
+            "server/im//Waddle<http://jabber.org/protocol/disco#info<urn:xmpp:dataforms:softwareinfo<software<<"
+        );
+    }
+
+    #[test]
+    fn test_compute_caps_hash_ignores_forms_with_duplicate_form_type_fields() {
+        let identities = vec![Identity::server(Some("Waddle"))];
+        let features = vec![Feature::disco_info(), Feature::disco_items()];
+        let baseline = compute_caps_hash(&identities, &features);
+        let extensions = vec![software_info_form_with_duplicate_form_type()];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, baseline);
+    }
+
+    #[test]
+    fn test_compute_caps_hash_ignores_forms_with_missing_var_fields() {
+        let identities = vec![Identity::server(Some("Waddle"))];
+        let features = vec![Feature::disco_info(), Feature::disco_items()];
+        let baseline = compute_caps_hash(&identities, &features);
+        let extensions = vec![software_info_form_with_missing_var()];
+
+        let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+        assert_eq!(hash, baseline);
     }
 
     #[test]
@@ -578,9 +957,32 @@ mod tests {
         assert_eq!(elem.ns(), NS_CAPS);
         assert_eq!(elem.attr("hash"), Some("sha-1"));
         assert_eq!(elem.attr("node"), Some(WADDLE_CAPS_NODE));
-        // ver should be a valid hash
         let ver = elem.attr("ver").unwrap();
         assert!(BASE64.decode(ver).is_ok());
+    }
+
+    #[test]
+    fn test_build_caps_element_with_extensions_uses_extension_hash() {
+        let identities = vec![
+            Identity::new("client", "pc", Some("Psi 0.11")).with_lang(Some("en")),
+            Identity::new("client", "pc", Some("\u{03A8} 0.11")).with_lang(Some("el")),
+        ];
+        let features = vec![
+            Feature::new("http://jabber.org/protocol/muc"),
+            Feature::new(DISCO_INFO_NS),
+            Feature::new(NS_CAPS),
+            Feature::new("http://jabber.org/protocol/disco#items"),
+        ];
+        let extensions = vec![software_info_form()];
+
+        let elem = build_caps_element_with_extensions(
+            WADDLE_CAPS_NODE,
+            &identities,
+            &features,
+            &extensions,
+        );
+
+        assert_eq!(elem.attr("ver"), Some("q07IKJEyjvHSyhy//CH0CxmKi8w="));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -316,9 +316,7 @@ fn parse_caps_data_form(extension: &Element) -> Option<CapsDataForm> {
         .children()
         .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
     {
-        let Some(var) = field.attr("var") else {
-            return None;
-        };
+        let var = field.attr("var")?;
 
         let values = field
             .children()

--- a/server/crates/waddle-xmpp/src/xep/xep0199.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0199.rs
@@ -1,27 +1,62 @@
 //! XEP-0199: XMPP Ping
 //!
-//! Provides helpers for detecting ping IQs and building responses.
+//! Provides helpers for validating ping IQs and building responses.
 
+use jid::{BareJid, Jid};
 use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 /// Namespace for XEP-0199 Ping.
 pub const NS_PING: &str = "urn:xmpp:ping";
 
-/// Check if an IQ stanza is a ping request (XEP-0199).
+fn response_from(original_iq: &Iq, domain: &str, session_bare: &BareJid) -> Option<Jid> {
+    match original_iq.to.as_ref() {
+        None => Some(domain.parse().expect("server domain should parse as a JID")),
+        Some(to) if to.try_as_full().is_err() && to.to_bare() == *session_bare => {
+            Some(domain.parse().expect("server domain should parse as a JID"))
+        }
+        Some(to) => Some(to.clone()),
+    }
+}
+
+fn ping_payload_is_valid(elem: &minidom::Element) -> bool {
+    elem.name() == "ping"
+        && elem.ns() == NS_PING
+        && elem.attrs().next().is_none()
+        && elem.children().next().is_none()
+        && elem.texts().next().is_none()
+}
+
+/// Check if an IQ stanza is a conformant ping request (XEP-0199).
 pub fn is_ping(iq: &Iq) -> bool {
     match &iq.payload {
-        IqType::Get(elem) => elem.name() == "ping" && elem.ns() == NS_PING,
+        IqType::Get(elem) => ping_payload_is_valid(elem),
         _ => false,
     }
 }
 
 /// Build an empty result IQ for a ping request.
-pub fn build_ping_result(original_iq: &Iq) -> Iq {
+pub fn build_ping_result(original_iq: &Iq, domain: &str, session_bare: &BareJid) -> Iq {
     Iq {
-        from: original_iq.to.clone(),
+        from: response_from(original_iq, domain, session_bare),
         to: original_iq.from.clone(),
         id: original_iq.id.clone(),
         payload: IqType::Result(None),
+    }
+}
+
+/// Build a typed `bad-request` IQ error for a malformed ping request.
+pub fn build_ping_bad_request(original_iq: &Iq, domain: &str, session_bare: &BareJid) -> Iq {
+    Iq {
+        from: response_from(original_iq, domain, session_bare),
+        to: original_iq.from.clone(),
+        id: original_iq.id.clone(),
+        payload: IqType::Error(StanzaError::new(
+            ErrorType::Modify,
+            DefinedCondition::BadRequest,
+            "en",
+            "",
+        )),
     }
 }
 
@@ -29,6 +64,10 @@ pub fn build_ping_result(original_iq: &Iq) -> Iq {
 mod tests {
     use super::*;
     use minidom::Element;
+
+    fn session_bare() -> BareJid {
+        "alice@example.com".parse().expect("valid bare JID")
+    }
 
     #[test]
     fn test_is_ping() {
@@ -41,6 +80,36 @@ mod tests {
         };
 
         assert!(is_ping(&iq));
+    }
+
+    #[test]
+    fn test_is_ping_false_for_ping_with_child() {
+        let ping_elem = Element::builder("ping", NS_PING)
+            .append(Element::builder("extra", NS_PING).build())
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "ping-child".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+
+        assert!(!is_ping(&iq));
+    }
+
+    #[test]
+    fn test_is_ping_false_for_ping_with_attribute() {
+        let ping_elem = Element::builder("ping", NS_PING)
+            .attr("id", "unexpected")
+            .build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "ping-attr".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+
+        assert!(!is_ping(&iq));
     }
 
     #[test]
@@ -66,12 +135,88 @@ mod tests {
             payload: IqType::Get(ping_elem),
         };
 
-        let result = build_ping_result(&iq);
+        let result = build_ping_result(&iq, "example.com", &session_bare());
 
         assert_eq!(result.id, "ping-3");
         assert_eq!(result.from, iq.to);
         assert_eq!(result.to, iq.from);
         assert!(matches!(result.payload, IqType::Result(None)));
+    }
+
+    #[test]
+    fn test_build_ping_result_uses_server_domain_for_absent_to() {
+        let ping_elem = Element::builder("ping", NS_PING).build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: None,
+            id: "ping-none".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let result = build_ping_result(&iq, "example.com", &session_bare());
+        assert_eq!(
+            result.from.as_ref().map(ToString::to_string),
+            Some("example.com".into())
+        );
+        assert_eq!(result.to, iq.from);
+        assert_eq!(result.id, "ping-none");
+    }
+
+    #[test]
+    fn test_build_ping_result_uses_server_domain_for_session_bare_target() {
+        let ping_elem = Element::builder("ping", NS_PING).build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some("alice@example.com".parse().unwrap()),
+            id: "ping-bare".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let result = build_ping_result(&iq, "example.com", &session_bare());
+        assert_eq!(
+            result.from.as_ref().map(ToString::to_string),
+            Some("example.com".into())
+        );
+        assert_eq!(result.to, iq.from);
+    }
+
+    #[test]
+    fn test_build_ping_result_keeps_full_jid_target_as_from() {
+        let ping_elem = Element::builder("ping", NS_PING).build();
+        let iq = Iq {
+            from: Some("alice@example.com/phone".parse().unwrap()),
+            to: Some("alice@example.com/web".parse().unwrap()),
+            id: "ping-full".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let result = build_ping_result(&iq, "example.com", &session_bare());
+        assert_eq!(
+            result.from.as_ref().map(ToString::to_string),
+            Some("alice@example.com/web".into())
+        );
+        assert_eq!(result.to, iq.from);
+    }
+
+    #[test]
+    fn test_build_ping_bad_request_uses_typed_error() {
+        let ping_elem = Element::builder("ping", NS_PING)
+            .append(Element::builder("extra", NS_PING).build())
+            .build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: None,
+            id: "ping-bad".to_string(),
+            payload: IqType::Get(ping_elem),
+        };
+        let result = build_ping_bad_request(&iq, "example.com", &session_bare());
+        let IqType::Error(error) = result.payload else {
+            panic!("expected typed IQ error")
+        };
+        assert_eq!(error.type_, ErrorType::Modify);
+        assert_eq!(error.defined_condition, DefinedCondition::BadRequest);
+        assert_eq!(
+            result.from.as_ref().map(ToString::to_string),
+            Some("example.com".into())
+        );
+        assert_eq!(result.to, iq.from);
     }
 
     #[test]
@@ -95,21 +240,6 @@ mod tests {
             payload: IqType::Result(None),
         };
         assert!(!is_ping(&iq));
-    }
-
-    #[test]
-    fn test_build_ping_result_with_none_addresses() {
-        let ping_elem = Element::builder("ping", NS_PING).build();
-        let iq = Iq {
-            from: None,
-            to: None,
-            id: "ping-none".to_string(),
-            payload: IqType::Get(ping_elem),
-        };
-        let result = build_ping_result(&iq);
-        assert!(result.from.is_none());
-        assert!(result.to.is_none());
-        assert_eq!(result.id, "ping-none");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0202.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0202.rs
@@ -1,7 +1,7 @@
 //! XEP-0202: Entity Time
 //!
 //! Provides helpers for detecting entity time queries and building responses.
-//! Allows clients to query the server's current time and timezone.
+//! Allows clients to query the server's current UTC time and local timezone offset.
 //!
 //! ## XML Format
 //!
@@ -26,27 +26,79 @@
 //!
 //! The server advertises `urn:xmpp:time` as a feature in disco#info.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, FixedOffset, Local, Offset, SecondsFormat, Utc};
 use minidom::Element;
 use xmpp_parsers::iq::{Iq, IqType};
 
 /// Namespace for XEP-0202 Entity Time.
 pub const NS_TIME: &str = "urn:xmpp:time";
 
+/// Parsed entity time payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityTime {
+    pub utc: DateTime<Utc>,
+    pub tzo: FixedOffset,
+}
+
+impl EntityTime {
+    /// Capture the current UTC timestamp and the host's local timezone offset.
+    pub fn now() -> Self {
+        let local = Local::now();
+        Self {
+            utc: local.with_timezone(&Utc),
+            tzo: local.offset().fix(),
+        }
+    }
+}
+
 /// Check if an IQ stanza is an entity time query.
 pub fn is_time_query(iq: &Iq) -> bool {
     matches!(&iq.payload, IqType::Get(elem) if elem.name() == "time" && elem.ns() == NS_TIME)
 }
 
-/// Build an entity time response IQ.
-///
-/// Returns the current UTC time and timezone offset.
-pub fn build_time_response(original_iq: &Iq, now: DateTime<Utc>, tzo: &str) -> Iq {
-    let utc_str = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+fn format_time_zone_offset(offset: FixedOffset) -> String {
+    let total_seconds = offset.local_minus_utc();
+    let sign = if total_seconds < 0 { '-' } else { '+' };
+    let absolute_seconds = total_seconds.abs();
+    let hours = absolute_seconds / 3600;
+    let minutes = (absolute_seconds % 3600) / 60;
+    format!("{sign}{hours:02}:{minutes:02}")
+}
 
+fn parse_time_zone_offset(value: &str) -> Option<FixedOffset> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 6 || bytes[3] != b':' {
+        return None;
+    }
+
+    let sign = match bytes[0] {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+
+    let hours = value[1..3].parse::<i32>().ok()?;
+    let minutes = value[4..6].parse::<i32>().ok()?;
+    if hours > 15 || minutes > 59 {
+        return None;
+    }
+
+    FixedOffset::east_opt(sign * (hours * 3600 + minutes * 60))
+}
+
+/// Build an entity time response IQ.
+pub fn build_time_response(original_iq: &Iq, entity_time: &EntityTime) -> Iq {
     let time_elem = Element::builder("time", NS_TIME)
-        .append(Element::builder("tzo", NS_TIME).append(tzo).build())
-        .append(Element::builder("utc", NS_TIME).append(utc_str).build())
+        .append(
+            Element::builder("tzo", NS_TIME)
+                .append(format_time_zone_offset(entity_time.tzo))
+                .build(),
+        )
+        .append(
+            Element::builder("utc", NS_TIME)
+                .append(entity_time.utc.to_rfc3339_opts(SecondsFormat::Secs, true))
+                .build(),
+        )
         .build();
 
     Iq {
@@ -57,15 +109,13 @@ pub fn build_time_response(original_iq: &Iq, now: DateTime<Utc>, tzo: &str) -> I
     }
 }
 
-/// Build an entity time response with the current UTC time and +00:00 offset.
-///
-/// Convenience wrapper for servers running in UTC.
-pub fn build_time_response_utc(original_iq: &Iq) -> Iq {
-    build_time_response(original_iq, Utc::now(), "+00:00")
+/// Build an entity time response with the current UTC time and host timezone offset.
+pub fn build_current_time_response(original_iq: &Iq) -> Iq {
+    build_time_response(original_iq, &EntityTime::now())
 }
 
-/// Parse a time response to extract UTC timestamp and timezone offset.
-pub fn parse_time_response(iq: &Iq) -> Option<(String, String)> {
+/// Parse a time response into typed UTC and timezone offset values.
+pub fn parse_time_response(iq: &Iq) -> Option<EntityTime> {
     let elem = match &iq.payload {
         IqType::Result(Some(elem)) if elem.name() == "time" && elem.ns() == NS_TIME => elem,
         _ => return None,
@@ -74,14 +124,22 @@ pub fn parse_time_response(iq: &Iq) -> Option<(String, String)> {
     let tzo = elem
         .children()
         .find(|c| c.is("tzo", NS_TIME))
-        .map(|c| c.text())?;
+        .map(|c| c.text())
+        .and_then(|value| parse_time_zone_offset(&value))?;
 
     let utc = elem
         .children()
         .find(|c| c.is("utc", NS_TIME))
-        .map(|c| c.text())?;
+        .map(|c| c.text())
+        .and_then(|value| DateTime::parse_from_rfc3339(&value).ok())?;
+    if utc.offset().local_minus_utc() != 0 {
+        return None;
+    }
 
-    Some((utc, tzo))
+    Some(EntityTime {
+        utc: utc.with_timezone(&Utc),
+        tzo,
+    })
 }
 
 #[cfg(test)]
@@ -96,6 +154,16 @@ mod tests {
             to: Some("example.com".parse().expect("valid jid")),
             id: "time-1".to_string(),
             payload: IqType::Get(time_elem),
+        }
+    }
+
+    fn sample_time(offset_seconds: i32) -> EntityTime {
+        EntityTime {
+            utc: Utc
+                .with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
+                .single()
+                .expect("valid test date"),
+            tzo: FixedOffset::east_opt(offset_seconds).expect("valid offset"),
         }
     }
 
@@ -132,11 +200,7 @@ mod tests {
     #[test]
     fn test_build_time_response() {
         let query = make_time_query();
-        let now = Utc
-            .with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
-            .single()
-            .expect("valid test date");
-        let result = build_time_response(&query, now, "+00:00");
+        let result = build_time_response(&query, &sample_time(0));
 
         assert_eq!(result.id, "time-1");
         assert_eq!(result.from, query.to);
@@ -165,11 +229,7 @@ mod tests {
     #[test]
     fn test_build_time_response_with_offset() {
         let query = make_time_query();
-        let now = Utc
-            .with_ymd_and_hms(2024, 1, 15, 18, 30, 0)
-            .single()
-            .expect("valid test date");
-        let result = build_time_response(&query, now, "-06:00");
+        let result = build_time_response(&query, &sample_time(-6 * 3600));
 
         if let IqType::Result(Some(elem)) = &result.payload {
             let tzo = elem
@@ -183,42 +243,22 @@ mod tests {
     }
 
     #[test]
-    fn test_build_time_response_utc() {
+    fn test_build_current_time_response() {
         let query = make_time_query();
-        let result = build_time_response_utc(&query);
+        let result = build_current_time_response(&query);
 
         assert_eq!(result.id, "time-1");
-        if let IqType::Result(Some(elem)) = &result.payload {
-            let tzo = elem
-                .children()
-                .find(|c| c.is("tzo", NS_TIME))
-                .expect("tzo present");
-            assert_eq!(tzo.text(), "+00:00");
-
-            let utc = elem
-                .children()
-                .find(|c| c.is("utc", NS_TIME))
-                .expect("utc present");
-            // Just verify it looks like an ISO timestamp
-            assert!(utc.text().contains('T'));
-            assert!(utc.text().ends_with('Z'));
-        } else {
-            panic!("Expected Result with payload");
-        }
+        let parsed = parse_time_response(&result).expect("parseable current entity time");
+        assert_eq!(parsed.tzo, EntityTime::now().tzo);
     }
 
     #[test]
     fn test_parse_time_response() {
         let query = make_time_query();
-        let now = Utc
-            .with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
-            .single()
-            .expect("valid test date");
-        let result = build_time_response(&query, now, "-05:00");
+        let result = build_time_response(&query, &sample_time(-5 * 3600));
 
-        let (utc, tzo) = parse_time_response(&result).expect("parseable");
-        assert_eq!(utc, "2024-06-01T12:00:00Z");
-        assert_eq!(tzo, "-05:00");
+        let parsed = parse_time_response(&result).expect("parseable");
+        assert_eq!(parsed, sample_time(-5 * 3600));
     }
 
     #[test]
@@ -228,10 +268,51 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_time_response_rejects_invalid_tzo() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "tzo-invalid".to_string(),
+            payload: IqType::Result(Some(
+                Element::builder("time", NS_TIME)
+                    .append(Element::builder("tzo", NS_TIME).append("+16:00").build())
+                    .append(
+                        Element::builder("utc", NS_TIME)
+                            .append("2024-06-01T12:00:00Z")
+                            .build(),
+                    )
+                    .build(),
+            )),
+        };
+
+        assert!(parse_time_response(&iq).is_none());
+    }
+
+    #[test]
+    fn test_parse_time_response_rejects_non_utc_timestamp() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "utc-invalid".to_string(),
+            payload: IqType::Result(Some(
+                Element::builder("time", NS_TIME)
+                    .append(Element::builder("tzo", NS_TIME).append("-05:00").build())
+                    .append(
+                        Element::builder("utc", NS_TIME)
+                            .append("2024-06-01T12:00:00-05:00")
+                            .build(),
+                    )
+                    .build(),
+            )),
+        };
+
+        assert!(parse_time_response(&iq).is_none());
+    }
+
+    #[test]
     fn test_build_time_response_swaps_to_from() {
         let query = make_time_query();
-        let now = Utc::now();
-        let result = build_time_response(&query, now, "+00:00");
+        let result = build_time_response(&query, &EntityTime::now());
 
         assert_eq!(result.from, query.to);
         assert_eq!(result.to, query.from);

--- a/server/crates/waddle-xmpp/src/xep/xep0308.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0308.rs
@@ -94,17 +94,33 @@ pub fn is_correction_message(msg: &Message) -> bool {
 
 // ── Extraction ───────────────────────────────────────────────────────
 
+/// Parse the correction from a message's payloads.
+///
+/// Returns `Ok(Some(Correction))` when the message contains a conformant
+/// `<replace/>` element, `Ok(None)` when no correction payload is present, and
+/// `Err(CorrectionError::MissingId)` when any `<replace/>` omits the required
+/// non-empty `id` attribute mandated by XEP-0308.
+pub fn parse_correction_from_message(msg: &Message) -> Result<Option<Correction>, CorrectionError> {
+    let Some(elem) = msg.payloads.iter().find(|elem| is_replace_element(elem)) else {
+        return Ok(None);
+    };
+
+    let id = elem
+        .attr("id")
+        .filter(|id| !id.is_empty())
+        .ok_or(CorrectionError::MissingId)?;
+
+    Ok(Some(Correction::new(id.to_owned())))
+}
+
 /// Extract the correction from a message's payloads.
 ///
-/// Returns `Some(Correction)` if the message contains a `<replace/>` element
-/// with a non-empty `id` attribute.
+/// Returns `Some(Correction)` if the message contains a conformant `<replace/>`
+/// element with a non-empty `id` attribute. Malformed correction payloads are
+/// ignored here; use [`parse_correction_from_message`] when they must be
+/// surfaced as protocol errors.
 pub fn extract_correction_from_message(msg: &Message) -> Option<Correction> {
-    msg.payloads
-        .iter()
-        .find(|e| is_replace_element(e))
-        .and_then(|e| e.attr("id"))
-        .filter(|id| !id.is_empty())
-        .map(Correction::new)
+    parse_correction_from_message(msg).ok().flatten()
 }
 
 /// Extract the replaced message id from a correction message.
@@ -205,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_correction() {
+    fn test_parse_correction() {
         let xml = "<message xmlns='jabber:client' type='chat' id='new-1'>\
                     <body>Corrected text</body>\
                     <replace xmlns='urn:xmpp:message-correct:0' id='orig-42'/>\
@@ -213,8 +229,11 @@ mod tests {
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
-        let correction = extract_correction_from_message(&msg).expect("has correction");
+        let correction = parse_correction_from_message(&msg)
+            .expect("valid correction")
+            .expect("has correction");
         assert_eq!(correction.replaces_id, "orig-42");
+        assert_eq!(extract_correction_from_message(&msg), Some(correction));
     }
 
     #[test]
@@ -224,14 +243,48 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_correction_empty_id_ignored() {
+    fn test_parse_correction_missing_id_errors() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <body>Bad</body>\
+                    <replace xmlns='urn:xmpp:message-correct:0'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(matches!(
+            parse_correction_from_message(&msg),
+            Err(CorrectionError::MissingId)
+        ));
+        assert!(extract_correction_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_correction_empty_id_errors() {
         let xml = "<message xmlns='jabber:client' type='chat'>\
                     <body>Bad</body>\
                     <replace xmlns='urn:xmpp:message-correct:0' id=''/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(matches!(
+            parse_correction_from_message(&msg),
+            Err(CorrectionError::MissingId)
+        ));
         assert!(extract_correction_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_correction_ignores_later_malformed_replace() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <body>Fixed</body>\
+                    <replace xmlns='urn:xmpp:message-correct:0' id='orig-1'/>\
+                    <replace xmlns='urn:xmpp:message-correct:0' id=''/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        let correction = parse_correction_from_message(&msg)
+            .expect("valid correction")
+            .expect("has correction");
+        assert_eq!(correction.replaces_id, "orig-1");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0333.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0333.rs
@@ -1,15 +1,13 @@
-//! XEP-0333: Displayed Markers (Chat Markers)
+//! XEP-0333: Displayed Markers
 //!
-//! Provides helpers for detecting, parsing, and building chat marker
-//! elements within XMPP message stanzas. Chat markers allow clients
-//! to signal message receipt and display status ("read receipts").
+//! Provides helpers for detecting, parsing, and building displayed marker
+//! elements within XMPP message stanzas. Displayed markers allow entities
+//! to signal that messages have been displayed up to a certain point.
 //!
 //! ## Marker Types
 //!
-//! - **`<markable/>`**: Included in outgoing messages to request markers.
-//! - **`<received id='...'/>`**: The message was received by the client.
-//! - **`<displayed id='...'/>`**: The message was displayed to the user.
-//! - **`<acknowledged id='...'/>`**: The message was explicitly acknowledged.
+//! - **`<markable/>`**: Included in outgoing messages to request displayed markers.
+//! - **`<displayed id='...'/>`**: The message identified by `id` was displayed.
 //!
 //! ## XML Format
 //!
@@ -21,7 +19,7 @@
 //! </message>
 //! ```
 //!
-//! Send a "displayed" marker:
+//! Send a displayed marker:
 //! ```xml
 //! <message type='chat' to='juliet@example.com'>
 //!   <displayed xmlns='urn:xmpp:chat-markers:0' id='msg-1'/>
@@ -30,18 +28,18 @@
 //!
 //! ## Server Behavior
 //!
-//! The server transparently routes marker messages. Standalone markers
-//! (body-less messages with only a marker element) should not be archived
+//! The server transparently routes displayed marker messages. Standalone markers
+//! (body-less messages with only a `<displayed/>` element) should not be archived
 //! but must be routed to the recipient.
 
 use minidom::Element;
 use thiserror::Error;
 use xmpp_parsers::message::Message;
 
-/// Namespace for XEP-0333 Chat Markers.
+/// Namespace for XEP-0333 Displayed Markers.
 pub const NS_CHAT_MARKERS: &str = "urn:xmpp:chat-markers:0";
 
-/// Errors that can occur when parsing chat marker elements.
+/// Errors that can occur when parsing displayed marker elements.
 #[derive(Debug, Error)]
 pub enum MarkerError {
     /// A marker element is missing its required `id` attribute.
@@ -49,17 +47,13 @@ pub enum MarkerError {
     MissingId,
 }
 
-/// Chat marker types defined by XEP-0333.
+/// Displayed marker types defined by XEP-0333.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Marker {
-    /// Request that the recipient send markers for this message.
+    /// Request that the recipient send displayed markers for this message.
     Markable,
-    /// The message was received by the client.
-    Received(String),
-    /// The message was displayed to the user (read receipt).
+    /// The message was displayed to the user.
     Displayed(String),
-    /// The message was explicitly acknowledged.
-    Acknowledged(String),
 }
 
 impl Marker {
@@ -67,17 +61,15 @@ impl Marker {
     pub fn element_name(&self) -> &'static str {
         match self {
             Self::Markable => "markable",
-            Self::Received(_) => "received",
             Self::Displayed(_) => "displayed",
-            Self::Acknowledged(_) => "acknowledged",
         }
     }
 
-    /// Returns the referenced message id, if this is a status marker.
+    /// Returns the referenced message id, if this is a displayed marker.
     pub fn referenced_id(&self) -> Option<&str> {
         match self {
             Self::Markable => None,
-            Self::Received(id) | Self::Displayed(id) | Self::Acknowledged(id) => Some(id),
+            Self::Displayed(id) => Some(id),
         }
     }
 
@@ -86,13 +78,13 @@ impl Marker {
         matches!(self, Self::Markable)
     }
 
-    /// Returns `true` if this is a `<displayed/>` marker (read receipt).
+    /// Returns `true` if this is a `<displayed/>` marker.
     pub fn is_displayed(&self) -> bool {
         matches!(self, Self::Displayed(_))
     }
 }
 
-/// Trait for types that can carry chat marker elements.
+/// Trait for types that can carry displayed marker elements.
 pub trait MarkerCarrier {
     /// Extract the marker from this carrier, if present.
     fn marker(&self) -> Option<Marker>;
@@ -105,7 +97,7 @@ pub trait MarkerCarrier {
     /// Returns `true` if this carrier is a standalone marker (no body).
     fn is_standalone_marker(&self) -> bool;
 
-    /// Returns the referenced message id if this is a status marker.
+    /// Returns the referenced message id if this is a displayed marker.
     fn marker_ref_id(&self) -> Option<String> {
         self.marker()
             .and_then(|m| m.referenced_id().map(|s| s.to_owned()))
@@ -118,38 +110,40 @@ impl MarkerCarrier for Message {
     }
 
     fn is_standalone_marker(&self) -> bool {
-        self.bodies.is_empty() && self.marker().is_some() && !self.is_markable()
+        is_standalone_marker(self)
     }
+}
+
+fn message_has_id(msg: &Message) -> bool {
+    msg.id.as_deref().is_some_and(|id| !id.is_empty())
 }
 
 // ── Detection ────────────────────────────────────────────────────────
 
-/// Check if an element is a chat marker element.
+/// Check if an element is a displayed marker element.
 pub fn is_marker_element(elem: &Element) -> bool {
-    elem.ns() == NS_CHAT_MARKERS
-        && matches!(
-            elem.name(),
-            "markable" | "received" | "displayed" | "acknowledged"
-        )
+    elem.ns() == NS_CHAT_MARKERS && matches!(elem.name(), "markable" | "displayed")
 }
 
-/// Check if a message contains any chat marker element.
+/// Check if a message contains any displayed marker element.
 pub fn has_marker(msg: &Message) -> bool {
     msg.payloads.iter().any(is_marker_element)
 }
 
-/// Check if a message requests markers (`<markable/>`).
+/// Check if a message validly requests displayed markers (`<markable/>`).
 pub fn has_markable(msg: &Message) -> bool {
-    msg.payloads
-        .iter()
-        .any(|e| e.ns() == NS_CHAT_MARKERS && e.name() == "markable")
+    message_has_id(msg)
+        && msg
+            .payloads
+            .iter()
+            .any(|e| e.ns() == NS_CHAT_MARKERS && e.name() == "markable")
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
 
-/// Extract the chat marker from a message's payloads.
+/// Extract the displayed marker from a message's payloads.
 ///
-/// Prefers status markers (received/displayed/acknowledged) over markable.
+/// Prefers `<displayed/>` over `<markable/>` when both are present.
 pub fn extract_marker_from_message(msg: &Message) -> Option<Marker> {
     let mut markable = false;
 
@@ -159,29 +153,24 @@ pub fn extract_marker_from_message(msg: &Message) -> Option<Marker> {
         }
         match elem.name() {
             "markable" => markable = true,
-            "received" | "displayed" | "acknowledged" => {
+            "displayed" => {
                 let id = elem.attr("id").unwrap_or("").to_owned();
                 if id.is_empty() {
                     continue;
                 }
-                return Some(match elem.name() {
-                    "received" => Marker::Received(id),
-                    "displayed" => Marker::Displayed(id),
-                    "acknowledged" => Marker::Acknowledged(id),
-                    _ => unreachable!(),
-                });
+                return Some(Marker::Displayed(id));
             }
             _ => {}
         }
     }
 
-    if markable {
+    if markable && message_has_id(msg) {
         return Some(Marker::Markable);
     }
     None
 }
 
-/// Extract the referenced message id from a status marker.
+/// Extract the referenced message id from a displayed marker.
 pub fn extract_marker_id(msg: &Message) -> Option<String> {
     extract_marker_from_message(msg).and_then(|m| m.referenced_id().map(|s| s.to_owned()))
 }
@@ -200,21 +189,7 @@ pub fn build_displayed_element(id: &str) -> Element {
         .build()
 }
 
-/// Build a `<received xmlns='urn:xmpp:chat-markers:0' id='...'>` element.
-pub fn build_received_element(id: &str) -> Element {
-    Element::builder("received", NS_CHAT_MARKERS)
-        .attr("id", id)
-        .build()
-}
-
-/// Build a `<acknowledged xmlns='urn:xmpp:chat-markers:0' id='...'>` element.
-pub fn build_acknowledged_element(id: &str) -> Element {
-    Element::builder("acknowledged", NS_CHAT_MARKERS)
-        .attr("id", id)
-        .build()
-}
-
-/// Build a standalone "displayed" marker message (read receipt).
+/// Build a standalone displayed marker message.
 pub fn build_displayed_message(
     to: impl Into<Option<jid::Jid>>,
     from: impl Into<Option<jid::Jid>>,
@@ -229,25 +204,26 @@ pub fn build_displayed_message(
 
 // ── Mutation ─────────────────────────────────────────────────────────
 
-/// Add a `<markable/>` element to a message (no-op if already present).
+/// Add a `<markable/>` element to a message when it has a traceable `id`.
 pub fn add_markable(msg: &mut Message) {
-    if !has_markable(msg) {
+    if message_has_id(msg) && !has_markable(msg) {
         msg.payloads.push(build_markable_element());
     }
 }
 
-/// Remove all chat marker elements from a message.
+/// Remove all displayed marker elements from a message.
 pub fn strip_markers(msg: &mut Message) {
     msg.payloads.retain(|e| e.ns() != NS_CHAT_MARKERS);
 }
 
-/// Check if a message is a standalone marker (no body, just a status marker).
+/// Check if a message is a standalone displayed marker (no body).
 /// These should be routed but not archived.
 pub fn is_standalone_marker(msg: &Message) -> bool {
     msg.bodies.is_empty()
         && msg.payloads.iter().any(|e| {
             e.ns() == NS_CHAT_MARKERS
-                && matches!(e.name(), "received" | "displayed" | "acknowledged")
+                && e.name() == "displayed"
+                && e.attr("id").is_some_and(|id| !id.is_empty())
         })
 }
 
@@ -258,16 +234,18 @@ mod tests {
 
     #[test]
     fn test_is_marker_element() {
-        for name in ["markable", "received", "displayed", "acknowledged"] {
+        for name in ["markable", "displayed"] {
             let elem = Element::builder(name, NS_CHAT_MARKERS).build();
             assert!(is_marker_element(&elem), "failed for {name}");
         }
 
+        for name in ["received", "acknowledged", "read"] {
+            let elem = Element::builder(name, NS_CHAT_MARKERS).build();
+            assert!(!is_marker_element(&elem), "unexpected marker for {name}");
+        }
+
         let wrong_ns = Element::builder("displayed", "jabber:client").build();
         assert!(!is_marker_element(&wrong_ns));
-
-        let wrong_name = Element::builder("read", NS_CHAT_MARKERS).build();
-        assert!(!is_marker_element(&wrong_name));
     }
 
     #[test]
@@ -280,6 +258,18 @@ mod tests {
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
         assert!(has_markable(&msg));
         assert!(has_marker(&msg));
+    }
+
+    #[test]
+    fn test_markable_without_message_id_is_ignored() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <markable xmlns='urn:xmpp:chat-markers:0'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        assert!(!has_markable(&msg));
+        assert_eq!(extract_marker_from_message(&msg), None);
     }
 
     #[test]
@@ -311,41 +301,13 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_received() {
-        let xml = "<message xmlns='jabber:client' type='chat'>\
-                    <received xmlns='urn:xmpp:chat-markers:0' id='msg-10'/>\
-                    </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
-
-        assert_eq!(
-            extract_marker_from_message(&msg),
-            Some(Marker::Received("msg-10".to_owned()))
-        );
-    }
-
-    #[test]
-    fn test_extract_acknowledged() {
-        let xml = "<message xmlns='jabber:client' type='chat'>\
-                    <acknowledged xmlns='urn:xmpp:chat-markers:0' id='msg-5'/>\
-                    </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
-
-        assert_eq!(
-            extract_marker_from_message(&msg),
-            Some(Marker::Acknowledged("msg-5".to_owned()))
-        );
-    }
-
-    #[test]
     fn test_extract_none() {
         let msg = Message::new(None::<jid::Jid>);
         assert!(extract_marker_from_message(&msg).is_none());
     }
 
     #[test]
-    fn test_extract_empty_id_ignored() {
+    fn test_extract_empty_displayed_id_ignored() {
         let xml = "<message xmlns='jabber:client' type='chat'>\
                     <displayed xmlns='urn:xmpp:chat-markers:0' id=''/>\
                     </message>";
@@ -355,8 +317,8 @@ mod tests {
     }
 
     #[test]
-    fn test_status_marker_preferred_over_markable() {
-        let xml = "<message xmlns='jabber:client' type='chat'>\
+    fn test_displayed_marker_preferred_over_markable() {
+        let xml = "<message xmlns='jabber:client' type='chat' id='msg-0'>\
                     <markable xmlns='urn:xmpp:chat-markers:0'/>\
                     <displayed xmlns='urn:xmpp:chat-markers:0' id='msg-1'/>\
                     </message>";
@@ -384,20 +346,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_received() {
-        let elem = build_received_element("msg-1");
-        assert_eq!(elem.name(), "received");
-        assert_eq!(elem.attr("id"), Some("msg-1"));
-    }
-
-    #[test]
-    fn test_build_acknowledged() {
-        let elem = build_acknowledged_element("msg-2");
-        assert_eq!(elem.name(), "acknowledged");
-        assert_eq!(elem.attr("id"), Some("msg-2"));
-    }
-
-    #[test]
     fn test_build_displayed_message() {
         let to: jid::Jid = "juliet@example.com".parse().expect("valid jid");
         let from: jid::Jid = "romeo@example.com".parse().expect("valid jid");
@@ -414,12 +362,16 @@ mod tests {
     }
 
     #[test]
-    fn test_add_markable() {
+    fn test_add_markable_requires_message_id() {
         let mut msg = Message::new(None::<jid::Jid>);
+        add_markable(&mut msg);
+        assert!(!has_markable(&msg));
+        assert!(msg.payloads.is_empty());
+
+        msg.id = Some("msg-1".to_string());
         add_markable(&mut msg);
         assert!(has_markable(&msg));
 
-        // Second add is no-op
         add_markable(&mut msg);
         assert_eq!(
             msg.payloads
@@ -446,7 +398,6 @@ mod tests {
 
     #[test]
     fn test_is_standalone_marker() {
-        // Displayed-only (no body) → standalone
         let xml = "<message xmlns='jabber:client' type='chat'>\
                     <displayed xmlns='urn:xmpp:chat-markers:0' id='msg-1'/>\
                     </message>";
@@ -454,7 +405,13 @@ mod tests {
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
         assert!(is_standalone_marker(&msg));
 
-        // Markable + body → not standalone
+        let invalid_xml = "<message xmlns='jabber:client' type='chat'>\
+                            <displayed xmlns='urn:xmpp:chat-markers:0' id=''/>\
+                            </message>";
+        let invalid = Message::try_from(invalid_xml.parse::<Element>().expect("valid xml"))
+            .expect("valid message");
+        assert!(!is_standalone_marker(&invalid));
+
         let xml2 = "<message xmlns='jabber:client' type='chat' id='msg-1'>\
                      <body>Hello</body>\
                      <markable xmlns='urn:xmpp:chat-markers:0'/>\
@@ -462,19 +419,10 @@ mod tests {
         let msg2 =
             Message::try_from(xml2.parse::<Element>().expect("valid xml")).expect("valid message");
         assert!(!is_standalone_marker(&msg2));
-
-        // Just markable, no body → not standalone (markable isn't a status marker)
-        let xml3 = "<message xmlns='jabber:client' type='chat'>\
-                     <markable xmlns='urn:xmpp:chat-markers:0'/>\
-                     </message>";
-        let msg3 =
-            Message::try_from(xml3.parse::<Element>().expect("valid xml")).expect("valid message");
-        assert!(!is_standalone_marker(&msg3));
     }
 
     #[test]
     fn test_marker_carrier_trait() {
-        // Markable
         let xml = "<message xmlns='jabber:client' type='chat' id='m1'>\
                     <body>Hi</body>\
                     <markable xmlns='urn:xmpp:chat-markers:0'/>\
@@ -485,7 +433,6 @@ mod tests {
         assert!(!msg.is_standalone_marker());
         assert_eq!(msg.marker_ref_id(), None);
 
-        // Displayed
         let xml2 = "<message xmlns='jabber:client' type='chat'>\
                      <displayed xmlns='urn:xmpp:chat-markers:0' id='m1'/>\
                      </message>";
@@ -499,11 +446,6 @@ mod tests {
     #[test]
     fn test_marker_element_name() {
         assert_eq!(Marker::Markable.element_name(), "markable");
-        assert_eq!(Marker::Received("x".into()).element_name(), "received");
         assert_eq!(Marker::Displayed("x".into()).element_name(), "displayed");
-        assert_eq!(
-            Marker::Acknowledged("x".into()).element_name(),
-            "acknowledged"
-        );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0334.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0334.rs
@@ -178,8 +178,12 @@ pub fn strip_hints(msg: &mut Message) {
 // ── Convenience queries ──────────────────────────────────────────────
 
 /// Returns `true` if the message should NOT be carbon-copied (XEP-0280).
+///
+/// XEP-0334 limits `<no-copy/>` to messages addressed to full JIDs; for
+/// bare-JID targets the hint does not override the normal RFC 6121 routing
+/// rules that may fan a stanza out to multiple resources.
 pub fn should_skip_carbons(msg: &Message) -> bool {
-    has_hint(msg, Hint::NoCopy)
+    has_hint(msg, Hint::NoCopy) && msg.to.as_ref().and_then(|jid| jid.resource()).is_some()
 }
 
 /// Returns `true` if the message should NOT be archived (MAM/offline).
@@ -336,8 +340,8 @@ mod tests {
     }
 
     #[test]
-    fn test_should_skip_carbons() {
-        let xml = "<message xmlns='jabber:client' type='chat'>\
+    fn test_should_skip_carbons_for_full_jid_target() {
+        let xml = "<message xmlns='jabber:client' type='chat' to='juliet@example.com/phone'>\
                     <body>Secret</body>\
                     <no-copy xmlns='urn:xmpp:hints'/>\
                     </message>";
@@ -347,6 +351,17 @@ mod tests {
 
         let plain = Message::new(None::<jid::Jid>);
         assert!(!should_skip_carbons(&plain));
+    }
+
+    #[test]
+    fn test_should_not_skip_carbons_for_bare_jid_target() {
+        let xml = "<message xmlns='jabber:client' type='chat' to='juliet@example.com'>\
+                    <body>Secret</body>\
+                    <no-copy xmlns='urn:xmpp:hints'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(!should_skip_carbons(&msg));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0359.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0359.rs
@@ -66,7 +66,8 @@ fn stanza_id_matches_by(elem: &Element, by: &str) -> bool {
         return false;
     }
 
-    elem.attr("by").is_some_and(|existing| stanza_id_by_matches(existing, by))
+    elem.attr("by")
+        .is_some_and(|existing| stanza_id_by_matches(existing, by))
 }
 
 /// A client-assigned origin ID.
@@ -305,7 +306,10 @@ mod tests {
             extract_stanza_id_by(&msg, "room@muc.example.com"),
             Some("arc-1".to_owned())
         );
-        assert_eq!(msg.stanza_id_by("room@muc.example.com"), Some("arc-1".to_owned()));
+        assert_eq!(
+            msg.stanza_id_by("room@muc.example.com"),
+            Some("arc-1".to_owned())
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0359.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0359.rs
@@ -28,6 +28,7 @@
 //! - Clients MUST NOT trust `<stanza-id/>` from other clients; only the
 //!   `by` entity that matches the server/MUC JID is authoritative.
 
+use jid::BareJid;
 use minidom::Element;
 use xmpp_parsers::message::Message;
 
@@ -53,6 +54,21 @@ impl StanzaId {
     }
 }
 
+fn stanza_id_by_matches(existing: &str, by: &str) -> bool {
+    match (existing.parse::<BareJid>().ok(), by.parse::<BareJid>().ok()) {
+        (Some(existing), Some(expected)) => existing == expected,
+        _ => existing == by,
+    }
+}
+
+fn stanza_id_matches_by(elem: &Element, by: &str) -> bool {
+    if !is_stanza_id_element(elem) {
+        return false;
+    }
+
+    elem.attr("by").is_some_and(|existing| stanza_id_by_matches(existing, by))
+}
+
 /// A client-assigned origin ID.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OriginId {
@@ -76,7 +92,7 @@ pub trait StanzaIdCarrier {
     fn stanza_id_by(&self, by: &str) -> Option<String> {
         self.stanza_ids()
             .into_iter()
-            .find(|sid| sid.by == by)
+            .find(|sid| stanza_id_by_matches(&sid.by, by))
             .map(|sid| sid.id)
     }
 
@@ -140,7 +156,7 @@ pub fn extract_stanza_ids(msg: &Message) -> Vec<StanzaId> {
 pub fn extract_stanza_id_by(msg: &Message, by: &str) -> Option<String> {
     extract_stanza_ids(msg)
         .into_iter()
-        .find(|sid| sid.by == by)
+        .find(|sid| stanza_id_by_matches(&sid.by, by))
         .map(|sid| sid.id)
 }
 
@@ -181,6 +197,7 @@ pub fn build_origin_id_element(id: &str) -> Element {
 /// This is the primary function used by the server when archiving messages.
 /// Multiple stanza-ids from different entities may coexist.
 pub fn add_stanza_id(msg: &mut Message, id: &str, by: &str) {
+    remove_stanza_ids_by(msg, by);
     msg.payloads.push(build_stanza_id_element(id, by));
 }
 
@@ -193,8 +210,7 @@ pub fn add_origin_id(msg: &mut Message, id: &str) {
 
 /// Remove all stanza-id elements assigned by a specific entity.
 pub fn remove_stanza_ids_by(msg: &mut Message, by: &str) {
-    msg.payloads
-        .retain(|e| !(is_stanza_id_element(e) && e.attr("by") == Some(by)));
+    msg.payloads.retain(|e| !stanza_id_matches_by(e, by));
 }
 
 /// Strip all stanza-id and origin-id elements from a message.
@@ -277,6 +293,22 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_stanza_id_by_matches_case_folded_bare_jid() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <body>Hello</body>\
+                    <stanza-id xmlns='urn:xmpp:sid:0' id='arc-1' by='room@muc.example.COM'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        assert_eq!(
+            extract_stanza_id_by(&msg, "room@muc.example.com"),
+            Some("arc-1".to_owned())
+        );
+        assert_eq!(msg.stanza_id_by("room@muc.example.com"), Some("arc-1".to_owned()));
+    }
+
+    #[test]
     fn test_extract_origin_id() {
         let xml = "<message xmlns='jabber:client' type='chat'>\
                     <body>Hello</body>\
@@ -337,6 +369,19 @@ mod tests {
     }
 
     #[test]
+    fn test_add_stanza_id_replaces_existing_same_by() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        msg.payloads
+            .push(build_stanza_id_element("spoofed", "alice@example.com"));
+
+        add_stanza_id(&mut msg, "fresh", "alice@example.com");
+
+        let ids = extract_stanza_ids(&msg);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], StanzaId::new("fresh", "alice@example.com"));
+    }
+
+    #[test]
     fn test_add_origin_id() {
         let mut msg = Message::new(None::<jid::Jid>);
         add_origin_id(&mut msg, "client-1");
@@ -358,6 +403,20 @@ mod tests {
         let mut msg = Message::new(None::<jid::Jid>);
         add_stanza_id(&mut msg, "arc-1", "room@muc.example.com");
         add_stanza_id(&mut msg, "arc-2", "example.com");
+
+        remove_stanza_ids_by(&mut msg, "room@muc.example.com");
+        let ids = extract_stanza_ids(&msg);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].by, "example.com");
+    }
+
+    #[test]
+    fn test_remove_stanza_ids_by_matches_case_folded_bare_jid() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        msg.payloads
+            .push(build_stanza_id_element("arc-1", "room@muc.example.COM"));
+        msg.payloads
+            .push(build_stanza_id_element("arc-2", "example.com"));
 
         remove_stanza_ids_by(&mut msg, "room@muc.example.com");
         let ids = extract_stanza_ids(&msg);

--- a/server/crates/waddle-xmpp/src/xep/xep0372.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0372.rs
@@ -40,6 +40,9 @@ pub enum ReferenceError {
     /// Missing required `type` attribute.
     #[error("reference missing type attribute")]
     MissingType,
+    /// Missing required `uri` attribute.
+    #[error("reference missing uri attribute")]
+    MissingUri,
     /// Invalid begin/end range.
     #[error("invalid reference range: begin={begin}, end={end}")]
     InvalidRange { begin: usize, end: usize },
@@ -88,8 +91,8 @@ pub struct Reference {
     pub begin: Option<usize>,
     /// The end index (exclusive) in the body text.
     pub end: Option<usize>,
-    /// The URI of the referenced entity (e.g., `xmpp:alice@example.com`).
-    pub uri: Option<String>,
+    /// The required URI of the referenced entity (e.g., `xmpp:alice@example.com`).
+    pub uri: String,
     /// Optional anchor text (for display if body range unavailable).
     pub anchor: Option<String>,
 }
@@ -101,7 +104,7 @@ impl Reference {
             ref_type: ReferenceType::Mention,
             begin: None,
             end: None,
-            uri: Some(uri.into()),
+            uri: uri.into(),
             anchor: None,
         }
     }
@@ -112,7 +115,7 @@ impl Reference {
             ref_type: ReferenceType::Mention,
             begin: Some(begin),
             end: Some(end),
-            uri: Some(uri.into()),
+            uri: uri.into(),
             anchor: None,
         }
     }
@@ -123,7 +126,7 @@ impl Reference {
             ref_type: ReferenceType::Data,
             begin: None,
             end: None,
-            uri: Some(uri.into()),
+            uri: uri.into(),
             anchor: None,
         }
     }
@@ -141,7 +144,7 @@ impl Reference {
 
     /// Extract the bare JID from the URI (strips `xmpp:` prefix).
     pub fn bare_jid(&self) -> Option<&str> {
-        self.uri.as_deref().and_then(|u| u.strip_prefix("xmpp:"))
+        self.uri.strip_prefix("xmpp:")
     }
 }
 
@@ -163,7 +166,7 @@ pub trait ReferenceCarrier {
         let xmpp_uri = format!("xmpp:{jid}");
         self.references()
             .iter()
-            .any(|r| r.is_mention() && r.uri.as_deref() == Some(&xmpp_uri))
+            .any(|r| r.is_mention() && r.uri == xmpp_uri)
     }
 
     /// Returns `true` if this carrier has any references.
@@ -217,8 +220,9 @@ pub fn parse_reference_element(elem: &Element) -> Result<Reference, ReferenceErr
     let end = elem.attr("end").and_then(|s| s.parse().ok());
     let uri = elem
         .attr("uri")
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_owned());
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.to_owned())
+        .ok_or(ReferenceError::MissingUri)?;
     let anchor = elem
         .attr("anchor")
         .filter(|s| !s.is_empty())
@@ -238,7 +242,7 @@ pub fn extract_mention_uris(msg: &Message) -> Vec<String> {
     extract_references_from_message(msg)
         .into_iter()
         .filter(|r| r.is_mention())
-        .filter_map(|r| r.uri)
+        .map(|r| r.uri)
         .collect()
 }
 
@@ -264,9 +268,7 @@ pub fn build_reference_element(reference: &Reference) -> Element {
     if let Some(end) = reference.end {
         builder = builder.attr("end", end.to_string());
     }
-    if let Some(ref uri) = reference.uri {
-        builder = builder.attr("uri", uri.as_str());
-    }
+    builder = builder.attr("uri", reference.uri.as_str());
     if let Some(ref anchor) = reference.anchor {
         builder = builder.attr("anchor", anchor.as_str());
     }
@@ -317,7 +319,7 @@ mod tests {
         assert!(refs[0].is_mention());
         assert_eq!(refs[0].begin, Some(6));
         assert_eq!(refs[0].end, Some(12));
-        assert_eq!(refs[0].uri.as_deref(), Some("xmpp:alice@example.com"));
+        assert_eq!(refs[0].uri, "xmpp:alice@example.com");
         assert_eq!(refs[0].bare_jid(), Some("alice@example.com"));
     }
 
@@ -350,6 +352,54 @@ mod tests {
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
         // Missing type → skipped (not an error, just ignored)
+        assert!(extract_references_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_parse_reference_requires_uri() {
+        let elem = Element::builder("reference", NS_REFERENCE)
+            .attr("type", "mention")
+            .build();
+
+        assert!(matches!(
+            parse_reference_element(&elem),
+            Err(ReferenceError::MissingUri)
+        ));
+    }
+
+    #[test]
+    fn test_reference_missing_uri_skipped() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <body>Hello</body>\
+                    <reference xmlns='urn:xmpp:reference:0' type='mention'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        assert!(extract_references_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_reference_empty_uri_skipped() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <body>Hello</body>\
+                    <reference xmlns='urn:xmpp:reference:0' type='mention' uri=''/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        assert!(extract_references_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_reference_whitespace_uri_skipped() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <body>Hello</body>\
+                    <reference xmlns='urn:xmpp:reference:0' type='mention' uri='   '/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
         assert!(extract_references_from_message(&msg).is_empty());
     }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0410.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0410.rs
@@ -36,13 +36,17 @@
 //!
 //! ## Service Discovery
 //!
-//! The MUC service advertises `urn:xmpp:muc-selfping:0` in disco#info
+//! The MUC service advertises
+//! `http://jabber.org/protocol/muc#self-ping-optimization` in disco#info
 //! to indicate support for the optimized self-ping flow.
 
-use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::{
+    iq::{Iq, IqType},
+    stanza_error::DefinedCondition,
+};
 
-/// Feature string for XEP-0410 MUC Self-Ping.
-pub const FEATURE_MUC_SELFPING: &str = "urn:xmpp:muc-selfping:0";
+/// Feature string for XEP-0410 MUC Self-Ping optimization.
+pub const FEATURE_MUC_SELFPING: &str = "http://jabber.org/protocol/muc#self-ping-optimization";
 
 /// Namespace for XEP-0199 Ping (used in self-ping).
 const NS_PING: &str = "urn:xmpp:ping";
@@ -108,7 +112,15 @@ pub fn is_self_ping(iq: &Iq) -> bool {
 pub fn interpret_self_ping_response(response: &Iq) -> SelfPingResult {
     match &response.payload {
         IqType::Result(_) => SelfPingResult::Connected,
-        IqType::Error(_) => SelfPingResult::Disconnected,
+        IqType::Error(error) => match error.defined_condition {
+            DefinedCondition::ServiceUnavailable
+            | DefinedCondition::FeatureNotImplemented
+            | DefinedCondition::ItemNotFound => SelfPingResult::Connected,
+            DefinedCondition::RemoteServerNotFound | DefinedCondition::RemoteServerTimeout => {
+                SelfPingResult::Timeout
+            }
+            _ => SelfPingResult::Disconnected,
+        },
         _ => SelfPingResult::Timeout,
     }
 }
@@ -123,6 +135,7 @@ pub const PING_TIMEOUT_SECS: u64 = 10;
 mod tests {
     use super::*;
     use minidom::Element;
+    use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
     #[test]
     fn test_build_self_ping() {
@@ -184,18 +197,48 @@ mod tests {
         assert_eq!(interpret_self_ping_response(&iq), SelfPingResult::Connected);
     }
 
+    fn error_iq(condition: DefinedCondition) -> Iq {
+        Iq {
+            from: Some("room@muc.example.com/mynick".parse().expect("valid")),
+            to: Some("juliet@example.com/client".parse().expect("valid")),
+            id: "sp-err".to_owned(),
+            payload: IqType::Error(StanzaError::new(ErrorType::Cancel, condition, "en", "")),
+        }
+    }
+
     #[test]
-    fn test_interpret_error_disconnected() {
-        let xml =
-            "<iq xmlns='jabber:client' type='error' from='room@muc.example.com/mynick' id='sp-1'>\
-                    <error type='cancel'>\
-                      <not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
-                    </error>\
-                    </iq>";
-        let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid iq");
+    fn test_interpret_not_acceptable_as_disconnected() {
         assert_eq!(
-            interpret_self_ping_response(&iq),
+            interpret_self_ping_response(&error_iq(DefinedCondition::NotAcceptable)),
             SelfPingResult::Disconnected
+        );
+    }
+
+    #[test]
+    fn test_interpret_service_unavailable_as_connected() {
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(DefinedCondition::ServiceUnavailable)),
+            SelfPingResult::Connected
+        );
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(DefinedCondition::FeatureNotImplemented)),
+            SelfPingResult::Connected
+        );
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(DefinedCondition::ItemNotFound)),
+            SelfPingResult::Connected
+        );
+    }
+
+    #[test]
+    fn test_interpret_remote_server_errors_as_timeout() {
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(DefinedCondition::RemoteServerNotFound)),
+            SelfPingResult::Timeout
+        );
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(DefinedCondition::RemoteServerTimeout)),
+            SelfPingResult::Timeout
         );
     }
 
@@ -217,6 +260,9 @@ mod tests {
     fn test_constants() {
         assert_eq!(RECOMMENDED_INTERVAL_SECS, 60);
         assert_eq!(PING_TIMEOUT_SECS, 10);
-        assert_eq!(FEATURE_MUC_SELFPING, "urn:xmpp:muc-selfping:0");
+        assert_eq!(
+            FEATURE_MUC_SELFPING,
+            "http://jabber.org/protocol/muc#self-ping-optimization"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0424.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0424.rs
@@ -16,7 +16,7 @@
 //! Tombstone (server-side replacement in archives):
 //! ```xml
 //! <message type='groupchat' from='room@muc.example.com/nick' id='original-msg-id'>
-//!   <retracted stamp='2024-01-15T12:00:00Z' xmlns='urn:xmpp:message-retract:1'/>
+//!   <retracted xmlns='urn:xmpp:message-retract:1' id='retract-1' stamp='2024-01-15T12:00:00Z'/>
 //! </message>
 //! ```
 //!
@@ -41,9 +41,9 @@ pub enum RetractionError {
     /// A `<retract/>` element is missing its required `id` attribute.
     #[error("retract element missing id attribute")]
     MissingId,
-    /// A `<retracted/>` element is missing its required `stamp` attribute.
-    #[error("retracted element missing stamp attribute")]
-    MissingStamp,
+    /// A `<retracted/>` element is missing its required `id` attribute.
+    #[error("retracted element missing retraction id attribute")]
+    MissingRetractionId,
 }
 
 /// A message retraction request.
@@ -65,15 +65,18 @@ impl Retraction {
 /// A tombstone indicating a message was retracted.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Retracted {
+    /// The id of the retraction message that produced this tombstone.
+    pub retraction_id: String,
     /// The timestamp when the message was retracted (ISO 8601 / XEP-0082).
-    pub stamp: String,
+    pub stamp: Option<String>,
 }
 
 impl Retracted {
     /// Create a new retracted tombstone.
-    pub fn new(stamp: impl Into<String>) -> Self {
+    pub fn new(retraction_id: impl Into<String>, stamp: Option<String>) -> Self {
         Self {
-            stamp: stamp.into(),
+            retraction_id: retraction_id.into(),
+            stamp,
         }
     }
 }
@@ -155,9 +158,12 @@ pub fn extract_retraction_from_message(msg: &Message) -> Option<RetractionKind> 
                 }
             }
             "retracted" => {
-                let stamp = elem.attr("stamp").unwrap_or("").to_owned();
-                if !stamp.is_empty() {
-                    return Some(RetractionKind::Tombstone(Retracted::new(stamp)));
+                let retraction_id = elem.attr("id").unwrap_or("").to_owned();
+                if !retraction_id.is_empty() {
+                    return Some(RetractionKind::Tombstone(Retracted::new(
+                        retraction_id,
+                        elem.attr("stamp").map(ToOwned::to_owned),
+                    )));
                 }
             }
             _ => {}
@@ -185,11 +191,13 @@ pub fn build_retract_element(original_id: &str) -> Element {
         .build()
 }
 
-/// Build a `<retracted stamp='...' xmlns='urn:xmpp:message-retract:1'/>` tombstone element.
-pub fn build_retracted_element(stamp: &str) -> Element {
-    Element::builder("retracted", NS_MESSAGE_RETRACT)
-        .attr("stamp", stamp)
-        .build()
+/// Build a `<retracted id='...' xmlns='urn:xmpp:message-retract:1'/>` tombstone element.
+pub fn build_retracted_element(retraction_id: &str, stamp: Option<&str>) -> Element {
+    let mut builder = Element::builder("retracted", NS_MESSAGE_RETRACT).attr("id", retraction_id);
+    if let Some(stamp) = stamp {
+        builder = builder.attr("stamp", stamp);
+    }
+    builder.build()
 }
 
 /// Build a retraction request message.
@@ -219,13 +227,15 @@ pub fn build_tombstone_message(
     to: impl Into<Option<jid::Jid>>,
     from: impl Into<Option<jid::Jid>>,
     original_id: &str,
-    stamp: &str,
+    retraction_id: &str,
+    stamp: Option<&str>,
 ) -> Message {
     let mut msg = Message::new(to.into());
     msg.from = from.into();
     msg.type_ = xmpp_parsers::message::MessageType::Groupchat;
     msg.id = Some(original_id.to_owned());
-    msg.payloads.push(build_retracted_element(stamp));
+    msg.payloads
+        .push(build_retracted_element(retraction_id, stamp));
     msg
 }
 
@@ -264,6 +274,7 @@ mod tests {
     #[test]
     fn test_is_retracted_element() {
         let retracted = Element::builder("retracted", NS_MESSAGE_RETRACT)
+            .attr("id", "retract-1")
             .attr("stamp", "2024-01-15T12:00:00Z")
             .build();
         assert!(is_retracted_element(&retracted));
@@ -287,7 +298,7 @@ mod tests {
     #[test]
     fn test_is_tombstone_message() {
         let xml = "<message xmlns='jabber:client' type='groupchat' id='orig-1'>\
-                    <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-01-15T12:00:00Z'/>\
+                    <retracted xmlns='urn:xmpp:message-retract:1' id='retract-1' stamp='2024-01-15T12:00:00Z'/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -311,7 +322,7 @@ mod tests {
     #[test]
     fn test_extract_retraction_tombstone() {
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-06-01T09:00:00Z'/>\
+                    <retracted xmlns='urn:xmpp:message-retract:1' id='retract-7' stamp='2024-06-01T09:00:00Z'/>\
                     </message>";
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -319,7 +330,10 @@ mod tests {
         let kind = extract_retraction_from_message(&msg).expect("has retraction");
         assert_eq!(
             kind,
-            RetractionKind::Tombstone(Retracted::new("2024-06-01T09:00:00Z"))
+            RetractionKind::Tombstone(Retracted::new(
+                "retract-7",
+                Some("2024-06-01T09:00:00Z".to_owned()),
+            ))
         );
     }
 
@@ -337,6 +351,29 @@ mod tests {
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
         assert!(extract_retraction_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_extract_tombstone_missing_id_ignored() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-06-01T09:00:00Z'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert!(extract_retraction_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_extract_tombstone_without_stamp() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <retracted xmlns='urn:xmpp:message-retract:1' id='retract-8'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+        assert_eq!(
+            extract_retraction_from_message(&msg),
+            Some(RetractionKind::Tombstone(Retracted::new("retract-8", None)))
+        );
     }
 
     #[test]
@@ -359,9 +396,10 @@ mod tests {
 
     #[test]
     fn test_build_retracted_element() {
-        let elem = build_retracted_element("2024-01-15T12:00:00Z");
+        let elem = build_retracted_element("retract-1", Some("2024-01-15T12:00:00Z"));
         assert_eq!(elem.name(), "retracted");
         assert_eq!(elem.ns(), NS_MESSAGE_RETRACT);
+        assert_eq!(elem.attr("id"), Some("retract-1"));
         assert_eq!(elem.attr("stamp"), Some("2024-01-15T12:00:00Z"));
     }
 
@@ -385,14 +423,16 @@ mod tests {
             None::<jid::Jid>,
             None::<jid::Jid>,
             "orig-1",
-            "2024-01-15T12:00:00Z",
+            "retract-1",
+            Some("2024-01-15T12:00:00Z"),
         );
 
         assert_eq!(msg.id.as_deref(), Some("orig-1"));
         assert!(is_tombstone_message(&msg));
         match extract_retraction_from_message(&msg) {
             Some(RetractionKind::Tombstone(t)) => {
-                assert_eq!(t.stamp, "2024-01-15T12:00:00Z");
+                assert_eq!(t.retraction_id, "retract-1");
+                assert_eq!(t.stamp.as_deref(), Some("2024-01-15T12:00:00Z"));
             }
             other => panic!("Expected tombstone, got {:?}", other),
         }
@@ -443,7 +483,7 @@ mod tests {
 
         // Tombstone
         let xml2 = "<message xmlns='jabber:client' type='groupchat'>\
-                     <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-01-01T00:00:00Z'/>\
+                     <retracted xmlns='urn:xmpp:message-retract:1' id='retract-1' stamp='2024-01-01T00:00:00Z'/>\
                      </message>";
         let msg2 =
             Message::try_from(xml2.parse::<Element>().expect("valid xml")).expect("valid message");
@@ -465,7 +505,8 @@ mod tests {
 
     #[test]
     fn test_retracted_new() {
-        let t = Retracted::new("2024-06-01T00:00:00Z");
-        assert_eq!(t.stamp, "2024-06-01T00:00:00Z");
+        let t = Retracted::new("retract-9", Some("2024-06-01T00:00:00Z".to_owned()));
+        assert_eq!(t.retraction_id, "retract-9");
+        assert_eq!(t.stamp.as_deref(), Some("2024-06-01T00:00:00Z"));
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0428.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0428.rs
@@ -36,8 +36,8 @@ pub struct FallbackRange {
 pub struct FallbackIndication {
     /// The feature namespace this fallback is for (e.g. `urn:xmpp:reply:0`).
     pub for_ns: String,
-    /// Optional body range; absent means "the entire body is fallback".
-    pub body_range: Option<FallbackRange>,
+    /// Optional body ranges; absent means "the entire body is fallback".
+    pub body_ranges: Option<Vec<FallbackRange>>,
 }
 
 impl FallbackIndication {
@@ -45,15 +45,24 @@ impl FallbackIndication {
     pub fn whole_body(for_ns: impl Into<String>) -> Self {
         Self {
             for_ns: for_ns.into(),
-            body_range: None,
+            body_ranges: None,
         }
     }
 
     /// Construct a body-range fallback.
     pub fn for_range(for_ns: impl Into<String>, start: usize, end: usize) -> Self {
+        Self::for_ranges(for_ns, [FallbackRange { start, end }])
+    }
+
+    /// Construct a fallback with multiple body ranges.
+    pub fn for_ranges(
+        for_ns: impl Into<String>,
+        body_ranges: impl IntoIterator<Item = FallbackRange>,
+    ) -> Self {
+        let body_ranges: Vec<FallbackRange> = body_ranges.into_iter().collect();
         Self {
             for_ns: for_ns.into(),
-            body_range: Some(FallbackRange { start, end }),
+            body_ranges: (!body_ranges.is_empty()).then_some(body_ranges),
         }
     }
 }
@@ -63,20 +72,46 @@ pub fn is_fallback_element(elem: &Element) -> bool {
     elem.name() == "fallback" && elem.ns() == NS_FALLBACK
 }
 
-fn parse_usize_attr(elem: &Element, name: &str) -> Option<usize> {
-    elem.attr(name)
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-        .and_then(|v| v.parse::<usize>().ok())
+fn parse_usize_attr(elem: &Element, name: &str) -> Result<Option<usize>, ()> {
+    match elem.attr(name).map(str::trim).filter(|v| !v.is_empty()) {
+        Some(value) => value.parse::<usize>().map(Some).map_err(|_| ()),
+        None => Ok(None),
+    }
 }
 
-fn parse_body_range(fallback_elem: &Element) -> Option<FallbackRange> {
-    let body_elem = fallback_elem
+fn parse_body_ranges(fallback_elem: &Element) -> Result<Option<Vec<FallbackRange>>, ()> {
+    let body_children: Vec<&Element> = fallback_elem
         .children()
-        .find(|child| child.name() == "body" && child.ns() == NS_FALLBACK)?;
-    let start = parse_usize_attr(body_elem, "start").unwrap_or(0);
-    let end = parse_usize_attr(body_elem, "end").unwrap_or(start);
-    Some(FallbackRange { start, end })
+        .filter(|child| child.name() == "body" && child.ns() == NS_FALLBACK)
+        .collect();
+    if body_children.is_empty() {
+        if fallback_elem.children().next().is_none() {
+            return Ok(None);
+        }
+        return Err(());
+    }
+
+    let mut ranges = Vec::with_capacity(body_children.len());
+    let mut whole_body = false;
+    for body_elem in body_children {
+        let start = parse_usize_attr(body_elem, "start")?;
+        let end = parse_usize_attr(body_elem, "end")?;
+        match (start, end) {
+            (None, None) => whole_body = true,
+            (Some(start), Some(end)) if end >= start => ranges.push(FallbackRange { start, end }),
+            _ => return Err(()),
+        }
+    }
+
+    if whole_body {
+        if ranges.is_empty() {
+            Ok(None)
+        } else {
+            Err(())
+        }
+    } else {
+        Ok(Some(ranges))
+    }
 }
 
 /// Parse all `<fallback/>` payloads attached to a message.
@@ -86,9 +121,10 @@ pub fn parse_fallbacks_from_message(msg: &Message) -> Vec<FallbackIndication> {
         .filter(|elem| is_fallback_element(elem))
         .filter_map(|elem| {
             let for_ns = elem.attr("for").map(str::trim).filter(|v| !v.is_empty())?;
+            let body_ranges = parse_body_ranges(elem).ok()?;
             Some(FallbackIndication {
                 for_ns: for_ns.to_owned(),
-                body_range: parse_body_range(elem),
+                body_ranges,
             })
         })
         .collect()
@@ -98,12 +134,19 @@ pub fn parse_fallbacks_from_message(msg: &Message) -> Vec<FallbackIndication> {
 pub fn build_fallback_element(fallback: &FallbackIndication) -> Element {
     let mut builder =
         Element::builder("fallback", NS_FALLBACK).attr("for", fallback.for_ns.as_str());
-    if let Some(range) = fallback.body_range {
-        let body = Element::builder("body", NS_FALLBACK)
-            .attr("start", range.start.to_string())
-            .attr("end", range.end.to_string())
-            .build();
-        builder = builder.append(body);
+    match &fallback.body_ranges {
+        None => {
+            builder = builder.append(Element::builder("body", NS_FALLBACK).build());
+        }
+        Some(ranges) => {
+            for range in ranges {
+                let body = Element::builder("body", NS_FALLBACK)
+                    .attr("start", range.start.to_string())
+                    .attr("end", range.end.to_string())
+                    .build();
+                builder = builder.append(body);
+            }
+        }
     }
     builder.build()
 }
@@ -165,7 +208,7 @@ mod tests {
         let fallbacks = parse_fallbacks_from_message(&msg);
         assert_eq!(fallbacks.len(), 1);
         assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
-        assert_eq!(fallbacks[0].body_range, None);
+        assert_eq!(fallbacks[0].body_ranges, None);
     }
 
     #[test]
@@ -180,9 +223,58 @@ mod tests {
         let fallbacks = parse_fallbacks_from_message(&msg);
         assert_eq!(fallbacks.len(), 1);
         assert_eq!(
-            fallbacks[0].body_range,
-            Some(FallbackRange { start: 0, end: 42 })
+            fallbacks[0].body_ranges,
+            Some(vec![FallbackRange { start: 0, end: 42 }])
         );
+    }
+
+    #[test]
+    fn test_parse_body_child_without_offsets_means_whole_body() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'>\
+                <body/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:sfs:0");
+        assert_eq!(fallbacks[0].body_ranges, None);
+    }
+
+    #[test]
+    fn test_parse_multiple_body_ranges() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+                <body start='20' end='30'/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        let fallbacks = parse_fallbacks_from_message(&msg);
+        assert_eq!(fallbacks.len(), 1);
+        assert_eq!(
+            fallbacks[0].body_ranges,
+            Some(vec![
+                FallbackRange { start: 0, end: 10 },
+                FallbackRange { start: 20, end: 30 },
+            ])
+        );
+    }
+
+    #[test]
+    fn test_parse_mixed_whole_body_and_range_is_skipped() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+                <body/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        assert!(parse_fallbacks_from_message(&msg).is_empty());
     }
 
     #[test]
@@ -212,6 +304,42 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_subject_only_fallback_is_skipped() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <subject start='0' end='4'/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        assert!(parse_fallbacks_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_parse_partial_body_range_is_skipped() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0'/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        assert!(parse_fallbacks_from_message(&msg).is_empty());
+    }
+
+    #[test]
+    fn test_parse_end_before_start_is_skipped() {
+        let xml = "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='4' end='1'/>\
+            </fallback>\
+        </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
+        assert!(parse_fallbacks_from_message(&msg).is_empty());
+    }
+
+    #[test]
     fn test_build_round_trip() {
         let original = FallbackIndication::for_range("urn:xmpp:reply:0", 0, 17);
         let elem = build_fallback_element(&original);
@@ -223,6 +351,23 @@ mod tests {
             .expect("body child");
         assert_eq!(body.attr("start"), Some("0"));
         assert_eq!(body.attr("end"), Some("17"));
+    }
+
+    #[test]
+    fn test_build_whole_body_fallback_emits_body_child_without_offsets() {
+        let elem = build_fallback_element(&FallbackIndication::whole_body("urn:xmpp:sfs:0"));
+        assert_eq!(elem.attr("for"), Some("urn:xmpp:sfs:0"));
+        let body = elem.get_child("body", NS_FALLBACK).expect("body child");
+        assert!(body.attr("start").is_none());
+        assert!(body.attr("end").is_none());
+    }
+
+    #[test]
+    fn test_empty_body_ranges_canonicalize_to_whole_body() {
+        let fallback = FallbackIndication::for_ranges("urn:xmpp:sfs:0", std::iter::empty());
+        assert_eq!(fallback.body_ranges, None);
+        let elem = build_fallback_element(&fallback);
+        assert!(elem.get_child("body", NS_FALLBACK).is_some());
     }
 
     #[test]
@@ -242,8 +387,8 @@ mod tests {
         assert_eq!(fallbacks.len(), 1);
         assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
         assert_eq!(
-            fallbacks[0].body_range,
-            Some(FallbackRange { start: 2, end: 5 })
+            fallbacks[0].body_ranges,
+            Some(vec![FallbackRange { start: 2, end: 5 }])
         );
     }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0444.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0444.rs
@@ -34,6 +34,8 @@
 //! The server transparently routes reaction messages. They should not be
 //! archived as regular messages but may be stored for reaction aggregation.
 
+use std::collections::HashSet;
+
 use minidom::Element;
 use thiserror::Error;
 use xmpp_parsers::message::Message;
@@ -63,7 +65,7 @@ impl ReactionSet {
     pub fn new(message_id: impl Into<String>, emojis: Vec<String>) -> Self {
         Self {
             message_id: message_id.into(),
-            emojis,
+            emojis: normalize_reactions(emojis),
         }
     }
 
@@ -114,11 +116,10 @@ pub fn extract_reactions_from_message(msg: &Message) -> Option<ReactionSet> {
     let elem = msg.payloads.iter().find(|e| is_reactions_element(e))?;
     let id = elem.attr("id").filter(|s| !s.is_empty())?.to_owned();
 
-    let emojis: Vec<String> = elem
+    let emojis = elem
         .children()
         .filter(|child| child.name() == "reaction" && child.ns() == NS_REACTIONS)
         .map(|child| child.text())
-        .filter(|text| !text.is_empty())
         .collect();
 
     Some(ReactionSet::new(id, emojis))
@@ -143,13 +144,36 @@ pub fn build_reaction_element(emoji: &str) -> Element {
     elem
 }
 
+fn normalize_reactions<I, S>(emojis: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::new();
+
+    for emoji in emojis {
+        let emoji = emoji.as_ref().trim();
+        if emoji.is_empty() {
+            continue;
+        }
+
+        let emoji = emoji.to_owned();
+        if seen.insert(emoji.clone()) {
+            normalized.push(emoji);
+        }
+    }
+
+    normalized
+}
+
 /// Build a `<reactions id='...'><reaction>...</reaction>...</reactions>` element.
 pub fn build_reactions_element(message_id: &str, emojis: &[&str]) -> Element {
     let mut reactions = Element::builder("reactions", NS_REACTIONS)
         .attr("id", message_id)
         .build();
-    for emoji in emojis {
-        reactions.append_child(build_reaction_element(emoji));
+    for emoji in normalize_reactions(emojis.iter().copied()) {
+        reactions.append_child(build_reaction_element(&emoji));
     }
     reactions
 }
@@ -191,10 +215,7 @@ pub fn strip_reactions(msg: &mut Message) {
 
 impl From<xmpp_parsers::reactions::Reactions> for ReactionSet {
     fn from(r: xmpp_parsers::reactions::Reactions) -> Self {
-        Self {
-            message_id: r.id,
-            emojis: r.reactions.into_iter().map(|rx| rx.emoji).collect(),
-        }
+        Self::new(r.id, r.reactions.into_iter().map(|rx| rx.emoji).collect())
     }
 }
 
@@ -242,9 +263,7 @@ mod tests {
 
         let set = extract_reactions_from_message(&msg).expect("has reactions");
         assert_eq!(set.message_id, "msg-42");
-        assert_eq!(set.emojis.len(), 2);
-        assert!(set.emojis.contains(&"👍".to_owned()));
-        assert!(set.emojis.contains(&"❤️".to_owned()));
+        assert_eq!(set.emojis, vec!["👍", "❤️"]);
         assert!(!set.is_removal());
     }
 
@@ -260,6 +279,24 @@ mod tests {
         assert_eq!(set.message_id, "msg-1");
         assert!(set.emojis.is_empty());
         assert!(set.is_removal());
+    }
+
+    #[test]
+    fn test_extract_reactions_deduplicates_duplicates() {
+        let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                    <reactions xmlns='urn:xmpp:reactions:0' id='msg-42'>\
+                      <reaction> 👍 </reaction>\
+                      <reaction>👍</reaction>\
+                      <reaction>❤️</reaction>\
+                      <reaction>👍</reaction>\
+                      <reaction>   </reaction>\
+                    </reactions>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        let set = extract_reactions_from_message(&msg).expect("has reactions");
+        assert_eq!(set.emojis, vec!["👍", "❤️"]);
     }
 
     #[test]
@@ -306,6 +343,15 @@ mod tests {
         assert_eq!(elem.name(), "reactions");
         assert_eq!(elem.ns(), NS_REACTIONS);
         assert_eq!(elem.attr("id"), Some("msg-99"));
+        let children: Vec<_> = elem.children().collect();
+        assert_eq!(children.len(), 2);
+        assert_eq!(children[0].text(), "👍");
+        assert_eq!(children[1].text(), "❤️");
+    }
+
+    #[test]
+    fn test_build_reactions_element_deduplicates_duplicates() {
+        let elem = build_reactions_element("msg-99", &["👍", " 👍 ", "", "❤️", "👍"]);
         let children: Vec<_> = elem.children().collect();
         assert_eq!(children.len(), 2);
         assert_eq!(children[0].text(), "👍");
@@ -394,8 +440,17 @@ mod tests {
 
     #[test]
     fn test_reaction_set_new() {
-        let set = ReactionSet::new("msg-1", vec!["👍".to_owned()]);
+        let set = ReactionSet::new(
+            "msg-1",
+            vec![
+                "👍".to_owned(),
+                " 👍 ".to_owned(),
+                "❤️".to_owned(),
+                "   ".to_owned(),
+            ],
+        );
         assert_eq!(set.message_id, "msg-1");
+        assert_eq!(set.emojis, vec!["👍", "❤️"]);
         assert!(!set.is_removal());
 
         let empty = ReactionSet::new("msg-2", vec![]);
@@ -407,6 +462,9 @@ mod tests {
         let parser_reactions = xmpp_parsers::reactions::Reactions {
             id: "msg-1".to_owned(),
             reactions: vec![
+                xmpp_parsers::reactions::Reaction {
+                    emoji: "👍".to_owned(),
+                },
                 xmpp_parsers::reactions::Reaction {
                     emoji: "👍".to_owned(),
                 },

--- a/server/crates/waddle-xmpp/src/xep/xep0461.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0461.rs
@@ -5,6 +5,7 @@
 //!
 //! Thread identifiers continue to use RFC 6121 `<thread/>`.
 
+use jid::Jid;
 use minidom::Element;
 use xmpp_parsers::message::Message;
 
@@ -17,7 +18,7 @@ pub struct ReplyReference {
     /// The ID of the message being replied to.
     pub id: String,
     /// Optional JID of the original message sender.
-    pub to: Option<String>,
+    pub to: Option<Jid>,
 }
 
 impl ReplyReference {
@@ -30,8 +31,8 @@ impl ReplyReference {
     }
 
     /// Attach the optional original sender JID.
-    pub fn with_to(mut self, to: impl Into<String>) -> Self {
-        self.to = Some(to.into());
+    pub fn with_to(mut self, to: Jid) -> Self {
+        self.to = Some(to);
         self
     }
 }
@@ -43,36 +44,31 @@ pub fn is_reply_element(elem: &Element) -> bool {
 
 /// Parse an XEP-0461 reply payload from a message.
 ///
-/// Accepts both:
-/// - `<reply id='message-id' to='sender@domain'/>` (preferred)
-/// - `<reply to='message-id'/>` (legacy compatibility)
+/// XEP-0461 requires an `id` attribute.
+///
+/// The optional `to` attribute is parsed as a JID when valid; malformed `to`
+/// values are ignored here and rejected at protocol ingress.
 pub fn parse_reply_from_message(msg: &Message) -> Option<ReplyReference> {
     let reply_elem = msg.payloads.iter().find(|elem| is_reply_element(elem))?;
 
-    let id_attr = reply_elem
+    let id = reply_elem
         .attr("id")
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+        .map(ToOwned::to_owned)?;
 
-    let to_attr = reply_elem
+    let to = reply_elem
         .attr("to")
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned);
+        .and_then(|value| value.trim().parse::<Jid>().ok());
 
-    // Backward compatibility with older examples that used @to as the message id.
-    match id_attr {
-        Some(id) => Some(ReplyReference { id, to: to_attr }),
-        None => to_attr.map(ReplyReference::new),
-    }
+    Some(ReplyReference { id, to })
 }
 
 /// Build an XEP-0461 `<reply/>` payload element.
 pub fn build_reply_element(reply: &ReplyReference) -> Element {
     let mut builder = Element::builder("reply", NS_REPLY).attr("id", reply.id.as_str());
-    if let Some(to) = reply.to.as_deref() {
-        builder = builder.attr("to", to);
+    if let Some(to) = reply.to.as_ref() {
+        builder = builder.attr("to", to.to_string());
     }
     builder.build()
 }
@@ -94,16 +90,26 @@ mod tests {
         let msg = Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("message");
         let reply = parse_reply_from_message(&msg).expect("reply present");
         assert_eq!(reply.id, "parent-1");
-        assert_eq!(reply.to.as_deref(), Some("alice@example.com"));
+        assert_eq!(
+            reply.to.as_ref().map(ToString::to_string).as_deref(),
+            Some("alice@example.com")
+        );
     }
 
     #[test]
-    fn test_parse_reply_legacy_to_as_id() {
+    fn test_parse_reply_requires_id() {
         let xml =
-            "<message xmlns='jabber:client'><reply xmlns='urn:xmpp:reply:0' to='legacy-id'/></message>";
+            "<message xmlns='jabber:client'><reply xmlns='urn:xmpp:reply:0' to='alice@example.com'/></message>";
+        let msg = Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("message");
+        assert!(parse_reply_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_parse_reply_ignores_invalid_to_jid() {
+        let xml = "<message xmlns='jabber:client'><reply xmlns='urn:xmpp:reply:0' id='parent-1' to=' '/></message>";
         let msg = Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("message");
         let reply = parse_reply_from_message(&msg).expect("reply present");
-        assert_eq!(reply.id, "legacy-id");
+        assert_eq!(reply.id, "parent-1");
         assert_eq!(reply.to, None);
     }
 
@@ -116,12 +122,16 @@ mod tests {
 
         set_reply_payload(
             &mut msg,
-            &ReplyReference::new("new-id").with_to("bob@example.com"),
+            &ReplyReference::new("new-id")
+                .with_to("bob@example.com".parse::<Jid>().expect("valid jid")),
         );
 
         let reply = parse_reply_from_message(&msg).expect("reply present");
         assert_eq!(reply.id, "new-id");
-        assert_eq!(reply.to.as_deref(), Some("bob@example.com"));
+        assert_eq!(
+            reply.to.as_ref().map(ToString::to_string).as_deref(),
+            Some("bob@example.com")
+        );
         assert_eq!(
             msg.payloads
                 .iter()
@@ -143,7 +153,8 @@ mod tests {
 
     #[test]
     fn test_build_reply_element_with_to() {
-        let reply = ReplyReference::new("msg-1").with_to("alice@example.com");
+        let reply = ReplyReference::new("msg-1")
+            .with_to("alice@example.com".parse::<Jid>().expect("valid jid"));
         let elem = build_reply_element(&reply);
         assert_eq!(elem.attr("id"), Some("msg-1"));
         assert_eq!(elem.attr("to"), Some("alice@example.com"));

--- a/server/crates/waddle-xmpp/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp/tests/xep0085_chat_state_notifications.rs
@@ -1,7 +1,7 @@
 //! XEP-0085: Chat State Notifications dedicated suite.
 
 use jid::Jid;
-use waddle_xmpp::disco::{server_features, Feature};
+use waddle_xmpp::disco::{muc_room_features, server_features, Feature};
 use waddle_xmpp::xep::{classify_message_urgency, StanzaUrgency};
 use xmpp_parsers::message::{Body, Message};
 
@@ -28,5 +28,12 @@ fn xep0085_message_with_body_is_urgent() {
 #[test]
 fn xep0085_advertisement_consistency_no_false_feature_claim() {
     let features = server_features();
-    assert!(!features.contains(&Feature::new(CHAT_STATES_NS)));
+    assert!(!features.contains(&Feature::chat_states()));
+}
+
+#[test]
+fn xep0085_muc_rooms_advertise_chat_states() {
+    let features = muc_room_features(false, false, false, false);
+    assert!(features.contains(&Feature::chat_states()));
+    assert_eq!(Feature::chat_states(), Feature::new(CHAT_STATES_NS));
 }

--- a/server/crates/waddle-xmpp/tests/xep0184_message_delivery_receipts.rs
+++ b/server/crates/waddle-xmpp/tests/xep0184_message_delivery_receipts.rs
@@ -1,0 +1,164 @@
+//! XEP-0184: Message Delivery Receipts dedicated suite.
+
+use jid::{BareJid, FullJid, Jid};
+use std::sync::Arc;
+use waddle_xmpp::disco::{server_features, Feature};
+use waddle_xmpp::protocol::{
+    handlers::register_default_message_handlers, FixedIdGenerator, InboundEvent, OutboundEvent,
+    StanzaDispatcher, XmppStateMachine, HEADLESS_RECIPIENT_RESOURCE,
+};
+use waddle_xmpp::xep::{build_receipt_request_element, extract_received_id, has_receipt_request};
+use waddle_xmpp::Stanza;
+use xmpp_parsers::message::{Body, Message, MessageType};
+
+fn full(s: &str) -> FullJid {
+    s.parse().expect("valid full jid")
+}
+
+fn bare(s: &str) -> BareJid {
+    s.parse().expect("valid bare jid")
+}
+
+fn build_dispatcher() -> StanzaDispatcher {
+    let mut dispatcher = StanzaDispatcher::new();
+    register_default_message_handlers(&mut dispatcher);
+    dispatcher
+}
+
+fn ready_machine(full_jid: &FullJid) -> XmppStateMachine {
+    let mut machine = XmppStateMachine::with_id_gen(
+        "example.com",
+        build_dispatcher(),
+        Arc::new(FixedIdGenerator("receipt-stamp".to_string())),
+    );
+    machine.transition_to_ready(full_jid.clone(), false);
+    machine
+}
+
+fn direct_message(
+    from: &FullJid,
+    to: &BareJid,
+    message_type: MessageType,
+    id: Option<&str>,
+) -> Message {
+    let mut message = Message::new(Some(Jid::from(to.clone())));
+    message.from = Some(Jid::from(from.clone()));
+    message.type_ = message_type;
+    message.id = id.map(str::to_string);
+    message
+        .bodies
+        .insert(String::new(), Body("hello".to_string()));
+    message.payloads.push(build_receipt_request_element());
+    message
+}
+
+fn receipt_route<'a>(events: &'a [OutboundEvent]) -> Option<(usize, &'a Jid, &'a Message)> {
+    events
+        .iter()
+        .enumerate()
+        .find_map(|(idx, event)| match event {
+            OutboundEvent::RouteToConnection { jid, stanza } => match stanza.as_ref() {
+                Stanza::Message(message) => Some((idx, jid, message)),
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+#[test]
+fn xep0184_server_root_advertises_receipts_support() {
+    let features = server_features();
+    assert!(features.contains(&Feature::receipts()));
+}
+
+#[test]
+fn xep0184_recipient_pass_emits_receipt_after_original_delivery() {
+    let bob = full("bob@example.com/desk");
+    let alice = full("alice@example.com/web");
+    let mut machine = ready_machine(&bob);
+
+    let message = direct_message(
+        &alice,
+        &bare("bob@example.com"),
+        MessageType::Chat,
+        Some("msg-1"),
+    );
+    let events = machine.handle(InboundEvent::StanzaFromPeer(Box::new(Stanza::Message(
+        message,
+    ))));
+
+    let send_idx = events
+        .iter()
+        .enumerate()
+        .find_map(|(idx, event)| matches!(event, OutboundEvent::SendStanza(_)).then_some(idx))
+        .expect("recipient pass should deliver original stanza to the wire");
+    let (receipt_idx, receipt_jid, receipt) =
+        receipt_route(&events).expect("recipient pass should emit a receipt route");
+
+    assert!(
+        send_idx < receipt_idx,
+        "receipt route must be emitted after the original SendStanza event"
+    );
+    assert_eq!(*receipt_jid, Jid::from(alice.clone()));
+    assert_eq!(receipt.to, Some(Jid::from(alice.clone())));
+    assert_eq!(receipt.from, Some(Jid::from(bob.clone())));
+    assert_eq!(receipt.type_, MessageType::Chat);
+    assert!(
+        receipt.bodies.is_empty(),
+        "ack must not include body content"
+    );
+    assert!(
+        !has_receipt_request(receipt),
+        "ack must not request another receipt"
+    );
+    assert_eq!(
+        receipt.payloads.len(),
+        1,
+        "ack should contain only the receipt payload"
+    );
+    assert_eq!(extract_received_id(receipt), Some("msg-1".to_string()));
+}
+
+#[test]
+fn xep0184_groupchat_messages_do_not_trigger_delivery_receipts() {
+    let bob = full("bob@example.com/desk");
+    let alice = full("alice@example.com/web");
+    let mut machine = ready_machine(&bob);
+
+    let message = direct_message(
+        &alice,
+        &bare("bob@example.com"),
+        MessageType::Groupchat,
+        Some("group-1"),
+    );
+    let events = machine.handle(InboundEvent::StanzaFromPeer(Box::new(Stanza::Message(
+        message,
+    ))));
+
+    assert!(
+        receipt_route(&events).is_none(),
+        "groupchat receipt requests are not eligible for automatic XEP-0184 acks"
+    );
+}
+
+#[test]
+fn xep0184_messages_without_ids_do_not_trigger_delivery_receipts() {
+    let bob = full("bob@example.com/desk");
+    let alice = full("alice@example.com/web");
+    let mut machine = ready_machine(&bob);
+
+    let message = direct_message(&alice, &bare("bob@example.com"), MessageType::Normal, None);
+    let events = machine.handle(InboundEvent::StanzaFromPeer(Box::new(Stanza::Message(
+        message,
+    ))));
+
+    assert!(
+        receipt_route(&events).is_none(),
+        "messages missing the required content-message id must not receive an ack"
+    );
+}
+
+#[test]
+fn xep0184_headless_resource_constant_matches_offline_pass_guard() {
+    assert_eq!(HEADLESS_RECIPIENT_RESOURCE, "offline-recipient-pass");
+}

--- a/server/crates/waddle-xmpp/tests/xep0184_message_delivery_receipts.rs
+++ b/server/crates/waddle-xmpp/tests/xep0184_message_delivery_receipts.rs
@@ -52,7 +52,7 @@ fn direct_message(
     message
 }
 
-fn receipt_route<'a>(events: &'a [OutboundEvent]) -> Option<(usize, &'a Jid, &'a Message)> {
+fn receipt_route(events: &[OutboundEvent]) -> Option<(usize, &Jid, &Message)> {
     events
         .iter()
         .enumerate()

--- a/server/crates/waddle-xmpp/tests/xep0199_ping.rs
+++ b/server/crates/waddle-xmpp/tests/xep0199_ping.rs
@@ -1,0 +1,171 @@
+//! XEP-0199: XMPP Ping dedicated suite.
+
+use minidom::Element;
+use waddle_xmpp::disco::{server_features, Feature};
+use waddle_xmpp::protocol::event::{OutboundEvent, StanzaContext};
+use waddle_xmpp::protocol::handlers::ping::PingHandler;
+use waddle_xmpp::protocol::IqHandler;
+use waddle_xmpp::xep::{is_ping, NS_PING};
+use waddle_xmpp::Stanza;
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType};
+
+fn session_jid() -> jid::FullJid {
+    "alice@waddle.social/web".parse().expect("valid full jid")
+}
+
+fn stanza_ctx<'a>(jid: &'a jid::FullJid) -> StanzaContext<'a> {
+    StanzaContext {
+        domain: "waddle.social",
+        full_jid: jid,
+    }
+}
+
+#[test]
+fn xep0199_server_disco_advertises_ping() {
+    let features = server_features();
+    assert!(features.contains(&Feature::ping()));
+}
+
+#[test]
+fn xep0199_only_empty_iq_get_ping_is_accepted() {
+    let valid = Iq {
+        from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        to: None,
+        id: "ping-valid".to_string(),
+        payload: IqType::Get(Element::builder("ping", NS_PING).build()),
+    };
+    let malformed = Iq {
+        from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        to: None,
+        id: "ping-bad".to_string(),
+        payload: IqType::Get(
+            Element::builder("ping", NS_PING)
+                .append(Element::builder("extra", NS_PING).build())
+                .build(),
+        ),
+    };
+
+    assert!(is_ping(&valid));
+    assert!(!is_ping(&malformed));
+}
+
+#[test]
+fn xep0199_bare_jid_ping_replies_from_server_domain() {
+    let iq = Iq {
+        from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        to: Some("alice@waddle.social".parse().expect("valid jid")),
+        id: "ping-bare".to_string(),
+        payload: IqType::Get(Element::builder("ping", NS_PING).build()),
+    };
+    let jid = session_jid();
+
+    let events = PingHandler.handle(&iq, &stanza_ctx(&jid));
+
+    match &events[0] {
+        OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+            Stanza::Iq(reply) => {
+                assert_eq!(
+                    reply.from.as_ref().map(|j| j.to_string()),
+                    Some("waddle.social".into())
+                );
+                assert_eq!(
+                    reply.to.as_ref().map(|j| j.to_string()),
+                    Some("alice@waddle.social/web".into())
+                );
+                assert!(matches!(reply.payload, IqType::Result(None)));
+            }
+            other => panic!("expected IQ reply, got {other:?}"),
+        },
+        other => panic!("expected SendStanza, got {other:?}"),
+    }
+}
+
+#[test]
+fn xep0199_full_jid_ping_keeps_full_jid_as_reply_from() {
+    let iq = Iq {
+        from: Some("alice@waddle.social/phone".parse().expect("valid jid")),
+        to: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        id: "ping-full".to_string(),
+        payload: IqType::Get(Element::builder("ping", NS_PING).build()),
+    };
+    let jid = session_jid();
+
+    let events = PingHandler.handle(&iq, &stanza_ctx(&jid));
+
+    match &events[0] {
+        OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+            Stanza::Iq(reply) => {
+                assert_eq!(
+                    reply.from.as_ref().map(|j| j.to_string()),
+                    Some("alice@waddle.social/web".into())
+                );
+                assert_eq!(
+                    reply.to.as_ref().map(|j| j.to_string()),
+                    Some("alice@waddle.social/phone".into())
+                );
+                assert!(matches!(reply.payload, IqType::Result(None)));
+            }
+            other => panic!("expected IQ reply, got {other:?}"),
+        },
+        other => panic!("expected SendStanza, got {other:?}"),
+    }
+}
+
+#[test]
+fn xep0199_malformed_ping_get_returns_bad_request() {
+    let iq = Iq {
+        from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        to: None,
+        id: "ping-bad".to_string(),
+        payload: IqType::Get(
+            Element::builder("ping", NS_PING)
+                .append(Element::builder("extra", NS_PING).build())
+                .build(),
+        ),
+    };
+    let jid = session_jid();
+
+    let events = PingHandler.handle(&iq, &stanza_ctx(&jid));
+
+    match &events[0] {
+        OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+            Stanza::Iq(reply) => {
+                let IqType::Error(error) = &reply.payload else {
+                    panic!("expected typed error reply")
+                };
+                assert_eq!(error.type_, ErrorType::Modify);
+                assert_eq!(error.defined_condition, DefinedCondition::BadRequest);
+            }
+            other => panic!("expected IQ reply, got {other:?}"),
+        },
+        other => panic!("expected SendStanza, got {other:?}"),
+    }
+}
+
+#[test]
+fn xep0199_ping_set_returns_bad_request() {
+    let iq = Iq {
+        from: Some("alice@waddle.social/web".parse().expect("valid jid")),
+        to: Some("waddle.social".parse().expect("valid jid")),
+        id: "ping-set".to_string(),
+        payload: IqType::Set(Element::builder("ping", NS_PING).build()),
+    };
+    let jid = session_jid();
+
+    let events = PingHandler.handle(&iq, &stanza_ctx(&jid));
+
+    match &events[0] {
+        OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+            Stanza::Iq(reply) => {
+                let IqType::Error(error) = &reply.payload else {
+                    panic!("expected typed error reply")
+                };
+                assert_eq!(error.type_, ErrorType::Modify);
+                assert_eq!(error.defined_condition, DefinedCondition::BadRequest);
+            }
+            other => panic!("expected IQ reply, got {other:?}"),
+        },
+        other => panic!("expected SendStanza, got {other:?}"),
+    }
+}

--- a/server/crates/waddle-xmpp/tests/xep0202_entity_time.rs
+++ b/server/crates/waddle-xmpp/tests/xep0202_entity_time.rs
@@ -1,0 +1,59 @@
+//! XEP-0202: Entity Time dedicated suite.
+
+use chrono::{FixedOffset, TimeZone, Utc};
+use minidom::Element;
+use waddle_xmpp::disco::{server_features, Feature};
+use waddle_xmpp::xep::{build_time_response, parse_time_response, EntityTime, NS_TIME};
+use xmpp_parsers::iq::{Iq, IqType};
+
+fn make_time_query() -> Iq {
+    Iq {
+        from: Some("alice@localhost/web".parse().expect("valid jid")),
+        to: Some("localhost".parse().expect("valid jid")),
+        id: "xep0202-1".to_string(),
+        payload: IqType::Get(Element::builder("time", NS_TIME).build()),
+    }
+}
+
+#[test]
+fn xep0202_server_disco_advertises_entity_time() {
+    assert!(server_features().contains(&Feature::entity_time()));
+}
+
+#[test]
+fn xep0202_roundtrips_typed_utc_and_tzo_values() {
+    let query = make_time_query();
+    let entity_time = EntityTime {
+        utc: Utc
+            .with_ymd_and_hms(2024, 7, 4, 16, 30, 0)
+            .single()
+            .expect("valid time"),
+        tzo: FixedOffset::west_opt(7 * 3600).expect("valid offset"),
+    };
+
+    let response = build_time_response(&query, &entity_time);
+    let parsed = parse_time_response(&response).expect("typed parse");
+
+    assert_eq!(parsed, entity_time);
+}
+
+#[test]
+fn xep0202_rejects_non_utc_utc_children() {
+    let iq = Iq {
+        from: None,
+        to: None,
+        id: "xep0202-invalid-utc".to_string(),
+        payload: IqType::Result(Some(
+            Element::builder("time", NS_TIME)
+                .append(Element::builder("tzo", NS_TIME).append("+01:00").build())
+                .append(
+                    Element::builder("utc", NS_TIME)
+                        .append("2024-07-04T16:30:00+01:00")
+                        .build(),
+                )
+                .build(),
+        )),
+    };
+
+    assert!(parse_time_response(&iq).is_none());
+}

--- a/server/crates/waddle-xmpp/tests/xep0280_message_carbons.rs
+++ b/server/crates/waddle-xmpp/tests/xep0280_message_carbons.rs
@@ -1,0 +1,60 @@
+//! XEP-0280: Message Carbons dedicated suite.
+
+use jid::Jid;
+use minidom::Element;
+use waddle_xmpp::carbons::should_copy_message;
+use waddle_xmpp::xep::{NS_CHATSTATES, NS_CHAT_MARKERS, NS_RECEIPTS};
+use xmpp_parsers::message::{Body, Message, MessageType};
+
+fn message_of_type(message_type: MessageType) -> Message {
+    let to: Jid = "peer@localhost".parse().expect("valid jid");
+    let mut msg = Message::new(Some(to));
+    msg.type_ = message_type;
+    msg
+}
+
+#[test]
+fn xep0280_bodyless_chat_message_is_eligible_for_carbons() {
+    let msg = message_of_type(MessageType::Chat);
+    assert!(should_copy_message(&msg));
+}
+
+#[test]
+fn xep0280_normal_message_with_body_is_eligible_for_carbons() {
+    let mut msg = message_of_type(MessageType::Normal);
+    msg.bodies.insert(String::new(), Body("hello".to_string()));
+    assert!(should_copy_message(&msg));
+}
+
+#[test]
+fn xep0280_normal_message_without_body_or_im_payload_is_not_eligible() {
+    let msg = message_of_type(MessageType::Normal);
+    assert!(!should_copy_message(&msg));
+}
+
+#[test]
+fn xep0280_bodyless_chat_state_message_is_eligible_for_carbons() {
+    let mut msg = message_of_type(MessageType::Normal);
+    msg.payloads
+        .push(Element::builder("composing", NS_CHATSTATES).build());
+    assert!(should_copy_message(&msg));
+}
+
+#[test]
+fn xep0280_bodyless_receipt_request_is_eligible_for_carbons() {
+    let mut msg = message_of_type(MessageType::Normal);
+    msg.payloads
+        .push(Element::builder("request", NS_RECEIPTS).build());
+    assert!(should_copy_message(&msg));
+}
+
+#[test]
+fn xep0280_bodyless_chat_marker_is_eligible_for_carbons() {
+    let mut msg = message_of_type(MessageType::Normal);
+    msg.payloads.push(
+        Element::builder("displayed", NS_CHAT_MARKERS)
+            .attr("id", "msg-1")
+            .build(),
+    );
+    assert!(should_copy_message(&msg));
+}

--- a/server/crates/waddle-xmpp/tests/xep0313_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0313_mam.rs
@@ -1,0 +1,17 @@
+use waddle_xmpp::disco::info::{muc_room_features, server_features, Feature};
+
+#[test]
+fn server_disco_advertises_mam_extended_for_supported_id_filters() {
+    let features = server_features();
+
+    assert!(features.contains(&Feature::mam()));
+    assert!(features.contains(&Feature::mam_extended()));
+}
+
+#[test]
+fn muc_room_disco_advertises_mam_extended_for_supported_id_filters() {
+    let features = muc_room_features(true, true, false, false);
+
+    assert!(features.contains(&Feature::mam()));
+    assert!(features.contains(&Feature::mam_extended()));
+}

--- a/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
+++ b/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
@@ -1,0 +1,37 @@
+//! XEP-0333: Displayed Markers dedicated suite.
+
+use jid::Jid;
+use waddle_xmpp::disco::{muc_room_features, server_features, Feature};
+use waddle_xmpp::xep::{add_markable, extract_marker_from_message, has_markable, Marker};
+use xmpp_parsers::message::Message;
+
+#[test]
+fn xep0333_server_and_muc_disco_advertise_displayed_markers() {
+    let server = server_features();
+    assert!(server.contains(&Feature::chat_markers()));
+
+    let room = muc_room_features(false, false, false, false);
+    assert!(room.contains(&Feature::chat_markers()));
+}
+
+#[test]
+fn xep0333_markable_requires_message_id_for_traceability() {
+    let to: Jid = "peer@localhost".parse().expect("valid jid");
+    let mut msg = Message::new(Some(to));
+    add_markable(&mut msg);
+
+    assert!(!has_markable(&msg));
+    assert_eq!(extract_marker_from_message(&msg), None);
+}
+
+#[test]
+fn xep0333_markable_with_message_id_is_detected() {
+    let to: Jid = "peer@localhost".parse().expect("valid jid");
+    let mut msg = Message::new(Some(to));
+    msg.id = Some("msg-1".to_string());
+    add_markable(&mut msg);
+
+    assert!(has_markable(&msg));
+    assert_eq!(extract_marker_from_message(&msg), Some(Marker::Markable));
+}
+

--- a/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
+++ b/server/crates/waddle-xmpp/tests/xep0333_displayed_markers.rs
@@ -34,4 +34,3 @@ fn xep0333_markable_with_message_id_is_detected() {
     assert!(has_markable(&msg));
     assert_eq!(extract_marker_from_message(&msg), Some(Marker::Markable));
 }
-

--- a/server/crates/waddle-xmpp/tests/xep0334_message_processing_hints.rs
+++ b/server/crates/waddle-xmpp/tests/xep0334_message_processing_hints.rs
@@ -1,0 +1,31 @@
+//! XEP-0334: Message Processing Hints dedicated suite.
+
+use jid::Jid;
+use minidom::Element;
+use waddle_xmpp::carbons::should_copy_message;
+use waddle_xmpp::xep::{should_skip_carbons, Hint, NS_HINTS};
+use xmpp_parsers::message::{Body, Message, MessageType};
+
+fn chat_message(to: &str) -> Message {
+    let to: Jid = to.parse().expect("valid jid");
+    let mut msg = Message::new(Some(to));
+    msg.type_ = MessageType::Chat;
+    msg.bodies.insert(String::new(), Body("secret".to_string()));
+    msg.payloads
+        .push(Element::builder(Hint::NoCopy.element_name(), NS_HINTS).build());
+    msg
+}
+
+#[test]
+fn xep0334_no_copy_suppresses_carbons_for_full_jid_targets() {
+    let msg = chat_message("peer@localhost/phone");
+    assert!(should_skip_carbons(&msg));
+    assert!(!should_copy_message(&msg));
+}
+
+#[test]
+fn xep0334_no_copy_does_not_override_bare_jid_routing() {
+    let msg = chat_message("peer@localhost");
+    assert!(!should_skip_carbons(&msg));
+    assert!(should_copy_message(&msg));
+}


### PR DESCRIPTION
## Summary
- advertise XEP-0313 extended MAM support when Waddle accepts extended filter fields
- align server disco with the implemented `before-id` / `after-id` archive filters
- add focused regression coverage for the XEP-0313 extended feature advertisement

## Plan
- review `xeps/xep-0313.xml` against the MAM query and disco implementation
- add the `urn:xmpp:mam:2#extended` disco feature alongside base MAM support
- add or update `waddle-xmpp` tests covering the advertised extended feature
- run `cargo check`, `cargo test --package waddle-xmpp`, and `nix flake check` before committing