### PR TITLE
test(server): add cue reaction refresh regression

### DIFF
--- a/server/crates/waddle-server/tests/xep0444_reactions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0444_reactions_ws.rs
@@ -2,22 +2,34 @@
 
 mod ws_common;
 
+use std::str::FromStr;
 use tokio::sync::Mutex;
 use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
+const BOB_USERNAME: &str = "bob";
+const BOB_PASSWORD: &str = "bob-password";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 async fn setup() -> (TestServer, WsXmppClient) {
     let server = TestServer::start();
-    let resource = format!("xep0444-{}", uuid::Uuid::new_v4());
     let password = server.fixed_account_password().to_string();
-    let client =
-        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
-            .await
-            .expect("connect and auth");
+    let client = connect(&server, USERNAME, &password, "xep0444").await;
     (server, client)
+}
+
+async fn connect(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource_prefix: &str,
+) -> WsXmppClient {
+    let resource = format!("{resource_prefix}-{}", uuid::Uuid::new_v4());
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, &resource)
+        .await
+        .expect("connect and auth")
 }
 
 async fn join_room(client: &mut WsXmppClient, room: &str) {
@@ -35,6 +47,94 @@ async fn join_room(client: &mut WsXmppClient, room: &str) {
 
 fn stanza_id(frame: &str) -> String {
     extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
+}
+
+fn frame_has_direct_message_body(frame: &str) -> bool {
+    Element::from_str(frame)
+        .ok()
+        .is_some_and(|element| element_contains_direct_message_body(&element))
+}
+
+fn element_contains_direct_message_body(element: &Element) -> bool {
+    let this_element_matches = element.name() == "message"
+        && element
+            .children()
+            .any(|child| child.name() == "body" && child.ns() == element.ns());
+
+    this_element_matches || element.children().any(element_contains_direct_message_body)
+}
+
+#[tokio::test]
+async fn direct_reaction_replays_from_personal_mam_after_reconnect() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start_with_extra_accounts(&[(BOB_USERNAME, BOB_PASSWORD)]);
+    let admin_password = server.fixed_account_password().to_string();
+    let mut alice = connect(&server, USERNAME, &admin_password, "xep0444-alice").await;
+    let mut bob = connect(&server, BOB_USERNAME, BOB_PASSWORD, "xep0444-bob").await;
+    let alice_jid = format!("{USERNAME}@{DOMAIN}");
+    let bob_jid = format!("{BOB_USERNAME}@{DOMAIN}");
+
+    alice
+        .send(&format!(
+            r#"<message type="chat" to="{bob_jid}" id="direct-original"><body>direct reaction target</body></message>"#
+        ))
+        .await
+        .expect("send original direct message");
+    bob.recv_matching(|frame| frame.contains("direct reaction target"))
+        .await
+        .expect("receive original direct message");
+
+    bob.send(&format!(
+        r#"<message type="chat" to="{alice_jid}" id="direct-reaction">
+                <reactions xmlns="urn:xmpp:reactions:0" id="direct-original">
+                    <reaction>🔥</reaction>
+                </reactions>
+                <store xmlns="urn:xmpp:hints"/>
+            </message>"#
+    ))
+    .await
+    .expect("send direct reaction");
+    alice
+        .recv_matching(|frame| {
+            frame.contains("urn:xmpp:reactions:0") && frame.contains("direct-original")
+        })
+        .await
+        .expect("receive direct reaction");
+
+    alice.close().await;
+    let mut alice = connect(
+        &server,
+        USERNAME,
+        &admin_password,
+        "xep0444-alice-reconnect",
+    )
+    .await;
+    alice
+        .send(&format!(
+            r#"<iq type="set" id="mam-direct-reaction" to="{alice_jid}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send personal MAM query");
+    let frames = alice
+        .recv_until(|frame| frame.contains("mam-direct-reaction") && frame.contains("<fin"))
+        .await
+        .expect("personal MAM frames");
+
+    let reaction = frames
+        .iter()
+        .find(|frame| {
+            frame.contains("direct-reaction")
+                && frame.contains("urn:xmpp:reactions:0")
+                && frame.contains("direct-original")
+        })
+        .unwrap_or_else(|| panic!("personal MAM did not replay direct reaction: {frames:?}"));
+    assert!(
+        !frame_has_direct_message_body(reaction),
+        "direct reaction replay unexpectedly had a body: {reaction}"
+    );
+
+    bob.close().await;
+    alice.close().await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -8,8 +8,11 @@ use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
+use waddle_xmpp::xep::xep0334::{self, Hint};
+use waddle_xmpp::xep::xep0444;
 use waddle_xmpp::Stanza;
 use ws_common::{TestServer, WsXmppClient};
 use xmpp_parsers::iq::{Iq, IqType};
@@ -54,6 +57,10 @@ struct Actor {
 enum Step {
     #[serde(rename = "enableCarbons")]
     EnableCarbons { actor: Actor },
+    #[serde(rename = "connectActor")]
+    ConnectActor { actor: Actor },
+    #[serde(rename = "disconnectActor")]
+    DisconnectActor { actor: Actor },
     #[serde(rename = "sendMessage")]
     SendMessage {
         from: Actor,
@@ -71,7 +78,13 @@ enum Step {
     ExpectMessage {
         target: Actor,
         body: Option<String>,
+        #[serde(default, rename = "bodyAbsent")]
+        body_absent: bool,
         from: Option<Actor>,
+        #[serde(default, rename = "captureStanzaIdAs")]
+        capture_stanza_id_as: Option<String>,
+        #[serde(default, rename = "captureStanzaIdBy")]
+        capture_stanza_id_by: Option<String>,
         #[serde(default)]
         payloads: Vec<Payload>,
         #[serde(default)]
@@ -82,6 +95,8 @@ enum Step {
         target: Actor,
         carbon: CarbonKind,
         body: Option<String>,
+        #[serde(default, rename = "bodyAbsent")]
+        body_absent: bool,
         #[serde(default)]
         payloads: Vec<Payload>,
         #[serde(default)]
@@ -132,6 +147,8 @@ enum Step {
     #[serde(rename = "expectMamResult")]
     ExpectMamResult {
         body: Option<String>,
+        #[serde(default, rename = "bodyAbsent")]
+        body_absent: bool,
         #[serde(default)]
         payloads: Vec<Payload>,
         #[serde(default)]
@@ -183,12 +200,36 @@ enum Payload {
     },
     #[serde(rename = "messageCorrection")]
     MessageCorrection { id: String },
+    #[serde(rename = "reactions")]
+    Reactions {
+        id: Option<String>,
+        #[serde(rename = "idFrom")]
+        id_from: Option<String>,
+        #[serde(default)]
+        emojis: Vec<String>,
+    },
+    #[serde(rename = "processingHint")]
+    ProcessingHint { name: ProcessingHint },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum ProcessingHint {
+    NoPermanentStore,
+    NoStore,
+    NoCopy,
+    Store,
 }
 
 struct ScenarioContext {
     clients: HashMap<String, WsXmppClient>,
     pending_frames: HashMap<String, VecDeque<String>>,
     last_mam_frames: Vec<String>,
+    captures: HashMap<String, String>,
+    ws_url: String,
+    domain: String,
+    admin_password: String,
+    account_passwords: BTreeMap<String, String>,
 }
 
 #[tokio::test]
@@ -273,18 +314,15 @@ async fn run_scenario(scenario: Scenario) -> Result<()> {
         .map(|(username, password)| (username.as_str(), password.as_str()))
         .collect::<Vec<_>>();
     let server = TestServer::start_with_extra_accounts(&account_refs);
+    let ws_url = server.ws_url();
+    let admin_password = server.fixed_account_password().to_string();
     let mut clients = HashMap::new();
 
     for user in scenario.users.values() {
         for actor in user.devices.values() {
-            let admin_password = server.fixed_account_password();
-            let password = accounts
-                .get(&actor.username)
-                .map(String::as_str)
-                .or_else(|| (actor.username == "admin").then_some(admin_password))
-                .ok_or_else(|| anyhow!("missing password for {}", actor.username))?;
+            let password = account_password(&accounts, &admin_password, &actor.username)?;
             let client = WsXmppClient::connect_and_auth(
-                &server.ws_url(),
+                &ws_url,
                 &scenario.domain,
                 &actor.username,
                 password,
@@ -300,6 +338,11 @@ async fn run_scenario(scenario: Scenario) -> Result<()> {
         clients,
         pending_frames: HashMap::new(),
         last_mam_frames: Vec::new(),
+        captures: HashMap::new(),
+        ws_url,
+        domain: scenario.domain.clone(),
+        admin_password,
+        account_passwords: accounts,
     };
 
     for (index, step) in scenario.steps.iter().enumerate() {
@@ -327,10 +370,46 @@ fn scenario_accounts(scenario: &Scenario) -> BTreeMap<String, String> {
     accounts
 }
 
+fn account_password<'a>(
+    accounts: &'a BTreeMap<String, String>,
+    admin_password: &'a str,
+    username: &str,
+) -> Result<&'a str> {
+    accounts
+        .get(username)
+        .map(String::as_str)
+        .or_else(|| (username == "admin").then_some(admin_password))
+        .ok_or_else(|| anyhow!("missing password for {username}"))
+}
+
 async fn close_clients(clients: HashMap<String, WsXmppClient>) {
     for client in clients.into_values() {
         client.close().await;
     }
+}
+
+async fn disconnect_actor(ctx: &mut ScenarioContext, actor: &Actor) {
+    let key = actor_key(actor);
+    ctx.pending_frames.remove(&key);
+    if let Some(client) = ctx.clients.remove(&key) {
+        client.close().await;
+    }
+}
+
+async fn reconnect_actor(ctx: &mut ScenarioContext, actor: &Actor) -> Result<()> {
+    disconnect_actor(ctx, actor).await;
+    let password = account_password(&ctx.account_passwords, &ctx.admin_password, &actor.username)?;
+    let client = WsXmppClient::connect_and_auth(
+        &ctx.ws_url,
+        &ctx.domain,
+        &actor.username,
+        password,
+        &actor.resource,
+    )
+    .await
+    .map_err(|error| anyhow!("reconnect {}.{}: {error}", actor.user, actor.device))?;
+    ctx.clients.insert(actor_key(actor), client);
+    Ok(())
 }
 
 async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
@@ -352,6 +431,12 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             let response = recv_matching(ctx, actor, |frame| frame.contains(&id)).await?;
             assert_contains_all(&response, ["type=\"result\""], "enable carbons response")?;
         }
+        Step::DisconnectActor { actor } => {
+            disconnect_actor(ctx, actor).await;
+        }
+        Step::ConnectActor { actor } => {
+            reconnect_actor(ctx, actor).await?;
+        }
         Step::SendMessage {
             from,
             to,
@@ -371,7 +456,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                 message.bodies.insert(String::new(), Body(body.clone()));
             }
             for payload in payloads {
-                message.payloads.push(payload_element(payload));
+                message.payloads.push(payload_element(payload, ctx)?);
             }
             if body.is_some()
                 && payloads
@@ -390,7 +475,10 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
         Step::ExpectMessage {
             target,
             body,
+            body_absent,
             from,
+            capture_stanza_id_as,
+            capture_stanza_id_by,
             payloads,
             contains,
         } => {
@@ -398,7 +486,8 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             if let Some(body) = body {
                 expected.push(body_text_marker(body));
             }
-            expected.extend(payload_expectations(payloads)?);
+            let payload_expectations = payload_expectations(payloads, ctx)?;
+            expected.extend(payload_expectations.clone());
             if let Some(from) = from {
                 expected.push(format!("from=\"{}", from.bare_jid));
             }
@@ -407,21 +496,31 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
+                    && (!*body_absent || !frame.contains("<body"))
                     && from
                         .as_ref()
                         .is_none_or(|from| frame.contains(&format!("from=\"{}", from.bare_jid)))
-                    && payload_expectations(payloads)
-                        .map(|parts| parts.iter().all(|part| frame.contains(part)))
-                        .unwrap_or(false)
+                    && payload_expectations.iter().all(|part| frame.contains(part))
                     && contains.iter().all(|part| frame.contains(part))
             })
             .await?;
+            if *body_absent && frame.contains("<body") {
+                return Err(anyhow!(
+                    "message expectation expected no <body> element, got: {frame}"
+                ));
+            }
             assert_contains_all(&frame, &expected, "message expectation")?;
+            if let Some(capture_name) = capture_stanza_id_as {
+                let stanza_id =
+                    extract_stanza_id_from_frame(&frame, capture_stanza_id_by.as_deref())?;
+                ctx.captures.insert(capture_name.clone(), stanza_id);
+            }
         }
         Step::ExpectCarbon {
             target,
             carbon,
             body,
+            body_absent,
             payloads,
             contains,
         } => {
@@ -435,19 +534,24 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             if let Some(body) = body {
                 expected.push(body_text_marker(body));
             }
-            expected.extend(payload_expectations(payloads)?);
+            let payload_expectations = payload_expectations(payloads, ctx)?;
+            expected.extend(payload_expectations.clone());
             let frame = recv_matching(ctx, target, |frame| {
                 frame.contains("urn:xmpp:carbons:2")
                     && frame.contains(carbon_tag)
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
-                    && payload_expectations(payloads)
-                        .map(|parts| parts.iter().all(|part| frame.contains(part)))
-                        .unwrap_or(false)
+                    && (!*body_absent || !frame.contains("<body"))
+                    && payload_expectations.iter().all(|part| frame.contains(part))
                     && contains.iter().all(|part| frame.contains(part))
             })
             .await?;
+            if *body_absent && frame.contains("<body") {
+                return Err(anyhow!(
+                    "carbon expectation expected no <body> element, got: {frame}"
+                ));
+            }
             assert_contains_all(&frame, &expected, "carbon expectation")?;
         }
         Step::JoinMuc { actor, room, nick } => {
@@ -568,15 +672,17 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
         }
         Step::ExpectMamResult {
             body,
+            body_absent,
             payloads,
             contains,
         } => {
-            let payload_expectations = payload_expectations(payloads)?;
+            let payload_expectations = payload_expectations(payloads, ctx)?;
             let matched = ctx.last_mam_frames.iter().find(|frame| {
                 frame.contains("<forwarded")
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
+                    && (!*body_absent || !frame.contains("<body"))
                     && payload_expectations.iter().all(|part| frame.contains(part))
                     && contains.iter().all(|part| frame.contains(part))
             });
@@ -590,6 +696,11 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             };
             if let Some(body) = body {
                 assert_contains_all(frame, std::slice::from_ref(body), "MAM result body")?;
+            }
+            if *body_absent && frame.contains("<body") {
+                return Err(anyhow!(
+                    "MAM result expected no <body> element, got: {frame}"
+                ));
             }
             assert_contains_all(frame, &payload_expectations, "MAM result payloads")?;
             assert_contains_all(frame, contains, "MAM result contains")?;
@@ -757,7 +868,7 @@ async fn send_muc_admin_iq(
     Ok(())
 }
 
-fn payload_element(payload: &Payload) -> Element {
+fn payload_element(payload: &Payload, ctx: &ScenarioContext) -> Result<Element> {
     match payload {
         Payload::FileShare {
             disposition,
@@ -765,7 +876,7 @@ fn payload_element(payload: &Payload) -> Element {
             media_type,
             size,
             url,
-        } => Element::builder("file-sharing", "urn:xmpp:sfs:0")
+        } => Ok(Element::builder("file-sharing", "urn:xmpp:sfs:0")
             .attr("disposition", disposition.as_str())
             .append(
                 Element::builder("file", "urn:xmpp:file:metadata:0")
@@ -795,44 +906,56 @@ fn payload_element(payload: &Payload) -> Element {
                     )
                     .build(),
             )
-            .build(),
+            .build()),
         Payload::LinkMetadata {
             about,
             title,
             description,
             url,
-        } => Element::builder("Description", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-            .prefix(
-                Some("rdf".to_string()),
-                "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-            )
-            .expect("static RDF prefix is unique")
-            .attr("rdf:about", about.as_str())
-            .append(
-                Element::builder("title", "https://ogp.me/ns#")
-                    .append(title.as_str())
-                    .build(),
-            )
-            .append(
-                Element::builder("description", "https://ogp.me/ns#")
-                    .append(description.as_str())
-                    .build(),
-            )
-            .append(
-                Element::builder("url", "https://ogp.me/ns#")
-                    .append(url.as_str())
-                    .build(),
-            )
-            .build(),
+        } => Ok(
+            Element::builder("Description", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+                .prefix(
+                    Some("rdf".to_string()),
+                    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                )
+                .expect("static RDF prefix is unique")
+                .attr("rdf:about", about.as_str())
+                .append(
+                    Element::builder("title", "https://ogp.me/ns#")
+                        .append(title.as_str())
+                        .build(),
+                )
+                .append(
+                    Element::builder("description", "https://ogp.me/ns#")
+                        .append(description.as_str())
+                        .build(),
+                )
+                .append(
+                    Element::builder("url", "https://ogp.me/ns#")
+                        .append(url.as_str())
+                        .build(),
+                )
+                .build(),
+        ),
         Payload::MessageCorrection { id } => {
-            Element::builder("replace", "urn:xmpp:message-correct:0")
+            Ok(Element::builder("replace", "urn:xmpp:message-correct:0")
                 .attr("id", id.as_str())
-                .build()
+                .build())
         }
+        Payload::Reactions {
+            id,
+            id_from,
+            emojis,
+        } => {
+            let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
+            let emoji_refs = emojis.iter().map(String::as_str).collect::<Vec<_>>();
+            Ok(xep0444::build_reactions_element(&target_id, &emoji_refs))
+        }
+        Payload::ProcessingHint { name } => Ok(xep0334::build_hint_element(Hint::from(name))),
     }
 }
 
-fn payload_expectations(payloads: &[Payload]) -> Result<Vec<String>> {
+fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<Vec<String>> {
     let mut expected = Vec::new();
     for payload in payloads {
         match payload {
@@ -875,9 +998,56 @@ fn payload_expectations(payloads: &[Payload]) -> Result<Vec<String>> {
             Payload::MessageCorrection { id } => {
                 expected.extend(["urn:xmpp:message-correct:0".to_string(), id.clone()]);
             }
+            Payload::Reactions {
+                id,
+                id_from,
+                emojis,
+            } => {
+                let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
+                expected.extend([
+                    "urn:xmpp:reactions:0".to_string(),
+                    format!("id=\"{target_id}\""),
+                ]);
+                expected.extend(emojis.iter().map(|emoji| text_node_marker(emoji)));
+            }
+            Payload::ProcessingHint { name } => {
+                let hint = Hint::from(name);
+                expected.extend([
+                    "urn:xmpp:hints".to_string(),
+                    format!("<{}", hint.element_name()),
+                ]);
+            }
         }
     }
     Ok(expected)
+}
+
+fn resolve_payload_id(
+    ctx: &ScenarioContext,
+    id: Option<&str>,
+    id_from: Option<&str>,
+) -> Result<String> {
+    match (id, id_from) {
+        (Some(id), None) => Ok(id.to_string()),
+        (None, Some(capture)) => ctx
+            .captures
+            .get(capture)
+            .cloned()
+            .ok_or_else(|| anyhow!("unknown captured id {capture:?}")),
+        (Some(_), Some(_)) => Err(anyhow!("payload must specify id or idFrom, not both")),
+        (None, None) => Err(anyhow!("payload requires id or idFrom")),
+    }
+}
+
+impl From<&ProcessingHint> for Hint {
+    fn from(value: &ProcessingHint) -> Self {
+        match value {
+            ProcessingHint::NoPermanentStore => Self::NoPermanentStore,
+            ProcessingHint::NoStore => Self::NoStore,
+            ProcessingHint::NoCopy => Self::NoCopy,
+            ProcessingHint::Store => Self::Store,
+        }
+    }
 }
 
 fn validate_file_share_fallback_body(body: Option<&str>, payloads: &[Payload]) -> Result<()> {
@@ -886,7 +1056,10 @@ fn validate_file_share_fallback_body(body: Option<&str>, payloads: &[Payload]) -
     };
     let represented_by_payload = payloads.iter().any(|payload| match payload {
         Payload::FileShare { url, .. } => body == url,
-        Payload::LinkMetadata { .. } | Payload::MessageCorrection { .. } => false,
+        Payload::LinkMetadata { .. }
+        | Payload::MessageCorrection { .. }
+        | Payload::Reactions { .. }
+        | Payload::ProcessingHint { .. } => false,
     });
     if represented_by_payload {
         Ok(())
@@ -920,6 +1093,27 @@ fn body_text_marker(body: &str) -> String {
 
 fn text_node_marker(value: &str) -> String {
     format!(">{value}</")
+}
+
+fn extract_stanza_id_from_frame(frame: &str, by: Option<&str>) -> Result<String> {
+    let element =
+        Element::from_str(frame).with_context(|| format!("parse message frame: {frame}"))?;
+    find_stanza_id(&element, by)
+        .ok_or_else(|| anyhow!("no stanza-id matched by {:?} in frame: {frame}", by))
+}
+
+fn find_stanza_id(element: &Element, by: Option<&str>) -> Option<String> {
+    if element.name() == "stanza-id" && element.ns() == "urn:xmpp:sid:0" {
+        let by_matches = by.is_none_or(|expected| element.attr("by") == Some(expected));
+        if by_matches {
+            if let Some(id) = element.attr("id").filter(|id| !id.is_empty()) {
+                return Some(id.to_string());
+            }
+        }
+    }
+    element
+        .children()
+        .find_map(|child| find_stanza_id(child, by))
 }
 
 fn assert_contains_all<I, S>(frame: &str, expected: I, context: &str) -> Result<()>

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -496,7 +496,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
-                    && (!*body_absent || !frame.contains("<body"))
+                    && (!*body_absent || !frame_has_direct_message_body(frame))
                     && from
                         .as_ref()
                         .is_none_or(|from| frame.contains(&format!("from=\"{}", from.bare_jid)))
@@ -504,7 +504,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     && contains.iter().all(|part| frame.contains(part))
             })
             .await?;
-            if *body_absent && frame.contains("<body") {
+            if *body_absent && frame_has_direct_message_body(&frame) {
                 return Err(anyhow!(
                     "message expectation expected no <body> element, got: {frame}"
                 ));
@@ -542,12 +542,12 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
-                    && (!*body_absent || !frame.contains("<body"))
+                    && (!*body_absent || !frame_has_direct_message_body(frame))
                     && payload_expectations.iter().all(|part| frame.contains(part))
                     && contains.iter().all(|part| frame.contains(part))
             })
             .await?;
-            if *body_absent && frame.contains("<body") {
+            if *body_absent && frame_has_direct_message_body(&frame) {
                 return Err(anyhow!(
                     "carbon expectation expected no <body> element, got: {frame}"
                 ));
@@ -682,7 +682,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     && body
                         .as_ref()
                         .is_none_or(|body| frame_contains_body(frame, body))
-                    && (!*body_absent || !frame.contains("<body"))
+                    && (!*body_absent || !frame_has_direct_message_body(frame))
                     && payload_expectations.iter().all(|part| frame.contains(part))
                     && contains.iter().all(|part| frame.contains(part))
             });
@@ -697,7 +697,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             if let Some(body) = body {
                 assert_contains_all(frame, std::slice::from_ref(body), "MAM result body")?;
             }
-            if *body_absent && frame.contains("<body") {
+            if *body_absent && frame_has_direct_message_body(frame) {
                 return Err(anyhow!(
                     "MAM result expected no <body> element, got: {frame}"
                 ));
@@ -1008,7 +1008,7 @@ fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<V
                     "urn:xmpp:reactions:0".to_string(),
                     format!("id=\"{target_id}\""),
                 ]);
-                expected.extend(emojis.iter().map(|emoji| text_node_marker(emoji)));
+                expected.extend(normalized_reaction_text_markers(&target_id, emojis));
             }
             Payload::ProcessingHint { name } => {
                 let hint = Hint::from(name);
@@ -1084,7 +1084,39 @@ fn stanza_xml(stanza: Stanza) -> Result<String> {
 }
 
 fn frame_contains_body(frame: &str, body: &str) -> bool {
-    frame.contains("<body") && frame.contains(&body_text_marker(body))
+    parse_frame(frame)
+        .is_some_and(|element| element_contains_direct_message_body(&element, Some(body)))
+}
+
+fn frame_has_direct_message_body(frame: &str) -> bool {
+    parse_frame(frame).is_some_and(|element| element_contains_direct_message_body(&element, None))
+}
+
+fn parse_frame(frame: &str) -> Option<Element> {
+    Element::from_str(frame).ok()
+}
+
+fn element_contains_direct_message_body(element: &Element, expected: Option<&str>) -> bool {
+    let this_element_matches = element.name() == "message"
+        && element.children().any(|child| {
+            child.name() == "body"
+                && child.ns() == element.ns()
+                && expected.is_none_or(|body| child.text() == body)
+        });
+
+    this_element_matches
+        || element
+            .children()
+            .any(|child| element_contains_direct_message_body(child, expected))
+}
+
+fn normalized_reaction_text_markers(target_id: &str, emojis: &[String]) -> Vec<String> {
+    let emoji_refs = emojis.iter().map(String::as_str).collect::<Vec<_>>();
+    xep0444::build_reactions_element(target_id, &emoji_refs)
+        .children()
+        .filter(|child| child.name() == "reaction" && child.ns() == xep0444::NS_REACTIONS)
+        .map(|child| text_node_marker(&child.text()))
+        .collect()
 }
 
 fn body_text_marker(body: &str) -> String {

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -26,6 +26,8 @@ package xmpp_e2e_scenarios
 
 #Step:
 	#EnableCarbons |
+	#ConnectActor |
+	#DisconnectActor |
 	#SendMessage |
 	#ExpectMessage |
 	#ExpectCarbon |
@@ -40,6 +42,18 @@ package xmpp_e2e_scenarios
 
 #EnableCarbons: {
 	kind:  "enableCarbons"
+	actor: #Actor
+	...
+}
+
+#ConnectActor: {
+	kind:  "connectActor"
+	actor: #Actor
+	...
+}
+
+#DisconnectActor: {
+	kind:  "disconnectActor"
 	actor: #Actor
 	...
 }
@@ -68,20 +82,24 @@ package xmpp_e2e_scenarios
 }
 
 #ExpectMessage: {
-	kind:   "expectMessage"
-	target: #Actor
-	body?:  string
-	from?:  #Actor
+	kind:              "expectMessage"
+	target:            #Actor
+	body?:             string
+	bodyAbsent?:       bool
+	from?:             #Actor
+	captureStanzaIdAs?: string
+	captureStanzaIdBy?: string
 	payloads?: [...#ExpectedPayload]
 	contains?: [...string]
 	...
 }
 
 #ExpectCarbon: {
-	kind:   "expectCarbon"
-	target: #Actor
-	carbon: "sent" | "received"
-	body?:  string
+	kind:        "expectCarbon"
+	target:      #Actor
+	carbon:      "sent" | "received"
+	body?:       string
+	bodyAbsent?: bool
 	payloads?: [...#ExpectedPayload]
 	contains?: [...string]
 	...
@@ -144,8 +162,9 @@ package xmpp_e2e_scenarios
 }
 
 #ExpectMamResult: {
-	kind: "expectMamResult"
-	body?: string
+	kind:        "expectMamResult"
+	body?:       string
+	bodyAbsent?: bool
 	payloads?: [...#ExpectedPayload]
 	contains?: [...string]
 	...
@@ -160,13 +179,36 @@ package xmpp_e2e_scenarios
 	...
 }
 
-#Payload: #FileShare | #LinkMetadata | #MessageCorrection
+#Payload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint
 
-#ExpectedPayload: #FileShare | #LinkMetadata | #MessageCorrection
+#ExpectedPayload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint
 
 #MessageCorrection: {
 	kind: "messageCorrection"
 	id:   string
+	...
+}
+
+#Reactions: {
+	kind: "reactions"
+	(#ReactionId | #ReactionIdFrom)
+	emojis: [...string]
+	...
+}
+
+#ReactionId: {
+	id: string
+	idFrom?: _|_
+}
+
+#ReactionIdFrom: {
+	id?: _|_
+	idFrom: string
+}
+
+#ProcessingHint: {
+	kind: "processingHint"
+	name: "no-permanent-store" | "no-store" | "no-copy" | "store"
 	...
 }
 

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -84,8 +84,7 @@ package xmpp_e2e_scenarios
 #ExpectMessage: {
 	kind:              "expectMessage"
 	target:            #Actor
-	body?:             string
-	bodyAbsent?:       bool
+	#BodyExpectation
 	from?:             #Actor
 	captureStanzaIdAs?: string
 	captureStanzaIdBy?: string
@@ -98,8 +97,7 @@ package xmpp_e2e_scenarios
 	kind:        "expectCarbon"
 	target:      #Actor
 	carbon:      "sent" | "received"
-	body?:       string
-	bodyAbsent?: bool
+	#BodyExpectation
 	payloads?: [...#ExpectedPayload]
 	contains?: [...string]
 	...
@@ -163,11 +161,18 @@ package xmpp_e2e_scenarios
 
 #ExpectMamResult: {
 	kind:        "expectMamResult"
-	body?:       string
-	bodyAbsent?: bool
+	#BodyExpectation
 	payloads?: [...#ExpectedPayload]
 	contains?: [...string]
 	...
+}
+
+#BodyExpectation: {
+	body?:       string
+	bodyAbsent?: false
+} | {
+	body?:       _|_
+	bodyAbsent: true
 }
 
 #ExpectNoStanza: {

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_direct_reaction_refresh.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_direct_reaction_refresh.cue
@@ -1,0 +1,81 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0444-direct-reaction-refresh"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-direct-react-original"
+			body: "direct reaction survives refresh"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "direct reaction survives refresh"
+		},
+		#SendMessage & {
+			from: bobPhone
+			to:   alicePhone
+			type: "chat"
+			id:   "cue-direct-reaction-1"
+			payloads: [
+				#Reactions & {
+					id:     "cue-direct-react-original"
+					emojis: ["🔥"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+		#ExpectMessage & {
+			target:     alicePhone
+			from:       bobPhone
+			bodyAbsent: true
+			payloads: [
+				#Reactions & {
+					id:     "cue-direct-react-original"
+					emojis: ["🔥"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+		#DisconnectActor & {actor: alicePhone},
+		#ConnectActor & {actor: alicePhone},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: alicePhone.bareJid
+			id:      "cue-direct-reaction-refresh-mam"
+		},
+		#ExpectMamResult & {
+			bodyAbsent: true
+			contains: ["cue-direct-reaction-1"]
+			payloads: [
+				#Reactions & {
+					id:     "cue-direct-react-original"
+					emojis: ["🔥"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_muc_reaction_refresh.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0444_muc_reaction_refresh.cue
@@ -1,0 +1,88 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0444-muc-reaction-refresh"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "admin"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-reactions@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice-phone"},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
+		#SendMessage & {
+			from:  alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-muc-react-original"
+			body:  "muc reaction survives refresh"
+		},
+		#ExpectMessage & {
+			target:             bobPhone
+			body:               "muc reaction survives refresh"
+			contains:           [roomJid, "cue-muc-react-original"]
+			captureStanzaIdAs:  "mucOriginalStanzaId"
+			captureStanzaIdBy:  roomJid
+		},
+		#SendMessage & {
+			from:  bobPhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-muc-reaction-1"
+			payloads: [
+				#Reactions & {
+					idFrom: "mucOriginalStanzaId"
+					emojis: ["👍"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+		#ExpectMessage & {
+			target:     alicePhone
+			bodyAbsent: true
+			contains:   [roomJid, "cue-muc-reaction-1"]
+			payloads: [
+				#Reactions & {
+					idFrom: "mucOriginalStanzaId"
+					emojis: ["👍"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+		#DisconnectActor & {actor: alicePhone},
+		#ConnectActor & {actor: alicePhone},
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice-phone"},
+		#QueryMam & {
+			actor:   alicePhone
+			archive: roomJid
+			id:      "cue-muc-reaction-refresh-mam"
+		},
+		#ExpectMamResult & {
+			bodyAbsent: true
+			contains: ["cue-muc-reaction-1"]
+			payloads: [
+				#Reactions & {
+					idFrom: "mucOriginalStanzaId"
+					emojis: ["👍"]
+				},
+				#ProcessingHint & {name: "store"},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -120,7 +120,7 @@ pub fn is_archivable(message: &Message) -> bool {
         return false;
     }
     // Require either a non-empty body or a substantive payload (e.g.
-    // a XEP-0424 retraction, XEP-0308 correction). Pure presence-like
+    // a XEP-0424 retraction, XEP-0308 correction, or XEP-0444 reaction). Pure presence-like
     // messages with no body and no archivable payload are dropped.
     has_body || has_archivable_payload(message)
 }
@@ -133,12 +133,13 @@ fn has_substantive_body(message: &Message) -> bool {
 }
 
 fn has_archivable_payload(message: &Message) -> bool {
-    use crate::xep::{xep0308, xep0424};
+    use crate::xep::{xep0308, xep0424, xep0444};
     xep0308::is_correction_message(message)
         || matches!(
             xep0424::extract_retraction_from_message(message),
             Some(xep0424::RetractionKind::Request(_))
         )
+        || xep0444::extract_reactions_from_message(message).is_some()
 }
 
 #[cfg(test)]
@@ -407,5 +408,41 @@ mod tests {
             .push(crate::xep::xep0424::build_retract_element("stanza-X"));
         let outcome = run(&local, &mut msg);
         assert_eq!(extract_archive_events(&outcome).len(), 1);
+    }
+
+    #[test]
+    fn xep_0313_reaction_without_body_is_archivable_payload() {
+        // XEP-0444 reaction messages are bodyless, but clients reload
+        // reaction state from MAM after reconnect/page refresh.
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Chat;
+        msg.payloads
+            .push(crate::xep::xep0444::build_reactions_element(
+                "stanza-X",
+                &["🔥"],
+            ));
+        let outcome = run(&local, &mut msg);
+        assert_eq!(extract_archive_events(&outcome).len(), 1);
+    }
+
+    #[test]
+    fn xep_0313_malformed_reaction_without_target_id_is_not_archived() {
+        let local = full("alice@example.com/web");
+        let mut msg = Message::new(Some("bob@example.com".parse().expect("jid")));
+        msg.from = Some("alice@example.com/web".parse().expect("jid"));
+        msg.type_ = MessageType::Chat;
+        msg.payloads.push(
+            Element::builder("reactions", crate::xep::xep0444::NS_REACTIONS)
+                .append(
+                    Element::builder("reaction", crate::xep::xep0444::NS_REACTIONS)
+                        .append("🔥")
+                        .build(),
+                )
+                .build(),
+        );
+        let outcome = run(&local, &mut msg);
+        assert!(extract_archive_events(&outcome).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Add active CUE-based WebSocket e2e coverage that proves reactions survive a refresh-style reload through XMPP MAM. Cover both direct chats and MUC channels. The first implementation pass should add the red test and run it before fixing code; the direct-chat case is expected to fail today because bodyless XEP-0444 reactions are not treated as direct-message archivable payloads.

## Key Changes

- Extend the CUE e2e DSL with reaction payloads, XEP-0334 store hints, body-absence assertions, stanza-id capture, and actor reconnect steps.
- Add direct-chat refresh coverage: live reaction is received, actor reconnects, personal MAM replay must include the bodyless reaction.
- Add MUC refresh coverage: capture the room-assigned XEP-0359 stanza-id, react to it, reconnect/rejoin, and confirm room MAM replay includes the bodyless reaction.
- After proving the red test, fix direct archive eligibility so XEP-0444 reactions count as archivable bodyless payloads while preserving XEP-0334 skip/override behavior.

## Test Plan

- Red step: `cargo test -p waddle-server --test xmpp_e2e_cue -- cue_scenarios_run_over_websocket`
- Focused archive eligibility unit coverage for bodyless direct reactions.
- Green step: rerun CUE e2e, existing XEP-0444 WebSocket test, and clippy for touched Rust packages.

## Assumptions

- “Page refresh” is represented at XMPP e2e level as reconnect plus MAM reload, not browser UI automation.
- Keep the existing hand-written WebSocket reactions test.
- Use official XEP namespaces and wire shapes only: `urn:xmpp:reactions:0`, `urn:xmpp:hints`, `urn:xmpp:sid:0`, and `urn:xmpp:mam:2`.
