### PR TITLE
fix(chat): clear unread counters

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -17,7 +17,8 @@ import { useReadReceipts } from "@/composables/useReadReceipts";
 import { useVersion } from "@/composables/useVersion";
 import { useRosterContacts } from "@/composables/useRosterContacts";
 import { buildDmPath, buildPath, buildSettingsPath, parseRoute, pushDmRoute, pushRoute, pushSettingsRoute, resolveChannel, shouldLoadStructureForRoute } from "@/composables/useRouting";
-import { barePeerJid, jidDomain, parseManagedRoomBareJid, roomBareJidFor } from "@/lib/xmpp-client";
+import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-client";
+import { roomJidForChannelId as resolveRoomJidForChannelId } from "@/lib/channel-room";
 import { mergeRoomHats, roomHatsFromMembers } from "@/lib/xmpp/occupant-badges";
 import { connectionStore } from "@/lib/connection-store";
 import LandingState from "@/components/chat/LandingState.vue";
@@ -431,7 +432,7 @@ const readReceiptsActiveRoomJid = computed<string | null>(() => {
   const channelId = waddles.activeChannelId.value;
   const sess = session.value;
   if (!channelId || !sess) return null;
-  return roomBareJidFor(sess, channelId);
+  return resolveRoomJidForChannelId(sess, waddles.channels.value, channelId);
 });
 const readReceiptsActivePeerJid = computed<string | null>(() =>
   readReceiptsKind.value === "dm" ? dmConversations.activePeerJid.value : null,
@@ -761,14 +762,20 @@ function openThread(threadId: string, targetMessageId?: string) {
   void messaging.backfillThread(threadId);
 }
 
+function roomJidForChannelId(channelId: string): string | null {
+  const sess = connectionStore.session;
+  if (!sess) return null;
+  return resolveRoomJidForChannelId(sess, waddles.channels.value, channelId);
+}
+
 async function onSelectThread(channelId: string, threadId: string) {
   // Navigate to the channel if not already there
   if (waddles.activeChannelId.value !== channelId) {
     await selectChannel(channelId);
   }
   // Mark thread as read
-  if (connectionStore.session) {
-    const roomJid = roomBareJidFor(connectionStore.session, channelId);
+  const roomJid = roomJidForChannelId(channelId);
+  if (roomJid) {
     channelUnread.markThreadRead(roomJid, threadId);
   }
   openThread(threadId);
@@ -1121,8 +1128,8 @@ async function selectChannel(channelId: string) {
   void waddles.reloadChannelMembers(channelId);
   messaging.clearMessages();
   // XEP-0502: Clear activity indicator for this channel
-  if (connectionStore.session) {
-    const roomJid = roomBareJidFor(connectionStore.session, channelId);
+  const roomJid = roomJidForChannelId(channelId);
+  if (roomJid) {
     messaging.clearChannelActivity(roomJid);
   }
   const unreadAtLoad = computedChannelUnreadMap.value[channelId]?.unread ?? 0;

--- a/chat/src/composables/useMessaging.ts
+++ b/chat/src/composables/useMessaging.ts
@@ -6,7 +6,6 @@ import type { WaddleSession } from "@/lib/server-auth";
 import {
   BrowserXmppClient,
   barePeerJid,
-  roomBareJidFor,
   type LiveRoomMessage,
   type MessageSearchResult,
   type RoomActivityEvent,
@@ -42,6 +41,7 @@ import {
 } from "@/lib/outbound-queue-store";
 import { mentionMatchesUsername } from "@/lib/mentions";
 import { useScrollDirection } from "@/composables/useScrollDirection";
+import { roomJidForChannelSummary } from "@/lib/channel-room";
 
 export function fromLiveMessage(
   session: WaddleSession,
@@ -356,9 +356,18 @@ export function useMessaging(
 
   const currentRoomJid = computed(() => {
     if (!session.value || !activeChannelId.value) return null;
-    return roomBareJidFor(session.value, activeChannelId.value);
+    return roomJidForChannel(activeChannelId.value);
   });
   const channelIsForum = computed(() => isForumChannel(currentChannel.value));
+
+  function roomJidForChannel(channelId: string): string | null {
+    const currentSession = session.value;
+    if (!currentSession) return null;
+    const channel = currentChannel.value?.id === channelId
+      ? currentChannel.value
+      : { id: channelId };
+    return roomJidForChannelSummary(currentSession, channel);
+  }
 
   function queuedMessagesForRoom(roomJid: string): TimelineMessage[] {
     const currentSession = session.value;
@@ -1005,7 +1014,8 @@ export function useMessaging(
     if (!session.value) return;
 
     const requestId = ++messageRequestId;
-    const roomJid = roomBareJidFor(session.value, channelId);
+    const roomJid = roomJidForChannel(channelId);
+    if (!roomJid) return;
     initialLatestPagePinned = false;
     isLoadingMessages.value = true;
     isLoadingOlderMessages.value = false;
@@ -1118,7 +1128,9 @@ export function useMessaging(
       oldestArchiveId = page.firstArchiveId ?? oldestArchiveId;
       hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before;
       const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
-      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), roomBareJidFor(session.value!, channelId));
+      const roomJid = roomJidForChannel(channelId);
+      if (!roomJid) return;
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), roomJid);
       await nextTick();
       if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
         el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
@@ -1135,6 +1147,8 @@ export function useMessaging(
     const client = xmppClient.value;
     const channelId = activeChannelId.value;
     if (!client || !channelId || !session.value || !("queryMamPage" in client)) return false;
+    const roomJid = roomJidForChannel(channelId);
+    if (!roomJid) return false;
 
     let before = oldestArchiveId;
     while (before && hasOlderMessages.value && !findMessageById(messages.value, messageId)) {
@@ -1156,7 +1170,7 @@ export function useMessaging(
       const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
       messages.value = appendQueuedMessages(
         buildTimelineFromMamResults(page.messages, withoutQueued),
-        roomBareJidFor(session.value, channelId),
+        roomJid,
       );
       if (findMessageById(messages.value, messageId)) return true;
       if (!page.firstArchiveId || page.firstArchiveId === previousBefore || page.complete) break;

--- a/chat/src/lib/channel-room.ts
+++ b/chat/src/lib/channel-room.ts
@@ -1,0 +1,19 @@
+import type { ChannelSummary } from "@/lib/chat-types";
+import type { WaddleSession } from "@/lib/server-auth";
+import { barePeerJid, roomBareJidFor } from "@/lib/xmpp-client";
+
+export function roomJidForChannelSummary(
+  session: WaddleSession,
+  channel: Pick<ChannelSummary, "id" | "jid">,
+): string {
+  return channel.jid ? barePeerJid(channel.jid) : roomBareJidFor(session, channel.id);
+}
+
+export function roomJidForChannelId(
+  session: WaddleSession,
+  channels: readonly Pick<ChannelSummary, "id" | "jid">[],
+  channelId: string,
+): string {
+  const channel = channels.find((c) => c.id === channelId);
+  return roomJidForChannelSummary(session, channel ?? { id: channelId });
+}

--- a/chat/tests/channel-room.test.ts
+++ b/chat/tests/channel-room.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { roomJidForChannelId, roomJidForChannelSummary } from "../src/lib/channel-room";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+const session = {
+  jid: "alice@example.com/desktop",
+  username: "alice",
+  token: "token",
+} as WaddleSession;
+
+describe("roomJidForChannelSummary", () => {
+  test("uses the discovered channel JID when present", () => {
+    expect(roomJidForChannelSummary(session, {
+      id: "general",
+      jid: "general@conference.example.net",
+    })).toBe("general@conference.example.net");
+  });
+
+  test("strips any accidental resource from the discovered channel JID", () => {
+    expect(roomJidForChannelSummary(session, {
+      id: "general",
+      jid: "general@conference.example.net/alice",
+    })).toBe("general@conference.example.net");
+  });
+
+  test("falls back to the managed room JID when discovery has no JID", () => {
+    expect(roomJidForChannelSummary(session, { id: "general" })).toBe("general@muc.example.com");
+  });
+
+  test("resolves active channel ids through discovered topology", () => {
+    expect(roomJidForChannelId(session, [
+      { id: "general", jid: "general@conference.example.net" },
+      { id: "random", jid: "random@conference.example.net" },
+    ], "random")).toBe("random@conference.example.net");
+  });
+
+  test("ChatApp routes unread and activity clearing through the discovered room resolver", () => {
+    const source = readFileSync(
+      new URL("../src/components/ChatApp.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("roomJidForChannelId as resolveRoomJidForChannelId");
+    expect(source).toContain("readReceiptsActiveRoomJid");
+    expect(source).toContain("resolveRoomJidForChannelId(sess, waddles.channels.value, channelId)");
+    expect(source).toContain("channelUnread.markThreadRead(roomJid, threadId)");
+    expect(source).toContain("messaging.clearChannelActivity(roomJid)");
+    expect(source).not.toContain("roomBareJidFor");
+  });
+});

--- a/chat/tests/channel-unread.test.ts
+++ b/chat/tests/channel-unread.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
-import { ref } from "vue";
+import { computed, effectScope, ref } from "vue";
 import { useChannelUnread } from "../src/composables/useChannelUnread";
+import { useReadReceipts } from "../src/composables/useReadReceipts";
+import { roomJidForChannelId } from "../src/lib/channel-room";
+import type { ChannelSummary } from "../src/lib/chat-types";
+import type { WaddleSession } from "../src/lib/server-auth";
 import type { BrowserXmppClient, InboxEntry } from "../src/lib/xmpp-client";
 
 type MockClient = BrowserXmppClient & {
@@ -97,6 +101,62 @@ describe("useChannelUnread", () => {
     expect(composable.totalThreadUnreadCount.value).toBe(0);
     expect(composable.totalUnreadCount.value).toBe(0);
     expect(client.markInboxRead).toHaveBeenCalledWith("space_channel@conference.example.com", "thread-1");
+  });
+
+  test("read receipts clear active discovered-MUC row and bell counts", async () => {
+    const client = makeClient();
+    const composable = useChannelUnread(ref<BrowserXmppClient | null>(client));
+    const session = ref({
+      jid: "alice@example.com/desktop",
+      username: "alice",
+      token: "token",
+    } as WaddleSession);
+    const activeChannelId = ref("c1");
+    const channels = ref([
+      { id: "c1", name: "general", jid: "c1@conference.example.net" },
+    ] as ChannelSummary[]);
+    const activeRoomJid = computed(() =>
+      roomJidForChannelId(session.value, channels.value, activeChannelId.value),
+    );
+    const unreadCountForActive = computed(() =>
+      composable.channelUnreadMap()[activeChannelId.value]?.unread ?? 0,
+    );
+    const markDisplayed = mock(() => undefined);
+    const scope = effectScope();
+
+    composable.onInboxPush({
+      partner: "c1@conference.example.net",
+      kind: "muc",
+      lastStanzaId: "sid-1",
+      lastUpdated: 100,
+      unread: 4,
+    });
+
+    expect(composable.totalUnreadCount.value).toBe(4);
+    expect(unreadCountForActive.value).toBe(4);
+
+    scope.run(() => {
+      useReadReceipts({
+        isWindowFocused: ref(true),
+        isPinnedAtEdge: ref(true),
+        activeKind: ref<"channel" | "dm" | null>("channel"),
+        activeRoomJid,
+        activePeerJid: ref(null),
+        latestRemoteMessageId: ref("remote-1"),
+        unreadCountForActive,
+        markChannelRead: (jid) => composable.markRead(jid),
+        markDmRead: () => undefined,
+        markDisplayed,
+      });
+    });
+    await Promise.resolve();
+
+    expect(markDisplayed).toHaveBeenCalledWith("remote-1");
+    expect(client.markInboxRead).toHaveBeenCalledWith("c1@conference.example.net");
+    expect(composable.totalUnreadCount.value).toBe(0);
+    expect(unreadCountForActive.value).toBe(0);
+
+    scope.stop();
   });
 
   test("clears stale unread state without a client", async () => {

--- a/chat/tests/scroll-direction.test.ts
+++ b/chat/tests/scroll-direction.test.ts
@@ -1021,7 +1021,7 @@ describe("scroll direction preference", () => {
     expect(timelineEl.scrollTop).toBe(0);
   });
 
-  test("live room messages pin through the virtual timeline edge scroller when available", async () => {
+  test("live room messages from discovered MUC JIDs pin through the virtual timeline edge scroller", async () => {
     let liveHandler: ((msg: LiveRoomMessage) => void) | null = null;
     const virtualScroll = mock(async () => true);
     const actionError = ref("");
@@ -1036,7 +1036,7 @@ describe("scroll direction preference", () => {
       } as never) as never,
       ref("w1"),
       ref("c1"),
-      ref({ id: "c1", name: "general", channel_type: "text" }),
+      ref({ id: "c1", name: "general", jid: "c1@conference.example.net", channel_type: "text" }),
       String,
       actionError,
       () => {
@@ -1049,7 +1049,7 @@ describe("scroll direction preference", () => {
 
     liveHandler?.({
       id: "room-live",
-      roomJid: "c1@muc.example.com",
+      roomJid: "c1@conference.example.net",
       nick: "bob",
       body: "from room",
       createdAt: "2024-01-01T00:00:00Z",
@@ -1059,6 +1059,7 @@ describe("scroll direction preference", () => {
     await nextTick();
 
     expect(virtualScroll).toHaveBeenCalledWith("chat");
+    expect(messaging.messages.value.at(-1)?.id).toBe("room-live");
     expect(timelineEl.scrollTop).toBe(240);
   });
 


### PR DESCRIPTION
## Summary
- Use discovered room JIDs for channel unread mark-read, thread mark-read, activity clearing, and live room message filtering.
- Keep XEP-0333 displayed marker shapes unchanged; this fix is local inbox/read-state routing.
- Add regressions for discovered MUC unread wiring, bell count clearing, and live message acceptance.

## Verification
- `bun test tests/channel-unread.test.ts tests/use-read-receipts.test.ts tests/channel-room.test.ts tests/scroll-direction.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`

## Notes
- `bun install --frozen-lockfile` was needed locally because locked package `keystrok` was missing from `node_modules`; no tracked dependency files changed.