### PR TITLE
perf(chat): show immediate startup loading state

### DIFF
--- a/chat/src/components/ChatApp.vue
+++ b/chat/src/components/ChatApp.vue
@@ -347,8 +347,19 @@ const activeForumTitle = computed({
 const activeTypingUsers = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.typingUsers.value : messaging.typingUsers.value,
 );
+const isApplyingRoute = ref(false);
+let routeRequestId = 0;
 const activeIsLoadingMessages = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingMessages.value : messaging.isLoadingMessages.value,
+);
+const isResolvingActiveConversation = computed(() =>
+  ui.activePage.value === "chat"
+  && !waddles.currentChannel.value
+  && !activeDmPeer.value
+  && (isApplyingRoute.value || waddles.isLoadingStructure.value),
+);
+const contentAreaIsLoadingMessages = computed(() =>
+  activeIsLoadingMessages.value || isResolvingActiveConversation.value,
 );
 const activeIsLoadingOlderMessages = computed(() =>
   ui.sidebarMode.value === "dms" ? dmMessaging.isLoadingOlderMessages.value : messaging.isLoadingOlderMessages.value,
@@ -606,8 +617,6 @@ watch(xmppClient, (client) => {
   });
 }, { immediate: true });
 
-const isApplyingRoute = ref(false);
-let routeRequestId = 0;
 const settingsPath = buildChatSettingsPath();
 
 const currentChatPath = computed(() =>
@@ -1602,7 +1611,7 @@ onUnmounted(() => {
                :action-error="activeActionError"
               :update-available="appUpdate.updateAvailable.value"
               :is-applying-update="appUpdate.isApplyingUpdate.value"
-              :is-loading-messages="activeIsLoadingMessages"
+              :is-loading-messages="contentAreaIsLoadingMessages"
               :is-loading-older-messages="activeIsLoadingOlderMessages"
               :has-older-messages="activeHasOlderMessages"
               :is-sending="activeIsSending"

--- a/chat/src/layouts/AppLayout.astro
+++ b/chat/src/layouts/AppLayout.astro
@@ -66,6 +66,55 @@ const giphyApiKey = env.GIPHY_API_KEY ?? "";
   </head>
   <body class="bg-background text-foreground font-sans antialiased">
     <XmppProvider client:only="vue" transition:persist serverBaseUrl={serverBaseUrl ?? ""} />
-    <ChatApp client:only="vue" giphyApiKey={giphyApiKey} />
+    <ChatApp client:only="vue" giphyApiKey={giphyApiKey}>
+      <div slot="fallback" class="chat-app-shell chat-startup-shell" role="status" aria-live="polite">
+        <div class="chat-desktop-shell">
+          <div class="chat-desktop-rail-slot">
+            <div class="chat-startup-rail">
+              <div class="chat-startup-logo" aria-hidden="true">
+                <img src="/waddle-logo.svg" alt="" width="32" height="32" />
+              </div>
+            </div>
+          </div>
+          <div class="chat-sidebar-slot">
+            <aside class="chat-sidebar-pane glass-panel">
+              <div class="chat-sidebar-header">
+                <span class="type-pane-title text-sidebar-foreground">Spaces</span>
+              </div>
+              <div class="chat-pane-scroll chat-sidebar-scroll">
+                <div class="chat-startup-sidebar-loading type-caption text-sidebar-muted">
+                  <div class="flex items-center justify-center gap-1" aria-hidden="true">
+                    <span class="typing-dot"></span>
+                    <span class="typing-dot"></span>
+                    <span class="typing-dot"></span>
+                  </div>
+                  <span class="sr-only">Loading Waddle</span>
+                </div>
+              </div>
+            </aside>
+          </div>
+          <main class="chat-workspace">
+            <section class="chat-content-pane">
+              <header class="chat-startup-header">
+                <div class="chat-startup-mobile-logo" aria-hidden="true">
+                  <img src="/waddle-logo.svg" alt="" width="28" height="28" />
+                </div>
+                <span class="type-pane-title">Waddle</span>
+              </header>
+              <div class="chat-pane-scroll chat-message-scroll chat-startup-main">
+                <div class="type-caption flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">
+                  <div class="flex items-center justify-center gap-1.5" aria-hidden="true">
+                    <span class="typing-dot"></span>
+                    <span class="typing-dot"></span>
+                    <span class="typing-dot"></span>
+                  </div>
+                  <p class="text-muted-foreground/60">Checking session.</p>
+                </div>
+              </div>
+            </section>
+          </main>
+        </div>
+      </div>
+    </ChatApp>
   </body>
 </html>

--- a/chat/src/styles/global.css
+++ b/chat/src/styles/global.css
@@ -603,6 +603,77 @@
   background: var(--background);
 }
 
+.chat-startup-shell {
+  color: var(--foreground);
+}
+
+.chat-startup-rail {
+  display: flex;
+  width: var(--chat-rail-width);
+  flex-direction: column;
+  align-items: center;
+  border-right: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  background: var(--rail);
+  padding-block: var(--space-md);
+}
+
+.chat-startup-logo,
+.chat-startup-mobile-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+}
+
+.chat-startup-logo {
+  width: var(--chat-rail-logo-size);
+  height: var(--chat-rail-logo-size);
+}
+
+.chat-startup-logo img,
+.chat-startup-mobile-logo img {
+  display: block;
+  object-fit: contain;
+}
+
+.chat-startup-sidebar-loading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding-block: 2.5rem;
+  text-align: center;
+}
+
+.chat-startup-header {
+  display: flex;
+  min-height: var(--chat-header-height);
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-sm);
+  border-bottom: 1px solid var(--border);
+  padding-inline: var(--chat-content-inline);
+}
+
+.chat-startup-mobile-logo {
+  width: var(--control-lg);
+  height: var(--control-lg);
+}
+
+.chat-startup-main {
+  display: flex;
+  flex: 1 1 0%;
+  align-items: center;
+  justify-content: center;
+  padding-inline: var(--chat-content-inline);
+}
+
+@media (min-width: 64rem) {
+  .chat-startup-mobile-logo {
+    display: none;
+  }
+}
+
 .chat-mobile-header {
   min-height: var(--chat-mobile-header-height);
 }

--- a/chat/tests/startup-loading.test.ts
+++ b/chat/tests/startup-loading.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+
+function builtAppLayoutChunk(): string {
+  const chunksDir = new URL("../dist/server/chunks/", import.meta.url);
+  const chunk = readdirSync(chunksDir).find((name) => name.startsWith("AppLayout_") && name.endsWith(".mjs"));
+  if (!chunk) throw new Error("built AppLayout chunk not found; run `bun run build` before this test");
+  return readFileSync(new URL(chunk, chunksDir), "utf8");
+}
 
 describe("startup loading fallback", () => {
-  test("renders a static shell before ChatApp hydrates", () => {
-    const layout = readFileSync(new URL("../src/layouts/AppLayout.astro", import.meta.url), "utf8");
+  test("build output includes the static shell before ChatApp hydrates", () => {
+    const html = builtAppLayoutChunk();
 
-    expect(layout).toContain('<ChatApp client:only="vue" giphyApiKey={giphyApiKey}>');
-    expect(layout).toContain('slot="fallback"');
-    expect(layout).toContain("chat-app-shell chat-startup-shell");
-    expect(layout).toContain("Checking session.");
+    expect(html).toContain("chat-app-shell chat-startup-shell");
+    expect(html).toContain("Loading Waddle");
+    expect(html).toContain("Checking session.");
   });
 
   test("keeps fallback dimensions stable without Vue", () => {

--- a/chat/tests/startup-loading.test.ts
+++ b/chat/tests/startup-loading.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("startup loading fallback", () => {
+  test("renders a static shell before ChatApp hydrates", () => {
+    const layout = readFileSync(new URL("../src/layouts/AppLayout.astro", import.meta.url), "utf8");
+
+    expect(layout).toContain('<ChatApp client:only="vue" giphyApiKey={giphyApiKey}>');
+    expect(layout).toContain('slot="fallback"');
+    expect(layout).toContain("chat-app-shell chat-startup-shell");
+    expect(layout).toContain("Checking session.");
+  });
+
+  test("keeps fallback dimensions stable without Vue", () => {
+    const styles = readFileSync(new URL("../src/styles/global.css", import.meta.url), "utf8");
+
+    expect(styles).toContain(".chat-app-shell");
+    expect(styles).toContain("height: 100dvh;");
+    expect(styles).toContain(".chat-startup-main");
+    expect(styles).toContain("flex: 1 1 0%;");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #382.

This PR removes the cold-start blank screen by rendering an immediate Astro `client:only` fallback shell before Vue hydration and by surfacing route/topology loading through the existing message-loading state while the active channel or DM is still being resolved.

## Complete Work

- Added static `client:only` fallback markup in `chat/src/layouts/AppLayout.astro`.
- Added startup shell styles in `chat/src/styles/global.css` using the existing app shell, sidebar, typography, and typing-dot treatment.
- Updated `chat/src/components/ChatApp.vue` so unresolved route/topology startup displays the existing `ContentArea` loading state instead of the empty select-channel state.
- Added `chat/tests/startup-loading.test.ts` as a regression check for the built Astro output and stable first-viewport dimensions.

## Validation

- `cd chat && bun run build` - passed
- `cd chat && bun test tests/startup-loading.test.ts` - passed after build
- `cd chat && bun run lint` - passed with existing Knip configuration hints only
- Local cold-response check from the earlier implementation pass verified the initial HTML contains `chat-startup-shell`, `Loading Waddle`, and `Checking session.` before client hydration.

## Notes

- No XEP wire behavior changes.
- No Knip exceptions added.
- The startup test now asserts built output, not only source strings; PR #404 makes chat PR tests depend on build so this artifact exists in CI.
