### PR TITLE
ci(chat): run tests in pull request pipeline

### DIFF
--- a/chat/env.cue
+++ b/chat/env.cue
@@ -131,7 +131,7 @@ schema.#Project & {
 		test: schema.#Task & {
 			command: "bun"
 			args: ["test"]
-			dependsOn: [buildWasm, generateTypes]
+			dependsOn: [build]
 			inputs: [
 				"../package.json",
 				"../bun.lock",
@@ -139,6 +139,7 @@ schema.#Project & {
 				"tsconfig.json",
 				"src/**",
 				"tests/**",
+				"dist/**",
 			]
 		}
 

--- a/chat/env.cue
+++ b/chat/env.cue
@@ -61,7 +61,7 @@ schema.#Project & {
 				contents:   "read"
 				"id-token": "write"
 			}
-			"tasks": [tasks.lint, tasks.build]
+			"tasks": [tasks.test, tasks.lint, tasks.build]
 		}
 	}
 
@@ -124,6 +124,20 @@ schema.#Project & {
 				"astro.config.mjs",
 				"src/**",
 				"scripts/**",
+				"tests/**",
+			]
+		}
+
+		test: schema.#Task & {
+			command: "bun"
+			args: ["test"]
+			dependsOn: [buildWasm, generateTypes]
+			inputs: [
+				"../package.json",
+				"../bun.lock",
+				"package.json",
+				"tsconfig.json",
+				"src/**",
 				"tests/**",
 			]
 		}


### PR DESCRIPTION
## Summary

Adds chat regression tests to the pull request CI pipeline so P0 chat fixes are gated by `bun test` in addition to lint and build.

## Complete Work

- Added `tasks.test` in `chat/env.cue`.
- Wired `tasks.test` into the chat `pullRequest` pipeline before lint/build.
- Made `tasks.test` depend on the existing build task so tests that assert built Astro output have `dist/` available.
- Kept generated WASM and Worker type prerequisites flowing through the existing build task.

## Validation

- `cue fmt chat/env.cue` - passed
- `cuenv ci --dry-run --pipeline pullRequest --path chat` - parsed the project and exited successfully
- `cuenv task test --path chat` - blocked locally before this refinement because the existing `generateTypes` dependency could not find `wrangler` in this shell (`wrangler: command not found`)

## Notes

- No app runtime behavior changes.
- No XEP wire behavior changes.
- This PR addresses the adversarial review finding that chat regression tests were not enforced in PR CI.
