### PR TITLE
fix(xmpp): preserve muc occupant real jids in presence

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -131,6 +131,44 @@ function parseMucInfo(pres: ReceivedMUCPresence): { affiliation?: string; role?:
   };
 }
 
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+function jidValueToString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  const candidate = record(value);
+  if (!candidate || typeof candidate.toString !== "function") return null;
+  const jid = candidate.toString();
+  return jid && jid !== "[object Object]" ? jid : null;
+}
+
+function realBareJid(value: unknown): string | null {
+  const jid = jidValueToString(value);
+  if (!jid || !jid.includes("@")) return null;
+  return barePeerJid(jid);
+}
+
+export function mucPresenceRealBareJid(presence: unknown): string | null {
+  const muc = record(record(presence)?.muc);
+  if (!muc) return null;
+
+  const direct = realBareJid(muc.jid);
+  if (direct) return direct;
+
+  const item = record(muc.item);
+  const itemJid = realBareJid(item?.jid);
+  if (itemJid) return itemJid;
+
+  const items = Array.isArray(muc.items) ? muc.items : [];
+  for (const maybeItem of items) {
+    const jid = realBareJid(record(maybeItem)?.jid);
+    if (jid) return jid;
+  }
+
+  return null;
+}
+
 const OPTIONAL_XMPP_FEATURE_ERROR_CONDITIONS = new Set([
   "feature-not-implemented",
   "service-unavailable",
@@ -1936,9 +1974,8 @@ export class BrowserXmppClient {
           this.hatsHandler?.({ ...this.roomHats });
           this.roomPresence[nick] = parsePresenceShow(pres.show);
           this.presenceHandler?.({ ...this.roomPresence });
-          const muc = ext(pres).muc as { jid?: string } | undefined;
-          if (muc?.jid) {
-            const bareJid = barePeerJid(String(muc.jid));
+          const bareJid = mucPresenceRealBareJid(ext(pres));
+          if (bareJid) {
             this.roomMemberJids[nick] = bareJid;
             this.memberJidHandler?.(nick, bareJid);
           }

--- a/chat/tests/muc-presence-jids.test.ts
+++ b/chat/tests/muc-presence-jids.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { mucPresenceRealBareJid } from "../src/lib/xmpp/client";
+
+class TestJid {
+  constructor(private readonly value: string) {}
+
+  toString() {
+    return this.value;
+  }
+}
+
+describe("mucPresenceRealBareJid", () => {
+  test("normalizes top-level stanza.js muc.jid values", () => {
+    expect(mucPresenceRealBareJid({ muc: { jid: "bob@example.com/web" } })).toBe("bob@example.com");
+  });
+
+  test("normalizes muc#user item jid values", () => {
+    expect(mucPresenceRealBareJid({ muc: { item: { jid: "bob@example.com/web" } } })).toBe("bob@example.com");
+  });
+
+  test("normalizes muc#user items jid values", () => {
+    expect(mucPresenceRealBareJid({ muc: { items: [{ jid: "bob@example.com/web" }] } })).toBe("bob@example.com");
+  });
+
+  test("accepts stanza JID objects", () => {
+    expect(mucPresenceRealBareJid({
+      muc: { item: { jid: new TestJid("bob@example.com/web") } },
+    })).toBe("bob@example.com");
+  });
+
+  test("returns null when presence has no real JID", () => {
+    expect(mucPresenceRealBareJid({ muc: { affiliation: "member", role: "participant" } })).toBeNull();
+    expect(mucPresenceRealBareJid({})).toBeNull();
+  });
+
+  test("returns null for malformed real JID values", () => {
+    expect(mucPresenceRealBareJid({ muc: { item: { jid: "not-a-jid" } } })).toBeNull();
+    expect(mucPresenceRealBareJid({ muc: { item: { jid: {} } } })).toBeNull();
+  });
+});

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -1704,15 +1704,16 @@ pub async fn handle_muc_join(
         .filter(|existing| existing.nick != nick)
         .filter(|existing| replayed_nicks.insert(existing.nick.clone()))
     {
-        responses.push(build_muc_join_presence_xml(
+        responses.push(build_muc_join_presence_xml(MucJoinPresence {
+            occupant_id_secret: &state.deps.occupant_id_secret,
             room_jid,
-            &existing.nick,
-            sender_jid,
-            affiliation_str(existing.affiliation),
-            role_str(existing.role),
-            &existing.jid,
-            false,
-        ));
+            nick: &existing.nick,
+            to_jid: sender_jid,
+            affiliation: existing.affiliation,
+            role: existing.role,
+            real_jid: &existing.jid,
+            include_self_status: false,
+        }));
     }
 
     // Broadcast the new occupant's presence to all existing occupants.
@@ -1742,15 +1743,16 @@ pub async fn handle_muc_join(
     }
 
     // Send self-presence to the joining user (with status code 110)
-    responses.push(build_muc_join_presence_xml(
+    responses.push(build_muc_join_presence_xml(MucJoinPresence {
+        occupant_id_secret: &state.deps.occupant_id_secret,
         room_jid,
         nick,
-        sender_jid,
-        affiliation_str(join_outcome.new_occupant_affiliation),
-        role_str(join_outcome.new_occupant_role),
-        sender_jid,
-        true,
-    ));
+        to_jid: sender_jid,
+        affiliation: join_outcome.new_occupant_affiliation,
+        role: join_outcome.new_occupant_role,
+        real_jid: sender_jid,
+        include_self_status: true,
+    }));
 
     // XEP-0045 §7.2.15 historical room subject. The typed builder
     // produces the conformant envelope: nick-form `from` + `<delay/>`
@@ -1910,57 +1912,41 @@ pub async fn handle_muc_leave(
     )]
 }
 
-fn build_muc_join_presence_xml(
-    room_jid: &BareJid,
-    nick: &str,
-    to_jid: &FullJid,
-    affiliation: &str,
-    role: &str,
-    real_jid: &FullJid,
+struct MucJoinPresence<'a> {
+    occupant_id_secret: &'a waddle_xmpp::xep::xep0421::OccupantIdSecret,
+    room_jid: &'a BareJid,
+    nick: &'a str,
+    to_jid: &'a FullJid,
+    affiliation: Affiliation,
+    role: Role,
+    real_jid: &'a FullJid,
     include_self_status: bool,
-) -> String {
-    let from_jid = room_jid
+}
+
+fn build_muc_join_presence_xml(params: MucJoinPresence<'_>) -> String {
+    let presence = build_muc_join_presence_stanza(params);
+    stanza_to_xml(&Stanza::Presence(presence))
+}
+
+fn build_muc_join_presence_stanza(params: MucJoinPresence<'_>) -> xmpp_parsers::presence::Presence {
+    let from_jid = params
+        .room_jid
         .clone()
-        .with_resource_str(nick)
-        .unwrap_or_else(|_| to_jid.clone());
-
-    let mut user_payload = Element::builder("x", "http://jabber.org/protocol/muc#user")
-        .append(
-            Element::builder("item", "http://jabber.org/protocol/muc#user")
-                .attr("affiliation", affiliation)
-                .attr("role", role)
-                .attr("jid", real_jid.to_string())
-                .build(),
-        )
-        .append(
-            Element::builder("status", "http://jabber.org/protocol/muc#user")
-                .attr("code", "100")
-                .build(),
-        );
-
-    if include_self_status {
-        user_payload = user_payload.append(
-            Element::builder("status", "http://jabber.org/protocol/muc#user")
-                .attr("code", "110")
-                .build(),
-        );
-    }
-
-    let mut hats = waddle_xmpp::xep::xep0317::hats_from_affiliation(affiliation);
-    if role == "moderator" && !hats.has_uri(waddle_xmpp::xep::xep0317::well_known::MODERATOR) {
-        hats = hats.with_hat(waddle_xmpp::xep::xep0317::Hat::moderator());
-    }
-
-    let mut presence = Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
-        .attr("from", from_jid.to_string())
-        .attr("to", to_jid.to_string())
-        .append(user_payload.build());
-
-    if !hats.is_empty() {
-        presence = presence.append(waddle_xmpp::xep::xep0317::build_hats_element(&hats));
-    }
-
-    element_to_xml(presence.build())
+        .with_resource_str(params.nick)
+        .unwrap_or_else(|_| params.to_jid.clone());
+    let real_bare = params.real_jid.to_bare();
+    waddle_xmpp::muc::build_occupant_presence(
+        &from_jid,
+        params.to_jid,
+        params.affiliation,
+        params.role,
+        params.include_self_status,
+        &waddle_xmpp::xep::xep0421::OccupantIdentity {
+            bare_jid: &real_bare,
+            real_jid: Some(params.real_jid),
+            secret: params.occupant_id_secret,
+        },
+    )
 }
 
 /// XEP-0045 §7.2.9 conflict presence: the requested nick is already in use
@@ -2074,45 +2060,16 @@ fn create_presence_stanza(
     affiliation: Affiliation,
     role: Role,
 ) -> xmpp_parsers::presence::Presence {
-    let from_jid = room_jid
-        .clone()
-        .with_resource_str(nick)
-        .unwrap_or_else(|_| real_jid.clone());
-
-    let real_bare = real_jid.to_bare();
-    waddle_xmpp::muc::build_occupant_presence(
-        &from_jid,
+    build_muc_join_presence_stanza(MucJoinPresence {
+        occupant_id_secret: &state.deps.occupant_id_secret,
+        room_jid,
+        nick,
         to_jid,
         affiliation,
         role,
-        false,
-        &waddle_xmpp::xep::xep0421::OccupantIdentity {
-            bare_jid: &real_bare,
-            real_jid: Some(real_jid),
-            secret: &state.deps.occupant_id_secret,
-        },
-    )
-}
-
-/// Convert Affiliation to string
-fn affiliation_str(affiliation: Affiliation) -> &'static str {
-    match affiliation {
-        Affiliation::Owner => "owner",
-        Affiliation::Admin => "admin",
-        Affiliation::Member => "member",
-        Affiliation::Outcast => "outcast",
-        Affiliation::None => "none",
-    }
-}
-
-/// Convert Role to string
-fn role_str(role: Role) -> &'static str {
-    match role {
-        Role::Moderator => "moderator",
-        Role::Participant => "participant",
-        Role::Visitor => "visitor",
-        Role::None => "none",
-    }
+        real_jid,
+        include_self_status: false,
+    })
 }
 
 /// Derive the single-space id and channel id from a room's bare JID node.
@@ -2143,19 +2100,24 @@ mod tests {
 
     #[test]
     fn muc_join_presence_includes_owner_and_moderator_hats() {
+        let secret = waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"join-presence-handler-test-secret".to_vec(),
+        )
+        .expect("test secret meets length floor");
         let room_jid: BareJid = "chat@muc.example.com".parse().unwrap();
         let to_jid: FullJid = "alice@example.com/web".parse().unwrap();
         let real_jid: FullJid = "bob@example.com/mobile".parse().unwrap();
 
-        let xml = build_muc_join_presence_xml(
-            &room_jid,
-            "bob",
-            &to_jid,
-            "owner",
-            "moderator",
-            &real_jid,
-            false,
-        );
+        let xml = build_muc_join_presence_xml(MucJoinPresence {
+            occupant_id_secret: &secret,
+            room_jid: &room_jid,
+            nick: "bob",
+            to_jid: &to_jid,
+            affiliation: Affiliation::Owner,
+            role: Role::Moderator,
+            real_jid: &real_jid,
+            include_self_status: false,
+        });
 
         assert!(
             xml.contains("xmlns=\"urn:xmpp:hats:0\"") || xml.contains("xmlns='urn:xmpp:hats:0'")
@@ -2167,6 +2129,10 @@ mod tests {
         assert!(
             xml.contains("uri=\"urn:xmpp:hats:moderator\"")
                 || xml.contains("uri='urn:xmpp:hats:moderator'")
+        );
+        assert!(
+            xml.contains("<occupant-id") && xml.contains("urn:xmpp:occupant-id:0"),
+            "typed join presence builder must stamp XEP-0421 occupant-id: {xml}"
         );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -4045,14 +4045,110 @@ mod tests {
         let user_x = self_presence
             .get_child("x", "http://jabber.org/protocol/muc#user")
             .expect("muc user payload");
+        let item = user_x
+            .get_child("item", "http://jabber.org/protocol/muc#user")
+            .expect("muc user item");
+        assert_eq!(item.attr("jid"), Some("alice@example.com/web"));
+        assert_eq!(item.attr("affiliation"), Some("owner"));
+        assert_eq!(item.attr("role"), Some("moderator"));
+        assert!(user_x
+            .children()
+            .any(|child| child.name() == "status" && child.attr("code") == Some("100")));
         assert!(user_x
             .children()
             .any(|child| child.name() == "status" && child.attr("code") == Some("110")));
+        assert!(
+            self_presence
+                .get_child("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
+                .is_some(),
+            "self-presence must carry XEP-0421 occupant-id"
+        );
 
         let subject_message = Element::from_str(&responses[1]).expect("subject xml");
         assert_eq!(subject_message.name(), "message");
         assert_eq!(subject_message.ns(), waddle_xmpp::ns::JABBER_CLIENT);
         assert_eq!(subject_message.attr("type"), Some("groupchat"));
+    }
+
+    #[tokio::test]
+    async fn xep_0045_join_replay_exposes_existing_occupant_real_jids() {
+        let state = create_test_websocket_state().await;
+        let owner_session = create_test_server_owner_session(state.as_ref(), "icepuma").await;
+        let room_jid: BareJid = "mentions@muc.example.com".parse().expect("room jid");
+
+        let occupants = [
+            ("icepuma", "icepuma@example.com/web"),
+            ("randax", "randax@example.com/desktop"),
+            ("rawkode", "rawkode@example.com/mobile"),
+        ];
+
+        for (index, (nick, full_jid)) in occupants.iter().enumerate() {
+            let sender_jid: FullJid = full_jid.parse().expect("occupant jid");
+            let session = if index == 0 {
+                Some(owner_session.clone())
+            } else {
+                None
+            };
+            let _ = handle_muc_join(
+                state.as_ref(),
+                "example.com",
+                &room_jid,
+                &sender_jid,
+                nick,
+                &session,
+            )
+            .await;
+        }
+
+        let joiner: FullJid = "witness@example.com/browser".parse().expect("joiner jid");
+        let responses = handle_muc_join(
+            state.as_ref(),
+            "example.com",
+            &room_jid,
+            &joiner,
+            "witness",
+            &None,
+        )
+        .await;
+
+        for (nick, full_jid) in occupants {
+            let from = format!("{room_jid}/{nick}");
+            let replay = responses
+                .iter()
+                .filter_map(|xml| Element::from_str(xml).ok())
+                .find(|element| {
+                    element.name() == "presence"
+                        && element.attr("from") == Some(from.as_str())
+                        && element.attr("to") == Some(joiner.as_str())
+                })
+                .unwrap_or_else(|| panic!("missing replay presence for {nick}: {responses:?}"));
+            let user_x = replay
+                .get_child("x", "http://jabber.org/protocol/muc#user")
+                .expect("muc user payload");
+            let item = user_x
+                .get_child("item", "http://jabber.org/protocol/muc#user")
+                .expect("muc user item");
+
+            assert_eq!(item.attr("jid"), Some(full_jid));
+            assert!(
+                user_x
+                    .children()
+                    .any(|child| child.name() == "status" && child.attr("code") == Some("100")),
+                "non-anonymous replay must disclose status 100 for {nick}"
+            );
+            assert!(
+                !user_x
+                    .children()
+                    .any(|child| child.name() == "status" && child.attr("code") == Some("110")),
+                "replay presence for another occupant must not be self-presence"
+            );
+            assert!(
+                replay
+                    .get_child("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
+                    .is_some(),
+                "replay presence for {nick} must carry XEP-0421 occupant-id"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Plan

- Reproduce the missing bare occupant JID invariant against MUC presence.
- Fix server MUC presence so replay, broadcast, and self-presence all use the same typed XEP-0045/XEP-0421 occupant presence builder.
- Preserve full real occupant JIDs in `muc#user <item jid='...'/>` while keeping status 100/110 semantics correct.
- Teach the browser client to read real JIDs from stanza.js MUC presence shapes and keep missing/malformed JIDs visible to the invariant.
- Add focused server and chat regression coverage.

## Validation

- `bun test`
- `bun test tests/muc-presence-jids.test.ts tests/member-query.test.ts`
- `bun run lint`
- `cargo fmt --check`
- `cargo test -p waddle-xmpp`
- `cargo test -p waddle-server muc_join`
- `cargo test -p waddle-server xep_0045_join_replay_exposes_existing_occupant_real_jids`
- `cargo clippy -p waddle-server --all-targets -- -D warnings`

## Review

- Adversarial chat-state review: no actionable issues.
- Adversarial XEP-0045/XEP-0421 protocol review: no actionable issues.
- Adversarial test/maintainability review: no actionable issues.
