### PR TITLE
feat(server): SM-ack-keyed pending_delivery lifecycle (slice d phase 5, #209)

### DIFF
--- a/.rules.cue
+++ b/.rules.cue
@@ -58,11 +58,4 @@ ignore: git: [
 	"# Gateway generated schemas",
 	"gateway/schemas/",
 	"gateway/supergraph.graphql",
-	"",
-	"",
-	"# WASM build artifacts — built by CI and published to GitHub Packages",
-	"# WASM build artifacts — binary blobs only; package.json/entry.js/.d.ts are committed stubs",
-	"server/wasm-pkg/waddle-xmpp-client-wasm/*_bg.js",
-	"server/wasm-pkg/waddle-xmpp-client-wasm/*_bg.wasm",
-	"server/wasm-pkg/waddle-xmpp-client-wasm/*_bg.wasm.d.ts",
 ]

--- a/docs/rfc/209-offline-dm-durability.md
+++ b/docs/rfc/209-offline-dm-durability.md
@@ -8,8 +8,8 @@ Tracking doc for the multi-PR implementation of issue [#209](https://github.com/
 |---|---|---|---|
 | Foundation | [#339](https://github.com/waddle-social/waddle/pull/339) | ✅ merged | Typed `DmRouting` classifier, `pending_delivery` storage trait + in-memory + libSQL backend, `OfflineDeliveryHandler`, presence-driven flush, `<service-unavailable/>` bounce on quota |
 | Slice (d) phases 2–3 | [#344](https://github.com/waddle-social/waddle/pull/344) | ✅ merged | `DatabaseSmPersistence` libSQL/Postgres backend, `InMemorySmSessionRegistry` plumbed through `SmPersistenceStorage`, restart restoration |
-| Slice (d) phase 4 | [#346](https://github.com/waddle-social/waddle/pull/346) | 🟡 in review | Q6 SM-expiry promotion (alt-resource → offline → service-unavailable), graceful-shutdown drain, persist-after-promotion ordering |
-| Q7 lifecycle | [#347](#pr-347--q7b--q7c-sm-ack-lifecycle--planned) | ⬜ planned | SM-ack-keyed deletion of `pending_delivery` rows + pre-ack session-death re-flush |
+| Slice (d) phase 4 | [#346](https://github.com/waddle-social/waddle/pull/346) | ✅ merged | Q6 SM-expiry promotion (alt-resource → offline → service-unavailable), graceful-shutdown drain, persist-after-promotion ordering |
+| Q7 lifecycle | [#358](https://github.com/waddle-social/waddle/pull/358) | 🟡 in review | SM-ack-keyed deletion of `pending_delivery` rows + pre-ack session-death re-flush |
 | Janitor + flush-time block | [#348](#pr-348--claim-expiry-janitor--xep-0191-flush-time-block-re-eval--planned) | ⬜ planned | Claim-expiry janitor + XEP-0191 flush-time block re-eval |
 | Receipt-time plumbing | [#349](#pr-349--original_receipt_at-plumbing-through-detachedsession--planned) | ⬜ planned | `original_receipt_at` plumbing through `DetachedSession.unacked_stanzas` |
 | Test-coverage debt | [#350](#pr-350--test-coverage-debt--planned) | ⬜ planned | Un-ignore XEP-0160 integration tests + extend dedicated XEP-0198/0334/0280/0313/0203/0359/0191 suites |
@@ -26,8 +26,8 @@ Tracking doc for the multi-PR implementation of issue [#209](https://github.com/
 | Q5 | Wire shape on flush (preserve `to`, stamp stanza-id only on Archived, `<delay/>` per XEP-0203) | ✅ shipped |
 | Q6 | Alt-resource → offline-storage → `<service-unavailable/>` priority chain | ✅ shipped (#346) |
 | Q7a | Flush triggers on first non-neg-priority presence of fresh session | ✅ shipped |
-| Q7b | SM-ack-keyed deletion of `pending_delivery` rows | ⬜ planned (#347) |
-| Q7c | Pre-ack session-death → release row for re-flush | ⬜ planned (#347) |
+| Q7b | SM-ack-keyed deletion of `pending_delivery` rows | 🟡 in review (#358) |
+| Q7c | Pre-ack session-death → release row for re-flush | 🟡 in review (#358) |
 | Q7d | Priority transition negative→non-negative also triggers flush | ✅ shipped |
 | Q8=B | SM session/unacked persistence durable across restart | ✅ shipped (#344+#346) |
 | Q9 | Per-recipient row count cap, server-wide config, refuse-on-overflow | ✅ shipped |

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -64,22 +64,50 @@ pub struct FlushOutcome {
 /// returned `true` on the recovering [`ConnectionEntry`] — i.e. the
 /// first non-negative-priority presence of a fresh session.
 ///
-/// The session-id used to claim rows is derived from the recovering
-/// full JID (a concrete SM session id is wired in slice (d)).
-#[instrument(skip(storage, registry, archive_resolver), fields(recipient = %recipient, resource = %resource))]
+/// `sm_session` is the recovering connection's XEP-0198 stream id
+/// (`Some(_)` when the client has enabled SM, `None` otherwise). The
+/// SM-enabled path uses the locked Q7b SM-ack lifecycle: claim → tag
+/// outbound stanza → recipient main loop stamps `outbound_sequence`
+/// → SM `<a h>` deletes via `delete_acked_through`. The non-SM path
+/// falls back to delete-on-push: the recipient cannot ack so we
+/// can't gate deletion on it. (Codex/Qodo review on PR #358:
+/// previously the JID was used as the session key, conflating
+/// distinct SM sessions on the same resource and leaking rows for
+/// non-SM clients.)
+#[instrument(
+    skip(storage, registry, archive_resolver, sm_session),
+    fields(recipient = %recipient, resource = %resource)
+)]
 pub async fn flush_for_resource<R>(
     storage: &Arc<dyn PendingDeliveryStorage>,
     registry: &ConnectionRegistry,
     server_domain: &str,
     recipient: &BareJid,
     resource: &FullJid,
+    sm_session: Option<&SmSessionId>,
     archive_resolver: &R,
 ) -> FlushOutcome
 where
     R: ArchiveResolver + ?Sized,
 {
-    let session_id = SmSessionId::new(resource.to_string());
-    let claimed = match storage.claim_for_session(recipient, &session_id).await {
+    // For non-SM sessions, use a transient per-flush session id so the
+    // claim row tag is consistent within the batch. The post-push
+    // delete path keys on row id, not session id, so the transient
+    // value never escapes this function. Only the SM path keeps the
+    // claim alive past the push for the SM-ack lifecycle.
+    let transient_session_id;
+    let session_id_for_claim: &SmSessionId = match sm_session {
+        Some(id) => id,
+        None => {
+            transient_session_id =
+                SmSessionId::new(format!("transient:{}:{}", resource, uuid::Uuid::new_v4()));
+            &transient_session_id
+        }
+    };
+    let claimed = match storage
+        .claim_for_session(recipient, session_id_for_claim)
+        .await
+    {
         Ok(rows) => rows,
         Err(error) => {
             warn!(error = %error, "claim_for_session failed; skipping flush");
@@ -114,20 +142,34 @@ where
         };
         let replay = build_replay_stanza(payload, server_domain, row.original_receipt_at);
         let stanza = Stanza::Message(replay);
-        // Locked Q7b SM-ack lifecycle: do NOT delete on push. Tag the
-        // outbound stanza with the source row id so the recipient's
-        // main loop can bind the assigned XEP-0198 outbound counter
-        // back to the row via `record_pushed_at`. The row is then
-        // deleted only when an SM `<a h>` from the recovering session
-        // covers `outbound_sequence` (handled in the SM ack path,
-        // `delete_acked_through`).
-        match registry
-            .send_pending_flush(resource, stanza, row.id.clone())
-            .await
-        {
+        // SM-enabled path: tag outbound with row id so the recipient's
+        // main loop can stamp `outbound_sequence` post-`record_outbound`.
+        // The row stays claimed for the SM-ack lifecycle.
+        // Non-SM path: same outbound tag (cheap), but we delete on Sent
+        // because there's no SM session to ack against.
+        let push_result = if sm_session.is_some() {
+            registry
+                .send_pending_flush(resource, stanza, row.id.clone())
+                .await
+        } else {
+            registry.send_to(resource, stanza).await
+        };
+        match push_result {
             SendResult::Sent => {
                 outcome.pushed += 1;
-                // Row stays claimed by `session_id` with
+                if sm_session.is_none() {
+                    // Non-SM fallback: delete on push since no `<a h>`
+                    // will ever fire (Codex review on PR #358).
+                    if let Err(error) = storage.delete_row(&row.id).await {
+                        warn!(
+                            row_id = %row.id,
+                            error = %error,
+                            "pending_delivery delete_row (non-SM push) failed; \
+                             row may re-deliver on next presence"
+                        );
+                    }
+                }
+                // SM-enabled: row stays claimed by `sm_session` with
                 // `outbound_sequence = NULL` until the recipient's
                 // main loop stamps it via `record_pushed_at`. If the
                 // session dies before push, `release_claim` clears
@@ -353,6 +395,40 @@ impl DatabasePendingDeliveryStorage {
             (),
         )
         .await?;
+        // Idempotent column-add migration for the locked Q7b
+        // outbound_sequence column. Tables created by an older
+        // version of waddle-server (before PR #358) were missing this
+        // column, and `CREATE TABLE IF NOT EXISTS` is a no-op when the
+        // table already exists — so the SELECT/INSERT/UPDATE statements
+        // below would fail with "no such column: outbound_sequence" at
+        // first use without this ALTER. (Codex/Qodo review on PR #358.)
+        //
+        // Both backends support `ADD COLUMN IF NOT EXISTS` syntax in
+        // recent versions (SQLite ≥ 3.35.0, Postgres ≥ 9.6); for older
+        // SQLite we fall through to a tolerant ALTER + best-effort
+        // ignore of the "duplicate column" error.
+        let alter_sql = match self.db.driver() {
+            DatabaseDriver::Postgres => {
+                "ALTER TABLE pending_delivery ADD COLUMN IF NOT EXISTS outbound_sequence INTEGER"
+            }
+            DatabaseDriver::Sqlite => {
+                "ALTER TABLE pending_delivery ADD COLUMN outbound_sequence INTEGER"
+            }
+        };
+        if let Err(error) = self.execute(alter_sql, ()).await {
+            // SQLite's `ALTER TABLE … ADD COLUMN` is not idempotent
+            // and reports "duplicate column name" when the column
+            // already exists. Treat that specific error as a no-op so
+            // the migration stays idempotent for both freshly-created
+            // tables (where the column exists from CREATE TABLE
+            // above) and pre-existing older tables.
+            let msg = error.to_string().to_lowercase();
+            if msg.contains("duplicate column") || msg.contains("already exists") {
+                debug!("pending_delivery.outbound_sequence column already present");
+            } else {
+                return Err(error);
+            }
+        }
         self.execute(
             "CREATE INDEX IF NOT EXISTS idx_pending_delivery_recipient \
              ON pending_delivery (recipient_jid, row_id)",
@@ -627,8 +703,14 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         // tags the rows, the loser's UPDATE finds zero matches and the
         // loser's SELECT returns rows already tagged for the other
         // session — filtered out by the WHERE.
+        // Defensive: clear outbound_sequence on claim too. release_*
+        // already does this, but a future code path that leaves a row
+        // half-released should not be able to confuse the SM-ack
+        // delete. Targets only newly-claimed rows (flushed_in_session
+        // IS NULL filter ensures we don't trample another session's
+        // ongoing claim).
         self.execute(
-            "UPDATE pending_delivery SET flushed_in_session = ? \
+            "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL \
              WHERE recipient_jid = ? AND flushed_in_session IS NULL",
             crate::db_params![session.as_str().to_string(), recipient.to_string()],
         )
@@ -672,8 +754,13 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
     }
 
     async fn release_claim(&self, session: &SmSessionId) -> Result<u64, PendingStorageError> {
+        // Clear `outbound_sequence` alongside `flushed_in_session` so a
+        // stale sequence from the dead session can't survive a re-claim
+        // and trick a later session's SM ack into deleting an unack'd
+        // row. (Qodo review on PR #358.)
         self.execute(
-            "UPDATE pending_delivery SET flushed_in_session = NULL \
+            "UPDATE pending_delivery SET flushed_in_session = NULL, \
+                                          outbound_sequence = NULL \
              WHERE flushed_in_session = ?",
             crate::db_params![session.as_str().to_string()],
         )
@@ -682,7 +769,9 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
 
     async fn release_row(&self, id: &PendingRowId) -> Result<u64, PendingStorageError> {
         self.execute(
-            "UPDATE pending_delivery SET flushed_in_session = NULL WHERE row_id = ?",
+            "UPDATE pending_delivery SET flushed_in_session = NULL, \
+                                          outbound_sequence = NULL \
+             WHERE row_id = ?",
             crate::db_params![id.as_str().to_string()],
         )
         .await
@@ -787,6 +876,7 @@ mod tests {
             "example.com",
             &bare("alice@example.com"),
             &full("alice@example.com/web"),
+            None,
             &NullArchiveResolver,
         )
         .await;
@@ -794,10 +884,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flush_pushes_transient_rows_and_deletes_on_success() {
+    async fn flush_pushes_transient_rows_and_keeps_them_for_sm_ack() {
+        // SM-enabled flush: rows are pushed but stay in storage
+        // claimed by the SM session until `delete_acked_through` is
+        // called by the SM ack handler.
         let storage: Arc<dyn PendingDeliveryStorage> =
             Arc::new(InMemoryPendingDeliveryStorage::unlimited());
-        // Insert two transient rows.
         for body in ["one", "two"] {
             storage
                 .insert(transient_row("alice@example.com", body))
@@ -805,7 +897,71 @@ mod tests {
                 .unwrap();
         }
 
-        // Wire a registered connection so send_to actually has a sink.
+        let registry = ConnectionRegistry::new();
+        let resource = full("alice@example.com/web");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        registry.register(resource.clone(), tx);
+
+        let sm_session = SmSessionId::new("sm-stream-uuid-1");
+        let outcome = flush_for_resource(
+            &storage,
+            &registry,
+            "example.com",
+            &bare("alice@example.com"),
+            &resource,
+            Some(&sm_session),
+            &NullArchiveResolver,
+        )
+        .await;
+        assert_eq!(outcome.claimed, 2);
+        assert_eq!(outcome.pushed, 2);
+        assert_eq!(outcome.unresolved, 0);
+
+        let mut received = Vec::new();
+        while let Ok(stanza) = rx.try_recv() {
+            received.push(stanza);
+        }
+        assert_eq!(received.len(), 2);
+
+        // Locked Q7b SM-ack lifecycle: rows stay in storage tagged
+        // `flushed_in_session` after push; deletion happens on SM
+        // `<a h>` ack via `delete_acked_through`, NOT on send.
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 2);
+        let listed = storage.list(&bare("alice@example.com")).await.unwrap();
+        for row in &listed {
+            assert_eq!(
+                row.flushed_in_session.as_ref(),
+                Some(&sm_session),
+                "row claimed by the recovering SM session until SM-ack"
+            );
+        }
+        let row_ids: std::collections::HashSet<_> = received
+            .iter()
+            .filter_map(|o| o.pending_row_id.clone())
+            .collect();
+        assert_eq!(
+            row_ids.len(),
+            2,
+            "every flush stanza carries its pending_row_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_non_sm_session_deletes_on_push() {
+        // Codex review on PR #358: when the recovering connection has
+        // NOT enabled XEP-0198, the SM ack handler will never fire to
+        // delete claimed rows. The flush function must fall back to
+        // delete-on-push so the queue doesn't leak forever for non-SM
+        // clients.
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        for body in ["one", "two"] {
+            storage
+                .insert(transient_row("alice@example.com", body))
+                .await
+                .unwrap();
+        }
+
         let registry = ConnectionRegistry::new();
         let resource = full("alice@example.com/web");
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
@@ -817,12 +973,12 @@ mod tests {
             "example.com",
             &bare("alice@example.com"),
             &resource,
+            None, // ← no SM session: delete-on-push fallback
             &NullArchiveResolver,
         )
         .await;
         assert_eq!(outcome.claimed, 2);
         assert_eq!(outcome.pushed, 2);
-        assert_eq!(outcome.unresolved, 0);
 
         // Both messages were sent on the wire.
         let mut received = Vec::new();
@@ -831,33 +987,9 @@ mod tests {
         }
         assert_eq!(received.len(), 2);
 
-        // Locked Q7b SM-ack lifecycle (issue #209 PR #347): rows
-        // stay in storage tagged `flushed_in_session` after push;
-        // deletion happens on SM `<a h>` ack via
-        // `delete_acked_through`, NOT on send. Verify the rows are
-        // claimed by the resource session and have NOT been deleted
-        // by the flush itself.
-        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 2);
-        let listed = storage.list(&bare("alice@example.com")).await.unwrap();
-        for row in &listed {
-            assert!(
-                row.flushed_in_session.is_some(),
-                "row stays claimed by recovering session until SM-ack"
-            );
-        }
-        // Each pushed OutboundStanza carries the row id so the
-        // recipient's main loop can stamp `outbound_sequence` after
-        // its `record_outbound`. The pending stanzas in `received`
-        // correspond to the claimed rows.
-        let row_ids: std::collections::HashSet<_> = received
-            .iter()
-            .filter_map(|o| o.pending_row_id.clone())
-            .collect();
-        assert_eq!(
-            row_ids.len(),
-            2,
-            "every flush stanza carries its pending_row_id"
-        );
+        // Non-SM fallback: rows are deleted on Sent (no ack will ever
+        // fire). Storage is empty.
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
     }
 
     #[tokio::test]
@@ -873,12 +1005,14 @@ mod tests {
         let registry = ConnectionRegistry::new();
         let resource = full("alice@example.com/web");
 
+        let sm_session = SmSessionId::new("sm-stream-uuid-1");
         let outcome = flush_for_resource(
             &storage,
             &registry,
             "example.com",
             &bare("alice@example.com"),
             &resource,
+            Some(&sm_session),
             &NullArchiveResolver,
         )
         .await;
@@ -1021,12 +1155,14 @@ mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(8);
         registry.register(resource.clone(), tx);
 
+        let session_id = waddle_xmpp::pending_delivery::SmSessionId::new("sm-stream-uuid-7");
         let outcome = flush_for_resource(
             &storage,
             &registry,
             "example.com",
             &bare("alice@example.com"),
             &resource,
+            Some(&session_id),
             &NullArchiveResolver,
         )
         .await;
@@ -1047,7 +1183,6 @@ mod tests {
         assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
 
         // Pre-ack with h=6 (covers earlier stanzas, not this one).
-        let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(resource.to_string());
         let removed = storage.delete_acked_through(&session_id, 6).await.unwrap();
         assert_eq!(removed, 0, "ack(h=6) does not cover h=7 row");
         assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
@@ -1084,12 +1219,14 @@ mod tests {
         let (tx_a, mut rx_a) = tokio::sync::mpsc::channel(8);
         registry.register(resource_a.clone(), tx_a);
 
+        let session_a = waddle_xmpp::pending_delivery::SmSessionId::new("sm-stream-laptop-uuid");
         let outcome = flush_for_resource(
             &storage,
             &registry,
             "example.com",
             &bare("alice@example.com"),
             &resource_a,
+            Some(&session_a),
             &NullArchiveResolver,
         )
         .await;
@@ -1101,20 +1238,30 @@ mod tests {
 
         // Session-A dies pre-ack — the SM janitor's release_claim
         // restores the row to the unclaimed pool.
-        let session_a = waddle_xmpp::pending_delivery::SmSessionId::new(resource_a.to_string());
         let released = storage.release_claim(&session_a).await.unwrap();
         assert_eq!(released, 1);
 
-        // Second resource comes online and claims for itself.
+        // Verify release_claim cleared outbound_sequence too — a
+        // stale value would let session-B's first ack delete the row
+        // before it even pushes (Qodo review on PR #358).
+        let after_release = storage.list(&bare("alice@example.com")).await.unwrap();
+        assert_eq!(after_release.len(), 1);
+        assert!(after_release[0].outbound_sequence.is_none());
+        assert!(after_release[0].flushed_in_session.is_none());
+
+        // Second resource comes online and claims for itself with a
+        // distinct SM session id (different XEP-0198 stream).
         let resource_b = full("alice@example.com/web");
         let (tx_b, mut rx_b) = tokio::sync::mpsc::channel(8);
         registry.register(resource_b.clone(), tx_b);
+        let session_b = waddle_xmpp::pending_delivery::SmSessionId::new("sm-stream-web-uuid");
         let outcome = flush_for_resource(
             &storage,
             &registry,
             "example.com",
             &bare("alice@example.com"),
             &resource_b,
+            Some(&session_b),
             &NullArchiveResolver,
         )
         .await;

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -12,15 +12,21 @@
 //! - **Q7a/Q7d** — caller (presence handler) gates this on the first
 //!   non-negative-priority presence of a fresh session via
 //!   [`ConnectionEntry::claim_offline_flush`].
+//! - **Q7b** — SM-ack-keyed deletion. The flush no longer deletes
+//!   rows on push; it tags each [`OutboundStanza`] with its source
+//!   [`PendingRowId`] so the recipient's main loop can stamp the
+//!   assigned XEP-0198 outbound counter via
+//!   [`PendingDeliveryStorage::record_pushed_at`]. Rows are deleted
+//!   only on SM `<a h>` ack via
+//!   [`PendingDeliveryStorage::delete_acked_through`].
 //! - **Q7c** — `claim_for_session` atomically tags rows with the
 //!   recipient's resource so a concurrent presence from another
-//!   resource sees an empty pool.
+//!   resource sees an empty pool. On pre-ack session death the SM
+//!   janitor / shutdown drain calls
+//!   [`PendingDeliveryStorage::release_claim`] to restore the rows
+//!   for re-flush by the next recovering resource.
 //! - **Q5** — wire shape (`<delay/>` with original receipt time, server
 //!   `from`, preserved `to`/extensions, no `<stanza-id/>` for Transient).
-//! - **Q7b (partial)** — currently rows are deleted on send rather than
-//!   on SM-ack. Full SM-ack-keyed lifecycle lands with slice (d) (SM
-//!   persistence). Re-flush after pre-ack session death (Q7c) requires
-//!   the SM-ack lifecycle and is therefore TODO with the same slice.
 
 use std::sync::Arc;
 
@@ -108,31 +114,29 @@ where
         };
         let replay = build_replay_stanza(payload, server_domain, row.original_receipt_at);
         let stanza = Stanza::Message(replay);
-        match registry.send_to(resource, stanza).await {
+        // Locked Q7b SM-ack lifecycle: do NOT delete on push. Tag the
+        // outbound stanza with the source row id so the recipient's
+        // main loop can bind the assigned XEP-0198 outbound counter
+        // back to the row via `record_pushed_at`. The row is then
+        // deleted only when an SM `<a h>` from the recovering session
+        // covers `outbound_sequence` (handled in the SM ack path,
+        // `delete_acked_through`).
+        match registry
+            .send_pending_flush(resource, stanza, row.id.clone())
+            .await
+        {
             SendResult::Sent => {
                 outcome.pushed += 1;
-                // SLICE (d) TODO: defer deletion until SM-ack of the
-                // flush stanza (locked Q7b). Until SM session
-                // persistence lands, delete on push so a successful
-                // flush doesn't re-deliver on the next presence
-                // update. The MAM catch-up path (Q10a) still recovers
-                // Archived rows on crash; Transient rows are by-design
-                // ephemeral on crash.
-                if let Err(error) = storage.delete_row(&row.id).await {
-                    warn!(
-                        row_id = %row.id,
-                        error = %error,
-                        "pending_delivery delete_row (delivered) failed; \
-                         row may re-deliver on next presence"
-                    );
-                }
+                // Row stays claimed by `session_id` with
+                // `outbound_sequence = NULL` until the recipient's
+                // main loop stamps it via `record_pushed_at`. If the
+                // session dies before push, `release_claim` clears
+                // the claim for re-flush (Q7c).
             }
             other => {
                 debug!(?other, row_id = %row.id, "send to recovering resource failed mid-flush");
                 // Per-row release so an undelivered row stays eligible
-                // for re-claim on the next flush trigger, while
-                // delivered rows in the same batch were already
-                // deleted above (partial-success correctness).
+                // for re-claim on the next flush trigger.
                 if let Err(error) = storage.release_row(&row.id).await {
                     warn!(
                         row_id = %row.id,
@@ -269,7 +273,11 @@ type RecipientLockMap = dashmap::DashMap<BareJid, std::sync::Arc<tokio::sync::Mu
 ///     archive_stanza_by TEXT,             -- bare jid stamping `<stanza-id/>`
 ///     archive_stanza_id TEXT,             -- XEP-0359 id (Archived rows)
 ///     transient_xml TEXT,                 -- serialized minidom (Transient)
-///     flushed_in_session TEXT
+///     flushed_in_session TEXT,
+///     outbound_sequence INTEGER           -- XEP-0198 outbound counter,
+///                                         -- stamped post-record_outbound
+///                                         -- so SM `<a h>` can range-delete
+///                                         -- (locked Q7b SM-ack lifecycle)
 /// );
 /// ```
 ///
@@ -338,7 +346,8 @@ impl DatabasePendingDeliveryStorage {
                 archive_stanza_by TEXT,
                 archive_stanza_id TEXT,
                 transient_xml TEXT,
-                flushed_in_session TEXT
+                flushed_in_session TEXT,
+                outbound_sequence INTEGER
             )
             "#,
             (),
@@ -438,6 +447,12 @@ impl DatabasePendingDeliveryStorage {
         let flushed_in_session: Option<String> = row
             .get(7)
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let outbound_sequence_i64: Option<i64> = row
+            .get(8)
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let outbound_sequence = outbound_sequence_i64
+            .map(|v| u32::try_from(v).map_err(|e| PendingStorageError::Other(e.to_string())))
+            .transpose()?;
 
         let payload = match payload_kind.as_str() {
             PAYLOAD_KIND_ARCHIVED => {
@@ -479,6 +494,7 @@ impl DatabasePendingDeliveryStorage {
             original_receipt_at,
             payload,
             flushed_in_session: flushed_in_session.map(SmSessionId::new),
+            outbound_sequence,
         })
     }
 }
@@ -530,8 +546,9 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                 self.execute(
                     "INSERT INTO pending_delivery (\
                         row_id, recipient_jid, original_receipt_at, payload_kind, \
-                        archive_stanza_by, archive_stanza_id, transient_xml, flushed_in_session \
-                     ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)",
+                        archive_stanza_by, archive_stanza_id, transient_xml, \
+                        flushed_in_session, outbound_sequence \
+                     ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL)",
                     crate::db_params![
                         row_id,
                         row.recipient.to_string(),
@@ -548,9 +565,10 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                 self.execute(
                     "INSERT INTO pending_delivery (\
                         row_id, recipient_jid, original_receipt_at, payload_kind, \
-                        archive_stanza_by, archive_stanza_id, transient_xml, flushed_in_session \
+                        archive_stanza_by, archive_stanza_id, transient_xml, \
+                        flushed_in_session, outbound_sequence \
                      ) \
-                     SELECT ?, ?, ?, ?, ?, ?, ?, NULL \
+                     SELECT ?, ?, ?, ?, ?, ?, ?, NULL, NULL \
                      WHERE (SELECT COUNT(*) FROM pending_delivery WHERE recipient_jid = ?) < ?",
                     crate::db_params![
                         row_id,
@@ -578,7 +596,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let mut rows = self
             .query(
                 "SELECT row_id, recipient_jid, original_receipt_at, payload_kind, \
-                        archive_stanza_by, archive_stanza_id, transient_xml, flushed_in_session \
+                        archive_stanza_by, archive_stanza_id, transient_xml, \
+                        flushed_in_session, outbound_sequence \
                  FROM pending_delivery \
                  WHERE recipient_jid = ? \
                  ORDER BY row_id ASC",
@@ -617,7 +636,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let mut rows = self
             .query(
                 "SELECT row_id, recipient_jid, original_receipt_at, payload_kind, \
-                        archive_stanza_by, archive_stanza_id, transient_xml, flushed_in_session \
+                        archive_stanza_by, archive_stanza_id, transient_xml, \
+                        flushed_in_session, outbound_sequence \
                  FROM pending_delivery \
                  WHERE recipient_jid = ? AND flushed_in_session = ? \
                  ORDER BY row_id ASC",
@@ -664,6 +684,33 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         self.execute(
             "UPDATE pending_delivery SET flushed_in_session = NULL WHERE row_id = ?",
             crate::db_params![id.as_str().to_string()],
+        )
+        .await
+    }
+
+    async fn record_pushed_at(
+        &self,
+        id: &PendingRowId,
+        sequence: u32,
+    ) -> Result<u64, PendingStorageError> {
+        self.execute(
+            "UPDATE pending_delivery SET outbound_sequence = ? WHERE row_id = ?",
+            crate::db_params![i64::from(sequence), id.as_str().to_string()],
+        )
+        .await
+    }
+
+    async fn delete_acked_through(
+        &self,
+        session: &SmSessionId,
+        sequence_max: u32,
+    ) -> Result<u64, PendingStorageError> {
+        self.execute(
+            "DELETE FROM pending_delivery \
+             WHERE flushed_in_session = ? \
+               AND outbound_sequence IS NOT NULL \
+               AND outbound_sequence <= ?",
+            crate::db_params![session.as_str().to_string(), i64::from(sequence_max)],
         )
         .await
     }
@@ -725,6 +772,7 @@ mod tests {
             original_receipt_at: Utc::now(),
             payload: PendingPayload::Transient(Box::new(m)),
             flushed_in_session: None,
+            outbound_sequence: None,
         }
     }
 
@@ -783,9 +831,33 @@ mod tests {
         }
         assert_eq!(received.len(), 2);
 
-        // Rows have been deleted on successful push (slice (d) will
-        // shift this to SM-ack-keyed deletion).
-        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+        // Locked Q7b SM-ack lifecycle (issue #209 PR #347): rows
+        // stay in storage tagged `flushed_in_session` after push;
+        // deletion happens on SM `<a h>` ack via
+        // `delete_acked_through`, NOT on send. Verify the rows are
+        // claimed by the resource session and have NOT been deleted
+        // by the flush itself.
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 2);
+        let listed = storage.list(&bare("alice@example.com")).await.unwrap();
+        for row in &listed {
+            assert!(
+                row.flushed_in_session.is_some(),
+                "row stays claimed by recovering session until SM-ack"
+            );
+        }
+        // Each pushed OutboundStanza carries the row id so the
+        // recipient's main loop can stamp `outbound_sequence` after
+        // its `record_outbound`. The pending stanzas in `received`
+        // correspond to the claimed rows.
+        let row_ids: std::collections::HashSet<_> = received
+            .iter()
+            .filter_map(|o| o.pending_row_id.clone())
+            .collect();
+        assert_eq!(
+            row_ids.len(),
+            2,
+            "every flush stanza carries its pending_row_id"
+        );
     }
 
     #[tokio::test]
@@ -840,6 +912,7 @@ mod tests {
                 id: StanzaIdValue::new("mam-id"),
             }),
             flushed_in_session: None,
+            outbound_sequence: None,
         };
         let trans = transient_row("alice@example.com", "transient body");
         assert_eq!(
@@ -924,5 +997,129 @@ mod tests {
         let removed = storage.delete_claimed(&session2).await.unwrap();
         assert_eq!(removed, 3);
         assert_eq!(storage.count(&recipient).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn pending_row_deleted_only_after_sm_ack() {
+        // Q7b end-to-end (issue #209 PR #347):
+        // 1. Insert a transient row.
+        // 2. Flush to a registered resource — row is claimed + pushed
+        //    (OutboundStanza in the channel) but stays in storage.
+        // 3. Simulate the recipient main loop's `record_pushed_at`
+        //    after `record_outbound`.
+        // 4. Simulate an SM `<a h>` ack via `delete_acked_through`.
+        // 5. Verify the row is now gone.
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        storage
+            .insert(transient_row("alice@example.com", "hi"))
+            .await
+            .unwrap();
+
+        let registry = ConnectionRegistry::new();
+        let resource = full("alice@example.com/web");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+        registry.register(resource.clone(), tx);
+
+        let outcome = flush_for_resource(
+            &storage,
+            &registry,
+            "example.com",
+            &bare("alice@example.com"),
+            &resource,
+            &NullArchiveResolver,
+        )
+        .await;
+        assert_eq!(outcome.pushed, 1);
+        // Row stays in storage post-flush, claimed by this session.
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+        let pushed = rx.try_recv().expect("flush stanza pushed to channel");
+        let row_id = pushed
+            .pending_row_id
+            .clone()
+            .expect("flush stanza carries source row id");
+
+        // Recipient main loop simulation: after `record_outbound`
+        // assigns SM outbound counter (say h=7), bind it to the row.
+        storage.record_pushed_at(&row_id, 7).await.unwrap();
+
+        // Pre-ack: row is still there.
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+
+        // Pre-ack with h=6 (covers earlier stanzas, not this one).
+        let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(resource.to_string());
+        let removed = storage.delete_acked_through(&session_id, 6).await.unwrap();
+        assert_eq!(removed, 0, "ack(h=6) does not cover h=7 row");
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+
+        // SM ack arrives covering h=7.
+        let removed = storage.delete_acked_through(&session_id, 7).await.unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(
+            storage.count(&bare("alice@example.com")).await.unwrap(),
+            0,
+            "row deleted only after SM-ack (locked Q7b)"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_row_released_on_pre_ack_session_death() {
+        // Q7c end-to-end (issue #209 PR #347):
+        // 1. Insert a row + flush via session-A.
+        // 2. Stamp it with outbound_sequence (push happened).
+        // 3. Session-A dies BEFORE the recipient's SM `<a h>` ack
+        //    arrives (e.g. socket dropped). `release_claim(session_A)`
+        //    is called by the SM janitor / shutdown drain.
+        // 4. A second resource (session-B) recovers and re-claims —
+        //    the released row must be eligible.
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        storage
+            .insert(transient_row("alice@example.com", "hi"))
+            .await
+            .unwrap();
+
+        let registry = ConnectionRegistry::new();
+        let resource_a = full("alice@example.com/laptop");
+        let (tx_a, mut rx_a) = tokio::sync::mpsc::channel(8);
+        registry.register(resource_a.clone(), tx_a);
+
+        let outcome = flush_for_resource(
+            &storage,
+            &registry,
+            "example.com",
+            &bare("alice@example.com"),
+            &resource_a,
+            &NullArchiveResolver,
+        )
+        .await;
+        assert_eq!(outcome.pushed, 1);
+        let pushed = rx_a.try_recv().expect("flush stanza pushed");
+        let row_id = pushed.pending_row_id.clone().unwrap();
+        // Recipient stamped sequence, but no SM-ack arrives.
+        storage.record_pushed_at(&row_id, 3).await.unwrap();
+
+        // Session-A dies pre-ack — the SM janitor's release_claim
+        // restores the row to the unclaimed pool.
+        let session_a = waddle_xmpp::pending_delivery::SmSessionId::new(resource_a.to_string());
+        let released = storage.release_claim(&session_a).await.unwrap();
+        assert_eq!(released, 1);
+
+        // Second resource comes online and claims for itself.
+        let resource_b = full("alice@example.com/web");
+        let (tx_b, mut rx_b) = tokio::sync::mpsc::channel(8);
+        registry.register(resource_b.clone(), tx_b);
+        let outcome = flush_for_resource(
+            &storage,
+            &registry,
+            "example.com",
+            &bare("alice@example.com"),
+            &resource_b,
+            &NullArchiveResolver,
+        )
+        .await;
+        assert_eq!(outcome.pushed, 1, "row re-flushed to recovering resource-B");
+        let pushed_b = rx_b.try_recv().expect("flush stanza pushed to resource-B");
+        assert_eq!(pushed_b.pending_row_id.unwrap(), row_id, "same row");
     }
 }

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -1269,4 +1269,51 @@ mod tests {
         let pushed_b = rx_b.try_recv().expect("flush stanza pushed to resource-B");
         assert_eq!(pushed_b.pending_row_id.unwrap(), row_id, "same row");
     }
+
+    #[tokio::test]
+    async fn ack_before_record_pushed_at_skips_unsequenced_row() {
+        // Greptile review on PR #358: documents the storage-layer
+        // contract that motivates the `record_pushed_at` /
+        // `delete_acked_through` ordering rule in the websocket main
+        // loop. If `delete_acked_through` runs while a freshly-claimed
+        // row's `outbound_sequence` is still NULL, the row is skipped
+        // (correct: NULL means "not yet pushed, no h-coverage
+        // possible"). The websocket main loop guarantees the
+        // record_pushed_at completes before the next inbound frame
+        // (including the SM ack) is processed by awaiting it inline
+        // — this test pins down the storage semantics so a future
+        // refactor that re-introduces async stamping breaks visibly.
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        storage
+            .insert(transient_row("alice@example.com", "hi"))
+            .await
+            .unwrap();
+        let session = waddle_xmpp::pending_delivery::SmSessionId::new("sm-stream");
+        let claimed = storage
+            .claim_for_session(&bare("alice@example.com"), &session)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        let row_id = claimed[0].id.clone();
+        // Ack runs before record_pushed_at — outbound_sequence is
+        // NULL so the row is skipped. This is the failure mode
+        // Greptile flagged when both calls were spawned: the row
+        // would persist claimed-but-never-acked until session death.
+        let removed = storage.delete_acked_through(&session, 100).await.unwrap();
+        assert_eq!(
+            removed, 0,
+            "NULL outbound_sequence is skipped by delete_acked_through"
+        );
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+
+        // Now record_pushed_at fires (inline ordering would have done
+        // this BEFORE the ack). A subsequent ack covering the same
+        // h DOES delete the row. This proves recovery — the next ack
+        // after the stamp completes the cleanup.
+        storage.record_pushed_at(&row_id, 50).await.unwrap();
+        let removed = storage.delete_acked_through(&session, 50).await.unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+    }
 }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1391,6 +1391,28 @@ async fn create_router(
                         .sm_session_registry
                         .confirm_drained(&session.stream_id)
                         .await;
+                    // Locked Q7c re-flush (issue #209): release any
+                    // `pending_delivery` rows still claimed by this
+                    // session so the next recovering resource can
+                    // re-flush them. The flush path uses
+                    // `SmSessionId::new(resource.to_string())` for
+                    // claim_for_session; mirror that here.
+                    let session_id =
+                        waddle_xmpp::pending_delivery::SmSessionId::new(session.jid.to_string());
+                    if let Err(error) = state
+                        .deps
+                        .protocol
+                        .pending_delivery_storage
+                        .release_claim(&session_id)
+                        .await
+                    {
+                        warn!(
+                            jid = %session.jid,
+                            error = %error,
+                            "SM janitor: pending_delivery release_claim failed; \
+                             rows remain claimed and will be released by claim-expiry janitor"
+                        );
+                    }
 
                     if session.presence_available {
                         routes::websocket::handlers::presence::broadcast_unavailable_for_expired_detached_session(
@@ -1577,6 +1599,29 @@ async fn create_router(
                         .sm_session_registry
                         .confirm_drained(&session.stream_id)
                         .await;
+                    // Locked Q7c re-flush (issue #209): release any
+                    // `pending_delivery` rows still claimed by this
+                    // session. On restart, the recovering resource
+                    // gets a fresh `SmSessionId`, and these now-
+                    // unclaimed rows will be picked up by its first
+                    // `claim_for_session`.
+                    let session_id =
+                        waddle_xmpp::pending_delivery::SmSessionId::new(session.jid.to_string());
+                    if let Err(error) = drain_state
+                        .deps
+                        .protocol
+                        .pending_delivery_storage
+                        .release_claim(&session_id)
+                        .await
+                    {
+                        warn!(
+                            jid = %session.jid,
+                            error = %error,
+                            "Graceful shutdown: pending_delivery release_claim failed; \
+                             rows remain claimed and will be released by next-startup \
+                             claim-expiry janitor"
+                        );
+                    }
                 }
                 tokio::time::sleep(POLL_INTERVAL).await;
             }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1393,12 +1393,14 @@ async fn create_router(
                         .await;
                     // Locked Q7c re-flush (issue #209): release any
                     // `pending_delivery` rows still claimed by this
-                    // session so the next recovering resource can
-                    // re-flush them. The flush path uses
-                    // `SmSessionId::new(resource.to_string())` for
-                    // claim_for_session; mirror that here.
+                    // SM session so the next recovering resource can
+                    // re-flush them. Key by XEP-0198 stream_id —
+                    // matches what flush_for_resource uses (Codex/
+                    // Qodo review on PR #358: keying by JID would
+                    // conflate distinct SM sessions on the same
+                    // resource).
                     let session_id =
-                        waddle_xmpp::pending_delivery::SmSessionId::new(session.jid.to_string());
+                        waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone());
                     if let Err(error) = state
                         .deps
                         .protocol
@@ -1408,6 +1410,7 @@ async fn create_router(
                     {
                         warn!(
                             jid = %session.jid,
+                            stream_id = %session.stream_id,
                             error = %error,
                             "SM janitor: pending_delivery release_claim failed; \
                              rows remain claimed and will be released by claim-expiry janitor"
@@ -1601,12 +1604,14 @@ async fn create_router(
                         .await;
                     // Locked Q7c re-flush (issue #209): release any
                     // `pending_delivery` rows still claimed by this
-                    // session. On restart, the recovering resource
-                    // gets a fresh `SmSessionId`, and these now-
-                    // unclaimed rows will be picked up by its first
+                    // SM session. Key by XEP-0198 stream_id (Codex/
+                    // Qodo review on PR #358). On restart, the
+                    // recovering resource gets a fresh
+                    // `SmSessionId`, and these now-unclaimed rows
+                    // will be picked up by its first
                     // `claim_for_session`.
                     let session_id =
-                        waddle_xmpp::pending_delivery::SmSessionId::new(session.jid.to_string());
+                        waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone());
                     if let Err(error) = drain_state
                         .deps
                         .protocol
@@ -1616,6 +1621,7 @@ async fn create_router(
                     {
                         warn!(
                             jid = %session.jid,
+                            stream_id = %session.stream_id,
                             error = %error,
                             "Graceful shutdown: pending_delivery release_claim failed; \
                              rows remain claimed and will be released by next-startup \

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -1073,6 +1073,7 @@ async fn interpret_with_depth(
                     original_receipt_at,
                     payload,
                     flushed_in_session: None,
+                    outbound_sequence: None,
                 };
                 match storage.insert(row).await {
                     Ok(waddle_xmpp::pending_delivery::InsertOutcome::Inserted) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -1446,12 +1446,21 @@ async fn maybe_flush_pending_delivery(state: &WebSocketState, sender_jid: &FullJ
     let resolver = crate::pending_delivery::MamArchiveResolver {
         mam_storage: std::sync::Arc::clone(&state.deps.protocol.mam_storage),
     };
+    // Locked Q7b SM-ack lifecycle (issue #209): when the recovering
+    // connection has an active XEP-0198 session, key claims by its
+    // stream id so a subsequent `<a h>` from the same session deletes
+    // exactly its acked rows. Without SM, the flush function falls
+    // back to delete-on-push (no ack will ever fire).
+    let sm_session_id = entry
+        .sm_stream_id()
+        .map(waddle_xmpp::pending_delivery::SmSessionId::new);
     let outcome = crate::pending_delivery::flush_for_resource(
         &state.deps.protocol.pending_delivery_storage,
         &state.deps.protocol.connection_registry,
         state.deps.auth_state.xmpp_domain.as_str(),
         &recipient_bare,
         sender_jid,
+        sm_session_id.as_ref(),
         &resolver,
     )
     .await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -1451,9 +1451,7 @@ async fn maybe_flush_pending_delivery(state: &WebSocketState, sender_jid: &FullJ
     // stream id so a subsequent `<a h>` from the same session deletes
     // exactly its acked rows. Without SM, the flush function falls
     // back to delete-on-push (no ack will ever fire).
-    let sm_session_id = entry
-        .sm_stream_id()
-        .map(waddle_xmpp::pending_delivery::SmSessionId::new);
+    let sm_session_id = entry.sm_stream_id();
     let outcome = crate::pending_delivery::flush_for_resource(
         &state.deps.protocol.pending_delivery_storage,
         &state.deps.protocol.connection_registry,

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -638,8 +638,43 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                 // PR1–PR10 semantic, byte-for-byte
                                 // unchanged.
                                 let xml = stanza_to_xml(&outbound_stanza.stanza);
+                                let pending_row_id = outbound_stanza.pending_row_id.clone();
                                 if conn.sm_state.enabled && is_countable_stanza(&xml) {
                                     conn.sm_state.record_outbound(xml.clone());
+                                    // Locked Q7b SM-ack lifecycle: when
+                                    // this is a `pending_delivery` flush
+                                    // replay, bind the just-assigned
+                                    // outbound counter back onto the
+                                    // source row so a subsequent SM
+                                    // `<a h>` ack can range-delete it
+                                    // via `delete_acked_through`. If
+                                    // SM is disabled or the stanza
+                                    // isn't countable (rare for replay
+                                    // messages), the row stays claimed
+                                    // and is released on session death
+                                    // for re-flush (Q7c).
+                                    if let Some(row_id) = pending_row_id {
+                                        let storage = state
+                                            .deps
+                                            .protocol
+                                            .pending_delivery_storage
+                                            .clone();
+                                        let sequence = conn.sm_state.outbound_count;
+                                        tokio::spawn(async move {
+                                            if let Err(error) =
+                                                storage.record_pushed_at(&row_id, sequence).await
+                                            {
+                                                warn!(
+                                                    row_id = %row_id,
+                                                    sequence,
+                                                    error = %error,
+                                                    "pending_delivery record_pushed_at \
+                                                     failed; row remains claimed but unsequenced \
+                                                     and will be released on session death"
+                                                );
+                                            }
+                                        });
+                                    }
                                 }
                                 if !send_ws_message(
                                     &mut ws_sender,
@@ -1654,6 +1689,44 @@ async fn handle_sm_stanza(sm: SmStanza, state: &WebSocketState, ctx: SmCtx<'_>) 
         SmStanza::Request => vec![SmAck::new(ctx.sm_state.get_inbound_count()).to_xml()],
         SmStanza::Ack(ack) => {
             ctx.sm_state.acknowledge(ack.h);
+            // Locked Q7b SM-ack lifecycle (issue #209): range-delete
+            // every `pending_delivery` row claimed by this session
+            // whose recorded outbound counter is <= `ack.h`. This is
+            // what actually frees the row from the durable queue —
+            // the flush path no longer deletes on push (PR #346 left
+            // the row claimed; we used to ALSO delete in flush, but
+            // that defeated the durability guarantee for the push-to-
+            // ack window). The session id is the same value the
+            // flush function uses for `claim_for_session`:
+            // `SmSessionId::new(resource.to_string())`.
+            if let Some(full_jid) = ctx.phase.bound_jid().cloned() {
+                let session_id =
+                    waddle_xmpp::pending_delivery::SmSessionId::new(full_jid.to_string());
+                let storage = state.deps.protocol.pending_delivery_storage.clone();
+                let h = ack.h;
+                tokio::spawn(async move {
+                    match storage.delete_acked_through(&session_id, h).await {
+                        Ok(removed) if removed > 0 => {
+                            debug!(
+                                session = %session_id,
+                                h,
+                                removed,
+                                "pending_delivery rows cleared by SM ack"
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            warn!(
+                                session = %session_id,
+                                h,
+                                error = %error,
+                                "pending_delivery delete_acked_through failed; rows \
+                                 will be retried on next session via release_claim"
+                            );
+                        }
+                    }
+                });
+            }
             vec![]
         }
         SmStanza::Resume(resume) => handle_sm_resume(resume, state, ctx).await,

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -446,6 +446,20 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                     conn.roster_interested,
                                 );
                                 conn.registry_owner = Some(owner.clone());
+                                // Publish the SM stream id onto the freshly-registered entry
+                                // so the offline-flush path keys claims by the XEP-0198
+                                // session id, not the resource JID. Locked Q7b SM-ack
+                                // lifecycle (issue #209). For a fresh bind without SM
+                                // enabled, sm_state.stream_id is None — the flush path
+                                // falls back to delete-on-push for non-SM sessions.
+                                if let Some(entry) = state
+                                    .deps
+                                    .protocol
+                                    .connection_registry
+                                    .get_entry(&jid)
+                                {
+                                    entry.set_sm_stream_id(conn.sm_state.stream_id.clone());
+                                }
                                 if conn.presence_available {
                                     state
                                         .deps
@@ -1685,23 +1699,25 @@ async fn handle_sm_stanza(sm: SmStanza, state: &WebSocketState, ctx: SmCtx<'_>) 
     use waddle_xmpp::stream_management::SmAck;
 
     match sm {
-        SmStanza::Enable(enable) => handle_sm_enable(enable, ctx.sm_state, ctx.phase),
+        SmStanza::Enable(enable) => handle_sm_enable(enable, state, ctx.sm_state, ctx.phase),
         SmStanza::Request => vec![SmAck::new(ctx.sm_state.get_inbound_count()).to_xml()],
         SmStanza::Ack(ack) => {
             ctx.sm_state.acknowledge(ack.h);
             // Locked Q7b SM-ack lifecycle (issue #209): range-delete
-            // every `pending_delivery` row claimed by this session
-            // whose recorded outbound counter is <= `ack.h`. This is
-            // what actually frees the row from the durable queue —
-            // the flush path no longer deletes on push (PR #346 left
-            // the row claimed; we used to ALSO delete in flush, but
-            // that defeated the durability guarantee for the push-to-
-            // ack window). The session id is the same value the
-            // flush function uses for `claim_for_session`:
-            // `SmSessionId::new(resource.to_string())`.
-            if let Some(full_jid) = ctx.phase.bound_jid().cloned() {
-                let session_id =
-                    waddle_xmpp::pending_delivery::SmSessionId::new(full_jid.to_string());
+            // every `pending_delivery` row claimed by this XEP-0198
+            // session whose recorded outbound counter is <= `ack.h`.
+            // This is what actually frees the row from the durable
+            // queue — the flush path no longer deletes on push.
+            //
+            // Session id is the XEP-0198 stream_id (NOT the resource
+            // JID — Qodo review on PR #358: distinct SM sessions on
+            // the same resource share the same JID, so keying by JID
+            // would let one session's ack delete another's claimed
+            // rows). The flush function reads the same stream_id from
+            // the connection's `ConnectionEntry` so claim and delete
+            // agree on the key.
+            if let Some(stream_id) = ctx.sm_state.stream_id.clone() {
+                let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
                 let storage = state.deps.protocol.pending_delivery_storage.clone();
                 let h = ack.h;
                 tokio::spawn(async move {
@@ -1737,6 +1753,7 @@ async fn handle_sm_stanza(sm: SmStanza, state: &WebSocketState, ctx: SmCtx<'_>) 
 
 fn handle_sm_enable(
     enable: SmEnable,
+    state: &WebSocketState,
     sm_state: &mut StreamManagementState,
     phase: &ConnectionPhase,
 ) -> Vec<String> {
@@ -1759,6 +1776,18 @@ fn handle_sm_enable(
         .map(|m| m.min(MAX_RESUME_SECS))
         .unwrap_or(MAX_RESUME_SECS);
     sm_state.enable(stream_id.clone(), enable.resume, Some(max));
+
+    // Publish the stream id onto the registry's ConnectionEntry so
+    // the offline-flush path can claim `pending_delivery` rows under
+    // a session id that's unique to this XEP-0198 session (not just
+    // the resource JID — distinct SM sessions on the same resource
+    // would otherwise share the same key, causing cross-session row
+    // deletion). Locked Q7b SM-ack lifecycle (issue #209).
+    if let Some(jid) = phase.bound_jid() {
+        if let Some(entry) = state.deps.protocol.connection_registry.get_entry(jid) {
+            entry.set_sm_stream_id(Some(stream_id.clone()));
+        }
+    }
 
     info!(stream_id = %stream_id, resume = enable.resume, max = max, "SM enabled");
     if enable.resume {

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -458,7 +458,12 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                     .connection_registry
                                     .get_entry(&jid)
                                 {
-                                    entry.set_sm_stream_id(conn.sm_state.stream_id.clone());
+                                    entry.set_sm_stream_id(
+                                        conn.sm_state
+                                            .stream_id
+                                            .clone()
+                                            .map(waddle_xmpp::pending_delivery::SmSessionId::new),
+                                    );
                                 }
                                 if conn.presence_available {
                                     state
@@ -661,33 +666,37 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                     // outbound counter back onto the
                                     // source row so a subsequent SM
                                     // `<a h>` ack can range-delete it
-                                    // via `delete_acked_through`. If
-                                    // SM is disabled or the stanza
-                                    // isn't countable (rare for replay
-                                    // messages), the row stays claimed
-                                    // and is released on session death
-                                    // for re-flush (Q7c).
+                                    // via `delete_acked_through`.
+                                    //
+                                    // Greptile review on PR #358: this
+                                    // MUST happen synchronously before
+                                    // we yield to the next event so
+                                    // an SM ack frame queued right
+                                    // behind this push doesn't run
+                                    // `delete_acked_through` while the
+                                    // row's `outbound_sequence` is
+                                    // still NULL (which would skip
+                                    // the delete and leave the row
+                                    // claimed indefinitely until the
+                                    // session dies).
                                     if let Some(row_id) = pending_row_id {
-                                        let storage = state
+                                        let sequence = conn.sm_state.outbound_count;
+                                        if let Err(error) = state
                                             .deps
                                             .protocol
                                             .pending_delivery_storage
-                                            .clone();
-                                        let sequence = conn.sm_state.outbound_count;
-                                        tokio::spawn(async move {
-                                            if let Err(error) =
-                                                storage.record_pushed_at(&row_id, sequence).await
-                                            {
-                                                warn!(
-                                                    row_id = %row_id,
-                                                    sequence,
-                                                    error = %error,
-                                                    "pending_delivery record_pushed_at \
-                                                     failed; row remains claimed but unsequenced \
-                                                     and will be released on session death"
-                                                );
-                                            }
-                                        });
+                                            .record_pushed_at(&row_id, sequence)
+                                            .await
+                                        {
+                                            warn!(
+                                                row_id = %row_id,
+                                                sequence,
+                                                error = %error,
+                                                "pending_delivery record_pushed_at \
+                                                 failed; row remains claimed but unsequenced \
+                                                 and will be released on session death"
+                                            );
+                                        }
                                     }
                                 }
                                 if !send_ws_message(
@@ -1716,32 +1725,42 @@ async fn handle_sm_stanza(sm: SmStanza, state: &WebSocketState, ctx: SmCtx<'_>) 
             // rows). The flush function reads the same stream_id from
             // the connection's `ConnectionEntry` so claim and delete
             // agree on the key.
+            // Greptile review on PR #358: this MUST run inline so it
+            // executes after any preceding `record_pushed_at` for the
+            // same connection. Spawning would let a quick ack arrive
+            // and run delete_acked_through against a row whose
+            // outbound_sequence is still NULL (because the
+            // record_pushed_at task hadn't completed), silently
+            // skipping the delete.
             if let Some(stream_id) = ctx.sm_state.stream_id.clone() {
                 let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
-                let storage = state.deps.protocol.pending_delivery_storage.clone();
                 let h = ack.h;
-                tokio::spawn(async move {
-                    match storage.delete_acked_through(&session_id, h).await {
-                        Ok(removed) if removed > 0 => {
-                            debug!(
-                                session = %session_id,
-                                h,
-                                removed,
-                                "pending_delivery rows cleared by SM ack"
-                            );
-                        }
-                        Ok(_) => {}
-                        Err(error) => {
-                            warn!(
-                                session = %session_id,
-                                h,
-                                error = %error,
-                                "pending_delivery delete_acked_through failed; rows \
-                                 will be retried on next session via release_claim"
-                            );
-                        }
+                match state
+                    .deps
+                    .protocol
+                    .pending_delivery_storage
+                    .delete_acked_through(&session_id, h)
+                    .await
+                {
+                    Ok(removed) if removed > 0 => {
+                        debug!(
+                            session = %session_id,
+                            h,
+                            removed,
+                            "pending_delivery rows cleared by SM ack"
+                        );
                     }
-                });
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(
+                            session = %session_id,
+                            h,
+                            error = %error,
+                            "pending_delivery delete_acked_through failed; rows \
+                             will be retried on next session via release_claim"
+                        );
+                    }
+                }
             }
             vec![]
         }
@@ -1785,7 +1804,9 @@ fn handle_sm_enable(
     // deletion). Locked Q7b SM-ack lifecycle (issue #209).
     if let Some(jid) = phase.bound_jid() {
         if let Some(entry) = state.deps.protocol.connection_registry.get_entry(jid) {
-            entry.set_sm_stream_id(Some(stream_id.clone()));
+            entry.set_sm_stream_id(Some(waddle_xmpp::pending_delivery::SmSessionId::new(
+                stream_id.clone(),
+            )));
         }
     }
 

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -318,6 +318,7 @@ async fn insert_pending(
         original_receipt_at,
         payload,
         flushed_in_session: None,
+        outbound_sequence: None,
     };
     match pending_storage.insert(row).await {
         Ok(InsertOutcome::Inserted) => PromotedOutcome::Queued,
@@ -985,6 +986,20 @@ mod tests {
                 Ok(0)
             }
             async fn release_row(&self, _id: &PendingRowId) -> Result<u64, PendingStorageError> {
+                Ok(0)
+            }
+            async fn record_pushed_at(
+                &self,
+                _id: &PendingRowId,
+                _sequence: u32,
+            ) -> Result<u64, PendingStorageError> {
+                Ok(0)
+            }
+            async fn delete_acked_through(
+                &self,
+                _session: &SmSessionId,
+                _sequence_max: u32,
+            ) -> Result<u64, PendingStorageError> {
                 Ok(0)
             }
             async fn count(&self, _recipient: &BareJid) -> Result<u32, PendingStorageError> {

--- a/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
@@ -160,6 +160,7 @@ mod tests {
                 id: StanzaIdValue::new("mam-id"),
             }),
             flushed_in_session: Some(SmSessionId::new("s1")),
+            outbound_sequence: None,
         }
     }
 
@@ -174,6 +175,7 @@ mod tests {
                 body,
             ))),
             flushed_in_session: None,
+            outbound_sequence: None,
         }
     }
 

--- a/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
@@ -142,6 +142,14 @@ pub struct PendingRow {
     /// SM-ack. Released back to `None` on session expiry pre-ack
     /// (Q7c re-flush).
     pub flushed_in_session: Option<SmSessionId>,
+    /// XEP-0198 outbound counter value assigned to this row's flush
+    /// stanza when it was pushed onto the recovering session's
+    /// outbound queue (Q7b). `None` until [`storage::PendingDeliveryStorage::record_pushed_at`]
+    /// stamps it post-`record_outbound`. The SM `<a h='N'/>` ack
+    /// handler uses this to range-delete only rows whose flush stanza
+    /// was actually acknowledged: `flushed_in_session = session AND
+    /// outbound_sequence IS NOT NULL AND outbound_sequence <= N`.
+    pub outbound_sequence: Option<u32>,
 }
 
 /// Quota policy controlling [`storage::PendingDeliveryStorage::insert`]

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -71,6 +71,35 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// push becomes eligible for re-claim on the next flush trigger.
     async fn release_row(&self, id: &PendingRowId) -> Result<u64, PendingStorageError>;
 
+    /// Stamp the XEP-0198 outbound counter value onto a previously-
+    /// claimed row, after that row's flush stanza has been pushed
+    /// onto the recovering session's outbound queue and assigned its
+    /// SM outbound sequence (locked Q7b). Pair with
+    /// [`Self::delete_acked_through`]: an SM `<a h='N'/>` ack from
+    /// the recovering session range-deletes claimed rows whose
+    /// `outbound_sequence <= N`.
+    async fn record_pushed_at(
+        &self,
+        id: &PendingRowId,
+        sequence: u32,
+    ) -> Result<u64, PendingStorageError>;
+
+    /// Range-delete rows previously claimed by `session` whose
+    /// recorded `outbound_sequence <= sequence_max` (locked Q7b
+    /// SM-ack-keyed deletion). The SM ack handler invokes this with
+    /// the `h` value carried in the ack so only stanzas the recovering
+    /// session has actually acknowledged are removed; rows whose
+    /// flush stanzas haven't yet been ack'd stay claimed for a future
+    /// ack. Rows with `outbound_sequence = NULL` (claimed but not yet
+    /// pushed) are intentionally NOT deleted by this call — they are
+    /// either still in the push pipeline or were claimed by a session
+    /// that died pre-push (handled by [`Self::release_claim`]).
+    async fn delete_acked_through(
+        &self,
+        session: &SmSessionId,
+        sequence_max: u32,
+    ) -> Result<u64, PendingStorageError>;
+
     /// Current row count for `recipient` (used by the quota check;
     /// also exposed for metrics).
     async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError>;
@@ -235,6 +264,49 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         Ok(0)
     }
 
+    async fn record_pushed_at(
+        &self,
+        id: &PendingRowId,
+        sequence: u32,
+    ) -> Result<u64, PendingStorageError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        for queue in guard.values_mut() {
+            for row in queue.iter_mut() {
+                if &row.id == id {
+                    row.outbound_sequence = Some(sequence);
+                    return Ok(1);
+                }
+            }
+        }
+        Ok(0)
+    }
+
+    async fn delete_acked_through(
+        &self,
+        session: &SmSessionId,
+        sequence_max: u32,
+    ) -> Result<u64, PendingStorageError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let mut removed = 0u64;
+        for queue in guard.values_mut() {
+            let before = queue.len();
+            queue.retain(|row| {
+                let claimed_by_session = row.flushed_in_session.as_ref() == Some(session);
+                let acked = matches!(row.outbound_sequence, Some(seq) if seq <= sequence_max);
+                !(claimed_by_session && acked)
+            });
+            removed += (before - queue.len()) as u64;
+        }
+        guard.retain(|_, q| !q.is_empty());
+        Ok(removed)
+    }
+
     async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError> {
         let guard = self
             .inner
@@ -266,6 +338,7 @@ mod tests {
                 id: StanzaIdValue::new(id),
             }),
             flushed_in_session: None,
+            outbound_sequence: None,
         }
     }
 
@@ -276,6 +349,7 @@ mod tests {
             original_receipt_at: Utc::now(),
             payload: PendingPayload::Transient(Box::new(Message::new(None::<jid::Jid>))),
             flushed_in_session: None,
+            outbound_sequence: None,
         }
     }
 
@@ -419,5 +493,119 @@ mod tests {
     async fn empty_recipient_count_is_zero() {
         let store = InMemoryPendingDeliveryStorage::unlimited();
         assert_eq!(store.count(&bare("nobody@example.com")).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_acked_through_only_removes_acked_session_rows() {
+        // Locked Q7b SM-ack-keyed deletion: an SM `<a h>` ack with
+        // h=N must remove rows where flushed_in_session = current
+        // AND outbound_sequence <= N — and must leave alone:
+        // - rows with outbound_sequence = NULL (claimed but not yet
+        //   pushed),
+        // - rows with outbound_sequence > N (pushed but not yet
+        //   ack'd),
+        // - rows claimed by a different session.
+        let store = InMemoryPendingDeliveryStorage::unlimited();
+        let recipient = bare("alice@example.com");
+        for n in 0..4 {
+            store
+                .insert(archived_row("alice@example.com", &format!("id-{n}")))
+                .await
+                .unwrap();
+        }
+        let session_a = SmSessionId::new("s-a");
+        let claimed = store
+            .claim_for_session(&recipient, &session_a)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 4);
+
+        // Three rows pushed and assigned outbound_sequences 1, 2, 3;
+        // fourth row was claimed but the recipient's main loop never
+        // got around to pushing it (e.g. socket died) — sequence
+        // stays NULL.
+        store.record_pushed_at(&claimed[0].id, 1).await.unwrap();
+        store.record_pushed_at(&claimed[1].id, 2).await.unwrap();
+        store.record_pushed_at(&claimed[2].id, 3).await.unwrap();
+        // claimed[3] left without record_pushed_at.
+
+        // SM ack with h=2 covers the first two only.
+        let removed = store.delete_acked_through(&session_a, 2).await.unwrap();
+        assert_eq!(removed, 2);
+        let remaining = store.list(&recipient).await.unwrap();
+        assert_eq!(remaining.len(), 2);
+        // Surviving rows: the one with outbound_sequence=3 and the
+        // unsequenced one.
+        let mut seen_seq3 = false;
+        let mut seen_unseq = false;
+        for row in &remaining {
+            match row.outbound_sequence {
+                Some(3) => seen_seq3 = true,
+                None => seen_unseq = true,
+                other => panic!("unexpected outbound_sequence: {other:?}"),
+            }
+        }
+        assert!(seen_seq3, "outbound_sequence=3 row survives ack(h=2)");
+        assert!(
+            seen_unseq,
+            "unsequenced (claimed but unpushed) row survives ack"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_acked_through_ignores_other_sessions() {
+        // Two sessions for the same recipient (e.g. parallel
+        // resources): an ack from session A must not affect rows
+        // claimed by session B.
+        let store = InMemoryPendingDeliveryStorage::unlimited();
+        store
+            .insert(archived_row("alice@example.com", "x"))
+            .await
+            .unwrap();
+        let session_a = SmSessionId::new("s-a");
+        let claimed_a = store
+            .claim_for_session(&bare("alice@example.com"), &session_a)
+            .await
+            .unwrap();
+        store.record_pushed_at(&claimed_a[0].id, 5).await.unwrap();
+
+        // A different session's ack with h=10 must not touch
+        // session_a's row.
+        let session_b = SmSessionId::new("s-b");
+        let removed = store.delete_acked_through(&session_b, 10).await.unwrap();
+        assert_eq!(removed, 0);
+        assert_eq!(
+            store.count(&bare("alice@example.com")).await.unwrap(),
+            1,
+            "session_a row preserved"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_pushed_at_is_idempotent_per_row() {
+        // Locked Q7b: outbound_sequence updates are only valid when
+        // they progress forward, but the storage layer is permissive —
+        // it just sets the value. The invariant "first write wins" is
+        // maintained at the call site (the recipient main loop calls
+        // record_outbound exactly once per stanza). Here we verify the
+        // storage layer preserves the latest write.
+        let store = InMemoryPendingDeliveryStorage::unlimited();
+        store
+            .insert(archived_row("alice@example.com", "a"))
+            .await
+            .unwrap();
+        let session = SmSessionId::new("s");
+        let claimed = store
+            .claim_for_session(&bare("alice@example.com"), &session)
+            .await
+            .unwrap();
+        let id = &claimed[0].id;
+        store.record_pushed_at(id, 7).await.unwrap();
+        let rows = store.list(&bare("alice@example.com")).await.unwrap();
+        assert_eq!(rows[0].outbound_sequence, Some(7));
+        // Latest write wins (no monotonicity check at storage layer).
+        store.record_pushed_at(id, 12).await.unwrap();
+        let rows = store.list(&bare("alice@example.com")).await.unwrap();
+        assert_eq!(rows[0].outbound_sequence, Some(12));
     }
 }

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -195,6 +195,12 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         for row in queue.iter_mut() {
             if row.flushed_in_session.is_none() {
                 row.flushed_in_session = Some(session.clone());
+                // Defensive: clear any leftover sequence so the new
+                // claim starts from a known-clean state. release_*
+                // already does this, but a future code path that
+                // leaves a row half-released should not be able to
+                // confuse the SM-ack delete.
+                row.outbound_sequence = None;
                 claimed.push(row.clone());
             }
         }
@@ -232,6 +238,10 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
     }
 
     async fn release_claim(&self, session: &SmSessionId) -> Result<u64, PendingStorageError> {
+        // Clear `outbound_sequence` alongside `flushed_in_session` so
+        // a stale sequence from the dead session can't survive a
+        // re-claim and trick a later session's SM ack into deleting
+        // an unack'd row. (Qodo review on PR #358.)
         let mut guard = self
             .inner
             .lock()
@@ -241,6 +251,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             for row in queue.iter_mut() {
                 if row.flushed_in_session.as_ref() == Some(session) {
                     row.flushed_in_session = None;
+                    row.outbound_sequence = None;
                     released += 1;
                 }
             }
@@ -257,6 +268,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             for row in queue.iter_mut() {
                 if &row.id == id {
                     row.flushed_in_session = None;
+                    row.outbound_sequence = None;
                     return Ok(1);
                 }
             }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -140,16 +140,18 @@ pub struct ConnectionEntry {
     /// Q7d) so subsequent presence updates do not re-flush an already-
     /// drained `pending_delivery` queue (issue #209).
     pub offline_flushed: Arc<AtomicBool>,
-    /// Per-connection XEP-0198 stream id, set when the client enables
-    /// SM (or resumes onto this connection). `None` while SM is
-    /// disabled. Used to key
-    /// [`crate::pending_delivery::SmSessionId`] for the locked Q7b
-    /// SM-ack lifecycle (issue #209): each SM session is a distinct
-    /// id, so reconnect-on-same-resource never collides with the
-    /// dead session's claimed pending_delivery rows. Stored behind
-    /// `Mutex<Option<String>>` so the websocket SM-enable handler can
-    /// publish into it without taking the registry-level lock.
-    pub sm_stream_id: Arc<std::sync::Mutex<Option<String>>>,
+    /// Per-connection XEP-0198 SM session id, set when the client
+    /// enables SM (or resumes onto this connection). `None` while SM
+    /// is disabled. Used directly by the offline-flush path for
+    /// `claim_for_session` so each SM session has a distinct id and
+    /// reconnect-on-same-resource never collides with the dead
+    /// session's claimed pending_delivery rows (locked Q7b
+    /// SM-ack lifecycle, issue #209). Stored as the typed
+    /// [`crate::pending_delivery::SmSessionId`] so the registry
+    /// boundary stays typed end-to-end (Qodo review on PR #358:
+    /// previous `Option<String>` form violated the typed-payloads
+    /// rule).
+    pub sm_stream_id: Arc<std::sync::Mutex<Option<crate::pending_delivery::SmSessionId>>>,
 }
 
 impl ConnectionEntry {
@@ -199,23 +201,23 @@ impl ConnectionEntry {
             .is_ok()
     }
 
-    /// Publish the XEP-0198 SM stream id for this connection. Called
-    /// by the websocket main loop after `<enable/>` (fresh SM session)
-    /// and after `<resume/>` (continuation onto a previously-stored
-    /// stream id). Used to key [`crate::pending_delivery::SmSessionId`]
-    /// for the locked Q7b SM-ack lifecycle.
-    pub fn set_sm_stream_id(&self, stream_id: Option<String>) {
+    /// Publish the XEP-0198 SM session id for this connection.
+    /// Called by the websocket main loop after `<enable/>` (fresh
+    /// SM session) and after `<resume/>` (continuation onto a
+    /// previously-stored session). Used by the offline-flush path
+    /// for `claim_for_session` (locked Q7b SM-ack lifecycle).
+    pub fn set_sm_stream_id(&self, session_id: Option<crate::pending_delivery::SmSessionId>) {
         if let Ok(mut guard) = self.sm_stream_id.lock() {
-            *guard = stream_id;
+            *guard = session_id;
         }
     }
 
-    /// Read the XEP-0198 SM stream id for this connection, if SM is
+    /// Read the XEP-0198 SM session id for this connection, if SM is
     /// enabled. Returns `None` while SM is disabled (no
     /// `pending_delivery` row will be claimed under an SM session id
     /// in that case — the flush falls back to the delete-on-push
     /// path).
-    pub fn sm_stream_id(&self) -> Option<String> {
+    pub fn sm_stream_id(&self) -> Option<crate::pending_delivery::SmSessionId> {
         self.sm_stream_id
             .lock()
             .ok()

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -60,6 +60,16 @@ pub struct OutboundStanza {
     pub stanza: Stanza,
     /// How the destination connection should handle the stanza.
     pub kind: DeliveryKind,
+    /// `pending_delivery` row id when this stanza is the replay of a
+    /// queued offline-delivery row (locked Q7b SM-ack lifecycle). The
+    /// destination's main loop reads this after `record_outbound`
+    /// assigns a new XEP-0198 outbound counter, then stamps the
+    /// counter onto the row via
+    /// [`crate::pending_delivery::storage::PendingDeliveryStorage::record_pushed_at`]
+    /// so a subsequent SM `<a h>` ack can range-delete only those
+    /// rows whose flush stanza was actually acknowledged. `None` for
+    /// every other outbound (the common case).
+    pub pending_row_id: Option<crate::pending_delivery::PendingRowId>,
 }
 
 impl OutboundStanza {
@@ -74,6 +84,7 @@ impl OutboundStanza {
         Self {
             stanza,
             kind: DeliveryKind::DirectFrame,
+            pending_row_id: None,
         }
     }
 
@@ -86,6 +97,24 @@ impl OutboundStanza {
         Self {
             stanza,
             kind: DeliveryKind::PeerStanza,
+            pending_row_id: None,
+        }
+    }
+
+    /// Create an outbound stanza that replays a queued
+    /// `pending_delivery` row to a recovering session (locked Q7b
+    /// SM-ack lifecycle). The destination's main loop uses
+    /// [`Self::pending_row_id`] to bind the stanza's assigned
+    /// XEP-0198 outbound counter back to the row so subsequent SM
+    /// `<a h>` acks can range-delete it.
+    pub fn for_pending_flush(
+        stanza: Stanza,
+        row_id: crate::pending_delivery::PendingRowId,
+    ) -> Self {
+        Self {
+            stanza,
+            kind: DeliveryKind::DirectFrame,
+            pending_row_id: Some(row_id),
         }
     }
 }
@@ -418,6 +447,35 @@ impl ConnectionRegistry {
     pub async fn send_to(&self, jid: &FullJid, stanza: Stanza) -> SendResult {
         self.send_to_with_kind(jid, stanza, DeliveryKind::DirectFrame)
             .await
+    }
+
+    /// Send a [`pending_delivery`](crate::pending_delivery) flush stanza
+    /// to a recovering session. Identical to [`Self::send_to`] except
+    /// the queued [`OutboundStanza`] carries the source row id so the
+    /// destination's main loop can bind the stanza's assigned XEP-0198
+    /// outbound counter back to the row (locked Q7b SM-ack lifecycle).
+    #[instrument(skip(self, stanza), fields(to = %jid, row = %row_id))]
+    pub async fn send_pending_flush(
+        &self,
+        jid: &FullJid,
+        stanza: Stanza,
+        row_id: crate::pending_delivery::PendingRowId,
+    ) -> SendResult {
+        let sender = match self.connections.get(jid) {
+            Some(entry) => entry.value().sender.clone(),
+            None => {
+                debug!("Recipient not connected for pending flush");
+                return SendResult::NotConnected;
+            }
+        };
+        let outbound = OutboundStanza::for_pending_flush(stanza, row_id);
+        match sender.send(outbound).await {
+            Ok(()) => SendResult::Sent,
+            Err(_) => {
+                self.remove_if_sender_closed_owner(jid, &sender);
+                SendResult::ChannelClosed
+            }
+        }
     }
 
     /// Send a stanza to a connected user as a [`DeliveryKind::PeerStanza`]

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -140,6 +140,16 @@ pub struct ConnectionEntry {
     /// Q7d) so subsequent presence updates do not re-flush an already-
     /// drained `pending_delivery` queue (issue #209).
     pub offline_flushed: Arc<AtomicBool>,
+    /// Per-connection XEP-0198 stream id, set when the client enables
+    /// SM (or resumes onto this connection). `None` while SM is
+    /// disabled. Used to key
+    /// [`crate::pending_delivery::SmSessionId`] for the locked Q7b
+    /// SM-ack lifecycle (issue #209): each SM session is a distinct
+    /// id, so reconnect-on-same-resource never collides with the
+    /// dead session's claimed pending_delivery rows. Stored behind
+    /// `Mutex<Option<String>>` so the websocket SM-enable handler can
+    /// publish into it without taking the registry-level lock.
+    pub sm_stream_id: Arc<std::sync::Mutex<Option<String>>>,
 }
 
 impl ConnectionEntry {
@@ -152,6 +162,7 @@ impl ConnectionEntry {
             presence_priority: Arc::new(std::sync::atomic::AtomicI8::new(0)),
             roster_interested: Arc::new(AtomicBool::new(false)),
             offline_flushed: Arc::new(AtomicBool::new(false)),
+            sm_stream_id: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -186,6 +197,29 @@ impl ConnectionEntry {
         self.offline_flushed
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
+    }
+
+    /// Publish the XEP-0198 SM stream id for this connection. Called
+    /// by the websocket main loop after `<enable/>` (fresh SM session)
+    /// and after `<resume/>` (continuation onto a previously-stored
+    /// stream id). Used to key [`crate::pending_delivery::SmSessionId`]
+    /// for the locked Q7b SM-ack lifecycle.
+    pub fn set_sm_stream_id(&self, stream_id: Option<String>) {
+        if let Ok(mut guard) = self.sm_stream_id.lock() {
+            *guard = stream_id;
+        }
+    }
+
+    /// Read the XEP-0198 SM stream id for this connection, if SM is
+    /// enabled. Returns `None` while SM is disabled (no
+    /// `pending_delivery` row will be claimed under an SM session id
+    /// in that case — the flush falls back to the delete-on-push
+    /// path).
+    pub fn sm_stream_id(&self) -> Option<String> {
+        self.sm_stream_id
+            .lock()
+            .ok()
+            .and_then(|g| g.as_ref().cloned())
     }
 }
 

--- a/server/crates/waddle-xmpp/tests/xep0160_offline_message_handling.rs
+++ b/server/crates/waddle-xmpp/tests/xep0160_offline_message_handling.rs
@@ -17,7 +17,7 @@ use jid::{BareJid, FullJid, Jid};
 use minidom::Element;
 use waddle_xmpp::disco::{server_features, Feature};
 use waddle_xmpp::pending_delivery::flush::{build_replay_stanza, MaterializedPayload};
-use waddle_xmpp::pending_delivery::{PendingPayload, PendingRow, PendingRowId};
+use waddle_xmpp::pending_delivery::{PendingPayload, PendingRow, PendingRowId, SmSessionId};
 use waddle_xmpp::protocol::dm_routing::{
     classify_dm_intake, ArchiveDecision, CarbonsDecision, InboxDecision, LiveDecision,
     OnlineResources, PendingDecision,
@@ -207,6 +207,7 @@ fn transient_row(recipient: &str, body: &str) -> PendingRow {
         original_receipt_at: fixed_receipt(),
         payload: PendingPayload::Transient(Box::new(m)),
         flushed_in_session: None,
+        outbound_sequence: None,
     }
 }
 
@@ -322,10 +323,71 @@ fn xep0160_concurrent_resources_first_presence_wins_via_lock() {
     todo!("integration: race two resources' presence; second sees empty claim pool");
 }
 
-#[test]
-#[ignore = "TODO #209 slice (d) phase 2: SM-ack-keyed deletion (locked Q7b)"]
-fn xep0160_pending_row_survives_pre_ack_session_death_for_reflush() {
-    todo!("integration: claim → session dies before SM-ack → next resource re-claims");
+#[tokio::test]
+async fn xep0160_pending_row_survives_pre_ack_session_death_for_reflush() {
+    // Locked Q7b + Q7c (issue #209 PR #347): when a recovering
+    // session claims a pending_delivery row, has its flush stanza
+    // pushed (`record_pushed_at` stamps the outbound counter), and
+    // then the session dies BEFORE the SM `<a h>` ack arrives, the
+    // SM-expiry janitor / shutdown drain calls `release_claim` which
+    // restores the row to the unclaimed pool. A subsequent resource
+    // can then re-claim and re-flush the same row — its content is
+    // preserved exactly because deletion is gated on SM-ack via
+    // `delete_acked_through`, not on push.
+    use std::sync::Arc;
+    use waddle_xmpp::pending_delivery::storage::{
+        InMemoryPendingDeliveryStorage, PendingDeliveryStorage,
+    };
+
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let recipient = bare("alice@example.com");
+    storage
+        .insert(transient_row("alice@example.com", "missed during detach"))
+        .await
+        .unwrap();
+
+    // Session-A claims and pushes (recipient main loop stamped seq=4).
+    let session_a = SmSessionId::new("alice@example.com/laptop");
+    let claimed_a = storage
+        .claim_for_session(&recipient, &session_a)
+        .await
+        .unwrap();
+    assert_eq!(claimed_a.len(), 1);
+    let row_id = claimed_a[0].id.clone();
+    storage.record_pushed_at(&row_id, 4).await.unwrap();
+
+    // Session-A dies pre-ack. Janitor / shutdown drain releases.
+    let released = storage.release_claim(&session_a).await.unwrap();
+    assert_eq!(released, 1);
+
+    // The row's still in storage with flushed_in_session = NULL.
+    let rows = storage.list(&recipient).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows[0].flushed_in_session.is_none(),
+        "release_claim cleared the dead session's tag"
+    );
+
+    // Session-B (a new resource) recovers and re-claims.
+    let session_b = SmSessionId::new("alice@example.com/web");
+    let claimed_b = storage
+        .claim_for_session(&recipient, &session_b)
+        .await
+        .unwrap();
+    assert_eq!(claimed_b.len(), 1);
+    assert_eq!(
+        claimed_b[0].id, row_id,
+        "same row, preserved across pre-ack session death"
+    );
+
+    // Session-B's flush stanza assigned outbound seq=2 (different
+    // counter on a different SM stream). On its SM ack, the row is
+    // finally deleted.
+    storage.record_pushed_at(&row_id, 2).await.unwrap();
+    let removed = storage.delete_acked_through(&session_b, 2).await.unwrap();
+    assert_eq!(removed, 1);
+    assert_eq!(storage.count(&recipient).await.unwrap(), 0);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Continues from PR #346 (slice d phase 4, merged on main as `6713231f`).

## Scope

**Locked Q7b + Q7c from issue #209 grilling session:** make `pending_delivery` row deletion correct under crash and pre-ack session death. Today, rows are deleted on `SendResult::Sent` regardless of whether the recipient's SM session actually acknowledges the flushed stanza — defeating the durability guarantee for the window between push and ack.

**Q7b — SM-ack-keyed deletion (RFC 6121 §8.2.4 + XEP-0198 §6 ack semantics):**
> A `pending_delivery` row is deleted only when an SM `<a/>` ack from the recovering session covers the flush stanza's outbound sequence number.

**Q7c — Pre-ack session-death re-flush:**
> If the recovering SM session dies before ack-ing the flush, the row's `flushed_in_session` tag is cleared (`release_row` / `release_claim`) so a subsequent resource flush picks it up.

Stanza-id deduplication on the client handles the rare case where the recipient receives both the SM-replay stanza (from XEP-0198 resume) and the re-flushed pending row (locked Q10d — server is best-efforts; XEP-0359 stanza-id is the dedup key).

## Plan

1. **Storage trait extension** (`server/crates/waddle-xmpp/src/pending_delivery/storage.rs`):
   - New method `delete_acked_through(session: &SmSessionId, sequence_max: u32) -> Result<u64>` — per-session range-delete in one DB op for the common case where SM `<a/>` covers a contiguous range. Backends: `InMemoryPendingDeliveryStorage` walks the per-recipient `VecDeque`; libSQL backend uses `DELETE WHERE flushed_in_session = ? AND outbound_sequence <= ?`.
   - Extend `PendingRow` with `outbound_sequence: Option<u32>` so the flush path can stamp the SM outbound counter onto the claim.
2. **Flush path rewrite** (`server/crates/waddle-server/src/pending_delivery.rs`):
   - `flush_for_resource`: instead of `delete_row` on `SendResult::Sent`, call `claim_for_session` (already does this) + record `outbound_sequence` per row from the registry's outbound counter. Defer the delete until SM-ack.
3. **SM-ack hook** (`server/crates/waddle-xmpp/src/stream_management/session_registry.rs`):
   - `record_inbound_ack(session, h)` (or wherever XEP-0198 `<a h='N'/>` is parsed) invokes a new `pending_delivery::confirm_acked(session_id, sequence_max=N)` callback that range-deletes claimed rows ≤ N.
   - `take_session` / `cleanup_expired` / `drain_expired` / `drain_all_for_shutdown` invoke `pending_delivery::release_session(session_id)` so claimed-but-unacked rows are released for re-flush by the next resource.
4. **Tests:**
   - New: `pending_row_deleted_only_after_sm_ack` — push flush, no ack, row stays; ack, row gone.
   - New: `pending_row_released_on_pre_ack_session_death` — push flush, kill session pre-ack, verify `flushed_in_session` cleared, fresh resource picks it up.
   - Un-ignore: `xep0160_pending_row_survives_pre_ack_session_death_for_reflush` (currently `#[ignore]`'d).

## Risks

- **Off-by-one on outbound-sequence alignment** — SM's outbound counter increments per stanza pushed, including the pending-flush stanzas themselves. The flush path tags each pushed row with the post-increment counter value; ack `<a h='N'/>` deletes rows with `outbound_sequence <= N`. Verified via the new tests.
- **Concurrent flush + ack races** — the per-session lock in `claim_for_session` already serializes; ordering: flush (claim + push) → ack arrives → confirm_acked (delete by session+sequence). The session_id is the synchronization key.

## Out of scope (queued)

- **PR #348** Claim-expiry janitor + XEP-0191 flush-time block re-evaluation
- **PR #349** `original_receipt_at` plumbing through `DetachedSession.unacked_stanzas`
- **PR #350** Test-coverage debt: un-ignore the remaining XEP-0160 cases + extend dedicated XEP suites
- **PR #351** Storage performance (low priority)

## Test plan

- [ ] `pending_row_deleted_only_after_sm_ack` (new)
- [ ] `pending_row_released_on_pre_ack_session_death` (new)
- [ ] `xep0160_pending_row_survives_pre_ack_session_death_for_reflush` (un-ignore)
- [ ] All existing 419 server lib + 1781 waddle-xmpp lib + 50 SM-related tests stay green
- [ ] `cargo clippy --release --locked --workspace --all-features --all-targets -- -D warnings` clean
- [ ] `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
