### PR TITLE
fix(server): restore extension route access

### DIFF
--- a/server/crates/waddle-server/src/server/managed_channel_policy.rs
+++ b/server/crates/waddle-server/src/server/managed_channel_policy.rs
@@ -1,0 +1,27 @@
+use crate::permissions::Permission;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManagedChannelServerPolicy {
+    ChannelOnly,
+    DeploymentOwnerOnly,
+    DeploymentMembership,
+}
+
+pub(crate) fn server_policy_for_managed_channel(
+    channel_id: &str,
+    permission: &Permission,
+) -> ManagedChannelServerPolicy {
+    match (channel_id, permission) {
+        ("announcements", Permission::SendMessage) => {
+            ManagedChannelServerPolicy::DeploymentOwnerOnly
+        }
+        ("chat", Permission::View | Permission::Read | Permission::SendMessage)
+        | ("announcements", Permission::View | Permission::Read) => {
+            ManagedChannelServerPolicy::DeploymentMembership
+        }
+        _ => ManagedChannelServerPolicy::ChannelOnly,
+    }
+}
+
+pub(crate) const DEPLOYMENT_MEMBERSHIP_PERMISSIONS: [Permission; 3] =
+    [Permission::Owner, Permission::Admin, Permission::Member];

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -7,6 +7,11 @@ use crate::permissions::{
     CheckPermission, Object, ObjectType, Permission, PermissionActor, Subject,
 };
 use crate::pubsub::build_pubsub_storage;
+use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
+use crate::server::managed_channel_policy::{
+    server_policy_for_managed_channel, ManagedChannelServerPolicy,
+    DEPLOYMENT_MEMBERSHIP_PERMISSIONS,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 use axum::{
@@ -53,6 +58,7 @@ use waddle_xmpp::{muc::room_registry_actor::RoomRegistryActor, registry::Connect
 
 pub(crate) mod bootstrap_membership;
 pub mod extension_host_adapter;
+pub(crate) mod managed_channel_policy;
 mod routes;
 pub mod xmpp_state;
 
@@ -1584,7 +1590,7 @@ async fn authorize_extension_pubsub_publish(
     let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&room_jid) else {
         return Err("PubSub node is not bound to a managed channel".to_string());
     };
-    let object = Object::new(ObjectType::Channel, channel_id);
+    let object = Object::new(ObjectType::Channel, channel_id.clone());
     let subject = Subject::user(user_id);
     let outcast = context
         .app_state
@@ -1599,21 +1605,75 @@ async fn authorize_extension_pubsub_publish(
     if outcast.allowed {
         return Err("requester is not allowed in this channel".to_string());
     }
-    let send = context
-        .app_state
-        .permission_actor
-        .ask(CheckPermission {
-            subject,
-            permission: Permission::SendMessage,
-            object,
-        })
-        .await
-        .map_err(|error| format!("permission check failed: {error}"))?;
-    if send.allowed {
+    if managed_channel_permission_allowed(
+        &context.app_state,
+        &subject,
+        channel_id.as_str(),
+        Permission::SendMessage,
+    )
+    .await?
+    {
         Ok(())
     } else {
         Err("requester cannot write extension state for this channel".to_string())
     }
+}
+
+async fn managed_channel_permission_allowed(
+    app_state: &AppState,
+    subject: &Subject,
+    channel_id: &str,
+    permission: Permission,
+) -> Result<bool, String> {
+    let policy = server_policy_for_managed_channel(channel_id, &permission);
+    if policy == ManagedChannelServerPolicy::DeploymentOwnerOnly {
+        let server_owner = app_state
+            .permission_actor
+            .ask(CheckPermission {
+                subject: subject.clone(),
+                permission: Permission::Owner,
+                object: Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+            })
+            .await
+            .map_err(|error| format!("permission check failed: {error}"))?;
+        return Ok(server_owner.allowed);
+    }
+
+    let allowed = app_state
+        .permission_actor
+        .ask(CheckPermission {
+            subject: subject.clone(),
+            permission: permission.clone(),
+            object: Object::new(ObjectType::Channel, channel_id),
+        })
+        .await
+        .map_err(|error| format!("permission check failed: {error}"))?;
+    if allowed.allowed {
+        return Ok(true);
+    }
+
+    if policy == ManagedChannelServerPolicy::DeploymentMembership {
+        // Keep these as explicit relation/permission checks. The local permission
+        // schema makes `member` inherit owner/admin, but the SpiceDB schema uses
+        // server relations directly for compatibility.
+        for server_permission in DEPLOYMENT_MEMBERSHIP_PERMISSIONS {
+            let server_allowed = app_state
+                .permission_actor
+                .ask(CheckPermission {
+                    subject: subject.clone(),
+                    permission: server_permission,
+                    object: Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                })
+                .await
+                .map_err(|error| format!("permission check failed: {error}"))?;
+            if server_allowed.allowed {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+
+    Ok(false)
 }
 
 async fn extension_command_result(
@@ -2149,6 +2209,7 @@ async fn detailed_health_handler(State(state): State<Arc<AppState>>) -> impl Int
 mod tests {
     use super::*;
     use crate::db::{DatabaseConfig, MigrationRunner, PoolConfig};
+    use crate::permissions::{Relation, Tuple, WriteTuple};
     use axum::body::Body;
     use axum::http::{header, Request, StatusCode};
     use base64::prelude::*;
@@ -2182,6 +2243,118 @@ mod tests {
         runner.run(db_pool.global()).await.unwrap();
 
         Arc::new(AppState::new(Arc::new(db_pool)))
+    }
+
+    #[tokio::test]
+    async fn extension_pubsub_permission_allows_bootstrap_chat_member() {
+        let state = create_test_state().await;
+        let subject = Subject::user("user-alice");
+
+        assert!(
+            !managed_channel_permission_allowed(&state, &subject, "chat", Permission::SendMessage)
+                .await
+                .expect("initial permission check"),
+            "server membership should be required before default chat policy applies"
+        );
+
+        state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                    Relation::new("member"),
+                    subject.clone(),
+                ),
+            })
+            .await
+            .expect("server member tuple");
+
+        let owner_subject = Subject::user("user-owner");
+        state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                    Relation::new("owner"),
+                    owner_subject.clone(),
+                ),
+            })
+            .await
+            .expect("server owner tuple");
+
+        assert!(
+            managed_channel_permission_allowed(&state, &subject, "chat", Permission::SendMessage)
+                .await
+                .expect("chat permission check"),
+            "default chat extension publishes should inherit deployment membership"
+        );
+        assert!(
+            managed_channel_permission_allowed(&state, &subject, "announcements", Permission::View)
+                .await
+                .expect("announcements view permission check"),
+            "default announcement route reads should inherit deployment membership"
+        );
+        assert!(
+            managed_channel_permission_allowed(&state, &owner_subject, "chat", Permission::View)
+                .await
+                .expect("owner chat permission check"),
+            "default room membership policy must include deployment owners"
+        );
+        assert!(
+            managed_channel_permission_allowed(
+                &state,
+                &owner_subject,
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("owner announcements send permission check"),
+            "deployment owners should be allowed to publish announcement extension state"
+        );
+        assert!(
+            !managed_channel_permission_allowed(
+                &state,
+                &subject,
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("announcements send permission check"),
+            "announcement extension publishes still require owner permissions"
+        );
+        state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Channel, "announcements"),
+                    Relation::new("writer"),
+                    subject.clone(),
+                ),
+            })
+            .await
+            .expect("announcement writer tuple");
+        assert!(
+            !managed_channel_permission_allowed(
+                &state,
+                &subject,
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("announcements writer permission check"),
+            "announcement channel writer grants must not bypass server-owner write policy"
+        );
+        assert!(
+            !managed_channel_permission_allowed(
+                &state,
+                &subject,
+                "random",
+                Permission::SendMessage
+            )
+            .await
+            .expect("random permission check"),
+            "non-default channels still require channel permissions"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq.rs
@@ -94,6 +94,10 @@ use crate::permissions::{
     SubjectType, Tuple, WriteTuple,
 };
 use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
+use crate::server::managed_channel_policy::{
+    server_policy_for_managed_channel, ManagedChannelServerPolicy,
+    DEPLOYMENT_MEMBERSHIP_PERMISSIONS,
+};
 use crate::server::xmpp_state::{get_xmpp_channel, list_xmpp_channels, XmppChannelRecord};
 use crate::vcard::VCardStore;
 
@@ -4475,6 +4479,43 @@ async fn server_permission_allowed(
     .await
 }
 
+pub(crate) async fn managed_channel_permission_allowed(
+    state: &WebSocketState,
+    session: Option<&Session>,
+    channel_id: &str,
+    permission: Permission,
+) -> Result<bool, String> {
+    let policy = server_policy_for_managed_channel(channel_id, &permission);
+    if policy == ManagedChannelServerPolicy::DeploymentOwnerOnly {
+        return server_permission_allowed(state, session, Permission::Owner).await;
+    }
+
+    if permission_allowed(
+        state,
+        session,
+        Object::new(ObjectType::Channel, channel_id),
+        permission.clone(),
+    )
+    .await?
+    {
+        return Ok(true);
+    }
+
+    if policy == ManagedChannelServerPolicy::DeploymentMembership {
+        // Keep these as explicit relation/permission checks. The local permission
+        // schema makes `member` inherit owner/admin, but the SpiceDB schema uses
+        // server relations directly for compatibility.
+        for server_permission in DEPLOYMENT_MEMBERSHIP_PERMISSIONS {
+            if server_permission_allowed(state, session, server_permission).await? {
+                return Ok(true);
+            }
+        }
+        return Ok(false);
+    }
+
+    Ok(false)
+}
+
 async fn server_affiliation_for_requester(
     state: &WebSocketState,
     session: Option<&Session>,
@@ -4868,11 +4909,10 @@ async fn handle_extension_route_items(
     let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(&room_jid) else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
-    let channel = Object::new(ObjectType::Channel, channel_id);
     match permission_allowed(
         state,
         session,
-        channel.clone(),
+        Object::new(ObjectType::Channel, channel_id.clone()),
         Permission::Custom("outcast".into()),
     )
     .await
@@ -4884,7 +4924,7 @@ async fn handle_extension_route_items(
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
         }
     }
-    match permission_allowed(state, session, channel, Permission::View).await {
+    match managed_channel_permission_allowed(state, session, &channel_id, Permission::View).await {
         Ok(true) => {}
         Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
         Err(error) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -2571,7 +2571,9 @@ mod tests {
     use super::*;
     use crate::config::ServerConfig;
     use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
-    use crate::permissions::{Object, ObjectType, Relation, Subject, Tuple, WriteTuple};
+    use crate::permissions::{
+        Object, ObjectType, Permission, Relation, Subject, Tuple, WriteTuple,
+    };
     use crate::server::bootstrap_membership::DEPLOYMENT_SERVER_ID;
     use crate::server::AppState;
     use futures::Sink;
@@ -2583,7 +2585,9 @@ mod tests {
     use std::task::{Context, Poll};
     use tokio::sync::mpsc;
     // Handler functions moved to sub-modules but called directly in tests
-    use handlers::iq::{handle_iq, handle_iq_with_conn_state, IqConnState};
+    use handlers::iq::{
+        handle_iq, handle_iq_with_conn_state, managed_channel_permission_allowed, IqConnState,
+    };
     use handlers::presence::{handle_muc_join, handle_muc_leave, parse_room_jid_context};
     // Types moved out of mod.rs scope but used in tests
     use waddle_extensions::ExtensionConfig;
@@ -2772,6 +2776,144 @@ mod tests {
             .await
             .expect("server owner tuple");
         session
+    }
+
+    #[tokio::test]
+    async fn extension_route_channel_permission_allows_bootstrap_chat_member() {
+        let state = create_test_websocket_state().await;
+        let session = create_test_session(state.as_ref(), "alice").await;
+
+        assert!(
+            !managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "chat",
+                Permission::View,
+            )
+            .await
+            .expect("initial permission check"),
+            "server membership should be required before default chat policy applies"
+        );
+
+        state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                    Relation::new("member"),
+                    Subject::user(&session.user_id),
+                ),
+            })
+            .await
+            .expect("server member tuple");
+
+        let owner_session = create_test_session(state.as_ref(), "owner").await;
+        state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Server, DEPLOYMENT_SERVER_ID),
+                    Relation::new("owner"),
+                    Subject::user(&owner_session.user_id),
+                ),
+            })
+            .await
+            .expect("server owner tuple");
+
+        assert!(
+            managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "chat",
+                Permission::View,
+            )
+            .await
+            .expect("chat permission check"),
+            "default chat routes should inherit deployment membership"
+        );
+        assert!(
+            managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "announcements",
+                Permission::View,
+            )
+            .await
+            .expect("announcements view permission check"),
+            "default announcement route reads should inherit deployment membership"
+        );
+        assert!(
+            managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&owner_session),
+                "chat",
+                Permission::View,
+            )
+            .await
+            .expect("owner chat permission check"),
+            "default room membership policy must include deployment owners"
+        );
+        assert!(
+            managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&owner_session),
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("owner announcements send permission check"),
+            "deployment owners should be allowed to publish announcement extension state"
+        );
+        assert!(
+            !managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("announcements send permission check"),
+            "announcement extension publishes still require owner permissions"
+        );
+        state
+            .deps
+            .app_state
+            .permission_actor
+            .ask(WriteTuple {
+                tuple: Tuple::new(
+                    Object::new(ObjectType::Channel, "announcements"),
+                    Relation::new("writer"),
+                    Subject::user(&session.user_id),
+                ),
+            })
+            .await
+            .expect("announcement writer tuple");
+        assert!(
+            !managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "announcements",
+                Permission::SendMessage,
+            )
+            .await
+            .expect("announcements writer permission check"),
+            "announcement channel writer grants must not bypass server-owner write policy"
+        );
+        assert!(
+            !managed_channel_permission_allowed(
+                state.as_ref(),
+                Some(&session),
+                "random",
+                Permission::View,
+            )
+            .await
+            .expect("random channel permission check"),
+            "non-default channels still require channel permissions"
+        );
     }
 
     async fn register_test_native_user(state: &WebSocketState, username: &str, password: &str) {


### PR DESCRIPTION
## Plan

- Reproduce and trace the extension route denial from the chat route view through XMPP PubSub access.
- Review the relevant XEP rules under ./xeps before changing the wire behavior.
- Fix the conformant XMPP route access path without adding non-XMPP APIs.
- Add focused tests for the denied and allowed default-room route permission flows.
- Run server validation, push the branch, and monitor CI.