### PR TITLE
fix(chat): make dm load failures actionable

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -666,6 +666,15 @@ const activeUploadProgress = computed(() =>
 const activeActionError = computed(() =>
   ui.actionError.value || (ui.sidebarMode.value === "channels" ? mentionSourceDiagnostic.value : "")
 );
+const activeErrorActionLabel = computed(() => {
+  const peer = activeDmPeer.value;
+  return ui.sidebarMode.value === "dms" &&
+    peer &&
+    dmMessaging.loadErrorPeerJid.value === peer.peerJid &&
+    activeActionError.value === dmMessaging.loadErrorMessage.value
+    ? "Try again"
+    : null;
+});
 let setupPromptShown = false;
 
 function showFirstRunSetupIfNeeded() {
@@ -832,6 +841,12 @@ function clearActiveSearch() {
 
 function loadOlderActiveMessages() {
   void activeTarget.value.loadOlderMessages();
+}
+
+function retryActiveLoad() {
+  const peer = activeDmPeer.value;
+  if (ui.sidebarMode.value !== "dms" || !peer) return;
+  void dmMessaging.loadMessages(peer.peerJid);
 }
 
 function ensureActiveMessageLoaded(messageId: string) {
@@ -1599,7 +1614,8 @@ onUnmounted(() => {
               :messages="activeMessages"
               :first-unseen-id="activeFirstUnseenId"
               :xmpp-status="messaging.xmppStatus.value"
-               :action-error="activeActionError"
+              :action-error="activeActionError"
+              :error-action-label="activeErrorActionLabel"
               :update-available="appUpdate.updateAvailable.value"
               :is-applying-update="appUpdate.isApplyingUpdate.value"
               :is-loading-messages="activeIsLoadingMessages"
@@ -1634,6 +1650,7 @@ onUnmounted(() => {
               @search="searchActiveMessages"
               @clear-search="clearActiveSearch"
               @load-older="loadOlderActiveMessages"
+              @retry-load="retryActiveLoad"
               @edit-channel="openChannelEdit"
               @open-nav="ui.showMobileNav.value = true"
               @open-details="ui.showMobileDetails.value = true"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -795,6 +795,9 @@ function dayDividerLabel(createdAt: string): string {
     <div
       v-if="actionError"
       class="type-control bg-destructive/10 border-b border-destructive/20 text-destructive animate-fade-in"
+      role="alert"
+      aria-live="assertive"
+      aria-atomic="true"
     >
       <div class="chat-message-lane flex flex-col gap-2 px-[var(--chat-content-inline)] py-3 sm:flex-row sm:items-center sm:justify-between">
         <span>{{ actionError }}</span>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -42,6 +42,7 @@ const props = defineProps<{
   firstUnseenId: string | null;
   xmppStatus: XmppStatusSnapshot;
   actionError: string;
+  errorActionLabel?: string | null;
   updateAvailable: boolean;
   isApplyingUpdate: boolean;
   isLoadingMessages: boolean;
@@ -93,6 +94,7 @@ const emit = defineEmits<{
   openThread: [threadId: string, targetMessageId?: string];
   refreshUpdate: [];
   loadOlder: [];
+  retryLoad: [];
 }>();
 
 // Hide thread members from the main feed — they live inside the thread panel.
@@ -794,7 +796,18 @@ function dayDividerLabel(createdAt: string): string {
       v-if="actionError"
       class="type-control bg-destructive/10 border-b border-destructive/20 text-destructive animate-fade-in"
     >
-      <div class="chat-message-lane px-[var(--chat-content-inline)] py-3">{{ actionError }}</div>
+      <div class="chat-message-lane flex flex-col gap-2 px-[var(--chat-content-inline)] py-3 sm:flex-row sm:items-center sm:justify-between">
+        <span>{{ actionError }}</span>
+        <button
+          v-if="errorActionLabel"
+          type="button"
+          class="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-md border border-destructive/25 bg-background/80 px-3 text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30"
+          @click="emit('retryLoad')"
+        >
+          <RefreshCw class="h-3.5 w-3.5" />
+          {{ errorActionLabel }}
+        </button>
+      </div>
     </div>
     <div
       v-if="replyJumpNotice"
@@ -907,6 +920,20 @@ function dayDividerLabel(createdAt: string): string {
               ? "Select a forum to browse topics"
               : "Select a channel to start chatting" }}
         </p>
+      </div>
+
+      <div v-else-if="errorActionLabel" class="chat-empty-state">
+        <div class="w-12 h-12 rounded-lg bg-destructive/10 flex items-center justify-center">
+          <AlertCircle class="w-5 h-5 text-destructive" />
+        </div>
+        <div class="chat-field-stack">
+          <p class="type-empty-title">
+            Messages are not available right now.
+          </p>
+          <p class="type-field text-muted-foreground">
+            Check the connection and try again.
+          </p>
+        </div>
       </div>
 
       <div v-else-if="feedMessages.length === 0" class="chat-empty-state">

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -121,6 +121,10 @@ export function useDirectMessages(
 ) {
   const { mode: scrollDirection } = useScrollDirectionPreference();
   const peerNameFromJid = (jid: string) => barePeerJid(jid).split("@")[0] ?? "unknown";
+  const dmLoadErrorMessage = (peerJid: string) => {
+    const username = peerNameFromJid(peerJid).trim();
+    return `Could not load ${username ? `@${username}` : "this chat"}. Check the connection and try again.`;
+  };
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
   const isLoadingMessages = ref(false);
@@ -139,6 +143,8 @@ export function useDirectMessages(
   const isSearching = ref(false);
   const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const firstUnseenId = ref<string | null>(null);
+  const loadErrorPeerJid = ref<string | null>(null);
+  const loadErrorMessage = ref("");
   const latestRemoteMessageId = computed<string | null>(() => {
     for (let i = messages.value.length - 1; i >= 0; i--) {
       const m = messages.value[i];
@@ -508,6 +514,8 @@ export function useDirectMessages(
     pinnedEdgeScroller.disconnect();
     firstUnseenId.value = null;
     clearActionError();
+    loadErrorPeerJid.value = null;
+    loadErrorMessage.value = "";
     pendingEchoClientIds.clear();
     messages.value = appendQueuedMessages([], peerJid);
     try {
@@ -520,6 +528,8 @@ export function useDirectMessages(
           ? await xmppClient.value.queryPersonalMam(peerJid, 100)
           : [];
       if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      loadErrorPeerJid.value = null;
+      loadErrorMessage.value = "";
       oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
       hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
       const timeline = buildTimelineFromMamResults(mamResults);
@@ -539,9 +549,12 @@ export function useDirectMessages(
       if (newest) setLastSeen(key, newest.id);
     } catch (e) {
       if (requestId === messageRequestId) {
+        console.error("Could not load DM conversation", e);
         const queuedOnly = appendQueuedMessages([], peerJid);
         messages.value = queuedOnly;
-        actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
+        loadErrorPeerJid.value = queuedOnly.length > 0 ? null : peerJid;
+        loadErrorMessage.value = queuedOnly.length > 0 ? "" : dmLoadErrorMessage(peerJid);
+        actionError.value = loadErrorMessage.value;
         isLoadingMessages.value = false;
       }
     }
@@ -576,7 +589,10 @@ export function useDirectMessages(
         el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
       }
     } catch (e) {
-      if (isCurrentRequest()) actionError.value = normalizeError(e);
+      if (isCurrentRequest()) {
+        console.error("Could not load older DM messages", e);
+        actionError.value = dmLoadErrorMessage(peerJid);
+      }
     } finally {
       if (isCurrentRequest()) isLoadingOlderMessages.value = false;
     }
@@ -957,6 +973,8 @@ export function useDirectMessages(
     timelineEdgeScroller,
     searchResults,
     isSearching,
+    loadErrorPeerJid,
+    loadErrorMessage,
     loadMessages,
     loadOlderMessages,
     ensureMessageLoaded,

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -121,9 +121,12 @@ export function useDirectMessages(
 ) {
   const { mode: scrollDirection } = useScrollDirectionPreference();
   const peerNameFromJid = (jid: string) => barePeerJid(jid).split("@")[0] ?? "unknown";
-  const dmLoadErrorMessage = (peerJid: string) => {
+  const dmLoadErrorMessage = (peerJid: string, opts: { queuedOnly?: boolean } = {}) => {
     const username = peerNameFromJid(peerJid).trim();
-    return `Could not load ${username ? `@${username}` : "this chat"}. Check the connection and try again.`;
+    const target = username ? `@${username}` : "this chat";
+    return opts.queuedOnly
+      ? `Could not load ${target} history. Showing queued messages only. Check the connection and try again.`
+      : `Could not load ${target}. Check the connection and try again.`;
   };
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
@@ -547,13 +550,13 @@ export function useDirectMessages(
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) setLastSeen(key, newest.id);
-    } catch (e) {
+    } catch {
       if (requestId === messageRequestId) {
-        console.error("Could not load DM conversation", e);
+        console.warn("Could not load DM conversation");
         const queuedOnly = appendQueuedMessages([], peerJid);
         messages.value = queuedOnly;
-        loadErrorPeerJid.value = queuedOnly.length > 0 ? null : peerJid;
-        loadErrorMessage.value = queuedOnly.length > 0 ? "" : dmLoadErrorMessage(peerJid);
+        loadErrorPeerJid.value = peerJid;
+        loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
         actionError.value = loadErrorMessage.value;
         isLoadingMessages.value = false;
       }
@@ -588,9 +591,9 @@ export function useDirectMessages(
       if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
         el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
       }
-    } catch (e) {
+    } catch {
       if (isCurrentRequest()) {
-        console.error("Could not load older DM messages", e);
+        console.warn("Could not load older DM messages");
         actionError.value = dmLoadErrorMessage(peerJid);
       }
     } finally {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -5,7 +5,7 @@ import type { WaddleSession } from "../src/lib/server-auth";
 import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
 import { BrowserXmppClient, roomBareJidFor, type InboxEntry } from "../src/lib/xmpp-client";
-import { listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
+import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -77,9 +77,9 @@ describe("client send readiness", () => {
     } as unknown as BrowserXmppClient;
     const actionError = ref("");
     const normalize = mock(() => "Something went wrong. remote-server-timeout at xmpp.example.com for bob@example.com");
-    const originalConsoleError = console.error;
-    const consoleError = mock(() => undefined);
-    console.error = consoleError as typeof console.error;
+    const originalConsoleWarn = console.warn;
+    const consoleWarn = mock(() => undefined);
+    console.warn = consoleWarn as typeof console.warn;
     try {
       const dm = useDirectMessages(
         ref<WaddleSession | null>(session()),
@@ -98,10 +98,58 @@ describe("client send readiness", () => {
       expect(actionError.value).not.toContain("xmpp.example.com");
       expect(actionError.value).not.toContain("bob@example.com");
       expect(normalize).not.toHaveBeenCalled();
-      expect(consoleError).toHaveBeenCalledWith("Could not load DM conversation", rawError);
+      expect(consoleWarn).toHaveBeenCalledWith("Could not load DM conversation");
+      expect(consoleWarn.mock.calls.flat().join(" ")).not.toContain("xmpp.example.com");
+      expect(consoleWarn.mock.calls.flat().join(" ")).not.toContain("bob@example.com");
       expect(dm.loadErrorPeerJid.value).toBe("bob@example.com");
     } finally {
-      console.error = originalConsoleError;
+      console.warn = originalConsoleWarn;
+    }
+  });
+
+  test("DM load failures keep queued messages visible with a retryable warning", async () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "queued-dm-1",
+      createdAt: "2026-05-07T00:00:00Z",
+      peerJid: "bob@example.com",
+      body: "queued while offline",
+    });
+    const client = {
+      queryPersonalMamPage: mock(async () => {
+        throw new Error("remote-server-timeout at xmpp.example.com for bob@example.com");
+      }),
+    } as unknown as BrowserXmppClient;
+    const actionError = ref("");
+    const originalConsoleWarn = console.warn;
+    console.warn = mock(() => undefined) as typeof console.warn;
+    try {
+      const dm = useDirectMessages(
+        ref<WaddleSession | null>(session()),
+        ref<BrowserXmppClient | null>(client),
+        ref("bob@example.com"),
+        normalizeError,
+        actionError,
+        () => {
+          actionError.value = "";
+        },
+      );
+
+      await dm.loadMessages("bob@example.com");
+
+      expect(dm.messages.value).toHaveLength(1);
+      expect(dm.messages.value[0]).toMatchObject({
+        id: "queued-dm-1",
+        body: "queued while offline",
+        deliveryStatus: "queued",
+      });
+      expect(actionError.value).toBe(
+        "Could not load @bob history. Showing queued messages only. Check the connection and try again.",
+      );
+      expect(dm.loadErrorPeerJid.value).toBe("bob@example.com");
+      expect(dm.loadErrorMessage.value).toBe(actionError.value);
+    } finally {
+      console.warn = originalConsoleWarn;
     }
   });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -68,6 +68,43 @@ afterEach(() => {
 });
 
 describe("client send readiness", () => {
+  test("DM load failures use deterministic UI copy and keep raw errors out of actionError", async () => {
+    const rawError = new Error("remote-server-timeout at xmpp.example.com for bob@example.com");
+    const client = {
+      queryPersonalMamPage: mock(async () => {
+        throw rawError;
+      }),
+    } as unknown as BrowserXmppClient;
+    const actionError = ref("");
+    const normalize = mock(() => "Something went wrong. remote-server-timeout at xmpp.example.com for bob@example.com");
+    const originalConsoleError = console.error;
+    const consoleError = mock(() => undefined);
+    console.error = consoleError as typeof console.error;
+    try {
+      const dm = useDirectMessages(
+        ref<WaddleSession | null>(session()),
+        ref<BrowserXmppClient | null>(client),
+        ref("bob@example.com"),
+        normalize,
+        actionError,
+        () => {
+          actionError.value = "";
+        },
+      );
+
+      await dm.loadMessages("bob@example.com");
+
+      expect(actionError.value).toBe("Could not load @bob. Check the connection and try again.");
+      expect(actionError.value).not.toContain("xmpp.example.com");
+      expect(actionError.value).not.toContain("bob@example.com");
+      expect(normalize).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith("Could not load DM conversation", rawError);
+      expect(dm.loadErrorPeerJid.value).toBe("bob@example.com");
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
   test("room sends immediately when the room is ready", async () => {
     const xmpp = { send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id) };
     const client = new BrowserXmppClient(session());

--- a/chat/tests/dm-load-error-ui.test.ts
+++ b/chat/tests/dm-load-error-ui.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("DM load error UI contract", () => {
+  test("renders an announced retryable error state", () => {
+    const contentArea = readFileSync(new URL("../src/components/chat/ContentArea.vue", import.meta.url), "utf8");
+
+    expect(contentArea).toContain("errorActionLabel?: string | null");
+    expect(contentArea).toContain("retryLoad: []");
+    expect(contentArea).toContain('role="alert"');
+    expect(contentArea).toContain('aria-live="assertive"');
+    expect(contentArea).toContain("@click=\"emit('retryLoad')\"");
+    expect(contentArea).toContain("Messages are not available right now.");
+  });
+
+  test("wires the retry action only for active DM load failures", () => {
+    const chatApp = readFileSync(new URL("../src/components/ChatApp.vue", import.meta.url), "utf8");
+
+    expect(chatApp).toContain("dmMessaging.loadErrorPeerJid.value === peer.peerJid");
+    expect(chatApp).toContain("activeActionError.value === dmMessaging.loadErrorMessage.value");
+    expect(chatApp).toContain('? "Try again"');
+    expect(chatApp).toContain("void dmMessaging.loadMessages(peer.peerJid)");
+    expect(chatApp).toContain('@retry-load="retryActiveLoad"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #378.

This PR makes DM conversation load failures actionable without exposing raw XMPP errors, JIDs, hostnames, exception text, or archive internals in the UI or browser console.

## What changed

- Replaced initial DM MAM load failure UI with deterministic copy: `Could not load @chat. Check the connection and try again.`
- Added queued-only failure copy: `Could not load @chat history. Showing queued messages only. Check the connection and try again.`
- Kept queued messages visible while still showing a retryable warning when history load fails.
- Redacted console diagnostics so raw remote errors are not logged from this user-facing path.
- Added a scoped retry action for failed DM conversation loads through optional `ContentArea` props/events.
- Added an announced async error banner (`role="alert"`, live region attrs) and failed-load empty state.
- Kept the change limited to DM conversation loading; no broad alert framework or XMPP wire behavior changed.

## XEP review

- Reviewed the local XEP-0313/MAM reference for the affected history-load path.
- No MAM query shape, namespace, stanza serialization, or pagination behavior changed.

## Validation

- `cd chat && bun test dm-conversations.test client-send-readiness.test dm-load-error-ui.test` - passed
- `cd chat && bun run lint` - passed
- `cd chat && bun run build` - passed

## Notes

- No Knip exceptions added.
- No WASM API changes or checked-in WASM artifact changes.
