### PR TITLE
perf(server): single-JOIN SM restore + atomic upsert (slice d phase 9, #209)

### DIFF
--- a/docs/rfc/209-offline-dm-durability.md
+++ b/docs/rfc/209-offline-dm-durability.md
@@ -12,8 +12,8 @@ Tracking doc for the multi-PR implementation of issue [#209](https://github.com/
 | Q7 lifecycle | [#358](https://github.com/waddle-social/waddle/pull/358) | ✅ merged | SM-ack-keyed deletion of `pending_delivery` rows + pre-ack session-death re-flush |
 | Janitor + flush-time block | [#360](https://github.com/waddle-social/waddle/pull/360) | ✅ merged | Claim-expiry janitor + XEP-0191 flush-time block re-eval |
 | Receipt-time plumbing | [#361](https://github.com/waddle-social/waddle/pull/361) | ✅ merged | `original_receipt_at` plumbing through `DetachedSession.unacked_stanzas` |
-| Test-coverage debt | [#362](https://github.com/waddle-social/waddle/pull/362) | 🟡 in review | Un-ignore XEP-0160 integration tests + extend dedicated XEP-0198/0203/0359/0191 suites |
-| Storage performance | [#351](#pr-351--storage-performance--planned) | ⬜ planned (low priority) | N+1 `list_unacked` JOIN; atomic transactions in `Database` abstraction |
+| Test-coverage debt | [#362](https://github.com/waddle-social/waddle/pull/362) | ✅ merged | Un-ignore XEP-0160 integration tests + extend dedicated XEP-0198/0203/0359/0191 suites |
+| Storage performance | [#405](https://github.com/waddle-social/waddle/pull/405) | 🟡 in review | Single-JOIN restore (replaces N+1) + atomic upsert via `Database::begin` |
 
 ## Locked design (from grilling session)
 

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -315,6 +315,40 @@ impl DatabaseSmPersistence {
             original_receipt_at,
         })
     }
+
+    /// Decode an unacked-stanza row from a JOIN result. Reads
+    /// `stream_id` from column 0 (the session's stream_id),
+    /// `stanza_xml` from column 16, and `original_receipt_at_ms`
+    /// from column 17. Caller already has `sequence` (column 15).
+    /// Used by `list_all_sessions_with_unacked` (issue #209 PR #405).
+    fn decode_unacked_join_row(
+        row: &crate::db::Row,
+        sequence_i64: i64,
+    ) -> Result<PersistedUnackedStanza, SmPersistenceError> {
+        let stream_id: String = row
+            .get(0)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let stanza_xml: String = row
+            .get(16)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let receipt_ms: i64 = row
+            .get(17)
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let original_receipt_at = DateTime::<Utc>::from_timestamp_millis(receipt_ms)
+            .ok_or_else(|| SmPersistenceError::Other("invalid unacked receipt timestamp".into()))?;
+        let element: xmpp_parsers::minidom::Element = stanza_xml
+            .parse()
+            .map_err(|e: xmpp_parsers::minidom::Error| SmPersistenceError::Other(e.to_string()))?;
+        let stanza = parse_stanza(element)?;
+        let sequence =
+            u32::try_from(sequence_i64).map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        Ok(PersistedUnackedStanza {
+            stream_id: SmSessionId::new(stream_id),
+            sequence,
+            stanza: Box::new(stanza),
+            original_receipt_at,
+        })
+    }
 }
 
 #[async_trait]
@@ -560,53 +594,103 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             )
             .await?;
         let mut out: Vec<(PersistedSession, Vec<PersistedUnackedStanza>)> = Vec::new();
+        // Track the most recently seen stream_id so we only call
+        // `decode_session` once per group rather than per JOIN row
+        // (Copilot review on PR #405 — re-decoding for every unacked
+        // row in the same session was undercutting the cold-start
+        // perf goal for large queues).
+        let mut current_stream_id: Option<String> = None;
+        let mut poison_sessions = 0usize;
         while let Some(row) = rows
             .next()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
         {
-            // Columns 0..15 are the session columns (same shape as
-            // `list_all_sessions`). 15..18 are the unacked columns;
-            // NULL when the LEFT JOIN had no match.
-            let session = Self::decode_session(&row)?;
-            let stream_id_for_unacked = SmSessionId::new(session.stream_id.as_str());
-            // The sequence column is i64 in storage; if NULL the
-            // session has no unacked rows.
-            let sequence_opt: Option<i64> = row
-                .get(15)
-                .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-            // Look up the existing entry for this stream_id (rows are
-            // grouped by stream_id thanks to ORDER BY) or push a new
-            // one. Common case is consecutive rows for the same id.
-            if out.last().map(|(s, _)| &s.stream_id) != Some(&session.stream_id) {
-                out.push((session, Vec::new()));
-            }
-            if let Some(sequence_i64) = sequence_opt {
-                let xml: String = row
-                    .get(16)
-                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-                let receipt_ms: i64 = row
-                    .get(17)
-                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-                let original_receipt_at =
-                    chrono::DateTime::<Utc>::from_timestamp_millis(receipt_ms).ok_or_else(
-                        || SmPersistenceError::Other("invalid unacked receipt timestamp".into()),
-                    )?;
-                let element: xmpp_parsers::minidom::Element =
-                    xml.parse().map_err(|e: xmpp_parsers::minidom::Error| {
-                        SmPersistenceError::Other(e.to_string())
-                    })?;
-                let stanza = parse_stanza(element)?;
-                let sequence = u32::try_from(sequence_i64)
-                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-                let entry = PersistedUnackedStanza {
-                    stream_id: stream_id_for_unacked,
-                    sequence,
-                    stanza: Box::new(stanza),
-                    original_receipt_at,
+            // Read the session's stream_id (column 0) up-front so
+            // we can decide whether this row starts a new group
+            // before paying for the full session decode.
+            let row_stream_id: String = match row.get(0) {
+                Ok(s) => s,
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "list_all_sessions_with_unacked: skipping row with unreadable stream_id"
+                    );
+                    continue;
+                }
+            };
+            let starts_new_group = current_stream_id.as_deref() != Some(row_stream_id.as_str());
+            if starts_new_group {
+                // Decode the session columns (0..=14, 15 columns)
+                // exactly once per stream_id group. On decode
+                // failure, skip the entire group's rows so a single
+                // poison-pill session can't brick cold startup
+                // (Greptile/Copilot/Qodo P1 review on PR #405).
+                let session = match Self::decode_session(&row) {
+                    Ok(s) => s,
+                    Err(error) => {
+                        tracing::debug!(
+                            stream_id = %row_stream_id,
+                            error = %error,
+                            "list_all_sessions_with_unacked: skipping session whose row \
+                             failed to decode (poison pill)"
+                        );
+                        // Mark current_stream_id so subsequent rows
+                        // for the same stream_id are recognized as
+                        // belonging to the same skipped group and
+                        // also dropped.
+                        current_stream_id = Some(row_stream_id);
+                        poison_sessions += 1;
+                        continue;
+                    }
                 };
-                out.last_mut().expect("just pushed above").1.push(entry);
+                current_stream_id = Some(row_stream_id);
+                out.push((session, Vec::new()));
+            } else if out.last().is_none() {
+                // Same stream_id as a previously-skipped poison
+                // session; drop this unacked row too.
+                continue;
             }
+            // Unacked columns: sequence (15), stanza_xml (16),
+            // original_receipt_at_ms (17). NULL when LEFT JOIN had
+            // no match. Per-row decode failure skips that row but
+            // keeps the rest of the session's queue.
+            let sequence_opt: Option<i64> = match row.get(15) {
+                Ok(v) => v,
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "list_all_sessions_with_unacked: skipping row with unreadable sequence"
+                    );
+                    continue;
+                }
+            };
+            let Some(sequence_i64) = sequence_opt else {
+                continue;
+            };
+            let entry = match Self::decode_unacked_join_row(&row, sequence_i64) {
+                Ok(entry) => entry,
+                Err(error) => {
+                    tracing::debug!(
+                        stream_id = %current_stream_id.as_deref().unwrap_or("<unknown>"),
+                        sequence = sequence_i64,
+                        error = %error,
+                        "list_all_sessions_with_unacked: skipping unacked row with \
+                         decode failure (poison pill)"
+                    );
+                    continue;
+                }
+            };
+            if let Some(group) = out.last_mut() {
+                group.1.push(entry);
+            }
+        }
+        if poison_sessions > 0 {
+            tracing::warn!(
+                count = poison_sessions,
+                "list_all_sessions_with_unacked: skipped poison-pill session(s); \
+                 cold startup proceeds with the remaining sessions"
+            );
         }
         Ok(out)
     }
@@ -635,6 +719,26 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+
+        // Drop any pre-existing unacked rows for this stream_id
+        // BEFORE the inserts so a previous `persist_delete_session`
+        // failure (eviction path logs-and-swallows) doesn't trip the
+        // `(stream_id, sequence)` PRIMARY KEY constraint on the new
+        // inserts and roll the whole transaction back — including
+        // the session row update we WANT to commit. (Greptile P1
+        // review on PR #405.) The session row's `ON CONFLICT DO
+        // UPDATE` already handles its own duplicate; the unacked
+        // table has no upsert path because it normally only sees
+        // appends. The DELETE here makes the atomic-store call
+        // idempotent against partial-prior-state on the same
+        // stream_id.
+        tx.execute(
+            "DELETE FROM sm_unacked WHERE stream_id = ?",
+            crate::db_params![session.stream_id.as_str().to_string()],
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+
         tx.execute(
             r#"
             INSERT INTO sm_sessions (
@@ -1053,5 +1157,169 @@ mod tests {
         assert_eq!(listed.len(), 3);
         assert_eq!(listed[0].sequence, 1);
         assert_eq!(listed[2].sequence, 3);
+    }
+
+    /// Issue #209 PR #405 (Greptile/Copilot P2 review):
+    /// `store_session_atomic` MUST roll back the entire transaction
+    /// on any mid-batch failure — including the session-row update.
+    /// Force a fault by passing two unacked stanzas with the same
+    /// sequence; the second INSERT trips the `(stream_id, sequence)`
+    /// PRIMARY KEY constraint inside the transaction.
+    ///
+    /// After the failed call, both `get_session` and `list_unacked`
+    /// MUST observe the prior state (here: nothing), proving the
+    /// session row update did NOT commit.
+    #[tokio::test]
+    async fn store_session_atomic_rolls_back_on_unacked_constraint_violation() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        let session = fixture_session("rollback-stream");
+        // Two stanzas with the SAME sequence — the second INSERT
+        // hits the (stream_id, sequence) PRIMARY KEY constraint.
+        // Note that the new DELETE-before-INSERT (Greptile P1 fix)
+        // clears any pre-existing rows, so the conflict is between
+        // the two stanzas in THIS batch, not against pre-existing
+        // state.
+        let unacked = vec![
+            fixture_unacked("rollback-stream", 1),
+            fixture_unacked("rollback-stream", 1), // duplicate sequence
+        ];
+        let result = storage.store_session_atomic(session, unacked).await;
+        assert!(
+            result.is_err(),
+            "duplicate (stream_id, sequence) MUST fail the transaction"
+        );
+
+        // Critical assertion: the session row MUST NOT be present.
+        // Without `tx.commit()`, dropping the Transaction rolls back
+        // every statement including the session upsert.
+        let session_after = storage
+            .get_session(&SmSessionId::new("rollback-stream"))
+            .await
+            .unwrap();
+        assert!(
+            session_after.is_none(),
+            "transaction rollback MUST hide the session row update"
+        );
+
+        // No unacked rows leaked either.
+        let unacked_after = storage
+            .list_unacked(&SmSessionId::new("rollback-stream"))
+            .await
+            .unwrap();
+        assert!(
+            unacked_after.is_empty(),
+            "transaction rollback MUST hide partial unacked inserts"
+        );
+    }
+
+    /// Issue #209 PR #405 (Greptile P1 review): `store_session_atomic`
+    /// must be idempotent against pre-existing unacked rows for the
+    /// same stream_id (e.g., a previous `persist_delete_session`
+    /// failure left rows behind). The atomic store DELETEs existing
+    /// rows inside the transaction before the INSERT loop, so the
+    /// (stream_id, sequence) PRIMARY KEY constraint can't roll back
+    /// the session row update.
+    #[tokio::test]
+    async fn store_session_atomic_clears_stale_unacked_before_inserting() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        // Pre-seed an unacked row at (stream_id, sequence=1) — this
+        // simulates a previous persist_delete_session that failed in
+        // the eviction path.
+        storage
+            .append_unacked(fixture_unacked("retry-stream", 1))
+            .await
+            .unwrap();
+        // Now atomic-store with NEW unacked rows that include the
+        // same sequence (1). Without the DELETE-before-INSERT, the
+        // INSERT for sequence=1 would fail and roll back the session.
+        let session = fixture_session("retry-stream");
+        let unacked = vec![
+            fixture_unacked("retry-stream", 1),
+            fixture_unacked("retry-stream", 2),
+        ];
+        storage
+            .store_session_atomic(session, unacked)
+            .await
+            .expect("atomic store survives pre-existing unacked rows");
+
+        // Session row written.
+        assert!(storage
+            .get_session(&SmSessionId::new("retry-stream"))
+            .await
+            .unwrap()
+            .is_some());
+        // Exactly the new unacked rows are present (the stale row
+        // was DELETEd inside the transaction).
+        let listed = storage
+            .list_unacked(&SmSessionId::new("retry-stream"))
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].sequence, 1);
+        assert_eq!(listed[1].sequence, 2);
+    }
+
+    /// Issue #209 PR #405 (Greptile/Copilot/Qodo P1 review): a
+    /// single poison-pill `sm_unacked` row MUST NOT brick cold
+    /// startup. `list_all_sessions_with_unacked` should skip the
+    /// poisoned session and return the rest.
+    #[tokio::test]
+    async fn list_all_sessions_with_unacked_skips_poison_pill_unacked_rows() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        // Two healthy sessions.
+        storage
+            .upsert_session(fixture_session("alpha"))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("alpha", 1))
+            .await
+            .unwrap();
+        storage
+            .upsert_session(fixture_session("gamma"))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("gamma", 1))
+            .await
+            .unwrap();
+        // One poison-pill session: insert a sm_unacked row whose
+        // stanza_xml is malformed XML so decode fails. We bypass
+        // `append_unacked` (which serializes a typed Stanza) and
+        // write the raw poison directly via the underlying db.
+        storage
+            .upsert_session(fixture_session("beta"))
+            .await
+            .unwrap();
+        storage
+            .execute(
+                "INSERT INTO sm_unacked (stream_id, sequence, stanza_xml, original_receipt_at_ms) \
+                 VALUES (?, ?, ?, ?)",
+                crate::db_params![
+                    "beta".to_string(),
+                    1i64,
+                    "not valid xml <<<".to_string(),
+                    0i64
+                ],
+            )
+            .await
+            .expect("insert poison row");
+
+        let grouped = storage.list_all_sessions_with_unacked().await.unwrap();
+        // Healthy sessions present; poison-pill session's unacked
+        // row was skipped, so beta appears with an empty queue
+        // (since the only row failed to decode).
+        let stream_ids: Vec<_> = grouped
+            .iter()
+            .map(|(s, _)| s.stream_id.as_str().to_string())
+            .collect();
+        assert!(stream_ids.contains(&"alpha".to_string()));
+        assert!(stream_ids.contains(&"gamma".to_string()));
+        assert!(stream_ids.contains(&"beta".to_string()));
+        let beta_unacked = grouped
+            .iter()
+            .find(|(s, _)| s.stream_id.as_str() == "beta")
+            .map(|(_, u)| u);
+        assert_eq!(beta_unacked.map(Vec::len), Some(0));
     }
 }

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -531,6 +531,177 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
         }
         Ok(out)
     }
+
+    /// Single-query JOIN that fetches every persisted SM session
+    /// AND its unacked queue in one round-trip (issue #209 PR #405:
+    /// replaces the trait default's N+1 — 1 list_all_sessions + N
+    /// list_unacked — used by `restore_from_persistence` on cold
+    /// startup).
+    ///
+    /// `LEFT JOIN` so sessions with empty unacked queues still
+    /// appear (a single row with NULL unacked columns). Rows are
+    /// grouped by stream_id during decode; the SQL `ORDER BY` keeps
+    /// unacked entries ascending by sequence per session.
+    async fn list_all_sessions_with_unacked(
+        &self,
+    ) -> Result<Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>, SmPersistenceError> {
+        let mut rows = self
+            .query(
+                "SELECT s.stream_id, s.user_id, s.full_jid, s.inbound_count, \
+                        s.outbound_count, s.last_acked, s.max_resume_secs, \
+                        s.detached_at_ms, s.max_resume_duration_ms, \
+                        s.carbons_enabled, s.roster_interested, s.presence_available, \
+                        s.presence_show, s.presence_status, s.presence_priority, \
+                        u.sequence, u.stanza_xml, u.original_receipt_at_ms \
+                 FROM sm_sessions s \
+                 LEFT JOIN sm_unacked u ON s.stream_id = u.stream_id \
+                 ORDER BY s.stream_id ASC, u.sequence ASC",
+                (),
+            )
+            .await?;
+        let mut out: Vec<(PersistedSession, Vec<PersistedUnackedStanza>)> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            // Columns 0..15 are the session columns (same shape as
+            // `list_all_sessions`). 15..18 are the unacked columns;
+            // NULL when the LEFT JOIN had no match.
+            let session = Self::decode_session(&row)?;
+            let stream_id_for_unacked = SmSessionId::new(session.stream_id.as_str());
+            // The sequence column is i64 in storage; if NULL the
+            // session has no unacked rows.
+            let sequence_opt: Option<i64> = row
+                .get(15)
+                .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+            // Look up the existing entry for this stream_id (rows are
+            // grouped by stream_id thanks to ORDER BY) or push a new
+            // one. Common case is consecutive rows for the same id.
+            if out.last().map(|(s, _)| &s.stream_id) != Some(&session.stream_id) {
+                out.push((session, Vec::new()));
+            }
+            if let Some(sequence_i64) = sequence_opt {
+                let xml: String = row
+                    .get(16)
+                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+                let receipt_ms: i64 = row
+                    .get(17)
+                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+                let original_receipt_at =
+                    chrono::DateTime::<Utc>::from_timestamp_millis(receipt_ms).ok_or_else(
+                        || SmPersistenceError::Other("invalid unacked receipt timestamp".into()),
+                    )?;
+                let element: xmpp_parsers::minidom::Element =
+                    xml.parse().map_err(|e: xmpp_parsers::minidom::Error| {
+                        SmPersistenceError::Other(e.to_string())
+                    })?;
+                let stanza = parse_stanza(element)?;
+                let sequence = u32::try_from(sequence_i64)
+                    .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+                let entry = PersistedUnackedStanza {
+                    stream_id: stream_id_for_unacked,
+                    sequence,
+                    stanza: Box::new(stanza),
+                    original_receipt_at,
+                };
+                out.last_mut().expect("just pushed above").1.push(entry);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Atomically write a session record + its unacked queue (issue
+    /// #209 PR #405). Wraps the upsert and N appends in a single
+    /// `Database::begin` transaction so a panic / process crash
+    /// mid-batch leaves the durable view consistent — either every
+    /// row commits or none does. Replaces the trait default which
+    /// performs the same ops without a transaction.
+    async fn store_session_atomic(
+        &self,
+        session: PersistedSession,
+        unacked: Vec<PersistedUnackedStanza>,
+    ) -> Result<(), SmPersistenceError> {
+        let lock = self.lock_for(&session.stream_id);
+        let _guard = lock.lock().await;
+
+        let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
+            .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
+        let detached_at_ms = session.detached_at.timestamp_millis();
+        let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        tx.execute(
+            r#"
+            INSERT INTO sm_sessions (
+                stream_id, user_id, full_jid, inbound_count, outbound_count,
+                last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
+                carbons_enabled, roster_interested, presence_available,
+                presence_show, presence_status, presence_priority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (stream_id) DO UPDATE SET
+                user_id = excluded.user_id,
+                full_jid = excluded.full_jid,
+                inbound_count = excluded.inbound_count,
+                outbound_count = excluded.outbound_count,
+                last_acked = excluded.last_acked,
+                max_resume_secs = excluded.max_resume_secs,
+                detached_at_ms = excluded.detached_at_ms,
+                max_resume_duration_ms = excluded.max_resume_duration_ms,
+                carbons_enabled = excluded.carbons_enabled,
+                roster_interested = excluded.roster_interested,
+                presence_available = excluded.presence_available,
+                presence_show = excluded.presence_show,
+                presence_status = excluded.presence_status,
+                presence_priority = excluded.presence_priority
+            "#,
+            crate::db_params![
+                session.stream_id.as_str().to_string(),
+                session.user_id.clone(),
+                session.jid.to_string(),
+                i64::from(session.inbound_count),
+                i64::from(session.outbound_count),
+                i64::from(session.last_acked),
+                session.max_resume_time.map(i64::from),
+                detached_at_ms,
+                max_resume_duration_ms,
+                i64::from(session.carbons_enabled),
+                i64::from(session.roster_interested),
+                i64::from(session.presence_available),
+                presence_show_str.map(str::to_string),
+                session.presence_status.clone(),
+                i64::from(session.presence_priority),
+            ],
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+
+        for stanza in &unacked {
+            let xml = serialize_stanza(&stanza.stanza)?;
+            let receipt_ms = stanza.original_receipt_at.timestamp_millis();
+            tx.execute(
+                "INSERT INTO sm_unacked (stream_id, sequence, stanza_xml, original_receipt_at_ms) \
+                 VALUES (?, ?, ?, ?)",
+                crate::db_params![
+                    stanza.stream_id.as_str().to_string(),
+                    i64::from(stanza.sequence),
+                    xml,
+                    receipt_ms,
+                ],
+            )
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        Ok(())
+    }
 }
 
 fn show_wire_str(show: &Show) -> &'static str {
@@ -778,5 +949,109 @@ mod tests {
             _ => panic!("expected Message"),
         };
         assert_eq!(body.map(|b| b.0), Some("m1".to_string()));
+    }
+
+    /// Issue #209 PR #405: the libSQL backend overrides
+    /// `list_all_sessions_with_unacked` with a single LEFT JOIN
+    /// query (vs the trait default's N+1). Verify the SQL grouping
+    /// produces correct (PersistedSession, Vec<PersistedUnackedStanza>)
+    /// tuples for sessions with 0, 1, and N unacked rows.
+    #[tokio::test]
+    async fn list_all_sessions_with_unacked_uses_single_join_query() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        // Insert mixed-cardinality fixture: alpha=0, beta=2, gamma=1.
+        storage
+            .upsert_session(fixture_session("alpha"))
+            .await
+            .unwrap();
+        storage
+            .upsert_session(fixture_session("beta"))
+            .await
+            .unwrap();
+        storage
+            .upsert_session(fixture_session("gamma"))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("beta", 1))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("beta", 2))
+            .await
+            .unwrap();
+        storage
+            .append_unacked(fixture_unacked("gamma", 1))
+            .await
+            .unwrap();
+
+        let grouped = storage.list_all_sessions_with_unacked().await.unwrap();
+        // The libSQL backend ORDERs BY stream_id ASC, so the
+        // assertions can rely on alphabetical order without an
+        // explicit sort.
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.stream_id.as_str(), "alpha");
+        assert!(grouped[0].1.is_empty(), "session with no unacked");
+        assert_eq!(grouped[1].0.stream_id.as_str(), "beta");
+        assert_eq!(grouped[1].1.len(), 2);
+        assert_eq!(grouped[1].1[0].sequence, 1);
+        assert_eq!(grouped[1].1[1].sequence, 2);
+        assert_eq!(grouped[2].0.stream_id.as_str(), "gamma");
+        assert_eq!(grouped[2].1.len(), 1);
+
+        // Sanity: the round-tripped unacked stanzas decode back to
+        // typed Message values (same shape `list_unacked` returns).
+        let body = match &*grouped[1].1[0].stanza {
+            Stanza::Message(m) => m.bodies.values().next().cloned(),
+            _ => panic!("expected Message"),
+        };
+        assert_eq!(body.map(|b| b.0), Some("m1".to_string()));
+
+        // The JOIN result MUST equal the N+1 trait default applied
+        // to the same data — pin the JOIN's correctness by spot-
+        // checking the stream-id ordering directly.
+        let mut sessions = grouped
+            .iter()
+            .map(|(s, _)| s.stream_id.as_str().to_string())
+            .collect::<Vec<_>>();
+        sessions.sort();
+        assert_eq!(sessions, vec!["alpha", "beta", "gamma"]);
+    }
+
+    /// Issue #209 PR #405: `store_session_atomic` wraps the upsert
+    /// + N appends in a `Database::begin` transaction. Verify the
+    /// success path produces the same observable state as the
+    /// non-atomic upsert + appends, and that `get_session` /
+    /// `list_unacked` see the rows after commit.
+    #[tokio::test]
+    async fn store_session_atomic_round_trips_via_transaction() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        let session = fixture_session("atomic-stream");
+        let unacked = vec![
+            fixture_unacked("atomic-stream", 1),
+            fixture_unacked("atomic-stream", 2),
+            fixture_unacked("atomic-stream", 3),
+        ];
+        storage
+            .store_session_atomic(session, unacked)
+            .await
+            .unwrap();
+
+        // Session row written.
+        let read = storage
+            .get_session(&SmSessionId::new("atomic-stream"))
+            .await
+            .unwrap()
+            .expect("session present after atomic write");
+        assert_eq!(read.stream_id.as_str(), "atomic-stream");
+
+        // All unacked rows written.
+        let listed = storage
+            .list_unacked(&SmSessionId::new("atomic-stream"))
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 3);
+        assert_eq!(listed[0].sequence, 1);
+        assert_eq!(listed[2].sequence, 3);
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -160,6 +160,45 @@ pub trait SmPersistenceStorage: Send + Sync {
     /// XEP-0198 `<resume previd='…'/>` finds sessions that detached
     /// before the most recent restart.
     async fn list_all_sessions(&self) -> Result<Vec<PersistedSession>, SmPersistenceError>;
+
+    /// Enumerate every persisted session AND its unacked queue in a
+    /// single round-trip. Used by `restore_from_persistence` so cold
+    /// startup doesn't issue an N+1 (1 list_all_sessions + N
+    /// list_unacked). Default impl falls back to the N+1 sequence so
+    /// in-memory backends and bring-up tests keep working without
+    /// implementing a JOIN; the libSQL/Postgres backend overrides
+    /// with a single `SELECT … LEFT JOIN sm_unacked` query.
+    async fn list_all_sessions_with_unacked(
+        &self,
+    ) -> Result<Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>, SmPersistenceError> {
+        let sessions = self.list_all_sessions().await?;
+        let mut out = Vec::with_capacity(sessions.len());
+        for session in sessions {
+            let unacked = self.list_unacked(&session.stream_id).await?;
+            out.push((session, unacked));
+        }
+        Ok(out)
+    }
+
+    /// Atomically write a session record + its unacked queue. Either
+    /// every row commits or none does, so a panic / process crash
+    /// mid-batch leaves the durable view consistent (no half-stored
+    /// session whose row claims N unacked stanzas but the table only
+    /// holds K < N). Default impl falls back to upsert + N appends
+    /// without a transaction so backends that don't support nested
+    /// ops keep working; the libSQL/Postgres backend overrides with
+    /// a `BEGIN; … ; COMMIT;` block via `Database::begin`.
+    async fn store_session_atomic(
+        &self,
+        session: PersistedSession,
+        unacked: Vec<PersistedUnackedStanza>,
+    ) -> Result<(), SmPersistenceError> {
+        self.upsert_session(session).await?;
+        for entry in unacked {
+            self.append_unacked(entry).await?;
+        }
+        Ok(())
+    }
 }
 
 /// In-memory implementation suitable for tests and as the structural
@@ -431,5 +470,72 @@ mod tests {
             "original_receipt_at must round-trip exactly (not be re-stamped \
              at write or read time)"
         );
+    }
+
+    /// Issue #209 PR #405: the trait default for
+    /// `list_all_sessions_with_unacked` falls back to N+1; verify
+    /// it returns sessions paired with their unacked queues. The
+    /// libSQL backend overrides with a single LEFT JOIN — that
+    /// override is exercised separately in
+    /// `server/crates/waddle-server/src/sm_persistence.rs` tests.
+    #[tokio::test]
+    async fn list_all_sessions_with_unacked_groups_by_session() {
+        let store = InMemorySmPersistence::new();
+        // Session A: 0 unacked rows.
+        store
+            .upsert_session(fixture_session("alpha"))
+            .await
+            .unwrap();
+        // Session B: 2 unacked rows.
+        store.upsert_session(fixture_session("beta")).await.unwrap();
+        store
+            .append_unacked(fixture_unacked("beta", 1))
+            .await
+            .unwrap();
+        store
+            .append_unacked(fixture_unacked("beta", 2))
+            .await
+            .unwrap();
+        // Session C: 1 unacked row.
+        store
+            .upsert_session(fixture_session("gamma"))
+            .await
+            .unwrap();
+        store
+            .append_unacked(fixture_unacked("gamma", 1))
+            .await
+            .unwrap();
+
+        let mut grouped = store.list_all_sessions_with_unacked().await.unwrap();
+        // Sort by stream_id for deterministic assertions (the trait
+        // doesn't mandate ordering since the in-memory backend uses a
+        // HashMap).
+        grouped.sort_by(|a, b| a.0.stream_id.as_str().cmp(b.0.stream_id.as_str()));
+        assert_eq!(grouped.len(), 3);
+        assert_eq!(grouped[0].0.stream_id.as_str(), "alpha");
+        assert!(grouped[0].1.is_empty(), "session with no unacked");
+        assert_eq!(grouped[1].0.stream_id.as_str(), "beta");
+        assert_eq!(grouped[1].1.len(), 2);
+        assert_eq!(grouped[2].0.stream_id.as_str(), "gamma");
+        assert_eq!(grouped[2].1.len(), 1);
+    }
+
+    /// Issue #209 PR #405: the trait default for
+    /// `store_session_atomic` falls back to upsert + N appends.
+    /// Verify the success path produces the same result as
+    /// individually-issued ops.
+    #[tokio::test]
+    async fn store_session_atomic_writes_session_and_unacked_together() {
+        let store = InMemorySmPersistence::new();
+        let session = fixture_session("atomic-1");
+        let unacked = vec![
+            fixture_unacked("atomic-1", 1),
+            fixture_unacked("atomic-1", 2),
+            fixture_unacked("atomic-1", 3),
+        ];
+        store.store_session_atomic(session, unacked).await.unwrap();
+        assert!(store.get_session(&sid("atomic-1")).await.unwrap().is_some());
+        let listed = store.list_unacked(&sid("atomic-1")).await.unwrap();
+        assert_eq!(listed.len(), 3);
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -164,18 +164,38 @@ pub trait SmPersistenceStorage: Send + Sync {
     /// Enumerate every persisted session AND its unacked queue in a
     /// single round-trip. Used by `restore_from_persistence` so cold
     /// startup doesn't issue an N+1 (1 list_all_sessions + N
-    /// list_unacked). Default impl falls back to the N+1 sequence so
-    /// in-memory backends and bring-up tests keep working without
-    /// implementing a JOIN; the libSQL/Postgres backend overrides
-    /// with a single `SELECT … LEFT JOIN sm_unacked` query.
+    /// list_unacked).
+    ///
+    /// **Best-effort semantics**: a session whose unacked queue
+    /// fails to decode (corrupted XML, invalid timestamp, etc.) is
+    /// SKIPPED with a debug log; other sessions still appear in the
+    /// returned set. This mirrors the prior per-session try-catch
+    /// in `restore_from_persistence` so a single poison-pill row
+    /// can't brick cold startup. (Greptile/Copilot/Qodo P1 review
+    /// on PR #405.)
+    ///
+    /// Default impl falls back to the N+1 sequence so in-memory
+    /// backends keep working without implementing a JOIN; the
+    /// libSQL/Postgres backend overrides with a single
+    /// `SELECT … LEFT JOIN sm_unacked` query that applies the same
+    /// poison-pill skip per-row.
     async fn list_all_sessions_with_unacked(
         &self,
     ) -> Result<Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>, SmPersistenceError> {
         let sessions = self.list_all_sessions().await?;
         let mut out = Vec::with_capacity(sessions.len());
         for session in sessions {
-            let unacked = self.list_unacked(&session.stream_id).await?;
-            out.push((session, unacked));
+            match self.list_unacked(&session.stream_id).await {
+                Ok(unacked) => out.push((session, unacked)),
+                Err(error) => {
+                    tracing::debug!(
+                        stream_id = %session.stream_id,
+                        error = %error,
+                        "list_all_sessions_with_unacked: skipping session whose unacked \
+                         queue failed to decode (poison pill); other sessions continue"
+                    );
+                }
+            }
         }
         Ok(out)
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -360,18 +360,19 @@ impl InMemorySmSessionRegistry {
             return Ok(0);
         };
         let now = chrono::Utc::now();
+        // Single round-trip — replaces an N+1 (1 list_all_sessions +
+        // N list_unacked) with a single SELECT … LEFT JOIN sm_unacked
+        // on backends that override (libSQL/Postgres). In-memory
+        // backends fall back to the trait-default N+1 path. Issue
+        // #209 PR #405.
         let stored = storage
-            .list_all_sessions()
+            .list_all_sessions_with_unacked()
             .await
             .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
-        // First await all the unacked queries (no lock held); then
-        // do a single short-lived write critical section to insert
-        // the hydrated sessions. RwLock guards are not Send and
-        // cannot be held across .await points.
         let mut hydrated_sessions = Vec::with_capacity(stored.len());
         let mut expired_ids = Vec::new();
         let mut bad_rows = 0usize;
-        for persisted in stored {
+        for (persisted, unacked) in stored {
             // Filter expired-during-downtime: detached_at +
             // max_resume_duration <= now means the resume window is
             // already closed. Hydrating these would let them appear
@@ -386,18 +387,6 @@ impl InMemorySmSessionRegistry {
                 expired_ids.push(persisted.stream_id.clone());
                 continue;
             }
-            let unacked = match storage.list_unacked(&persisted.stream_id).await {
-                Ok(u) => u,
-                Err(error) => {
-                    debug!(
-                        stream_id = %persisted.stream_id,
-                        error = %error,
-                        "skipping persisted session: list_unacked failed"
-                    );
-                    bad_rows += 1;
-                    continue;
-                }
-            };
             match persisted_to_detached(&persisted, &unacked) {
                 Ok(session) => hydrated_sessions.push(session),
                 Err(error) => {
@@ -640,26 +629,20 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         }
 
         // Persist the detached session + its unacked queue so it
-        // survives a server restart per locked Q8 = B.
+        // survives a server restart per locked Q8 = B. Use the
+        // atomic store API (issue #209 PR #405): backends that
+        // support transactions wrap the session upsert + N unacked
+        // appends in a single BEGIN/COMMIT so a panic / process
+        // crash mid-batch leaves the durable view consistent —
+        // either every row commits or none does. Backends that
+        // don't (in-memory) fall back to the trait default which
+        // performs the same upsert + N appends without atomicity.
         if let Some(storage) = &self.persistence {
             let persisted = detached_to_persisted(&session)?;
-            storage
-                .upsert_session(persisted)
-                .await
-                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
-            // Replace any prior unacked rows for this stream id with
-            // the current snapshot. Persistence ack_through can have
-            // truncated rows already, so the cleanest approach is to
-            // delete-via-ack to a high watermark and re-append, but
-            // that's a churn-y O(n) round-trip per detach; instead
-            // we rely on the fact that store_session is called only
-            // on detach and the unacked vec at that moment IS the
-            // snapshot we want to persist. Existing rows from a
-            // prior detach for the same stream id would have been
-            // taken on resume; if they're still there we replace
-            // them via append (PRIMARY KEY (stream_id, sequence)
-            // would conflict — caller is expected to take_session
-            // before storing a new one with the same id).
+            // Pre-decode every stanza outside the storage call so
+            // any parse failure rolls the whole batch back without
+            // a round-trip to the backend.
+            let mut unacked_rows = Vec::with_capacity(session.unacked_stanzas.len());
             for entry in &session.unacked_stanzas {
                 let element: minidom::Element =
                     entry.stanza_xml.parse().map_err(|e: minidom::Error| {
@@ -692,17 +675,17 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                 // future Q6 SM-expiry promotion advertise the original
                 // failed-delivery time per XEP-0203 §4.1 + XEP-0198
                 // §5 line 364.
-                let unacked = super::persistence::PersistedUnackedStanza {
+                unacked_rows.push(super::persistence::PersistedUnackedStanza {
                     stream_id: crate::pending_delivery::SmSessionId::new(stream_id.clone()),
                     sequence: entry.sequence,
                     stanza: Box::new(stanza),
                     original_receipt_at: entry.original_receipt_at,
-                };
-                storage
-                    .append_unacked(unacked)
-                    .await
-                    .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+                });
             }
+            storage
+                .store_session_atomic(persisted, unacked_rows)
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
         }
 
         debug!(stream_id = %stream_id, count = count, "Stored detached SM session");


### PR DESCRIPTION
Continues from PR #362 (slice d phase 8, merged on main as `dda0406f`).

## Scope

Final cleanup PR for issue #209 — addresses the two bot-flagged storage optimization items that don't affect correctness:

**A — Single JOIN restore**

`InMemorySmSessionRegistry::restore_from_persistence` currently reads sessions via `list_all_sessions()` then issues an N+1 query loop calling `list_unacked(stream_id)` for each. With many durably-stored sessions this is a real cold-start cost. Add `SmPersistenceStorage::list_all_sessions_with_unacked() -> Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>` so the libSQL/Postgres backend can do a single LEFT JOIN.

**B — Atomic upsert+append**

`InMemorySmSessionRegistry::store_session` writes the session row then loops appending unacked stanzas. A panic / process crash between the session write and the last append leaves a half-stored session on disk: the durable row says "X stanzas in queue" but the table only has K < X. Restart-time `restore_from_persistence` reads back inconsistent state.

Add a transaction primitive to `crate::db::Database` (`begin_tx() -> TxGuard` with driver-aware BEGIN/COMMIT) and wrap `store_session`'s persistence write so session + all unacked appends commit atomically.

## Plan

1. **Storage trait extension** (`server/crates/waddle-xmpp/src/stream_management/persistence.rs`):
   - New trait method `list_all_sessions_with_unacked(now: DateTime<Utc>) -> Result<Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>>`.
   - Default impl can fall back to N+1 for backends that don't natively support JOIN.
   - In-memory impl: trivial group-by.

2. **libSQL/Postgres JOIN query** (`server/crates/waddle-server/src/sm_persistence.rs`):
   - Single SELECT with `LEFT JOIN sm_unacked ON sm_session.stream_id = sm_unacked.stream_id`.
   - Group rows by stream_id during decode.
   - Honour the same `is_expired` filter `list_all_sessions` already applies.

3. **Database transaction primitive** (`server/crates/waddle-server/src/db/mod.rs`):
   - New method `Database::begin_tx() -> Result<TxGuard, DatabaseError>`.
   - `TxGuard` is a RAII handle with `commit()` / `rollback()` methods. Drop without explicit commit defaults to rollback.
   - Driver-aware: `BEGIN IMMEDIATE; … ; COMMIT;` for SQLite, `BEGIN; … ; COMMIT;` for Postgres.

4. **Use the tx in store_session** (`server/crates/waddle-xmpp/src/stream_management/session_registry.rs`):
   - Wrap the upsert + append loop in a single `begin_tx()` → ops → `commit()` block.
   - Failure of any append rolls back the whole batch.

## Tests

- Storage-trait test for `list_all_sessions_with_unacked`: insert 3 sessions with varying unacked counts; assert one call returns them all grouped correctly.
- libSQL JOIN test: same against `DatabaseSmPersistence` to verify the SQL is correct (file-backed tempdir).
- Atomicity test: inject a fault during `store_session`'s append loop; assert `get_session` returns None (full rollback) rather than the partial session.
- All existing 438 server lib + 1789 waddle-xmpp lib tests stay green.

## Risks

- Transaction support touches the `Database` abstraction at its core. Adding `begin_tx` requires both SQLite and Postgres path-coverage; the existing `Database::guard()` API uses an Arc<Mutex<Connection>>-style pattern that may or may not support nested ops. May need to thread a connection guard through `TxGuard`.

## Out of scope

- The S2S `<service-unavailable/>` bounce, MAM XEP-0313 §4.4 per-user storage prefs, and issue #210 remain separate — none on the #209 critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
