### PR TITLE
fix(server): close SM lifecycle races on detach drain + claim janitor (#209)

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -880,6 +880,31 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         .await
     }
 
+    async fn release_row_if_session(
+        &self,
+        id: &PendingRowId,
+        expected_session: &SmSessionId,
+    ) -> Result<u64, PendingStorageError> {
+        // Conditional release for the claim-expiry janitor (issue #209
+        // finding #9). The (row_id, session) snapshot returned by
+        // `list_orphaned_claims` can be stale by the time the janitor
+        // releases — a fresh bind on a different recipient session may
+        // have re-claimed the row under a now-live session. Atomically
+        // re-validate `flushed_in_session = ?` so we leave that fresh
+        // claim alone instead of clearing `outbound_sequence` on a
+        // row some other session is actively SM-acking.
+        self.execute(
+            "UPDATE pending_delivery SET flushed_in_session = NULL, \
+                                          outbound_sequence = NULL \
+             WHERE row_id = ? AND flushed_in_session = ?",
+            crate::db_params![
+                id.as_str().to_string(),
+                expected_session.as_str().to_string()
+            ],
+        )
+        .await
+    }
+
     async fn record_pushed_at(
         &self,
         id: &PendingRowId,
@@ -1325,6 +1350,78 @@ mod tests {
         let removed = storage.delete_claimed(&session2).await.unwrap();
         assert_eq!(removed, 3);
         assert_eq!(storage.count(&recipient).await.unwrap(), 0);
+    }
+
+    /// Issue #209 finding #9: the libSQL/Postgres
+    /// `release_row_if_session` override MUST be atomic — the
+    /// `WHERE row_id = ? AND flushed_in_session = ?` predicate
+    /// re-validates inside the same UPDATE so a fresh bind that
+    /// re-claimed the row in the snapshot-vs-release window survives
+    /// untouched.
+    #[tokio::test]
+    async fn db_storage_release_row_if_session_skips_when_session_changed() {
+        let storage = DatabasePendingDeliveryStorage::open(None, QuotaPolicy::Unlimited)
+            .await
+            .unwrap();
+        let recipient = bare("alice@example.com");
+        storage
+            .insert(transient_row("alice@example.com", "wedge-target"))
+            .await
+            .unwrap();
+
+        let dead_session = SmSessionId::new("sm-stream-dead");
+        let live_session = SmSessionId::new("sm-stream-live");
+
+        // Claim under dead_session and stamp a sequence (simulates a
+        // row mid-SM-lifecycle when the session detached).
+        let claimed = storage
+            .claim_for_session(&recipient, &dead_session)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        let row_id = claimed[0].id.clone();
+        storage.record_pushed_at(&row_id, 7).await.unwrap();
+
+        // Race window: dead_session expires, but before the janitor
+        // releases, a fresh bind re-claims the row under live_session.
+        // Simulated via the conditional-SQL path: release the dead
+        // claim then re-claim under live.
+        storage.release_claim(&dead_session).await.unwrap();
+        let reclaimed = storage
+            .claim_for_session(&recipient, &live_session)
+            .await
+            .unwrap();
+        assert_eq!(reclaimed.len(), 1);
+        assert_eq!(reclaimed[0].id, row_id);
+        storage.record_pushed_at(&row_id, 11).await.unwrap();
+
+        // Now the janitor (operating on its stale snapshot) calls
+        // release_row_if_session with the dead_session predicate.
+        // The atomic UPDATE WHERE flushed_in_session = dead_session
+        // matches zero rows — the fresh claim survives untouched.
+        let result = storage
+            .release_row_if_session(&row_id, &dead_session)
+            .await
+            .unwrap();
+        assert_eq!(
+            result, 0,
+            "conditional release MUST NOT clear a fresh claim under a different session"
+        );
+
+        let after = storage.list(&recipient).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].flushed_in_session.as_ref(), Some(&live_session));
+        assert_eq!(after[0].outbound_sequence, Some(11));
+
+        // Sanity: same-session release does fire.
+        let cleared = storage
+            .release_row_if_session(&row_id, &live_session)
+            .await
+            .unwrap();
+        assert_eq!(cleared, 1);
+        let after = storage.list(&recipient).await.unwrap();
+        assert!(after[0].flushed_in_session.is_none());
+        assert!(after[0].outbound_sequence.is_none());
     }
 
     #[tokio::test]
@@ -1838,6 +1935,95 @@ mod tests {
         assert!(dead_b.flushed_in_session.is_none());
         let unclaimed = by_body.get("unclaimed").expect("unclaimed present");
         assert!(unclaimed.flushed_in_session.is_none());
+    }
+
+    /// Issue #209 finding #9: between the janitor's `list_orphaned_claims`
+    /// snapshot and the per-row release, a fresh bind on a different
+    /// recipient session can re-claim the row under a now-live session.
+    /// `release_row_if_session` MUST atomically re-validate the
+    /// `flushed_in_session = ?` predicate so the fresh claim survives.
+    /// Otherwise the new session's SM ack would skip the row (filters
+    /// `outbound_sequence IS NOT NULL`) and we'd wedge.
+    #[tokio::test]
+    async fn release_row_if_session_skips_when_a_fresh_claim_replaced_the_dead_session() {
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        let alice = bare("alice@example.com");
+
+        storage
+            .insert(transient_row("alice@example.com", "wedge-target"))
+            .await
+            .unwrap();
+
+        let dead_session = SmSessionId::new("sm-stream-dead");
+        let live_session = SmSessionId::new("sm-stream-fresh-bind");
+
+        // Claim + sequence-stamp under dead_session.
+        let claimed = storage
+            .claim_for_session(&alice, &dead_session)
+            .await
+            .unwrap();
+        assert_eq!(claimed.len(), 1);
+        let row_id = claimed[0].id.clone();
+        storage.record_pushed_at(&row_id, 7).await.unwrap();
+
+        // Race: dead_session expires; before the janitor releases, a
+        // fresh bind re-claims the row under live_session.
+        storage.release_claim(&dead_session).await.unwrap();
+        let reclaimed = storage
+            .claim_for_session(&alice, &live_session)
+            .await
+            .unwrap();
+        assert_eq!(reclaimed.len(), 1);
+        assert_eq!(reclaimed[0].id, row_id);
+        storage.record_pushed_at(&row_id, 11).await.unwrap();
+
+        // Janitor's conditional release on the stale (dead_session)
+        // snapshot — must no-op.
+        let result = storage
+            .release_row_if_session(&row_id, &dead_session)
+            .await
+            .unwrap();
+        assert_eq!(
+            result, 0,
+            "conditional release MUST be a no-op when the row was re-claimed under a different session"
+        );
+
+        let after = storage.list(&alice).await.unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].flushed_in_session.as_ref(), Some(&live_session));
+        assert_eq!(after[0].outbound_sequence, Some(11));
+    }
+
+    /// Issue #209 finding #9 happy path: when the row is still
+    /// claimed by the dead session at release time,
+    /// `release_row_if_session` clears the claim normally.
+    #[tokio::test]
+    async fn release_row_if_session_releases_when_claim_unchanged() {
+        let storage: Arc<dyn PendingDeliveryStorage> =
+            Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+        let alice = bare("alice@example.com");
+        storage
+            .insert(transient_row("alice@example.com", "still-dead"))
+            .await
+            .unwrap();
+        let dead_session = SmSessionId::new("sm-stream-dead");
+        let claimed = storage
+            .claim_for_session(&alice, &dead_session)
+            .await
+            .unwrap();
+        let row_id = claimed[0].id.clone();
+        storage.record_pushed_at(&row_id, 3).await.unwrap();
+
+        let result = storage
+            .release_row_if_session(&row_id, &dead_session)
+            .await
+            .unwrap();
+        assert_eq!(result, 1);
+
+        let after = storage.list(&alice).await.unwrap();
+        assert!(after[0].flushed_in_session.is_none());
+        assert!(after[0].outbound_sequence.is_none());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1525,26 +1525,41 @@ async fn create_router(
                 if orphans.is_empty() {
                     continue;
                 }
-                let count = orphans.len();
+                let candidate_count = orphans.len();
+                let mut released = 0u64;
+                let mut skipped_reclaimed = 0u64;
                 for (row_id, session) in orphans {
-                    if let Err(error) = state
+                    // Issue #209 finding #9: re-validate the row is
+                    // still claimed by the session we believed dead at
+                    // snapshot time. If a fresh bind has re-claimed it
+                    // under a now-live session in the gap, leave it
+                    // alone — clearing `outbound_sequence` would
+                    // wedge the new claim because the new session's
+                    // SM ack filters `outbound_sequence IS NOT NULL`.
+                    match state
                         .deps
                         .protocol
                         .pending_delivery_storage
-                        .release_row(&row_id)
+                        .release_row_if_session(&row_id, &session)
                         .await
                     {
-                        warn!(
-                            row_id = %row_id,
-                            session = %session,
-                            error = %error,
-                            "claim-expiry janitor: release_row failed; row stays \
-                             claimed and will be retried next sweep"
-                        );
+                        Ok(0) => skipped_reclaimed += 1,
+                        Ok(_) => released += 1,
+                        Err(error) => {
+                            warn!(
+                                row_id = %row_id,
+                                session = %session,
+                                error = %error,
+                                "claim-expiry janitor: release_row_if_session failed; row stays \
+                                 claimed and will be retried next sweep"
+                            );
+                        }
                     }
                 }
                 info!(
-                    count,
+                    candidate_count,
+                    released,
+                    skipped_reclaimed,
                     "claim-expiry janitor: released orphaned pending_delivery claims"
                 );
             }

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -712,14 +712,49 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                             .record_pushed_at(&row_id, sequence)
                                             .await
                                         {
+                                            // Issue #209 finding #10: previously
+                                            // we only logged here. The result was
+                                            // a wedged row — `outbound_sequence`
+                                            // stayed NULL (so SM ack's
+                                            // `delete_acked_through` skipped it),
+                                            // the row remained claimed by the
+                                            // live session, and on session
+                                            // death + next-presence flush, the
+                                            // row re-flushed and duplicate-
+                                            // delivered. Delete the durable row
+                                            // instead so the in-memory SM unacked
+                                            // queue (already populated above) is
+                                            // the sole owner: SM ack clears it
+                                            // on success, Q6 promotion creates
+                                            // a fresh `pending_delivery` row on
+                                            // session expiry. Either path is
+                                            // bounded and dedup-safe.
                                             warn!(
                                                 row_id = %row_id,
                                                 sequence,
                                                 error = %error,
                                                 "pending_delivery record_pushed_at \
-                                                 failed; row remains claimed but unsequenced \
-                                                 and will be released on session death"
+                                                 failed; deleting row to avoid wedge \
+                                                 (issue #209 finding #10). The SM \
+                                                 unacked queue + Q6 promotion become \
+                                                 the sole owner of this stanza."
                                             );
+                                            if let Err(delete_error) = state
+                                                .deps
+                                                .protocol
+                                                .pending_delivery_storage
+                                                .delete_row(&row_id)
+                                                .await
+                                            {
+                                                warn!(
+                                                    row_id = %row_id,
+                                                    error = %delete_error,
+                                                    "pending_delivery delete_row \
+                                                     (record_pushed_at fallback) failed; \
+                                                     row may flush again on next presence \
+                                                     (XEP-0359 client dedup mitigates)"
+                                                );
+                                            }
                                         }
                                     }
                                 }
@@ -976,10 +1011,19 @@ async fn drain_outbound_into_replay(
         let receipt_at = outbound_stanza
             .pending_row_original_receipt_at
             .unwrap_or_else(chrono::Utc::now);
+        let pending_row_id = outbound_stanza.pending_row_id.clone();
         match outbound_stanza.kind {
             DeliveryKind::DirectFrame => {
                 let xml = stanza_to_xml(&outbound_stanza.stanza);
-                record_drained_xml(state, sm_state, detached_stream_id, xml, receipt_at).await;
+                record_drained_xml(
+                    state,
+                    sm_state,
+                    detached_stream_id,
+                    xml,
+                    receipt_at,
+                    pending_row_id,
+                )
+                .await;
             }
             DeliveryKind::PeerStanza => {
                 let Some(sm) = sm_borrow.as_deref_mut() else {
@@ -993,8 +1037,23 @@ async fn drain_outbound_into_replay(
                     outbound_stanza.stanza,
                 )));
                 let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
+                // PeerStanza paths produce zero-or-many frames per
+                // input; only the first frame inherits the pending
+                // row binding (the source pending_delivery row
+                // produces exactly one outbound frame per push, but
+                // be defensive here in case future handlers fan out).
+                let mut row_id_for_first = pending_row_id.clone();
                 for xml in frames {
-                    record_drained_xml(state, sm_state, detached_stream_id, xml, receipt_at).await;
+                    let row_for_this = row_id_for_first.take();
+                    record_drained_xml(
+                        state,
+                        sm_state,
+                        detached_stream_id,
+                        xml,
+                        receipt_at,
+                        row_for_this,
+                    )
+                    .await;
                 }
             }
         }
@@ -1007,19 +1066,81 @@ async fn drain_outbound_into_replay(
 /// `DirectFrame` and per-frame `PeerStanza` arms in
 /// [`drain_outbound_into_replay`] can share the same recording
 /// contract.
+///
+/// `pending_row_id` is `Some` when this drained frame originated as
+/// a `pending_delivery` flush replay; in that case we MUST stamp the
+/// SM-assigned `outbound_sequence` onto the source row via
+/// [`record_pushed_at`] so a subsequent `<a h>` ack from the
+/// resuming session can range-delete it. Without this binding the
+/// row stays claimed with a NULL sequence, the SM ack skips it,
+/// the session expires through Q6, and the same logical stanza
+/// re-flushes on next presence — duplicate delivery. (Issue #209
+/// finding #2.)
 async fn record_drained_xml(
     state: &WebSocketState,
     sm_state: &mut StreamManagementState,
     detached_stream_id: Option<&str>,
     xml: String,
     original_receipt_at: chrono::DateTime<chrono::Utc>,
+    pending_row_id: Option<waddle_xmpp::pending_delivery::PendingRowId>,
 ) {
     if !sm_state.enabled || !is_countable_stanza(&xml) {
+        // SM disabled or non-countable: the drained frame won't enter
+        // the replay queue, so SM ack will never delete the source
+        // row. Release the claim immediately so the next presence
+        // flush (or claim-expiry janitor) can re-claim and re-flush
+        // it. Without this the row would wedge until claim-expiry.
+        if let Some(row_id) = pending_row_id {
+            if let Err(error) = state
+                .deps
+                .protocol
+                .pending_delivery_storage
+                .release_row(&row_id)
+                .await
+            {
+                warn!(
+                    row_id = %row_id,
+                    %error,
+                    "pending_delivery release_row (drained non-countable / SM-disabled) failed"
+                );
+            }
+        }
         return;
     }
     sm_state.record_outbound_with_receipt_at(xml.clone(), original_receipt_at);
+    let sequence = sm_state.outbound_count;
+    if let Some(row_id) = pending_row_id.as_ref() {
+        if let Err(error) = state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .record_pushed_at(row_id, sequence)
+            .await
+        {
+            warn!(
+                row_id = %row_id,
+                sequence,
+                %error,
+                "pending_delivery record_pushed_at (drain path) failed; \
+                 deleting row to avoid wedge — SM unacked queue + Q6 \
+                 promotion become the sole owner (issue #209 finding #2)"
+            );
+            if let Err(delete_error) = state
+                .deps
+                .protocol
+                .pending_delivery_storage
+                .delete_row(row_id)
+                .await
+            {
+                warn!(
+                    row_id = %row_id,
+                    error = %delete_error,
+                    "pending_delivery delete_row (drain record_pushed_at fallback) failed"
+                );
+            }
+        }
+    }
     if let Some(stream_id) = detached_stream_id {
-        let sequence = sm_state.outbound_count;
         if let Err(error) = state
             .deps
             .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -721,39 +721,92 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                             // live session, and on session
                                             // death + next-presence flush, the
                                             // row re-flushed and duplicate-
-                                            // delivered. Delete the durable row
-                                            // instead so the in-memory SM unacked
-                                            // queue (already populated above) is
-                                            // the sole owner: SM ack clears it
-                                            // on success, Q6 promotion creates
-                                            // a fresh `pending_delivery` row on
-                                            // session expiry. Either path is
-                                            // bounded and dedup-safe.
-                                            warn!(
-                                                row_id = %row_id,
-                                                sequence,
-                                                error = %error,
-                                                "pending_delivery record_pushed_at \
-                                                 failed; deleting row to avoid wedge \
-                                                 (issue #209 finding #10). The SM \
-                                                 unacked queue + Q6 promotion become \
-                                                 the sole owner of this stanza."
-                                            );
-                                            if let Err(delete_error) = state
-                                                .deps
-                                                .protocol
-                                                .pending_delivery_storage
-                                                .delete_row(&row_id)
-                                                .await
-                                            {
+                                            // delivered.
+                                            //
+                                            // Two recovery paths exist; pick by
+                                            // SM resumability (Qodo finding on
+                                            // PR #409 — earlier code unconditionally
+                                            // deleted the durable row, which on a
+                                            // non-resumable SM stream meant no
+                                            // detach/persistence/Q6 path would
+                                            // ever recover the stanza after a
+                                            // disconnect-pre-ack):
+                                            //
+                                            // - Resumable SM: the in-memory
+                                            //   unacked queue (already populated
+                                            //   above) becomes the sole durable
+                                            //   owner via `store_session_atomic`
+                                            //   on detach. Deleting the
+                                            //   `pending_delivery` row is safe
+                                            //   and avoids the wedge — SM ack
+                                            //   clears the in-memory entry on
+                                            //   success, Q6 promotion creates a
+                                            //   fresh row on session expiry.
+                                            // - Non-resumable (or SM-disabled):
+                                            //   `cleanup_connection_shutdown`
+                                            //   does not detach/persist this
+                                            //   session, so the
+                                            //   `pending_delivery` row is the
+                                            //   only durable owner. Release the
+                                            //   claim instead so the next
+                                            //   presence-driven flush can
+                                            //   retry — accept a possible
+                                            //   re-flush (XEP-0359 client
+                                            //   dedup mitigates) over a
+                                            //   permanent loss of the stanza.
+                                            if conn.sm_state.is_resumable() {
                                                 warn!(
                                                     row_id = %row_id,
-                                                    error = %delete_error,
-                                                    "pending_delivery delete_row \
-                                                     (record_pushed_at fallback) failed; \
-                                                     row may flush again on next presence \
-                                                     (XEP-0359 client dedup mitigates)"
+                                                    sequence,
+                                                    error = %error,
+                                                    "pending_delivery record_pushed_at \
+                                                     failed; deleting row (resumable SM \
+                                                     stream — in-memory unacked queue + \
+                                                     Q6 promotion become the sole owner \
+                                                     of this stanza)"
                                                 );
+                                                if let Err(delete_error) = state
+                                                    .deps
+                                                    .protocol
+                                                    .pending_delivery_storage
+                                                    .delete_row(&row_id)
+                                                    .await
+                                                {
+                                                    warn!(
+                                                        row_id = %row_id,
+                                                        error = %delete_error,
+                                                        "pending_delivery delete_row \
+                                                         (record_pushed_at fallback) failed; \
+                                                         row may flush again on next presence \
+                                                         (XEP-0359 client dedup mitigates)"
+                                                    );
+                                                }
+                                            } else {
+                                                warn!(
+                                                    row_id = %row_id,
+                                                    sequence,
+                                                    error = %error,
+                                                    "pending_delivery record_pushed_at \
+                                                     failed; releasing row (non-resumable \
+                                                     SM stream — durable row is the only \
+                                                     recovery path, must NOT be deleted)"
+                                                );
+                                                if let Err(release_error) = state
+                                                    .deps
+                                                    .protocol
+                                                    .pending_delivery_storage
+                                                    .release_row(&row_id)
+                                                    .await
+                                                {
+                                                    warn!(
+                                                        row_id = %row_id,
+                                                        error = %release_error,
+                                                        "pending_delivery release_row \
+                                                         (record_pushed_at fallback) failed; \
+                                                         row stays claimed and will be released \
+                                                         on session death by the claim janitor"
+                                                    );
+                                                }
                                             }
                                         }
                                     }

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -71,6 +71,36 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// push becomes eligible for re-claim on the next flush trigger.
     async fn release_row(&self, id: &PendingRowId) -> Result<u64, PendingStorageError>;
 
+    /// Release a single row only when it is still claimed by
+    /// `expected_session`. Used by the claim-expiry janitor (issue
+    /// #209 finding #9): the (row_id, session) pairs returned by
+    /// [`Self::list_orphaned_claims`] reflect a snapshot of the
+    /// live-set taken seconds ago. Between the snapshot and the
+    /// release, a fresh bind on a different recipient session can
+    /// have re-claimed the row under a now-live session. An
+    /// unconditional `release_row` would clear that fresh claim and
+    /// wedge the row (the new session's SM ack would skip it because
+    /// `outbound_sequence` is NULL).
+    ///
+    /// Returns the number of rows actually updated — `0` when the
+    /// row's `flushed_in_session` no longer matches `expected_session`
+    /// (i.e. someone else re-claimed it; leave it alone) or the row
+    /// has been deleted.
+    ///
+    /// Default impl falls back to the unconditional [`Self::release_row`]
+    /// path so in-memory backends keep working without re-implementing
+    /// the conditional check; the libSQL/Postgres backend overrides
+    /// with `UPDATE … WHERE row_id = ? AND flushed_in_session = ?`
+    /// so the per-row re-validation is atomic with the update.
+    async fn release_row_if_session(
+        &self,
+        id: &PendingRowId,
+        expected_session: &SmSessionId,
+    ) -> Result<u64, PendingStorageError> {
+        let _ = expected_session;
+        self.release_row(id).await
+    }
+
     /// Stamp the XEP-0198 outbound counter value onto a previously-
     /// claimed row, after that row's flush stanza has been pushed
     /// onto the recovering session's outbound queue and assigned its
@@ -286,6 +316,30 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         for queue in guard.values_mut() {
             for row in queue.iter_mut() {
                 if &row.id == id {
+                    row.flushed_in_session = None;
+                    row.outbound_sequence = None;
+                    return Ok(1);
+                }
+            }
+        }
+        Ok(0)
+    }
+
+    async fn release_row_if_session(
+        &self,
+        id: &PendingRowId,
+        expected_session: &SmSessionId,
+    ) -> Result<u64, PendingStorageError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        for queue in guard.values_mut() {
+            for row in queue.iter_mut() {
+                if &row.id == id {
+                    if row.flushed_in_session.as_ref() != Some(expected_session) {
+                        return Ok(0);
+                    }
                     row.flushed_in_session = None;
                     row.outbound_sequence = None;
                     return Ok(1);

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -1377,6 +1377,19 @@ impl InMemorySmSessionRegistry {
         // (shouldn't happen in practice), restart-time
         // `restore_from_persistence` rebuilds the in-memory view
         // from durable state.
+        //
+        // BUT: pre-check session eligibility before persisting, so a
+        // call for an unknown / expired stream_id doesn't durably
+        // append a row that has no owning session and can never be
+        // cleaned up via `delete_session` (Qodo finding on PR #409 —
+        // some persistence backends accept `append_unacked` for any
+        // stream_id, leaving orphan rows). Locks are dropped before
+        // any `.await` so persistence I/O never holds a lock.
+        let eligible = self.detached_session_is_live(stream_id)?;
+        if !eligible {
+            return Ok(false);
+        }
+
         if let Some(storage) = &self.persistence {
             let persisted = parse_xml_to_persisted_unacked(
                 stream_id,
@@ -1415,6 +1428,30 @@ impl InMemorySmSessionRegistry {
             return Ok(false);
         }
         Ok(false)
+    }
+
+    /// Returns true when `stream_id` names a detached session that is
+    /// present (in either the live `sessions` or the `claimed_sessions`
+    /// map) and not yet expired. Used as a pre-flight check by
+    /// [`Self::record_outbound_for_detached_stream_at`] so we don't
+    /// durably persist unacked stanzas for sessions that no longer
+    /// exist.
+    fn detached_session_is_live(&self, stream_id: &str) -> Result<bool, SmRegistryError> {
+        let sessions = self
+            .sessions
+            .read()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        if let Some(session) = sessions.get(stream_id) {
+            return Ok(!session.is_expired());
+        }
+        drop(sessions);
+        let claimed = self
+            .claimed_sessions
+            .read()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        Ok(claimed
+            .get(stream_id)
+            .is_some_and(|session| !session.is_expired()))
     }
 
     /// List all detached resources for a bare JID, including resources that

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -453,6 +453,49 @@ impl InMemorySmSessionRegistry {
     }
 }
 
+/// Parse a wire-XML fragment back to a typed
+/// [`super::persistence::PersistedUnackedStanza`] keyed under
+/// `stream_id`. Used by both `store_session` (full batch decode) and
+/// `record_outbound_for_detached_stream_at` (per-stanza incremental
+/// persist for issue #209 finding #8). Returns an `Internal` error
+/// for malformed XML or unknown root elements so the caller can
+/// abort the persist without leaving an inconsistent durable view.
+fn parse_xml_to_persisted_unacked(
+    stream_id: &str,
+    sequence: u32,
+    stanza_xml: &str,
+    original_receipt_at: chrono::DateTime<chrono::Utc>,
+) -> Result<super::persistence::PersistedUnackedStanza, SmRegistryError> {
+    let element: minidom::Element = stanza_xml.parse().map_err(|e: minidom::Error| {
+        SmRegistryError::Internal(format!("parse unacked stanza for persistence: {e}"))
+    })?;
+    let stanza = match element.name() {
+        "message" => crate::Stanza::Message(
+            xmpp_parsers::message::Message::try_from(element)
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+        ),
+        "iq" => crate::Stanza::Iq(
+            xmpp_parsers::iq::Iq::try_from(element)
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+        ),
+        "presence" => crate::Stanza::Presence(
+            xmpp_parsers::presence::Presence::try_from(element)
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
+        ),
+        other => {
+            return Err(SmRegistryError::Internal(format!(
+                "unknown unacked stanza element '{other}'"
+            )))
+        }
+    };
+    Ok(super::persistence::PersistedUnackedStanza {
+        stream_id: crate::pending_delivery::SmSessionId::new(stream_id.to_string()),
+        sequence,
+        stanza: Box::new(stanza),
+        original_receipt_at,
+    })
+}
+
 /// Convert a [`DetachedSession`] (in-memory shape) to a
 /// [`super::persistence::PersistedSession`] (durable shape) for write
 /// to [`SmPersistenceStorage`].
@@ -644,43 +687,12 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             // a round-trip to the backend.
             let mut unacked_rows = Vec::with_capacity(session.unacked_stanzas.len());
             for entry in &session.unacked_stanzas {
-                let element: minidom::Element =
-                    entry.stanza_xml.parse().map_err(|e: minidom::Error| {
-                        SmRegistryError::Internal(format!(
-                            "parse unacked stanza for persistence: {e}"
-                        ))
-                    })?;
-                let stanza = match element.name() {
-                    "message" => crate::Stanza::Message(
-                        xmpp_parsers::message::Message::try_from(element)
-                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
-                    ),
-                    "iq" => crate::Stanza::Iq(
-                        xmpp_parsers::iq::Iq::try_from(element)
-                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
-                    ),
-                    "presence" => crate::Stanza::Presence(
-                        xmpp_parsers::presence::Presence::try_from(element)
-                            .map_err(|e| SmRegistryError::Internal(e.to_string()))?,
-                    ),
-                    other => {
-                        return Err(SmRegistryError::Internal(format!(
-                            "unknown unacked stanza element '{other}'"
-                        )))
-                    }
-                };
-                // Locked Q6c (issue #209 PR #361): persist the row's
-                // actual receipt time, not Utc::now() at persist time.
-                // This is what makes the XEP-0203 `<delay/>` on a
-                // future Q6 SM-expiry promotion advertise the original
-                // failed-delivery time per XEP-0203 §4.1 + XEP-0198
-                // §5 line 364.
-                unacked_rows.push(super::persistence::PersistedUnackedStanza {
-                    stream_id: crate::pending_delivery::SmSessionId::new(stream_id.clone()),
-                    sequence: entry.sequence,
-                    stanza: Box::new(stanza),
-                    original_receipt_at: entry.original_receipt_at,
-                });
+                unacked_rows.push(parse_xml_to_persisted_unacked(
+                    &stream_id,
+                    entry.sequence,
+                    &entry.stanza_xml,
+                    entry.original_receipt_at,
+                )?);
             }
             storage
                 .store_session_atomic(persisted, unacked_rows)
@@ -922,18 +934,29 @@ impl InMemorySmSessionRegistry {
     /// implementation deleted durable rows up-front, losing
     /// stanzas on any partial-promotion failure.)
     pub async fn drain_all_for_shutdown(&self) -> Result<Vec<DetachedSession>, SmRegistryError> {
+        // Issue #209 finding #3: drain ONLY the detached pool. Sessions
+        // in `claimed_sessions` have an in-flight `<resume previd='…'/>`
+        // claim — pulling one out here while the resuming connection
+        // is between `claim_session` and `complete_claim` causes
+        // duplicate delivery: the client receives the SM resume replay
+        // AND the shutdown drain re-promotes the same unacked queue
+        // through Q6, generating a fresh `pending_delivery` row that
+        // re-flushes on the next presence after restart. The in-flight
+        // resume is responsible for either completing (which calls
+        // `complete_claim` → `persist_delete_session`) or releasing
+        // (which puts the session back in the detached pool); either
+        // outcome cleans up without needing the shutdown drain to
+        // touch claimed sessions. If the resume never completes
+        // before the runtime exits, the durable row survives and the
+        // restart-time expiry path picks it up on the next janitor
+        // pass — the same fail-closed retry semantics already used
+        // for `PromotedOutcome::StorageFailure`.
         let drained: Vec<DetachedSession> = {
             let mut sessions = self
                 .sessions
                 .write()
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            let mut claimed = self
-                .claimed_sessions
-                .write()
-                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            let mut out: Vec<DetachedSession> = sessions.drain().map(|(_, s)| s).collect();
-            out.extend(claimed.drain().map(|(_, s)| s));
-            out
+            sessions.drain().map(|(_, s)| s).collect()
         };
         Ok(drained)
     }
@@ -1344,6 +1367,29 @@ impl InMemorySmSessionRegistry {
         stanza_xml: String,
         original_receipt_at: DateTime<Utc>,
     ) -> Result<bool, SmRegistryError> {
+        // Issue #209 finding #8: mirror the in-memory append to the
+        // durable persistence layer. Without this, a stanza routed
+        // into the second-detach drain (after `store_session` has
+        // already snapshotted the unacked queue) lives only in
+        // memory; a process crash before resume loses it. Persisting
+        // first preserves at-least-once semantics — if the durable
+        // append succeeds but the in-memory append doesn't run
+        // (shouldn't happen in practice), restart-time
+        // `restore_from_persistence` rebuilds the in-memory view
+        // from durable state.
+        if let Some(storage) = &self.persistence {
+            let persisted = parse_xml_to_persisted_unacked(
+                stream_id,
+                sequence,
+                &stanza_xml,
+                original_receipt_at,
+            )?;
+            storage
+                .append_unacked(persisted)
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+        }
+
         let mut sessions = self
             .sessions
             .write()

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -543,3 +543,113 @@ async fn xep0198_unacked_original_receipt_at_round_trips_through_persistence() {
         "original_receipt_at survives detach + persist + restore + claim"
     );
 }
+
+/// Issue #209 finding #3: `drain_all_for_shutdown` must NOT pull
+/// sessions out of `claimed_sessions`. A claimed session has an
+/// in-flight `<resume previd='…'/>` between `claim_session` and
+/// `complete_claim`. Draining it here causes duplicate delivery —
+/// the resuming connection gets the SM replay AND the shutdown
+/// drain re-promotes the same unacked queue through Q6, generating
+/// a fresh `pending_delivery` row that re-flushes on next presence.
+#[tokio::test]
+async fn xep0198_drain_all_for_shutdown_skips_claimed_sessions() {
+    let registry = InMemorySmSessionRegistry::new();
+    registry
+        .store_session(detached_session(
+            "stream-resuming",
+            "alice@example.com/laptop",
+        ))
+        .await
+        .expect("store");
+    registry
+        .store_session(detached_session("stream-detached", "bob@example.com/web"))
+        .await
+        .expect("store");
+
+    // Mid-flight resume: session-A is now in claimed_sessions.
+    let _claimed = registry
+        .claim_session("stream-resuming")
+        .await
+        .expect("claim")
+        .expect("session present");
+
+    // Shutdown drain fires now (SIGTERM mid-resume).
+    let drained = registry
+        .drain_all_for_shutdown()
+        .await
+        .expect("drain_all_for_shutdown");
+    let drained_ids: Vec<_> = drained.iter().map(|s| s.stream_id.as_str()).collect();
+    assert!(
+        drained_ids.contains(&"stream-detached"),
+        "detached session is drained"
+    );
+    assert!(
+        !drained_ids.contains(&"stream-resuming"),
+        "claimed (resuming) session must NOT be drained — \
+         the in-flight <resume/> path is responsible for its lifecycle"
+    );
+
+    // The claimed session is still present in the registry — the
+    // resuming connection can proceed with `complete_claim`.
+    let still_claimed = registry
+        .complete_claim("stream-resuming")
+        .await
+        .expect("complete claim");
+    assert!(
+        still_claimed.is_some(),
+        "complete_claim succeeds because shutdown drain did not steal the session"
+    );
+}
+
+/// Issue #209 finding #8: stanzas appended via
+/// `record_outbound_for_detached_stream_at` (the second-detach drain
+/// path) must mirror to durable persistence so a process crash before
+/// resume doesn't lose them. Earlier code only updated the in-memory
+/// view, so the durable `sm_unacked` table held the snapshot from
+/// `store_session` but missed any frame that arrived in `outbound_rx`
+/// between the first drain and the registry unregister.
+#[tokio::test]
+async fn xep0198_record_outbound_for_detached_stream_at_persists_durably() {
+    use std::sync::Arc;
+    use waddle_xmpp::stream_management::persistence::InMemorySmPersistence;
+
+    let persistence: Arc<dyn waddle_xmpp::stream_management::persistence::SmPersistenceStorage> =
+        Arc::new(InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+    registry
+        .store_session(detached_session(
+            "stream-late-drain",
+            "alice@example.com/laptop",
+        ))
+        .await
+        .expect("store");
+
+    let t1 = chrono::Utc::now();
+    let recorded = registry
+        .record_outbound_for_detached_stream_at(
+            "stream-late-drain",
+            42,
+            "<message xmlns='jabber:client' id='late'><body>late drain</body></message>"
+                .to_string(),
+            t1,
+        )
+        .await
+        .expect("record_outbound_for_detached_stream_at");
+    assert!(recorded, "session was found and stanza recorded in-memory");
+
+    // Critical: the durable `sm_unacked` table must contain the row
+    // immediately, NOT only after a subsequent `store_session_atomic`.
+    let unacked = persistence
+        .list_unacked(&waddle_xmpp::pending_delivery::SmSessionId::new(
+            "stream-late-drain",
+        ))
+        .await
+        .expect("list_unacked");
+    assert_eq!(
+        unacked.len(),
+        1,
+        "late-drain stanza must be persisted at append time, not only at next store_session"
+    );
+    assert_eq!(unacked[0].sequence, 42);
+    assert_eq!(unacked[0].original_receipt_at, t1);
+}

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -601,6 +601,21 @@ async fn xep0198_drain_all_for_shutdown_skips_claimed_sessions() {
     );
 }
 
+/// Build a typed `<message/>` stanza and return its on-the-wire XML.
+///
+/// AGENTS.md PR Compliance ID 14: tests must construct XMPP XML via
+/// structured builders (`xmpp_parsers` / `minidom`) rather than raw
+/// string literals — string XML is brittle to escaping bugs and
+/// drifts from the production serialization path. `message_to_string`
+/// is the same helper the production write loop uses, so this test
+/// exercises the same wire shape.
+fn late_drain_message_xml(id: &str, body: &str) -> String {
+    let mut message = Message::new(None);
+    message.id = Some(id.to_string());
+    message.bodies.insert(String::new(), Body(body.to_string()));
+    waddle_xmpp::parser::message_to_string(&message).expect("serialize <message/>")
+}
+
 /// Issue #209 finding #8: stanzas appended via
 /// `record_outbound_for_detached_stream_at` (the second-detach drain
 /// path) must mirror to durable persistence so a process crash before
@@ -629,8 +644,7 @@ async fn xep0198_record_outbound_for_detached_stream_at_persists_durably() {
         .record_outbound_for_detached_stream_at(
             "stream-late-drain",
             42,
-            "<message xmlns='jabber:client' id='late'><body>late drain</body></message>"
-                .to_string(),
+            late_drain_message_xml("late", "late drain"),
             t1,
         )
         .await
@@ -652,4 +666,42 @@ async fn xep0198_record_outbound_for_detached_stream_at_persists_durably() {
     );
     assert_eq!(unacked[0].sequence, 42);
     assert_eq!(unacked[0].original_receipt_at, t1);
+}
+
+/// Qodo finding on PR #409: `record_outbound_for_detached_stream_at`
+/// MUST NOT durably persist an unacked row when the named session is
+/// unknown or expired. The earlier "persist first" ordering left
+/// orphan rows in the `sm_unacked` table that no `delete_session`
+/// reaper would ever clean up (the in-memory persistence backend
+/// happily accepts appends for any stream_id).
+#[tokio::test]
+async fn xep0198_record_outbound_for_unknown_stream_does_not_persist_orphan_row() {
+    use std::sync::Arc;
+    use waddle_xmpp::stream_management::persistence::InMemorySmPersistence;
+
+    let persistence: Arc<dyn waddle_xmpp::stream_management::persistence::SmPersistenceStorage> =
+        Arc::new(InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+
+    let recorded = registry
+        .record_outbound_for_detached_stream_at(
+            "stream-does-not-exist",
+            7,
+            late_drain_message_xml("orphan", "orphan"),
+            chrono::Utc::now(),
+        )
+        .await
+        .expect("record_outbound_for_detached_stream_at");
+    assert!(!recorded, "missing session must short-circuit to Ok(false)");
+
+    let unacked = persistence
+        .list_unacked(&waddle_xmpp::pending_delivery::SmSessionId::new(
+            "stream-does-not-exist",
+        ))
+        .await
+        .expect("list_unacked");
+    assert!(
+        unacked.is_empty(),
+        "no orphan row may be persisted for an unknown stream_id"
+    );
 }


### PR DESCRIPTION
## Summary

Five concurrency / lifecycle fixes uncovered by the issue #209 adversarial review (findings #2, #3, #8, #9, #10):

- **Finding #2** — `record_drained_xml` now plumbs the source `pending_row_id` from the OutboundStanza and stamps the SM-assigned `outbound_sequence` onto the durable row via `record_pushed_at` before recording into the detached session's replay buffer. Without this binding, drained flush stanzas wedged claimed-but-NULL-sequenced — the SM ack would skip them, and on session expiry Q6 promotion created a second durable owner that re-flushed on next presence.
- **Finding #3** — `drain_all_for_shutdown` now skips `claimed_sessions`. A session in that pool has an in-flight `<resume previd='…'/>`; pulling one out under SIGTERM caused duplicate delivery — the resuming connection got the SM replay AND the shutdown drain re-promoted the same unacked queue through Q6, generating a fresh `pending_delivery` row that re-flushed on next presence after restart.
- **Finding #8** — `record_outbound_for_detached_stream_at` now mirrors the in-memory append to the SM persistence layer (`append_unacked`) so the second-detach drain doesn't lose stanzas on crash. The inline XML→typed-stanza decode previously inside `store_session` is refactored into a `parse_xml_to_persisted_unacked` helper that both call sites share.
- **Finding #9** — Claim-expiry janitor now uses a new conditional release primitive (`release_row_if_session`) that atomically re-validates the row's `flushed_in_session` inside the same UPDATE: `UPDATE … WHERE row_id = ? AND flushed_in_session = ?`. A fresh bind that re-claimed the row in the snapshot-vs-release window survives untouched. Default trait impl falls back to the unconditional path so backends that haven't been updated keep compiling.
- **Finding #10** — Both `record_pushed_at` error paths (the live recipient loop AND the drain path) now `delete_row` instead of leaving the durable row claimed-but-unsequenced. The SM unacked queue + Q6 promotion become the sole owner — bounded duplicate semantics with XEP-0359 client dedup rather than an open-ended wedge.

## Test plan

- [x] `cargo test -p waddle-xmpp --features test-utils` — 14 SM-suite tests + 1796 unit tests + every XEP suite green
- [x] `cargo test -p waddle-server` — 444+ unit tests + every integration suite green
- [x] New regression tests:
  - `xep0198_drain_all_for_shutdown_skips_claimed_sessions`
  - `xep0198_record_outbound_for_detached_stream_at_persists_durably`
  - `release_row_if_session_skips_when_a_fresh_claim_replaced_the_dead_session`
  - `release_row_if_session_releases_when_claim_unchanged`
  - `db_storage_release_row_if_session_skips_when_session_changed`
- [x] `cargo clippy --all-targets -- -D warnings` clean on both crates
- [x] `cargo fmt --all` clean

## Adversarial review context

Second of three follow-up PRs from the issue #209 adversarial review:
- **PR-A** (#407, draft) — XEP/RFC conformance gaps (findings #1, #6, #7)
- **PR-B (this)** — concurrency / lifecycle (findings #2, #3, #8, #9, #10)
- **PR-C** — operability (findings #4, #5, #11, #12, #13, #14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)