### PR TITLE
fix(chat): clear unread without a latest remote message id

### DIFF
--- a/chat/src/composables/useReadReceipts.ts
+++ b/chat/src/composables/useReadReceipts.ts
@@ -51,21 +51,23 @@ export function useReadReceipts(options: UseReadReceiptsOptions) {
 
       if (!state.focused || !state.pinned) return;
       if (!state.kind) return;
-      if (!state.latestId) return;
 
       const target = state.kind === "channel" ? state.roomJid : state.peerJid;
       if (!target) return;
 
-      const idChanged = state.latestId !== lastDispatchedDisplayedId;
-      const hasUnread = state.unread > 0;
-      if (!idChanged && !hasUnread) return;
-
-      if (idChanged) {
+      // XEP-0333 displayed markers need a message id to point at, so they
+      // only fire when latestId is known and has advanced. Inbox mark-read
+      // (urn:waddle:inbox:0) doesn't take a message id — clear it whenever
+      // the active conversation has unread, regardless of latestId. Without
+      // this split, body-less server projections (reactions on own
+      // messages, retractions, backlog older than MAM) would leave the
+      // unread badge stuck.
+      if (state.latestId && state.latestId !== lastDispatchedDisplayedId) {
         lastDispatchedDisplayedId = state.latestId;
         options.markDisplayed(state.latestId);
       }
 
-      if (hasUnread) {
+      if (state.unread > 0) {
         if (state.kind === "channel") {
           options.markChannelRead(target);
         } else {

--- a/chat/tests/use-read-receipts.test.ts
+++ b/chat/tests/use-read-receipts.test.ts
@@ -185,4 +185,28 @@ describe("useReadReceipts", () => {
     expect(h.markChannelRead).toHaveBeenLastCalledWith("room-b@chat.example.com");
     h.stop();
   });
+
+  test("clears channel unread when latestId is null (e.g. reaction-only or backlog bump)", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "channel";
+    h.activeRoomJid.value = "room@chat.example.com";
+    h.latestRemoteMessageId.value = null;
+    h.unreadCountForActive.value = 1;
+    await Promise.resolve();
+    expect(h.markChannelRead).toHaveBeenCalledWith("room@chat.example.com");
+    expect(h.markDisplayed).not.toHaveBeenCalled();
+    h.stop();
+  });
+
+  test("clears DM unread when latestId is null", async () => {
+    const h = makeHarness();
+    h.activeKind.value = "dm";
+    h.activePeerJid.value = "bob@example.com";
+    h.latestRemoteMessageId.value = null;
+    h.unreadCountForActive.value = 2;
+    await Promise.resolve();
+    expect(h.markDmRead).toHaveBeenCalledWith("bob@example.com");
+    expect(h.markDisplayed).not.toHaveBeenCalled();
+    h.stop();
+  });
 });


### PR DESCRIPTION
## Summary
- `useReadReceipts` bailed at `!latestId`, silently disabling the inbox mark-read path when the visible timeline had no remote message — even though `urn:waddle:inbox:0` mark-read takes no message id.
- Anything that bumped server-side unread without appending a fresh remote message left the badge stuck: reactions on your own messages, retractions, backlog older than the MAM window, channels where only you have ever posted.
- Symptom: badge clears the first time you open a channel with remote messages (`displayed` marker dispatch carries the inbox mark-read along), then never clears again for body-less inbox bumps.

## Fix
Split the early-return so only the XEP-0333 `displayed` dispatch is gated on `latestId`; inbox mark-read runs whenever the active conversation has unread (still gated on focused + pinned + kind + target).

## Tests
- Added regressions: channel mark-read fires when `latestId` is `null` and there is unread; same for DMs.
- `bun test tests/use-read-receipts.test.ts tests/channel-unread.test.ts tests/channel-room.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`

## XEP conformance
- XEP-0333 (`displayed`) still requires a message id — unchanged. We only stopped using its absence to gate `urn:waddle:inbox:0`, which is a separate, message-id-less namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)