### PR TITLE
fix(chat): preserve xep-0372 references for links

### DIFF
--- a/chat/src/lib/rich-message.ts
+++ b/chat/src/lib/rich-message.ts
@@ -94,29 +94,42 @@ const BARE_URL_PATTERN = /\bhttps?:\/\/[^\s<>"'`]+/gi;
 function autolinkifyBareUrls(state: SerializeState): void {
   if (!state.body) return;
 
+  state.references.push(
+    ...inferBareUrlReferences(state.body, state.references, codeRangesFromMarkup(state.markup)),
+  );
+}
+
+function codeRangesFromMarkup(markup: readonly MarkupSpan[]): Array<[number, number]> {
+  return markup
+    .filter((span) =>
+      span.type === "bcode"
+      || (span.type === "span" && span.styles.includes("code"))
+    )
+    .map((span) => [span.start, span.end]);
+}
+
+function inferBareUrlReferences(
+  body: string,
+  references: readonly MessageReference[],
+  codeRanges: Array<[number, number]>,
+): MessageReference[] {
   // Existing reference ranges in the typed projection. URLs already wrapped by
-  // a TipTap `link` mark must not be auto-linkified a second time — the mark
-  // path wins because it preserves the user's chosen href text.
-  const existingRanges: Array<[number, number]> = state.references
+  // a TipTap `link` mark or an inbound XEP-0372 reference must not be
+  // auto-linkified a second time — the explicit reference path wins.
+  const existingRanges: Array<[number, number]> = references
     .filter((reference) =>
       typeof reference.begin === "number"
       && typeof reference.end === "number"
       && reference.end > reference.begin
     )
     .map((reference) => [reference.begin as number, reference.end as number]);
-
-  // Code ranges to skip. XEP-0394 `<bcode>` covers fenced code blocks; an
-  // inline `<span styles=["code", ...]>` covers backtick code in TipTap.
-  const codeRanges: Array<[number, number]> = state.markup
-    .filter((span) =>
-      span.type === "bcode"
-      || (span.type === "span" && span.styles.includes("code"))
-    )
-    .map((span) => [span.start, span.end]);
+  const inferred: MessageReference[] = [];
 
   let match: RegExpExecArray | null;
   BARE_URL_PATTERN.lastIndex = 0;
-  while ((match = BARE_URL_PATTERN.exec(state.body)) !== null) {
+  while ((match = BARE_URL_PATTERN.exec(body)) !== null) {
+    if (body.slice(Math.max(0, match.index - 2), match.index) === "](") continue;
+
     const raw = stripUrlTrailingPunctuation(match[0]);
     if (!raw) continue;
 
@@ -126,15 +139,17 @@ function autolinkifyBareUrls(state: SerializeState): void {
     // codePointLength on the prefix gives a Unicode-scalar offset, matching
     // XEP-0372 begin/end semantics. `match.index` is a UTF-16 code-unit
     // offset and would mis-align after surrogate pairs (emoji, CJK).
-    const begin = codePointLength(state.body.slice(0, match.index));
+    const begin = codePointLength(body.slice(0, match.index));
     const end = begin + codePointLength(raw);
 
     if (rangesOverlap(begin, end, existingRanges)) continue;
     if (rangesOverlap(begin, end, codeRanges)) continue;
 
-    state.references.push({ type: "data", uri: href, begin, end });
+    inferred.push({ type: "data", uri: href, begin, end });
     existingRanges.push([begin, end]);
   }
+
+  return inferred;
 }
 
 function rangesOverlap(begin: number, end: number, ranges: Array<[number, number]>): boolean {
@@ -568,6 +583,7 @@ function createParseContext(
   const validReferences = references
     .filter((reference) => isValidInboundReference(reference, length))
     .sort((a, b) => (a.begin ?? 0) - (b.begin ?? 0) || (a.end ?? 0) - (b.end ?? 0));
+  const inferredReferences = inferBareUrlReferences(body, validReferences, codeRangesFromMarkup(validMarkup));
 
   return {
     body,
@@ -575,7 +591,8 @@ function createParseContext(
     markup: validMarkup,
     spans: validMarkup.filter((span): span is Extract<MarkupSpan, { type: "span" }> => span.type === "span"),
     blocks: validMarkup.filter((span): span is Exclude<MarkupSpan, { type: "span" }> => BLOCK_TYPES.has(span.type)),
-    references: validReferences,
+    references: [...validReferences, ...inferredReferences]
+      .sort((a, b) => (a.begin ?? 0) - (b.begin ?? 0) || (a.end ?? 0) - (b.end ?? 0)),
   };
 }
 

--- a/chat/tests/chat-ui-render.test.ts
+++ b/chat/tests/chat-ui-render.test.ts
@@ -70,6 +70,22 @@ describe("renderStyledBody", () => {
     expect(html).toContain(">docs</a>");
   });
 
+  test("renders bare safe URLs as links when archived messages have no references", () => {
+    const html = renderStyledBody("see https://example.com today");
+
+    expect(html).toContain('<a href="https://example.com/"');
+    expect(html).toContain(">https://example.com</a>");
+  });
+
+  test("does not autolink bare URLs inside code markup", () => {
+    const html = renderStyledBody("`https://example.com`", [
+      { type: "span", start: 1, end: 20, styles: ["code"] },
+    ]);
+
+    expect(html).toContain("<code>https://example.com</code>");
+    expect(html).not.toContain("<a ");
+  });
+
   test("escapes unsafe HTML and rejects unsafe links", () => {
     const html = renderStyledBody("<script>x</script>", undefined, [
       { type: "data", uri: "javascript:alert(1)", begin: 0, end: 8 },

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, test } from "bun:test";
+import type { JSONContent } from "@tiptap/core";
+import { mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import { renderStyledBody } from "@/lib/chat-ui";
+import { tiptapToRichMessage } from "@/lib/rich-message";
 import {
   dmMessageFromArchived,
   roomMessageFromArchived,
 } from "@/lib/xmpp/client";
+import type { WaddleSession } from "@/lib/server-auth";
 import type { WasmArchivedMessage } from "@/lib/xmpp/wasm-types";
+
+function paragraph(...content: JSONContent[]): JSONContent {
+  return { type: "paragraph", content };
+}
+
+function text(text: string): JSONContent {
+  return { type: "text", text };
+}
+
+function doc(...content: JSONContent[]): JSONContent {
+  return { type: "doc", content };
+}
+
+const session: WaddleSession = {
+  session_id: "session-1",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/web",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
 
 const baseArchivedRoom: WasmArchivedMessage = {
   mam_id: "mam-1",
@@ -36,6 +65,48 @@ const baseArchivedDm: WasmArchivedMessage = {
 };
 
 describe("roomMessageFromArchived", () => {
+  test("keeps editor autolink XEP-0372 references clickable after live echo and MAM reload", () => {
+    const outbound = tiptapToRichMessage(doc(paragraph(text("see https://example.com today"))));
+    expect(outbound.references).toEqual([
+      { type: "data", uri: "https://example.com/", begin: 4, end: 23 },
+    ]);
+
+    const wasmReferences = outbound.references.map((reference) => ({
+      ref_type: reference.type,
+      uri: reference.uri,
+      begin: reference.begin ?? 0,
+      end: reference.end ?? 0,
+      ...(reference.anchor ? { anchor: reference.anchor } : {}),
+    }));
+    const liveEcho = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "live-echo",
+      id: "client-1",
+      stanza_id: "room-stanza-1",
+      from: "room@conf.example.com/alice",
+      body: outbound.body,
+      references: wasmReferences,
+    });
+    const mamReload = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-reload-1",
+      id: "server-1",
+      stanza_id: "room-stanza-1",
+      from: "room@conf.example.com/alice",
+      body: outbound.body,
+      references: wasmReferences,
+    });
+
+    for (const message of [liveEcho, mamReload]) {
+      expect(message).not.toBeNull();
+      const timeline = mapLiveRoomMessageToTimeline(session, message!, () => undefined);
+      expect(timeline.references).toEqual(outbound.references);
+      const html = renderStyledBody(timeline.body, timeline.markup, timeline.references);
+      expect(html).toContain('<a href="https://example.com/"');
+      expect(html).toContain(">https://example.com</a>");
+    }
+  });
+
   test("maps XEP-0372 references with anchor onto LiveRoomMessage.references", () => {
     const archived: WasmArchivedMessage = {
       ...baseArchivedRoom,

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -3069,6 +3069,11 @@ mod inbound_to_js_tests {
         }
     }
 
+    fn parse_mam_archived(xml: &str) -> waddle_xmpp_client::ArchivedMessage {
+        let el: Element = xml.parse().expect("invalid XML");
+        waddle_xmpp_client::mam::parse_mam_result(&el).expect("expected MAM result")
+    }
+
     #[test]
     fn inbound_to_js_propagates_data_reference_with_anchor() {
         let inbound = parse_message_element(
@@ -3089,6 +3094,35 @@ mod inbound_to_js_tests {
         assert_eq!(reference.begin, 4);
         assert_eq!(reference.end, 23);
         assert_eq!(reference.anchor.as_deref(), Some("https://example.com"));
+    }
+
+    #[test]
+    fn archived_to_js_propagates_mam_data_references_for_reload_rendering() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-1' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='m-data' \
+                            from='room@conf.example/alice'>\
+                     <body>see https://example.com</body>\
+                     <reference xmlns='urn:xmpp:reference:0' type='data' \
+                        uri='https://example.com/' begin='4' end='23'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let js = archived_to_js(archived);
+
+        assert_eq!(js.references.len(), 1);
+        let reference = &js.references[0];
+        assert_eq!(reference.ref_type, "data");
+        assert_eq!(reference.uri, "https://example.com/");
+        assert_eq!(reference.begin, 4);
+        assert_eq!(reference.end, 23);
+        assert!(reference.anchor.is_none());
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mot7n8sa";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mot7n8sa";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mot7n8sa";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mouuxfuk";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mot7n8sa";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";


### PR DESCRIPTION
## Summary

Fixes #381.

This PR restores link clickability for pasted and archived HTTP(S) URLs. It keeps the XEP-0372 path conformant, adds regression coverage for reference preservation, and adds a safe renderer fallback so older archived messages without stored references still render bare URLs as links.

## Completed Work

- Reviewed `xeps/xep-0372.xml` before implementation.
- Added a chat round-trip regression test for editor/autolink references through live echo, MAM reload, timeline mapping, and rendered HTML.
- Added a Rust/WASM MAM conversion regression test proving archived XEP-0372 data references reach the JS boundary for reload rendering.
- Added renderer-side bare HTTP(S) autolinking for safe URLs when no XEP-0372 reference exists, while explicit references still take precedence.
- Kept autolinking out of code spans and Markdown link/image syntax so existing literal Markdown behavior remains intact.
- Regenerated the checked-in WASM wrapper cache token with `REBUILD_WASM=1 bun run wasm:build` after verifying the package path.
- Did not add link previews, unfurls, REST fetches, custom namespaces, or out-of-band APIs.

## Validation

- `cd server && cargo test -p waddle-xmpp-client references` - passed
- `cd server && cargo test -p waddle-xmpp-client-wasm references` - passed
- `cd server && cargo test -p waddle-server --test xep0372_references_ws` - passed
- `cd server && cargo clippy --workspace --tests -- -D warnings` - passed
- `cd chat && REBUILD_WASM=1 bun run wasm:build` - passed
- `cd chat && bun test autolinkify-bare-urls.test inbound-references.test chat-ui-render.test` - passed
- `cd chat && bun run lint` - passed
- `cd chat && bun run build` - passed

## Notes

- No Knip exceptions added.
- No XMPP wire-shape changes outside conformant XEP-0372 reference preservation.
