### PR TITLE
fix(chat): key channel unread map by full bare JID

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -419,7 +419,7 @@ const activeDmPeer = computed(() => {
   };
 });
 
-const computedChannelUnreadMap = computed(() => channelUnread.channelUnreadMap());
+const computedChannelUnreadMap = computed(() => channelUnread.channelUnreadMap(waddles.channels.value));
 // Thread rows are drill-down detail; room unread already carries the
 // server-equivalent conversation total, so the browser badge must not add both.
 const totalTabUnreadCount = computed(() =>
@@ -471,9 +471,9 @@ const readReceiptsUnreadCount = computed<number>(() => {
     return dmConversations.conversations.value.find((c) => c.peerJid === peer)?.unreadCount ?? 0;
   }
   if (readReceiptsKind.value === "channel") {
-    const channelId = waddles.activeChannelId.value;
-    if (!channelId) return 0;
-    return computedChannelUnreadMap.value[channelId]?.unread ?? 0;
+    const jid = readReceiptsActiveRoomJid.value;
+    if (!jid) return 0;
+    return channelUnread.unreadForRoomJid(jid);
   }
   return 0;
 });

--- a/chat/src/composables/useChannelUnread.ts
+++ b/chat/src/composables/useChannelUnread.ts
@@ -1,6 +1,7 @@
 import { computed, ref, type Ref } from "vue";
 import type { BrowserXmppClient, InboxEntry } from "@/lib/xmpp-client";
-import { parseManagedRoomBareJid } from "@/lib/xmpp-client";
+import { barePeerJid } from "@/lib/xmpp-client";
+import type { ChannelSummary } from "@/lib/chat-types";
 import {
   createInboxState,
   applyEntry,
@@ -104,15 +105,28 @@ export function useChannelUnread(
     }
   }
 
-  function channelUnreadMap(): Record<string, { unread: number; mentions: number }> {
+  /**
+   * Build a `channelId → unread` map by matching topology channel JIDs
+   * against inbox entries. Keying by JID (not partner-localpart) is
+   * required: stale inbox rows from a different deployment can share a
+   * localpart with a live room (e.g. `chat@muc.waddle.local` vs
+   * `chat@muc.waddle.social`) and a localpart-keyed map silently
+   * overwrites the live row, leaving its unread count stuck.
+   */
+  function channelUnreadMap(
+    channels: readonly Pick<ChannelSummary, "id" | "jid">[],
+  ): Record<string, { unread: number; mentions: number }> {
     const map: Record<string, { unread: number; mentions: number }> = {};
-    for (const entry of inboxState.value.channels.values()) {
-      if (entry.kind !== "muc") continue;
-      const parsed = parseManagedRoomBareJid(entry.partner);
-      if (!parsed) continue;
-      map[parsed.channelId] = { unread: entry.unread, mentions: 0 };
+    for (const channel of channels) {
+      if (!channel.jid) continue;
+      const entry = inboxState.value.channels.get(barePeerJid(channel.jid));
+      map[channel.id] = { unread: entry?.unread ?? 0, mentions: 0 };
     }
     return map;
+  }
+
+  function unreadForRoomJid(roomJid: string): number {
+    return inboxState.value.channels.get(roomJid)?.unread ?? 0;
   }
 
   function threadEntries(roomJid: string): ThreadInboxEntry[] {
@@ -141,6 +155,7 @@ export function useChannelUnread(
     markRead,
     markThreadRead,
     channelUnreadMap,
+    unreadForRoomJid,
     threadEntries,
   };
 }

--- a/chat/tests/channel-unread.test.ts
+++ b/chat/tests/channel-unread.test.ts
@@ -60,7 +60,9 @@ describe("useChannelUnread", () => {
     expect(composable.totalChannelUnreadCount.value).toBe(2);
     expect(composable.totalThreadUnreadCount.value).toBe(3);
     expect(composable.totalUnreadCount.value).toBe(2);
-    expect(composable.channelUnreadMap()).toMatchObject({
+    expect(composable.channelUnreadMap([
+      { id: "space_channel", jid: "space_channel@conference.example.com" },
+    ])).toMatchObject({
       space_channel: { unread: 2, mentions: 0 },
     });
   });
@@ -119,7 +121,7 @@ describe("useChannelUnread", () => {
       roomJidForChannelId(session.value, channels.value, activeChannelId.value),
     );
     const unreadCountForActive = computed(() =>
-      composable.channelUnreadMap()[activeChannelId.value]?.unread ?? 0,
+      composable.unreadForRoomJid(activeRoomJid.value),
     );
     const markDisplayed = mock(() => undefined);
     const scope = effectScope();
@@ -157,6 +159,50 @@ describe("useChannelUnread", () => {
     expect(unreadCountForActive.value).toBe(0);
 
     scope.stop();
+  });
+
+  test("does not let a stale same-localpart inbox row mask the live room's unread", async () => {
+    // Real-world scenario captured from user logs: the inbox holds rows
+    // from a previously-used deployment (`muc.waddle.social`) alongside
+    // the live deployment (`muc.waddle.local`). Both rooms share the
+    // localpart `chat`. A localpart-keyed map silently overwrote the
+    // live row, so opening the channel reported unread=0 and the
+    // mark-read path never fired.
+    const client = makeClient();
+    const composable = useChannelUnread(ref<BrowserXmppClient | null>(client));
+    composable.onInboxPush({
+      partner: "chat@muc.waddle.local",
+      kind: "muc",
+      lastStanzaId: "live-1",
+      lastUpdated: 200,
+      unread: 38,
+    });
+    composable.onInboxPush({
+      partner: "chat@muc.waddle.social",
+      kind: "muc",
+      lastStanzaId: "stale-1",
+      lastUpdated: 100,
+      unread: 0,
+    });
+
+    const liveChannel: Pick<ChannelSummary, "id" | "jid"> = {
+      id: "chat",
+      jid: "chat@muc.waddle.local",
+    };
+
+    expect(composable.unreadForRoomJid("chat@muc.waddle.local")).toBe(38);
+    expect(composable.channelUnreadMap([liveChannel])).toMatchObject({
+      chat: { unread: 38, mentions: 0 },
+    });
+
+    composable.markRead("chat@muc.waddle.local");
+
+    expect(composable.unreadForRoomJid("chat@muc.waddle.local")).toBe(0);
+    expect(composable.channelUnreadMap([liveChannel])).toMatchObject({
+      chat: { unread: 0, mentions: 0 },
+    });
+    expect(composable.totalChannelUnreadCount.value).toBe(0);
+    expect(client.markInboxRead).toHaveBeenCalledWith("chat@muc.waddle.local");
   });
 
   test("clears stale unread state without a client", async () => {


### PR DESCRIPTION
## Summary

`useChannelUnread.channelUnreadMap()` keyed the per-channel unread map by the **localpart** of `entry.partner` (via `parseManagedRoomBareJid`). When the inbox holds two `kind="muc"` rows that share a localpart but live in different domains — e.g. a live `chat@muc.waddle.local` (unread=38) alongside a stale `chat@muc.waddle.social` row from a previously-used deployment (unread=0) — the second row silently overwrote the first under the key `"chat"`. The active-channel lookup then reported `unread=0`, the read-receipts watcher took the `noMarkRead.unreadZero` branch, and mark-read was never dispatched for the live row.

Result: bell badge, `*` tab title, and favicon dot stayed pinned at the unreachable count forever, while `totalChannelUnreadCount` (which iterates `inboxState.channels` directly) faithfully kept reporting it.

## Fix

- `chat/src/composables/useChannelUnread.ts` — `channelUnreadMap(channels)` now takes the topology channel list and keys the result by `channel.id`, looking up each channel's row via its full bare JID (`barePeerJid(channel.jid)`). Distinct domains can no longer collide.
- New `unreadForRoomJid(jid)` does the direct full-JID lookup the read-receipts watcher needs.
- `chat/src/components/ChatApp.vue` — `computedChannelUnreadMap` passes `waddles.channels.value`. `readReceiptsUnreadCount` for the active channel reads via `unreadForRoomJid(readReceiptsActiveRoomJid.value)`, so the JID we resolve to look up unread is the same one we later dispatch to `markChannelRead`.

## Reproduction

Real session logs from a user with both deployments' rows in their inbox:

```
xmpp.fetchInbox.result mucPartners=["chat@muc.waddle.local=38","chat@muc.waddle.social=0","announcements@muc.waddle.social=0"]
chatApp.readReceiptsUnreadCount.channel channelId=chat unread=0 mapKeys=["chat","announcements"]
chatApp.totalTabUnreadCount channels=38 total=38
```

Active channel reports `unread=0` for `chat`, total reports 38, no mark-read fires.

## Tests

- New regression test `does not let a stale same-localpart inbox row mask the live room's unread` in `chat/tests/channel-unread.test.ts` reproduces the two-domain-same-localpart scenario and asserts `unreadForRoomJid`, `channelUnreadMap`, the totals, and the IQ all use the live JID and clear correctly.
- Migrated existing read-receipts test to `unreadForRoomJid`.
- `bun test` (`chat/`) — 527 pass.
- `bun run lint` (`chat/`) — knip clean.
- `bun run build` (`chat/`) — astro check + bundle clean.

## XEP conformance

No protocol-shape changes. `urn:waddle:inbox:0` mark-read still ships `partner=<bare-jid>` via `xmppClient.markInboxRead` (which `barePeerJid()`s the input). XEP-0333 `<displayed/>` dispatch in `useReadReceipts` is untouched. Adversarial XMPP review confirmed no conformance regression.

## Follow-ups (out of scope)

Surfaced by adversarial review, filed for separate PRs:

1. `parseManagedRoomBareJid` is still used in `ChatApp.resolveChannelNameFromJid` and the mention-notification `onNavigate` (`ChatApp.vue:571,593`) — same key-collision class, but unrelated to the unread surface this PR fixes.
2. `totalChannelUnreadCount` iterates raw inbox state and would still over-count if a stale-domain row ever had `unread > 0` — for the reported scenario `stale.unread=0`, so it didn't manifest.
3. `applyEntry` doesn't lowercase / normalise the partner key. In practice the server emits canonical bare JIDs (Rust `BareJid` runs stringprep), and disco emits the same canonical form, so byte-equality holds today. Worth an explicit normalisation helper later for defence in depth.