### PR TITLE
fix(server): XEP-0424 groupchat retraction lookup uses message id, not archive PK (#281)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -2646,15 +2646,23 @@ async fn validate_groupchat_rich_targets(
     Ok(())
 }
 
+/// XEP-0424 §3.1 retraction target resolution for groupchat. The
+/// retract stanza cites the target by its wire `id` (mirrors the
+/// XEP-0308 correction path at `validate_groupchat_rich_targets` —
+/// both XEPs name the same room-archive row by the same accessor).
+///
+/// Looks the row up by **wire message id scoped to the room archive**
+/// via [`MamStorage::get_message_by_message_id`]; never by archive
+/// primary key. The PK happens to coincide with the room's XEP-0359
+/// stamp UUID, so a PK lookup against the wire id can only match when
+/// the storage backend collides them — which is not a guarantee waddle
+/// makes (and SQL backends never do).
 async fn lookup_groupchat_retraction_target(
     mam_storage: &Arc<dyn MamStorage>,
     room: &BareJid,
     target_id: &str,
 ) -> Result<Option<MamArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
-    mam_storage
-        .get_message(target_id)
-        .await
-        .map(|message| message.filter(|message| message.to.to_bare() == *room))
+    mam_storage.get_message_by_message_id(room, target_id).await
 }
 
 /// Compare a XEP-0045 sender (the in-room full JID `room/nick`) against
@@ -2940,9 +2948,17 @@ async fn apply_groupchat_retraction_tombstone(
     target_message_id: &str,
     retraction_message: &Message,
 ) {
-    let original = match mam_storage.get_message(target_message_id).await {
-        Ok(Some(row)) if row.to.to_bare() == *room => row,
-        Ok(_) => {
+    // XEP-0424 §3.1: the retraction names the target by its wire
+    // message id within the room's archive, not by the archive's
+    // primary key. Use the same accessor as the XEP-0308 correction
+    // path (`validate_groupchat_rich_targets`) so reflection-time
+    // validation and tombstone application agree on the lookup key.
+    let original = match mam_storage
+        .get_message_by_message_id(room, target_message_id)
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
             debug!(
                 archive = %room,
                 target = target_message_id,
@@ -5393,5 +5409,184 @@ mod tests {
         let outcome = interpret(events, &deps).await;
         assert!(outcome.frames.is_empty());
         assert!(!outcome.close);
+    }
+
+    // -----------------------------------------------------------------
+    // XEP-0424 — groupchat retraction lookup (#281)
+    // -----------------------------------------------------------------
+
+    /// Seed the room archive with a single message whose **archive
+    /// primary key** (`row.id`) differs from its **wire message id**
+    /// (`row.stanza_id`), so a successful lookup proves which one the
+    /// caller is keying on.
+    async fn seed_groupchat_archive_row(
+        mam: &Arc<dyn MamStorage>,
+        room: &jid::BareJid,
+        archive_pk: &str,
+        wire_id: &str,
+    ) -> MamArchivedMessage {
+        let row = MamArchivedMessage {
+            id: archive_pk.to_string(),
+            timestamp: chrono::Utc::now(),
+            from: format!("{room}/alice").parse().expect("room/nick jid"),
+            to: jid::Jid::from(room.clone()),
+            body: Some("remove me".to_string()),
+            stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+                wire_id,
+                jid::Jid::from(room.clone()),
+            )),
+            thread: None,
+            reply: None,
+            origin_id: None,
+            message_type: XmppMessageType::Groupchat,
+            stanza_xml: Some(format!(
+                r#"<message xmlns='jabber:client' type='groupchat' from='{room}/alice' id='{wire_id}'><body>remove me</body><stanza-id xmlns='urn:xmpp:sid:0' by='{room}' id='{archive_pk}'/></message>"#
+            )),
+            rich: None,
+            nickname_generation: Some(0),
+        };
+        mam.store_message(room, &row).await.expect("seed mam row");
+        row
+    }
+
+    #[tokio::test]
+    async fn xep_0424_groupchat_retraction_target_looked_up_by_message_id_not_archive_pk() {
+        // Regression for #281: the groupchat retraction lookup must
+        // match the wire `<retract id='...'/>` against the archive
+        // row's stored wire message id (i.e. `stanza_id` column),
+        // never against the storage primary key. The bug returned
+        // `<item-not-found/>` to legitimate retractions because the
+        // PK-based lookup only happened to match when the storage
+        // backend coincidentally collided `id` with `stanza_id`.
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let room: jid::BareJid = "retract-l1@muc.example.com".parse().expect("room");
+        let archive_pk = "room-stamp-uuid-AAA";
+        let wire_id = "alice-orig-1";
+        seed_groupchat_archive_row(&mam, &room, archive_pk, wire_id).await;
+
+        // Lookup by the wire id resolves the row.
+        let resolved = lookup_groupchat_retraction_target(&mam, &room, wire_id)
+            .await
+            .expect("lookup must not error");
+        let resolved =
+            resolved.expect("wire-id retraction target must resolve to the seeded archive row");
+        assert_eq!(
+            resolved.id, archive_pk,
+            "lookup_groupchat_retraction_target returned the seeded row keyed by wire id"
+        );
+        assert_eq!(
+            resolved
+                .stanza_id
+                .as_ref()
+                .map(|s| s.id.as_str())
+                .unwrap_or_default(),
+            wire_id,
+            "resolved row's wire stanza_id matches the retraction target"
+        );
+
+        // Lookup by the archive PK must NOT match — that was the
+        // pre-fix behavior the issue called out.
+        let pk_lookup = lookup_groupchat_retraction_target(&mam, &room, archive_pk)
+            .await
+            .expect("lookup must not error");
+        assert!(
+            pk_lookup.is_none(),
+            "PK lookup must not satisfy a retraction whose target id is a wire id"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep_0424_groupchat_retraction_lookup_is_room_scoped() {
+        // The accessor must scope the lookup to the room archive so
+        // a colliding wire id in another room does not satisfy the
+        // retraction. (The pre-fix global `get_message` PK lookup
+        // performed the room scope via a manual `to.to_bare()`
+        // post-filter; the new accessor scopes via the SQL/in-memory
+        // archive_jid predicate. Either path must reject cross-room
+        // matches.)
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let room_a: jid::BareJid = "room-a@muc.example.com".parse().expect("room a");
+        let room_b: jid::BareJid = "room-b@muc.example.com".parse().expect("room b");
+        let wire_id = "shared-wire-id-1";
+        seed_groupchat_archive_row(&mam, &room_a, "pk-A", wire_id).await;
+
+        // Same wire id queried under room B — must not resolve.
+        let cross = lookup_groupchat_retraction_target(&mam, &room_b, wire_id)
+            .await
+            .expect("lookup must not error");
+        assert!(
+            cross.is_none(),
+            "groupchat retraction lookup must not return rows from a different room archive"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep_0424_apply_groupchat_retraction_tombstone_keys_off_wire_id() {
+        // Regression for #281's second defective site: the tombstone
+        // application must also key off the wire id. Drives the
+        // `OutboundEvent::ApplyGroupchatRetractionTombstone` arm of
+        // `interpret` and asserts the seeded row gets its body
+        // scrubbed and a `<retracted/>` tombstone written in its
+        // place.
+        use waddle_xmpp::mam::storage::InMemoryMamStorage;
+
+        let registry = ConnectionRegistry::new();
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> =
+            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+        let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+        let room: jid::BareJid = "retract-tombstone@muc.example.com".parse().expect("room");
+        let archive_pk = "room-stamp-uuid-BBB";
+        let wire_id = "alice-orig-2";
+        seed_groupchat_archive_row(&mam, &room, archive_pk, wire_id).await;
+
+        // Build the retraction message the chain would emit.
+        let mut retraction =
+            xmpp_parsers::message::Message::new(Some(jid::Jid::from(room.clone())));
+        retraction.id = Some("retract-stanza-1".to_string());
+        retraction.from = Some(format!("{room}/alice").parse().expect("room/nick"));
+        retraction.type_ = XmppMessageType::Groupchat;
+        retraction
+            .payloads
+            .push(waddle_xmpp::xep::xep0424::build_retract_element(wire_id));
+
+        let events = vec![OutboundEvent::ApplyGroupchatRetractionTombstone {
+            room: room.clone(),
+            target_message_id: wire_id.to_string(),
+            retraction_message: Box::new(retraction),
+        }];
+        let _outcome = interpret(events, &deps).await;
+
+        // The seeded row's body must now be scrubbed and a
+        // `<retracted/>` payload must replace it (XEP-0424 §"prevent
+        // further distribution"). Reading the row back via the same
+        // wire-id accessor proves both sites agree on the lookup key.
+        let row = mam
+            .get_message_by_message_id(&room, wire_id)
+            .await
+            .expect("post-tombstone lookup")
+            .expect("row still present after tombstone replace");
+        assert!(row.body.is_none(), "tombstone must clear the original body");
+        let rich = row
+            .rich
+            .as_ref()
+            .expect("post-tombstone row must carry an ArchivedRichMessage");
+        match rich.payload.as_ref() {
+            Some(waddle_xmpp::mam::ArchivedRichPayload::Tombstone(ts)) => {
+                assert_eq!(
+                    ts.retraction_id.as_ref().map(|id| id.as_str()),
+                    Some("retract-stanza-1"),
+                    "tombstone cites the retraction stanza id"
+                );
+            }
+            other => {
+                panic!("expected ArchivedRichPayload::Tombstone after retraction, got {other:?}")
+            }
+        }
     }
 }

--- a/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
+++ b/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
@@ -3,7 +3,7 @@
 mod ws_common;
 
 use tokio::sync::Mutex;
-use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
@@ -33,34 +33,44 @@ async fn join_room(client: &mut WsXmppClient, room: &str) {
         .expect("join responses");
 }
 
-fn stanza_id(frame: &str) -> String {
-    extract_attr_after(frame, "stanza-id", "id").expect("stanza-id id")
-}
-
 #[tokio::test]
-async fn retraction_routes_and_replays_from_mam() {
+async fn xep_0424_groupchat_retraction_round_trip_succeeds() {
+    // L4 wire-trace coverage for #281: alice sends a groupchat
+    // message, the room reflects, alice retracts citing the
+    // **wire `id`** of the original (matching the XEP-0308 correction
+    // path's accessor — see `validate_groupchat_rich_targets` in
+    // `interpret.rs`). The retraction MUST be reflected (proving the
+    // validator resolved the target instead of returning
+    // `<item-not-found/>`), and a `<retracted/>` tombstone MUST
+    // replace the original row in MAM (XEP-0424 §"prevent further
+    // distribution").
+    //
+    // Pre-fix this assertion failed because the interpreter's
+    // groupchat retraction lookup keyed off the storage primary key
+    // instead of the wire id, so any client retraction citing the
+    // wire id (the only id XEP-0308 corrections accept in this
+    // codebase) returned `<item-not-found/>` to the sender.
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = setup().await;
     let room = format!("retract-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
     join_room(&mut client, &room).await;
 
+    let original_id = "orig-1";
     client
         .send(&format!(
-            r#"<message type="groupchat" to="{room}" id="orig-1"><body>remove me</body></message>"#
+            r#"<message type="groupchat" to="{room}" id="{original_id}"><body>remove me</body></message>"#
         ))
         .await
         .expect("send original");
-    let target = stanza_id(
-        &client
-            .recv_matching(|frame| frame.contains("remove me"))
-            .await
-            .expect("original echo"),
-    );
+    let _echo = client
+        .recv_matching(|frame| frame.contains("remove me"))
+        .await
+        .expect("original echo");
 
     client
         .send(&format!(
             r#"<message type="groupchat" to="{room}" id="retract-1">
-                <retract xmlns="urn:xmpp:message-retract:1" id="{target}"/>
+                <retract xmlns="urn:xmpp:message-retract:1" id="{original_id}"/>
                 <body>/me retracted a previous message</body>
             </message>"#
         ))
@@ -70,7 +80,14 @@ async fn retraction_routes_and_replays_from_mam() {
         .recv_matching(|frame| frame.contains("urn:xmpp:message-retract:1"))
         .await
         .expect("retraction echo");
-    assert!(echo.contains(&target), "missing retraction target: {echo}");
+    assert!(
+        echo.contains(&format!("id=\"{original_id}\"")),
+        "retraction echo must cite the original wire id: {echo}"
+    );
+    assert!(
+        !echo.contains("<error"),
+        "successful retraction must not be an error stanza: {echo}"
+    );
 
     client
         .send(&format!(
@@ -89,8 +106,9 @@ async fn retraction_routes_and_replays_from_mam() {
     assert!(
         frames
             .iter()
-            .any(|frame| frame.contains("<retract ") && frame.contains(&target)),
-        "MAM did not replay retraction event: {frames:?}"
+            .any(|frame| frame.contains("<retract ")
+                && frame.contains(&format!("id=\"{original_id}\""))),
+        "MAM did not replay retraction event citing the original wire id: {frames:?}"
     );
 
     // XEP-0424 §"prevent further distribution… by replacing the


### PR DESCRIPTION
Fixes #281.

## Summary

The groupchat retraction validator and the tombstone applier in
`server/crates/waddle-server/src/server/routes/interpret.rs` looked up
the retract target by `MamStorage::get_message`, which is a global
lookup against the storage primary key. The PK is derived from the
room's XEP-0359 stanza-id stamp, while the wire `<retract id='...'/>`
cites the target's wire message id (matching the XEP-0308 correction
path's accessor `get_message_by_message_id`). Every legitimate
groupchat retraction therefore resolved to `<item-not-found/>` unless
a storage backend coincidentally collided the two ids -- SQL backends
never do.

## Plan

1. Branch `fix/281-xep0424-groupchat-retraction-lookup` from `main` in
   the agent worktree.
2. Read `interpret.rs` and confirm the two defective sites:
   - `lookup_groupchat_retraction_target` (current line ~2649) used
     `mam_storage.get_message(target_id)` plus a manual
     `to.to_bare() == *room` post-filter.
   - `apply_groupchat_retraction_tombstone` (current line ~2943) used
     the same defective accessor.
3. Replace both with
   `mam_storage.get_message_by_message_id(room, target_id)` so:
   - The accessor matches the column that stores the wire id (the
     `stanza_id` column, populated from `archive_clone.id` in
     `finish_archive_groupchat_message`).
   - The room scope is enforced by the SQL/`InMemory` archive_jid
     predicate; the manual `to.to_bare() == *room` post-filter is
     removed.
   - Reflection-time validation (`validate_groupchat_rich_targets`,
     XEP-0308 correction path) and tombstone application agree on the
     same lookup key.
4. Confirm against XEP-0424 §3.1 (cloned `xsf/xeps` to `./xeps`).
5. Add L1 unit coverage inline in `interpret.rs`'s test module:
   - `xep_0424_groupchat_retraction_target_looked_up_by_message_id_not_archive_pk`
     seeds an archive row whose PK differs from its wire id and
     asserts the lookup resolves by wire id and not by PK.
   - `xep_0424_groupchat_retraction_lookup_is_room_scoped` asserts a
     colliding wire id in another room does not satisfy the
     retraction.
   - `xep_0424_apply_groupchat_retraction_tombstone_keys_off_wire_id`
     drives the `OutboundEvent::ApplyGroupchatRetractionTombstone`
     interpreter arm end-to-end and verifies the seeded row's body is
     scrubbed and a `<retracted/>` tombstone replaces it.
6. Replace the existing wire-trace test
   `retraction_routes_and_replays_from_mam` with
   `xep_0424_groupchat_retraction_round_trip_succeeds`, which exercises
   the full L4 path with a wire-id retract target. Pre-fix this asserts
   would have failed with `<item-not-found/>`.
7. `cargo build`, `cargo fmt`, `cargo clippy --workspace --all-targets
   -- -D warnings`, and the touched test crates (`xep0424`, `xep0308`,
   `xep0425`, plus the `interpret.rs` lib tests) must all pass.
8. Self-adversarial review for additional defective sites and missing
   coverage.

## Files changed

- `server/crates/waddle-server/src/server/routes/interpret.rs` --
  swap accessor in both groupchat retraction sites; remove the
  redundant `to.to_bare() == *room` post-filter; add three L1 unit
  tests + a shared `seed_groupchat_archive_row` helper.
- `server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs`
  -- replace the misaligned wire-trace test with the round-trip test
  required by the issue; drop the now-unused `extract_attr_after`
  import and `stanza_id` helper.

## Notes / follow-ups

The same `MamStorage::get_message` PK-lookup pattern still exists for
**XEP-0425 moderation** in
`server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs`
(two sites, lines ~1238 and ~1348). That has the same root-cause
shape but is out of scope for this PR (the issue is scoped to
XEP-0424). I have intentionally left those untouched and they should
get their own ticket so the change can land with its own dedicated
test coverage.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p waddle-server --lib server::routes::interpret::tests`
  -- all 48 pass, including the three new XEP-0424 tests
- [x] `cargo test -p waddle-server --test xep0424_message_retraction_ws`
  -- both pass
- [x] `cargo test -p waddle-server --test xep0308_message_corrections_ws`
  -- 5 pass
- [x] `cargo test -p waddle-server --test xep0425_message_moderation_ws`
  -- 2 pass
- [ ] Full CI green