### PR TITLE
fix(chat): repair room presence and member counts

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type ComponentPublicInstance, computed, onMounted, onUnmounted, ref, watch, watchEffect } from "vue";
 import { createKeystrok, type Keystrok } from "keystrok";
-import { useWaddleDirectory } from "@/waddles/directory";
+import { useWaddleDirectory, type MemberLoadState } from "@/waddles/directory";
 import { useWaddleMembers } from "@/waddles/members";
 import { useDirectMessageConversations } from "@/dms/conversations";
 import { useDirectMessages } from "@/dms/messages";
@@ -405,6 +405,29 @@ const mentionCandidates = computed(() =>
 const mentionSourceDiagnostic = computed(() =>
   mergedMentionMembers.value.diagnostics.join(" "),
 );
+watch(mentionSourceDiagnostic, (detail) => {
+  if (detail) console.warn(detail);
+});
+const memberRoleOrder = { owner: 0, admin: 1, member: 2, outcast: 3, none: 4 } as const;
+const displayedMembers = computed<MemberSummary[]>(() =>
+  [...mergedMentionMembers.value.members].sort(
+    (a, b) =>
+      (memberRoleOrder[a.role] ?? 4) - (memberRoleOrder[b.role] ?? 4) ||
+      a.username.localeCompare(b.username, undefined, { sensitivity: "base" }),
+  ),
+);
+const displayedMemberCount = computed<number | null>(() => {
+  const count = displayedMembers.value.length;
+  if (count > 0) return count;
+  return waddles.memberLoadState.value === "ready" ? 0 : null;
+});
+const displayedMemberState = computed<MemberLoadState>(() => waddles.memberLoadState.value);
+const memberCountLabel = computed(() => {
+  if (displayedMemberCount.value !== null) return String(displayedMemberCount.value);
+  if (displayedMemberState.value === "loading") return "syncing";
+  if (displayedMemberState.value === "unavailable") return "unavailable";
+  return "0";
+});
 const activeDmPeer = computed(() => {
   const active = dmConversations.activePeerJid.value;
   if (!active) return null;
@@ -481,13 +504,13 @@ const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
   return avatars;
 });
 const membersWithAvatars = computed<MemberSummary[]>(() =>
-  waddles.sortedMembers.value.map((member) => ({
+  displayedMembers.value.map((member) => ({
     ...member,
     avatar_url: fetchedAvatarUrlByJid.value[member.jid] ?? member.avatar_url,
   })),
 );
 const authorHatsByNick = computed(() =>
-  mergeRoomHats(roomHatsFromMembers(waddles.members.value), messaging.roomHats.value),
+  mergeRoomHats(roomHatsFromMembers(displayedMembers.value), messaging.roomHats.value),
 );
 
 watch(
@@ -663,9 +686,7 @@ async function refreshAppUpdate() {
 const activeUploadProgress = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.uploadProgress.value : messaging.uploadProgress.value,
 );
-const activeActionError = computed(() =>
-  ui.actionError.value || (ui.sidebarMode.value === "channels" ? mentionSourceDiagnostic.value : "")
-);
+const activeActionError = computed(() => ui.actionError.value);
 const activeErrorActionLabel = computed(() => {
   const peer = activeDmPeer.value;
   return ui.sidebarMode.value === "dms" &&
@@ -1408,7 +1429,8 @@ onUnmounted(() => {
           :can-manage-channels="waddles.canManageChannels.value"
           :can-manage-community="waddles.canManageCommunity.value"
           :is-loading="waddles.isLoadingStructure.value"
-          :member-count="waddles.members.value.length"
+          :member-count="displayedMemberCount"
+          :member-state="displayedMemberState"
           :active-channel-jids="messaging.activeChannels.value"
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
@@ -1477,7 +1499,7 @@ onUnmounted(() => {
             type="button"
             @click="ui.showMobileDetails.value = false; ui.showMembers.value = true"
           >
-            Members ({{ waddles.members.value.length }})
+            Members ({{ memberCountLabel }})
           </button>
         </div>
       </div>
@@ -1519,7 +1541,8 @@ onUnmounted(() => {
           :can-manage-channels="waddles.canManageChannels.value"
           :can-manage-community="waddles.canManageCommunity.value"
           :is-loading="waddles.isLoadingStructure.value"
-          :member-count="waddles.members.value.length"
+          :member-count="displayedMemberCount"
+          :member-state="displayedMemberState"
           :active-channel-jids="messaging.activeChannels.value"
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
@@ -1623,7 +1646,8 @@ onUnmounted(() => {
               :has-older-messages="activeHasOlderMessages"
               :is-sending="activeIsSending"
               :can-manage-channels="waddles.canManageChannels.value"
-              :member-count="waddles.members.value.length"
+              :member-count="displayedMemberCount"
+              :member-state="displayedMemberState"
               :typing-users="activeTypingUsers"
               :current-user="connectionStore.session?.username"
               :self-domain="selfDomain"
@@ -1812,6 +1836,7 @@ onUnmounted(() => {
     <MemberManagement
       v-model:open="ui.showMembers.value"
       :members="membersWithAvatars"
+      :member-state="displayedMemberState"
       :member-query="members.memberQuery.value"
       :new-member-role="members.newMemberRole.value"
       :search-results="members.memberSearchResults.value"

--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -416,6 +416,12 @@ const displayedMembers = computed<MemberSummary[]>(() =>
       a.username.localeCompare(b.username, undefined, { sensitivity: "base" }),
   ),
 );
+const authoritativeMemberJids = computed(() => new Set(waddles.members.value.map((member) => member.jid)));
+const inferredMemberJids = computed(() =>
+  new Set(displayedMembers.value
+    .filter((member) => !authoritativeMemberJids.value.has(member.jid))
+    .map((member) => member.jid)),
+);
 const displayedMemberCount = computed<number | null>(() => {
   const count = displayedMembers.value.length;
   if (count > 0) return count;
@@ -1836,6 +1842,7 @@ onUnmounted(() => {
     <MemberManagement
       v-model:open="ui.showMembers.value"
       :members="membersWithAvatars"
+      :inferred-member-jids="inferredMemberJids"
       :member-state="displayedMemberState"
       :member-query="members.memberQuery.value"
       :new-member-role="members.newMemberRole.value"

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import type { Component } from "vue";
+import { computed, type Component } from "vue";
 import { ChevronRight, Hash, Menu, MessageCircle, MessagesSquare, Search, Settings, Users } from "lucide-vue-next";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ConnectionNoticeCopy } from "@/lib/connection-notice";
+import type { MemberLoadState } from "@/waddles/directory";
 
 interface ConnectionStatusClasses {
   banner: string;
@@ -17,7 +18,8 @@ const props = defineProps<{
   dmPeer?: { peerJid?: string; peerUsername: string; presenceShow?: string } | null;
   isForumChannel: boolean;
   canManageChannels: boolean;
-  memberCount: number;
+  memberCount: number | null;
+  memberState: MemberLoadState;
   connectionNotice: ConnectionNoticeCopy | null;
   connectionStatusClasses: ConnectionStatusClasses | null;
   connectionStatusIcon: Component;
@@ -38,6 +40,35 @@ function presenceText(show?: string): string {
   if (show === "xa") return "extended away";
   return "offline";
 }
+
+const memberButtonCopy = computed(() => {
+  if (props.memberCount !== null) {
+    const noun = props.memberCount === 1 ? "member" : "members";
+    const suffix = props.memberState === "unavailable" ? ", last synced" : "";
+    return {
+      title: `${props.memberCount} ${noun}${suffix}`,
+      aria: `Open details (${props.memberCount} ${noun}${suffix})`,
+      primary: String(props.memberCount),
+      secondary: noun,
+    };
+  }
+
+  if (props.memberState === "loading") {
+    return {
+      title: "Members syncing",
+      aria: "Open details (members syncing)",
+      primary: "Syncing",
+      secondary: "members",
+    };
+  }
+
+  return {
+    title: "Members unavailable",
+    aria: "Open details (members unavailable)",
+    primary: "Unavailable",
+    secondary: "members",
+  };
+});
 </script>
 
 <template>
@@ -119,13 +150,13 @@ function presenceText(show?: string): string {
           v-if="channel"
           class="chat-action-button chat-action-button--secondary text-muted-foreground hover:text-foreground"
           type="button"
-          :title="`${memberCount} ${memberCount === 1 ? 'member' : 'members'}`"
-          :aria-label="`Open details (${memberCount} ${memberCount === 1 ? 'member' : 'members'})`"
+          :title="memberButtonCopy.title"
+          :aria-label="memberButtonCopy.aria"
           @click="emit('openDetails')"
         >
           <Users class="w-3.5 h-3.5" />
-          <span class="type-control">{{ memberCount }}</span>
-          <span class="hidden lg:inline type-control">{{ memberCount === 1 ? "member" : "members" }}</span>
+          <span class="type-control">{{ memberButtonCopy.primary }}</span>
+          <span class="hidden lg:inline type-control">{{ memberButtonCopy.secondary }}</span>
           <ChevronRight class="w-3.5 h-3.5 opacity-60" />
         </button>
       </div>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -17,6 +17,7 @@ import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, TimelineMessage, MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { MentionCandidate } from "@/lib/mentions";
 import type { BrowserXmppClient, MessageSearchResult, XmppStatusSnapshot, RoomHats, RoomPresence } from "@/lib/xmpp-client";
+import type { MemberLoadState } from "@/waddles/directory";
 import type { DiscoveredExtensionCommand, ExtensionCommandAction, ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MessageThreadIndex } from "@/channels/threads";
@@ -50,7 +51,8 @@ const props = defineProps<{
   hasOlderMessages: boolean;
   isSending: boolean;
   canManageChannels: boolean;
-  memberCount: number;
+  memberCount: number | null;
+  memberState: MemberLoadState;
   typingUsers: string[];
   currentUser?: string;
   selfDomain?: string;
@@ -666,6 +668,7 @@ function dayDividerLabel(createdAt: string): string {
       :is-forum-channel="isForumChannel"
       :can-manage-channels="canManageChannels"
       :member-count="memberCount"
+      :member-state="memberState"
       :connection-notice="connectionNotice"
       :connection-status-classes="connectionStatusClasses"
       :connection-status-icon="connectionStatusIcon"

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -6,6 +6,7 @@ import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+import type { MemberLoadState } from "@/waddles/directory";
 
 const props = defineProps<{
   waddle: SpaceSummary | null;
@@ -15,7 +16,8 @@ const props = defineProps<{
   canManageChannels: boolean;
   canManageCommunity: boolean;
   isLoading: boolean;
-  memberCount: number;
+  memberCount: number | null;
+  memberState: MemberLoadState;
   activeChannelJids: Set<string>;
   collapsedGroupIds: Set<string>;
   channelUnreadMap?: Record<string, { unread: number; mentions: number }>;
@@ -76,6 +78,13 @@ function activityLabel(summary: { unread: number; mentions: number; hasActivity:
     parts.push("active");
   }
   return parts.length > 0 ? parts.join(", ") : "no unread activity";
+}
+
+function memberCountLabel() {
+  if (props.memberCount !== null) return String(props.memberCount);
+  if (props.memberState === "loading") return "syncing";
+  if (props.memberState === "unavailable") return "unavailable";
+  return "0";
 }
 
 function channelRowLabel(
@@ -398,7 +407,7 @@ watch(
       >
         <Users class="w-3.5 h-3.5 flex-shrink-0 opacity-40 group-hover:opacity-70 transition-opacity" />
         <span class="type-control flex-1">Members</span>
-        <span class="type-meta type-numeric text-sidebar-muted">{{ memberCount }}</span>
+        <span class="type-meta text-sidebar-muted">{{ memberCountLabel() }}</span>
       </button>
     </div>
   </div>

--- a/chat/src/components/modals/MemberManagement.vue
+++ b/chat/src/components/modals/MemberManagement.vue
@@ -5,11 +5,13 @@ import AppAvatar from "@/components/ui/AppAvatar.vue";
 import type { MemberSummary, UserSearchResult } from "@/lib/chat-types";
 import type { EditableRole } from "@/lib/chat-ui";
 import type { RoomPresence } from "@/lib/xmpp-client";
+import type { MemberLoadState } from "@/waddles/directory";
 
 const open = defineModel<boolean>("open", { required: true });
 
 defineProps<{
   members: MemberSummary[];
+  memberState: MemberLoadState;
   memberQuery: string;
   newMemberRole: EditableRole;
   searchResults: UserSearchResult[];
@@ -104,6 +106,12 @@ const roles: EditableRole[] = ["member", "admin", "owner", "outcast"];
     <!-- Member list -->
     <div class="flex max-h-96 flex-col gap-1 overflow-auto px-4 py-3 sm:px-5">
       <div
+        v-if="memberState === 'unavailable' && members.length > 0"
+        class="type-caption rounded-md border border-border bg-muted/35 px-3 py-2 text-muted-foreground"
+      >
+        Showing last synced members.
+      </div>
+      <div
         v-for="member in members"
         :key="member.jid"
         class="chat-list-row flex min-h-12 items-center gap-2.5 p-2 hover:bg-muted/50"
@@ -135,7 +143,13 @@ const roles: EditableRole[] = ["member", "admin", "owner", "outcast"];
         </div>
       </div>
 
-      <div v-if="members.length === 0" class="type-caption text-center py-6 text-muted-foreground">
+      <div v-if="members.length === 0 && memberState === 'loading'" class="type-caption text-center py-6 text-muted-foreground">
+        Syncing members…
+      </div>
+      <div v-else-if="members.length === 0 && memberState === 'unavailable'" class="type-caption text-center py-6 text-muted-foreground">
+        Members are unavailable right now.
+      </div>
+      <div v-else-if="members.length === 0" class="type-caption text-center py-6 text-muted-foreground">
         No members
       </div>
     </div>

--- a/chat/src/components/modals/MemberManagement.vue
+++ b/chat/src/components/modals/MemberManagement.vue
@@ -11,6 +11,7 @@ const open = defineModel<boolean>("open", { required: true });
 
 defineProps<{
   members: MemberSummary[];
+  inferredMemberJids: Set<string>;
   memberState: MemberLoadState;
   memberQuery: string;
   newMemberRole: EditableRole;
@@ -120,10 +121,10 @@ const roles: EditableRole[] = ["member", "admin", "owner", "outcast"];
         <div class="flex-1 min-w-0">
           <div class="type-control truncate">{{ member.username }}</div>
           <div class="type-caption text-muted-foreground capitalize">
-            {{ member.role }}
+            {{ inferredMemberJids.has(member.jid) ? "Present now" : member.role }}
           </div>
         </div>
-        <div v-if="canManageMembers && member.role !== 'owner'" class="flex items-center gap-1.5">
+        <div v-if="canManageMembers && !inferredMemberJids.has(member.jid) && member.role !== 'owner'" class="flex items-center gap-1.5">
           <select
             :value="member.role"
             class="type-caption type-emphasis h-8 appearance-none rounded-lg border border-border bg-muted/60 px-2.5 capitalize transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary/20"
@@ -140,6 +141,9 @@ const roles: EditableRole[] = ["member", "admin", "owner", "outcast"];
           >
             <X class="w-3.5 h-3.5" />
           </button>
+        </div>
+        <div v-else-if="inferredMemberJids.has(member.jid)" class="type-caption text-muted-foreground">
+          Synced from presence
         </div>
       </div>
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -475,6 +475,13 @@ async function loadWasmModule(): Promise<WasmModule> {
   return wasmModulePromise;
 }
 
+export class RoomMemberListUnavailableError extends Error {
+  constructor(message = "Member list is temporarily unavailable.") {
+    super(message);
+    this.name = "RoomMemberListUnavailableError";
+  }
+}
+
 export class BrowserXmppClient {
   private session: WaddleSession;
   private get queueScope() { return barePeerJid(this.session.jid); }
@@ -724,7 +731,9 @@ export class BrowserXmppClient {
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.roomJoinWaiters.delete(fullJid);
-        reject(new Error(`Timed out waiting for self-presence in ${roomJid}`));
+        const detail = `Timed out waiting for self-presence in ${roomJid}`;
+        this.emitError({ kind: "connect-timeout", recoverable: true, detail });
+        reject(new Error("Channel presence did not finish syncing. Try again in a moment."));
       }, 4000);
       this.roomJoinWaiters.set(fullJid, {
         resolve: () => {
@@ -1112,7 +1121,9 @@ export class BrowserXmppClient {
     for (const affiliation of affiliations) {
       try { const result = await listMembers(affiliation); for (const item of result ?? []) { if (!item.jid) continue; members.push({ jid: item.jid, username: item.jid.split("@")[0] ?? item.jid, avatar_url: null, role: affiliation, joined_at: "" }); } } catch (error: any) { failedAffiliations.push(affiliation); const condition = error?.condition ?? error?.error?.condition; const detail = condition === "forbidden" ? `forbidden affiliation query — ${roomJid}` : condition === "service-unavailable" ? `unsupported member query — ${roomJid}` : `affiliation query failed for ${affiliation} — ${roomJid}; reconstructed room JID may not match`; this.emitError({ kind: "member-query", recoverable: true, detail, cause: error, condition }); }
     }
-    if (members.length === 0 && failedAffiliations.length > 0) throw new Error("refusing to show Members 0");
+    if (members.length === 0 && failedAffiliations.length > 0) {
+      throw new RoomMemberListUnavailableError();
+    }
     return members;
   }
   async setRoomAffiliation(channelId: string, jid: string, affiliation: MemberSummary["role"]): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.set_room_affiliation?.(this.roomJidForChannel(channelId), jid, affiliation === "none" ? "none" : affiliation); }

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -1,4 +1,7 @@
-export { BrowserXmppClient } from "./client";
+export {
+  BrowserXmppClient,
+  RoomMemberListUnavailableError,
+} from "./client";
 export {
   barePeerJid,
   jidDomain,

--- a/chat/src/waddles/directory.ts
+++ b/chat/src/waddles/directory.ts
@@ -21,6 +21,8 @@ interface LoadStructureOptions {
   noChannelSelect?: boolean;
 }
 
+export type MemberLoadState = "idle" | "loading" | "ready" | "unavailable";
+
 export function useWaddleDirectory(
   _api: Ref<null>,
   xmppClient: Ref<BrowserXmppClient | null>,
@@ -32,6 +34,7 @@ export function useWaddleDirectory(
   const waddles = ref<SpaceSummary[]>([]);
   const channels = ref<ChannelSummary[]>([]);
   const members = ref<MemberSummary[]>([]);
+  const memberLoadState = ref<MemberLoadState>("idle");
   const serverRole = ref<SpaceSummary["role"]>(null);
   const mucServiceJid = ref<string | null>(null);
   const spacesServiceJid = ref<string | null>(null);
@@ -45,6 +48,7 @@ export function useWaddleDirectory(
   let spaceRequestId = 0;
   let structureRequestId = 0;
   let memberRequestId = 0;
+  const memberSnapshotsByChannelId = new Map<string, MemberSummary[]>();
 
   const editWaddleForm = ref<CommunityFormData>({
     name: "",
@@ -146,6 +150,23 @@ export function useWaddleDirectory(
     createChannelForm.value = defaultCreateForm();
   }
 
+  function beginMemberLoad(channelId: string) {
+    memberLoadState.value = "loading";
+    members.value = memberSnapshotsByChannelId.get(channelId) ?? [];
+  }
+
+  function completeMemberLoad(channelId: string, freshMembers: MemberSummary[]) {
+    memberSnapshotsByChannelId.set(channelId, freshMembers);
+    members.value = freshMembers;
+    memberLoadState.value = "ready";
+  }
+
+  function failMemberLoad(channelId: string, error: unknown) {
+    console.warn("Unable to load room members", error);
+    members.value = memberSnapshotsByChannelId.get(channelId) ?? members.value;
+    memberLoadState.value = "unavailable";
+  }
+
   function prepareCreateChannelForContext(spaceId: string | null = currentSpace.value?.id ?? null) {
     createChannelForm.value = defaultCreateFormForContext(spaceId);
   }
@@ -185,11 +206,12 @@ export function useWaddleDirectory(
       }));
 
       channels.value = channelList;
-      members.value = [];
 
       if (opts?.noChannelSelect) {
         activeChannelId.value = null;
         selectedSpaceId.value = null;
+        members.value = [];
+        memberLoadState.value = "idle";
         resetForms();
         return null;
       }
@@ -206,19 +228,20 @@ export function useWaddleDirectory(
       selectedSpaceId.value = nextChannel ? nextChannel.spaceId ?? null : selectedSpaceId.value;
       if (nextChannelId && xmppClient.value) {
         const memberReqId = ++memberRequestId;
+        beginMemberLoad(nextChannelId);
         try {
           const freshMembers = await xmppClient.value.listRoomMembers(nextChannelId, { roomJid: nextChannel?.jid });
           if (requestId === structureRequestId && memberReqId === memberRequestId) {
-            members.value = freshMembers;
+            completeMemberLoad(nextChannelId, freshMembers);
           }
         } catch (e) {
           if (requestId === structureRequestId && memberReqId === memberRequestId) {
-            console.warn("Unable to load room members", e);
-            members.value = [];
+            failMemberLoad(nextChannelId, e);
           }
         }
       } else {
         members.value = [];
+        memberLoadState.value = "idle";
       }
       resetForms();
       return nextChannelId;
@@ -254,14 +277,15 @@ export function useWaddleDirectory(
 
     const channel = channels.value.find((c) => c.id === channelId);
     const requestId = ++memberRequestId;
+    beginMemberLoad(channelId);
 
     try {
       const freshMembers = await xmppClient.value.listRoomMembers(channelId, { roomJid: channel?.jid });
       if (requestId !== memberRequestId) return;
-      members.value = freshMembers;
+      completeMemberLoad(channelId, freshMembers);
     } catch (e) {
       if (requestId === memberRequestId) {
-        actionError.value = normalizeError(e);
+        failMemberLoad(channelId, e);
       }
     }
   }
@@ -414,6 +438,8 @@ export function useWaddleDirectory(
     waddles.value = [];
     channels.value = [];
     members.value = [];
+    memberLoadState.value = "idle";
+    memberSnapshotsByChannelId.clear();
     serverRole.value = null;
     activeChannelId.value = null;
     selectedSpaceId.value = null;
@@ -423,6 +449,7 @@ export function useWaddleDirectory(
     waddles,
     channels,
     members,
+    memberLoadState,
     serverRole,
     activeSpaceId,
     activeChannelId,

--- a/chat/tests/channel-reload.test.ts
+++ b/chat/tests/channel-reload.test.ts
@@ -56,6 +56,7 @@ describe("useWaddleDirectory.loadStructure", () => {
     expect(listRoomMembers.mock.calls[0]![0]).toBe("general");
     expect(listRoomMembers.mock.calls[0]![1]).toEqual({ roomJid: "general@conference.example.com" });
     expect(w.members.value).toEqual([ALICE]);
+    expect(w.memberLoadState.value).toBe("ready");
   });
 
   test("loads members for the preferred channel when a channelId is supplied", async () => {
@@ -71,6 +72,7 @@ describe("useWaddleDirectory.loadStructure", () => {
     expect(listRoomMembers.mock.calls[0]![1]).toEqual({ roomJid: "random@conference.example.com" });
     expect(w.members.value).toEqual([BOB]);
     expect(w.activeChannelId.value).toBe("random");
+    expect(w.memberLoadState.value).toBe("ready");
   });
 
   test("routes to the first channel when preferred channel is not in the topology", async () => {
@@ -125,24 +127,33 @@ describe("useWaddleDirectory.reloadChannelMembers", () => {
     expect(w.members.value).toEqual([ALICE]);
   });
 
-  test("preserves previous members on failure and sets actionError", async () => {
+  test("preserves previous members on failure and marks members unavailable", async () => {
+    const warn = mock(() => {});
+    const previousWarn = console.warn;
+    console.warn = warn;
     const listRoomMembers = mock(async (_id: string) => [BOB]);
     const client = makeClient({ listRoomMembers });
     const { w, actionError } = makeWaddles(client);
 
-    await w.loadStructure();
-    // Seed members for the active channel
-    await w.reloadChannelMembers("general");
-    expect(w.members.value).toEqual([BOB]);
+    try {
+      await w.loadStructure();
+      // Seed members for the active channel
+      await w.reloadChannelMembers("general");
+      expect(w.members.value).toEqual([BOB]);
 
-    // Now make it fail
-    listRoomMembers.mockImplementation(async () => { throw new Error("forbidden"); });
+      // Now make it fail
+      listRoomMembers.mockImplementation(async () => { throw new Error("forbidden"); });
 
-    await w.reloadChannelMembers("general");
+      await w.reloadChannelMembers("general");
 
-    // Members preserved, error surfaced
-    expect(w.members.value).toEqual([BOB]);
-    expect(actionError.value).toBe("forbidden");
+      // Members preserved, failure represented in member-specific state.
+      expect(w.members.value).toEqual([BOB]);
+      expect(w.memberLoadState.value).toBe("unavailable");
+      expect(actionError.value).toBe("");
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      console.warn = previousWarn;
+    }
   });
 
   test("discards stale result when channel switches rapidly", async () => {
@@ -186,6 +197,7 @@ describe("useWaddleDirectory.reloadChannelMembers", () => {
     await w.reloadChannelMembers("general");
 
     expect(w.members.value).toEqual([]);
+    expect(w.memberLoadState.value).toBe("idle");
     expect(actionError.value).toBe("");
   });
 });

--- a/chat/tests/member-management-source.test.ts
+++ b/chat/tests/member-management-source.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("member management source contract", () => {
+  test("presence-inferred occupants are displayed but not editable as affiliations", () => {
+    const chatApp = readFileSync(new URL("../src/components/ChatApp.vue", import.meta.url), "utf8");
+    const memberManagement = readFileSync(new URL("../src/components/modals/MemberManagement.vue", import.meta.url), "utf8");
+
+    expect(chatApp).toContain("authoritativeMemberJids");
+    expect(chatApp).toContain("inferredMemberJids");
+    expect(chatApp).toContain(':inferred-member-jids="inferredMemberJids"');
+    expect(memberManagement).toContain("inferredMemberJids: Set<string>");
+    expect(memberManagement).toContain('!inferredMemberJids.has(member.jid)');
+    expect(memberManagement).toContain("Synced from presence");
+  });
+});

--- a/chat/tests/member-query.test.ts
+++ b/chat/tests/member-query.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
-import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import { BrowserXmppClient, RoomMemberListUnavailableError } from "../src/lib/xmpp-client";
 import type { XmppErrorEvent } from "../src/lib/xmpp-client";
 
 type TestXmpp = {
@@ -84,7 +84,7 @@ describe("BrowserXmppClient.listRoomMembers", () => {
     expect(errors[1].detail).toContain("unsupported member query");
   });
 
-  test("does not silently show zero members when only failed queries could contain members", async () => {
+  test("reports unavailable member lists without the retired zero-member failure copy", async () => {
     const listRoomMembers = mock(async (
       _room: string,
       affiliation: "owner" | "admin" | "member" | "outcast",
@@ -98,7 +98,10 @@ describe("BrowserXmppClient.listRoomMembers", () => {
     const errors: XmppErrorEvent[] = [];
     client.onError((event) => errors.push(event));
 
-    await expect(client.listRoomMembers("general")).rejects.toThrow("refusing to show Members 0");
+    const result = client.listRoomMembers("general");
+
+    await expect(result).rejects.toBeInstanceOf(RoomMemberListUnavailableError);
+    await expect(result).rejects.toThrow("Member list is temporarily unavailable.");
 
     expect(listRoomMembers).toHaveBeenCalledTimes(4);
     expect(errors.some((event) => event.detail.includes("reconstructed room JID may not match"))).toBe(true);

--- a/chat/tests/mentions.test.ts
+++ b/chat/tests/mentions.test.ts
@@ -72,6 +72,17 @@ describe("mention helpers", () => {
     expect(names).toEqual(["everyone", "here", "alice", "bob"]);
   });
 
+  test("displayed member counts include affiliation members and live occupants", () => {
+    const merged = mergeMentionMembers({
+      members: [{ jid: "alice@example.com", username: "alice", avatar_url: null, role: "owner", joined_at: "" }],
+      roomPresence: { alice: "online", bob: "online", carol: "offline" },
+      memberJidsByNick: { Bob: "bob@example.com" },
+    });
+
+    expect(merged.members.map((member) => member.username)).toEqual(["alice", "bob"]);
+    expect(merged.members).toHaveLength(2);
+  });
+
   test("autocomplete candidates include registered offline members once", () => {
     const merged = mergeMentionMembers({
       members: [


### PR DESCRIPTION
## Summary

Fixes #377, #379, #380, and #387.

This PR repairs the room self-presence/member-state path so chat no longer shows raw developer diagnostics, false `0 members` counts, or an empty Members modal while occupants are visibly present.

## What Changed

- Replaced the user-facing self-presence timeout with safe retry-oriented copy while keeping raw room JID detail in telemetry.
- Retired the `refusing to show Members 0` failure path and replaced it with a typed member-list unavailable error.
- Added explicit member load states (`idle`, `loading`, `ready`, `unavailable`) in the directory path.
- Preserved the last known members for a channel when member reloads fail.
- Derived displayed member rows and counts from affiliation members plus live presence occupants through the existing mention/presence merge path.
- Kept presence-inferred occupants visible for count/modal context but read-only in the Members management modal so admins cannot mistake them for authoritative affiliation rows.
- Updated the header, sidebar footer, details drawer, and Members modal to show syncing/unavailable state instead of false numeric zero.
- Kept raw presence/mention diagnostics out of the global chat error banner; diagnostics now remain in developer logs.

## XEP Review

- Reviewed `xeps/xep-0045.xml` before implementation.
- Kept MUC behavior aligned with XEP-0045's split between long-lived affiliations and live occupant presence.
- Continued to treat self-presence as the room join synchronization signal, without adding out-of-band APIs.

## Validation

- `cd chat && bun test member-query.test mentions.test channel-reload.test.ts member-management-source.test.ts` - passed
- `cd chat && bun run lint` - passed
- `cd chat && bun run build` - passed

## Notes

- No Knip exceptions added.
- No REST or out-of-band APIs added.
- No WASM artifact regeneration required.
