### PR TITLE
fix(charts): eliminate helm template drift on auto-generated secrets (#303)

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: waddle-server
-      version: 0.1.x
+      version: 0.2.x
       sourceRef:
         kind: HelmRepository
         name: waddle-server

--- a/server/charts/waddle-server/Chart.yaml
+++ b/server/charts/waddle-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: waddle-server
 description: Helm chart for deploying Waddle Social server to Kubernetes.
 type: application
-version: 0.1.12
+version: 0.2.0
 appVersion: "0.1.0"

--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -84,23 +84,83 @@ helm upgrade --install waddle ./charts/waddle-server \
 
 ## Secret handling
 
-The chart supports an app secret containing:
+The chart manages two distinct Secrets:
 
-- `WADDLE_SESSION_KEY` (required by server features relying on encrypted session data)
-- `WADDLE_OCCUPANT_ID_SECRET` (**required**; per-deployment HMAC key for XEP-0421 occupant identifiers; ≥32 bytes)
-- `WADDLE_AUTH_PROVIDERS_JSON` (optional; required to enable `/api/auth/*` broker flows)
-- `WADDLE_DATABASE_URL` (optional; preferred location for DB DSN with credentials)
-- `WADDLE_XMPP_MAM_DATABASE_URL` (optional MAM DSN override)
-- `WADDLE_XMPP_INBOX_DATABASE_URL` (optional inbox DSN override)
+1. **Bootstrap Secret** (`<release>-waddle-server-bootstrap-secrets`) — created
+   out-of-band by a `pre-install` Helm hook Job. Holds chart-managed
+   auto-generated keys:
+   - `WADDLE_SESSION_KEY` — server session encryption key.
+   - `WADDLE_OCCUPANT_ID_SECRET` — per-deployment HMAC key for XEP-0421
+     occupant identifiers (≥32 bytes). Only included when
+     `secret.manageOccupantIdSecret=true` (default).
+2. **Operator Secret** (`<release>-waddle-server-secrets`) — regular Helm
+   template, populated only from operator-supplied values:
+   - `WADDLE_AUTH_PROVIDERS_JSON` (optional; required to enable `/api/auth/*`
+     broker flows).
+   - `WADDLE_DATABASE_URL` (optional; preferred location for DB DSN with
+     credentials).
+   - `WADDLE_XMPP_MAM_DATABASE_URL`, `WADDLE_XMPP_INBOX_DATABASE_URL`,
+     `WADDLE_XMPP_PUBSUB_DATABASE_URL` (optional DSN overrides).
+   - `WADDLE_SPICEDB_PRESHARED_KEY` (required when `spicedb.enabled=true`
+     and not supplied via `extraSecretRefs`).
+   - Any of the bootstrap keys above when set explicitly via values
+     (operator override; `envFrom` ordering puts the operator Secret
+     after the bootstrap Secret so operator values win).
 
-Provider JSON may also be set in `config.authProvidersJson`, but `secret.authProvidersJson`
-is recommended because provider definitions usually include client secrets.
+Provider JSON may also be set in `config.authProvidersJson`, but
+`secret.authProvidersJson` is recommended because provider definitions usually
+include client secrets.
+
+### Why two Secrets?
+
+Earlier versions of this chart used Helm's `lookup` function to preserve
+auto-generated values across upgrades. `lookup` only works when Helm has
+cluster access, so `helm template`, ArgoCD's `helm template` strategy, and
+`helm upgrade --dry-run=server` would render a fresh `randAlphaNum 64` value
+on every render — producing spurious diffs and (worst case) silent rotation
+of secrets that downstream tooling then applied to the cluster. See
+[#303](https://github.com/waddle-social/waddle/issues/303).
+
+The pre-install hook moves generation entirely out of the Helm template
+phase. The bootstrap Secret is created by `kubectl` from inside the hook Job
+and is owned by neither Helm nor the chart, so subsequent renders never
+reference it. `helm template` is now byte-stable across runs.
+
+### Hook lifecycle
+
+- Hook runs on `pre-install` only. It creates the bootstrap Secret if it
+  does not exist; if it already exists the Job exits cleanly (idempotent).
+- Hook is **not** run on `pre-upgrade` — the bootstrap Secret is
+  long-lived. Upgrade flows use whatever the cluster already holds.
+- Job, ServiceAccount, Role, and RoleBinding are deleted automatically
+  after the Job succeeds (`hook-delete-policy: hook-succeeded`).
+- The bootstrap Secret itself has **no Helm ownership labels** and is never
+  garbage-collected by `helm uninstall`. Operators must clean it up
+  explicitly if they want full namespace teardown.
+
+### Disaster recovery
+
+If the bootstrap Secret is deleted (accidentally or as part of a
+namespace wipe) the chart will not regenerate it on `helm upgrade` — the
+hook is `pre-install` only, by design, so that occupant-id continuity is
+never silently rotated. Pods will fail to start with a clear error from
+the server about missing `WADDLE_OCCUPANT_ID_SECRET`. Recover by either:
+
+- Restoring the Secret from your external backup (Velero, sealed-secrets,
+  password manager) — preserves XEP-0421 occupant-id continuity.
+- Re-running `helm uninstall <release> && helm install <release> …` —
+  triggers the hook to regenerate fresh values; **breaks** XEP-0421
+  occupant-id continuity for every existing room/user pair.
+
+This is the intended trade-off — a noisy failure that demands operator
+attention, rather than a silent regeneration that quietly invalidates
+client state.
 
 ### Required keys when bringing your own Secret
 
-Setting `secret.create=false` and providing `secret.existingSecret=<name>` skips
-chart templating entirely. The externally-managed Secret **must** contain at
-minimum:
+Setting `secret.create=false` and providing `secret.existingSecret=<name>`
+skips both the bootstrap hook and the operator Secret template. The
+externally-managed Secret **must** contain at minimum:
 
 - `WADDLE_SESSION_KEY`
 - `WADDLE_OCCUPANT_ID_SECRET`
@@ -110,25 +170,102 @@ SpiceDB preshared key) that your deployment relies on. If
 `WADDLE_OCCUPANT_ID_SECRET` is missing, the server hard-fails at startup with
 a clear error.
 
+### Disabling auto-generation
+
+Set `secret.autoGenerate=false` to suppress the pre-install hook. In this
+mode you **must** supply `WADDLE_SESSION_KEY` (and
+`WADDLE_OCCUPANT_ID_SECRET` when `manageOccupantIdSecret=true`) through one
+of:
+
+- `secret.sessionKey` / `secret.occupantIdSecret` values (rendered into the
+  operator Secret).
+- `secret.existingSecret` pointing to a pre-existing Secret.
+- An entry in `extraSecretRefs`.
+
+The chart fails render with a clear error if none of these are satisfied.
+
 ### Default behavior
 
-- `secret.create=true` creates a chart-managed secret
-- `secret.manageOccupantIdSecret=true` makes the chart own `WADDLE_OCCUPANT_ID_SECRET`
-- If `secret.sessionKey` / `secret.occupantIdSecret` is empty:
-  - on first install, a random 64-character alphanumeric value is generated
-  - on upgrades, the existing in-cluster value is preserved (via `lookup`)
-
-Set `secret.manageOccupantIdSecret=false` only when `WADDLE_OCCUPANT_ID_SECRET`
-is supplied by an external Secret in `extraSecretRefs`; otherwise the server
-will fail startup because the occupant secret is required.
+- `secret.create=true` and `secret.autoGenerate=true` (defaults): the
+  pre-install hook generates a 64-character alphanumeric
+  `WADDLE_SESSION_KEY` and (when `manageOccupantIdSecret=true`)
+  `WADDLE_OCCUPANT_ID_SECRET`, persisted in the bootstrap Secret.
+- The operator Secret is only created when at least one operator-supplied
+  value is set (auth providers, DB DSNs, spicedb key, or explicit
+  session/occupant overrides).
+- Set `secret.manageOccupantIdSecret=false` only when
+  `WADDLE_OCCUPANT_ID_SECRET` is supplied by an external Secret in
+  `extraSecretRefs`; otherwise the server will fail startup because the
+  occupant secret is required.
 
 > ⚠️ **Do not rotate `WADDLE_OCCUPANT_ID_SECRET` without an explicit migration plan.**
 > The XEP-0421 occupant identifier is the only stable per-(room, user) handle for
 > client-side identity continuity (recognising users across nick changes). Rotating
 > the secret invalidates every previously-issued occupant-id, severing that continuity.
-> The chart auto-generates the secret once on first install; back up the resulting
-> Kubernetes Secret externally (Velero, sealed-secrets export, password manager) so a
-> namespace deletion or etcd loss does not silently rotate the key.
+> The pre-install hook creates the secret once; back up the resulting Kubernetes
+> Secret externally (Velero, sealed-secrets export, password manager) so a namespace
+> deletion or etcd loss does not silently rotate the key.
+
+Manual rotation (only when intentional):
+
+```bash
+kubectl -n <ns> delete secret <release>-waddle-server-bootstrap-secrets
+helm upgrade --install <release> ./charts/waddle-server   # hook re-runs
+```
+
+### Migrating from chart < 0.2.0
+
+Two breaking behavior changes versus chart 0.1.x:
+
+1. **Auto-generated keys** (`WADDLE_SESSION_KEY`,
+   `WADDLE_OCCUPANT_ID_SECRET`) used to live in
+   `<release>-waddle-server-secrets` and were preserved across upgrades
+   via `lookup`. They now live in a dedicated bootstrap Secret created
+   by a pre-install hook (the cause of the change is
+   [#303](https://github.com/waddle-social/waddle/issues/303)).
+2. **Operator-supplied keys** (`WADDLE_AUTH_PROVIDERS_JSON`,
+   `WADDLE_DATABASE_URL`, `WADDLE_XMPP_*_DATABASE_URL`,
+   `WADDLE_SPICEDB_PRESHARED_KEY`) no longer use `lookup` to preserve
+   values across upgrades when the operator stops passing them. This
+   was a bug — the chart should reflect the values you actually pass on
+   each upgrade — but the silent "preserve" behavior may have masked
+   missing values in your `helm upgrade` invocation. Audit your
+   operator scripts and ensure all required values are passed on every
+   upgrade.
+
+For the bootstrap Secret split, two migration paths:
+
+**Option A — copy existing values into the new bootstrap Secret (preserves
+session/occupant-id state):**
+
+```bash
+NS=<namespace>
+REL=<release>
+SK=$(kubectl -n "$NS" get secret "${REL}-waddle-server-secrets" -o jsonpath='{.data.WADDLE_SESSION_KEY}' | base64 -d)
+OID=$(kubectl -n "$NS" get secret "${REL}-waddle-server-secrets" -o jsonpath='{.data.WADDLE_OCCUPANT_ID_SECRET}' | base64 -d)
+kubectl -n "$NS" create secret generic "${REL}-waddle-server-bootstrap-secrets" \
+  --from-literal=WADDLE_SESSION_KEY="$SK" \
+  --from-literal=WADDLE_OCCUPANT_ID_SECRET="$OID"
+helm upgrade "$REL" ./charts/waddle-server  # the hook detects the existing Secret and is a no-op
+```
+
+**Option B — pin existing values in values.yaml (operator override path,
+no bootstrap Secret):**
+
+```bash
+helm upgrade "$REL" ./charts/waddle-server \
+  --set secret.autoGenerate=false \
+  --set secret.sessionKey="$SK" \
+  --set secret.occupantIdSecret="$OID"
+```
+
+If you skip migration, the pre-install hook will not run on upgrade
+(`pre-install` only) and the chart will not regenerate the bootstrap
+Secret. Pods will still pick up the existing
+`<release>-waddle-server-secrets` keys via the operator Secret `envFrom`
+entry, so existing deployments keep working — but the next fresh
+`helm install` (e.g. into a new namespace) will use the new bootstrap
+flow.
 
 Recommended for stable upgrades:
 

--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -87,8 +87,8 @@ helm upgrade --install waddle ./charts/waddle-server \
 The chart manages two distinct Secrets:
 
 1. **Bootstrap Secret** (`<release>-waddle-server-bootstrap-secrets`) — created
-   out-of-band by a `pre-install` Helm hook Job. Holds chart-managed
-   auto-generated keys:
+   out-of-band by a `pre-install` / `pre-upgrade` Helm hook Job. Holds
+   chart-managed auto-generated keys:
    - `WADDLE_SESSION_KEY` — server session encryption key.
    - `WADDLE_OCCUPANT_ID_SECRET` — per-deployment HMAC key for XEP-0421
      occupant identifiers (≥32 bytes). Only included when
@@ -121,17 +121,25 @@ on every render — producing spurious diffs and (worst case) silent rotation
 of secrets that downstream tooling then applied to the cluster. See
 [#303](https://github.com/waddle-social/waddle/issues/303).
 
-The pre-install hook moves generation entirely out of the Helm template
-phase. The bootstrap Secret is created by `kubectl` from inside the hook Job
-and is owned by neither Helm nor the chart, so subsequent renders never
-reference it. `helm template` is now byte-stable across runs.
+The pre-install / pre-upgrade hook moves generation entirely out of the
+Helm template phase. The bootstrap Secret is created by `kubectl` from
+inside the hook Job and is owned by neither Helm nor the chart, so
+subsequent renders never reference it. `helm template` is now byte-stable
+across runs.
 
 ### Hook lifecycle
 
-- Hook runs on `pre-install` only. It creates the bootstrap Secret if it
-  does not exist; if it already exists the Job exits cleanly (idempotent).
-- Hook is **not** run on `pre-upgrade` — the bootstrap Secret is
-  long-lived. Upgrade flows use whatever the cluster already holds.
+- Hooks run on both `pre-install` and `pre-upgrade`.
+- The Job is idempotent: it runs `kubectl get` first; if the bootstrap
+  Secret already exists it exits 0 without touching anything.
+- On a fresh install (no bootstrap Secret, no legacy operator Secret),
+  fresh 64-character alphanumeric values are generated.
+- On the first `pre-upgrade` from chart 0.1.x (bootstrap Secret missing
+  but legacy `<release>-waddle-server-secrets` exists with
+  `WADDLE_SESSION_KEY` / `WADDLE_OCCUPANT_ID_SECRET`), the Job copies
+  those values forward into the new bootstrap Secret **before** Helm
+  rewrites the operator Secret. This preserves XEP-0421 occupant-id
+  continuity automatically across the chart upgrade.
 - Job, ServiceAccount, Role, and RoleBinding are deleted automatically
   after the Job succeeds (`hook-delete-policy: hook-succeeded`).
 - The bootstrap Secret itself has **no Helm ownership labels** and is never
@@ -141,20 +149,22 @@ reference it. `helm template` is now byte-stable across runs.
 ### Disaster recovery
 
 If the bootstrap Secret is deleted (accidentally or as part of a
-namespace wipe) the chart will not regenerate it on `helm upgrade` — the
-hook is `pre-install` only, by design, so that occupant-id continuity is
-never silently rotated. Pods will fail to start with a clear error from
-the server about missing `WADDLE_OCCUPANT_ID_SECRET`. Recover by either:
+namespace wipe) the chart will regenerate it on the next `helm upgrade`.
+The hook first looks for surviving values in the legacy
+`<release>-waddle-server-secrets`; if none are present (or the operator
+Secret has also been deleted), fresh values are generated. Generating a
+fresh `WADDLE_OCCUPANT_ID_SECRET` **breaks XEP-0421 occupant-id
+continuity** for every existing room/user pair, so the recommended
+recovery path is:
 
-- Restoring the Secret from your external backup (Velero, sealed-secrets,
-  password manager) — preserves XEP-0421 occupant-id continuity.
-- Re-running `helm uninstall <release> && helm install <release> …` —
-  triggers the hook to regenerate fresh values; **breaks** XEP-0421
-  occupant-id continuity for every existing room/user pair.
+- Restore the bootstrap Secret from your external backup (Velero,
+  sealed-secrets, password manager) before the next upgrade —
+  preserves XEP-0421 continuity.
+- Or, accept the rotation and let `helm upgrade` regenerate the keys.
 
-This is the intended trade-off — a noisy failure that demands operator
-attention, rather than a silent regeneration that quietly invalidates
-client state.
+The Job logs which path it took (`migrated WADDLE_OCCUPANT_ID_SECRET
+from <name>` vs. `generated fresh WADDLE_OCCUPANT_ID_SECRET`); audit
+that line in your operator's deployment logs after a recovery upgrade.
 
 ### Required keys when bringing your own Secret
 
@@ -172,8 +182,8 @@ a clear error.
 
 ### Disabling auto-generation
 
-Set `secret.autoGenerate=false` to suppress the pre-install hook. In this
-mode you **must** supply `WADDLE_SESSION_KEY` (and
+Set `secret.autoGenerate=false` to suppress the pre-install / pre-upgrade
+hook. In this mode you **must** supply `WADDLE_SESSION_KEY` (and
 `WADDLE_OCCUPANT_ID_SECRET` when `manageOccupantIdSecret=true`) through one
 of:
 
@@ -187,7 +197,7 @@ The chart fails render with a clear error if none of these are satisfied.
 ### Default behavior
 
 - `secret.create=true` and `secret.autoGenerate=true` (defaults): the
-  pre-install hook generates a 64-character alphanumeric
+  pre-install / pre-upgrade hook generates a 64-character alphanumeric
   `WADDLE_SESSION_KEY` and (when `manageOccupantIdSecret=true`)
   `WADDLE_OCCUPANT_ID_SECRET`, persisted in the bootstrap Secret.
 - The operator Secret is only created when at least one operator-supplied
@@ -202,15 +212,25 @@ The chart fails render with a clear error if none of these are satisfied.
 > The XEP-0421 occupant identifier is the only stable per-(room, user) handle for
 > client-side identity continuity (recognising users across nick changes). Rotating
 > the secret invalidates every previously-issued occupant-id, severing that continuity.
-> The pre-install hook creates the secret once; back up the resulting Kubernetes
-> Secret externally (Velero, sealed-secrets export, password manager) so a namespace
-> deletion or etcd loss does not silently rotate the key.
+> The pre-install / pre-upgrade hook creates the secret once and is idempotent
+> on subsequent runs; back up the resulting Kubernetes Secret externally
+> (Velero, sealed-secrets export, password manager) so a namespace deletion or
+> etcd loss does not silently rotate the key.
 
-Manual rotation (only when intentional):
+Manual rotation (only when intentional and after you have a recovery
+plan for the broken occupant-id continuity):
 
 ```bash
+# Drop both the bootstrap Secret AND the legacy operator Secret keys
+# (otherwise the pre-upgrade hook will helpfully migrate them back in).
 kubectl -n <ns> delete secret <release>-waddle-server-bootstrap-secrets
-helm upgrade --install <release> ./charts/waddle-server   # hook re-runs
+kubectl -n <ns> patch secret <release>-waddle-server-secrets \
+  --type=json \
+  -p='[{"op":"remove","path":"/data/WADDLE_SESSION_KEY"},{"op":"remove","path":"/data/WADDLE_OCCUPANT_ID_SECRET"}]' \
+  || true   # operator Secret may not exist if you supply no operator values
+
+helm upgrade --install <release> ./charts/waddle-server
+# pre-upgrade hook regenerates fresh values
 ```
 
 ### Migrating from chart < 0.2.0
@@ -221,7 +241,7 @@ Two breaking behavior changes versus chart 0.1.x:
    `WADDLE_OCCUPANT_ID_SECRET`) used to live in
    `<release>-waddle-server-secrets` and were preserved across upgrades
    via `lookup`. They now live in a dedicated bootstrap Secret created
-   by a pre-install hook (the cause of the change is
+   by a pre-install / pre-upgrade hook (the cause of the change is
    [#303](https://github.com/waddle-social/waddle/issues/303)).
 2. **Operator-supplied keys** (`WADDLE_AUTH_PROVIDERS_JSON`,
    `WADDLE_DATABASE_URL`, `WADDLE_XMPP_*_DATABASE_URL`,
@@ -233,39 +253,33 @@ Two breaking behavior changes versus chart 0.1.x:
    operator scripts and ensure all required values are passed on every
    upgrade.
 
-For the bootstrap Secret split, two migration paths:
+For (1), the upgrade is **automatic**. On the first `helm upgrade` from
+chart 0.1.x to 0.2.x, the `pre-upgrade` hook runs before Helm rewrites
+the operator Secret. It detects the surviving auto-generated keys in
+`<release>-waddle-server-secrets`, copies them into the new bootstrap
+Secret, and only then does Helm rewrite the operator Secret without
+those keys. XEP-0421 occupant-id continuity is preserved without any
+operator intervention.
 
-**Option A — copy existing values into the new bootstrap Secret (preserves
-session/occupant-id state):**
+Look for these lines in the Job logs to confirm migration succeeded:
 
-```bash
-NS=<namespace>
-REL=<release>
-SK=$(kubectl -n "$NS" get secret "${REL}-waddle-server-secrets" -o jsonpath='{.data.WADDLE_SESSION_KEY}' | base64 -d)
-OID=$(kubectl -n "$NS" get secret "${REL}-waddle-server-secrets" -o jsonpath='{.data.WADDLE_OCCUPANT_ID_SECRET}' | base64 -d)
-kubectl -n "$NS" create secret generic "${REL}-waddle-server-bootstrap-secrets" \
-  --from-literal=WADDLE_SESSION_KEY="$SK" \
-  --from-literal=WADDLE_OCCUPANT_ID_SECRET="$OID"
-helm upgrade "$REL" ./charts/waddle-server  # the hook detects the existing Secret and is a no-op
+```
+migrated WADDLE_SESSION_KEY from <release>-waddle-server-secrets
+migrated WADDLE_OCCUPANT_ID_SECRET from <release>-waddle-server-secrets
 ```
 
-**Option B — pin existing values in values.yaml (operator override path,
-no bootstrap Secret):**
+If the chart logs `generated fresh WADDLE_OCCUPANT_ID_SECRET` instead,
+that is a signal the legacy Secret was missing those keys (e.g. you ran
+with `manageOccupantIdSecret=false` and supplied them via
+`extraSecretRefs`, in which case migration is a no-op and the existing
+external source remains authoritative).
 
-```bash
-helm upgrade "$REL" ./charts/waddle-server \
-  --set secret.autoGenerate=false \
-  --set secret.sessionKey="$SK" \
-  --set secret.occupantIdSecret="$OID"
-```
-
-If you skip migration, the pre-install hook will not run on upgrade
-(`pre-install` only) and the chart will not regenerate the bootstrap
-Secret. Pods will still pick up the existing
-`<release>-waddle-server-secrets` keys via the operator Secret `envFrom`
-entry, so existing deployments keep working — but the next fresh
-`helm install` (e.g. into a new namespace) will use the new bootstrap
-flow.
+If you prefer to migrate manually (e.g. to vault-style storage),
+disable the auto-migration by deleting the legacy keys from
+`<release>-waddle-server-secrets` *before* the upgrade, then either
+pre-create the bootstrap Secret yourself (`kubectl create secret
+generic <release>-waddle-server-bootstrap-secrets ...`) or set
+`secret.autoGenerate=false` and supply the keys explicitly.
 
 Recommended for stable upgrades:
 

--- a/server/charts/waddle-server/templates/NOTES.txt
+++ b/server/charts/waddle-server/templates/NOTES.txt
@@ -14,8 +14,9 @@ Image:   {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.ima
 {{- $autoGenerate = .Values.secret.autoGenerate -}}
 {{- end -}}
 
-{{- if .Release.IsInstall }}
 {{- if and .Values.secret.create (not .Values.secret.existingSecret) $autoGenerate }}
+
+{{- if .Release.IsInstall }}
 
 A pre-install / pre-upgrade Helm hook generated and persisted a Kubernetes
 Secret holding the chart-managed auto-generated keys
@@ -28,6 +29,40 @@ the rendered chart manifest. `helm template` and GitOps tools that render
 charts without cluster access will not produce drift against it. The Secret
 persists for the life of the namespace; subsequent upgrades detect the
 existing Secret and leave it untouched (the hook is idempotent).
+{{- else }}
+
+A pre-upgrade Helm hook ran before this upgrade rewrote the operator
+Secret. If you are upgrading from chart 0.1.x, the hook copied the
+auto-generated keys (WADDLE_SESSION_KEY{{ if .Values.secret.manageOccupantIdSecret }}, WADDLE_OCCUPANT_ID_SECRET{{ end }})
+forward into the bootstrap Secret BEFORE Helm pruned them from the
+operator Secret. XEP-0421 occupant-id continuity is preserved
+automatically.
+
+VERIFY MIGRATION (especially on the first 0.1.x → 0.2.x upgrade):
+
+  kubectl -n {{ .Release.Namespace }} get secret {{ include "waddle-server.bootstrapSecretName" . }}
+  kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/component=secret-bootstrap --tail=50
+
+The Job logs one of:
+
+  migrated WADDLE_SESSION_KEY from {{ include "waddle-server.secretName" . }}
+  migrated WADDLE_OCCUPANT_ID_SECRET from {{ include "waddle-server.secretName" . }}
+  generated fresh WADDLE_SESSION_KEY
+  generated fresh WADDLE_OCCUPANT_ID_SECRET
+
+A `generated fresh ...` line on a chart upgrade (rather than first
+install) means the legacy operator Secret did not contain that key —
+either you were already on 0.2.x, or the key was supplied externally
+(extraSecretRefs / existingSecret). A `generated fresh
+WADDLE_OCCUPANT_ID_SECRET` line on a 0.1.x → 0.2.x upgrade where you
+relied on the chart to manage the key indicates the migration did NOT
+find the legacy value and XEP-0421 occupant-id continuity has been
+broken — investigate before rolling restart.
+
+The Job, ServiceAccount, Role, and RoleBinding are deleted automatically
+after the Job succeeds, so the logs above are only available for ~5
+minutes (`ttlSecondsAfterFinished: 300`). Capture them now if needed.
+{{- end }}
 
 To rotate (DESTRUCTIVE -- breaks XEP-0421 occupant-id continuity and
 encrypted session state). Both the bootstrap Secret AND the auto-managed
@@ -43,7 +78,6 @@ helpfully migrates the legacy values back in:
 
 Back up the Secret externally (Velero, sealed-secrets export, password
 manager) so namespace deletion or etcd loss does not silently rotate it.
-{{- end }}
 {{- end }}
 
 {{- if .Values.secret.existingSecret }}

--- a/server/charts/waddle-server/templates/NOTES.txt
+++ b/server/charts/waddle-server/templates/NOTES.txt
@@ -1,0 +1,52 @@
+Waddle Social server has been {{ if .Release.IsInstall }}installed{{ else }}upgraded{{ end }}.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+Chart:   {{ .Chart.Name }}-{{ .Chart.Version }}
+{{ if .Values.image.digest -}}
+Image:   {{ .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else -}}
+Image:   {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+
+{{- $autoGenerate := true -}}
+{{- if hasKey .Values.secret "autoGenerate" -}}
+{{- $autoGenerate = .Values.secret.autoGenerate -}}
+{{- end -}}
+
+{{- if .Release.IsInstall }}
+{{- if and .Values.secret.create (not .Values.secret.existingSecret) $autoGenerate }}
+
+A pre-install Helm hook generated and persisted a Kubernetes Secret holding
+the chart-managed auto-generated keys (WADDLE_SESSION_KEY{{ if .Values.secret.manageOccupantIdSecret }}, WADDLE_OCCUPANT_ID_SECRET{{ end }}):
+
+  kubectl -n {{ .Release.Namespace }} get secret {{ include "waddle-server.bootstrapSecretName" . }}
+
+This Secret is owned by `kubectl` (not Helm) and is intentionally NOT part of
+the rendered chart manifest. `helm template` and GitOps tools that render
+charts without cluster access will not produce drift against it. The Secret
+persists for the life of the namespace and is never re-created on subsequent
+upgrades.
+
+To rotate (DESTRUCTIVE — breaks XEP-0421 occupant-id continuity and
+encrypted session state):
+
+  kubectl -n {{ .Release.Namespace }} delete secret {{ include "waddle-server.bootstrapSecretName" . }}
+  helm upgrade --install {{ .Release.Name }} <chart>   # hook re-runs
+
+Back up the Secret externally (Velero, sealed-secrets export, password
+manager) so namespace deletion or etcd loss does not silently rotate it.
+{{- end }}
+{{- end }}
+
+{{- if .Values.secret.existingSecret }}
+
+Using operator-managed Secret: {{ .Values.secret.existingSecret }}
+The chart did not create a Secret. Ensure WADDLE_SESSION_KEY{{ if .Values.secret.manageOccupantIdSecret }} and WADDLE_OCCUPANT_ID_SECRET{{ end }} are present.
+{{- end }}
+
+To check pod status:
+  kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }}
+
+To follow server logs:
+  kubectl -n {{ .Release.Namespace }} logs -f -l app.kubernetes.io/instance={{ .Release.Name }}

--- a/server/charts/waddle-server/templates/NOTES.txt
+++ b/server/charts/waddle-server/templates/NOTES.txt
@@ -17,22 +17,29 @@ Image:   {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.ima
 {{- if .Release.IsInstall }}
 {{- if and .Values.secret.create (not .Values.secret.existingSecret) $autoGenerate }}
 
-A pre-install Helm hook generated and persisted a Kubernetes Secret holding
-the chart-managed auto-generated keys (WADDLE_SESSION_KEY{{ if .Values.secret.manageOccupantIdSecret }}, WADDLE_OCCUPANT_ID_SECRET{{ end }}):
+A pre-install / pre-upgrade Helm hook generated and persisted a Kubernetes
+Secret holding the chart-managed auto-generated keys
+(WADDLE_SESSION_KEY{{ if .Values.secret.manageOccupantIdSecret }}, WADDLE_OCCUPANT_ID_SECRET{{ end }}):
 
   kubectl -n {{ .Release.Namespace }} get secret {{ include "waddle-server.bootstrapSecretName" . }}
 
 This Secret is owned by `kubectl` (not Helm) and is intentionally NOT part of
 the rendered chart manifest. `helm template` and GitOps tools that render
 charts without cluster access will not produce drift against it. The Secret
-persists for the life of the namespace and is never re-created on subsequent
-upgrades.
+persists for the life of the namespace; subsequent upgrades detect the
+existing Secret and leave it untouched (the hook is idempotent).
 
-To rotate (DESTRUCTIVE — breaks XEP-0421 occupant-id continuity and
-encrypted session state):
+To rotate (DESTRUCTIVE -- breaks XEP-0421 occupant-id continuity and
+encrypted session state). Both the bootstrap Secret AND the auto-managed
+keys in the legacy operator Secret must be removed; otherwise the hook
+helpfully migrates the legacy values back in:
 
   kubectl -n {{ .Release.Namespace }} delete secret {{ include "waddle-server.bootstrapSecretName" . }}
-  helm upgrade --install {{ .Release.Name }} <chart>   # hook re-runs
+  kubectl -n {{ .Release.Namespace }} patch secret {{ include "waddle-server.secretName" . }} \
+    --type=json \
+    -p='[{"op":"remove","path":"/data/WADDLE_SESSION_KEY"},{"op":"remove","path":"/data/WADDLE_OCCUPANT_ID_SECRET"}]' \
+    || true   # operator Secret may not exist if you supply no operator values
+  helm upgrade --install {{ .Release.Name }} <chart>   # pre-upgrade hook regenerates fresh values
 
 Back up the Secret externally (Velero, sealed-secrets export, password
 manager) so namespace deletion or etcd loss does not silently rotate it.

--- a/server/charts/waddle-server/templates/_helpers.tpl
+++ b/server/charts/waddle-server/templates/_helpers.tpl
@@ -80,7 +80,7 @@ ConfigMap name.
 {{- end -}}
 
 {{/*
-Secret name.
+Secret name (operator-supplied values).
 */}}
 {{- define "waddle-server.secretName" -}}
 {{- if .Values.secret.existingSecret -}}
@@ -91,9 +91,29 @@ Secret name.
 {{- end -}}
 
 {{/*
+Bootstrap Secret name (chart-managed auto-generated keys).
+
+The bootstrap Secret is created out-of-band by a pre-install hook (see
+templates/secret-bootstrap-hook.yaml) so that `helm template` does not
+produce drift against the live cluster. See waddle-social/waddle#303.
+*/}}
+{{- define "waddle-server.bootstrapSecretName" -}}
+{{- printf "%s-bootstrap-secrets" (include "waddle-server.fullname" .) -}}
+{{- end -}}
+
+{{/*
 Checksum external envFrom Secret contents so Helm reconciles roll pods after
 ExternalSecret-backed key rotation. The Secret values stay hashed; they are not
 rendered into the pod template.
+
+This deliberately uses `lookup` to observe live Secret data. Without cluster
+access (`helm template`) the checksum collapses to `missing`; the
+deployment annotation will then differ from a live render. That is benign
+drift -- the annotation only drives pod template hashing, never secret
+generation, and matches the documented purpose of `extraSecretChecksum`
+(rotate pods when ExternalSecret keys change). For a cluster-access-free
+GitOps flow that needs stable annotations, set `extraSecretChecksum` from
+`HelmRelease.spec.valuesFrom` referencing the source-of-truth checksum.
 */}}
 {{- define "waddle-server.extraSecretChecksum" -}}
 {{- range $name := .Values.extraSecretRefs }}

--- a/server/charts/waddle-server/templates/deployment.yaml
+++ b/server/charts/waddle-server/templates/deployment.yaml
@@ -52,9 +52,25 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "waddle-server.configMapName" . }}
+            {{- /*
+              Order matters: later envFrom sources override earlier ones for
+              the same key. Auto-generated bootstrap keys come first; then
+              operator-supplied values (which may override session/occupant);
+              then external Secrets injected via extraSecretRefs.
+            */}}
+            {{- $autoGenerate := true -}}
+            {{- if hasKey .Values.secret "autoGenerate" -}}
+            {{- $autoGenerate = .Values.secret.autoGenerate -}}
+            {{- end }}
+            {{- if and .Values.secret.create (not .Values.secret.existingSecret) $autoGenerate }}
+            - secretRef:
+                name: {{ include "waddle-server.bootstrapSecretName" . }}
+                optional: true
+            {{- end }}
             {{- if or .Values.secret.create .Values.secret.existingSecret }}
             - secretRef:
                 name: {{ include "waddle-server.secretName" . }}
+                optional: true
             {{- end }}
             {{- range .Values.extraSecretRefs }}
             - secretRef:

--- a/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
+++ b/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
@@ -1,0 +1,158 @@
+{{- /*
+Pre-install Helm hook that idempotently creates a separate Secret holding the
+auto-generated chart-managed keys (WADDLE_SESSION_KEY,
+WADDLE_OCCUPANT_ID_SECRET).
+
+Why a hook and not a regular template:
+
+  Helm's `lookup` only reads from a live cluster. When a chart is rendered
+  with `helm template` or by GitOps tooling that uses `helm template`-style
+  rendering (ArgoCD's helm template strategy, `helm upgrade --dry-run=server`
+  for some configs), `lookup` returns empty -- even when the in-cluster
+  Secret exists. A `lookup`-then-randAlphaNum fallback then produces drift
+  against the live Secret on every render. See waddle-social/waddle#303.
+
+  Moving generation to a hook removes the Secret from the rendered manifest
+  entirely. The hook only runs when Helm has cluster access (i.e. real
+  install/upgrade), and the Secret it creates is owned by `kubectl` -- not
+  Helm -- so no subsequent template render references it.
+
+The hook uses `kubectl create secret generic ... || true` semantics so it is
+idempotent: if the Secret already exists (re-install, repeated upgrade) it
+is left untouched. Rotating these values requires deleting the Secret and
+re-running install, or patching the Secret directly. See README.md.
+*/ -}}
+{{- $manageOccupantIdSecret := true -}}
+{{- if hasKey .Values.secret "manageOccupantIdSecret" -}}
+{{- $manageOccupantIdSecret = .Values.secret.manageOccupantIdSecret -}}
+{{- end -}}
+{{- $autoGenerate := true -}}
+{{- if hasKey .Values.secret "autoGenerate" -}}
+{{- $autoGenerate = .Values.secret.autoGenerate -}}
+{{- end -}}
+{{- if and .Values.secret.create (not .Values.secret.existingSecret) $autoGenerate }}
+{{- $bootstrapName := include "waddle-server.bootstrapSecretName" . -}}
+{{- $saName := printf "%s-bootstrap" (include "waddle-server.fullname" .) -}}
+{{- $bootstrap := default (dict) .Values.secret.bootstrap -}}
+{{- $bootstrapImage := default "bitnami/kubectl:1.31" (get $bootstrap "image") -}}
+{{- $imagePullPolicy := default "IfNotPresent" (get $bootstrap "imagePullPolicy") -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  labels:
+    {{- include "waddle-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $saName }}
+  labels:
+    {{- include "waddle-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  # `create` cannot be restricted by resourceNames in RBAC (the resource
+  # does not exist yet), so we narrow the create permission to the
+  # `secrets` resource only and rely on the bootstrap script using a
+  # fixed name. `get` is restricted to the specific bootstrap Secret so
+  # the hook cannot read other Secrets in the namespace.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+    resourceNames: [{{ $bootstrapName | quote }}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $saName }}
+  labels:
+    {{- include "waddle-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $saName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $saName }}
+  labels:
+    {{- include "waddle-server.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "waddle-server.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: secret-bootstrap
+    spec:
+      serviceAccountName: {{ $saName }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+        - name: bootstrap
+          image: {{ $bootstrapImage | quote }}
+          imagePullPolicy: {{ $imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: BOOTSTRAP_SECRET_NAME
+              value: {{ $bootstrapName | quote }}
+            - name: BOOTSTRAP_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: MANAGE_OCCUPANT_ID_SECRET
+              value: {{ $manageOccupantIdSecret | quote }}
+          command:
+            - /bin/bash
+            - -ceu
+            - |
+              if kubectl -n "$BOOTSTRAP_NAMESPACE" get secret "$BOOTSTRAP_SECRET_NAME" >/dev/null 2>&1; then
+                echo "secret $BOOTSTRAP_SECRET_NAME already exists; leaving untouched"
+                exit 0
+              fi
+              gen() {
+                # 64 alphanumeric chars; matches randAlphaNum 64 used previously.
+                LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64
+              }
+              SESSION_KEY="$(gen)"
+              ARGS=(--from-literal="WADDLE_SESSION_KEY=${SESSION_KEY}")
+              if [ "${MANAGE_OCCUPANT_ID_SECRET}" = "true" ]; then
+                OCCUPANT_ID_SECRET="$(gen)"
+                ARGS+=(--from-literal="WADDLE_OCCUPANT_ID_SECRET=${OCCUPANT_ID_SECRET}")
+              fi
+              kubectl -n "$BOOTSTRAP_NAMESPACE" create secret generic \
+                "$BOOTSTRAP_SECRET_NAME" \
+                --type=Opaque \
+                "${ARGS[@]}"
+              echo "created secret $BOOTSTRAP_SECRET_NAME"
+{{- end }}

--- a/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
+++ b/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
@@ -1,7 +1,7 @@
 {{- /*
-Pre-install Helm hook that idempotently creates a separate Secret holding the
-auto-generated chart-managed keys (WADDLE_SESSION_KEY,
-WADDLE_OCCUPANT_ID_SECRET).
+Idempotent pre-install / pre-upgrade Helm hook that creates a separate
+Secret holding the auto-generated chart-managed keys
+(WADDLE_SESSION_KEY, WADDLE_OCCUPANT_ID_SECRET).
 
 Why a hook and not a regular template:
 
@@ -14,13 +14,33 @@ Why a hook and not a regular template:
 
   Moving generation to a hook removes the Secret from the rendered manifest
   entirely. The hook only runs when Helm has cluster access (i.e. real
-  install/upgrade), and the Secret it creates is owned by `kubectl` -- not
-  Helm -- so no subsequent template render references it.
+  install or upgrade against a real apiserver), and the Secret it creates
+  is owned by `kubectl` -- not Helm -- so no subsequent template render
+  references it.
 
-The hook uses `kubectl create secret generic ... || true` semantics so it is
-idempotent: if the Secret already exists (re-install, repeated upgrade) it
-is left untouched. Rotating these values requires deleting the Secret and
-re-running install, or patching the Secret directly. See README.md.
+Idempotency:
+  The bash entrypoint runs `kubectl get secret` first; if the bootstrap
+  Secret already exists the Job exits 0 without touching it. Only the
+  first run (or a run after the bootstrap Secret was deleted) calls
+  `kubectl create`. This means:
+
+  * Repeated installs / upgrades never rotate the keys.
+  * Accidental deletion auto-heals on the next upgrade. The script
+    first looks for surviving values in the legacy operator Secret
+    (chart 0.1.x left them there) and migrates them forward; only when
+    no legacy values exist does it generate fresh keys. Generating a
+    fresh `WADDLE_OCCUPANT_ID_SECRET` breaks XEP-0421 continuity, which
+    is documented in README.md as a destructive recovery operation
+    requiring intent.
+
+Hooks run on both `pre-install` and `pre-upgrade` so:
+  * First-time installs get a freshly-generated bootstrap Secret.
+  * Upgrades from chart 0.1.x automatically migrate the existing
+    auto-generated keys out of the operator Secret into the new
+    bootstrap Secret BEFORE Helm rewrites the operator Secret manifest
+    (which would otherwise prune those keys).
+  * Accidental deletion of the bootstrap Secret auto-heals on the next
+    upgrade without forcing `helm uninstall`.
 */ -}}
 {{- $manageOccupantIdSecret := true -}}
 {{- if hasKey .Values.secret "manageOccupantIdSecret" -}}
@@ -44,7 +64,7 @@ metadata:
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
@@ -55,22 +75,26 @@ metadata:
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   # `create` cannot be restricted by resourceNames in RBAC (the resource
   # does not exist yet), so we narrow the create permission to the
-  # `secrets` resource only and rely on the bootstrap script using a
-  # fixed name. `get` is restricted to the specific bootstrap Secret so
-  # the hook cannot read other Secrets in the namespace.
+  # `secrets` resource only and rely on the bootstrap script using
+  # fixed names. `get` is restricted to the bootstrap Secret and the
+  # legacy operator Secret -- the latter so the chart-0.1.x → 0.2.0
+  # migration can copy WADDLE_SESSION_KEY / WADDLE_OCCUPANT_ID_SECRET
+  # forward without operator intervention.
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
-    resourceNames: [{{ $bootstrapName | quote }}]
+    resourceNames:
+      - {{ $bootstrapName | quote }}
+      - {{ include "waddle-server.secretName" . | quote }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -79,7 +103,7 @@ metadata:
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
@@ -98,7 +122,7 @@ metadata:
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "0"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -140,6 +164,8 @@ spec:
           env:
             - name: BOOTSTRAP_SECRET_NAME
               value: {{ $bootstrapName | quote }}
+            - name: LEGACY_SECRET_NAME
+              value: {{ include "waddle-server.secretName" . | quote }}
             - name: BOOTSTRAP_NAMESPACE
               value: {{ .Release.Namespace | quote }}
             - name: MANAGE_OCCUPANT_ID_SECRET
@@ -148,18 +174,48 @@ spec:
             - /bin/bash
             - -ceu
             - |
+              # Idempotent: if the bootstrap Secret already exists, do nothing.
               if kubectl -n "$BOOTSTRAP_NAMESPACE" get secret "$BOOTSTRAP_SECRET_NAME" >/dev/null 2>&1; then
                 echo "secret $BOOTSTRAP_SECRET_NAME already exists; leaving untouched"
                 exit 0
               fi
+
+              # Migration: chart 0.1.x stored auto-generated keys in the
+              # operator Secret. If we are running pre-upgrade against a
+              # release that pre-dates 0.2.0, copy the existing values
+              # forward instead of generating fresh ones (which would
+              # break XEP-0421 occupant-id continuity).
+              SESSION_KEY=""
+              OCCUPANT_ID_SECRET=""
+              if kubectl -n "$BOOTSTRAP_NAMESPACE" get secret "$LEGACY_SECRET_NAME" >/dev/null 2>&1; then
+                LEGACY_SESSION_KEY="$(kubectl -n "$BOOTSTRAP_NAMESPACE" get secret "$LEGACY_SECRET_NAME" -o jsonpath='{.data.WADDLE_SESSION_KEY}' 2>/dev/null || true)"
+                if [ -n "${LEGACY_SESSION_KEY}" ]; then
+                  SESSION_KEY="$(printf %s "${LEGACY_SESSION_KEY}" | base64 -d)"
+                  echo "migrated WADDLE_SESSION_KEY from $LEGACY_SECRET_NAME"
+                fi
+                if [ "${MANAGE_OCCUPANT_ID_SECRET}" = "true" ]; then
+                  LEGACY_OCCUPANT_ID_SECRET="$(kubectl -n "$BOOTSTRAP_NAMESPACE" get secret "$LEGACY_SECRET_NAME" -o jsonpath='{.data.WADDLE_OCCUPANT_ID_SECRET}' 2>/dev/null || true)"
+                  if [ -n "${LEGACY_OCCUPANT_ID_SECRET}" ]; then
+                    OCCUPANT_ID_SECRET="$(printf %s "${LEGACY_OCCUPANT_ID_SECRET}" | base64 -d)"
+                    echo "migrated WADDLE_OCCUPANT_ID_SECRET from $LEGACY_SECRET_NAME"
+                  fi
+                fi
+              fi
+
               gen() {
                 # 64 alphanumeric chars; matches randAlphaNum 64 used previously.
                 LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 64
               }
-              SESSION_KEY="$(gen)"
+              if [ -z "${SESSION_KEY}" ]; then
+                SESSION_KEY="$(gen)"
+                echo "generated fresh WADDLE_SESSION_KEY"
+              fi
               ARGS=(--from-literal="WADDLE_SESSION_KEY=${SESSION_KEY}")
               if [ "${MANAGE_OCCUPANT_ID_SECRET}" = "true" ]; then
-                OCCUPANT_ID_SECRET="$(gen)"
+                if [ -z "${OCCUPANT_ID_SECRET}" ]; then
+                  OCCUPANT_ID_SECRET="$(gen)"
+                  echo "generated fresh WADDLE_OCCUPANT_ID_SECRET"
+                fi
                 ARGS+=(--from-literal="WADDLE_OCCUPANT_ID_SECRET=${OCCUPANT_ID_SECRET}")
               fi
               kubectl -n "$BOOTSTRAP_NAMESPACE" create secret generic \

--- a/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
+++ b/server/charts/waddle-server/templates/secret-bootstrap-hook.yaml
@@ -115,7 +115,13 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1001
+        runAsGroup: 1001
         fsGroup: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
       containers:
         - name: bootstrap
           image: {{ $bootstrapImage | quote }}
@@ -123,8 +129,14 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
             capabilities:
               drop: ["ALL"]
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           env:
             - name: BOOTSTRAP_SECRET_NAME
               value: {{ $bootstrapName | quote }}

--- a/server/charts/waddle-server/templates/secret.yaml
+++ b/server/charts/waddle-server/templates/secret.yaml
@@ -1,69 +1,51 @@
+{{- /*
+Operator-supplied Secret. Chart-managed auto-generated keys
+(WADDLE_SESSION_KEY, WADDLE_OCCUPANT_ID_SECRET) live in a separate
+hook-managed Secret -- see templates/secret-bootstrap-hook.yaml -- so that
+`helm template` / GitOps rendering without cluster access does not produce
+drift against the live Secret (waddle-social/waddle#303).
+
+This template emits only keys the operator explicitly passes through values.
+Nothing here uses `lookup`, so render output is deterministic.
+
+The Secret is created only when the operator supplies at least one value;
+otherwise the Deployment relies on the bootstrap Secret plus extraSecretRefs.
+*/ -}}
 {{- if and .Values.secret.create (not .Values.secret.existingSecret) }}
-{{- $secretName := include "waddle-server.secretName" . -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $sessionKey := default "" .Values.secret.sessionKey -}}
+{{- $occupantIdSecret := default "" .Values.secret.occupantIdSecret -}}
+{{- $authProvidersJson := default "" .Values.secret.authProvidersJson -}}
+{{- $databaseUrl := default "" .Values.secret.databaseUrl -}}
+{{- $xmppMamDatabaseUrl := default "" .Values.secret.xmppMamDatabaseUrl -}}
+{{- $xmppInboxDatabaseUrl := default "" .Values.secret.xmppInboxDatabaseUrl -}}
+{{- $xmppPubsubDatabaseUrl := default "" .Values.secret.xmppPubsubDatabaseUrl -}}
+{{- $spicedbPresharedKey := default "" .Values.secret.spicedbPresharedKey -}}
 {{- $manageOccupantIdSecret := true -}}
 {{- if hasKey .Values.secret "manageOccupantIdSecret" -}}
 {{- $manageOccupantIdSecret = .Values.secret.manageOccupantIdSecret -}}
 {{- end -}}
-{{- $existingSessionKey := "" -}}
-{{- $existingAuthProvidersJson := "" -}}
-{{- $existingDatabaseUrl := "" -}}
-{{- $existingXmppMamDatabaseUrl := "" -}}
-{{- $existingXmppInboxDatabaseUrl := "" -}}
-{{- $existingXmppPubsubDatabaseUrl := "" -}}
-{{- $existingSpiceDbPresharedKey := "" -}}
-{{- $existingOccupantIdSecret := "" -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_SESSION_KEY") -}}
-{{- $existingSessionKey = (index $existing.data "WADDLE_SESSION_KEY" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_AUTH_PROVIDERS_JSON") -}}
-{{- $existingAuthProvidersJson = (index $existing.data "WADDLE_AUTH_PROVIDERS_JSON" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_DATABASE_URL") -}}
-{{- $existingDatabaseUrl = (index $existing.data "WADDLE_DATABASE_URL" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_XMPP_MAM_DATABASE_URL") -}}
-{{- $existingXmppMamDatabaseUrl = (index $existing.data "WADDLE_XMPP_MAM_DATABASE_URL" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_XMPP_INBOX_DATABASE_URL") -}}
-{{- $existingXmppInboxDatabaseUrl = (index $existing.data "WADDLE_XMPP_INBOX_DATABASE_URL" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_XMPP_PUBSUB_DATABASE_URL") -}}
-{{- $existingXmppPubsubDatabaseUrl = (index $existing.data "WADDLE_XMPP_PUBSUB_DATABASE_URL" | b64dec) -}}
-{{- end -}}
-{{- if and $existing $existing.data (hasKey $existing.data "WADDLE_SPICEDB_PRESHARED_KEY") -}}
-{{- $existingSpiceDbPresharedKey = (index $existing.data "WADDLE_SPICEDB_PRESHARED_KEY" | b64dec) -}}
-{{- end -}}
-{{- if and $manageOccupantIdSecret $existing $existing.data (hasKey $existing.data "WADDLE_OCCUPANT_ID_SECRET") -}}
-{{- $existingOccupantIdSecret = (index $existing.data "WADDLE_OCCUPANT_ID_SECRET" | b64dec) -}}
-{{- end -}}
-{{- $sessionKey := default "" (coalesce .Values.secret.sessionKey $existingSessionKey) -}}
-{{- $authProvidersJson := coalesce .Values.secret.authProvidersJson $existingAuthProvidersJson -}}
-{{- $databaseUrl := coalesce .Values.secret.databaseUrl $existingDatabaseUrl -}}
-{{- $xmppMamDatabaseUrl := coalesce .Values.secret.xmppMamDatabaseUrl $existingXmppMamDatabaseUrl -}}
-{{- $xmppInboxDatabaseUrl := coalesce .Values.secret.xmppInboxDatabaseUrl $existingXmppInboxDatabaseUrl -}}
-{{- $xmppPubsubDatabaseUrl := coalesce .Values.secret.xmppPubsubDatabaseUrl $existingXmppPubsubDatabaseUrl -}}
-{{- $spicedbPresharedKey := coalesce .Values.secret.spicedbPresharedKey $existingSpiceDbPresharedKey -}}
-{{- $occupantIdSecret := "" -}}
-{{- if $manageOccupantIdSecret -}}
-{{- $occupantIdSecret = default "" (coalesce .Values.secret.occupantIdSecret $existingOccupantIdSecret) -}}
-{{- end -}}
-{{- if empty $sessionKey -}}
-{{- $sessionKey = randAlphaNum 64 -}}
-{{- end -}}
-{{- if and $manageOccupantIdSecret (empty $occupantIdSecret) -}}
-{{- $occupantIdSecret = randAlphaNum 64 -}}
-{{- end -}}
+{{- $hasOperatorData := or
+  (ne $sessionKey "")
+  (and $manageOccupantIdSecret (ne $occupantIdSecret ""))
+  (ne $authProvidersJson "")
+  (ne $databaseUrl "")
+  (ne $xmppMamDatabaseUrl "")
+  (ne $xmppInboxDatabaseUrl "")
+  (ne $xmppPubsubDatabaseUrl "")
+  (ne $spicedbPresharedKey "") -}}
+{{- if $hasOperatorData }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ include "waddle-server.secretName" . }}
   labels:
     {{- include "waddle-server.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if $sessionKey }}
   WADDLE_SESSION_KEY: {{ $sessionKey | toString | b64enc }}
-  {{- if $manageOccupantIdSecret }}
+  {{- end }}
+  {{- if and $manageOccupantIdSecret $occupantIdSecret }}
   WADDLE_OCCUPANT_ID_SECRET: {{ $occupantIdSecret | toString | b64enc }}
   {{- end }}
   {{- if $authProvidersJson }}
@@ -84,4 +66,5 @@ data:
   {{- if $spicedbPresharedKey }}
   WADDLE_SPICEDB_PRESHARED_KEY: {{ $spicedbPresharedKey | b64enc }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/server/charts/waddle-server/templates/validations.yaml
+++ b/server/charts/waddle-server/templates/validations.yaml
@@ -99,3 +99,29 @@
 {{- fail "spicedb requires either secret.spicedbPresharedKey, secret.existingSecret, or extraSecretRefs providing WADDLE_SPICEDB_PRESHARED_KEY" -}}
 {{- end -}}
 {{- end -}}
+
+{{- /*
+Guard against a config where neither the chart's auto-generated bootstrap
+Secret nor any operator-supplied source carries WADDLE_SESSION_KEY /
+WADDLE_OCCUPANT_ID_SECRET. The server hard-fails at startup without these,
+so refuse to render rather than ship a broken Deployment.
+*/ -}}
+{{- if and .Values.secret.create (not .Values.secret.existingSecret) -}}
+{{- $autoGenerate := true -}}
+{{- if hasKey .Values.secret "autoGenerate" -}}
+{{- $autoGenerate = .Values.secret.autoGenerate -}}
+{{- end -}}
+{{- $hasExtraSecretRefs := gt (len .Values.extraSecretRefs) 0 -}}
+{{- if not $autoGenerate -}}
+{{- if and (not .Values.secret.sessionKey) (not $hasExtraSecretRefs) -}}
+{{- fail "secret.autoGenerate=false requires secret.sessionKey, secret.existingSecret, or extraSecretRefs providing WADDLE_SESSION_KEY" -}}
+{{- end -}}
+{{- $manageOccupantIdSecret := true -}}
+{{- if hasKey .Values.secret "manageOccupantIdSecret" -}}
+{{- $manageOccupantIdSecret = .Values.secret.manageOccupantIdSecret -}}
+{{- end -}}
+{{- if and $manageOccupantIdSecret (not .Values.secret.occupantIdSecret) (not $hasExtraSecretRefs) -}}
+{{- fail "secret.autoGenerate=false with secret.manageOccupantIdSecret=true requires secret.occupantIdSecret, secret.existingSecret, or extraSecretRefs providing WADDLE_OCCUPANT_ID_SECRET" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -143,14 +143,40 @@ telemetry:
 secret:
   create: true
   existingSecret: ""
+  # When true (default), a pre-install Helm hook generates and persists a
+  # separate Kubernetes Secret containing the auto-generated chart-managed
+  # keys (WADDLE_SESSION_KEY and, when manageOccupantIdSecret=true,
+  # WADDLE_OCCUPANT_ID_SECRET).
+  #
+  # The bootstrap Secret is owned by `kubectl` (not Helm), so it is never
+  # rendered by `helm template` and never produces drift in GitOps tools
+  # that render charts without cluster access. See
+  # https://github.com/waddle-social/waddle/issues/303.
+  #
+  # Set to false when supplying both secret.sessionKey and
+  # secret.occupantIdSecret (or manageOccupantIdSecret=false) explicitly,
+  # or when WADDLE_SESSION_KEY / WADDLE_OCCUPANT_ID_SECRET are injected
+  # through extraSecretRefs.
+  autoGenerate: true
+  bootstrap:
+    # Image used by the pre-install hook Job. Must contain `kubectl` and
+    # POSIX `tr` / `head` for random key generation.
+    image: "bitnami/kubectl:1.31"
+    imagePullPolicy: IfNotPresent
+  # When set, used as WADDLE_SESSION_KEY in the operator Secret and
+  # overrides the bootstrap-generated value (envFrom ordering: operator
+  # Secret follows the bootstrap Secret).
   sessionKey: ""
   # Set false when WADDLE_OCCUPANT_ID_SECRET is supplied by an external secret
   # referenced through extraSecretRefs.
   manageOccupantIdSecret: true
   # Per-deployment HMAC key used to derive XEP-0421 occupant identifiers.
-  # Required (≥32 bytes). When `secret.create` is true and this value is
-  # empty the chart auto-generates a 64-character alphanumeric secret on
-  # first install and preserves it across upgrades via `lookup`.
+  # Required (≥32 bytes). When `secret.create` is true,
+  # `secret.autoGenerate` is true, and this value is empty the pre-install
+  # hook auto-generates a 64-character alphanumeric secret on first
+  # install. The bootstrap Secret is created out-of-band by `kubectl`
+  # inside the hook Job and persists for the life of the namespace; it is
+  # never re-created on subsequent upgrades.
   # **Do not rotate** without an explicit migration plan — rotation breaks
   # XEP-0421 occupant-id continuity for every existing room/user pair.
   occupantIdSecret: ""

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -143,10 +143,10 @@ telemetry:
 secret:
   create: true
   existingSecret: ""
-  # When true (default), a pre-install Helm hook generates and persists a
-  # separate Kubernetes Secret containing the auto-generated chart-managed
-  # keys (WADDLE_SESSION_KEY and, when manageOccupantIdSecret=true,
-  # WADDLE_OCCUPANT_ID_SECRET).
+  # When true (default), a pre-install / pre-upgrade Helm hook generates
+  # and persists a separate Kubernetes Secret containing the
+  # auto-generated chart-managed keys (WADDLE_SESSION_KEY and, when
+  # manageOccupantIdSecret=true, WADDLE_OCCUPANT_ID_SECRET).
   #
   # The bootstrap Secret is owned by `kubectl` (not Helm), so it is never
   # rendered by `helm template` and never produces drift in GitOps tools
@@ -159,8 +159,10 @@ secret:
   # through extraSecretRefs.
   autoGenerate: true
   bootstrap:
-    # Image used by the pre-install hook Job. Must contain `kubectl` and
-    # POSIX `tr` / `head` for random key generation.
+    # Image used by the pre-install / pre-upgrade hook Job. Must contain
+    # `kubectl`, `bash` (the script uses bash arrays), and `tr` / `head`
+    # / `base64` for random key generation and legacy-secret migration.
+    # `bitnami/kubectl` ships all of these.
     image: "bitnami/kubectl:1.31"
     imagePullPolicy: IfNotPresent
   # When set, used as WADDLE_SESSION_KEY in the operator Secret and
@@ -172,11 +174,12 @@ secret:
   manageOccupantIdSecret: true
   # Per-deployment HMAC key used to derive XEP-0421 occupant identifiers.
   # Required (≥32 bytes). When `secret.create` is true,
-  # `secret.autoGenerate` is true, and this value is empty the pre-install
-  # hook auto-generates a 64-character alphanumeric secret on first
-  # install. The bootstrap Secret is created out-of-band by `kubectl`
-  # inside the hook Job and persists for the life of the namespace; it is
-  # never re-created on subsequent upgrades.
+  # `secret.autoGenerate` is true, and this value is empty the
+  # pre-install / pre-upgrade hook auto-generates a 64-character
+  # alphanumeric secret on first install. The bootstrap Secret is
+  # created out-of-band by `kubectl` inside the hook Job and persists
+  # for the life of the namespace; the hook is idempotent and leaves
+  # existing values untouched on subsequent upgrades.
   # **Do not rotate** without an explicit migration plan — rotation breaks
   # XEP-0421 occupant-id continuity for every existing room/user pair.
   occupantIdSecret: ""


### PR DESCRIPTION
## Summary

Closes #303.

`server/charts/waddle-server/templates/secret.yaml` used Helm `lookup` to preserve auto-generated secrets (`WADDLE_SESSION_KEY`, `WADDLE_OCCUPANT_ID_SECRET`) across upgrades. When the chart was rendered without cluster access (`helm template`, ArgoCD's `helm template` strategy, `helm upgrade --dry-run=server`), `lookup` returned empty unconditionally and the fallback path generated a fresh `randAlphaNum 64`. The result was a manifest that did not match the live Secret, causing spurious diffs in GitOps tooling and (worst case) silent rotation of XEP-0421 occupant-id continuity / encrypted session state.

## Approach

Approach **2** from the issue (chosen and applied):

Move auto-generation out of the regular `Secret` template and into a Helm `pre-install` / `pre-upgrade` hook. The hook Job uses `kubectl create secret generic ...` -- with a `kubectl get` idempotency check -- to create a separate `<release>-waddle-server-bootstrap-secrets` Secret. That Secret has **no Helm ownership labels**, so Helm never re-templates it; subsequent `helm template` renders are byte-stable regardless of cluster access.

Operator-supplied keys (`WADDLE_AUTH_PROVIDERS_JSON`, DB DSNs, `WADDLE_SPICEDB_PRESHARED_KEY`) also stop using `lookup` -- the chart now reflects exactly the values the operator passes, the conformant Helm pattern. The drift class disappears for those too.

### Trade-off analysis

| Option | Pros | Cons |
|---|---|---|
| 1. Require explicit operator-supplied value, fail render | Cleanest GitOps story, zero drift | Bad first-install ergonomics; every operator must pre-generate the secret out of band |
| **2. Pre-install / pre-upgrade hook (chosen)** | **Preserves first-install ergonomics; eliminates drift on subsequent renders; no external operator dependency; auto-migrates chart 0.1.x → 0.2.0** | **Hook needs RBAC; render-without-cluster does not show the Secret manifest (intentional)** |
| 3. External Secrets Operator / Sealed Secrets | Cleanest separation of concerns | Forces every operator to install another operator; out of scope for the chart's default UX |
| 4. Document only | Cheap | Does not fix the drift, only warns about it |

Option 2 is the smallest change that actually eliminates drift while keeping `helm install` working out of the box. Operators with stricter requirements can opt into option 1 by setting `secret.autoGenerate=false` (chart fails render with a clear message if no source can supply the keys), or option 3 by routing the keys through `extraSecretRefs`.

## Files changed

- `server/charts/waddle-server/templates/secret.yaml` -- drop `lookup` and auto-gen branches for `WADDLE_SESSION_KEY` / `WADDLE_OCCUPANT_ID_SECRET`; remove `lookup`-preserve branches for operator-supplied keys; only emit the operator Secret when at least one operator value is set.
- `server/charts/waddle-server/templates/secret-bootstrap-hook.yaml` -- new `pre-install` / `pre-upgrade` Job + ServiceAccount + Role + RoleBinding generating the bootstrap Secret. Idempotent via `kubectl get`-then-`kubectl create`. RBAC scoped to `create secrets` (cannot use `resourceNames` for `create`) and `get secrets` restricted to the bootstrap Secret name and the legacy operator Secret name (for the chart-0.1.x migration step). Pod runs `runAsNonRoot:1001`, `readOnlyRootFilesystem:true`, drops all capabilities, restricted-PSA-compatible.
- `server/charts/waddle-server/templates/_helpers.tpl` -- new `waddle-server.bootstrapSecretName` template; comment on the remaining `lookup` in `extraSecretChecksum` (benign; documented).
- `server/charts/waddle-server/templates/deployment.yaml` -- add `envFrom` ref for the bootstrap Secret with `optional: true`. Order ensures operator-supplied values win for any overlap.
- `server/charts/waddle-server/templates/validations.yaml` -- guard against `secret.autoGenerate=false` with no operator-supplied or extraSecretRefs source for the required keys.
- `server/charts/waddle-server/templates/NOTES.txt` -- new; covers first-install / upgrade / rotation / disaster recovery; emits explicit verification commands and migration log markers on every upgrade so operators can confirm the 0.1.x → 0.2.0 hand-off succeeded.
- `server/charts/waddle-server/values.yaml` -- add `secret.autoGenerate` (default `true`) and `secret.bootstrap.{image,imagePullPolicy}`; rewrite occupantIdSecret comment.
- `server/charts/waddle-server/README.md` -- rewrite "Secret handling" with the new two-Secret model + hook lifecycle + disaster recovery + (now-automatic) migration steps for operators upgrading from chart 0.1.x.
- `server/charts/waddle-server/Chart.yaml` -- bump 0.1.12 -> 0.2.0 (breaking).
- `infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml` -- track chart `0.2.x` so the live Flux HelmRelease continues to reconcile.

## Migration impact

This is a breaking chart change (0.1.x -> 0.2.0), but the upgrade path is now **automatic** for the chart-managed secrets:

- The `pre-upgrade` hook runs before Helm rewrites the operator Secret. The bash entrypoint reads the legacy `<release>-waddle-server-secrets` first, finds the surviving `WADDLE_SESSION_KEY` / `WADDLE_OCCUPANT_ID_SECRET`, and copies them forward into the new bootstrap Secret. Only then does Helm prune those keys from the operator Secret manifest. XEP-0421 occupant-id continuity and encrypted session state are preserved without operator intervention.
- The Job logs `migrated WADDLE_SESSION_KEY from <release>-waddle-server-secrets` (or `generated fresh ...` when the legacy value was not present) so operators can audit which path the upgrade took. NOTES.txt prints these markers and the exact `kubectl logs` command to read them after every upgrade.
- Operators who prefer manual control can disable the auto-migration by deleting the legacy keys before the upgrade, then either pre-creating the bootstrap Secret or passing values via `--set secret.autoGenerate=false --set secret.sessionKey=... --set secret.occupantIdSecret=...`.

The `infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml` change is part of this PR; the next Flux reconciliation will trigger the migration automatically.

## Verification

- `helm lint server/charts/waddle-server/` clean.
- `helm template server/charts/waddle-server/ --set spicedb.enabled=false` succeeds.
- Two consecutive `helm template` renders (install AND upgrade flavors) produce byte-identical output (idempotent; no `randAlphaNum` per render).
- `helm template ... | kubectl apply --dry-run=client -f -` accepts every emitted manifest.
- Render with `--set secret.create=false --set secret.existingSecret=foo` suppresses both the bootstrap hook and the operator Secret, leaving only the operator Secret reference in `envFrom`.
- Render with `--set secret.manageOccupantIdSecret=false` keeps the bootstrap hook but drops `WADDLE_OCCUPANT_ID_SECRET` (script reads `MANAGE_OCCUPANT_ID_SECRET=false`).
- Render with `--set secret.autoGenerate=false` (no other secret values, no extraSecretRefs) fails with a clear validation error.
- Render with `--set secret.autoGenerate=false --set secret.sessionKey=foo --set secret.occupantIdSecret=bar` succeeds without the bootstrap hook.
- Render with the live GitOps `helmrelease.yaml` values (`manageOccupantIdSecret=false`, `extraSecretRefs=[waddle-runtime-secrets, ...]`) succeeds and is idempotent.
- `helm template ... --is-upgrade` renders the new NOTES.txt upgrade-mode block (verification commands, log markers, broken-continuity callout, hook-resource TTL reminder).

## Review feedback

All Copilot and Greptile review comments addressed in commits e5104d9a and efcee660:

- e5104d9a — `pre-upgrade` added to the hook annotation; bash entrypoint auto-migrates surviving `WADDLE_SESSION_KEY` / `WADDLE_OCCUPANT_ID_SECRET` from the legacy operator Secret; Role grants `get` on the legacy Secret name; docstrings, NOTES.txt rotation steps, README hook-lifecycle / disaster-recovery / migration sections, and `values.yaml` `bootstrap` description corrected to reflect the actual `pre-install,pre-upgrade` behavior, the actual `kubectl get`-then-`kubectl create` idempotency check, and the bash dependency.
- efcee660 — NOTES.txt now emits upgrade-mode bootstrap guidance (verification `kubectl` commands, the four migration log markers, broken-continuity callout, hook-resource TTL reminder) on every upgrade where the bootstrap hook is enabled, not just on first install.