### PR TITLE
fix(chat): load extension routes

### DIFF
--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -557,10 +557,7 @@ export async function fetchExtensionRouteItems(
       getItems?: (jid: string, node: string, opts?: { max?: number }) => Promise<{ items?: Array<{ id?: string; content?: unknown }> }>;
     }).getItems?.(route.serviceJid, node, { max: 100 });
   } catch (error) {
-    // A pubsub state node that has never been published to returns
-    // `item-not-found`; surface that as an empty list rather than an error.
-    if (isItemNotFoundError(error)) return [];
-    throw error;
+    throw normalizeXmppRouteError(error);
   }
   return (response?.items ?? []).flatMap((item) => {
     const view = parseExtensionItemView(item.content, item.id);
@@ -568,16 +565,41 @@ export async function fetchExtensionRouteItems(
   });
 }
 
-function isItemNotFoundError(error: unknown): boolean {
-  if (!error || typeof error !== "object") return false;
+function normalizeXmppRouteError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  const condition = xmppErrorCondition(error) ?? xmppPubsubErrorCondition(error);
+  if (condition === "forbidden") return new Error("Extension route access was denied.");
+  if (condition === "item-not-found") return new Error("Extension route was not found.");
+  if (condition === "service-unavailable") return new Error("Extension route service is unavailable.");
+  if (condition === "timeout" || condition === "remote-server-timeout") {
+    return new Error("Extension route request timed out.");
+  }
+  if (condition) return new Error(`Extension route load failed: ${condition}.`);
+  return new Error("Could not load extension route.");
+}
+
+function xmppErrorCondition(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
   const candidate = error as Record<string, unknown>;
-  if (candidate.condition === "item-not-found") return true;
+  if (typeof candidate.condition === "string") return candidate.condition;
   const nested = candidate.error;
   if (nested && typeof nested === "object") {
     const nestedCondition = (nested as Record<string, unknown>).condition;
-    if (nestedCondition === "item-not-found") return true;
+    if (typeof nestedCondition === "string") return nestedCondition;
   }
-  return false;
+  return null;
+}
+
+function xmppPubsubErrorCondition(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as Record<string, unknown>;
+  if (typeof candidate.pubsubError === "string") return candidate.pubsubError;
+  const nested = candidate.error;
+  if (nested && typeof nested === "object") {
+    const nestedCondition = (nested as Record<string, unknown>).pubsubError;
+    if (typeof nestedCondition === "string") return nestedCondition;
+  }
+  return null;
 }
 
 function parseExtensionItemView(content: unknown, id: string | undefined): ExtensionRouteItem | null {

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -403,7 +403,30 @@ describe("extension command invocation", () => {
     }]);
   });
 
-  test("treats item-not-found pubsub errors as an empty list", async () => {
+  test("treats successful empty PubSub route item responses as empty routes", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems(jid: string, node: string, opts?: { max?: number }) {
+        expect(jid).toBe("extensions.example.com");
+        expect(node).toBe("urn:waddle:link-board:1:channel:general@muc.example.com:links");
+        expect(opts?.max).toBe(100);
+        return {};
+      },
+    };
+
+    expect(await fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).toEqual([]);
+  });
+
+  test("normalizes item-not-found pubsub errors as unavailable routes", async () => {
     const route = {
       serviceJid: "extensions.example.com",
       pluginId: "link-board",
@@ -420,10 +443,11 @@ describe("extension command invocation", () => {
       },
     };
 
-    expect(await fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).toEqual([]);
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route was not found.");
   });
 
-  test("treats nested item-not-found pubsub errors as an empty list", async () => {
+  test("normalizes nested item-not-found pubsub errors as unavailable routes", async () => {
     const route = {
       serviceJid: "extensions.example.com",
       pluginId: "decision-polls",
@@ -440,7 +464,104 @@ describe("extension command invocation", () => {
       },
     };
 
-    expect(await fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com")).toEqual([]);
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route was not found.");
+  });
+
+  test("normalizes stanza.js item-not-found IQ errors as unavailable routes", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw {
+          id: "pubsub-1",
+          type: "error",
+          error: { type: "cancel", condition: "item-not-found" },
+        };
+      },
+    };
+
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route was not found.");
+  });
+
+  test("normalizes pubsubError-only route load errors", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw {
+          id: "pubsub-1",
+          type: "error",
+          error: { type: "cancel", pubsubError: "item-not-found" },
+        };
+      },
+    };
+
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route was not found.");
+  });
+
+  test("normalizes stanza.js route load errors into actionable Error messages", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw {
+          id: "pubsub-1",
+          type: "error",
+          error: { type: "auth", condition: "forbidden" },
+        };
+      },
+    };
+
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route access was denied.");
+  });
+
+  test("normalizes remote server timeout route load errors", async () => {
+    const route = {
+      serviceJid: "extensions.example.com",
+      pluginId: "link-board",
+      routeId: "saved-links",
+      label: "Saved Links",
+      scope: "channel" as const,
+      surface: "gallery" as const,
+      stateNode: "urn:waddle:link-board:1:channel:{room}:links",
+      payloadNamespace: "urn:waddle:link-board:1",
+    };
+    const xmpp = {
+      async getItems() {
+        throw { error: { condition: "remote-server-timeout", type: "wait" } };
+      },
+    };
+
+    await expect(fetchExtensionRouteItems(xmpp as any, route, "general@muc.example.com"))
+      .rejects.toThrow("Extension route request timed out.");
   });
 
   test("propagates non-item-not-found errors to the caller", async () => {


### PR DESCRIPTION
## Plan

- Review route registration/load behavior against XEP-0030 and XEP-0060 shapes used by the extension route flow.
- Reproduce the route load failure in focused chat tests.
- Fix route item loading so raw stanza.js IQ errors become actionable Vue-visible Error messages instead of the generic fallback.
- Preserve the current server contract: successful empty PubSub items responses render empty routes, while item-not-found remains an unavailable route error.

## Validation

- `bun test tests/extension-command.test.ts`
- `bun test`
- `bun run lint`
- `bun run build`
- `cargo test -p waddle-server handle_iq_pubsub_items_empty_node_returns_result --lib`
- `git diff --check`

## Review

- XMPP/stanza semantics adversarial review: no actionable findings.
- Product/route-loading adversarial review found the original item-not-found masking risk; patch was revised and re-reviewed with no actionable findings.

## Notes

- Existing local changes to `.claude/settings.local.json` and `GAPS.md` are unrelated and preserved.
- No knip ignores or clippy suppressions added.