### PR TITLE
fix(chat): handle extension route refresh and centralize giphy key

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -55,10 +55,10 @@ import {
 } from "@/lib/reaction-mode";
 
 const props = defineProps<{
-  tenorApiKey?: string;
+  giphyApiKey?: string;
 }>();
 
-const tenorApiKey = props.tenorApiKey ?? "";
+const giphyApiKey = props.giphyApiKey ?? "";
 
 const ui = useUiState();
 const { mode: scrollDirectionMode } = useScrollDirection();
@@ -1661,7 +1661,7 @@ onUnmounted(() => {
               :self-domain="selfDomain"
               :avatar-url-by-author="avatarUrlByAuthor"
                :author-jid-by-nick="authorJidByNick"
-              :tenor-api-key="tenorApiKey"
+              :giphy-api-key="giphyApiKey"
                :mention-candidates="mentionCandidates"
               :room-hats="authorHatsByNick"
               :room-presence="messaging.roomPresence.value"
@@ -1739,7 +1739,7 @@ onUnmounted(() => {
               :room-hats="authorHatsByNick"
               :room-presence="messaging.roomPresence.value"
               :room-last-seen="messaging.roomLastSeen.value"
-              :tenor-api-key="tenorApiKey"
+              :giphy-api-key="giphyApiKey"
                :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="messaging.slowModeCooldown.value"
               :is-sending="false"
@@ -1777,7 +1777,7 @@ onUnmounted(() => {
               :room-hats="authorHatsByNick"
               :room-presence="messaging.roomPresence.value"
               :room-last-seen="messaging.roomLastSeen.value"
-              :tenor-api-key="tenorApiKey"
+              :giphy-api-key="giphyApiKey"
                :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="messaging.slowModeCooldown.value"
               :is-sending="messaging.isSending.value"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -62,7 +62,7 @@ const props = defineProps<{
   selfDomain?: string;
   avatarUrlByAuthor: Record<string, string | null>;
   authorJidByNick?: Record<string, string>;
-  tenorApiKey: string;
+  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   roomHats: RoomHats;
   roomPresence: RoomPresence;
@@ -969,7 +969,7 @@ function dayDividerLabel(createdAt: string): string {
       :is-forum-channel="isForumChannel"
       :is-sending="isSending"
       :disabled="!canShowComposer"
-      :tenor-api-key="tenorApiKey"
+      :giphy-api-key="giphyApiKey"
       :mention-candidates="mentionCandidates"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
@@ -1170,7 +1170,7 @@ function dayDividerLabel(createdAt: string): string {
       :is-forum-channel="isForumChannel"
       :is-sending="isSending"
       :disabled="!canShowComposer"
-      :tenor-api-key="tenorApiKey"
+      :giphy-api-key="giphyApiKey"
       :mention-candidates="mentionCandidates"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
   isForumChannel: boolean;
   isSending: boolean;
   disabled: boolean;
-  tenorApiKey: string;
+  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   slowModeCooldown: number;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
@@ -569,7 +569,7 @@ watch(
 
     <GifPicker
       v-if="showGifPicker"
-      :api-key="tenorApiKey"
+      :api-key="giphyApiKey"
       :is-top-pinned="isTopPinned"
       @select="onGifSelected"
       @close="showGifPicker = false"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -32,7 +32,7 @@ const props = defineProps<{
   roomHats: RoomHats;
   roomPresence: RoomPresence;
   roomLastSeen: Record<string, number>;
-  tenorApiKey: string;
+  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   slowModeCooldown: number;
   isSending: boolean;
@@ -457,7 +457,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :channel-name="`thread in ${channelName}`"
         :is-sending="isSending"
         :disabled="false"
-        :tenor-api-key="tenorApiKey"
+        :giphy-api-key="giphyApiKey"
         :mention-candidates="mentionCandidates"
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"
@@ -605,7 +605,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :channel-name="`thread in ${channelName}`"
         :is-sending="isSending"
         :disabled="false"
-        :tenor-api-key="tenorApiKey"
+        :giphy-api-key="giphyApiKey"
         :mention-candidates="mentionCandidates"
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"

--- a/chat/src/env.d.ts
+++ b/chat/src/env.d.ts
@@ -10,3 +10,12 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// `GIPHY_API_KEY` is a Cloudflare Pages secret rather than a `wrangler.jsonc`
+// var, so `wrangler types` can't see it. Augment the generated `Cloudflare.Env`
+// here so layouts can read `env.GIPHY_API_KEY` without an unsafe cast.
+declare namespace Cloudflare {
+  interface Env {
+    GIPHY_API_KEY?: string;
+  }
+}

--- a/chat/src/layouts/AppLayout.astro
+++ b/chat/src/layouts/AppLayout.astro
@@ -1,10 +1,12 @@
 ---
 import { ClientRouter } from "astro:transitions";
 import { env } from "cloudflare:workers";
+import ChatApp from "@/components/ChatApp.vue";
 import XmppProvider from "@/components/XmppProvider.vue";
 import "@/styles/global.css";
 
 const serverBaseUrl = env.SERVER_BASE_URL;
+const giphyApiKey = env.GIPHY_API_KEY ?? "";
 ---
 
 <html lang="en">
@@ -64,6 +66,6 @@ const serverBaseUrl = env.SERVER_BASE_URL;
   </head>
   <body class="bg-background text-foreground font-sans antialiased">
     <XmppProvider client:only="vue" transition:persist serverBaseUrl={serverBaseUrl} />
-    <slot />
+    <ChatApp client:only="vue" giphyApiKey={giphyApiKey} />
   </body>
 </html>

--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -551,13 +551,33 @@ export async function fetchExtensionRouteItems(
   roomJid: string,
 ): Promise<ExtensionRouteItem[]> {
   const node = resolveExtensionRouteStateNode(route, roomJid);
-  const response = await (xmpp as unknown as {
-    getItems?: (jid: string, node: string, opts?: { max?: number }) => Promise<{ items?: Array<{ id?: string; content?: unknown }> }>;
-  }).getItems?.(route.serviceJid, node, { max: 100 });
+  let response: { items?: Array<{ id?: string; content?: unknown }> } | undefined;
+  try {
+    response = await (xmpp as unknown as {
+      getItems?: (jid: string, node: string, opts?: { max?: number }) => Promise<{ items?: Array<{ id?: string; content?: unknown }> }>;
+    }).getItems?.(route.serviceJid, node, { max: 100 });
+  } catch (error) {
+    // A pubsub state node that has never been published to returns
+    // `item-not-found`; surface that as an empty list rather than an error.
+    if (isItemNotFoundError(error)) return [];
+    throw error;
+  }
   return (response?.items ?? []).flatMap((item) => {
     const view = parseExtensionItemView(item.content, item.id);
     return view ? [view] : [];
   });
+}
+
+function isItemNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as Record<string, unknown>;
+  if (candidate.condition === "item-not-found") return true;
+  const nested = candidate.error;
+  if (nested && typeof nested === "object") {
+    const nestedCondition = (nested as Record<string, unknown>).condition;
+    if (nestedCondition === "item-not-found") return true;
+  }
+  return false;
 }
 
 function parseExtensionItemView(content: unknown, id: string | undefined): ExtensionRouteItem | null {

--- a/chat/src/pages/dm/[username].astro
+++ b/chat/src/pages/dm/[username].astro
@@ -1,11 +1,5 @@
 ---
-import { env } from "cloudflare:workers";
 import AppLayout from "@/layouts/AppLayout.astro";
-import ChatApp from "@/components/ChatApp.vue";
-
-const tenorApiKey = (env as unknown as Record<string, string>).GIPHY_API_KEY ?? "";
 ---
 
-<AppLayout>
-  <ChatApp client:only="vue" tenorApiKey={tenorApiKey} />
-</AppLayout>
+<AppLayout />

--- a/chat/src/pages/index.astro
+++ b/chat/src/pages/index.astro
@@ -1,11 +1,5 @@
 ---
-import { env } from "cloudflare:workers";
 import AppLayout from "@/layouts/AppLayout.astro";
-import ChatApp from "@/components/ChatApp.vue";
-
-const tenorApiKey = (env as unknown as Record<string, string>).GIPHY_API_KEY ?? "";
 ---
 
-<AppLayout>
-  <ChatApp client:only="vue" tenorApiKey={tenorApiKey} />
-</AppLayout>
+<AppLayout />

--- a/chat/src/pages/r/[room].astro
+++ b/chat/src/pages/r/[room].astro
@@ -1,11 +1,5 @@
 ---
-import { env } from "cloudflare:workers";
 import AppLayout from "@/layouts/AppLayout.astro";
-import ChatApp from "@/components/ChatApp.vue";
-
-const tenorApiKey = (env as unknown as Record<string, string>).GIPHY_API_KEY ?? "";
 ---
 
-<AppLayout>
-  <ChatApp client:only="vue" tenorApiKey={tenorApiKey} />
-</AppLayout>
+<AppLayout />

--- a/chat/src/pages/r/[room]/x/[pluginId]/[routeId].astro
+++ b/chat/src/pages/r/[room]/x/[pluginId]/[routeId].astro
@@ -1,0 +1,5 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+---
+
+<AppLayout />

--- a/chat/src/pages/settings.astro
+++ b/chat/src/pages/settings.astro
@@ -1,11 +1,5 @@
 ---
-import { env } from "cloudflare:workers";
 import AppLayout from "@/layouts/AppLayout.astro";
-import ChatApp from "@/components/ChatApp.vue";
-
-const tenorApiKey = (env as unknown as Record<string, string>).GIPHY_API_KEY ?? "";
 ---
 
-<AppLayout>
-  <ChatApp client:only="vue" tenorApiKey={tenorApiKey} />
-</AppLayout>
+<AppLayout />

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -403,6 +403,66 @@ describe("extension command invocation", () => {
     }]);
   });
 
+  test("treats item-not-found pubsub errors as an empty list", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw { condition: "item-not-found", type: "cancel" };
+      },
+    };
+
+    expect(await fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).toEqual([]);
+  });
+
+  test("treats nested item-not-found pubsub errors as an empty list", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "decision-polls",
+      routeId: "active-polls",
+      label: "Polls",
+      scope: "channel" as const,
+      surface: "list" as const,
+      stateNode: "urn:waddle:decision-polls:1:channel:{room}:polls",
+      payloadNamespace: "urn:waddle:decision-polls:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw { error: { condition: "item-not-found", type: "cancel" } };
+      },
+    };
+
+    expect(await fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).toEqual([]);
+  });
+
+  test("propagates non-item-not-found errors to the caller", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw new Error("forbidden");
+      },
+    };
+
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).rejects.toThrow("forbidden");
+  });
+
   test("uses source stanza metadata when context only carries the waddle id", () => {
     const iq = buildExtensionLaunchInvokeIq("alice@example.com/web", {
       ...launch,


### PR DESCRIPTION
## Summary

Fixes two extension-route bugs reported on `https://waddle.chat/r/{room}/x/{plugin}/{route}` URLs, then cleans up the inherited boilerplate around the giphy API key.

### Bug 1 — refresh / cold load returns `404: Not found`

Astro only had `chat/src/pages/r/[room].astro`. A single `[room]` segment can't match a four-segment path, so worker routing 404'd before the SPA had a chance to parse the URL. Adds the missing nested page; `parseRoute` already handles the deep path (covered in `tests/use-routing.test.ts:64`).

### Bug 2 — clicking the extension route shows "Could not load extension route"

`fetchExtensionRouteItems` calls `xmpp.getItems` against the per-channel pubsub state node. For a channel that has never had a link saved / poll created, the node returns `item-not-found`. The catch in `ExtensionRouteView.vue:62` falls through to the generic error fallback. Treat `item-not-found` as an empty list, mirroring the local helper in `chat/src/lib/xmpp/dm-history.ts:13`.

### Cleanup — giphy API key plumbing

While in the area:

- **Type the binding.** `worker-configuration.d.ts` is generated from `wrangler.jsonc` and only knew about `SERVER_BASE_URL`; `GIPHY_API_KEY` is a Pages secret. Augment `Cloudflare.Env` in `src/env.d.ts` so the existing `(env as unknown as Record<string, string>).GIPHY_API_KEY` cast can go away.
- **Stop duplicating the env→prop dance across five page files.** `index.astro`, `settings.astro`, `r/[room].astro`, `dm/[username].astro`, and the new `r/[room]/x/[pluginId]/[routeId].astro` each rendered the same `<ChatApp client:only="vue" …Key={…} />` after the same cast. Move both the read and the mount into `AppLayout.astro`; pages collapse to a single `<AppLayout />`.
- **Rename `tenorApiKey` → `giphyApiKey`** end to end. The env var is `GIPHY_API_KEY`, `GifPicker.vue:34` hits `api.giphy.com`, and the "tenor" name was a leftover from a previous provider. `GifPicker`'s own `apiKey` prop stays — it's provider-agnostic at that boundary.

## Test plan

- [x] `bun test` (530 pass) including new `fetchExtensionRouteItems` cases for flat / nested `item-not-found` and unrelated errors.
- [x] `astro check` clean
- [x] `bun run lint` (knip) clean
- [x] `bun run build` succeeds
- [ ] Manual: open `https://<preview>/r/{room}/x/link-board/saved-links` directly (expect SPA load), refresh on that URL (expect SPA load, not 404), click the route in a channel with no saved links yet (expect "Nothing saved yet." instead of error).