### PR TITLE
fix(chat): restore extension service discovery

### DIFF
--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -817,7 +817,11 @@ function extensionServiceCandidates(domain: string, fallbackServiceJid: string, 
 }
 
 function isWaddleExtensionServiceInfo(features: string[]): boolean {
-  return features.includes(NS_WADDLE_EXTENSION_1) && features.includes(NS_ADHOC_COMMANDS);
+  return hasFeature(features, NS_WADDLE_EXTENSION_1) && hasFeature(features, NS_ADHOC_COMMANDS);
+}
+
+function hasFeature(features: string[], expected: string): boolean {
+  return features.some((feature) => feature === expected);
 }
 
 function parseDiscoInfoExtensions(xml: string): Array<{ fields: Array<{ var: string; value?: string; values?: string[] }> }> {

--- a/chat/src/lib/xmpp/extension-commands.ts
+++ b/chat/src/lib/xmpp/extension-commands.ts
@@ -789,11 +789,15 @@ async function discoverExtensionCommandService(xmpp: XmppSendIq, userJid: string
 
   try {
     const items = await rawDiscoItems(xmpp, domain);
-    const candidates = items.map((item) => item.jid).filter((jid): jid is string => !!jid);
-    for (const candidate of [domain, fallbackServiceJid, ...candidates.filter((jid) => jid !== fallbackServiceJid && jid !== domain)]) {
+    const candidates = extensionServiceCandidates(
+      domain,
+      fallbackServiceJid,
+      items.map((item) => item.jid).filter((jid): jid is string => !!jid),
+    );
+    for (const candidate of candidates) {
       try {
         const info = await rawDiscoInfo(xmpp, candidate);
-        if (info.features.some((feature) => feature === NS_ADHOC_COMMANDS)) return candidate;
+        if (isWaddleExtensionServiceInfo(info.features)) return candidate;
       } catch {
         // Try the next discovered component.
       }
@@ -802,6 +806,18 @@ async function discoverExtensionCommandService(xmpp: XmppSendIq, userJid: string
     // Fall through to returning the conventional extension service JID.
   }
   return fallbackServiceJid;
+}
+
+function extensionServiceCandidates(domain: string, fallbackServiceJid: string, discoveredJids: string[]): string[] {
+  const candidates: string[] = [];
+  for (const jid of [...discoveredJids, fallbackServiceJid, domain]) {
+    if (!candidates.includes(jid)) candidates.push(jid);
+  }
+  return candidates;
+}
+
+function isWaddleExtensionServiceInfo(features: string[]): boolean {
+  return features.includes(NS_WADDLE_EXTENSION_1) && features.includes(NS_ADHOC_COMMANDS);
 }
 
 function parseDiscoInfoExtensions(xml: string): Array<{ fields: Array<{ var: string; value?: string; values?: string[] }> }> {

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -83,6 +83,40 @@ describe("extension command invocation", () => {
     ]);
   });
 
+  test("prefers the advertised Waddle extension service over generic command services", async () => {
+    const commandItemTargets: string[] = [];
+    const xmpp = {
+      async send_raw_iq(xml: string) {
+        const target = xml.match(/\bto="([^"]+)"/)?.[1] ?? "";
+        if (xml.includes("disco#items") && !xml.includes('node="http://jabber.org/protocol/commands"')) {
+          expect(target).toBe("example.com");
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="automation.waddle.local" name="Automation" /><item jid="extensions.waddle.local" name="Extensions" /></query></iq>`;
+        }
+        if (xml.includes("disco#info") && !xml.includes(" node=")) {
+          if (target === "automation.waddle.local") {
+            return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><feature var="http://jabber.org/protocol/commands" /></query></iq>`;
+          }
+          expect(target).toBe("extensions.waddle.local");
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><feature var="urn:waddle:extension:1" /><feature var="http://jabber.org/protocol/commands" /></query></iq>`;
+        }
+        if (xml.includes("disco#items") && xml.includes('node="http://jabber.org/protocol/commands"')) {
+          commandItemTargets.push(target);
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.waddle.local" node="urn:waddle:extension:1:decision-polls" name="Create Decision Poll" /></query></iq>`;
+        }
+        expect(xml).toContain('node="urn:waddle:extension:1:decision-polls"');
+        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#plugin_id"><value>decision-polls</value></field><field var="waddle#command_node"><value>urn:waddle:extension:1:decision-polls</value></field><field var="waddle#command_label"><value>Create Decision Poll</value></field><field var="waddle#command_scope"><value>channel</value></field></x></query></iq>`;
+      },
+    };
+
+    expect(await discoverExtensionCommands(xmpp as any, "alice@example.com/web")).toEqual([{
+      serviceJid: "extensions.waddle.local",
+      node: "urn:waddle:extension:1:decision-polls",
+      name: "Create Decision Poll",
+      scope: "channel",
+    }]);
+    expect(commandItemTargets).toEqual(["extensions.waddle.local"]);
+  });
+
   test("builds a XEP-0050 invoke request from launch metadata", () => {
     const iq = buildExtensionLaunchInvokeIq("alice@example.com/web", launch);
     expect(iq.to).toBe("extensions.example.com");

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -2760,6 +2760,16 @@ mod tests {
     use xmpp_parsers::iq::{Iq, IqType};
     use xmpp_parsers::message::MessageType as XmppMessageType;
 
+    #[test]
+    fn service_domains_use_component_parent_for_extension_component() {
+        let domains = XmppServiceDomains::new("waddle.social", "waddle.local");
+
+        assert_eq!(domains.extensions, "extensions.waddle.local");
+        assert_eq!(domains.muc, "muc.waddle.local");
+        assert_eq!(domains.spaces, "spaces.waddle.local");
+        assert_eq!(domains.upload, "upload.waddle.social");
+    }
+
     #[derive(Default)]
     struct TestSink {
         fail_after: Option<usize>,

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -1490,26 +1490,22 @@ async fn discover_extension_command_service(
     domain: &str,
 ) -> String {
     let fallback_service_jid = format!("extensions.{domain}");
-    let mut candidates = vec![domain.to_string(), fallback_service_jid.clone()];
+    let mut discovered_items = Vec::new();
 
     if let Ok(items_result) =
         send_iq_command(inner.clone(), build_disco_items_iq(domain, None)).await
     {
         if let Some(items) = discovery::parse_disco_items_result(&items_result) {
-            for item in items {
-                if !candidates.iter().any(|candidate| candidate == &item.jid) {
-                    candidates.push(item.jid);
-                }
-            }
+            discovered_items = items;
         }
     }
 
-    for candidate in candidates {
+    for candidate in extension_command_service_candidates(domain, &discovered_items) {
         if let Ok(info_result) =
             send_iq_command(inner.clone(), build_disco_info_iq(&candidate, None)).await
         {
             if let Some(info) = discovery::parse_disco_info_result(&info_result, &candidate) {
-                if info.has_feature(NS_ADHOC_COMMANDS) {
+                if is_waddle_extension_service(&info) {
                     return candidate;
                 }
             }
@@ -1517,6 +1513,32 @@ async fn discover_extension_command_service(
     }
 
     fallback_service_jid
+}
+
+fn extension_command_service_candidates(
+    domain: &str,
+    items: &[discovery::DiscoItem],
+) -> Vec<String> {
+    let fallback_service_jid = format!("extensions.{domain}");
+    let mut candidates = Vec::new();
+
+    for item in items {
+        push_unique_candidate(&mut candidates, item.jid.as_str());
+    }
+    push_unique_candidate(&mut candidates, &fallback_service_jid);
+    push_unique_candidate(&mut candidates, domain);
+
+    candidates
+}
+
+fn push_unique_candidate(candidates: &mut Vec<String>, candidate: &str) {
+    if !candidates.iter().any(|existing| existing == candidate) {
+        candidates.push(candidate.to_string());
+    }
+}
+
+fn is_waddle_extension_service(info: &discovery::DiscoInfoResult) -> bool {
+    info.has_feature(NS_WADDLE_EXTENSION_1) && info.has_feature(NS_ADHOC_COMMANDS)
 }
 
 fn parse_extension_routes_from_info(
@@ -2857,6 +2879,42 @@ mod extension_route_tests {
     }
 
     #[test]
+    fn extension_service_candidates_probe_advertised_items_before_domain_fallbacks() {
+        let items = vec![
+            disco_item("muc.waddle.local"),
+            disco_item("upload.waddle.social"),
+            disco_item("extensions.waddle.local"),
+        ];
+
+        let candidates = extension_command_service_candidates("waddle.social", &items);
+
+        assert_eq!(
+            candidates,
+            vec![
+                "muc.waddle.local",
+                "upload.waddle.social",
+                "extensions.waddle.local",
+                "extensions.waddle.social",
+                "waddle.social",
+            ]
+        );
+    }
+
+    #[test]
+    fn waddle_extension_service_requires_framework_and_commands_features() {
+        assert!(!is_waddle_extension_service(&disco_info(&[
+            NS_ADHOC_COMMANDS
+        ])));
+        assert!(!is_waddle_extension_service(&disco_info(&[
+            NS_WADDLE_EXTENSION_1
+        ])));
+        assert!(is_waddle_extension_service(&disco_info(&[
+            NS_WADDLE_EXTENSION_1,
+            NS_ADHOC_COMMANDS,
+        ])));
+    }
+
+    #[test]
     fn parses_extension_item_envelopes_from_pubsub_items() {
         let iq = Element::builder("iq", NS_CLIENT)
             .attr("type", "result")
@@ -2953,6 +3011,24 @@ mod extension_route_tests {
         discovery::DiscoDataField {
             var: var.to_string(),
             values: vec![value.to_string()],
+        }
+    }
+
+    fn disco_item(jid: &str) -> discovery::DiscoItem {
+        discovery::DiscoItem {
+            jid: jid.to_string(),
+            name: None,
+            node: None,
+        }
+    }
+
+    fn disco_info(features: &[&str]) -> discovery::DiscoInfoResult {
+        discovery::DiscoInfoResult {
+            jid: "example.com".to_string(),
+            node: None,
+            identities: Vec::new(),
+            features: features.iter().map(|feature| feature.to_string()).collect(),
+            forms: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Root Cause

Production loads the extension modules correctly, but the Rust/WASM client route discovery could select a generic XEP-0050 command service before it reached the real Waddle extension component.

In production, `WADDLE_XMPP_DOMAIN=waddle.social` and `WADDLE_XMPP_COMPONENT_DOMAIN=waddle.local`, so the server advertises the extension service as `extensions.waddle.local`. The account root also advertises `http://jabber.org/protocol/commands`, which is not enough to identify Waddle's extension framework service.

## Changes

- Require discovered extension services to advertise both `urn:waddle:extension:1` and XEP-0050 commands.
- Probe server-advertised disco#items before falling back to `extensions.<account-domain>` or the account domain.
- Apply the same service-discovery discriminator to the TypeScript command/launch discovery path.
- Add regression coverage for a generic command service appearing before the real Waddle extension component.
- Add a small server unit assertion for split XMPP and component domains.
- Use explicit feature equality checks to keep CodeQL from treating URL-like feature constants as substring URL sanitization.
- Rebased onto current `origin/main` after `checkRootSyncDrift` exposed stale merge-base generated-file drift.

## XEP Review

- XEP-0030 supports discovering associated service JIDs through disco#items.
- XEP-0050 only proves that an entity supports commands; it does not identify Waddle's extension service.
- `urn:waddle:extension:1` is used only as the Waddle-specific discriminator.

## Validation

- `bun test tests/extension-command.test.ts` passed in `chat/` after the discovery fix and after the CodeQL follow-up.
- `cargo test -p waddle-xmpp-client-wasm extension_route_tests` passed in `server/`.
- `cargo fmt --all` passed in `server/`.
- `cuenv sync --check -p ..` passed in `server/` after rebasing onto current `origin/main`.

A broader filtered `waddle-server` test was still compiling when the user asked to commit and push urgently, so it was not completed before push.