### PR TITLE
fix(chat): restore encrypted file/image rendering after stanza→rust migration

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -38,6 +38,7 @@ import type {
 } from "./types";
 import { mergeOccupantHats, roleHatsForOccupant } from "./occupant-badges";
 import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
+import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
@@ -239,6 +240,29 @@ function sharedFileFromWasm(file: WasmSharedFile): SharedFileInfo {
     ...(typeof file.size === "number" ? { size: file.size } : {}),
     ...(typeof file.width === "number" ? { width: file.width } : {}),
     ...(typeof file.height === "number" ? { height: file.height } : {}),
+    ...(file.encrypted ? { encrypted: encryptedFromWasm(file.encrypted) } : {}),
+  };
+}
+
+function encryptedFromWasm(encrypted: NonNullable<WasmSharedFile["encrypted"]>): WaddleEncryptedFile {
+  return {
+    cipher: encrypted.cipher as WaddleEncryptedFile["cipher"],
+    keyB64: encrypted.key_b64,
+    ivB64: encrypted.iv_b64,
+    ...(encrypted.hashes.length
+      ? { hashes: encrypted.hashes.map((hash) => ({ algo: hash.algo, valueB64: hash.value_b64 })) }
+      : {}),
+    ...(encrypted.sources.length ? { sources: [...encrypted.sources] } : {}),
+  };
+}
+
+function encryptedToWasm(encrypted: WaddleEncryptedFile, fallbackUrl: string): NonNullable<WasmSharedFile["encrypted"]> {
+  return {
+    cipher: encrypted.cipher,
+    key_b64: encrypted.keyB64,
+    iv_b64: encrypted.ivB64,
+    hashes: (encrypted.hashes ?? []).map((hash) => ({ algo: hash.algo, value_b64: hash.valueB64 })),
+    sources: encrypted.sources?.length ? [...encrypted.sources] : [fallbackUrl],
   };
 }
 
@@ -424,6 +448,7 @@ function buildWasmSendOptions(opts: SendGroupMessageOptions | SendDirectMessageO
       width: file.width,
       height: file.height,
       disposition: file.disposition,
+      ...(file.encrypted ? { encrypted: encryptedToWasm(file.encrypted, file.url) } : {}),
     }));
   }
   if (opts.markup?.length) {

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -9,6 +9,19 @@ export interface WasmMarkupSpan {
   uri?: string;
 }
 
+export interface WasmEncryptedFileHash {
+  algo: string;
+  value_b64: string;
+}
+
+export interface WasmEncryptedFile {
+  cipher: string;
+  key_b64: string;
+  iv_b64: string;
+  hashes: WasmEncryptedFileHash[];
+  sources: string[];
+}
+
 export interface WasmSharedFile {
   url: string;
   name?: string;
@@ -17,6 +30,7 @@ export interface WasmSharedFile {
   width?: number;
   height?: number;
   disposition: string;
+  encrypted?: WasmEncryptedFile;
 }
 
 export interface WasmReference {
@@ -182,6 +196,7 @@ export interface WasmSendOptions {
     width?: number;
     height?: number;
     disposition: string;
+    encrypted?: WasmEncryptedFile;
   }>;
   markup_spans?: WasmMarkupSpan[];
   references?: WasmReference[];

--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -180,6 +180,32 @@ pub struct WaddleSharedFile {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub disposition: String,
+    /// XEP-0448 envelope when the bytes at `url` are ciphertext rather than
+    /// the plaintext file. Recipients MUST use these values to decrypt before
+    /// rendering.
+    pub encrypted: Option<WaddleEncryptedFile>,
+}
+
+/// XEP-0448 cipher/key/iv/hashes envelope for encrypted Stateless File
+/// Sharing payloads.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleEncryptedFile {
+    /// Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
+    pub cipher: String,
+    /// Base64-encoded symmetric key.
+    pub key_b64: String,
+    /// Base64-encoded initialization vector / nonce.
+    pub iv_b64: String,
+    pub hashes: Vec<WaddleEncryptedFileHash>,
+    /// Source URLs the ciphertext can be fetched from. Always non-empty.
+    pub sources: Vec<String>,
+}
+
+/// XEP-0300 hash entry nested under an `<encrypted/>` envelope.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleEncryptedFileHash {
+    pub algo: String,
+    pub value_b64: String,
 }
 
 /// Header the client must include when uploading to a XEP-0363 slot.
@@ -779,7 +805,48 @@ fn shared_file_to_ffi(file: waddle_xmpp_client::messaging::SharedFile) -> Waddle
         width: file.width,
         height: file.height,
         disposition: file.disposition.as_str().to_string(),
+        encrypted: file.encrypted.map(encrypted_file_to_ffi),
     }
+}
+
+fn encrypted_file_to_ffi(
+    enc: waddle_xmpp_client::xep::encrypted_file::EncryptedFile,
+) -> WaddleEncryptedFile {
+    WaddleEncryptedFile {
+        cipher: enc.cipher.as_uri().to_string(),
+        key_b64: enc.key_b64,
+        iv_b64: enc.iv_b64,
+        hashes: enc
+            .hashes
+            .into_iter()
+            .map(|h| WaddleEncryptedFileHash {
+                algo: h.algo,
+                value_b64: h.value_b64,
+            })
+            .collect(),
+        sources: enc.sources,
+    }
+}
+
+fn encrypted_file_from_ffi(
+    enc: WaddleEncryptedFile,
+) -> Option<waddle_xmpp_client::xep::encrypted_file::EncryptedFile> {
+    use waddle_xmpp_client::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
+    let cipher = Cipher::from_uri(&enc.cipher)?;
+    Some(EncryptedFile {
+        cipher,
+        key_b64: enc.key_b64,
+        iv_b64: enc.iv_b64,
+        hashes: enc
+            .hashes
+            .into_iter()
+            .map(|h| EncryptedHash {
+                algo: h.algo,
+                value_b64: h.value_b64,
+            })
+            .collect(),
+        sources: enc.sources,
+    })
 }
 
 fn upload_slot_to_ffi(slot: waddle_xmpp_client::discovery::UploadSlot) -> WaddleUploadSlot {
@@ -957,6 +1024,7 @@ fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessageOptions, 
                 Some(file.disposition.as_str()),
                 file.media_type.as_deref(),
             );
+            let encrypted = file.encrypted.and_then(encrypted_file_from_ffi);
             messaging::SharedFile {
                 url: file.url,
                 name: file.name,
@@ -965,6 +1033,7 @@ fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessageOptions, 
                 width: file.width,
                 height: file.height,
                 disposition,
+                encrypted,
             }
         })
         .collect();

--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -830,10 +830,21 @@ fn encrypted_file_to_ffi(
 
 fn encrypted_file_from_ffi(
     enc: WaddleEncryptedFile,
-) -> Option<waddle_xmpp_client::xep::encrypted_file::EncryptedFile> {
+) -> Result<waddle_xmpp_client::xep::encrypted_file::EncryptedFile, String> {
     use waddle_xmpp_client::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
-    let cipher = Cipher::from_uri(&enc.cipher)?;
-    Some(EncryptedFile {
+    let cipher = Cipher::from_uri(&enc.cipher).ok_or_else(|| {
+        format!(
+            "encrypted attachment has unknown cipher: {cipher}",
+            cipher = enc.cipher
+        )
+    })?;
+    if enc.sources.is_empty() {
+        return Err(
+            "encrypted attachment has no sources; recipients would receive ciphertext with no decryption metadata"
+                .to_string(),
+        );
+    }
+    Ok(EncryptedFile {
         cipher,
         key_b64: enc.key_b64,
         iv_b64: enc.iv_b64,
@@ -1016,6 +1027,10 @@ fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessageOptions, 
         parent: t.parent,
     });
 
+    // Surface invalid encryption metadata (unknown cipher, empty sources)
+    // as an explicit error rather than silently sending a ciphertext URL
+    // without the matching XEP-0448 envelope — that produces hard-to-debug
+    // broken attachments for recipients.
     let shared_files = opts
         .shared_files
         .into_iter()
@@ -1024,8 +1039,8 @@ fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessageOptions, 
                 Some(file.disposition.as_str()),
                 file.media_type.as_deref(),
             );
-            let encrypted = file.encrypted.and_then(encrypted_file_from_ffi);
-            messaging::SharedFile {
+            let encrypted = file.encrypted.map(encrypted_file_from_ffi).transpose()?;
+            Ok(messaging::SharedFile {
                 url: file.url,
                 name: file.name,
                 media_type: file.media_type,
@@ -1034,9 +1049,9 @@ fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessageOptions, 
                 height: file.height,
                 disposition,
                 encrypted,
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, String>>()?;
 
     let stanza_id = opts
         .stanza_id

--- a/server/crates/waddle-xmpp-client-ffi/src/waddle_xmpp_client.udl
+++ b/server/crates/waddle-xmpp-client-ffi/src/waddle_xmpp_client.udl
@@ -61,6 +61,20 @@ dictionary WaddleSharedFile {
     u32? width;
     u32? height;
     string disposition;
+    WaddleEncryptedFile? encrypted;
+};
+
+dictionary WaddleEncryptedFile {
+    string cipher;
+    string key_b64;
+    string iv_b64;
+    sequence<WaddleEncryptedFileHash> hashes;
+    sequence<string> sources;
+};
+
+dictionary WaddleEncryptedFileHash {
+    string algo;
+    string value_b64;
 };
 
 dictionary WaddleUploadHeader {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -2516,8 +2516,16 @@ fn send_options_from_js(options: JsValue) -> Result<SendMessageOptions, JsValue>
                     Some(file.disposition.as_str()),
                     file.media_type.as_deref(),
                 );
-                let encrypted = file.encrypted.and_then(encrypted_file_from_js);
-                messaging::SharedFile {
+                // Surface invalid encryption metadata as an explicit
+                // error rather than silently sending a ciphertext URL
+                // without the matching XEP-0448 envelope — that produces
+                // hard-to-debug broken attachments for recipients.
+                let encrypted = file
+                    .encrypted
+                    .map(encrypted_file_from_js)
+                    .transpose()
+                    .map_err(|err| js_error(err.to_string()))?;
+                Ok(messaging::SharedFile {
                     url: file.url,
                     name: file.name,
                     media_type: file.media_type,
@@ -2526,9 +2534,9 @@ fn send_options_from_js(options: JsValue) -> Result<SendMessageOptions, JsValue>
                     height: file.height,
                     disposition,
                     encrypted,
-                }
+                })
             })
-            .collect(),
+            .collect::<Result<Vec<_>, JsValue>>()?,
     })
 }
 
@@ -2804,15 +2812,30 @@ fn encrypted_file_to_js(
     }
 }
 
+/// Reasons `encrypted_file_from_js` may reject a payload from the JS side.
+/// Carried as a typed error so native unit tests do not have to construct
+/// `JsValue`s (wasm-bindgen panics on non-wasm32 targets); the WASM caller
+/// converts via `Display` at the boundary.
+#[derive(Debug, thiserror::Error)]
+enum EncryptedFileFromJsError {
+    #[error("encrypted attachment has unknown cipher: {0}")]
+    UnknownCipher(String),
+    #[error(
+        "encrypted attachment has no sources; recipients would receive ciphertext with no decryption metadata"
+    )]
+    NoSources,
+}
+
 fn encrypted_file_from_js(
     enc: WaddleEncryptedFile,
-) -> Option<waddle_xmpp_client::xep::encrypted_file::EncryptedFile> {
+) -> Result<waddle_xmpp_client::xep::encrypted_file::EncryptedFile, EncryptedFileFromJsError> {
     use waddle_xmpp_client::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
-    let cipher = Cipher::from_uri(&enc.cipher)?;
+    let cipher = Cipher::from_uri(&enc.cipher)
+        .ok_or_else(|| EncryptedFileFromJsError::UnknownCipher(enc.cipher.clone()))?;
     if enc.sources.is_empty() {
-        return None;
+        return Err(EncryptedFileFromJsError::NoSources);
     }
-    Some(EncryptedFile {
+    Ok(EncryptedFile {
         cipher,
         key_b64: enc.key_b64,
         iv_b64: enc.iv_b64,
@@ -3286,7 +3309,7 @@ mod encrypted_file_bridge_tests {
             hashes: Vec::new(),
             sources: vec!["https://x".to_string()],
         };
-        assert!(encrypted_file_from_js(invalid).is_none());
+        assert!(encrypted_file_from_js(invalid).is_err());
     }
 
     #[test]
@@ -3298,6 +3321,6 @@ mod encrypted_file_bridge_tests {
             hashes: Vec::new(),
             sources: Vec::new(),
         };
-        assert!(encrypted_file_from_js(invalid).is_none());
+        assert!(encrypted_file_from_js(invalid).is_err());
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -376,6 +376,35 @@ pub struct WaddleSharedFile {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub disposition: String,
+    /// XEP-0448 envelope when the bytes at `url` are ciphertext rather than
+    /// the plaintext file. Recipients MUST use these values to decrypt before
+    /// rendering. Absent for plaintext shares and on platforms that do not
+    /// produce encrypted attachments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encrypted: Option<WaddleEncryptedFile>,
+}
+
+/// XEP-0448 envelope (cipher / key / iv / hashes / sources) bridged across
+/// the WASM boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaddleEncryptedFile {
+    /// Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
+    pub cipher: String,
+    /// Base64-encoded symmetric key.
+    pub key_b64: String,
+    /// Base64-encoded initialization vector / nonce.
+    pub iv_b64: String,
+    #[serde(default)]
+    pub hashes: Vec<WaddleEncryptedFileHash>,
+    /// Source URLs the ciphertext can be fetched from. Always non-empty.
+    pub sources: Vec<String>,
+}
+
+/// XEP-0300 hash entry nested under a `WaddleEncryptedFile`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaddleEncryptedFileHash {
+    pub algo: String,
+    pub value_b64: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -2482,17 +2511,22 @@ fn send_options_from_js(options: JsValue) -> Result<SendMessageOptions, JsValue>
         shared_files: options
             .shared_files
             .into_iter()
-            .map(|file| messaging::SharedFile {
-                url: file.url,
-                name: file.name,
-                media_type: file.media_type.clone(),
-                size: file.size,
-                width: file.width,
-                height: file.height,
-                disposition: SharedFileDisposition::from_text_or_infer(
+            .map(|file| {
+                let disposition = SharedFileDisposition::from_text_or_infer(
                     Some(file.disposition.as_str()),
                     file.media_type.as_deref(),
-                ),
+                );
+                let encrypted = file.encrypted.and_then(encrypted_file_from_js);
+                messaging::SharedFile {
+                    url: file.url,
+                    name: file.name,
+                    media_type: file.media_type,
+                    size: file.size,
+                    width: file.width,
+                    height: file.height,
+                    disposition,
+                    encrypted,
+                }
             })
             .collect(),
     })
@@ -2747,7 +2781,51 @@ fn shared_file_to_js(file: messaging::SharedFile) -> WaddleSharedFile {
         width: file.width,
         height: file.height,
         disposition: file.disposition.as_str().to_string(),
+        encrypted: file.encrypted.map(encrypted_file_to_js),
     }
+}
+
+fn encrypted_file_to_js(
+    enc: waddle_xmpp_client::xep::encrypted_file::EncryptedFile,
+) -> WaddleEncryptedFile {
+    WaddleEncryptedFile {
+        cipher: enc.cipher.as_uri().to_string(),
+        key_b64: enc.key_b64,
+        iv_b64: enc.iv_b64,
+        hashes: enc
+            .hashes
+            .into_iter()
+            .map(|h| WaddleEncryptedFileHash {
+                algo: h.algo,
+                value_b64: h.value_b64,
+            })
+            .collect(),
+        sources: enc.sources,
+    }
+}
+
+fn encrypted_file_from_js(
+    enc: WaddleEncryptedFile,
+) -> Option<waddle_xmpp_client::xep::encrypted_file::EncryptedFile> {
+    use waddle_xmpp_client::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
+    let cipher = Cipher::from_uri(&enc.cipher)?;
+    if enc.sources.is_empty() {
+        return None;
+    }
+    Some(EncryptedFile {
+        cipher,
+        key_b64: enc.key_b64,
+        iv_b64: enc.iv_b64,
+        hashes: enc
+            .hashes
+            .into_iter()
+            .map(|h| EncryptedHash {
+                algo: h.algo,
+                value_b64: h.value_b64,
+            })
+            .collect(),
+        sources: enc.sources,
+    })
 }
 
 fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
@@ -3168,5 +3246,58 @@ mod inbound_to_js_tests {
         assert_eq!(references[0].anchor.as_deref(), Some("example.com"));
         assert_eq!(references[1].ref_type, "mention");
         assert!(references[1].anchor.is_none());
+    }
+}
+
+#[cfg(test)]
+mod encrypted_file_bridge_tests {
+    use super::*;
+    use waddle_xmpp_client::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
+
+    fn sample_native() -> EncryptedFile {
+        EncryptedFile {
+            cipher: Cipher::Aes256GcmNoPadding,
+            key_b64: "a2V5".to_string(),
+            iv_b64: "aXY=".to_string(),
+            hashes: vec![EncryptedHash {
+                algo: "sha-256".to_string(),
+                value_b64: "aGFzaA==".to_string(),
+            }],
+            sources: vec!["https://files.example.com/blob.enc".to_string()],
+        }
+    }
+
+    #[test]
+    fn round_trips_encrypted_file_through_js_bridge() {
+        let native = sample_native();
+        let js = encrypted_file_to_js(native.clone());
+        assert_eq!(js.cipher, "urn:xmpp:ciphers:aes-256-gcm-nopadding:0");
+        assert_eq!(js.sources, native.sources);
+        let back = encrypted_file_from_js(js).expect("known cipher round-trips");
+        assert_eq!(back, native);
+    }
+
+    #[test]
+    fn rejects_unknown_cipher_at_js_boundary() {
+        let invalid = WaddleEncryptedFile {
+            cipher: "urn:xmpp:ciphers:rot13:0".to_string(),
+            key_b64: "k".to_string(),
+            iv_b64: "v".to_string(),
+            hashes: Vec::new(),
+            sources: vec!["https://x".to_string()],
+        };
+        assert!(encrypted_file_from_js(invalid).is_none());
+    }
+
+    #[test]
+    fn rejects_empty_sources_at_js_boundary() {
+        let invalid = WaddleEncryptedFile {
+            cipher: "urn:xmpp:ciphers:aes-256-gcm-nopadding:0".to_string(),
+            key_b64: "k".to_string(),
+            iv_b64: "v".to_string(),
+            hashes: Vec::new(),
+            sources: Vec::new(),
+        };
+        assert!(encrypted_file_from_js(invalid).is_none());
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -12,6 +12,9 @@ use uuid::Uuid;
 use crate::client::ClientHandle;
 use crate::error::{ClientError, ClientResult};
 use crate::request::StanzaId;
+use crate::xep::encrypted_file::{
+    self as xep_encrypted_file, EncryptedFile, NS_ESFS as NS_ENCRYPTED_FILE,
+};
 use crate::xep::{reply as xep_reply, thread as xep_thread};
 
 // ─── Namespace constants ───────────────────────────────────────────────────
@@ -109,6 +112,10 @@ pub struct SharedFile {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub disposition: SharedFileDisposition,
+    /// XEP-0448 encryption envelope, when the bytes at `url` are ciphertext
+    /// rather than the plaintext file. Recipients MUST use these values to
+    /// decrypt before rendering.
+    pub encrypted: Option<EncryptedFile>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -475,6 +482,25 @@ fn parse_message(el: &Element) -> InboundMessage {
         }
     }
 
+    // XEP-0448: top-level `<encrypted xmlns='urn:xmpp:esfs:0'/>` siblings
+    // carry the cipher/key/iv metadata for any preceding `<file-sharing/>`
+    // entries. Match them up by URL so a `SharedFile` whose `url` already
+    // names the ciphertext gains the metadata needed to decrypt it.
+    for encrypted_el in el
+        .children()
+        .filter(|c| c.name() == "encrypted" && c.ns() == NS_ENCRYPTED_FILE)
+    {
+        let Some(encrypted) = xep_encrypted_file::parse_encrypted_element(encrypted_el) else {
+            continue;
+        };
+        let match_idx = shared_files
+            .iter()
+            .position(|f| encrypted.sources.iter().any(|src| src == &f.url));
+        if let Some(idx) = match_idx {
+            shared_files[idx].encrypted = Some(encrypted);
+        }
+    }
+
     // XEP-0447 / XEP-0363: also check <sims> children for file sharing
     for sims_el in el.children().filter(|c| c.ns() == NS_SIMS) {
         for source_el in sims_el.children() {
@@ -495,6 +521,7 @@ fn parse_message(el: &Element) -> InboundMessage {
                         width: None,
                         height: None,
                         disposition: SharedFileDisposition::Attachment,
+                        encrypted: None,
                     });
                 }
             }
@@ -759,6 +786,7 @@ fn parse_shared_file(reference_el: &Element) -> Option<SharedFile> {
         width,
         height,
         disposition,
+        encrypted: None,
     })
 }
 
@@ -806,6 +834,7 @@ fn parse_file_sharing_element(file_sharing_el: &Element) -> Option<SharedFile> {
         width,
         height,
         disposition,
+        encrypted: None,
     })
 }
 
@@ -1243,6 +1272,17 @@ pub fn build_outbound_message(
     }
     for file in &options.shared_files {
         builder = builder.append(build_file_sharing_element(file));
+        // XEP-0448: when the bytes at `file.url` are ciphertext, emit a
+        // sibling `<encrypted/>` envelope carrying the cipher/key/iv/hash
+        // metadata recipients need to decrypt. The `<file-sharing/>` element
+        // continues to advertise the plaintext metadata (filename, size,
+        // media-type) so peers without encryption support still see the
+        // attachment offer.
+        if let Some(encrypted) = file.encrypted.as_ref() {
+            if let Some(encrypted_el) = xep_encrypted_file::build_encrypted_element(encrypted) {
+                builder = builder.append(encrypted_el);
+            }
+        }
     }
     Ok((stanza_id, builder.build()))
 }
@@ -1808,6 +1848,7 @@ mod tests {
                 width: None,
                 height: None,
                 disposition: SharedFileDisposition::Inline,
+                encrypted: None,
             }],
             ..Default::default()
         };
@@ -1833,6 +1874,176 @@ mod tests {
                 .and_then(|url_data| url_data.attr("target")),
             Some("https://files.example.com/song.ogg")
         );
+    }
+
+    #[test]
+    fn build_outbound_message_emits_xep0448_when_encrypted() {
+        use crate::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash, NS_ESFS};
+        let url = "https://files.example.com/photo.jpg.enc";
+        let options = SendMessageOptions {
+            shared_files: vec![SharedFile {
+                url: url.to_string(),
+                name: Some("photo.jpg".to_string()),
+                media_type: Some("image/jpeg".to_string()),
+                size: Some(2048),
+                width: Some(800),
+                height: Some(600),
+                disposition: SharedFileDisposition::Inline,
+                encrypted: Some(EncryptedFile {
+                    cipher: Cipher::Aes256GcmNoPadding,
+                    key_b64: "a2V5".to_string(),
+                    iv_b64: "aXY=".to_string(),
+                    hashes: vec![EncryptedHash {
+                        algo: "sha-256".to_string(),
+                        value_b64: "aGFzaA==".to_string(),
+                    }],
+                    sources: vec![url.to_string()],
+                }),
+            }],
+            ..Default::default()
+        };
+        let (_, stanza) =
+            build_outbound_message("bob@example.com", "chat", "see attached", &options).unwrap();
+
+        // The plaintext metadata still rides on `<file-sharing/>` so peers
+        // without encryption support see the filename and disposition.
+        let file_sharing = stanza
+            .get_child("file-sharing", NS_SFS)
+            .expect("file-sharing child present");
+        assert_eq!(file_sharing.attr("disposition"), Some("inline"));
+
+        // The XEP-0448 envelope is a sibling carrying cipher + key + iv +
+        // hashes + sources pointing at the ciphertext blob.
+        let encrypted = stanza
+            .get_child("encrypted", NS_ESFS)
+            .expect("encrypted sibling present");
+        assert_eq!(
+            encrypted.attr("cipher"),
+            Some("urn:xmpp:ciphers:aes-256-gcm-nopadding:0")
+        );
+        assert_eq!(
+            encrypted.get_child("key", NS_ESFS).map(|e| e.text()),
+            Some("a2V5".to_string())
+        );
+        assert_eq!(
+            encrypted.get_child("iv", NS_ESFS).map(|e| e.text()),
+            Some("aXY=".to_string())
+        );
+        let sources = encrypted
+            .get_child("sources", NS_SFS)
+            .expect("encrypted sources");
+        let url_data = sources
+            .get_child("url-data", NS_URL_DATA)
+            .expect("url-data inside encrypted sources");
+        assert_eq!(url_data.attr("target"), Some(url));
+    }
+
+    #[test]
+    fn parse_message_collects_encrypted_metadata_into_shared_file() {
+        let url = "https://files.example.com/photo.jpg.enc";
+        let xml = format!(
+            "<message xmlns='jabber:client' type='chat' from='bob@example.com' id='m1'>\
+               <body>see attached</body>\
+               <file-sharing xmlns='urn:xmpp:sfs:0' disposition='inline'>\
+                 <file xmlns='urn:xmpp:file:metadata:0'>\
+                   <media-type>image/jpeg</media-type>\
+                   <name>photo.jpg</name>\
+                   <size>2048</size>\
+                 </file>\
+                 <sources xmlns='urn:xmpp:sfs:0'>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' target='{url}'/>\
+                 </sources>\
+               </file-sharing>\
+               <encrypted xmlns='urn:xmpp:esfs:0' \
+                          cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>\
+                 <key>a2V5</key>\
+                 <iv>aXY=</iv>\
+                 <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>aGFzaA==</hash>\
+                 <sources xmlns='urn:xmpp:sfs:0'>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' target='{url}'/>\
+                 </sources>\
+               </encrypted>\
+             </message>"
+        );
+        let el: Element = xml.parse().expect("valid xml");
+        let MessagingEvent::Message(parsed) = parse(&el).expect("parses to event") else {
+            panic!("expected message event");
+        };
+        assert_eq!(parsed.shared_files.len(), 1);
+        let file = &parsed.shared_files[0];
+        assert_eq!(file.url, url);
+        assert_eq!(file.media_type.as_deref(), Some("image/jpeg"));
+        let encrypted = file
+            .encrypted
+            .as_ref()
+            .expect("encrypted metadata attached");
+        assert_eq!(
+            encrypted.cipher,
+            crate::xep::encrypted_file::Cipher::Aes256GcmNoPadding
+        );
+        assert_eq!(encrypted.key_b64, "a2V5");
+        assert_eq!(encrypted.iv_b64, "aXY=");
+        assert_eq!(encrypted.hashes.len(), 1);
+        assert_eq!(encrypted.hashes[0].algo, "sha-256");
+        assert_eq!(encrypted.sources, vec![url.to_string()]);
+    }
+
+    #[test]
+    fn parse_message_leaves_encrypted_none_for_plaintext_share() {
+        let xml = "<message xmlns='jabber:client' type='chat' from='bob@example.com' id='m1'>\
+               <body>plain</body>\
+               <file-sharing xmlns='urn:xmpp:sfs:0' disposition='attachment'>\
+                 <file xmlns='urn:xmpp:file:metadata:0'>\
+                   <name>doc.pdf</name>\
+                 </file>\
+                 <sources xmlns='urn:xmpp:sfs:0'>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' \
+                             target='https://files.example.com/doc.pdf'/>\
+                 </sources>\
+               </file-sharing>\
+             </message>";
+        let el: Element = xml.parse().expect("valid xml");
+        let MessagingEvent::Message(parsed) = parse(&el).expect("parses to event") else {
+            panic!("expected message event");
+        };
+        assert!(parsed.shared_files[0].encrypted.is_none());
+    }
+
+    #[test]
+    fn build_then_parse_roundtrip_preserves_encrypted_metadata() {
+        use crate::xep::encrypted_file::{Cipher, EncryptedFile, EncryptedHash};
+        let url = "https://files.example.com/blob.enc";
+        let original = SharedFile {
+            url: url.to_string(),
+            name: Some("blob.bin".to_string()),
+            media_type: Some("application/octet-stream".to_string()),
+            size: Some(99),
+            width: None,
+            height: None,
+            disposition: SharedFileDisposition::Attachment,
+            encrypted: Some(EncryptedFile {
+                cipher: Cipher::Aes128GcmNoPadding,
+                key_b64: "k1".to_string(),
+                iv_b64: "i1".to_string(),
+                hashes: vec![EncryptedHash {
+                    algo: "sha-256".to_string(),
+                    value_b64: "h1".to_string(),
+                }],
+                sources: vec![url.to_string()],
+            }),
+        };
+        let options = SendMessageOptions {
+            shared_files: vec![original.clone()],
+            ..Default::default()
+        };
+        let (_, stanza) = build_outbound_message("bob@example.com", "chat", "x", &options).unwrap();
+        let MessagingEvent::Message(parsed) = parse(&stanza).expect("parses to event") else {
+            panic!("expected message event");
+        };
+        assert_eq!(parsed.shared_files.len(), 1);
+        let round_tripped = &parsed.shared_files[0];
+        assert_eq!(round_tripped.url, original.url);
+        assert_eq!(round_tripped.encrypted, original.encrypted);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -482,25 +482,6 @@ fn parse_message(el: &Element) -> InboundMessage {
         }
     }
 
-    // XEP-0448: top-level `<encrypted xmlns='urn:xmpp:esfs:0'/>` siblings
-    // carry the cipher/key/iv metadata for any preceding `<file-sharing/>`
-    // entries. Match them up by URL so a `SharedFile` whose `url` already
-    // names the ciphertext gains the metadata needed to decrypt it.
-    for encrypted_el in el
-        .children()
-        .filter(|c| c.name() == "encrypted" && c.ns() == NS_ENCRYPTED_FILE)
-    {
-        let Some(encrypted) = xep_encrypted_file::parse_encrypted_element(encrypted_el) else {
-            continue;
-        };
-        let match_idx = shared_files
-            .iter()
-            .position(|f| encrypted.sources.iter().any(|src| src == &f.url));
-        if let Some(idx) = match_idx {
-            shared_files[idx].encrypted = Some(encrypted);
-        }
-    }
-
     // XEP-0447 / XEP-0363: also check <sims> children for file sharing
     for sims_el in el.children().filter(|c| c.ns() == NS_SIMS) {
         for source_el in sims_el.children() {
@@ -524,6 +505,47 @@ fn parse_message(el: &Element) -> InboundMessage {
                         encrypted: None,
                     });
                 }
+            }
+        }
+    }
+
+    // XEP-0448: top-level `<encrypted xmlns='urn:xmpp:esfs:0'/>` siblings
+    // carry the cipher/key/iv metadata for the file-sharing entries
+    // collected above (XEP-0447 file-sharing AND legacy XEP-0385 SIMS).
+    // Match by URL so a `SharedFile` whose `url` already names the
+    // ciphertext gains the metadata needed to decrypt it; if multiple
+    // entries reference the same source URL (rare but legal — same blob
+    // shared twice in one stanza) every one of them is annotated so none
+    // render broken.
+    for encrypted_el in el
+        .children()
+        .filter(|c| c.name() == "encrypted" && c.ns() == NS_ENCRYPTED_FILE)
+    {
+        let Some(encrypted) = xep_encrypted_file::parse_encrypted_element(encrypted_el) else {
+            continue;
+        };
+        let mut matched = false;
+        for file in shared_files.iter_mut() {
+            if encrypted.sources.iter().any(|src| src == &file.url) {
+                file.encrypted = Some(encrypted.clone());
+                matched = true;
+            }
+        }
+        // If no matching `<file-sharing/>` (or `<sims>`) sibling exists,
+        // synthesise one from the encrypted envelope's first source so
+        // the recipient still sees the attachment.
+        if !matched {
+            if let Some(url) = encrypted.sources.first().cloned() {
+                shared_files.push(SharedFile {
+                    url,
+                    name: None,
+                    media_type: None,
+                    size: None,
+                    width: None,
+                    height: None,
+                    disposition: SharedFileDisposition::Attachment,
+                    encrypted: Some(encrypted),
+                });
             }
         }
     }
@@ -2007,6 +2029,76 @@ mod tests {
             panic!("expected message event");
         };
         assert!(parsed.shared_files[0].encrypted.is_none());
+    }
+
+    #[test]
+    fn parse_message_attaches_encrypted_metadata_to_sims_share() {
+        // SIMS-style (XEP-0385) shares are collected after `<file-sharing/>`
+        // entries, so the XEP-0448 sibling matching must run last to cover
+        // them too. Regression guard for the original PR review feedback.
+        let url = "https://files.example.com/sims-blob.enc";
+        let xml = format!(
+            "<message xmlns='jabber:client' type='chat' from='bob@example.com' id='m1'>\
+               <body>see attached</body>\
+               <reference xmlns='urn:xmpp:reference:0' type='data' \
+                          uri='{url}' begin='0' end='0'>\
+                 <media-sharing xmlns='urn:xmpp:sims:1'>\
+                   <sources>\
+                     <reference xmlns='urn:xmpp:reference:0' type='data' url='{url}'/>\
+                   </sources>\
+                 </media-sharing>\
+               </reference>\
+               <encrypted xmlns='urn:xmpp:esfs:0' \
+                          cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>\
+                 <key>a2V5</key>\
+                 <iv>aXY=</iv>\
+                 <sources xmlns='urn:xmpp:sfs:0'>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' target='{url}'/>\
+                 </sources>\
+               </encrypted>\
+             </message>"
+        );
+        let el: Element = xml.parse().expect("valid xml");
+        let MessagingEvent::Message(parsed) = parse(&el).expect("parses to event") else {
+            panic!("expected message event");
+        };
+        let with_url = parsed
+            .shared_files
+            .iter()
+            .find(|f| f.url == url)
+            .expect("sims-derived shared file present");
+        assert!(
+            with_url.encrypted.is_some(),
+            "sims-derived shared file gained xep-0448 metadata"
+        );
+    }
+
+    #[test]
+    fn parse_message_synthesises_share_for_orphan_encrypted_sibling() {
+        // A peer that only emits `<encrypted/>` (skipping the redundant
+        // `<file-sharing/>`) should still surface as a shared file so the
+        // chat UI can render it.
+        let url = "https://files.example.com/orphan.enc";
+        let xml = format!(
+            "<message xmlns='jabber:client' type='chat' from='bob@example.com' id='m1'>\
+               <body>orphan</body>\
+               <encrypted xmlns='urn:xmpp:esfs:0' \
+                          cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding:0'>\
+                 <key>a2V5</key>\
+                 <iv>aXY=</iv>\
+                 <sources xmlns='urn:xmpp:sfs:0'>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' target='{url}'/>\
+                 </sources>\
+               </encrypted>\
+             </message>"
+        );
+        let el: Element = xml.parse().expect("valid xml");
+        let MessagingEvent::Message(parsed) = parse(&el).expect("parses to event") else {
+            panic!("expected message event");
+        };
+        assert_eq!(parsed.shared_files.len(), 1);
+        assert_eq!(parsed.shared_files[0].url, url);
+        assert!(parsed.shared_files[0].encrypted.is_some());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/xep/encrypted_file.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/encrypted_file.rs
@@ -1,0 +1,270 @@
+//! XEP-0448: Encryption for Stateless File Sharing.
+//!
+//! Layers end-to-end encryption metadata over XEP-0447 file sharing. The
+//! ciphertext lives at the HTTP source URL (typically a XEP-0363 slot), and
+//! the sender publishes the symmetric `cipher`/`key`/`iv`/`hashes` needed to
+//! decrypt it once downloaded.
+//!
+//! Wire format:
+//!
+//! ```xml
+//! <encrypted xmlns='urn:xmpp:esfs:0' cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>
+//!   <key>BASE64(key)</key>
+//!   <iv>BASE64(iv)</iv>
+//!   <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>BASE64(digest)</hash>
+//!   <sources xmlns='urn:xmpp:sfs:0'>
+//!     <url-data xmlns='http://jabber.org/protocol/url-data'
+//!               target='https://files.example.com/blob.enc'/>
+//!   </sources>
+//! </encrypted>
+//! ```
+//!
+//! Waddle's chat sends `<encrypted/>` as a top-level child of `<message/>`,
+//! a sibling of the matching `<file-sharing/>` element (which carries the
+//! plaintext metadata such as filename, size, media-type and dimensions).
+
+use minidom::Element;
+
+/// XEP-0448 envelope namespace.
+pub const NS_ESFS: &str = "urn:xmpp:esfs:0";
+/// XEP-0300 hash element namespace.
+pub const NS_HASHES: &str = "urn:xmpp:hashes:2";
+/// XEP-0447 stateless file sharing namespace (re-used here for `<sources/>`).
+pub const NS_SFS: &str = "urn:xmpp:sfs:0";
+/// XEP-0103 URL data namespace (re-used here for `<url-data/>` source URLs).
+pub const NS_URL_DATA: &str = "http://jabber.org/protocol/url-data";
+
+/// Symmetric ciphers Waddle understands end-to-end. The XEP leaves the cipher
+/// set open; we keep this closed enum to refuse unknown values at the type
+/// boundary instead of dragging strings through the rest of the system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Cipher {
+    /// `urn:xmpp:ciphers:aes-128-gcm-nopadding:0`
+    Aes128GcmNoPadding,
+    /// `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`
+    Aes256GcmNoPadding,
+}
+
+impl Cipher {
+    pub fn as_uri(self) -> &'static str {
+        match self {
+            Cipher::Aes128GcmNoPadding => "urn:xmpp:ciphers:aes-128-gcm-nopadding:0",
+            Cipher::Aes256GcmNoPadding => "urn:xmpp:ciphers:aes-256-gcm-nopadding:0",
+        }
+    }
+
+    pub fn from_uri(raw: &str) -> Option<Cipher> {
+        Some(match raw {
+            "urn:xmpp:ciphers:aes-128-gcm-nopadding:0" => Cipher::Aes128GcmNoPadding,
+            "urn:xmpp:ciphers:aes-256-gcm-nopadding:0" => Cipher::Aes256GcmNoPadding,
+            _ => return None,
+        })
+    }
+}
+
+/// A `<hash xmlns='urn:xmpp:hashes:2' algo='…'>BASE64</hash>` entry nested
+/// inside the encrypted envelope. Algorithms are kept as `String` to allow
+/// servers and peers to advertise hashes Waddle does not itself produce.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedHash {
+    pub algo: String,
+    pub value_b64: String,
+}
+
+/// A typed encrypted stateless file-sharing envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedFile {
+    pub cipher: Cipher,
+    /// Base64-encoded symmetric key.
+    pub key_b64: String,
+    /// Base64-encoded initialization vector / nonce.
+    pub iv_b64: String,
+    /// One or more content hashes (typically the ciphertext digest).
+    pub hashes: Vec<EncryptedHash>,
+    /// HTTPS URLs the ciphertext can be fetched from.
+    pub sources: Vec<String>,
+}
+
+/// Build the `<encrypted/>` payload element from a typed value. Returns
+/// `None` if no source URLs were provided — XEP-0448 mandates at least one.
+pub fn build_encrypted_element(enc: &EncryptedFile) -> Option<Element> {
+    if enc.sources.is_empty() {
+        return None;
+    }
+    let mut builder = Element::builder("encrypted", NS_ESFS).attr("cipher", enc.cipher.as_uri());
+    builder = builder.append(
+        Element::builder("key", NS_ESFS)
+            .append(enc.key_b64.as_str())
+            .build(),
+    );
+    builder = builder.append(
+        Element::builder("iv", NS_ESFS)
+            .append(enc.iv_b64.as_str())
+            .build(),
+    );
+    for hash in &enc.hashes {
+        builder = builder.append(
+            Element::builder("hash", NS_HASHES)
+                .attr("algo", hash.algo.as_str())
+                .append(hash.value_b64.as_str())
+                .build(),
+        );
+    }
+    let mut sources = Element::builder("sources", NS_SFS);
+    for url in &enc.sources {
+        sources = sources.append(
+            Element::builder("url-data", NS_URL_DATA)
+                .attr("target", url.as_str())
+                .build(),
+        );
+    }
+    builder = builder.append(sources.build());
+    Some(builder.build())
+}
+
+/// Parse an `<encrypted/>` element. Returns `None` if the element is in the
+/// wrong namespace, advertises a cipher Waddle does not implement, or is
+/// missing any of the required `<key>`, `<iv>`, or `<sources>` children.
+pub fn parse_encrypted_element(elem: &Element) -> Option<EncryptedFile> {
+    if !is_encrypted_element(elem) {
+        return None;
+    }
+    let cipher = Cipher::from_uri(elem.attr("cipher")?)?;
+    let key_b64 = elem.get_child("key", NS_ESFS)?.text();
+    let iv_b64 = elem.get_child("iv", NS_ESFS)?.text();
+
+    let mut hashes = Vec::new();
+    for child in elem.children() {
+        if child.is("hash", NS_HASHES) {
+            let Some(algo) = child.attr("algo") else {
+                continue;
+            };
+            hashes.push(EncryptedHash {
+                algo: algo.to_string(),
+                value_b64: child.text(),
+            });
+        }
+    }
+
+    let sources_elem = elem.get_child("sources", NS_SFS)?;
+    let mut sources = Vec::new();
+    for child in sources_elem.children() {
+        if child.is("url-data", NS_URL_DATA) {
+            if let Some(target) = child.attr("target") {
+                sources.push(target.to_string());
+            }
+        }
+    }
+    if sources.is_empty() {
+        return None;
+    }
+
+    Some(EncryptedFile {
+        cipher,
+        key_b64,
+        iv_b64,
+        hashes,
+        sources,
+    })
+}
+
+/// Returns `true` for `<encrypted xmlns='urn:xmpp:esfs:0'/>`.
+pub fn is_encrypted_element(elem: &Element) -> bool {
+    elem.is("encrypted", NS_ESFS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> EncryptedFile {
+        EncryptedFile {
+            cipher: Cipher::Aes256GcmNoPadding,
+            key_b64: "a2V5".to_string(),
+            iv_b64: "aXY=".to_string(),
+            hashes: vec![EncryptedHash {
+                algo: "sha-256".to_string(),
+                value_b64: "aGFzaA==".to_string(),
+            }],
+            sources: vec!["https://files.example.com/blob.enc".to_string()],
+        }
+    }
+
+    #[test]
+    fn round_trips_through_minidom() {
+        let enc = sample();
+        let elem = build_encrypted_element(&enc).expect("at least one source");
+        let parsed = parse_encrypted_element(&elem).expect("round-trip parses");
+        assert_eq!(parsed, enc);
+    }
+
+    #[test]
+    fn build_returns_none_when_no_sources() {
+        let enc = EncryptedFile {
+            cipher: Cipher::Aes256GcmNoPadding,
+            key_b64: "a2V5".to_string(),
+            iv_b64: "aXY=".to_string(),
+            hashes: Vec::new(),
+            sources: Vec::new(),
+        };
+        assert!(build_encrypted_element(&enc).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_unknown_cipher() {
+        let xml = "<encrypted xmlns='urn:xmpp:esfs:0' \
+                       cipher='urn:xmpp:ciphers:rot13:0'>\
+                     <key>k</key><iv>v</iv>\
+                     <sources xmlns='urn:xmpp:sfs:0'>\
+                       <url-data xmlns='http://jabber.org/protocol/url-data' target='https://x'/>\
+                     </sources>\
+                   </encrypted>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_encrypted_element(&elem).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_missing_sources() {
+        let xml = "<encrypted xmlns='urn:xmpp:esfs:0' \
+                       cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>\
+                     <key>k</key><iv>v</iv>\
+                     <sources xmlns='urn:xmpp:sfs:0'/>\
+                   </encrypted>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_encrypted_element(&elem).is_none());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_namespace() {
+        let xml = "<encrypted xmlns='urn:waddle:other'/>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_encrypted_element(&elem).is_none());
+        assert!(!is_encrypted_element(&elem));
+    }
+
+    #[test]
+    fn cipher_round_trips() {
+        for c in [Cipher::Aes128GcmNoPadding, Cipher::Aes256GcmNoPadding] {
+            assert_eq!(Cipher::from_uri(c.as_uri()), Some(c));
+        }
+        assert!(Cipher::from_uri("urn:xmpp:ciphers:rot13:0").is_none());
+    }
+
+    #[test]
+    fn parses_multiple_hashes() {
+        let xml = "<encrypted xmlns='urn:xmpp:esfs:0' \
+                       cipher='urn:xmpp:ciphers:aes-128-gcm-nopadding:0'>\
+                     <key>k</key><iv>v</iv>\
+                     <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>aaa</hash>\
+                     <hash xmlns='urn:xmpp:hashes:2' algo='sha3-256'>bbb</hash>\
+                     <sources xmlns='urn:xmpp:sfs:0'>\
+                       <url-data xmlns='http://jabber.org/protocol/url-data' target='https://x'/>\
+                     </sources>\
+                   </encrypted>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let parsed = parse_encrypted_element(&elem).expect("parses");
+        assert_eq!(parsed.hashes.len(), 2);
+        assert_eq!(parsed.hashes[0].algo, "sha-256");
+        assert_eq!(parsed.hashes[1].algo, "sha3-256");
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/xep/encrypted_file.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/encrypted_file.rs
@@ -130,8 +130,12 @@ pub fn parse_encrypted_element(elem: &Element) -> Option<EncryptedFile> {
         return None;
     }
     let cipher = Cipher::from_uri(elem.attr("cipher")?)?;
-    let key_b64 = elem.get_child("key", NS_ESFS)?.text();
-    let iv_b64 = elem.get_child("iv", NS_ESFS)?.text();
+    // XML pretty-printing can introduce surrounding whitespace inside
+    // `<key/>`, `<iv/>`, and `<hash/>` elements. Strict base64 decoders
+    // (including the browser's `atob`) reject that whitespace, so trim
+    // before handing the value off.
+    let key_b64 = elem.get_child("key", NS_ESFS)?.text().trim().to_string();
+    let iv_b64 = elem.get_child("iv", NS_ESFS)?.text().trim().to_string();
 
     let mut hashes = Vec::new();
     for child in elem.children() {
@@ -141,7 +145,7 @@ pub fn parse_encrypted_element(elem: &Element) -> Option<EncryptedFile> {
             };
             hashes.push(EncryptedHash {
                 algo: algo.to_string(),
-                value_b64: child.text(),
+                value_b64: child.text().trim().to_string(),
             });
         }
     }
@@ -248,6 +252,27 @@ mod tests {
             assert_eq!(Cipher::from_uri(c.as_uri()), Some(c));
         }
         assert!(Cipher::from_uri("urn:xmpp:ciphers:rot13:0").is_none());
+    }
+
+    #[test]
+    fn parse_trims_whitespace_around_base64_text() {
+        // Pretty-printed XML often wraps the base64 payload with newlines
+        // and indentation; the resulting text content must round-trip
+        // cleanly to a strict base64 decoder.
+        let xml = "<encrypted xmlns='urn:xmpp:esfs:0' \
+                       cipher='urn:xmpp:ciphers:aes-256-gcm-nopadding:0'>\
+                     <key>\n  a2V5\n</key>\
+                     <iv>\n  aXY=\n</iv>\
+                     <hash xmlns='urn:xmpp:hashes:2' algo='sha-256'>\n  aGFzaA==\n</hash>\
+                     <sources xmlns='urn:xmpp:sfs:0'>\
+                       <url-data xmlns='http://jabber.org/protocol/url-data' target='https://x'/>\
+                     </sources>\
+                   </encrypted>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let parsed = parse_encrypted_element(&elem).expect("parses");
+        assert_eq!(parsed.key_b64, "a2V5");
+        assert_eq!(parsed.iv_b64, "aXY=");
+        assert_eq!(parsed.hashes[0].value_b64, "aGFzaA==");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/mod.rs
@@ -5,5 +5,6 @@
 //! namespaces or attribute names at call sites — everything flows through the
 //! typed module.
 
+pub mod encrypted_file;
 pub mod reply;
 pub mod thread;


### PR DESCRIPTION
## Context

Since #332 swapped stanza.js for the Rust `waddle-xmpp-client` WASM build, every shared file/image rendered as a broken icon for the recipient. Uploads themselves still hit the XEP-0363 slot fine; the regression is on the **wire shape** — XEP-0448 (Encryption for Stateless File Sharing, `urn:xmpp:esfs:0`) metadata was dropped at every layer between `OutboundFileAttachment.encrypted` in the chat and the outbound message stanza, and never extracted on the inbound side either. Recipients downloaded ciphertext and tried to render it as an image.

The XEP-0448 server module already exists (`server/crates/waddle-xmpp/src/xep/xep0448.rs`); the client never gained an equivalent.

## Changes

End-to-end fix that plumbs a typed encrypted-file envelope through every layer:

- **`waddle-xmpp-client`** — new `xep::encrypted_file` module mirroring the server's XEP-0448 helpers (`Cipher`, `EncryptedFile`, `EncryptedHash`, build + parse + namespace constants) with its own dedicated unit tests.
- **`messaging::SharedFile`** — gains `Option<EncryptedFile>`. `build_outbound_message` emits an `<encrypted xmlns='urn:xmpp:esfs:0'/>` sibling next to the existing `<file-sharing/>` when set; `parse_message` matches inbound `<encrypted/>` siblings to `SharedFile`s by URL so MAM playback also renders.
- **WASM bridge (`waddle-xmpp-client-wasm`)** — new `WaddleEncryptedFile` / `WaddleEncryptedFileHash` Serde structs; outbound and inbound conversions move encryption metadata in both directions across the JS boundary.
- **FFI (`waddle-xmpp-client-ffi`)** — the same fields on `WaddleSharedFile` and `.udl` dictionary so iOS does not silently drop encryption metadata when consuming the same client.
- **Chat (`chat/src/lib/xmpp`)** — `mapOptsToWasm` passes `OutboundFileAttachment.encrypted` into the WASM call; `sharedFileFromWasm` surfaces inbound encryption metadata so the existing `decryptEncryptedAttachment` helper renders the image.

## Tests

- 7 new XEP-0448 module-level tests in `xep::encrypted_file`
- 3 messaging integration tests covering build, parse, and build→parse round-trip
- 3 new bridge round-trip tests in `waddle-xmpp-client-wasm`
- All existing tests continue to pass (`cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi`, `bun test` in `chat/`).
- `cargo clippy -- -D warnings` clean across all three Rust crates; `cargo fmt --check` clean.
- `bun run lint` (knip) clean.

## Test plan

- [x] `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm`
- [x] `cd chat && bun test && bun run lint`
- [x] `cargo clippy --all-targets -- -D warnings` on touched crates
- [ ] Manual: send a JPEG to a peer and confirm the recipient renders it; reload the sender and confirm legacy/MAM messages also render
- [ ] Verify outbound stanza contains `<encrypted xmlns='urn:xmpp:esfs:0' …>` with `<key>`, `<iv>`, `<sources>`