### PR TITLE
feat(server): durable XEP-0198 SM session persistence (slice d phases 2-3, #209)

### DIFF
--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -10,6 +10,7 @@ pub mod permissions;
 pub mod pubsub;
 pub mod pubsub_authz;
 pub mod server;
+pub mod sm_persistence;
 pub mod spaces_pubsub_seed;
 pub mod storage;
 pub mod telemetry;

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -255,6 +255,15 @@ pub struct XmppConfig {
     /// deployments MUST set one of these env vars so queued offline
     /// DMs survive restart per issue #209.
     pub pending_delivery_database_url: Option<String>,
+    /// XEP-0198 stream-management persistence database URL —
+    /// prefers dedicated XMPP DSN, otherwise the main runtime DSN.
+    /// Resolution order:
+    /// `WADDLE_XMPP_SM_DATABASE_URL` → `WADDLE_DATABASE_URL`. When
+    /// unset the storage falls back to in-memory SQLite — suitable
+    /// for tests; production deployments MUST set one of these env
+    /// vars so detached sessions survive restart per issue #209
+    /// slice (d) Q8 = B.
+    pub sm_database_url: Option<String>,
     /// PubSub/PEP database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
     pub pubsub_database_url: Option<String>,
     /// Whether native JID authentication is enabled (default: true)
@@ -273,6 +282,7 @@ impl Default for XmppConfig {
             mam_database_url: None,
             inbox_database_url: None,
             pending_delivery_database_url: None,
+            sm_database_url: None,
             pubsub_database_url: None,
             native_auth_enabled: true,
             acme: XmppAcmeConfig {
@@ -301,6 +311,7 @@ impl XmppConfig {
         let inbox_database_url = resolve_xmpp_database_url("WADDLE_XMPP_INBOX_DATABASE_URL");
         let pending_delivery_database_url =
             resolve_xmpp_database_url("WADDLE_XMPP_PENDING_DELIVERY_DATABASE_URL");
+        let sm_database_url = resolve_xmpp_database_url("WADDLE_XMPP_SM_DATABASE_URL");
         let pubsub_database_url = resolve_xmpp_database_url("WADDLE_XMPP_PUBSUB_DATABASE_URL");
 
         let native_auth_enabled = std::env::var("WADDLE_NATIVE_AUTH_ENABLED")
@@ -328,6 +339,7 @@ impl XmppConfig {
             mam_database_url,
             inbox_database_url,
             pending_delivery_database_url,
+            sm_database_url,
             pubsub_database_url,
             native_auth_enabled,
             acme: XmppAcmeConfig {
@@ -1106,9 +1118,31 @@ async fn create_router(
         Arc::new(waddle_xmpp::push::InMemoryPushStore::new());
 
     // XEP-0198 detached-session registry for stream resumption across
-    // transient WebSocket drops.
-    let sm_session_registry =
-        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new());
+    // transient WebSocket drops. Backed by `DatabaseSmPersistence` so
+    // detached sessions and their unacked queues survive restart per
+    // locked Q8 = B (issue #209 slice d).
+    let sm_database_url = xmpp_config.sm_database_url.clone();
+    if sm_database_url.is_none() {
+        warn!(
+            "Neither WADDLE_XMPP_SM_DATABASE_URL nor WADDLE_DATABASE_URL is set; \
+             falling back to in-memory SQLite for SM session persistence. \
+             Detached XEP-0198 sessions will NOT survive restart. Set one of \
+             these env vars for durable session resumption (issue #209)."
+        );
+    }
+    let sm_persistence: Arc<dyn waddle_xmpp::stream_management::persistence::SmPersistenceStorage> =
+        Arc::new(
+            crate::sm_persistence::DatabaseSmPersistence::open(sm_database_url.as_deref())
+                .await
+                .expect("open SM persistence storage"),
+        );
+    let sm_session_registry = waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_persistence));
+    sm_session_registry
+        .restore_from_persistence()
+        .await
+        .expect("restore SM sessions from persistence");
+    let sm_session_registry = Arc::new(sm_session_registry);
     let resumable_sessions: Arc<dashmap::DashMap<String, crate::auth::Session>> =
         Arc::new(dashmap::DashMap::new());
 

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1138,10 +1138,22 @@ async fn create_router(
         );
     let sm_session_registry = waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
         .with_persistence(Arc::clone(&sm_persistence));
-    sm_session_registry
-        .restore_from_persistence()
-        .await
-        .expect("restore SM sessions from persistence");
+    // Don't panic on a top-level restore error — `restore_from_persistence`
+    // already skips individual corrupt rows internally; a top-level
+    // failure here would only surface for catastrophic storage outages
+    // (table unreadable, etc.). Log and continue with an empty in-memory
+    // view; clients reconnecting after restart will see `<failed/>` on
+    // resume and fall back to fresh sessions (XEP-0198 §5). Was
+    // previously `expect()` which turned one bad row into a boot
+    // failure — Qodo review on PR #344.
+    if let Err(error) = sm_session_registry.restore_from_persistence().await {
+        warn!(
+            error = %error,
+            "restore_from_persistence failed at startup; continuing with empty \
+             in-memory SM session view. XEP-0198 resume will return <failed/> \
+             until storage health is restored."
+        );
+    }
     let sm_session_registry = Arc::new(sm_session_registry);
     let resumable_sessions: Arc<dashmap::DashMap<String, crate::auth::Session>> =
         Arc::new(dashmap::DashMap::new());

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -1,0 +1,734 @@
+//! libSQL/Postgres-backed XEP-0198 stream-management persistence
+//! (issue #209 slice (d) phase 2).
+//!
+//! `waddle_xmpp::stream_management::persistence::SmPersistenceStorage`
+//! defines the typed contract; this module provides the production
+//! database backend. Mirrors the `crate::pending_delivery` module's
+//! storage shape: `Database::open` opens SQLite or Postgres; per-stream
+//! locks make multi-statement quota / append paths atomic across both
+//! drivers.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use jid::FullJid;
+use tracing::{info, instrument};
+use waddle_xmpp::pending_delivery::SmSessionId;
+use waddle_xmpp::stream_management::persistence::{
+    PersistedSession, PersistedUnackedStanza, SmPersistenceError, SmPersistenceStorage,
+};
+use waddle_xmpp::Stanza;
+use xmpp_parsers::presence::Show;
+
+use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+
+/// Per-stream insert/update mutex map. Serializes writes for the same
+/// session so the multi-statement append + ack paths are linearizable
+/// across SQLite (single-writer) and Postgres (READ-COMMITTED).
+type StreamLockMap = dashmap::DashMap<SmSessionId, Arc<tokio::sync::Mutex<()>>>;
+
+/// libSQL/Postgres-backed [`SmPersistenceStorage`].
+///
+/// Schema:
+///
+/// ```sql
+/// CREATE TABLE sm_sessions (
+///     stream_id TEXT PRIMARY KEY,
+///     user_id TEXT NOT NULL,
+///     full_jid TEXT NOT NULL,
+///     inbound_count INTEGER NOT NULL,
+///     outbound_count INTEGER NOT NULL,
+///     last_acked INTEGER NOT NULL,
+///     max_resume_secs INTEGER,
+///     detached_at_ms INTEGER NOT NULL,
+///     max_resume_duration_ms INTEGER NOT NULL,
+///     carbons_enabled INTEGER NOT NULL,
+///     roster_interested INTEGER NOT NULL,
+///     presence_available INTEGER NOT NULL,
+///     presence_show TEXT,
+///     presence_status TEXT,
+///     presence_priority INTEGER NOT NULL
+/// );
+///
+/// CREATE TABLE sm_unacked (
+///     stream_id TEXT NOT NULL,
+///     sequence INTEGER NOT NULL,
+///     stanza_xml TEXT NOT NULL,
+///     original_receipt_at_ms INTEGER NOT NULL,
+///     PRIMARY KEY (stream_id, sequence)
+/// );
+/// ```
+///
+/// `sm_unacked.stream_id` is logically a foreign key into
+/// `sm_sessions.stream_id`. We do NOT declare a hard FK because
+/// SQLite's default `PRAGMA foreign_keys = OFF` makes them advisory
+/// anyway, and we want `delete_session` to drain unacked rows
+/// explicitly via two statements (so the trait's lifecycle is
+/// observable in tests against the in-memory fake too).
+#[derive(Clone)]
+pub struct DatabaseSmPersistence {
+    db: Database,
+    stream_locks: Arc<StreamLockMap>,
+}
+
+impl DatabaseSmPersistence {
+    /// Open against `database_url` (SQLite path or Postgres DSN).
+    /// `None` falls back to in-memory SQLite suitable only for tests.
+    pub async fn open(database_url: Option<&str>) -> Result<Self, SmPersistenceError> {
+        let db = match database_url {
+            Some(url) => {
+                let driver = if url.starts_with("postgres://") || url.starts_with("postgresql://") {
+                    DatabaseDriver::Postgres
+                } else {
+                    DatabaseDriver::Sqlite
+                };
+                Database::from_config(
+                    "sm_persistence",
+                    &DatabaseConfig::new(driver, url.to_string()),
+                )
+                .await
+                .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+            }
+            None => Database::in_memory("sm_persistence")
+                .await
+                .map_err(|e| SmPersistenceError::Other(e.to_string()))?,
+        };
+        let storage = Self {
+            db,
+            stream_locks: Arc::new(StreamLockMap::new()),
+        };
+        storage.initialize().await?;
+        info!(driver = ?storage.db.driver(), "SM persistence storage initialized (XEP-0198)");
+        Ok(storage)
+    }
+
+    async fn initialize(&self) -> Result<(), SmPersistenceError> {
+        self.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS sm_sessions (
+                stream_id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                full_jid TEXT NOT NULL,
+                inbound_count INTEGER NOT NULL,
+                outbound_count INTEGER NOT NULL,
+                last_acked INTEGER NOT NULL,
+                max_resume_secs INTEGER,
+                detached_at_ms INTEGER NOT NULL,
+                max_resume_duration_ms INTEGER NOT NULL,
+                carbons_enabled INTEGER NOT NULL,
+                roster_interested INTEGER NOT NULL,
+                presence_available INTEGER NOT NULL,
+                presence_show TEXT,
+                presence_status TEXT,
+                presence_priority INTEGER NOT NULL
+            )
+            "#,
+            (),
+        )
+        .await?;
+        self.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS sm_unacked (
+                stream_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                stanza_xml TEXT NOT NULL,
+                original_receipt_at_ms INTEGER NOT NULL,
+                PRIMARY KEY (stream_id, sequence)
+            )
+            "#,
+            (),
+        )
+        .await?;
+        // Index on detached_at_ms + max_resume_duration_ms for the
+        // janitor's expired-session sweep. We can't compute the
+        // expiry timestamp directly in SQL portably, so the janitor
+        // filters in Rust over an index-supported scan.
+        self.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sm_sessions_detached \
+             ON sm_sessions (detached_at_ms)",
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn execute(&self, sql: &str, params: impl IntoParams) -> Result<u64, SmPersistenceError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))
+    }
+
+    async fn query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, SmPersistenceError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))
+    }
+
+    fn lock_for(&self, stream_id: &SmSessionId) -> Arc<tokio::sync::Mutex<()>> {
+        self.stream_locks
+            .entry(stream_id.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
+    fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, SmPersistenceError> {
+        let stream_id: String = row
+            .get(0)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let user_id: String = row
+            .get(1)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let full_jid_raw: String = row
+            .get(2)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let jid: FullJid = full_jid_raw
+            .parse()
+            .map_err(|e: jid::Error| SmPersistenceError::Other(e.to_string()))?;
+        let inbound_count: i64 = row
+            .get(3)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let outbound_count: i64 = row
+            .get(4)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let last_acked: i64 = row
+            .get(5)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let max_resume_secs: Option<i64> = row
+            .get(6)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let detached_at_ms: i64 = row
+            .get(7)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let max_resume_duration_ms: i64 = row
+            .get(8)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let carbons_enabled: i64 = row
+            .get(9)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let roster_interested: i64 = row
+            .get(10)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let presence_available: i64 = row
+            .get(11)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let presence_show_raw: Option<String> = row
+            .get(12)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let presence_status: Option<String> = row
+            .get(13)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let presence_priority: i64 = row
+            .get(14)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+
+        let detached_at = DateTime::<Utc>::from_timestamp_millis(detached_at_ms)
+            .ok_or_else(|| SmPersistenceError::Other("invalid detached_at_ms".into()))?;
+        let max_resume_duration =
+            std::time::Duration::from_millis(max_resume_duration_ms.max(0) as u64);
+        let presence_show = presence_show_raw.as_deref().map(parse_show).transpose()?;
+
+        Ok(PersistedSession {
+            stream_id: SmSessionId::new(stream_id),
+            user_id,
+            jid,
+            inbound_count: inbound_count.max(0) as u32,
+            outbound_count: outbound_count.max(0) as u32,
+            last_acked: last_acked.max(0) as u32,
+            max_resume_time: max_resume_secs.map(|v| v.max(0) as u32),
+            detached_at,
+            max_resume_duration,
+            carbons_enabled: carbons_enabled != 0,
+            roster_interested: roster_interested != 0,
+            presence_available: presence_available != 0,
+            presence_show,
+            presence_status,
+            presence_priority: presence_priority.clamp(i8::MIN as i64, i8::MAX as i64) as i8,
+        })
+    }
+
+    fn decode_unacked(row: &crate::db::Row) -> Result<PersistedUnackedStanza, SmPersistenceError> {
+        let stream_id: String = row
+            .get(0)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let sequence: i64 = row
+            .get(1)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let stanza_xml: String = row
+            .get(2)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let receipt_ms: i64 = row
+            .get(3)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+
+        let original_receipt_at = DateTime::<Utc>::from_timestamp_millis(receipt_ms)
+            .ok_or_else(|| SmPersistenceError::Other("invalid receipt timestamp".into()))?;
+        let element: xmpp_parsers::minidom::Element = stanza_xml
+            .parse()
+            .map_err(|e: xmpp_parsers::minidom::Error| SmPersistenceError::Other(e.to_string()))?;
+        let stanza = parse_stanza(element)?;
+
+        Ok(PersistedUnackedStanza {
+            stream_id: SmSessionId::new(stream_id),
+            sequence: sequence.max(0) as u32,
+            stanza: Box::new(stanza),
+            original_receipt_at,
+        })
+    }
+}
+
+#[async_trait]
+impl SmPersistenceStorage for DatabaseSmPersistence {
+    #[instrument(skip(self, session), fields(stream_id = %session.stream_id))]
+    async fn upsert_session(&self, session: PersistedSession) -> Result<(), SmPersistenceError> {
+        let lock = self.lock_for(&session.stream_id);
+        let _guard = lock.lock().await;
+
+        let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
+            .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
+        let detached_at_ms = session.detached_at.timestamp_millis();
+        let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+
+        // Portable upsert: SQLite and Postgres both support
+        // INSERT ... ON CONFLICT (col) DO UPDATE SET ...
+        self.execute(
+            r#"
+            INSERT INTO sm_sessions (
+                stream_id, user_id, full_jid, inbound_count, outbound_count,
+                last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
+                carbons_enabled, roster_interested, presence_available,
+                presence_show, presence_status, presence_priority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (stream_id) DO UPDATE SET
+                user_id = excluded.user_id,
+                full_jid = excluded.full_jid,
+                inbound_count = excluded.inbound_count,
+                outbound_count = excluded.outbound_count,
+                last_acked = excluded.last_acked,
+                max_resume_secs = excluded.max_resume_secs,
+                detached_at_ms = excluded.detached_at_ms,
+                max_resume_duration_ms = excluded.max_resume_duration_ms,
+                carbons_enabled = excluded.carbons_enabled,
+                roster_interested = excluded.roster_interested,
+                presence_available = excluded.presence_available,
+                presence_show = excluded.presence_show,
+                presence_status = excluded.presence_status,
+                presence_priority = excluded.presence_priority
+            "#,
+            crate::db_params![
+                session.stream_id.as_str().to_string(),
+                session.user_id,
+                session.jid.to_string(),
+                i64::from(session.inbound_count),
+                i64::from(session.outbound_count),
+                i64::from(session.last_acked),
+                session.max_resume_time.map(i64::from),
+                detached_at_ms,
+                max_resume_duration_ms,
+                i64::from(session.carbons_enabled),
+                i64::from(session.roster_interested),
+                i64::from(session.presence_available),
+                presence_show_str.map(str::to_string),
+                session.presence_status,
+                i64::from(session.presence_priority),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn get_session(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<Option<PersistedSession>, SmPersistenceError> {
+        let mut rows = self
+            .query(
+                "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
+                        last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
+                        carbons_enabled, roster_interested, presence_available, \
+                        presence_show, presence_status, presence_priority \
+                 FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![stream_id.as_str().to_string()],
+            )
+            .await?;
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            Ok(Some(Self::decode_session(&row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    #[instrument(skip(self), fields(stream_id = %stream_id))]
+    async fn delete_session(&self, stream_id: &SmSessionId) -> Result<(), SmPersistenceError> {
+        let lock = self.lock_for(stream_id);
+        let _guard = lock.lock().await;
+        // Two statements rather than ON DELETE CASCADE so the trait's
+        // observable lifecycle matches the in-memory fake.
+        self.execute(
+            "DELETE FROM sm_unacked WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await?;
+        self.execute(
+            "DELETE FROM sm_sessions WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self, stanza), fields(stream_id = %stanza.stream_id, seq = stanza.sequence))]
+    async fn append_unacked(
+        &self,
+        stanza: PersistedUnackedStanza,
+    ) -> Result<(), SmPersistenceError> {
+        let lock = self.lock_for(&stanza.stream_id);
+        let _guard = lock.lock().await;
+        let xml = serialize_stanza(&stanza.stanza)?;
+        let receipt_ms = stanza.original_receipt_at.timestamp_millis();
+        self.execute(
+            "INSERT INTO sm_unacked (stream_id, sequence, stanza_xml, original_receipt_at_ms) \
+             VALUES (?, ?, ?, ?)",
+            crate::db_params![
+                stanza.stream_id.as_str().to_string(),
+                i64::from(stanza.sequence),
+                xml,
+                receipt_ms,
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, SmPersistenceError> {
+        let lock = self.lock_for(stream_id);
+        let _guard = lock.lock().await;
+        self.execute(
+            "DELETE FROM sm_unacked WHERE stream_id = ? AND sequence <= ?",
+            crate::db_params![stream_id.as_str().to_string(), i64::from(up_to_sequence)],
+        )
+        .await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<Vec<PersistedUnackedStanza>, SmPersistenceError> {
+        let mut rows = self
+            .query(
+                "SELECT stream_id, sequence, stanza_xml, original_receipt_at_ms \
+                 FROM sm_unacked WHERE stream_id = ? \
+                 ORDER BY sequence ASC",
+                crate::db_params![stream_id.as_str().to_string()],
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            out.push(Self::decode_unacked(&row)?);
+        }
+        Ok(out)
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<PersistedSession>, SmPersistenceError> {
+        let now_ms = now.timestamp_millis();
+        // Filter via SQL where possible (detached_at + duration <= now)
+        // and double-check in Rust to handle clock-skew / partial-row
+        // edge cases.
+        let mut rows = self
+            .query(
+                "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
+                        last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
+                        carbons_enabled, roster_interested, presence_available, \
+                        presence_show, presence_status, presence_priority \
+                 FROM sm_sessions WHERE detached_at_ms + max_resume_duration_ms <= ?",
+                crate::db_params![now_ms],
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            out.push(Self::decode_session(&row)?);
+        }
+        Ok(out)
+    }
+}
+
+fn show_wire_str(show: &Show) -> &'static str {
+    match show {
+        Show::Away => "away",
+        Show::Chat => "chat",
+        Show::Dnd => "dnd",
+        Show::Xa => "xa",
+    }
+}
+
+fn parse_show(raw: &str) -> Result<Show, SmPersistenceError> {
+    match raw {
+        "away" => Ok(Show::Away),
+        "chat" => Ok(Show::Chat),
+        "dnd" => Ok(Show::Dnd),
+        "xa" => Ok(Show::Xa),
+        other => Err(SmPersistenceError::Other(format!(
+            "unknown presence show value '{other}'"
+        ))),
+    }
+}
+
+fn serialize_stanza(stanza: &Stanza) -> Result<String, SmPersistenceError> {
+    let element: xmpp_parsers::minidom::Element = match stanza {
+        Stanza::Message(m) => m.clone().into(),
+        Stanza::Iq(iq) => iq.clone().into(),
+        Stanza::Presence(p) => p.clone().into(),
+    };
+    let mut buf = Vec::new();
+    element
+        .write_to(&mut buf)
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+    String::from_utf8(buf).map_err(|e| SmPersistenceError::Other(e.to_string()))
+}
+
+fn parse_stanza(element: xmpp_parsers::minidom::Element) -> Result<Stanza, SmPersistenceError> {
+    match element.name() {
+        "message" => xmpp_parsers::message::Message::try_from(element)
+            .map(Stanza::Message)
+            .map_err(|e| SmPersistenceError::Other(e.to_string())),
+        "iq" => xmpp_parsers::iq::Iq::try_from(element)
+            .map(Stanza::Iq)
+            .map_err(|e| SmPersistenceError::Other(e.to_string())),
+        "presence" => xmpp_parsers::presence::Presence::try_from(element)
+            .map(Stanza::Presence)
+            .map_err(|e| SmPersistenceError::Other(e.to_string())),
+        other => Err(SmPersistenceError::Other(format!(
+            "unknown stanza element '{other}'"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::time::Duration;
+
+    fn full(s: &str) -> FullJid {
+        s.parse().unwrap()
+    }
+
+    fn fixed_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 1, 12, 30, 0).unwrap()
+    }
+
+    fn fixture_session(stream_id: &str) -> PersistedSession {
+        PersistedSession {
+            stream_id: SmSessionId::new(stream_id),
+            user_id: "alice".to_string(),
+            jid: full("alice@example.com/web"),
+            inbound_count: 7,
+            outbound_count: 12,
+            last_acked: 10,
+            max_resume_time: Some(60),
+            detached_at: fixed_time(),
+            max_resume_duration: Duration::from_secs(60),
+            carbons_enabled: true,
+            roster_interested: true,
+            presence_available: true,
+            presence_show: Some(Show::Chat),
+            presence_status: Some("at the keyboard".to_string()),
+            presence_priority: 5,
+        }
+    }
+
+    fn fixture_unacked(stream_id: &str, sequence: u32) -> PersistedUnackedStanza {
+        let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        message.bodies.insert(
+            String::new(),
+            xmpp_parsers::message::Body(format!("m{sequence}")),
+        );
+        PersistedUnackedStanza {
+            stream_id: SmSessionId::new(stream_id),
+            sequence,
+            stanza: Box::new(Stanza::Message(message)),
+            original_receipt_at: fixed_time(),
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_session_preserves_every_field() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        let s = fixture_session("stream-1");
+        storage.upsert_session(s.clone()).await.unwrap();
+        let loaded = storage
+            .get_session(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.stream_id, s.stream_id);
+        assert_eq!(loaded.user_id, s.user_id);
+        assert_eq!(loaded.jid, s.jid);
+        assert_eq!(loaded.inbound_count, s.inbound_count);
+        assert_eq!(loaded.outbound_count, s.outbound_count);
+        assert_eq!(loaded.last_acked, s.last_acked);
+        assert_eq!(loaded.max_resume_time, s.max_resume_time);
+        assert_eq!(loaded.detached_at, s.detached_at);
+        assert_eq!(loaded.max_resume_duration, s.max_resume_duration);
+        assert_eq!(loaded.carbons_enabled, s.carbons_enabled);
+        assert_eq!(loaded.roster_interested, s.roster_interested);
+        assert_eq!(loaded.presence_available, s.presence_available);
+        assert_eq!(loaded.presence_show, s.presence_show);
+        assert_eq!(loaded.presence_status, s.presence_status);
+        assert_eq!(loaded.presence_priority, s.presence_priority);
+    }
+
+    #[tokio::test]
+    async fn upsert_replaces_existing_session() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        let mut s = fixture_session("stream-1");
+        storage.upsert_session(s.clone()).await.unwrap();
+        s.inbound_count = 99;
+        s.presence_priority = -1;
+        storage.upsert_session(s.clone()).await.unwrap();
+        let loaded = storage
+            .get_session(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.inbound_count, 99);
+        assert_eq!(loaded.presence_priority, -1);
+    }
+
+    #[tokio::test]
+    async fn list_unacked_orders_ascending_by_sequence() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        for seq in [3u32, 1, 4, 2] {
+            storage
+                .append_unacked(fixture_unacked("stream-1", seq))
+                .await
+                .unwrap();
+        }
+        let rows = storage
+            .list_unacked(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap();
+        let seqs: Vec<u32> = rows.iter().map(|r| r.sequence).collect();
+        assert_eq!(seqs, vec![1, 2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn ack_through_drops_only_acked_sequences() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        for seq in 1..=4 {
+            storage
+                .append_unacked(fixture_unacked("stream-1", seq))
+                .await
+                .unwrap();
+        }
+        let dropped = storage
+            .ack_through(&SmSessionId::new("stream-1"), 2)
+            .await
+            .unwrap();
+        assert_eq!(dropped, 2);
+        let remaining = storage
+            .list_unacked(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap();
+        assert_eq!(
+            remaining.iter().map(|r| r.sequence).collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_session_clears_unacked_too() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        storage
+            .upsert_session(fixture_session("stream-1"))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("stream-1", 1))
+            .await
+            .unwrap();
+        storage
+            .delete_session(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap();
+        assert!(storage
+            .get_session(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap()
+            .is_none());
+        assert!(storage
+            .list_unacked(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_expired_filters_by_detached_plus_duration() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        let now = Utc::now();
+        let mut past = fixture_session("expired");
+        past.detached_at = now - chrono::Duration::seconds(120);
+        past.max_resume_duration = Duration::from_secs(60);
+        let mut active = fixture_session("active");
+        active.detached_at = now;
+        active.max_resume_duration = Duration::from_secs(600);
+        storage.upsert_session(past).await.unwrap();
+        storage.upsert_session(active).await.unwrap();
+
+        let expired = storage.list_expired_sessions(now).await.unwrap();
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].stream_id, SmSessionId::new("expired"));
+    }
+
+    #[tokio::test]
+    async fn round_trip_unacked_preserves_typed_stanza() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        storage
+            .append_unacked(fixture_unacked("stream-1", 1))
+            .await
+            .unwrap();
+        let rows = storage
+            .list_unacked(&SmSessionId::new("stream-1"))
+            .await
+            .unwrap();
+        let body = match &*rows[0].stanza {
+            Stanza::Message(m) => m.bodies.values().next().cloned(),
+            _ => panic!("expected Message"),
+        };
+        assert_eq!(body.map(|b| b.0), Some("m1".to_string()));
+    }
+}

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -483,6 +483,28 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
         }
         Ok(out)
     }
+
+    async fn list_all_sessions(&self) -> Result<Vec<PersistedSession>, SmPersistenceError> {
+        let mut rows = self
+            .query(
+                "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
+                        last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
+                        carbons_enabled, roster_interested, presence_available, \
+                        presence_show, presence_status, presence_priority \
+                 FROM sm_sessions",
+                (),
+            )
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            out.push(Self::decode_session(&row)?);
+        }
+        Ok(out)
+    }
 }
 
 fn show_wire_str(show: &Show) -> &'static str {

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -73,13 +73,28 @@ pub struct DatabaseSmPersistence {
 }
 
 impl DatabaseSmPersistence {
-    /// Open against `database_url` (SQLite path or Postgres DSN).
+    /// Open against `database_url`. Supported schemes:
+    ///
+    /// - `postgres://…` / `postgresql://…` → Postgres adapter
+    /// - `sqlite://…`, bare path, or `:memory:` → SQLite adapter
+    ///
     /// `None` falls back to in-memory SQLite suitable only for tests.
+    /// `libsql://…` URLs are NOT supported by the current
+    /// [`crate::db::DatabaseDriver`] enum and would silently route to
+    /// the SQLite adapter (which doesn't speak the libSQL wire
+    /// protocol). Reject them explicitly so misconfigured deployments
+    /// fail loudly at startup. (Copilot review on PR #344.)
     pub async fn open(database_url: Option<&str>) -> Result<Self, SmPersistenceError> {
         let db = match database_url {
             Some(url) => {
                 let driver = if url.starts_with("postgres://") || url.starts_with("postgresql://") {
                     DatabaseDriver::Postgres
+                } else if url.starts_with("libsql://") || url.starts_with("libsql+") {
+                    return Err(SmPersistenceError::Other(format!(
+                        "libsql:// URL '{url}' is not supported by the current \
+                         crate::db::DatabaseDriver (SQLite or Postgres only); \
+                         use sqlite:// or postgres:// instead"
+                    )));
                 } else {
                     DatabaseDriver::Sqlite
                 };

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -104,39 +104,50 @@ impl DatabaseSmPersistence {
     }
 
     async fn initialize(&self) -> Result<(), SmPersistenceError> {
+        // Driver-aware bigint type: Postgres INTEGER is i32 (overflows
+        // for `timestamp_millis()` after Jan 2038); BIGINT is i64.
+        // SQLite INTEGER is dynamically sized so the same DDL works.
+        let bigint = match self.db.driver() {
+            DatabaseDriver::Postgres => "BIGINT",
+            DatabaseDriver::Sqlite => "INTEGER",
+        };
         self.execute(
-            r#"
-            CREATE TABLE IF NOT EXISTS sm_sessions (
-                stream_id TEXT PRIMARY KEY,
-                user_id TEXT NOT NULL,
-                full_jid TEXT NOT NULL,
-                inbound_count INTEGER NOT NULL,
-                outbound_count INTEGER NOT NULL,
-                last_acked INTEGER NOT NULL,
-                max_resume_secs INTEGER,
-                detached_at_ms INTEGER NOT NULL,
-                max_resume_duration_ms INTEGER NOT NULL,
-                carbons_enabled INTEGER NOT NULL,
-                roster_interested INTEGER NOT NULL,
-                presence_available INTEGER NOT NULL,
-                presence_show TEXT,
-                presence_status TEXT,
-                presence_priority INTEGER NOT NULL
-            )
-            "#,
+            &format!(
+                r#"
+                CREATE TABLE IF NOT EXISTS sm_sessions (
+                    stream_id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL,
+                    full_jid TEXT NOT NULL,
+                    inbound_count {bigint} NOT NULL,
+                    outbound_count {bigint} NOT NULL,
+                    last_acked {bigint} NOT NULL,
+                    max_resume_secs {bigint},
+                    detached_at_ms {bigint} NOT NULL,
+                    max_resume_duration_ms {bigint} NOT NULL,
+                    carbons_enabled INTEGER NOT NULL,
+                    roster_interested INTEGER NOT NULL,
+                    presence_available INTEGER NOT NULL,
+                    presence_show TEXT,
+                    presence_status TEXT,
+                    presence_priority INTEGER NOT NULL
+                )
+                "#
+            ),
             (),
         )
         .await?;
         self.execute(
-            r#"
-            CREATE TABLE IF NOT EXISTS sm_unacked (
-                stream_id TEXT NOT NULL,
-                sequence INTEGER NOT NULL,
-                stanza_xml TEXT NOT NULL,
-                original_receipt_at_ms INTEGER NOT NULL,
-                PRIMARY KEY (stream_id, sequence)
-            )
-            "#,
+            &format!(
+                r#"
+                CREATE TABLE IF NOT EXISTS sm_unacked (
+                    stream_id TEXT NOT NULL,
+                    sequence {bigint} NOT NULL,
+                    stanza_xml TEXT NOT NULL,
+                    original_receipt_at_ms {bigint} NOT NULL,
+                    PRIMARY KEY (stream_id, sequence)
+                )
+                "#
+            ),
             (),
         )
         .await?;

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -153,6 +153,13 @@ pub trait SmPersistenceStorage: Send + Sync {
         &self,
         now: chrono::DateTime<chrono::Utc>,
     ) -> Result<Vec<PersistedSession>, SmPersistenceError>;
+
+    /// Enumerate every currently-persisted session, regardless of
+    /// expiry. Used by [`InMemorySmSessionRegistry`] on startup to
+    /// rebuild the in-memory view from durable storage so an
+    /// XEP-0198 `<resume previd='…'/>` finds sessions that detached
+    /// before the most recent restart.
+    async fn list_all_sessions(&self) -> Result<Vec<PersistedSession>, SmPersistenceError>;
 }
 
 /// In-memory implementation suitable for tests and as the structural
@@ -272,6 +279,14 @@ impl SmPersistenceStorage for InMemorySmPersistence {
             }
         }
         Ok(out)
+    }
+
+    async fn list_all_sessions(&self) -> Result<Vec<PersistedSession>, SmPersistenceError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        Ok(guard.sessions.values().cloned().collect())
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -58,7 +58,21 @@ pub struct DetachedSession {
     pub outbound_count: u32,
     /// Last acknowledged outbound stanza count
     pub last_acked: u32,
-    /// Unacknowledged stanzas (sequence, xml)
+    /// Unacknowledged stanzas (sequence, xml).
+    ///
+    /// **Known limitation**: this tuple does not carry an
+    /// original_receipt_at timestamp. When the session is persisted
+    /// via [`super::persistence::SmPersistenceStorage`], each
+    /// unacked stanza inherits the persist-time `Utc::now()` for its
+    /// `PersistedUnackedStanza::original_receipt_at`, not the
+    /// actual server receipt time. For the Q6c `<delay/>` stamping
+    /// path (XEP-0203 §4.1 + XEP-0198 §5 line 364) this is
+    /// approximate — bounded by the session's detach latency in
+    /// practice (typically milliseconds). Plumbing the real receipt
+    /// time through every `record_*detached*` call site would touch
+    /// many files and is queued as a follow-up to issue #209 slice
+    /// (d) phase 4 (the SM-expiry promotion path that consumes this
+    /// timestamp).
     pub unacked_stanzas: Vec<(u32, String)>,
     /// Maximum resumption time in seconds
     pub max_resume_time: Option<u32>,
@@ -315,6 +329,7 @@ impl InMemorySmSessionRegistry {
         let Some(storage) = &self.persistence else {
             return Ok(0);
         };
+        let now = chrono::Utc::now();
         let stored = storage
             .list_all_sessions()
             .await
@@ -324,12 +339,57 @@ impl InMemorySmSessionRegistry {
         // the hydrated sessions. RwLock guards are not Send and
         // cannot be held across .await points.
         let mut hydrated_sessions = Vec::with_capacity(stored.len());
+        let mut expired_ids = Vec::new();
+        let mut bad_rows = 0usize;
         for persisted in stored {
-            let unacked = storage
-                .list_unacked(&persisted.stream_id)
-                .await
-                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
-            hydrated_sessions.push(persisted_to_detached(&persisted, &unacked)?);
+            // Filter expired-during-downtime: detached_at +
+            // max_resume_duration <= now means the resume window is
+            // already closed. Hydrating these would let them appear
+            // resumable on the wire and silently exceed
+            // max_sessions, plus they'd be re-loaded on every
+            // restart since the in-memory janitor doesn't drain
+            // durable rows. Mark for durable deletion below.
+            let expires_at = persisted.detached_at
+                + chrono::Duration::from_std(persisted.max_resume_duration)
+                    .unwrap_or(chrono::Duration::seconds(0));
+            if expires_at <= now {
+                expired_ids.push(persisted.stream_id.clone());
+                continue;
+            }
+            let unacked = match storage.list_unacked(&persisted.stream_id).await {
+                Ok(u) => u,
+                Err(error) => {
+                    debug!(
+                        stream_id = %persisted.stream_id,
+                        error = %error,
+                        "skipping persisted session: list_unacked failed"
+                    );
+                    bad_rows += 1;
+                    continue;
+                }
+            };
+            match persisted_to_detached(&persisted, &unacked) {
+                Ok(session) => hydrated_sessions.push(session),
+                Err(error) => {
+                    debug!(
+                        stream_id = %persisted.stream_id,
+                        error = %error,
+                        "skipping persisted session: row decode failed (poison pill)"
+                    );
+                    bad_rows += 1;
+                }
+            }
+        }
+        // Best-effort durable cleanup of expired rows. Failures here
+        // are non-fatal — the janitor's next pass will retry.
+        for stream_id in &expired_ids {
+            if let Err(error) = storage.delete_session(stream_id).await {
+                debug!(
+                    stream_id = %stream_id,
+                    error = %error,
+                    "failed to delete expired persisted SM session during restore; will retry"
+                );
+            }
         }
         let hydrated = hydrated_sessions.len();
         {
@@ -341,8 +401,38 @@ impl InMemorySmSessionRegistry {
                 sessions.insert(session.stream_id.clone(), session);
             }
         }
-        debug!(hydrated, "restored detached SM sessions from persistence");
+        debug!(
+            hydrated,
+            expired = expired_ids.len(),
+            bad_rows,
+            "restored detached SM sessions from persistence"
+        );
         Ok(hydrated)
+    }
+}
+
+impl InMemorySmSessionRegistry {
+    /// Helper: delete every durable row for `stream_id` (session +
+    /// unacked queue). Best-effort — failures are logged and
+    /// swallowed because the in-memory state has already mutated
+    /// when this is called and we'd rather have a transient durable
+    /// drift than fail the resume / cleanup path.
+    async fn persist_delete_session(&self, stream_id: &str) {
+        let Some(storage) = &self.persistence else {
+            return;
+        };
+        if let Err(error) = storage
+            .delete_session(&crate::pending_delivery::SmSessionId::new(
+                stream_id.to_string(),
+            ))
+            .await
+        {
+            debug!(
+                stream_id = %stream_id,
+                error = %error,
+                "failed to delete persisted SM session; will retry via janitor"
+            );
+        }
     }
 }
 
@@ -445,7 +535,10 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // Scope the RwLock guards in a block so they're definitively
         // dropped before any await point. RwLockWriteGuard is not
         // Send, and explicit `drop()` doesn't satisfy the async
-        // future's lifetime analysis.
+        // future's lifetime analysis. Capture eviction victims
+        // (jid-collision retain + max_sessions oldest) so we can
+        // mirror their durable rows after releasing the lock.
+        let mut evicted_stream_ids: Vec<String> = Vec::new();
         let count = {
             let mut sessions = self
                 .sessions
@@ -455,6 +548,18 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                 .claimed_sessions
                 .write()
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            // Capture jid-collision evictions in `sessions` before
+            // retain mutates; same for `claimed`.
+            for (id, existing) in sessions.iter() {
+                if id != &stream_id && existing.jid == jid {
+                    evicted_stream_ids.push(id.clone());
+                }
+            }
+            for (id, existing) in claimed.iter() {
+                if id != &stream_id && existing.jid == jid {
+                    evicted_stream_ids.push(id.clone());
+                }
+            }
             sessions.retain(|existing_stream_id, existing| {
                 existing_stream_id == &stream_id || existing.jid != jid
             });
@@ -471,12 +576,21 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                 {
                     sessions.remove(&oldest_key);
                     debug!(stream_id = %oldest_key, "Evicted oldest SM session to make room");
+                    evicted_stream_ids.push(oldest_key);
                 }
             }
 
             sessions.insert(stream_id.clone(), session.clone());
             sessions.len()
         };
+        // Mirror in-memory evictions to durable storage so a restart
+        // doesn't resurrect sessions that were displaced by a fresh
+        // bind for the same JID or by max_sessions overflow. (Copilot
+        // review on PR #344: durable rows for evicted streams must
+        // not be silently rehydrated.)
+        for evicted in &evicted_stream_ids {
+            self.persist_delete_session(evicted).await;
+        }
 
         // Persist the detached session + its unacked queue so it
         // survives a server restart per locked Q8 = B.
@@ -613,12 +727,19 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
     }
 
     async fn cleanup_expired(&self) -> Result<usize, SmRegistryError> {
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-
-        Ok(drain_expired_internal(&mut sessions).len())
+        // Lock-scoped block so guards drop before the durable
+        // delete awaits.
+        let drained: Vec<DetachedSession> = {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            drain_expired_internal(&mut sessions)
+        };
+        for session in &drained {
+            self.persist_delete_session(&session.stream_id).await;
+        }
+        Ok(drained.len())
     }
 
     async fn session_count(&self) -> usize {
@@ -737,12 +858,19 @@ impl InMemorySmSessionRegistry {
     /// sidecar auth context. `cleanup_expired` only returns a count, which
     /// isn't enough for that work.
     pub async fn drain_expired(&self) -> Result<Vec<DetachedSession>, SmRegistryError> {
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-
-        Ok(drain_expired_internal(&mut sessions))
+        // Lock-scoped block so guards drop before the durable
+        // delete awaits.
+        let drained: Vec<DetachedSession> = {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            drain_expired_internal(&mut sessions)
+        };
+        for session in &drained {
+            self.persist_delete_session(&session.stream_id).await;
+        }
+        Ok(drained)
     }
 
     /// Atomically claim a resumable session for a single resume attempt.
@@ -802,18 +930,32 @@ impl InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<SmClaimCompletion>, SmRegistryError> {
-        Ok(self
-            .claimed_sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
-            .remove(stream_id)
-            .map(|session| {
-                if session.is_expired() {
-                    SmClaimCompletion::Expired(session)
-                } else {
-                    SmClaimCompletion::Resumed(session)
-                }
-            }))
+        // Lock-scoped block so guards are dropped before the durable
+        // delete await (RwLockWriteGuard is not Send).
+        let outcome = {
+            self.claimed_sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                .remove(stream_id)
+                .map(|session| {
+                    if session.is_expired() {
+                        SmClaimCompletion::Expired(session)
+                    } else {
+                        SmClaimCompletion::Resumed(session)
+                    }
+                })
+        };
+        // Resume is the durable commitment point — once we hand the
+        // session back to the resuming connection (or detect it
+        // expired mid-claim), the durable record is no longer needed.
+        // Without this delete, restart_from_persistence would
+        // resurrect the just-resumed session (Copilot review on
+        // PR #344). For Expired we still delete: the session will
+        // not be resumable again.
+        if outcome.is_some() {
+            self.persist_delete_session(stream_id).await;
+        }
+        Ok(outcome)
     }
 
     /// Remove a stored detached session only if it has not been claimed by a
@@ -822,19 +964,27 @@ impl InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<DetachedSession>, SmRegistryError> {
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        if self
-            .claimed_sessions
-            .read()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
-            .contains_key(stream_id)
-        {
-            return Ok(None);
+        // Lock-scoped block so guards drop before the durable delete
+        // await.
+        let removed = {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            if self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                .contains_key(stream_id)
+            {
+                return Ok(None);
+            }
+            sessions.remove(stream_id)
+        };
+        if removed.is_some() {
+            self.persist_delete_session(stream_id).await;
         }
-        Ok(sessions.remove(stream_id))
+        Ok(removed)
     }
 
     /// Invalidate detached sessions for a FullJID after a fresh bind has
@@ -843,35 +993,46 @@ impl InMemorySmSessionRegistry {
         &self,
         jid: &FullJid,
     ) -> Result<Vec<DetachedSession>, SmRegistryError> {
-        let mut removed = Vec::new();
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        let matching_streams: Vec<_> = sessions
-            .iter()
-            .filter(|(_, session)| session.jid == *jid)
-            .map(|(stream_id, _)| stream_id.clone())
-            .collect();
-        for stream_id in matching_streams {
-            if let Some(session) = sessions.remove(&stream_id) {
-                removed.push(session);
+        // Lock-scoped block so guards drop before the durable delete
+        // awaits.
+        let (removed, removed_ids) = {
+            let mut removed = Vec::new();
+            let mut removed_ids: Vec<String> = Vec::new();
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let matching_streams: Vec<_> = sessions
+                .iter()
+                .filter(|(_, session)| session.jid == *jid)
+                .map(|(stream_id, _)| stream_id.clone())
+                .collect();
+            for stream_id in matching_streams {
+                if let Some(session) = sessions.remove(&stream_id) {
+                    removed_ids.push(stream_id);
+                    removed.push(session);
+                }
             }
-        }
-        drop(sessions);
-        let mut claimed = self
-            .claimed_sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        let matching_streams: Vec<_> = claimed
-            .iter()
-            .filter(|(_, session)| session.jid == *jid)
-            .map(|(stream_id, _)| stream_id.clone())
-            .collect();
-        for stream_id in matching_streams {
-            if let Some(session) = claimed.remove(&stream_id) {
-                removed.push(session);
+            drop(sessions);
+            let mut claimed = self
+                .claimed_sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let matching_streams: Vec<_> = claimed
+                .iter()
+                .filter(|(_, session)| session.jid == *jid)
+                .map(|(stream_id, _)| stream_id.clone())
+                .collect();
+            for stream_id in matching_streams {
+                if let Some(session) = claimed.remove(&stream_id) {
+                    removed_ids.push(stream_id);
+                    removed.push(session);
+                }
             }
+            (removed, removed_ids)
+        };
+        for stream_id in &removed_ids {
+            self.persist_delete_session(stream_id).await;
         }
         Ok(removed)
     }
@@ -1878,10 +2039,14 @@ mod tests {
     }
 
     fn realistic_test_session(stream_id: &str) -> DetachedSession {
+        realistic_test_session_for_jid(stream_id, make_test_jid())
+    }
+
+    fn realistic_test_session_for_jid(stream_id: &str, jid: FullJid) -> DetachedSession {
         DetachedSession {
             stream_id: stream_id.to_string(),
             user_id: "user@example.com".to_string(),
-            jid: make_test_jid(),
+            jid,
             inbound_count: 4,
             outbound_count: 7,
             last_acked: 5,
@@ -1940,15 +2105,26 @@ mod tests {
     async fn restore_from_persistence_rebuilds_in_memory_view() {
         let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
         // Pre-populate storage as if a previous server lifecycle had
-        // detached this session.
+        // detached two sessions for distinct users. Using distinct
+        // JIDs is important: store_session evicts any prior detached
+        // session with the same JID (RFC-aligned: a fresh bind for
+        // a JID supersedes any older detached stream for that JID),
+        // and the durable mirror also deletes the evicted row, so
+        // two sessions with the same JID would resolve to one.
         {
             let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
             registry
-                .store_session(realistic_test_session("stream-1"))
+                .store_session(realistic_test_session_for_jid(
+                    "stream-1",
+                    "alice@example.com/web".parse().unwrap(),
+                ))
                 .await
                 .unwrap();
             registry
-                .store_session(realistic_test_session("stream-2"))
+                .store_session(realistic_test_session_for_jid(
+                    "stream-2",
+                    "bob@example.com/laptop".parse().unwrap(),
+                ))
                 .await
                 .unwrap();
         }
@@ -1974,5 +2150,107 @@ mod tests {
     async fn restore_is_noop_when_no_persistence_attached() {
         let registry = InMemorySmSessionRegistry::new();
         assert_eq!(registry.restore_from_persistence().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn complete_claim_deletes_durable_session_on_resume() {
+        // The real resume path is claim_session -> complete_claim,
+        // not take_session. Without durable cleanup at the
+        // complete_claim commitment point, a successful resume
+        // would leave rows in storage that restart_from_persistence
+        // would resurrect. (Codex P1 + Copilot review on PR #344.)
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        registry
+            .store_session(realistic_test_session("stream-1"))
+            .await
+            .unwrap();
+        let stream_id = crate::pending_delivery::SmSessionId::new("stream-1");
+        assert!(storage.get_session(&stream_id).await.unwrap().is_some());
+
+        let _claimed = registry.claim_session("stream-1").await.unwrap();
+        let outcome = registry.complete_claim("stream-1").await.unwrap();
+        assert!(matches!(outcome, Some(SmClaimCompletion::Resumed(_))));
+
+        assert!(storage.get_session(&stream_id).await.unwrap().is_none());
+        assert!(storage.list_unacked(&stream_id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_session_evicts_jid_collision_durably() {
+        // Two store_session calls for the same JID with different
+        // stream_ids: the second supersedes the first per RFC
+        // resume semantics. The first's durable rows must be
+        // deleted too — otherwise restart_from_persistence
+        // resurrects the obsolete stream and exposes a stale
+        // <resume previd='…'/> path. (Copilot review on PR #344.)
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        registry
+            .store_session(realistic_test_session_for_jid(
+                "stream-old",
+                "alice@example.com/web".parse().unwrap(),
+            ))
+            .await
+            .unwrap();
+        registry
+            .store_session(realistic_test_session_for_jid(
+                "stream-new",
+                "alice@example.com/web".parse().unwrap(),
+            ))
+            .await
+            .unwrap();
+        let old_id = crate::pending_delivery::SmSessionId::new("stream-old");
+        let new_id = crate::pending_delivery::SmSessionId::new("stream-new");
+        assert!(
+            storage.get_session(&old_id).await.unwrap().is_none(),
+            "evicted stream-old should be removed from durable storage"
+        );
+        assert!(
+            storage.get_session(&new_id).await.unwrap().is_some(),
+            "stream-new should remain"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_skips_and_deletes_expired_sessions() {
+        // Sessions whose resume window already closed during the
+        // server's downtime must not be rehydrated, AND their
+        // durable rows must be deleted so restart doesn't re-load
+        // them next boot. (Copilot review on PR #344.)
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+
+        // Manually insert an already-expired session by writing
+        // directly to storage with a detached_at + duration in the
+        // past.
+        let now = chrono::Utc::now();
+        let expired = super::super::persistence::PersistedSession {
+            stream_id: crate::pending_delivery::SmSessionId::new("stream-expired"),
+            user_id: "alice".to_string(),
+            jid: "alice@example.com/web".parse().unwrap(),
+            inbound_count: 0,
+            outbound_count: 0,
+            last_acked: 0,
+            max_resume_time: Some(60),
+            detached_at: now - chrono::Duration::seconds(120),
+            max_resume_duration: Duration::from_secs(60),
+            carbons_enabled: false,
+            roster_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+        };
+        storage.upsert_session(expired).await.unwrap();
+
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        let hydrated = registry.restore_from_persistence().await.unwrap();
+        assert_eq!(hydrated, 0);
+        // Durable cleanup of expired rows.
+        assert!(storage
+            .get_session(&crate::pending_delivery::SmSessionId::new("stream-expired"))
+            .await
+            .unwrap()
+            .is_none());
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -226,20 +226,48 @@ pub enum SmClaimCompletion {
     Expired(DetachedSession),
 }
 
-/// In-memory implementation of the SM session registry.
+/// In-memory implementation of the SM session registry, optionally
+/// backed by a [`SmPersistenceStorage`] so detached sessions survive
+/// process restarts (issue #209 slice (d) phase 3, locked Q8 = B).
 ///
-/// Suitable for single-node deployments. For clustered deployments,
-/// use a distributed implementation backed by Redis or similar.
-#[derive(Debug)]
+/// When `persistence` is `Some`, every `store_session` /
+/// `take_session` / `cleanup_expired` mutation also writes to the
+/// durable backend; on startup, [`Self::restore_from_persistence`]
+/// rebuilds the in-memory view so an XEP-0198 `<resume previd='…'/>`
+/// finds sessions that detached before the most recent restart.
+///
+/// Custom Debug skips the persistence handle (the
+/// [`SmPersistenceStorage`] trait does not require `Debug`).
 pub struct InMemorySmSessionRegistry {
     sessions: RwLock<HashMap<String, DetachedSession>>,
     claimed_sessions: RwLock<HashMap<String, DetachedSession>>,
     max_sessions: usize,
+    /// Optional durable backing store. When `None` the registry is
+    /// strictly in-memory (legacy behaviour); production wiring sets
+    /// this via [`Self::with_persistence`] before Arc-wrapping.
+    persistence: Option<std::sync::Arc<dyn super::persistence::SmPersistenceStorage>>,
 }
 
 impl Default for InMemorySmSessionRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl std::fmt::Debug for InMemorySmSessionRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InMemorySmSessionRegistry")
+            .field("max_sessions", &self.max_sessions)
+            .field(
+                "session_count",
+                &self.sessions.read().map(|s| s.len()).unwrap_or(0),
+            )
+            .field(
+                "claimed_count",
+                &self.claimed_sessions.read().map(|s| s.len()).unwrap_or(0),
+            )
+            .field("persistence_attached", &self.persistence.is_some())
+            .finish()
     }
 }
 
@@ -250,6 +278,7 @@ impl InMemorySmSessionRegistry {
             sessions: RwLock::new(HashMap::new()),
             claimed_sessions: RwLock::new(HashMap::new()),
             max_sessions: DEFAULT_MAX_SESSIONS,
+            persistence: None,
         }
     }
 
@@ -259,47 +288,255 @@ impl InMemorySmSessionRegistry {
             sessions: RwLock::new(HashMap::with_capacity(max_sessions.min(10000))),
             claimed_sessions: RwLock::new(HashMap::new()),
             max_sessions,
+            persistence: None,
         }
     }
+
+    /// Attach a durable backing store. Must be called once at
+    /// construction time before the registry is wrapped in `Arc`.
+    /// Subsequent mutating writes are mirrored into `storage`; reads
+    /// stay in-memory for hot-path latency.
+    pub fn with_persistence(
+        mut self,
+        storage: std::sync::Arc<dyn super::persistence::SmPersistenceStorage>,
+    ) -> Self {
+        self.persistence = Some(storage);
+        self
+    }
+
+    /// Rebuild the in-memory view from the attached durable store.
+    /// Called on server startup before any traffic is accepted, so
+    /// an XEP-0198 `<resume previd='…'/>` for a session that
+    /// detached before restart still succeeds.
+    ///
+    /// Returns the number of sessions hydrated. No-op when no
+    /// persistence is attached.
+    pub async fn restore_from_persistence(&self) -> Result<usize, SmRegistryError> {
+        let Some(storage) = &self.persistence else {
+            return Ok(0);
+        };
+        let stored = storage
+            .list_all_sessions()
+            .await
+            .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+        // First await all the unacked queries (no lock held); then
+        // do a single short-lived write critical section to insert
+        // the hydrated sessions. RwLock guards are not Send and
+        // cannot be held across .await points.
+        let mut hydrated_sessions = Vec::with_capacity(stored.len());
+        for persisted in stored {
+            let unacked = storage
+                .list_unacked(&persisted.stream_id)
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+            hydrated_sessions.push(persisted_to_detached(&persisted, &unacked)?);
+        }
+        let hydrated = hydrated_sessions.len();
+        {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            for session in hydrated_sessions {
+                sessions.insert(session.stream_id.clone(), session);
+            }
+        }
+        debug!(hydrated, "restored detached SM sessions from persistence");
+        Ok(hydrated)
+    }
+}
+
+/// Convert a [`DetachedSession`] (in-memory shape) to a
+/// [`super::persistence::PersistedSession`] (durable shape) for write
+/// to [`SmPersistenceStorage`].
+fn detached_to_persisted(
+    session: &DetachedSession,
+) -> Result<super::persistence::PersistedSession, SmRegistryError> {
+    use super::persistence::PersistedSession;
+    Ok(PersistedSession {
+        stream_id: crate::pending_delivery::SmSessionId::new(session.stream_id.clone()),
+        user_id: session.user_id.clone(),
+        jid: session.jid.clone(),
+        inbound_count: session.inbound_count,
+        outbound_count: session.outbound_count,
+        last_acked: session.last_acked,
+        max_resume_time: session.max_resume_time,
+        // `detached_at: Instant` is process-relative; persistence
+        // captures the wall-clock moment of the persist write. The
+        // skew vs. the actual detach-event time is bounded by the
+        // store_session call latency (microseconds in practice).
+        detached_at: chrono::Utc::now(),
+        max_resume_duration: Duration::from_secs(
+            session
+                .max_resume_time
+                .map(u64::from)
+                .unwrap_or(DEFAULT_SESSION_TIMEOUT_SECS),
+        ),
+        carbons_enabled: session.carbons_enabled,
+        roster_interested: session.roster_interested,
+        presence_available: session.presence_available,
+        presence_show: session.presence_show.clone(),
+        presence_status: session.presence_status.clone(),
+        presence_priority: session.presence_priority,
+    })
+}
+
+/// Convert a [`super::persistence::PersistedSession`] + its unacked
+/// row set back to a [`DetachedSession`] for the in-memory view.
+fn persisted_to_detached(
+    persisted: &super::persistence::PersistedSession,
+    unacked: &[super::persistence::PersistedUnackedStanza],
+) -> Result<DetachedSession, SmRegistryError> {
+    // `Instant` cannot be reconstructed from a wall-clock, so we
+    // use `Instant::now()` minus the elapsed wall-clock since the
+    // persisted detach time. This preserves correct `is_expired`
+    // behaviour at the cost of a small bounded skew (the time
+    // since the persist write).
+    let elapsed_since_detach = chrono::Utc::now()
+        .signed_duration_since(persisted.detached_at)
+        .to_std()
+        .unwrap_or(Duration::ZERO);
+    let detached_at = Instant::now()
+        .checked_sub(elapsed_since_detach)
+        .unwrap_or_else(Instant::now);
+
+    let unacked_stanzas: Vec<(u32, String)> = unacked
+        .iter()
+        .map(|row| {
+            let element: minidom::Element = match &*row.stanza {
+                crate::Stanza::Message(m) => m.clone().into(),
+                crate::Stanza::Iq(iq) => iq.clone().into(),
+                crate::Stanza::Presence(p) => p.clone().into(),
+            };
+            let mut buf = Vec::new();
+            element
+                .write_to(&mut buf)
+                .map_err(|e| SmRegistryError::Internal(format!("serialize unacked stanza: {e}")))?;
+            let xml = String::from_utf8(buf)
+                .map_err(|e| SmRegistryError::Internal(format!("serialize unacked stanza: {e}")))?;
+            Ok((row.sequence, xml))
+        })
+        .collect::<Result<_, SmRegistryError>>()?;
+
+    Ok(DetachedSession {
+        stream_id: persisted.stream_id.as_str().to_string(),
+        user_id: persisted.user_id.clone(),
+        jid: persisted.jid.clone(),
+        inbound_count: persisted.inbound_count,
+        outbound_count: persisted.outbound_count,
+        last_acked: persisted.last_acked,
+        unacked_stanzas,
+        max_resume_time: persisted.max_resume_time,
+        detached_at,
+        carbons_enabled: persisted.carbons_enabled,
+        roster_interested: persisted.roster_interested,
+        presence_available: persisted.presence_available,
+        presence_show: persisted.presence_show.clone(),
+        presence_status: persisted.presence_status.clone(),
+        presence_priority: persisted.presence_priority,
+    })
 }
 
 #[async_trait]
 impl SmSessionRegistry for InMemorySmSessionRegistry {
     async fn store_session(&self, session: DetachedSession) -> Result<(), SmRegistryError> {
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-
         let stream_id = session.stream_id.clone();
         let jid = session.jid.clone();
-        let mut claimed = self
-            .claimed_sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        sessions.retain(|existing_stream_id, existing| {
-            existing_stream_id == &stream_id || existing.jid != jid
-        });
-        claimed.retain(|existing_stream_id, existing| {
-            existing_stream_id != &stream_id && existing.jid != jid
-        });
+        // Scope the RwLock guards in a block so they're definitively
+        // dropped before any await point. RwLockWriteGuard is not
+        // Send, and explicit `drop()` doesn't satisfy the async
+        // future's lifetime analysis.
+        let count = {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let mut claimed = self
+                .claimed_sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.retain(|existing_stream_id, existing| {
+                existing_stream_id == &stream_id || existing.jid != jid
+            });
+            claimed.retain(|existing_stream_id, existing| {
+                existing_stream_id != &stream_id && existing.jid != jid
+            });
 
-        if sessions.len() >= self.max_sessions {
-            // Remove oldest session
-            if let Some(oldest_key) = sessions
-                .iter()
-                .min_by_key(|(_, s)| s.detached_at)
-                .map(|(k, _)| k.clone())
-            {
-                sessions.remove(&oldest_key);
-                debug!(stream_id = %oldest_key, "Evicted oldest SM session to make room");
+            if sessions.len() >= self.max_sessions {
+                // Remove oldest session
+                if let Some(oldest_key) = sessions
+                    .iter()
+                    .min_by_key(|(_, s)| s.detached_at)
+                    .map(|(k, _)| k.clone())
+                {
+                    sessions.remove(&oldest_key);
+                    debug!(stream_id = %oldest_key, "Evicted oldest SM session to make room");
+                }
+            }
+
+            sessions.insert(stream_id.clone(), session.clone());
+            sessions.len()
+        };
+
+        // Persist the detached session + its unacked queue so it
+        // survives a server restart per locked Q8 = B.
+        if let Some(storage) = &self.persistence {
+            let persisted = detached_to_persisted(&session)?;
+            storage
+                .upsert_session(persisted)
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+            // Replace any prior unacked rows for this stream id with
+            // the current snapshot. Persistence ack_through can have
+            // truncated rows already, so the cleanest approach is to
+            // delete-via-ack to a high watermark and re-append, but
+            // that's a churn-y O(n) round-trip per detach; instead
+            // we rely on the fact that store_session is called only
+            // on detach and the unacked vec at that moment IS the
+            // snapshot we want to persist. Existing rows from a
+            // prior detach for the same stream id would have been
+            // taken on resume; if they're still there we replace
+            // them via append (PRIMARY KEY (stream_id, sequence)
+            // would conflict — caller is expected to take_session
+            // before storing a new one with the same id).
+            for (sequence, stanza_xml) in &session.unacked_stanzas {
+                let element: minidom::Element =
+                    stanza_xml.parse().map_err(|e: minidom::Error| {
+                        SmRegistryError::Internal(format!(
+                            "parse unacked stanza for persistence: {e}"
+                        ))
+                    })?;
+                let stanza = match element.name() {
+                    "message" => crate::Stanza::Message(
+                        xmpp_parsers::message::Message::try_from(element)
+                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+                    ),
+                    "iq" => crate::Stanza::Iq(
+                        xmpp_parsers::iq::Iq::try_from(element)
+                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+                    ),
+                    "presence" => crate::Stanza::Presence(
+                        xmpp_parsers::presence::Presence::try_from(element)
+                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+                    ),
+                    other => {
+                        return Err(SmRegistryError::Internal(format!(
+                            "unknown unacked stanza element '{other}'"
+                        )))
+                    }
+                };
+                let unacked = super::persistence::PersistedUnackedStanza {
+                    stream_id: crate::pending_delivery::SmSessionId::new(stream_id.clone()),
+                    sequence: *sequence,
+                    stanza: Box::new(stanza),
+                    original_receipt_at: chrono::Utc::now(),
+                };
+                storage
+                    .append_unacked(unacked)
+                    .await
+                    .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
             }
         }
-
-        sessions.insert(stream_id.clone(), session);
-        let count = sessions.len();
-        drop(claimed);
-        drop(sessions);
 
         debug!(stream_id = %stream_id, count = count, "Stored detached SM session");
         Ok(())
@@ -309,31 +546,48 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<DetachedSession>, SmRegistryError> {
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-
-        let removed = match sessions.remove(stream_id) {
-            Some(session) => {
-                if session.is_expired() {
-                    debug!(stream_id = %stream_id, "SM session found but expired");
-                    None
-                } else {
-                    debug!(stream_id = %stream_id, "Retrieved and removed SM session");
-                    Some(session)
+        // Lock-scoped block so guards drop before the await
+        // (RwLockWriteGuard is not Send and explicit drop() doesn't
+        // satisfy async future lifetime analysis).
+        let removed = {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let removed = match sessions.remove(stream_id) {
+                Some(session) => {
+                    if session.is_expired() {
+                        debug!(stream_id = %stream_id, "SM session found but expired");
+                        None
+                    } else {
+                        debug!(stream_id = %stream_id, "Retrieved and removed SM session");
+                        Some(session)
+                    }
                 }
-            }
-            None => {
-                debug!(stream_id = %stream_id, "SM session not found");
-                None
-            }
+                None => {
+                    debug!(stream_id = %stream_id, "SM session not found");
+                    None
+                }
+            };
+            self.claimed_sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                .remove(stream_id);
+            removed
         };
-        drop(sessions);
-        self.claimed_sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
-            .remove(stream_id);
+        // Mirror the take into durable storage. take_session is the
+        // resume path's commitment point — once we've decided to
+        // hand the session back to the resuming connection the
+        // durable record is no longer needed (the session is now
+        // live again).
+        if let Some(storage) = &self.persistence {
+            storage
+                .delete_session(&crate::pending_delivery::SmSessionId::new(
+                    stream_id.to_string(),
+                ))
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+        }
         Ok(removed)
     }
 
@@ -1603,5 +1857,122 @@ mod tests {
         let remaining = session.remaining_time();
         assert!(remaining.as_secs() <= 300);
         assert!(remaining.as_secs() >= 299); // Should be close to 300
+    }
+
+    // --- SmPersistenceStorage integration (slice (d) phase 3) -------
+
+    use super::super::persistence::SmPersistenceStorage as _;
+
+    fn realistic_message_stanza(body: &str) -> String {
+        // Build a valid XMPP message via the typed builder so the
+        // persistence path can parse it back to a typed Stanza on
+        // store_session. The fmt-pinned indentation is what the
+        // serializer emits when rebuilt via Element::from(message).
+        let mut m = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        m.bodies
+            .insert(String::new(), xmpp_parsers::message::Body(body.to_string()));
+        let element: xmpp_parsers::minidom::Element = m.into();
+        let mut buf = Vec::new();
+        element.write_to(&mut buf).expect("serialize message");
+        String::from_utf8(buf).expect("utf8")
+    }
+
+    fn realistic_test_session(stream_id: &str) -> DetachedSession {
+        DetachedSession {
+            stream_id: stream_id.to_string(),
+            user_id: "user@example.com".to_string(),
+            jid: make_test_jid(),
+            inbound_count: 4,
+            outbound_count: 7,
+            last_acked: 5,
+            unacked_stanzas: vec![
+                (6, realistic_message_stanza("first")),
+                (7, realistic_message_stanza("second")),
+            ],
+            max_resume_time: Some(120),
+            detached_at: Instant::now(),
+            carbons_enabled: true,
+            roster_interested: true,
+            presence_available: true,
+            presence_show: Some(Show::Chat),
+            presence_status: Some("online".to_string()),
+            presence_priority: 3,
+        }
+    }
+
+    #[tokio::test]
+    async fn store_session_mirrors_to_persistence_when_attached() {
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        let session = realistic_test_session("stream-1");
+        registry.store_session(session.clone()).await.unwrap();
+
+        let stream_id = crate::pending_delivery::SmSessionId::new("stream-1");
+        let persisted = storage.get_session(&stream_id).await.unwrap().unwrap();
+        assert_eq!(persisted.user_id, session.user_id);
+        assert_eq!(persisted.jid, session.jid);
+        assert_eq!(persisted.inbound_count, session.inbound_count);
+        assert_eq!(persisted.outbound_count, session.outbound_count);
+        assert_eq!(persisted.last_acked, session.last_acked);
+        assert_eq!(persisted.carbons_enabled, session.carbons_enabled);
+        let unacked = storage.list_unacked(&stream_id).await.unwrap();
+        assert_eq!(unacked.len(), 2);
+        let seqs: Vec<u32> = unacked.iter().map(|u| u.sequence).collect();
+        assert_eq!(seqs, vec![6, 7]);
+    }
+
+    #[tokio::test]
+    async fn take_session_deletes_from_persistence() {
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        registry
+            .store_session(realistic_test_session("stream-1"))
+            .await
+            .unwrap();
+        // Resume — should drain durable storage.
+        let _ = registry.take_session("stream-1").await.unwrap();
+        let stream_id = crate::pending_delivery::SmSessionId::new("stream-1");
+        assert!(storage.get_session(&stream_id).await.unwrap().is_none());
+        assert!(storage.list_unacked(&stream_id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn restore_from_persistence_rebuilds_in_memory_view() {
+        let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+        // Pre-populate storage as if a previous server lifecycle had
+        // detached this session.
+        {
+            let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+            registry
+                .store_session(realistic_test_session("stream-1"))
+                .await
+                .unwrap();
+            registry
+                .store_session(realistic_test_session("stream-2"))
+                .await
+                .unwrap();
+        }
+        // Simulate restart: brand-new registry, only persistence
+        // attached. The in-memory view starts empty.
+        let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+        assert_eq!(registry.session_count().await, 0);
+
+        let hydrated = registry.restore_from_persistence().await.unwrap();
+        assert_eq!(hydrated, 2);
+        assert_eq!(registry.session_count().await, 2);
+
+        // Both sessions resumable post-restart.
+        let resumed = registry.take_session("stream-1").await.unwrap();
+        assert!(resumed.is_some());
+        let resumed = resumed.unwrap();
+        assert_eq!(resumed.unacked_stanzas.len(), 2);
+        assert!(resumed.carbons_enabled);
+        assert_eq!(resumed.presence_priority, 3);
+    }
+
+    #[tokio::test]
+    async fn restore_is_noop_when_no_persistence_attached() {
+        let registry = InMemorySmSessionRegistry::new();
+        assert_eq!(registry.restore_from_persistence().await.unwrap(), 0);
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -413,26 +413,24 @@ impl InMemorySmSessionRegistry {
 
 impl InMemorySmSessionRegistry {
     /// Helper: delete every durable row for `stream_id` (session +
-    /// unacked queue). Best-effort — failures are logged and
-    /// swallowed because the in-memory state has already mutated
-    /// when this is called and we'd rather have a transient durable
-    /// drift than fail the resume / cleanup path.
-    async fn persist_delete_session(&self, stream_id: &str) {
+    /// unacked queue). Returns the underlying error so callers can
+    /// adopt a "persist-first" ordering — refuse to mutate the
+    /// in-memory map when the durable delete failed, so a transient
+    /// storage hiccup doesn't leave an orphaned `sm_sessions` row
+    /// that `restore_from_persistence` would resurrect on restart.
+    /// (Codex P1 + Copilot + Qodo on PR #344: best-effort silent
+    /// swallow allowed durable orphans whenever the in-memory state
+    /// had already moved on.)
+    async fn persist_delete_session(&self, stream_id: &str) -> Result<(), SmRegistryError> {
         let Some(storage) = &self.persistence else {
-            return;
+            return Ok(());
         };
-        if let Err(error) = storage
+        storage
             .delete_session(&crate::pending_delivery::SmSessionId::new(
                 stream_id.to_string(),
             ))
             .await
-        {
-            debug!(
-                stream_id = %stream_id,
-                error = %error,
-                "failed to delete persisted SM session; will retry via janitor"
-            );
-        }
+            .map_err(|e| SmRegistryError::Internal(e.to_string()))
     }
 }
 
@@ -589,7 +587,22 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // review on PR #344: durable rows for evicted streams must
         // not be silently rehydrated.)
         for evicted in &evicted_stream_ids {
-            self.persist_delete_session(evicted).await;
+            // Best-effort: failure to delete an evictee row means
+            // the next restart MAY resurrect it via
+            // restore_from_persistence (until its resume window
+            // expires and the restore-time expired-filter drops it).
+            // Bubbling the error here would fail the whole detach
+            // because an unrelated evictee row couldn't be cleaned;
+            // log loudly instead so operators can spot storage
+            // health issues.
+            if let Err(error) = self.persist_delete_session(evicted).await {
+                debug!(
+                    stream_id = %evicted,
+                    error = %error,
+                    "evicted SM session: durable delete failed; row will be \
+                     filtered by restore-time expiry check"
+                );
+            }
         }
 
         // Persist the detached session + its unacked queue so it
@@ -660,9 +673,23 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<DetachedSession>, SmRegistryError> {
-        // Lock-scoped block so guards drop before the await
-        // (RwLockWriteGuard is not Send and explicit drop() doesn't
-        // satisfy async future lifetime analysis).
+        // Persist-first ordering (same rationale as complete_claim):
+        // peek to see if the session exists, durably erase, then
+        // remove from in-memory. Failure to durably erase aborts
+        // the take so the caller can retry without leaving an
+        // orphan row in storage that restart would resurrect.
+        let exists = {
+            let sessions = self
+                .sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.contains_key(stream_id)
+        };
+        if !exists {
+            debug!(stream_id = %stream_id, "SM session not found");
+            return Ok(None);
+        }
+        self.persist_delete_session(stream_id).await?;
         let removed = {
             let mut sessions = self
                 .sessions
@@ -689,19 +716,6 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                 .remove(stream_id);
             removed
         };
-        // Mirror the take into durable storage. take_session is the
-        // resume path's commitment point — once we've decided to
-        // hand the session back to the resuming connection the
-        // durable record is no longer needed (the session is now
-        // live again).
-        if let Some(storage) = &self.persistence {
-            storage
-                .delete_session(&crate::pending_delivery::SmSessionId::new(
-                    stream_id.to_string(),
-                ))
-                .await
-                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
-        }
         Ok(removed)
     }
 
@@ -737,7 +751,18 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             drain_expired_internal(&mut sessions)
         };
         for session in &drained {
-            self.persist_delete_session(&session.stream_id).await;
+            // Best-effort: cleanup paths log and continue rather
+            // than aborting the whole sweep on a single bad row.
+            // Restart-time expired-filter still drops anything that
+            // slipped through.
+            if let Err(error) = self.persist_delete_session(&session.stream_id).await {
+                debug!(
+                    stream_id = %session.stream_id,
+                    error = %error,
+                    "expired SM session: durable delete failed in cleanup; \
+                     restart-time expiry filter will drop the orphan"
+                );
+            }
         }
         Ok(drained.len())
     }
@@ -868,7 +893,18 @@ impl InMemorySmSessionRegistry {
             drain_expired_internal(&mut sessions)
         };
         for session in &drained {
-            self.persist_delete_session(&session.stream_id).await;
+            // Best-effort: cleanup paths log and continue rather
+            // than aborting the whole sweep on a single bad row.
+            // Restart-time expired-filter still drops anything that
+            // slipped through.
+            if let Err(error) = self.persist_delete_session(&session.stream_id).await {
+                debug!(
+                    stream_id = %session.stream_id,
+                    error = %error,
+                    "expired SM session: durable delete failed in cleanup; \
+                     restart-time expiry filter will drop the orphan"
+                );
+            }
         }
         Ok(drained)
     }
@@ -930,31 +966,42 @@ impl InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<SmClaimCompletion>, SmRegistryError> {
-        // Lock-scoped block so guards are dropped before the durable
-        // delete await (RwLockWriteGuard is not Send).
-        let outcome = {
-            self.claimed_sessions
-                .write()
-                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
-                .remove(stream_id)
-                .map(|session| {
-                    if session.is_expired() {
-                        SmClaimCompletion::Expired(session)
-                    } else {
-                        SmClaimCompletion::Resumed(session)
-                    }
-                })
+        // Persist-first ordering: durably erase the session BEFORE
+        // we hand it back to the resuming connection. If the durable
+        // delete fails, abort the resume — the in-memory entry stays
+        // in claimed_sessions and the caller can retry, or
+        // release_claim to put it back. Without persist-first, a
+        // successful in-memory completion + failed durable delete
+        // would leave an orphan row that
+        // `restore_from_persistence` would resurrect on next
+        // restart, exposing a stale `<resume previd='…'/>` for an
+        // already-live session (Codex P1 + Copilot + Qodo on PR
+        // #344).
+        let exists = {
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            claimed.contains_key(stream_id)
         };
-        // Resume is the durable commitment point — once we hand the
-        // session back to the resuming connection (or detect it
-        // expired mid-claim), the durable record is no longer needed.
-        // Without this delete, restart_from_persistence would
-        // resurrect the just-resumed session (Copilot review on
-        // PR #344). For Expired we still delete: the session will
-        // not be resumable again.
-        if outcome.is_some() {
-            self.persist_delete_session(stream_id).await;
+        if !exists {
+            return Ok(None);
         }
+        self.persist_delete_session(stream_id).await?;
+        // Now remove from in-memory; the durable side has already
+        // committed.
+        let outcome = self
+            .claimed_sessions
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+            .remove(stream_id)
+            .map(|session| {
+                if session.is_expired() {
+                    SmClaimCompletion::Expired(session)
+                } else {
+                    SmClaimCompletion::Resumed(session)
+                }
+            });
         Ok(outcome)
     }
 
@@ -964,26 +1011,31 @@ impl InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
     ) -> Result<Option<DetachedSession>, SmRegistryError> {
-        // Lock-scoped block so guards drop before the durable delete
-        // await.
-        let removed = {
-            let mut sessions = self
+        // Persist-first ordering: peek + abort if claimed, durably
+        // erase, then remove from in-memory. Same rationale as
+        // complete_claim — failure to durably erase aborts the
+        // operation so a transient storage error doesn't leave an
+        // orphan that restart resurrects.
+        let exists_unclaimed = {
+            let sessions = self
                 .sessions
-                .write()
+                .read()
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            if self
+            let claimed = self
                 .claimed_sessions
                 .read()
-                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
-                .contains_key(stream_id)
-            {
-                return Ok(None);
-            }
-            sessions.remove(stream_id)
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.contains_key(stream_id) && !claimed.contains_key(stream_id)
         };
-        if removed.is_some() {
-            self.persist_delete_session(stream_id).await;
+        if !exists_unclaimed {
+            return Ok(None);
         }
+        self.persist_delete_session(stream_id).await?;
+        let removed = self
+            .sessions
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+            .remove(stream_id);
         Ok(removed)
     }
 
@@ -993,46 +1045,53 @@ impl InMemorySmSessionRegistry {
         &self,
         jid: &FullJid,
     ) -> Result<Vec<DetachedSession>, SmRegistryError> {
-        // Lock-scoped block so guards drop before the durable delete
-        // awaits.
-        let (removed, removed_ids) = {
-            let mut removed = Vec::new();
-            let mut removed_ids: Vec<String> = Vec::new();
+        // Persist-first: enumerate matching stream-ids under a brief
+        // lock, durably erase each, then remove from in-memory. If
+        // any durable erase fails, abort before in-memory mutation
+        // so a transient storage error doesn't leave orphans.
+        let matching_ids: Vec<String> = {
+            let sessions = self
+                .sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let mut ids: Vec<String> = sessions
+                .iter()
+                .filter(|(_, s)| s.jid == *jid)
+                .map(|(id, _)| id.clone())
+                .collect();
+            for (id, s) in claimed.iter() {
+                if s.jid == *jid {
+                    ids.push(id.clone());
+                }
+            }
+            ids
+        };
+        for stream_id in &matching_ids {
+            self.persist_delete_session(stream_id).await?;
+        }
+        // Now remove from in-memory (durable side already committed).
+        let mut removed = Vec::new();
+        {
             let mut sessions = self
                 .sessions
                 .write()
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            let matching_streams: Vec<_> = sessions
-                .iter()
-                .filter(|(_, session)| session.jid == *jid)
-                .map(|(stream_id, _)| stream_id.clone())
-                .collect();
-            for stream_id in matching_streams {
-                if let Some(session) = sessions.remove(&stream_id) {
-                    removed_ids.push(stream_id);
-                    removed.push(session);
-                }
-            }
-            drop(sessions);
             let mut claimed = self
                 .claimed_sessions
                 .write()
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            let matching_streams: Vec<_> = claimed
-                .iter()
-                .filter(|(_, session)| session.jid == *jid)
-                .map(|(stream_id, _)| stream_id.clone())
-                .collect();
-            for stream_id in matching_streams {
-                if let Some(session) = claimed.remove(&stream_id) {
-                    removed_ids.push(stream_id);
+            for stream_id in &matching_ids {
+                if let Some(session) = sessions.remove(stream_id) {
+                    removed.push(session);
+                }
+                if let Some(session) = claimed.remove(stream_id) {
                     removed.push(session);
                 }
             }
-            (removed, removed_ids)
-        };
-        for stream_id in &removed_ids {
-            self.persist_delete_session(stream_id).await;
         }
         Ok(removed)
     }


### PR DESCRIPTION
Tracks issue #209 — continues from PR #339 (now merged on main as `0c5eac1c`).

## Scope

Slice (d) phases 2–3 from the locked design:

1. **`DatabaseSmPersistence`** — libSQL/Postgres-backed implementation of the `SmPersistenceStorage` trait introduced in #339. Mirrors the `DatabasePendingDeliveryStorage` pattern: UUID-keyed sessions, typed `Stanza` payloads serialized at the I/O boundary, atomic operations under per-stream locks.
2. **Plumb `InMemorySmSessionRegistry` through `SmPersistenceStorage`** so every `store_session` / `record_detached_outbound` / `ack_through` mutates both the in-memory view (for hot-path resumption) and the durable backend (for restart recovery).
3. **Restart restoration** — `AppState` init loads persisted sessions back into the in-memory registry so an XEP-0198 `<resume previd='…'/>` finds the session after a server restart per locked Q8 = B.

## Out of scope (queued for follow-up PRs)

- **Phase 4** — graceful-shutdown drain + Q6 SM-expiry promotion path (unacked → `pending_delivery` via `classify_dm_intake`).
- **Q7b** — SM-ack-keyed deletion of `pending_delivery` rows (currently deleted on send).
- **Q7c re-flush** — pending_delivery rows released on pre-ack session death.
- **Claim-expiry janitor** — sweeps for `pending_delivery` rows orphaned by crash mid-flush.

## Plan

1. Schema: `sm_sessions(stream_id PK, user_id, full_jid, h_in, h_out, last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, carbons_enabled, roster_interested, presence_available, presence_show, presence_status, presence_priority)`; `sm_unacked(stream_id FK, sequence, stanza_xml, original_receipt_at_ms, PK(stream_id, sequence))`. Indexes on `(stream_id, sequence)` for ordered list, `expires_at_ms` for janitor.
2. `DatabaseSmPersistence::open(database_url, ...)` follows `DatabasePendingDeliveryStorage::open`'s shape; new env var `WADDLE_XMPP_SM_DATABASE_URL` (falls back to `WADDLE_DATABASE_URL`).
3. Refactor `InMemorySmSessionRegistry` to take `Arc<dyn SmPersistenceStorage>` in its constructor; every write method also persists.
4. `AppState::new_with_deps` (or equivalent) loads sessions on init via `list_unacked` + `get_session` per stream_id batch, hydrates the in-memory registry.
5. Tests: schema round-trip, restart restoration end-to-end, concurrent store_session, ack_through truncation correctness.

## Test plan

- [ ] `DatabaseSmPersistence` integration tests against in-memory SQLite (round-trip session, ack_through, list_unacked ordering, list_expired_sessions cutoff).
- [ ] `InMemorySmSessionRegistry` writes propagate to persistence (in-memory fake) — extend `xep0198_session_registry` test suite.
- [ ] Restart restoration test: store session + unacked, drop the registry, rebuild from storage, assert `<resume>` succeeds and replays unacked.
- [ ] Existing `xep0198_session_registry` integration tests remain green.
- [ ] `cargo fmt --all -- --check`, `cargo clippy --release --locked --workspace --all-features --all-targets -- -D warnings`, `bun test && bun run lint` all clean before un-drafting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)