### PR TITLE
refactor(server): IQ-error emission to typed StanzaError values (#234)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
@@ -10,12 +10,11 @@ pub(super) async fn handle_blocking_iq(
     state_machine: Option<&mut waddle_xmpp::protocol::XmppStateMachine>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let user_bare = sender_jid.to_bare();
@@ -23,12 +22,11 @@ pub(super) async fn handle_blocking_iq(
         Ok(db) => db,
         Err(error) => {
             warn!(error = %error, "Failed to access database for blocking IQ");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
     };
@@ -37,12 +35,11 @@ pub(super) async fn handle_blocking_iq(
         Ok(request) => request,
         Err(error) => {
             warn!(error = %error, "Invalid blocking IQ");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         }
     };
@@ -55,12 +52,11 @@ pub(super) async fn handle_blocking_iq(
                 )],
                 Err(error) => {
                     warn!(jid = %user_bare, error = %error, "Failed to load blocklist");
-                    vec![build_iq_error_xml_with_addresses(
+                    vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )]
                 }
             };
@@ -68,12 +64,11 @@ pub(super) async fn handle_blocking_iq(
         waddle_xmpp::xep::xep0191::BlockingRequest::Block(jids) => {
             if let Err(error) = storage.add_blocks(&user_bare, &jids).await {
                 warn!(jid = %user_bare, error = %error, "Failed to add blocks");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
             send_blocking_presence_side_effects(state, &user_bare, &jids, true).await;
@@ -88,35 +83,32 @@ pub(super) async fn handle_blocking_iq(
                     Ok(current) => current,
                     Err(error) => {
                         warn!(jid = %user_bare, error = %error, "Failed to load blocklist before unblock-all");
-                        return vec![build_iq_error_xml_with_addresses(
+                        return vec![build_iq_error_xml_typed(
                             &iq.id,
                             response_from,
                             response_to,
-                            "wait",
-                            "internal-server-error",
+                            internal_server_error_iq_error("Internal server error."),
                         )];
                     }
                 };
                 if let Err(error) = storage.remove_all_blocks(&user_bare).await {
                     warn!(jid = %user_bare, error = %error, "Failed to remove all blocks");
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
                 current
             } else {
                 if let Err(error) = storage.remove_blocks(&user_bare, &jids).await {
                     warn!(jid = %user_bare, error = %error, "Failed to remove blocks");
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
                 jids

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/errors.rs
@@ -1,0 +1,251 @@
+//! Typed `<iq type='error'>` constructors for the IQ-handler tree.
+//!
+//! Per the typed-payloads hard rule (CLAUDE.md), IQ-error responses
+//! MUST be modelled with `xmpp_parsers::stanza_error::StanzaError`
+//! (typed `ErrorType` + `DefinedCondition` enum variants), not as
+//! stringly-typed `&str` flags shuffled across function boundaries.
+//!
+//! This module groups the per-condition `StanzaError` constructors used
+//! across the WebSocket IQ handlers. Each helper returns a `StanzaError`
+//! ready to be passed to [`super::super::super::build_iq_error_xml_typed`]
+//! together with the `<iq>` `id` and addressing metadata.
+
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+/// Default human-readable language tag attached to every typed
+/// IQ-error helper. The XEP only requires text bodies be tagged when
+/// present; we use English for diagnostics.
+const DEFAULT_LANG: &str = "en";
+
+/// `<bad-request/>` (modify) — malformed payload, e.g. unparseable
+/// child element.
+pub(crate) fn bad_request_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Modify,
+        DefinedCondition::BadRequest,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<jid-malformed/>` (modify) — `<iq to=…>` carried a JID the parser
+/// rejected.
+pub(crate) fn jid_malformed_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Modify,
+        DefinedCondition::JidMalformed,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<not-acceptable/>` (modify) — request well-formed but the
+/// recipient refuses based on policy.
+pub(crate) fn not_acceptable_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Modify,
+        DefinedCondition::NotAcceptable,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<not-authorized/>` (auth) — the request requires authentication
+/// the sender has not provided.
+pub(crate) fn not_authorized_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Auth,
+        DefinedCondition::NotAuthorized,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<forbidden/>` (auth) — the sender is authenticated but lacks
+/// permission for the requested operation.
+pub(crate) fn forbidden_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Auth,
+        DefinedCondition::Forbidden,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<item-not-found/>` (cancel) — the addressed JID, node, or item
+/// does not exist.
+pub(crate) fn item_not_found_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ItemNotFound,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<service-unavailable/>` (cancel) — the addressed entity does not
+/// implement the requested feature/namespace at this address.
+pub(crate) fn service_unavailable_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ServiceUnavailable,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<feature-not-implemented/>` (cancel) — the namespace is recognised
+/// but this specific feature/profile is not implemented.
+pub(crate) fn feature_not_implemented_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::FeatureNotImplemented,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+/// `<internal-server-error/>` (wait) — unexpected failure in the
+/// server while processing an otherwise-valid request.
+pub(crate) fn internal_server_error_iq_error(text: &str) -> StanzaError {
+    StanzaError::new(
+        ErrorType::Wait,
+        DefinedCondition::InternalServerError,
+        DEFAULT_LANG,
+        text,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::minidom::Element;
+
+    fn assert_round_trip(error: StanzaError, expected_type: ErrorType, expected: DefinedCondition) {
+        assert_eq!(error.type_, expected_type);
+        assert_eq!(error.defined_condition, expected);
+        let element = Element::from(error);
+        assert_eq!(element.name(), "error");
+        assert_eq!(element.ns(), "jabber:client");
+        let condition = element
+            .children()
+            .find(|child| {
+                child.ns() == "urn:ietf:params:xml:ns:xmpp-stanzas" && child.name() != "text"
+            })
+            .expect("defined-condition child");
+        assert_eq!(condition.ns(), "urn:ietf:params:xml:ns:xmpp-stanzas");
+    }
+
+    #[test]
+    fn bad_request_typed() {
+        assert_round_trip(
+            bad_request_iq_error("nope"),
+            ErrorType::Modify,
+            DefinedCondition::BadRequest,
+        );
+    }
+
+    #[test]
+    fn jid_malformed_typed() {
+        assert_round_trip(
+            jid_malformed_iq_error("nope"),
+            ErrorType::Modify,
+            DefinedCondition::JidMalformed,
+        );
+    }
+
+    #[test]
+    fn not_acceptable_typed() {
+        assert_round_trip(
+            not_acceptable_iq_error("nope"),
+            ErrorType::Modify,
+            DefinedCondition::NotAcceptable,
+        );
+    }
+
+    #[test]
+    fn not_authorized_typed() {
+        assert_round_trip(
+            not_authorized_iq_error("nope"),
+            ErrorType::Auth,
+            DefinedCondition::NotAuthorized,
+        );
+    }
+
+    #[test]
+    fn forbidden_typed() {
+        assert_round_trip(
+            forbidden_iq_error("nope"),
+            ErrorType::Auth,
+            DefinedCondition::Forbidden,
+        );
+    }
+
+    #[test]
+    fn item_not_found_typed() {
+        assert_round_trip(
+            item_not_found_iq_error("nope"),
+            ErrorType::Cancel,
+            DefinedCondition::ItemNotFound,
+        );
+    }
+
+    #[test]
+    fn service_unavailable_typed() {
+        assert_round_trip(
+            service_unavailable_iq_error("nope"),
+            ErrorType::Cancel,
+            DefinedCondition::ServiceUnavailable,
+        );
+    }
+
+    #[test]
+    fn feature_not_implemented_typed() {
+        assert_round_trip(
+            feature_not_implemented_iq_error("nope"),
+            ErrorType::Cancel,
+            DefinedCondition::FeatureNotImplemented,
+        );
+    }
+
+    #[test]
+    fn internal_server_error_typed() {
+        assert_round_trip(
+            internal_server_error_iq_error("nope"),
+            ErrorType::Wait,
+            DefinedCondition::InternalServerError,
+        );
+    }
+
+    /// Wire-shape assertion: the typed helper emits the same
+    /// `<iq>/<error>/<defined-condition>` shape the previous
+    /// stringly-typed builder did. The exact byte-for-byte serialisation
+    /// (single vs. double quotes around `xmlns`, attribute ordering)
+    /// is owned by the `xmpp_parsers`/`minidom` serialiser; we assert
+    /// against its canonical output here so any future serialiser
+    /// change is caught by this test rather than by every per-XEP
+    /// integration test.
+    #[test]
+    fn wire_shape_matches_legacy_builder() {
+        let typed = super::super::super::super::build_iq_error_xml_typed(
+            "abc",
+            Some("from@example"),
+            Some("to@example"),
+            StanzaError {
+                type_: ErrorType::Cancel,
+                by: None,
+                defined_condition: DefinedCondition::ServiceUnavailable,
+                texts: std::collections::BTreeMap::new(),
+                other: None,
+                alternate_address: None,
+            },
+        );
+        let expected = "<iq xmlns='jabber:client' \
+                        from=\"from@example\" id=\"abc\" \
+                        to=\"to@example\" type=\"error\">\
+                        <error type=\"cancel\">\
+                        <service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
+                        </error></iq>";
+        assert_eq!(typed, expected);
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -72,6 +72,7 @@ use xmpp_parsers::minidom::Element;
 
 mod blocking;
 mod commands;
+pub(crate) mod errors;
 mod muc_admin;
 mod push;
 mod roster;
@@ -81,6 +82,15 @@ mod vcard_private;
 
 use blocking::handle_blocking_iq;
 use commands::handle_command_iq;
+// Re-exported via `pub(super)` so submodules that wildcard-import the
+// IQ-handler module's namespace (`use super::*;`) pick up the typed
+// IQ-error constructors without each having to re-import the
+// `errors` submodule directly.
+pub(super) use errors::{
+    bad_request_iq_error, feature_not_implemented_iq_error, forbidden_iq_error,
+    internal_server_error_iq_error, item_not_found_iq_error, jid_malformed_iq_error,
+    not_acceptable_iq_error, not_authorized_iq_error, service_unavailable_iq_error,
+};
 use muc_admin::handle_muc_admin_iq;
 use push::handle_push_iq;
 use roster::handle_roster_iq;
@@ -93,9 +103,13 @@ use vcard_private::{handle_private_storage_iq, handle_vcard_iq};
 #[cfg(test)]
 use waddle_xmpp::protocol::frame::{parse_frame, InboundFrame};
 
+// `build_iq_error_xml_typed` is re-exported via `pub(super) use` so
+// submodules wildcard-importing this module's namespace see it.
+pub(super) use super::super::build_iq_error_xml_typed;
+
 use super::super::{
-    build_iq_error_xml, build_iq_error_xml_with_addresses, build_iq_result_xml, destroy_room_actor,
-    get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml, WebSocketState,
+    build_iq_result_xml, destroy_room_actor, get_room_actor, iq_to_xml, is_muc_room_jid,
+    stanza_to_xml, WebSocketState,
 };
 use super::presence::{
     get_managed_channel_for_room, send_current_presence_from_user_to_user,
@@ -379,12 +393,11 @@ pub async fn handle_iq_with_conn_state(
         .has_iq_handler(payload_ns.as_str())
     {
         if payload_ns == waddle_xmpp::xep::NS_VERSION && !is_version_query(&iq) {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         }
         if payload_ns == waddle_xmpp::xep::NS_VERSION
@@ -393,22 +406,20 @@ pub async fn handle_iq_with_conn_state(
                 .as_ref()
                 .is_some_and(|target| target.to_bare().as_str() != domain)
         {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "cancel",
-                "service-unavailable",
+                service_unavailable_iq_error("Service unavailable at this address."),
             )];
         }
         if payload_ns == waddle_xmpp::xep::NS_TIME {
             if !is_time_query(&iq) {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "modify",
-                    "bad-request",
+                    bad_request_iq_error("Malformed IQ payload."),
                 )];
             }
             if iq
@@ -416,22 +427,20 @@ pub async fn handle_iq_with_conn_state(
                 .as_ref()
                 .is_some_and(|target| target.to_bare().as_str() != domain)
             {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "cancel",
-                    "service-unavailable",
+                    service_unavailable_iq_error("Service unavailable at this address."),
                 )];
             }
         }
         let Some(full_jid) = phase.bound_jid() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "not-authorized",
+                not_authorized_iq_error("Authentication required."),
             )];
         };
         if let Some(enabled) = carbons_toggle {
@@ -529,7 +538,14 @@ pub async fn handle_iq_with_conn_state(
         let request_iq = &iq;
         let query = match parse_disco_info_query(request_iq) {
             Ok(query) => query,
-            Err(_) => return vec![build_iq_error_xml(&id, "modify", "bad-request")],
+            Err(_) => {
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    bad_request_iq_error("Malformed IQ payload."),
+                )]
+            }
         };
 
         if to.as_deref() == Some(muc_domain) {
@@ -557,12 +573,11 @@ pub async fn handle_iq_with_conn_state(
                                 error = ?error,
                                 "Failed to load room snapshot for disco#info"
                             );
-                            return vec![build_iq_error_xml_with_addresses(
+                            return vec![build_iq_error_xml_typed(
                                 &id,
                                 response_from,
                                 response_to,
-                                "wait",
-                                "internal-server-error",
+                                internal_server_error_iq_error("Internal server error."),
                             )];
                         }
                     };
@@ -710,12 +725,11 @@ pub async fn handle_iq_with_conn_state(
                         .into_iter()
                         .find(|(_, descriptor)| descriptor.node.as_str() == node)
                     else {
-                        return vec![build_iq_error_xml_with_addresses(
+                        return vec![build_iq_error_xml_typed(
                             &id,
                             response_from,
                             response_to,
-                            "cancel",
-                            "item-not-found",
+                            item_not_found_iq_error("Requested item not found."),
                         )];
                     };
                     let identities = vec![Identity::automation(Some(descriptor.name.as_str()))];
@@ -744,12 +758,11 @@ pub async fn handle_iq_with_conn_state(
                     .iter()
                     .find(|route| extension_route_disco_node(route) == node)
                 else {
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &id,
                         response_from,
                         response_to,
-                        "cancel",
-                        "item-not-found",
+                        item_not_found_iq_error("Requested item not found."),
                     )];
                 };
                 let identities = vec![Identity::new(
@@ -792,7 +805,12 @@ pub async fn handle_iq_with_conn_state(
         if to.as_deref() == Some(spaces_domain.as_str()) {
             if let Some(node) = query.node.as_deref() {
                 let Ok(spaces_jid) = spaces_service_bare_jid(&spaces_domain) else {
-                    return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                    return vec![build_iq_error_xml_typed(
+                        &id,
+                        None,
+                        None,
+                        internal_server_error_iq_error("Internal server error."),
+                    )];
                 };
                 let space_node = match state
                     .deps
@@ -802,10 +820,22 @@ pub async fn handle_iq_with_conn_state(
                     .await
                 {
                     Ok(Some(node)) => node,
-                    Ok(None) => return vec![build_iq_error_xml(&id, "cancel", "item-not-found")],
+                    Ok(None) => {
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            item_not_found_iq_error("Requested item not found."),
+                        )]
+                    }
                     Err(error) => {
                         warn!(node, error = %error, "Failed to resolve Spaces node info");
-                        return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            item_not_found_iq_error("Requested item not found."),
+                        )];
                     }
                 };
 
@@ -893,7 +923,14 @@ pub async fn handle_iq_with_conn_state(
         let request_iq = &iq;
         let query = match parse_disco_items_query(request_iq) {
             Ok(query) => query,
-            Err(_) => return vec![build_iq_error_xml(&id, "modify", "bad-request")],
+            Err(_) => {
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    bad_request_iq_error("Malformed IQ payload."),
+                )]
+            }
         };
 
         if to.as_deref() == Some(muc_domain) {
@@ -930,12 +967,11 @@ pub async fn handle_iq_with_conn_state(
                     .iter()
                     .any(|route| extension_route_disco_node(route) == node);
                 if !known_route_node {
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &id,
                         response_from,
                         response_to,
-                        "cancel",
-                        "item-not-found",
+                        item_not_found_iq_error("Requested item not found."),
                     )];
                 }
                 let response = build_disco_items_response(request_iq, &[], Some(node));
@@ -1035,43 +1071,39 @@ pub async fn handle_iq_with_conn_state(
     // 2) submitting an empty owner form (`jabber:x:data` type='submit')
     if payload_ns == "http://jabber.org/protocol/muc#owner" {
         let Some(target) = to.as_deref() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         };
 
         let room_target = target.split('/').next().unwrap_or(target);
         let Ok(room_jid) = room_target.parse::<BareJid>() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "modify",
-                "jid-malformed",
+                jid_malformed_iq_error("Malformed JID in IQ addressing."),
             )];
         };
 
         if !is_muc_room_jid(state, &room_jid).await {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "cancel",
-                "item-not-found",
+                item_not_found_iq_error("Requested item not found."),
             )];
         }
 
         let Some(sender_jid) = phase.bound_jid() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "not-authorized",
+                not_authorized_iq_error("Authentication required."),
             )];
         };
         match muc_owner_authorized(state, &room_jid, sender_jid, authenticated_session.as_ref())
@@ -1079,12 +1111,11 @@ pub async fn handle_iq_with_conn_state(
         {
             Ok(true) => {}
             Ok(false) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "auth",
-                    "forbidden",
+                    forbidden_iq_error("Operation not permitted."),
                 )];
             }
             Err(error) => {
@@ -1093,12 +1124,11 @@ pub async fn handle_iq_with_conn_state(
                     error = %error,
                     "Failed to authorize MUC owner IQ"
                 );
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         }
@@ -1115,12 +1145,11 @@ pub async fn handle_iq_with_conn_state(
                 )];
             }
 
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "cancel",
-                "item-not-found",
+                item_not_found_iq_error("Requested item not found."),
             )];
         }
 
@@ -1133,12 +1162,11 @@ pub async fn handle_iq_with_conn_state(
                         error = %error,
                         "Failed to build MUC owner config response"
                     );
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
             }
@@ -1152,12 +1180,11 @@ pub async fn handle_iq_with_conn_state(
                 error = %error,
                 "Failed to apply MUC owner config"
             );
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
 
@@ -1173,30 +1200,27 @@ pub async fn handle_iq_with_conn_state(
 
     if let Some(request) = parse_moderation_iq(&iq) {
         let Some(sender_jid) = phase.bound_jid() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "not-authorized",
+                not_authorized_iq_error("Authentication required."),
             )];
         };
         let Some(room_jid) = iq.to.as_ref().map(|jid| jid.to_bare()) else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         };
         let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "cancel",
-                "item-not-found",
+                item_not_found_iq_error("Requested item not found."),
             )];
         };
         let context = match room_actor
@@ -1207,12 +1231,11 @@ pub async fn handle_iq_with_conn_state(
         {
             Ok(context) => context,
             Err(_) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )]
             }
         };
@@ -1223,12 +1246,11 @@ pub async fn handle_iq_with_conn_state(
         // entry; if an owner has explicitly taken a non-moderator role
         // (e.g. visitor), that signal is intentional and must be honoured.
         if !matches!(context.role, waddle_xmpp::Role::Moderator) {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "forbidden",
+                forbidden_iq_error("Operation not permitted."),
             )];
         }
         match state
@@ -1240,31 +1262,28 @@ pub async fn handle_iq_with_conn_state(
         {
             Ok(Some(message)) if message.to.to_string() == room_jid.to_string() => {}
             Ok(Some(_)) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "cancel",
-                    "item-not-found",
+                    item_not_found_iq_error("Requested item not found."),
                 )]
             }
             Ok(None) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "cancel",
-                    "item-not-found",
+                    item_not_found_iq_error("Requested item not found."),
                 )]
             }
             Err(error) => {
                 warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to look up moderation target");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         }
@@ -1459,12 +1478,22 @@ pub async fn handle_iq_with_conn_state(
     if is_mam_query(&iq) {
         let request_iq = &iq;
         let Some(target) = request_iq.to.as_ref().map(|jid| jid.to_string()) else {
-            return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+            return vec![build_iq_error_xml_typed(
+                &id,
+                None,
+                None,
+                bad_request_iq_error("Malformed IQ payload."),
+            )];
         };
 
         let room_target = target.split('/').next().unwrap_or(target.as_str());
         let Ok(target_bare) = room_target.parse::<BareJid>() else {
-            return vec![build_iq_error_xml(&id, "modify", "jid-malformed")];
+            return vec![build_iq_error_xml_typed(
+                &id,
+                None,
+                None,
+                jid_malformed_iq_error("Malformed JID in IQ addressing."),
+            )];
         };
 
         // Determine whether this is a personal archive query (to=self) or a
@@ -1477,7 +1506,12 @@ pub async fn handle_iq_with_conn_state(
             .is_some_and(|bare| *bare == target_bare);
 
         if !is_personal && !is_muc_room_jid(state, &target_bare).await {
-            return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
+            return vec![build_iq_error_xml_typed(
+                &id,
+                None,
+                None,
+                item_not_found_iq_error("Requested item not found."),
+            )];
         }
 
         if is_mam_query_form_request(request_iq) {
@@ -1489,9 +1523,19 @@ pub async fn handle_iq_with_conn_state(
             Err(err) => {
                 warn!(error = %err, target = %target_bare, "Invalid MAM query");
                 if matches!(err, waddle_xmpp::CoreError::NotImplemented) {
-                    return vec![build_iq_error_xml(&id, "cancel", "feature-not-implemented")];
+                    return vec![build_iq_error_xml_typed(
+                        &id,
+                        None,
+                        None,
+                        feature_not_implemented_iq_error("Requested feature not implemented."),
+                    )];
                 }
-                return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    bad_request_iq_error("Malformed IQ payload."),
+                )];
             }
         };
 
@@ -1504,11 +1548,21 @@ pub async fn handle_iq_with_conn_state(
         {
             Ok(result) => result,
             Err(waddle_xmpp::mam::MamStorageError::NotFound(_)) => {
-                return vec![build_iq_error_xml(&id, "cancel", "item-not-found")];
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    item_not_found_iq_error("Requested item not found."),
+                )];
             }
             Err(err) => {
                 warn!(error = %err, target = %target_bare, "MAM query failed");
-                return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
             }
         };
 
@@ -1535,7 +1589,12 @@ pub async fn handle_iq_with_conn_state(
             .clone()
             .or_else(|| phase.bound_jid().cloned().map(jid::Jid::from))
         else {
-            return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+            return vec![build_iq_error_xml_typed(
+                &id,
+                None,
+                None,
+                bad_request_iq_error("Malformed IQ payload."),
+            )];
         };
 
         let mut responses: Vec<String> =
@@ -1550,7 +1609,12 @@ pub async fn handle_iq_with_conn_state(
     if is_inbox_iq(&iq) {
         let request_iq = &iq;
         let Some(user_jid) = phase.bound_jid().map(|jid| jid.to_bare()) else {
-            return vec![build_iq_error_xml(&id, "auth", "not-authorized")];
+            return vec![build_iq_error_xml_typed(
+                &id,
+                None,
+                None,
+                not_authorized_iq_error("Authentication required."),
+            )];
         };
 
         match &request_iq.payload {
@@ -1559,7 +1623,12 @@ pub async fn handle_iq_with_conn_state(
                     Ok(query) => query,
                     Err(error) => {
                         warn!(error = %error, "Invalid inbox query");
-                        return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            bad_request_iq_error("Malformed IQ payload."),
+                        )];
                     }
                 };
                 let entries = if query.threads {
@@ -1574,22 +1643,33 @@ pub async fn handle_iq_with_conn_state(
                             Ok(entries) => entries,
                             Err(error) => {
                                 warn!(error = %error, jid = %user_jid, "Failed to list thread inbox");
-                                return vec![build_iq_error_xml(
+                                return vec![build_iq_error_xml_typed(
                                     &id,
-                                    "wait",
-                                    "internal-server-error",
+                                    None,
+                                    None,
+                                    internal_server_error_iq_error("Internal server error."),
                                 )];
                             }
                         }
                     } else {
-                        return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            bad_request_iq_error("Malformed IQ payload."),
+                        )];
                     }
                 } else {
                     match state.deps.protocol.inbox_storage.list(&user_jid).await {
                         Ok(entries) => entries,
                         Err(error) => {
                             warn!(error = %error, jid = %user_jid, "Failed to list inbox");
-                            return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                            return vec![build_iq_error_xml_typed(
+                                &id,
+                                None,
+                                None,
+                                internal_server_error_iq_error("Internal server error."),
+                            )];
                         }
                     }
                 };
@@ -1603,7 +1683,12 @@ pub async fn handle_iq_with_conn_state(
                     Ok(total_unread) => total_unread,
                     Err(error) => {
                         warn!(error = %error, jid = %user_jid, "Failed to count inbox unread");
-                        return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            internal_server_error_iq_error("Internal server error."),
+                        )];
                     }
                 };
                 let response = build_inbox_query_result(
@@ -1618,7 +1703,12 @@ pub async fn handle_iq_with_conn_state(
                     Ok(mark_read) => mark_read,
                     Err(error) => {
                         warn!(error = %error, "Invalid inbox mark-read");
-                        return vec![build_iq_error_xml(&id, "modify", "bad-request")];
+                        return vec![build_iq_error_xml_typed(
+                            &id,
+                            None,
+                            None,
+                            bad_request_iq_error("Malformed IQ payload."),
+                        )];
                     }
                 };
                 if let Err(error) = state
@@ -1633,11 +1723,23 @@ pub async fn handle_iq_with_conn_state(
                     .await
                 {
                     warn!(error = %error, jid = %user_jid, partner = %mark_read.partner, "Failed to mark inbox read");
-                    return vec![build_iq_error_xml(&id, "wait", "internal-server-error")];
+                    return vec![build_iq_error_xml_typed(
+                        &id,
+                        None,
+                        None,
+                        internal_server_error_iq_error("Internal server error."),
+                    )];
                 }
                 return vec![iq_to_xml(build_mark_read_result(request_iq))];
             }
-            _ => return vec![build_iq_error_xml(&id, "modify", "bad-request")],
+            _ => {
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    bad_request_iq_error("Malformed IQ payload."),
+                )]
+            }
         }
     }
 
@@ -1649,7 +1751,12 @@ pub async fn handle_iq_with_conn_state(
         let request_iq = &iq;
         if is_upload_request(request_iq) {
             let Some(sender_jid) = phase.bound_jid() else {
-                return vec![build_iq_error_xml(&id, "auth", "not-authorized")];
+                return vec![build_iq_error_xml_typed(
+                    &id,
+                    None,
+                    None,
+                    not_authorized_iq_error("Authentication required."),
+                )];
             };
             let request = match parse_upload_request(request_iq) {
                 Ok(req) => req,
@@ -1728,22 +1835,20 @@ pub async fn handle_iq_with_conn_state(
     // PubSub / PEP (XEP-0060, XEP-0163)
     if is_pubsub_iq(&iq) {
         if !phase.is_ready() {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "not-authorized",
+                not_authorized_iq_error("Authentication required."),
             )];
         }
 
         let Some(user_jid) = phase.bound_jid().map(|jid| jid.to_bare()) else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &id,
                 response_from,
                 response_to,
-                "auth",
-                "not-authorized",
+                not_authorized_iq_error("Authentication required."),
             )];
         };
 
@@ -2375,12 +2480,11 @@ pub async fn handle_iq_with_conn_state(
     // Unknown IQ - log a compact summary and return an error.
     let payload_ns = (!payload_ns.is_empty()).then_some(payload_ns.as_str());
     warn!(id = %id, payload_ns, "Unhandled IQ stanza");
-    vec![build_iq_error_xml_with_addresses(
+    vec![build_iq_error_xml_typed(
         &id,
         response_from,
         response_to,
-        "cancel",
-        "feature-not-implemented",
+        feature_not_implemented_iq_error("Requested feature not implemented."),
     )]
 }
 
@@ -2393,12 +2497,11 @@ async fn handle_last_activity_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
 
@@ -2443,12 +2546,11 @@ async fn handle_last_activity_iq(
             Ok(db) => db,
             Err(error) => {
                 warn!(error = %error, "Failed to access database for last-activity block check");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         };
@@ -2458,23 +2560,21 @@ async fn handle_last_activity_iq(
             .await
         {
             Ok(true) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "cancel",
-                    "service-unavailable",
+                    service_unavailable_iq_error("Service unavailable at this address."),
                 )];
             }
             Ok(false) => {}
             Err(error) => {
                 warn!(error = %error, target = %target_bare, "Failed to check last-activity block state");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         }
@@ -2505,54 +2605,49 @@ async fn handle_last_activity_iq(
         }
 
         let Some(node) = target_bare.node() else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "cancel",
-                "service-unavailable",
+                service_unavailable_iq_error("Service unavailable at this address."),
             )];
         };
         let native_user_store =
             NativeUserStore::new(state.deps.app_state.db_pool.global_actor().clone());
         match native_user_store.user_exists(node.as_str(), domain).await {
             Ok(false) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "cancel",
-                    "service-unavailable",
+                    service_unavailable_iq_error("Service unavailable at this address."),
                 )];
             }
             Ok(true) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "auth",
-                    "forbidden",
+                    forbidden_iq_error("Operation not permitted."),
                 )];
             }
             Err(error) => {
                 warn!(error = %error, target = %target_bare, "Failed to check local user for last-activity query");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         }
     }
 
-    vec![build_iq_error_xml_with_addresses(
+    vec![build_iq_error_xml_typed(
         &iq.id,
         response_from,
         response_to,
-        "cancel",
-        "service-unavailable",
+        service_unavailable_iq_error("Service unavailable at this address."),
     )]
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -9,12 +9,11 @@ pub(super) async fn handle_muc_admin_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let mut iq_with_from = iq.clone();
@@ -24,12 +23,11 @@ pub(super) async fn handle_muc_admin_iq(
         Err(error) => return vec![build_xmpp_error_response(&iq_with_from, error)],
     };
     let Some(room_actor) = get_room_actor(state, &query.room_jid).await else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "cancel",
-            "item-not-found",
+            item_not_found_iq_error("Requested item not found."),
         )];
     };
     let context = match room_actor
@@ -40,36 +38,33 @@ pub(super) async fn handle_muc_admin_iq(
     {
         Ok(context) => context,
         Err(_) => {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )]
         }
     };
     let is_admin = matches!(context.affiliation, Affiliation::Owner | Affiliation::Admin)
         || matches!(context.role, waddle_xmpp::Role::Moderator);
     if !is_admin {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "forbidden",
+            forbidden_iq_error("Operation not permitted."),
         )];
     }
     if query.is_get {
         let snapshot = match room_actor.ask(GetSnapshot).await {
             Ok(snapshot) => snapshot.room,
             Err(_) => {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )]
             }
         };
@@ -129,22 +124,20 @@ pub(super) async fn handle_muc_admin_iq(
         Ok(updates) => updates,
         Err(kameo::error::SendError::HandlerError(error)) => {
             warn!(room = %room_jid, error = %error, "MUC admin set rejected");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "auth",
-                "forbidden",
+                forbidden_iq_error("Operation not permitted."),
             )];
         }
         Err(error) => {
             warn!(room = %room_jid, error = ?error, "Failed to apply MUC admin IQ");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/push.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/push.rs
@@ -8,24 +8,22 @@ pub(super) async fn handle_push_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let bare_jid = sender_jid.to_bare().to_string();
 
     if is_push_enable(iq) {
         let Some(enable) = parse_push_enable(iq) else {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         };
         let endpoint = enable
@@ -48,12 +46,11 @@ pub(super) async fn handle_push_iq(
             || p256dh.is_none()
             || auth_key.is_none()
         {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "modify",
-                "bad-request",
+                bad_request_iq_error("Malformed IQ payload."),
             )];
         }
 
@@ -67,24 +64,22 @@ pub(super) async fn handle_push_iq(
         };
         if let Err(error) = state.deps.protocol.push_store.register(subscription).await {
             warn!(user = %bare_jid, error = %error, "Failed to register push subscription");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
         return vec![iq_to_xml(build_push_enable_result(iq))];
     }
 
     let Some(disable) = parse_push_disable(iq) else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "modify",
-            "bad-request",
+            bad_request_iq_error("Malformed IQ payload."),
         )];
     };
     if let Err(error) = state
@@ -95,12 +90,11 @@ pub(super) async fn handle_push_iq(
         .await
     {
         warn!(user = %bare_jid, error = %error, "Failed to remove push subscription");
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "wait",
-            "internal-server-error",
+            internal_server_error_iq_error("Internal server error."),
         )];
     }
     vec![iq_to_xml(build_push_disable_result(iq))]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/search.rs
@@ -12,21 +12,19 @@ pub(super) async fn handle_channel_search_iq(
         .as_ref()
         .is_some_and(|to| to.to_string() != muc_domain)
     {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "cancel",
-            "item-not-found",
+            item_not_found_iq_error("Requested item not found."),
         )];
     }
     let Some(request) = parse_search_request(iq) else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "modify",
-            "bad-request",
+            bad_request_iq_error("Malformed IQ payload."),
         )];
     };
     let limit = request.max.unwrap_or(50).clamp(1, 200) as usize;
@@ -36,12 +34,11 @@ pub(super) async fn handle_channel_search_iq(
             Ok(channels) => channels,
             Err(error) => {
                 warn!(error = %error, "Failed to load channels for WebSocket search");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         };
@@ -97,12 +94,11 @@ pub(super) async fn handle_user_search_iq(
                 .unwrap_or_default();
             let term = term.trim();
             if term.chars().count() < MIN_USER_SEARCH_TERM_CHARS {
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "modify",
-                    "bad-request",
+                    bad_request_iq_error("Malformed IQ payload."),
                 )];
             }
             let like = format!("%{}%", escape_like_pattern(term));
@@ -121,13 +117,12 @@ pub(super) async fn handle_user_search_iq(
                 Ok(rows) => rows,
                 Err(error) => {
                     warn!(error = %error, "Failed to search native users over WebSocket");
-                    return vec![build_iq_error_xml_with_addresses(
-                        &iq.id,
-                        response_from,
-                        response_to,
-                        "wait",
-                        "internal-server-error",
-                    )];
+                    return vec![build_iq_error_xml_typed(
+                                    &iq.id,
+                                    response_from,
+                                    response_to,
+                                    internal_server_error_iq_error("Internal server error."),
+                                )];
                 }
             };
             let mut query = Element::builder("query", "jabber:iq:search");
@@ -155,12 +150,11 @@ pub(super) async fn handle_user_search_iq(
                 Some(query.build()),
             )]
         }
-        _ => vec![build_iq_error_xml_with_addresses(
+        _ => vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "modify",
-            "bad-request",
+            bad_request_iq_error("Malformed IQ payload."),
         )],
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/session_misc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/session_misc.rs
@@ -8,12 +8,11 @@ pub(super) async fn handle_muc_self_ping_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let Some(target) = iq
@@ -21,23 +20,21 @@ pub(super) async fn handle_muc_self_ping_iq(
         .as_ref()
         .and_then(|jid| jid.clone().try_into_full().ok())
     else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "modify",
-            "bad-request",
+            bad_request_iq_error("Malformed IQ payload."),
         )];
     };
     let room_jid = target.to_bare();
     let nick = target.resource().to_string();
     let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "cancel",
-            "item-not-found",
+            item_not_found_iq_error("Requested item not found."),
         )];
     };
     match room_actor
@@ -53,21 +50,19 @@ pub(super) async fn handle_muc_self_ping_iq(
             response_to,
             None,
         )],
-        Err(kameo::error::SendError::HandlerError(_)) => vec![build_iq_error_xml_with_addresses(
+        Err(kameo::error::SendError::HandlerError(_)) => vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "cancel",
-            "not-acceptable",
+            not_acceptable_iq_error("IQ rejected by server policy."),
         )],
         Err(error) => {
             warn!(room = %room_jid, error = ?error, "Failed to process MUC self-ping");
-            vec![build_iq_error_xml_with_addresses(
+            vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )]
         }
     }
@@ -98,12 +93,11 @@ pub(super) async fn route_full_jid_iq(
     response_from: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             None,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let blocking = DatabaseBlockingStorage::new(state.deps.app_state.db_pool.global().clone());
@@ -112,23 +106,21 @@ pub(super) async fn route_full_jid_iq(
         .await
     {
         Ok(true) => {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 Some(sender_jid.as_str()),
-                "cancel",
-                "service-unavailable",
+                service_unavailable_iq_error("Service unavailable at this address."),
             )];
         }
         Ok(false) => {}
         Err(error) => {
             warn!(error = %error, target = %target, sender = %sender_jid, "Failed to check blocklist before routing IQ");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 Some(sender_jid.as_str()),
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
     }
@@ -145,12 +137,11 @@ pub(super) async fn route_full_jid_iq(
         waddle_xmpp::registry::SendResult::NotConnected
         | waddle_xmpp::registry::SendResult::ChannelClosed => {
             let sender = sender_jid.to_string();
-            vec![build_iq_error_xml_with_addresses(
+            vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 Some(sender.as_str()),
-                "cancel",
-                "service-unavailable",
+                service_unavailable_iq_error("Service unavailable at this address."),
             )]
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/vcard_private.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/vcard_private.rs
@@ -8,12 +8,11 @@ pub(super) async fn handle_vcard_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
 
@@ -21,12 +20,11 @@ pub(super) async fn handle_vcard_iq(
         Ok(db) => Arc::new(db),
         Err(error) => {
             warn!(error = %error, "Failed to access database for vCard IQ");
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "wait",
-                "internal-server-error",
+                internal_server_error_iq_error("Internal server error."),
             )];
         }
     };
@@ -48,45 +46,41 @@ pub(super) async fn handle_vcard_iq(
                 },
                 Err(error) => {
                     warn!(target = %target_jid, error = %error, "Stored vCard XML is invalid");
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
             },
             Ok(None) => match avatar_vcard_from_user_profile(Arc::clone(&db), &target_jid).await {
                 Ok(Some(vcard)) => waddle_xmpp::xep::xep0054::build_vcard_response(iq, &vcard),
                 Ok(None) => {
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "cancel",
-                        "item-not-found",
+                        item_not_found_iq_error("Requested item not found."),
                     )];
                 }
                 Err(error) => {
                     warn!(target = %target_jid, error = %error, "Failed to load avatar vCard fallback");
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
             },
             Err(error) => {
                 warn!(target = %target_jid, error = %error, "Failed to load vCard");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         };
@@ -95,34 +89,31 @@ pub(super) async fn handle_vcard_iq(
 
     if let Some(to) = &iq.to {
         if to.to_bare() != sender_jid.to_bare() {
-            return vec![build_iq_error_xml_with_addresses(
+            return vec![build_iq_error_xml_typed(
                 &iq.id,
                 response_from,
                 response_to,
-                "auth",
-                "forbidden",
+                forbidden_iq_error("Operation not permitted."),
             )];
         }
     }
 
     let xmpp_parsers::iq::IqType::Set(vcard) = &iq.payload else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "modify",
-            "bad-request",
+            bad_request_iq_error("Malformed IQ payload."),
         )];
     };
 
     if let Err(error) = store.set(&sender_jid.to_bare(), &String::from(vcard)).await {
         warn!(jid = %sender_jid, error = %error, "Failed to store vCard");
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "wait",
-            "internal-server-error",
+            internal_server_error_iq_error("Internal server error."),
         )];
     }
 
@@ -139,12 +130,11 @@ pub(super) async fn handle_private_storage_iq(
     response_to: Option<&str>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
-        return vec![build_iq_error_xml_with_addresses(
+        return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
-            "auth",
-            "not-authorized",
+            not_authorized_iq_error("Authentication required."),
         )];
     };
     let bare_jid = sender_jid.to_bare();
@@ -198,12 +188,11 @@ pub(super) async fn handle_private_storage_iq(
             Ok(row) => row,
             Err(error) => {
                 warn!(jid = %bare_jid, namespace = %key.namespace, error = %error, "Failed to load private XML");
-                return vec![build_iq_error_xml_with_addresses(
+                return vec![build_iq_error_xml_typed(
                     &iq.id,
                     response_from,
                     response_to,
-                    "wait",
-                    "internal-server-error",
+                    internal_server_error_iq_error("Internal server error."),
                 )];
             }
         };
@@ -212,12 +201,11 @@ pub(super) async fn handle_private_storage_iq(
                 Ok(value) => Some(value),
                 Err(error) => {
                     warn!(jid = %bare_jid, namespace = %key.namespace, error = %error, "Failed to decode private XML row");
-                    return vec![build_iq_error_xml_with_addresses(
+                    return vec![build_iq_error_xml_typed(
                         &iq.id,
                         response_from,
                         response_to,
-                        "wait",
-                        "internal-server-error",
+                        internal_server_error_iq_error("Internal server error."),
                     )];
                 }
             },
@@ -274,25 +262,23 @@ pub(super) async fn handle_private_storage_iq(
             .await
         {
             warn!(jid = %bare_jid, error = %error, "Failed to store private XML");
-            return vec![build_iq_error_xml_with_addresses(
-                &iq.id,
-                response_from,
-                response_to,
-                "wait",
-                "internal-server-error",
-            )];
+            return vec![build_iq_error_xml_typed(
+                            &iq.id,
+                            response_from,
+                            response_to,
+                            internal_server_error_iq_error("Internal server error."),
+                        )];
         }
         return vec![iq_to_xml(
             waddle_xmpp::xep::xep0049::build_private_storage_success(iq),
         )];
     }
 
-    vec![build_iq_error_xml_with_addresses(
+    vec![build_iq_error_xml_typed(
         &iq.id,
         response_from,
         response_to,
-        "modify",
-        "bad-request",
+        bad_request_iq_error("Malformed IQ payload."),
     )]
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -16,6 +16,7 @@ use waddle_xmpp::{
     Affiliation, Role, Stanza,
 };
 use xmpp_parsers::minidom::Element;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 use super::super::{
     element_to_xml, get_or_create_room_actor, get_room_actor, stanza_to_xml, WebSocketState,
@@ -1589,52 +1590,72 @@ pub async fn handle_muc_join(
         Ok(channel) => channel,
         Err(error) => {
             warn!(room = %room_jid, error = %error, "Failed to resolve managed MUC channel");
-            return vec![build_muc_join_error_xml(
+            return vec![build_muc_presence_error_xml(
                 room_jid,
                 nick,
                 sender_jid,
-                "wait",
-                "internal-server-error",
+                StanzaError::new(
+                    ErrorType::Wait,
+                    DefinedCondition::InternalServerError,
+                    "en",
+                    "Failed to resolve managed channel for room.",
+                ),
             )];
         }
     };
     let managed_affiliation = if let Some(channel) = managed_channel.as_ref() {
         let Some(session) = authenticated_session else {
-            return vec![build_muc_join_error_xml(
+            return vec![build_muc_presence_error_xml(
                 room_jid,
                 nick,
                 sender_jid,
-                "auth",
-                "not-authorized",
+                StanzaError::new(
+                    ErrorType::Auth,
+                    DefinedCondition::NotAuthorized,
+                    "en",
+                    "Authentication required to join managed channel.",
+                ),
             )];
         };
         match resolve_managed_channel_affiliation(state, session, &channel.id).await {
             Ok(Some(Affiliation::Outcast)) => {
-                return vec![build_muc_join_error_xml(
+                return vec![build_muc_presence_error_xml(
                     room_jid,
                     nick,
                     sender_jid,
-                    "auth",
-                    "forbidden",
+                    StanzaError::new(
+                        ErrorType::Auth,
+                        DefinedCondition::Forbidden,
+                        "en",
+                        "Banned from managed channel.",
+                    ),
                 )];
             }
             Ok(Some(affiliation)) => Some(affiliation),
             Ok(None) => {
-                return vec![build_muc_join_error_xml(
+                return vec![build_muc_presence_error_xml(
                     room_jid,
                     nick,
                     sender_jid,
-                    "auth",
-                    "registration-required",
+                    StanzaError::new(
+                        ErrorType::Auth,
+                        DefinedCondition::RegistrationRequired,
+                        "en",
+                        "Membership required to join managed channel.",
+                    ),
                 )];
             }
             Err(()) => {
-                return vec![build_muc_join_error_xml(
+                return vec![build_muc_presence_error_xml(
                     room_jid,
                     nick,
                     sender_jid,
-                    "wait",
-                    "internal-server-error",
+                    StanzaError::new(
+                        ErrorType::Wait,
+                        DefinedCondition::InternalServerError,
+                        "en",
+                        "Failed to resolve managed-channel affiliation.",
+                    ),
                 )];
             }
         }
@@ -1655,12 +1676,16 @@ pub async fn handle_muc_join(
                 .await
                 .unwrap_or(false)
             {
-                return vec![build_muc_join_error_xml(
+                return vec![build_muc_presence_error_xml(
                     room_jid,
                     nick,
                     sender_jid,
-                    "cancel",
-                    "not-allowed",
+                    StanzaError::new(
+                        ErrorType::Cancel,
+                        DefinedCondition::NotAllowed,
+                        "en",
+                        "Creating new MUC rooms is not permitted for this account.",
+                    ),
                 )];
             }
 
@@ -2003,49 +2028,44 @@ fn build_muc_join_presence_stanza(params: MucJoinPresence<'_>) -> xmpp_parsers::
 /// by a different user. The joiner receives a `<presence type='error'/>` and
 /// no room state changes.
 fn build_muc_conflict_presence_xml(room_jid: &BareJid, nick: &str, to_jid: &FullJid) -> String {
-    let from_jid = room_jid
-        .clone()
-        .with_resource_str(nick)
-        .unwrap_or_else(|_| to_jid.clone());
-
-    let error_payload = Element::builder("error", waddle_xmpp::ns::JABBER_CLIENT)
-        .attr("type", "cancel")
-        .append(Element::builder("conflict", "urn:ietf:params:xml:ns:xmpp-stanzas").build())
-        .build();
-
-    element_to_xml(
-        Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
-            .attr("from", from_jid.to_string())
-            .attr("to", to_jid.to_string())
-            .attr("type", "error")
-            .append(error_payload)
-            .build(),
+    build_muc_presence_error_xml(
+        room_jid,
+        nick,
+        to_jid,
+        StanzaError::new(
+            ErrorType::Cancel,
+            DefinedCondition::Conflict,
+            "en",
+            "Nickname is already in use by another occupant.",
+        ),
     )
 }
 
-fn build_muc_join_error_xml(
+/// Build a `<presence type='error'>` MUC join failure response.
+///
+/// Per the typed-payloads hard rule (CLAUDE.md), the error type and
+/// condition flow as a typed
+/// [`xmpp_parsers::stanza_error::StanzaError`] — never as `&str`. The
+/// `<error/>` element is serialised via the upstream
+/// `From<StanzaError> for Element` impl so the wire shape is identical
+/// to the legacy `Element::builder("error", …)` literal.
+fn build_muc_presence_error_xml(
     room_jid: &BareJid,
     nick: &str,
     to_jid: &FullJid,
-    error_type: &str,
-    condition: &str,
+    error: StanzaError,
 ) -> String {
     let from_jid = room_jid
         .clone()
         .with_resource_str(nick)
         .unwrap_or_else(|_| to_jid.clone());
 
-    let error_payload = Element::builder("error", waddle_xmpp::ns::JABBER_CLIENT)
-        .attr("type", error_type)
-        .append(Element::builder(condition, "urn:ietf:params:xml:ns:xmpp-stanzas").build())
-        .build();
-
     element_to_xml(
         Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
             .attr("from", from_jid.to_string())
             .attr("to", to_jid.to_string())
             .attr("type", "error")
-            .append(error_payload)
+            .append(Element::from(error))
             .build(),
     )
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -54,6 +54,10 @@ use waddle_xmpp::{
 };
 use xmpp_parsers::minidom::Element;
 
+use crate::server::routes::websocket::handlers::iq::errors::{
+    feature_not_implemented_iq_error, not_authorized_iq_error,
+};
+
 #[cfg(test)]
 use waddle_xmpp::mam::InMemoryMamStorage;
 
@@ -1535,12 +1539,20 @@ pub(crate) fn build_iq_result_xml(
     element_to_xml(iq)
 }
 
-pub(crate) fn build_iq_error_xml_with_addresses(
+/// Build an `<iq type='error'>` reply from a typed
+/// [`xmpp_parsers::stanza_error::StanzaError`].
+///
+/// Replaces the previous stringly-typed `build_iq_error_xml*` helpers
+/// per the typed-payloads hard rule (CLAUDE.md): `error_type` and
+/// `condition` MUST flow as typed enum values across function
+/// boundaries, never as `&str`. Serialization uses the upstream
+/// `From<StanzaError> for Element` impl so the wire shape is identical
+/// to the previous manual builder.
+pub(crate) fn build_iq_error_xml_typed(
     id: &str,
     from: Option<&str>,
     to: Option<&str>,
-    error_type: &str,
-    condition: &str,
+    error: xmpp_parsers::stanza_error::StanzaError,
 ) -> String {
     let mut iq = xmpp_parsers::minidom::Element::builder("iq", "jabber:client")
         .attr("id", id)
@@ -1553,25 +1565,10 @@ pub(crate) fn build_iq_error_xml_with_addresses(
     }
 
     let iq = iq
-        .append(
-            xmpp_parsers::minidom::Element::builder("error", "jabber:client")
-                .attr("type", error_type)
-                .append(
-                    xmpp_parsers::minidom::Element::builder(
-                        condition,
-                        "urn:ietf:params:xml:ns:xmpp-stanzas",
-                    )
-                    .build(),
-                )
-                .build(),
-        )
+        .append(xmpp_parsers::minidom::Element::from(error))
         .build();
 
     element_to_xml(iq)
-}
-
-pub(crate) fn build_iq_error_xml(id: &str, error_type: &str, condition: &str) -> String {
-    build_iq_error_xml_with_addresses(id, None, None, error_type, condition)
 }
 
 fn build_handled_count_too_high_stream_error(acknowledged: u32, send_count: u32) -> String {
@@ -2250,12 +2247,11 @@ fn invalid_iq_parse_error_response(frame: &str) -> Option<String> {
         .and_then(|element| element.attr("from"))
         .map(ToString::to_string)
         .or_else(|| decoded_raw_xml_attr_value(frame, "from"));
-    Some(build_iq_error_xml_with_addresses(
+    Some(build_iq_error_xml_typed(
         &id,
         response_from.as_deref(),
         response_to.as_deref(),
-        "cancel",
-        "feature-not-implemented",
+        feature_not_implemented_iq_error("Requested feature not implemented."),
     ))
 }
 
@@ -2697,12 +2693,22 @@ fn handle_resource_binding(
 
     if !phase.allows_resource_binding() {
         warn!(phase = ?phase, id = %id, "Resource binding received in invalid phase");
-        return vec![build_iq_error_xml(&id, "auth", "not-authorized")];
+        return vec![build_iq_error_xml_typed(
+            &id,
+            None,
+            None,
+            not_authorized_iq_error("Authentication required."),
+        )];
     }
 
     let Some(bare_jid) = phase.authenticated_bare_jid() else {
         warn!(id = %id, "Resource binding without authenticated session");
-        return vec![build_iq_error_xml(&id, "auth", "not-authorized")];
+        return vec![build_iq_error_xml_typed(
+            &id,
+            None,
+            None,
+            not_authorized_iq_error("Authentication required."),
+        )];
     };
     let bare_jid = bare_jid.clone();
     let resource = match &iq.payload {
@@ -4301,7 +4307,12 @@ mod tests {
 
         assert_eq!(
             bind_two_responses,
-            vec![build_iq_error_xml("bind-2", "auth", "not-authorized")]
+            vec![build_iq_error_xml_typed(
+                "bind-2",
+                None,
+                None,
+                not_authorized_iq_error("Authentication required."),
+            )]
         );
         assert_eq!(conn.phase.bound_jid(), first_bound_jid.as_ref());
         assert!(matches!(conn.phase, ConnectionPhase::Ready { .. }));


### PR DESCRIPTION
## Summary

Refactors IQ-error emission across the server WebSocket handler tree
from stringly-typed (`error_type: &str`, `condition: &str`) to typed
`xmpp_parsers::stanza_error::StanzaError` values, satisfying the
typed-payloads hard rule (CLAUDE.md). Mirrors the same migration in
`handlers/presence.rs` for MUC join/conflict presence-error responses
that used the same raw `Element::builder("error", ...)` pattern.

Closes #234.

## Changes

### New typed builder

`server/src/server/routes/websocket/mod.rs`:

- Replaces `build_iq_error_xml(id, type_str, condition_str) -> String`
  and `build_iq_error_xml_with_addresses(id, from, to, type_str, condition_str) -> String`
  with a single `build_iq_error_xml_typed(id, from, to, StanzaError) -> String`.
- The new builder uses the upstream
  `From<StanzaError> for Element` impl. No manual
  `Element::builder("error", ...)` literal anywhere.

### Per-condition typed constructors

`server/src/server/routes/websocket/handlers/iq/errors.rs` (new file):

- `bad_request_iq_error(text)` (modify / `<bad-request/>`)
- `jid_malformed_iq_error(text)` (modify / `<jid-malformed/>`)
- `not_acceptable_iq_error(text)` (modify / `<not-acceptable/>`)
- `not_authorized_iq_error(text)` (auth / `<not-authorized/>`)
- `forbidden_iq_error(text)` (auth / `<forbidden/>`)
- `item_not_found_iq_error(text)` (cancel / `<item-not-found/>`)
- `service_unavailable_iq_error(text)` (cancel / `<service-unavailable/>`)
- `feature_not_implemented_iq_error(text)` (cancel / `<feature-not-implemented/>`)
- `internal_server_error_iq_error(text)` (wait / `<internal-server-error/>`)

Each returns an `xmpp_parsers::stanza_error::StanzaError` with typed
`ErrorType` + `DefinedCondition` enum variants. Re-exported from
`iq/mod.rs` via `pub(super) use` so all submodules wildcard-importing
the namespace pick them up.

### Migrated callsites

| File | Migrated |
|---|---|
| `routes/websocket/mod.rs` | 4 |
| `handlers/iq/mod.rs` | 65 |
| `handlers/iq/blocking.rs` | 8 |
| `handlers/iq/muc_admin.rs` | 7 |
| `handlers/iq/push.rs` | 6 |
| `handlers/iq/search.rs` | 6 |
| `handlers/iq/session_misc.rs` | 9 |
| `handlers/iq/vcard_private.rs` | 14 |
| **IQ-handler total** | **119** |
| `handlers/presence.rs` (MUC join/conflict) | 7 |

### Presence-error migration

`handlers/presence.rs`:

- `build_muc_join_error_xml(room, nick, to, type_str, cond_str) -> String`
  is replaced by `build_muc_presence_error_xml(room, nick, to, StanzaError) -> String`.
- `build_muc_conflict_presence_xml` now delegates to it with a typed
  `StanzaError::new(ErrorType::Cancel, DefinedCondition::Conflict, ...)`.
- Every callsite (`InternalServerError`, `NotAuthorized`, `Forbidden`,
  `RegistrationRequired`, `NotAllowed`, `Conflict`) constructs a typed
  `StanzaError` at the call site.

### Wire format

Unchanged. Confirmed by:

- `iq/errors.rs::tests::wire_shape_matches_legacy_builder` byte-for-byte
  asserts the serialised
  `<iq xmlns='jabber:client' from='…' id='…' to='…' type='error'><error type='cancel'><service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/></error></iq>` shape.
- All 433 `waddle-server` lib tests + ~150 integration tests pass
  unmodified, including XEP-specific assertions on
  `<forbidden/>`, `<item-not-found/>`, `<service-unavailable/>`,
  `<conflict/>`, etc.

### Out of scope

- `Element::builder("error", ...)` literals in
  `waddle-xmpp-client/src/{client,error,runtime}.rs` are left alone:
  they are either client-side test fixtures constructing inbound IQs
  for the client to consume, or `<stream:error>` (stream-level, not
  stanza-error). Neither is in the IQ-handler tree.
- Non-stanza-error `&str` values (XEP namespace identifiers, log
  strings) are not touched.
- No backwards-compatibility shims: the old stringly helpers are
  deleted entirely.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p waddle-server` (lib + integration: 433 + ~150 tests)
- [x] Per-XEP integration tests (`xep0308`, `xep0425`, `xep0060`,
      `xep0012_0202`, `rfc6121_roster`, etc.) pass without modification.
- [x] Grep confirms no `Element::builder("error", ...)` literals
      remain in the IQ-handler or presence-handler trees.