### PR TITLE
refactor(server): consolidate StanzaId-ish newtypes across crates (#329)

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -699,7 +699,13 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let (kind, by, sid, xml) = match &row.payload {
             PendingPayload::Archived(stanza_id) => (
                 PAYLOAD_KIND_ARCHIVED,
-                Some(stanza_id.by.to_string()),
+                // The decode side parses `archive_stanza_by` as a `BareJid`
+                // (XEP-0313 archives are scoped per bare JID, see
+                // `MamArchiveResolver::resolve` which narrows via
+                // `.to_bare()`). Narrow on write too so a `StanzaId.by` that
+                // happens to carry a resource cannot poison a row that
+                // `decode_row` would later refuse to parse.
+                Some(stanza_id.by.to_bare().to_string()),
                 Some(stanza_id.id.clone()),
                 None,
             ),
@@ -1210,6 +1216,47 @@ mod tests {
         // FIFO: archived inserted first.
         assert!(rows[0].payload.is_archived());
         assert!(rows[1].payload.is_transient());
+    }
+
+    #[tokio::test]
+    async fn db_storage_archived_full_jid_by_round_trips_as_bare() {
+        // Regression: `StanzaId.by` is a `jid::Jid`, so a future call site
+        // could legitimately construct one with a resource. The
+        // `archive_stanza_by` column is decoded back as a `BareJid`, so the
+        // insert path must narrow with `.to_bare()`. Without that fix,
+        // round-tripping a Full-JID `StanzaId` through SQL would fail in
+        // `decode_row` and poison the recipient's pending queue.
+        let storage = DatabasePendingDeliveryStorage::open(None, QuotaPolicy::Unlimited)
+            .await
+            .expect("open in-memory storage");
+        let recipient = bare("alice@example.com");
+        let full_by: jid::Jid = "alice@example.com/resource"
+            .parse()
+            .expect("valid full jid");
+        let row = PendingRow {
+            id: PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::DateTime::<chrono::Utc>::from_timestamp_millis(
+                1_700_000_000_000,
+            )
+            .unwrap(),
+            payload: PendingPayload::Archived(StanzaId::new("mam-id", full_by)),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        };
+        assert_eq!(storage.insert(row).await.unwrap(), InsertOutcome::Inserted);
+
+        let rows = storage.list(&recipient).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        match &rows[0].payload {
+            PendingPayload::Archived(stanza_id) => {
+                assert_eq!(stanza_id.id, "mam-id");
+                // Decoded `by` must be the bare form even though we
+                // inserted a Full JID, so the column round-trips cleanly.
+                assert_eq!(stanza_id.by, jid::Jid::from(recipient));
+            }
+            other => panic!("expected Archived payload, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -38,9 +38,9 @@ use waddle_xmpp::pending_delivery::storage::{PendingDeliveryStorage, PendingStor
 use waddle_xmpp::pending_delivery::{
     InsertOutcome, PendingPayload, PendingRow, PendingRowId, QuotaPolicy, SmSessionId,
 };
-use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
 use waddle_xmpp::registry::{ConnectionRegistry, SendResult};
 use waddle_xmpp::Stanza;
+use waddle_xmpp_core::xep0359::StanzaId;
 
 use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
 
@@ -296,16 +296,13 @@ where
 /// [`NullArchiveResolver`] when only Transient rows are exercised.
 #[async_trait::async_trait]
 pub trait ArchiveResolver: Send + Sync {
-    /// Read the archived stanza by recipient bare JID + typed XEP-0359
-    /// stanza-id. Returns the typed [`xmpp_parsers::message::Message`]
-    /// reconstructed from the MAM row; returns `None` on miss or any
-    /// non-fatal lookup failure (the caller treats this as a poison
-    /// pill and drops the `pending_delivery` row).
-    async fn resolve(
-        &self,
-        archive_jid: &BareJid,
-        stanza_id: &waddle_xmpp::protocol::event::StanzaIdValue,
-    ) -> Option<xmpp_parsers::message::Message>;
+    /// Read the archived stanza by canonical XEP-0359 [`StanzaId`]
+    /// (`{ id, by }`). Returns the typed
+    /// [`xmpp_parsers::message::Message`] reconstructed from the MAM
+    /// row; returns `None` on miss or any non-fatal lookup failure
+    /// (the caller treats this as a poison pill and drops the
+    /// `pending_delivery` row).
+    async fn resolve(&self, stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message>;
 }
 
 /// MAM-backed resolver for production use.
@@ -315,14 +312,15 @@ pub struct MamArchiveResolver {
 
 #[async_trait::async_trait]
 impl ArchiveResolver for MamArchiveResolver {
-    async fn resolve(
-        &self,
-        archive_jid: &BareJid,
-        stanza_id: &waddle_xmpp::protocol::event::StanzaIdValue,
-    ) -> Option<xmpp_parsers::message::Message> {
+    async fn resolve(&self, stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message> {
+        // MAM lookup keys on the archive's *bare* JID — XEP-0313 §5
+        // archives are per-user / per-room (BareJid), and the canonical
+        // `StanzaId.by` Jid carries that information (the MAM writer
+        // always stamps with a bare-form Jid).
+        let archive_bare = stanza_id.by.to_bare();
         let archived = match self
             .mam_storage
-            .get_message_by_archive_or_stanza_id(archive_jid, stanza_id.as_str())
+            .get_message_by_archive_or_stanza_id(&archive_bare, stanza_id.as_str())
             .await
         {
             Ok(Some(archived)) => archived,
@@ -330,7 +328,7 @@ impl ArchiveResolver for MamArchiveResolver {
             Err(error) => {
                 warn!(
                     error = %error,
-                    archive_jid = %archive_jid,
+                    archive_jid = %archive_bare,
                     stanza_id = %stanza_id,
                     "MAM lookup failed during flush"
                 );
@@ -353,11 +351,7 @@ pub struct NullArchiveResolver;
 
 #[async_trait::async_trait]
 impl ArchiveResolver for NullArchiveResolver {
-    async fn resolve(
-        &self,
-        _archive_jid: &BareJid,
-        _stanza_id: &waddle_xmpp::protocol::event::StanzaIdValue,
-    ) -> Option<xmpp_parsers::message::Message> {
+    async fn resolve(&self, _stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message> {
         None
     }
 }
@@ -368,10 +362,8 @@ where
 {
     match &row.payload {
         PendingPayload::Transient(_) => MaterializedPayload::from_transient(row),
-        PendingPayload::Archived(stanza_id_ref) => {
-            let archived = resolver
-                .resolve(&stanza_id_ref.by, &stanza_id_ref.id)
-                .await?;
+        PendingPayload::Archived(stanza_id) => {
+            let archived = resolver.resolve(stanza_id).await?;
             Some(MaterializedPayload::Archived(Box::new(archived)))
         }
     }
@@ -648,10 +640,8 @@ impl DatabasePendingDeliveryStorage {
                 let id_str = archive_stanza_id.ok_or_else(|| {
                     PendingStorageError::Other("archived row missing archive_stanza_id".into())
                 })?;
-                PendingPayload::Archived(StanzaIdRef {
-                    by,
-                    id: StanzaIdValue::new(id_str),
-                })
+                let archive_jid: jid::Jid = by.into();
+                PendingPayload::Archived(StanzaId::new(id_str, archive_jid))
             }
             PAYLOAD_KIND_TRANSIENT => {
                 let xml = transient_xml.ok_or_else(|| {
@@ -707,10 +697,10 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         };
         let receipt_ms = row.original_receipt_at.timestamp_millis();
         let (kind, by, sid, xml) = match &row.payload {
-            PendingPayload::Archived(stanza_id_ref) => (
+            PendingPayload::Archived(stanza_id) => (
                 PAYLOAD_KIND_ARCHIVED,
-                Some(stanza_id_ref.by.to_string()),
-                Some(stanza_id_ref.id.as_str().to_string()),
+                Some(stanza_id.by.to_string()),
+                Some(stanza_id.id.clone()),
                 None,
             ),
             PendingPayload::Transient(message) => {
@@ -1198,10 +1188,10 @@ mod tests {
                 1_700_000_000_000,
             )
             .unwrap(),
-            payload: PendingPayload::Archived(StanzaIdRef {
-                by: recipient.clone(),
-                id: StanzaIdValue::new("mam-id"),
-            }),
+            payload: PendingPayload::Archived(StanzaId::new(
+                "mam-id",
+                jid::Jid::from(recipient.clone()),
+            )),
             flushed_in_session: None,
             outbound_sequence: None,
         };

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -97,8 +97,7 @@ use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parse_managed_room_jid;
 use waddle_xmpp::parser::{message_to_string, stanza_to_string};
 use waddle_xmpp::protocol::event::{
-    ArchivedMessage as ProtocolArchivedMessage, GroupchatThreadProjection, InboundEvent,
-    MessageRef, StanzaIdRef, StanzaIdValue,
+    ArchivedMessage as ProtocolArchivedMessage, GroupchatThreadProjection, InboundEvent, MessageRef,
 };
 use waddle_xmpp::protocol::id_gen::UuidV4Generator;
 use waddle_xmpp::protocol::room::{
@@ -2338,14 +2337,14 @@ async fn lookup_archived_message(
         return None;
     };
     let lookup = match reference {
-        MessageRef::StanzaId { id, .. } => {
+        MessageRef::StanzaId { stanza_id } => {
             // Strict stanza-id match: `get_message_by_message_id`
             // matches only the `stanza_id` column (not `origin_id`)
             // so the OR-collision identified in #229 PR8 review
             // (origin-id colliding with someone else's stanza-id)
             // can't return the wrong row.
             mam_storage
-                .get_message_by_message_id(archive, id.as_str())
+                .get_message_by_message_id(archive, stanza_id.as_str())
                 .await
         }
         MessageRef::OriginId { sender, origin_id } => {
@@ -2447,10 +2446,8 @@ fn project_archived_row(
     // wire `<message id>`. Follow-up handlers target the archived entry
     // by this canonical id; preferring `row.stanza_id.id` (the wire id)
     // would resolve incorrectly when the two differ.
-    let stanza_id = StanzaIdRef {
-        by: archive.clone(),
-        id: StanzaIdValue::new(&row.id),
-    };
+    let archive_jid: jid::Jid = archive.clone().into();
+    let stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(&row.id, archive_jid);
 
     Some(Box::new(ProtocolArchivedMessage {
         stanza_id,
@@ -3611,8 +3608,7 @@ mod tests {
         // the archive.
         use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
         use waddle_xmpp::mam::storage::InMemoryMamStorage;
-        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
-        use waddle_xmpp_core::xep0359::build_stanza_id_element;
+        use waddle_xmpp_core::xep0359::{build_stanza_id_element, StanzaId};
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
         let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
@@ -3643,10 +3639,7 @@ mod tests {
                 owner: alice.clone(),
                 peer: bob.clone(),
                 message: Box::new(msg),
-                archive_ref: StanzaIdRef {
-                    by: alice.clone(),
-                    id: StanzaIdValue::new(canonical_id),
-                },
+                archive_ref: StanzaId::new(canonical_id, jid::Jid::from(alice.clone())),
                 increment_unread: false,
             },
         ];
@@ -3830,7 +3823,7 @@ mod tests {
     async fn inbox_project_writes_owner_peer_keyed_row_with_typed_archive_ref() {
         use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
         use waddle_xmpp::mam::storage::InMemoryMamStorage;
-        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -3847,10 +3840,7 @@ mod tests {
             owner: owner.clone(),
             peer: peer.clone(),
             message: Box::new(msg),
-            archive_ref: StanzaIdRef {
-                by: owner.clone(),
-                id: StanzaIdValue::new("alice-archive-1"),
-            },
+            archive_ref: StanzaId::new("alice-archive-1", jid::Jid::from(owner.clone())),
             increment_unread: false,
         }];
         let _outcome = interpret(events, &deps).await;
@@ -3870,7 +3860,7 @@ mod tests {
     async fn inbox_project_increment_unread_bumps_recipient_count() {
         use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
         use waddle_xmpp::mam::storage::InMemoryMamStorage;
-        use waddle_xmpp::protocol::event::{StanzaIdRef, StanzaIdValue};
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -3886,10 +3876,7 @@ mod tests {
             owner: owner.clone(),
             peer: peer.clone(),
             message: Box::new(msg),
-            archive_ref: StanzaIdRef {
-                by: owner.clone(),
-                id: StanzaIdValue::new("bob-archive-1"),
-            },
+            archive_ref: StanzaId::new("bob-archive-1", jid::Jid::from(owner.clone())),
             increment_unread: true,
         }];
         let _outcome = interpret(events, &deps).await;
@@ -3909,7 +3896,7 @@ mod tests {
     async fn xep_0424_lookup_archived_message_by_stanza_id_feeds_archived_loaded_back() {
         use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
         use waddle_xmpp::protocol::event::CallbackId;
-        use waddle_xmpp::protocol::event::StanzaIdValue;
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -3946,8 +3933,7 @@ mod tests {
             id: CallbackId(7),
             archive: archive_jid.clone(),
             reference: MessageRef::StanzaId {
-                by: archive_jid.clone(),
-                id: StanzaIdValue::new("canon-A1"),
+                stanza_id: StanzaId::new("canon-A1", jid::Jid::from(archive_jid.clone())),
             },
         }];
         let outcome = interpret(events, &deps).await;
@@ -3957,8 +3943,8 @@ mod tests {
             InboundEvent::ArchivedMessageLoaded { id, result } => {
                 assert_eq!(id, CallbackId(7));
                 let archived = result.expect("row resolved");
-                assert_eq!(archived.stanza_id.id.as_str(), "canon-A1");
-                assert_eq!(archived.stanza_id.by, archive_jid);
+                assert_eq!(archived.stanza_id.as_str(), "canon-A1");
+                assert_eq!(archived.stanza_id.by, jid::Jid::from(archive_jid.clone()));
                 assert!(!archived.tombstoned);
                 assert_eq!(
                     archived.message.bodies.get("").map(|b| b.0.clone()),
@@ -3974,7 +3960,7 @@ mod tests {
     async fn xep_0424_lookup_archived_message_not_found_feeds_none_back() {
         use waddle_xmpp::mam::InMemoryMamStorage;
         use waddle_xmpp::protocol::event::CallbackId;
-        use waddle_xmpp::protocol::event::StanzaIdValue;
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -3987,8 +3973,7 @@ mod tests {
             id: CallbackId(11),
             archive: archive_jid.clone(),
             reference: MessageRef::StanzaId {
-                by: archive_jid,
-                id: StanzaIdValue::new("never-stamped"),
+                stanza_id: StanzaId::new("never-stamped", jid::Jid::from(archive_jid)),
             },
         }];
         let outcome = interpret(events, &deps).await;
@@ -4011,7 +3996,8 @@ mod tests {
         // post-filter on `sender` must pick the alice-authored row,
         // not the bob-authored one.
         use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
-        use waddle_xmpp::protocol::event::{CallbackId, OriginIdValue};
+        use waddle_xmpp::protocol::event::CallbackId;
+        use waddle_xmpp_core::xep0359::OriginId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -4075,7 +4061,7 @@ mod tests {
             archive: archive_jid.clone(),
             reference: MessageRef::OriginId {
                 sender: alice_bare.clone(),
-                origin_id: OriginIdValue::new("collision"),
+                origin_id: OriginId::new("collision"),
             },
         }];
         let outcome = interpret(events, &deps).await;
@@ -4106,7 +4092,8 @@ mod tests {
         // requested -> result MUST be None (handler will treat as
         // <item-not-found>).
         use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
-        use waddle_xmpp::protocol::event::{CallbackId, OriginIdValue};
+        use waddle_xmpp::protocol::event::CallbackId;
+        use waddle_xmpp_core::xep0359::OriginId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -4143,7 +4130,7 @@ mod tests {
             archive: archive_jid,
             reference: MessageRef::OriginId {
                 sender: charlie_bare,
-                origin_id: OriginIdValue::new("oid-1"),
+                origin_id: OriginId::new("oid-1"),
             },
         }];
         let outcome = interpret(events, &deps).await;
@@ -4165,7 +4152,8 @@ mod tests {
         // ONLY), so a row whose `origin_id` happens to equal the
         // requested stanza-id MUST NOT be returned.
         use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
-        use waddle_xmpp::protocol::event::{CallbackId, StanzaIdValue};
+        use waddle_xmpp::protocol::event::CallbackId;
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -4202,8 +4190,7 @@ mod tests {
             id: CallbackId(41),
             archive: archive_jid.clone(),
             reference: MessageRef::StanzaId {
-                by: archive_jid,
-                id: StanzaIdValue::new("queried-id"),
+                stanza_id: StanzaId::new("queried-id", jid::Jid::from(archive_jid)),
             },
         }];
         let outcome = interpret(events, &deps).await;
@@ -4226,7 +4213,7 @@ mod tests {
             InMemoryMamStorage, RichMessageId,
         };
         use waddle_xmpp::protocol::event::CallbackId;
-        use waddle_xmpp::protocol::event::StanzaIdValue;
+        use waddle_xmpp_core::xep0359::StanzaId;
 
         let registry = ConnectionRegistry::new();
         let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
@@ -4268,8 +4255,7 @@ mod tests {
             id: CallbackId(13),
             archive: archive_jid.clone(),
             reference: MessageRef::StanzaId {
-                by: archive_jid,
-                id: StanzaIdValue::new("tomb-1"),
+                stanza_id: StanzaId::new("tomb-1", jid::Jid::from(archive_jid)),
             },
         }];
         let outcome = interpret(events, &deps).await;

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -255,10 +255,10 @@ async fn promote_one(
                         .await;
                     }
                 };
-            PendingPayload::Archived(waddle_xmpp::protocol::event::StanzaIdRef {
-                by: recipient_bare,
-                id: waddle_xmpp::protocol::event::StanzaIdValue::new(stanza_id),
-            })
+            PendingPayload::Archived(waddle_xmpp_core::xep0359::StanzaId::new(
+                stanza_id,
+                recipient_jid,
+            ))
         }
         PendingDecision::Transient => PendingPayload::Transient(Box::new(message.clone())),
         PendingDecision::None => unreachable!("guarded above"),

--- a/server/crates/waddle-xmpp-client/src/request.rs
+++ b/server/crates/waddle-xmpp-client/src/request.rs
@@ -22,7 +22,18 @@ impl fmt::Display for RequestId {
     }
 }
 
-/// Typed wrapper for stanza ids used in IQ correlation.
+/// Typed wrapper for the client-side IQ-correlation token (the
+/// `<iq id='...'/>` value the client puts on outbound IQs and matches
+/// replies against).
+///
+/// **This is NOT a XEP-0359 server-stamped `<stanza-id/>`.** Per
+/// XEP-0359 §3 a stanza-id is server-stamped and inseparable from its
+/// assigning archive (`by`); the canonical workspace shape for that is
+/// [`waddle_xmpp_core::xep0359::StanzaId`]. The client-side
+/// correlation id has no `by` context (the client cannot stamp itself)
+/// and carries a non-emptiness invariant that the server-stamped type
+/// does not enforce — see issue #329 for the full rationale on why
+/// these two types stay distinct.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StanzaId(String);
 

--- a/server/crates/waddle-xmpp-core/src/xep0359.rs
+++ b/server/crates/waddle-xmpp-core/src/xep0359.rs
@@ -36,7 +36,16 @@ use xmpp_parsers::message::Message;
 pub const NS_SID: &str = "urn:xmpp:sid:0";
 
 /// A server-assigned stable stanza ID.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// This is the canonical workspace shape for an XEP-0359 stanza-id at every
+/// boundary above the wire — handler outputs, archive payloads, inbox
+/// projections, pending-delivery references — so the `id` cannot drift
+/// from its assigning `by` archive across crate boundaries.
+///
+/// Refs:
+/// - XEP-0359 §3 (`<stanza-id/>` element)
+/// - issue #329 (consolidation of duplicate StanzaId-ish newtypes)
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct StanzaId {
     /// The stable ID assigned by the server/service.
     pub id: String,
@@ -49,10 +58,20 @@ impl StanzaId {
     pub fn new(id: impl Into<String>, by: jid::Jid) -> Self {
         Self { id: id.into(), by }
     }
+
+    /// Borrow the opaque id portion as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.id
+    }
 }
 
 /// A client-assigned origin ID.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Per XEP-0359 §3 the origin-id is a client-stamped opaque identifier with
+/// no `by` context (the originating entity is implied by the message's
+/// `from`). This is the canonical workspace shape; the protocol-layer
+/// `OriginIdValue` newtype was removed in the #329 consolidation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OriginId {
     /// The unique ID assigned by the originating client.
     pub id: String,
@@ -62,6 +81,23 @@ impl OriginId {
     /// Create a new origin ID.
     pub fn new(id: impl Into<String>) -> Self {
         Self { id: id.into() }
+    }
+
+    /// Borrow the opaque id portion as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.id
+    }
+}
+
+impl std::fmt::Display for StanzaId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.id)
+    }
+}
+
+impl std::fmt::Display for OriginId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.id)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
@@ -129,9 +129,9 @@ fn build_offline_delay(
 mod tests {
     use super::*;
     use crate::pending_delivery::{PendingPayload, PendingRow, SmSessionId};
-    use crate::protocol::event::{StanzaIdRef, StanzaIdValue};
     use chrono::TimeZone;
     use jid::{BareJid, Jid};
+    use waddle_xmpp_core::xep0359::StanzaId;
     use xmpp_parsers::message::{Body, MessageType};
 
     fn bare(s: &str) -> BareJid {
@@ -151,14 +151,12 @@ mod tests {
     }
 
     fn archived_row(recipient: &str) -> PendingRow {
+        let archive_jid: jid::Jid = bare(recipient).into();
         PendingRow {
             id: crate::pending_delivery::PendingRowId::fresh(),
             recipient: bare(recipient),
             original_receipt_at: fixed_receipt(),
-            payload: PendingPayload::Archived(StanzaIdRef {
-                by: bare(recipient),
-                id: StanzaIdValue::new("mam-id"),
-            }),
+            payload: PendingPayload::Archived(StanzaId::new("mam-id", archive_jid)),
             flushed_in_session: Some(SmSessionId::new("s1")),
             outbound_sequence: None,
         }

--- a/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
@@ -27,9 +27,9 @@
 pub mod flush;
 pub mod storage;
 
-use crate::protocol::event::StanzaIdRef;
 use chrono::{DateTime, Utc};
 use jid::BareJid;
+use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::message::Message;
 
 /// Opaque per-row identifier for a `pending_delivery` row.
@@ -102,8 +102,8 @@ impl std::fmt::Display for SmSessionId {
 #[derive(Debug, Clone)]
 pub enum PendingPayload {
     /// Pointer into MAM. The flush handler reads the archived message
-    /// by `StanzaIdRef` and pushes that.
-    Archived(StanzaIdRef),
+    /// by the canonical [`StanzaId`] (`{ id, by }`) and pushes that.
+    Archived(StanzaId),
     /// Inline payload — `<no-permanent-store/>` stanzas have no MAM row.
     /// Boxed so the size of [`PendingPayload`] doesn't blow up.
     Transient(Box<Message>),
@@ -192,10 +192,8 @@ mod tests {
 
     #[test]
     fn pending_payload_classification() {
-        let archived = PendingPayload::Archived(StanzaIdRef {
-            by: "alice@example.com".parse().unwrap(),
-            id: crate::protocol::event::StanzaIdValue::new("opaque-id"),
-        });
+        let archive_jid: jid::Jid = "alice@example.com".parse().unwrap();
+        let archived = PendingPayload::Archived(StanzaId::new("opaque-id", archive_jid));
         assert!(archived.is_archived());
         assert!(!archived.is_transient());
 

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -376,8 +376,8 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
 mod tests {
     use super::*;
     use crate::pending_delivery::PendingPayload;
-    use crate::protocol::event::{StanzaIdRef, StanzaIdValue};
     use chrono::Utc;
+    use waddle_xmpp_core::xep0359::StanzaId;
     use xmpp_parsers::message::Message;
 
     fn bare(s: &str) -> BareJid {
@@ -385,14 +385,12 @@ mod tests {
     }
 
     fn archived_row(recipient: &str, id: &str) -> PendingRow {
+        let archive_jid: jid::Jid = bare(recipient).into();
         PendingRow {
             id: PendingRowId::fresh(),
             recipient: bare(recipient),
             original_receipt_at: Utc::now(),
-            payload: PendingPayload::Archived(StanzaIdRef {
-                by: bare(recipient),
-                id: StanzaIdValue::new(id),
-            }),
+            payload: PendingPayload::Archived(StanzaId::new(id, archive_jid)),
             flushed_in_session: None,
             outbound_sequence: None,
         }

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -20,65 +20,9 @@ use crate::Stanza;
 use chrono::{DateTime, Utc};
 use jid::{BareJid, FullJid};
 use tracing::Level;
+use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
-
-/// XEP-0359 stamped stanza-id value.
-///
-/// Newtype around the opaque id value so a stanza-id cannot be silently
-/// swapped for an origin-id, message id, or any other XMPP identifier
-/// crossing event boundaries. Per XEP-0359 §6 the value itself is
-/// opaque (no internal structure), but the *kind* is type-significant
-/// — typed-payloads hard rule (CLAUDE.md).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StanzaIdValue(String);
-
-impl StanzaIdValue {
-    /// Wrap an opaque id value coming from an [`super::id_gen::IdGenerator`]
-    /// or from a parsed XEP-0359 `<stanza-id/>` element.
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
-    /// Borrow the underlying value.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for StanzaIdValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-/// XEP-0359 client-supplied origin-id value.
-///
-/// Newtype companion to [`StanzaIdValue`] for the same reasons; an
-/// origin-id is owned by the originating client and is a different
-/// identity space from the server-stamped stanza-id, so it must not be
-/// confused at handler/storage boundaries.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct OriginIdValue(String);
-
-impl OriginIdValue {
-    /// Wrap an origin-id value parsed from a XEP-0359 `<origin-id/>`
-    /// element.
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
-    }
-
-    /// Borrow the underlying value.
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for OriginIdValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
 
 /// Reference to a previously-archived message.
 ///
@@ -89,7 +33,8 @@ impl std::fmt::Display for OriginIdValue {
 ///
 /// - [`MessageRef::StanzaId`] is keyed on `(archive, id)` — what
 ///   XEP-0359 §5 stamps and what XEP-0424 retractions / XEP-0461 replies
-///   reference.
+///   reference. Carries the canonical [`StanzaId`] so the stamped id is
+///   inseparable from its assigning archive (`by`) — see issue #329.
 /// - [`MessageRef::OriginId`] is keyed on `(sender, origin_id)` — what
 ///   XEP-0359 §3 origin-ids carry and what XEP-0308 corrections may use as
 ///   a fallback when the original message hasn't yet been seen by stanza-id.
@@ -97,20 +42,18 @@ impl std::fmt::Display for OriginIdValue {
 pub enum MessageRef {
     /// XEP-0359 stable stanza-id, scoped to its stamping archive.
     StanzaId {
-        /// `by=` of the stamping archive (user bare JID for 1:1, room JID
-        /// for groupchat).
-        by: BareJid,
-        /// The stamped opaque id value (typed via [`StanzaIdValue`] so
-        /// it cannot be confused with an origin-id at call boundaries).
-        id: StanzaIdValue,
+        /// The canonical [`StanzaId`] — opaque id paired with its
+        /// stamping archive (`by`). Use the bare archive JID (user bare
+        /// JID for 1:1, room JID for groupchat) when constructing.
+        stanza_id: StanzaId,
     },
     /// XEP-0359 origin-id, scoped to the original sender.
     OriginId {
         /// Bare JID of the original sender.
         sender: BareJid,
-        /// The client-supplied opaque origin-id value (typed via
-        /// [`OriginIdValue`]).
-        origin_id: OriginIdValue,
+        /// The client-supplied opaque origin-id value (canonical
+        /// [`OriginId`] from `waddle-xmpp-core`).
+        origin_id: OriginId,
     },
 }
 
@@ -125,22 +68,6 @@ pub enum CarbonKind {
     Received,
 }
 
-/// Typed reference to a stanza-id stamped by a specific archive.
-///
-/// Identical shape to [`MessageRef::StanzaId`] but kept separate because
-/// `StanzaIdRef` is an output (e.g. an inbox row links to its archived
-/// counterpart) whereas `MessageRef` is an input (a handler asks the
-/// archive to look up something).
-#[derive(Debug, Clone)]
-pub struct StanzaIdRef {
-    /// `by=` of the stamping archive.
-    pub by: BareJid,
-    /// The stamped opaque id value, typed via [`StanzaIdValue`] so it
-    /// cannot be confused with an origin-id at handler / storage
-    /// boundaries.
-    pub id: StanzaIdValue,
-}
-
 /// Placeholder for the typed archived-message payload from issue #228.
 ///
 /// PR1 of issue #229 reserves the variant slots for the
@@ -150,8 +77,9 @@ pub struct StanzaIdRef {
 /// public surface stays grep-able.
 #[derive(Debug, Clone)]
 pub struct ArchivedMessage {
-    /// XEP-0359 stamped stanza-id.
-    pub stanza_id: StanzaIdRef,
+    /// XEP-0359 stamped stanza-id (canonical [`StanzaId`] from
+    /// `waddle-xmpp-core`).
+    pub stanza_id: StanzaId,
     /// The archived message stanza, typed.
     pub message: Box<Message>,
     /// XEP-0424 tombstone state — `true` when this archive entry has
@@ -408,7 +336,10 @@ pub enum OutboundEvent {
         owner: BareJid,
         peer: BareJid,
         message: Box<Message>,
-        archive_ref: StanzaIdRef,
+        /// Canonical [`StanzaId`] linking the inbox row to its archived
+        /// counterpart so clients can pivot to the MAM entry using the
+        /// same XEP-0359 stanza-id space.
+        archive_ref: StanzaId,
         increment_unread: bool,
     },
     /// XEP-0045 §8.1 subject-change persistence. Emitted by the room

--- a/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
@@ -31,12 +31,12 @@
 //!   applies.
 
 use crate::inbox::runtime::should_project_message;
-use crate::protocol::event::{OutboundEvent, StanzaIdRef, StanzaIdValue};
+use crate::protocol::event::OutboundEvent;
 use crate::protocol::message_context::MessageContext;
 use crate::protocol::session_state::Locality;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
 use jid::{BareJid, Jid};
-use waddle_xmpp_core::xep0359::extract_stanza_id_by;
+use waddle_xmpp_core::xep0359::{extract_stanza_id_by, StanzaId};
 use xmpp_parsers::message::{Message, MessageType};
 
 /// Inbox projection handler.
@@ -111,14 +111,12 @@ fn build(
     local_archive_id: &str,
     increment_unread: bool,
 ) -> OutboundEvent {
+    let archive_jid: Jid = owner.clone().into();
     OutboundEvent::ProjectInbox {
-        owner: owner.clone(),
+        owner,
         peer,
         message: Box::new(message.clone()),
-        archive_ref: StanzaIdRef {
-            by: owner,
-            id: StanzaIdValue::new(local_archive_id),
-        },
+        archive_ref: StanzaId::new(local_archive_id, archive_jid),
         increment_unread,
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/offline_delivery.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/offline_delivery.rs
@@ -24,13 +24,13 @@ use crate::pending_delivery::PendingPayload;
 use crate::protocol::dm_routing::{
     classify_dm_intake, DmRouting, OnlineResources, PendingDecision,
 };
-use crate::protocol::event::{OutboundEvent, StanzaIdRef, StanzaIdValue};
+use crate::protocol::event::OutboundEvent;
 use crate::protocol::message_context::MessageContext;
 use crate::protocol::session_state::Locality;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
 use chrono::Utc;
 use jid::Jid;
-use waddle_xmpp_core::xep0359::extract_stanza_id_by;
+use waddle_xmpp_core::xep0359::{extract_stanza_id_by, StanzaId};
 use xmpp_parsers::message::Message;
 
 /// Intake handler for XEP-0160 offline storage.
@@ -102,10 +102,8 @@ impl MessageHandler for OfflineDeliveryHandler {
                         ),
                     }]);
                 };
-                let payload = PendingPayload::Archived(StanzaIdRef {
-                    by: recipient_bare.clone(),
-                    id: StanzaIdValue::new(stanza_id_str),
-                });
+                let payload =
+                    PendingPayload::Archived(StanzaId::new(stanza_id_str, owner_jid.clone()));
                 if message.from.is_none() {
                     return HandlerOutcome::Continue(Vec::new());
                 }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -46,13 +46,12 @@
 use super::errors::{
     bad_request_reply, item_not_found_reply, not_acceptable_reply, send_message_error,
 };
-use crate::protocol::event::{
-    ArchivedMessage, CallbackId, MessageRef, OriginIdValue, OutboundEvent, StanzaIdValue,
-};
+use crate::protocol::event::{ArchivedMessage, CallbackId, MessageRef, OutboundEvent};
 use crate::protocol::message_context::MessageContext;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
 use crate::xep::{xep0308, xep0424, xep0461};
 use jid::BareJid;
+use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
 use xmpp_parsers::message::{Message, MessageType};
 
 /// Sentinel callback id used by handlers that emit
@@ -190,7 +189,7 @@ pub fn detect(message: &Message, ctx: &MessageContext<'_>) -> Option<DetectedRic
             kind: RichTargetKind::Correction,
             reference: MessageRef::OriginId {
                 sender: author.clone(),
-                origin_id: OriginIdValue::new(correction.replaces_id),
+                origin_id: OriginId::new(correction.replaces_id),
             },
             author,
         });
@@ -201,11 +200,11 @@ pub fn detect(message: &Message, ctx: &MessageContext<'_>) -> Option<DetectedRic
     if let Some(xep0424::RetractionKind::Request(retraction)) =
         xep0424::extract_retraction_from_message(message)
     {
+        let archive_jid: jid::Jid = author.clone().into();
         return Some(DetectedRichTarget {
             kind: RichTargetKind::Retraction,
             reference: MessageRef::StanzaId {
-                by: author.clone(),
-                id: StanzaIdValue::new(retraction.retracts_id),
+                stanza_id: StanzaId::new(retraction.retracts_id, archive_jid),
             },
             author,
         });
@@ -213,11 +212,11 @@ pub fn detect(message: &Message, ctx: &MessageContext<'_>) -> Option<DetectedRic
 
     // XEP-0461 reply — references the target message by stanza-id.
     if let Some(reply) = xep0461::parse_reply_from_message(message) {
+        let archive_jid: jid::Jid = author.clone().into();
         return Some(DetectedRichTarget {
             kind: RichTargetKind::Reply,
             reference: MessageRef::StanzaId {
-                by: author.clone(),
-                id: StanzaIdValue::new(reply.id),
+                stanza_id: StanzaId::new(reply.id, archive_jid),
             },
             author,
         });
@@ -271,7 +270,6 @@ fn same_author(archived: &ArchivedMessage, author: &BareJid) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::event::StanzaIdRef;
     use crate::protocol::id_gen::FixedIdGenerator;
     use crate::protocol::message_context::MessageContextEnv;
     use crate::protocol::session_state::{Blocklist, CarbonsState, MucOccupancy};
@@ -331,11 +329,9 @@ mod tests {
         m.from = Some(from.parse().expect("jid"));
         m.type_ = MessageType::Chat;
         m.bodies.insert(String::new(), Body(body.to_string()));
+        let archive_jid: jid::Jid = bare("alice@example.com").into();
         ArchivedMessage {
-            stanza_id: StanzaIdRef {
-                by: bare("alice@example.com"),
-                id: StanzaIdValue::new("archive-A1"),
-            },
+            stanza_id: StanzaId::new("archive-A1", archive_jid),
             message: Box::new(m),
             tombstoned: false,
         }
@@ -442,9 +438,10 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let (_id, _archive, reference) = extract_lookup_event(&outcome);
         match reference {
-            MessageRef::StanzaId { by, id } => {
-                assert_eq!(*by, bare("alice@example.com"));
-                assert_eq!(id.as_str(), "stanza-X");
+            MessageRef::StanzaId { stanza_id } => {
+                let expected_by: jid::Jid = bare("alice@example.com").into();
+                assert_eq!(stanza_id.by, expected_by);
+                assert_eq!(stanza_id.as_str(), "stanza-X");
             }
             other => panic!("expected StanzaId ref, got {other:?}"),
         }
@@ -461,8 +458,8 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let (_id, _archive, reference) = extract_lookup_event(&outcome);
         match reference {
-            MessageRef::StanzaId { by: _, id } => {
-                assert_eq!(id.as_str(), "stanza-Y");
+            MessageRef::StanzaId { stanza_id } => {
+                assert_eq!(stanza_id.as_str(), "stanza-Y");
             }
             other => panic!("expected StanzaId ref, got {other:?}"),
         }

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -1118,13 +1118,14 @@ mod tests {
     // pipeline resumes and runs to completion.
     // ----------------------------------------------------------------
 
-    use crate::protocol::event::{ArchivedMessage, StanzaIdRef, StanzaIdValue};
+    use crate::protocol::event::ArchivedMessage;
     use crate::protocol::handlers::canonicalize::CanonicalizeHandler;
     use crate::protocol::handlers::enrichment_dispatch::EnrichmentDispatchHandler;
     use crate::protocol::handlers::rich_target_validation::RichTargetValidationHandler;
     use crate::protocol::message_context::MessageContext;
     use crate::protocol::traits::{HandlerOutcome, MessageHandler};
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use waddle_xmpp_core::xep0359::StanzaId;
     use xmpp_parsers::message::{Body, Message, MessageType};
 
     fn ready_machine_with_dispatcher(
@@ -1262,10 +1263,10 @@ mod tests {
             chat_with_body("alice@example.com/web", "bob@example.com", "original text");
         archived_msg.id = Some("orig-msg-1".to_string());
         let archived = ArchivedMessage {
-            stanza_id: StanzaIdRef {
-                by: "alice@example.com".parse().expect("bare"),
-                id: StanzaIdValue::new("archive-A1"),
-            },
+            stanza_id: StanzaId::new(
+                "archive-A1",
+                "alice@example.com".parse::<jid::Jid>().expect("jid"),
+            ),
             message: Box::new(archived_msg),
             tombstoned: false,
         };
@@ -1367,10 +1368,10 @@ mod tests {
             chat_with_body("mallory@example.com/web", "bob@example.com", "imposter");
         archived_msg.id = Some("orig-msg-1".to_string());
         let archived = ArchivedMessage {
-            stanza_id: StanzaIdRef {
-                by: "alice@example.com".parse().expect("bare"),
-                id: StanzaIdValue::new("archive-X"),
-            },
+            stanza_id: StanzaId::new(
+                "archive-X",
+                "alice@example.com".parse::<jid::Jid>().expect("jid"),
+            ),
             message: Box::new(archived_msg),
             tombstoned: false,
         };
@@ -1461,10 +1462,7 @@ mod tests {
         let mut archived_msg = chat_with_body("alice@example.com/web", "bob@example.com", "orig");
         archived_msg.id = Some("orig-msg-1".to_string());
         let archived = ArchivedMessage {
-            stanza_id: StanzaIdRef {
-                by: "alice@example.com".parse().expect("bare"),
-                id: StanzaIdValue::new("A1"),
-            },
+            stanza_id: StanzaId::new("A1", "alice@example.com".parse::<jid::Jid>().expect("jid")),
             message: Box::new(archived_msg),
             tombstoned: false,
         };

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -51,8 +51,8 @@ mod wire_trace_l4_tests;
 
 pub use dispatch::{MessageDispatchOutcome, MessageDispatchTermination, StanzaDispatcher};
 pub use event::{
-    ArchivedMessage, CallbackId, CarbonKind, InboundEvent, MessageRef, OriginIdValue,
-    OutboundEvent, StanzaContext, StanzaIdRef, StanzaIdValue, TimerId,
+    ArchivedMessage, CallbackId, CarbonKind, InboundEvent, MessageRef, OutboundEvent,
+    StanzaContext, TimerId,
 };
 pub use frame::InboundFrame;
 pub use id_gen::{CounterIdGenerator, FixedIdGenerator, IdGenerator, UuidV4Generator};


### PR DESCRIPTION
Closes #329.

## Problem

Three+ parallel `StanzaId`-ish types coexisted in the workspace, each invented for its layer without converging on the canonical XEP-0359 shape:

| Type | Location | Shape |
|---|---|---|
| `xep0359::StanzaId` | `waddle-xmpp-core::xep0359` (canonical, post-#228) | `{ id: String, by: Jid }` |
| `protocol::event::StanzaIdValue` | `waddle-xmpp::protocol::event` | newtype `String` |
| `protocol::event::StanzaIdRef` | `waddle-xmpp::protocol::event` | `{ by: BareJid, id: StanzaIdValue }` |
| `protocol::event::OriginIdValue` | `waddle-xmpp::protocol::event` | newtype `String` |
| `waddle-xmpp-client::request::StanzaId` | `waddle-xmpp-client::request` | newtype `String`, validated non-empty |

This forced `.to_string()` round-trips between layers and obscured the relationship between types.

## Audit

`StanzaIdValue` (id-only newtype in the protocol layer) — uses:
- `waddle-xmpp/src/protocol/event.rs` — definition + uses in `MessageRef::StanzaId`, `StanzaIdRef`
- `waddle-xmpp/src/protocol/handlers/rich_target_validation.rs` — XEP-0424 retraction + XEP-0461 reply construction
- `waddle-xmpp/src/protocol/handlers/inbox.rs`, `handlers/offline_delivery.rs` — building `StanzaIdRef` for inbox/pending payloads
- `waddle-xmpp/src/pending_delivery/{flush,storage,mod}.rs`, `protocol/machine.rs` — tests
- `waddle-server/src/sm_promotion.rs`, `pending_delivery.rs`, `server/routes/interpret.rs` — payload construction

`StanzaIdRef` (id+archive-jid struct in the protocol layer) — uses:
- `waddle-xmpp/src/protocol/event.rs` — definition + uses in `ArchivedMessage`, `OutboundEvent::ProjectInbox`
- `waddle-xmpp/src/pending_delivery/mod.rs` — `PendingPayload::Archived(StanzaIdRef)`
- handlers (inbox, offline_delivery, rich_target_validation) and server (`pending_delivery.rs`, `interpret.rs`, `sm_promotion.rs`) — payload construction

`OriginIdValue` (id-only newtype, sibling to `StanzaIdValue`) — uses:
- `waddle-xmpp/src/protocol/event.rs` — definition + uses in `MessageRef::OriginId`
- `waddle-xmpp/src/protocol/handlers/rich_target_validation.rs` — XEP-0308 correction
- `waddle-server/src/server/routes/interpret.rs` — tests

`waddle-xmpp-client::request::StanzaId` (validated id-only newtype) — uses:
- `waddle-xmpp-client/src/{request,client,messaging,bootstrap,event,error,runtime}.rs`
- `waddle-xmpp-client-ffi/src/lib.rs`
- `waddle-xmpp-client-wasm/src/lib.rs`

## Decisions

| Type | Decision | Rationale |
|---|---|---|
| `xep0359::StanzaId` (`{ id, by }`) | **Kept canonical** | Already the XEP-0359 §3 shape with typed `Jid`; post-#228 this is the workspace's canonical id+context type. |
| `xep0359::OriginId` (`{ id }`) | **Kept canonical** | XEP-0359 origin-id is identity-only by spec — already the right shape. |
| `protocol::event::StanzaIdValue(String)` | **Deleted** | Every existing call site eventually paired the id with a `BareJid` (via `StanzaIdRef`, `MessageRef::StanzaId`, or storage). Carrying just the id and re-attaching `by` one struct boundary later was redundant. Consolidated onto `xep0359::StanzaId`. |
| `protocol::event::StanzaIdRef { by: BareJid, id: StanzaIdValue }` | **Deleted** | Subsumed by `xep0359::StanzaId`. The structural difference (`BareJid` vs `Jid`) was bridged via `Jid::from(bare_jid)` at construction sites; storage round-trips parse back through `BareJid` so the bare-form is preserved. |
| `protocol::event::OriginIdValue(String)` | **Deleted** | Same argument as `StanzaIdValue`; replaced with `xep0359::OriginId`. |
| `waddle-xmpp-client::request::StanzaId(String)` | **Kept; documented** | Different concept — see "Note on the client newtype" below. Doc updated to clarify it's a client-side IQ-correlation token, not a XEP-0359 stamp. |

## Note on the client newtype

`waddle-xmpp-client::request::StanzaId` looks like a duplicate at first glance but it is a different concept:

- It models the *client*'s `<iq id='...'/>` correlation token — the value the client puts on outbound IQs and matches replies against.
- It is never paired with a `by` (the client cannot meaningfully stamp itself).
- It carries a non-emptiness invariant the canonical core type does not enforce (XEP-0359 ids are server-stamped UUIDs and assumed non-empty by construction; client correlation ids come from arbitrary code paths and need defensive validation).
- Its consumers are `RequestTracker`'s correlation map and FFI/WASM, neither of which has a `Jid` context.

Consolidating it into `xep0359::StanzaId` would either force every IQ-correlation site to fabricate a fake `by` Jid or strip the validation invariant — both worse than keeping the type. Doc-comment updated in this PR to clarify the distinction (referencing #329).

## Concrete changes

Commit 466153f2 — `refactor(server): extend xep0359 StanzaId with Display/Hash/as_str (#329)`:
- Added `Display`, `Hash`, `as_str()` to `xep0359::StanzaId` and `xep0359::OriginId`.
- Annotated both types with #329 cross-references.

Commit e5a7c13c — `refactor(server): replace protocol StanzaIdValue/Ref/OriginIdValue with xep0359 (#329)`:
- Deleted `StanzaIdValue`, `StanzaIdRef`, `OriginIdValue` from `waddle-xmpp::protocol::event`.
- `MessageRef::StanzaId { stanza_id: StanzaId }` (was `{ by, id }` with two fields).
- `MessageRef::OriginId { sender, origin_id: OriginId }` (was `OriginIdValue`).
- `ArchivedMessage.stanza_id: StanzaId` (was `StanzaIdRef`).
- `OutboundEvent::ProjectInbox.archive_ref: StanzaId` (was `StanzaIdRef`).
- `PendingPayload::Archived(StanzaId)` (was `StanzaIdRef`).
- `ArchiveResolver::resolve(&StanzaId)` (was `(&BareJid, &StanzaIdValue)`); the bare archive jid is now derived from `stanza_id.by.to_bare()`.
- Documented `waddle-xmpp-client::request::StanzaId` to clarify it's a client-side correlation token (see "Note on the client newtype").

Files touched: 14, net `-99` lines.

## Verification

- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (no `#[allow(...)]` introduced).
- `cargo fmt --all -- --check` — clean.
- `cargo test --workspace` — 61 test suites, all green.
- No wire-format change. No semantic change. No backwards-compat shims.
- No `.to_string()` round-trips introduced. The few `Jid::from(bare_jid)` widenings happen at construction sites where the next consumer needs a `Jid` (the canonical `StanzaId.by` is `Jid`); in the storage round-trip the value is parsed back into `BareJid` directly.

## Out of scope

- Wire-format or semantic changes — pure consolidation.
- The `by: Jid` retyping (#228 already lands that).