### PR TITLE
feat(server): operability fixes for offline DM + SM-expiry surface (#209)

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -177,6 +177,7 @@ where
             // perspective; we surface it loudly so production logs
             // can flag MAM corruption / unexpected tombstones.
             outcome.unresolved += 1;
+            waddle_xmpp::prometheus::increment_pending_delivery_unresolved_poison_pill();
             if let Err(error) = storage.delete_row(&row.id).await {
                 warn!(
                     row_id = %row.id,
@@ -400,6 +401,32 @@ const PAYLOAD_KIND_TRANSIENT: &str = "transient";
 /// Lock granularity is per recipient — concurrent inserts for
 /// *different* recipients don't contend.
 type RecipientLockMap = dashmap::DashMap<BareJid, std::sync::Arc<tokio::sync::Mutex<()>>>;
+
+/// Sweep [`RecipientLockMap`] entries that no caller is currently
+/// holding. Called periodically from the claim-expiry janitor (issue
+/// #209 finding #4): the map was previously append-only and grew with
+/// every distinct recipient bare-JID seen by the process, leaking an
+/// `Arc<Mutex<()>>` per user permanently.
+///
+/// Race-safe: `remove_if` evaluates the predicate while holding the
+/// shard's write lock, and the predicate (`strong_count == 1`) is
+/// only true when no other task currently has a clone of the lock.
+/// If a clone is in flight we leave the entry alone and the next
+/// sweep retries.
+pub fn sweep_recipient_locks(
+    locks: &dashmap::DashMap<BareJid, std::sync::Arc<tokio::sync::Mutex<()>>>,
+) -> usize {
+    let mut removed = 0;
+    locks.retain(|_, lock| {
+        if std::sync::Arc::strong_count(lock) > 1 {
+            true
+        } else {
+            removed += 1;
+            false
+        }
+    });
+    removed
+}
 
 /// libSQL/Postgres-backed [`PendingDeliveryStorage`] implementation.
 ///
@@ -961,6 +988,21 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             .get(0)
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
         Ok(count.max(0) as u32)
+    }
+
+    async fn delete_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, PendingStorageError> {
+        self.execute(
+            "DELETE FROM pending_delivery WHERE original_receipt_at < ?",
+            crate::db_params![cutoff.timestamp_millis()],
+        )
+        .await
+    }
+
+    fn sweep_internal_bookkeeping(&self) -> usize {
+        sweep_recipient_locks(&self.recipient_locks)
     }
 }
 
@@ -1921,6 +1963,12 @@ mod tests {
             }
             async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError> {
                 self.inner.count(recipient).await
+            }
+            async fn delete_older_than(
+                &self,
+                cutoff: chrono::DateTime<chrono::Utc>,
+            ) -> Result<u64, PendingStorageError> {
+                self.inner.delete_older_than(cutoff).await
             }
         }
 

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -584,6 +584,17 @@ impl DatabasePendingDeliveryStorage {
             (),
         )
         .await?;
+        // Range index for the issue #209 finding #5 aging janitor's
+        // `DELETE FROM pending_delivery WHERE original_receipt_at < ?`
+        // query. Without this, the periodic delete is a full scan and
+        // becomes a significant DB load source on large tables (Qodo
+        // finding on PR #410).
+        self.execute(
+            "CREATE INDEX IF NOT EXISTS idx_pending_delivery_original_receipt_at \
+             ON pending_delivery (original_receipt_at)",
+            (),
+        )
+        .await?;
         Ok(())
     }
 

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1389,8 +1389,57 @@ async fn create_router(
                         Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
                         Err(error) => {
                             waddle_xmpp::prometheus::increment_sm_promotion_blocklist_failed();
+                            // Dead-letter cap (Qodo finding on PR #410):
+                            // a permanent blocklist-storage failure must
+                            // not retry forever. Reuse the same durable
+                            // attempt counter that the storage-failure
+                            // path uses (issue #209 finding #14) so a
+                            // session that can never load its blocklist
+                            // is eventually drained and stops re-tripping
+                            // every janitor pass.
+                            let attempts = match state
+                                .deps
+                                .protocol
+                                .sm_session_registry
+                                .record_promotion_failure(&session.stream_id)
+                                .await
+                            {
+                                Ok(n) => n,
+                                Err(record_error) => {
+                                    warn!(
+                                        jid = %session.jid,
+                                        error = %error,
+                                        record_error = %record_error,
+                                        "SM janitor: blocklist load failed AND \
+                                         record_promotion_failure also failed; preserving \
+                                         session state for retry"
+                                    );
+                                    continue;
+                                }
+                            };
+                            if attempts >= max_promotion_attempts_from_env() {
+                                waddle_xmpp::prometheus::increment_sm_promotion_dead_lettered();
+                                error!(
+                                    jid = %session.jid,
+                                    stream_id = %session.stream_id,
+                                    attempts,
+                                    error = %error,
+                                    "SM janitor: blocklist load has failed {attempts} times \
+                                     in a row for this session; dead-lettering the durable \
+                                     row to break the retry loop. Unacked stanzas are \
+                                     permanently lost (Qodo finding on PR #410)."
+                                );
+                                state
+                                    .deps
+                                    .protocol
+                                    .sm_session_registry
+                                    .confirm_drained(&session.stream_id)
+                                    .await;
+                                continue;
+                            }
                             warn!(
                                 jid = %session.jid,
+                                attempts,
                                 error = %error,
                                 "SM janitor: blocklist load failed; SKIPPING promotion to \
                                  preserve fail-closed XEP-0191 policy. Durable SM row will \
@@ -1616,51 +1665,63 @@ async fn create_router(
                     .active_sm_stream_ids();
                 let mut live_sessions = detached_live;
                 live_sessions.extend(active_live);
-                let orphans = match state
+                // Orphan-claim release: only runs when there are
+                // orphans to release, and only if the listing query
+                // succeeds. A failure here MUST NOT skip the
+                // unrelated periodic housekeeping below (Qodo
+                // finding on PR #410 — earlier code `continue`d on
+                // both the error path and the empty-orphans path,
+                // suppressing aging + lock-map GC entirely on most
+                // ticks for healthy systems).
+                match state
                     .deps
                     .protocol
                     .pending_delivery_storage
                     .list_orphaned_claims(&live_sessions)
                     .await
                 {
-                    Ok(rows) => rows,
-                    Err(error) => {
-                        warn!(error = %error, "claim-expiry janitor: list_orphaned_claims failed");
-                        continue;
-                    }
-                };
-                if orphans.is_empty() {
-                    continue;
-                }
-                let count = orphans.len();
-                for (row_id, session) in orphans {
-                    if let Err(error) = state
-                        .deps
-                        .protocol
-                        .pending_delivery_storage
-                        .release_row(&row_id)
-                        .await
-                    {
-                        warn!(
-                            row_id = %row_id,
-                            session = %session,
-                            error = %error,
-                            "claim-expiry janitor: release_row failed; row stays \
-                             claimed and will be retried next sweep"
+                    Ok(orphans) if !orphans.is_empty() => {
+                        let count = orphans.len();
+                        for (row_id, session) in orphans {
+                            if let Err(error) = state
+                                .deps
+                                .protocol
+                                .pending_delivery_storage
+                                .release_row(&row_id)
+                                .await
+                            {
+                                warn!(
+                                    row_id = %row_id,
+                                    session = %session,
+                                    error = %error,
+                                    "claim-expiry janitor: release_row failed; row stays \
+                                     claimed and will be retried next sweep"
+                                );
+                            }
+                        }
+                        info!(
+                            count,
+                            "claim-expiry janitor: released orphaned pending_delivery claims"
+                        );
+                        waddle_xmpp::prometheus::add_pending_delivery_orphan_claims_released(
+                            count as u64,
                         );
                     }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(error = %error, "claim-expiry janitor: list_orphaned_claims failed");
+                    }
                 }
-                info!(
-                    count,
-                    "claim-expiry janitor: released orphaned pending_delivery claims"
-                );
-                waddle_xmpp::prometheus::add_pending_delivery_orphan_claims_released(count as u64);
                 // Issue #209 finding #4: piggy-back the per-recipient
                 // insert-lock GC on the same ticker. Backends that
                 // don't track these (in-memory) return 0; the libSQL/
                 // Postgres backend prunes entries with
                 // `Arc::strong_count == 1` so the map can't accumulate
                 // permanently across the process lifetime.
+                //
+                // MUST run on every tick regardless of whether
+                // orphan claims were found, otherwise a healthy
+                // system never reclaims the locks it stops using.
                 let swept = state
                     .deps
                     .protocol
@@ -1676,6 +1737,11 @@ async fn create_router(
                 // older than the configured max age so a permanently-
                 // offline recipient can't wedge their per-recipient
                 // quota and bounce future legitimate senders forever.
+                //
+                // MUST run on every tick regardless of orphan-claim
+                // outcome, otherwise aging never advances on a
+                // healthy system that has no orphans (Qodo finding
+                // on PR #410).
                 let max_age_days = i64::from(pending_delivery_max_age_days_from_env());
                 let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days);
                 match state

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -41,7 +41,7 @@ use tower_http::{
     cors::CorsLayer,
     trace::{DefaultOnResponse, TraceLayer},
 };
-use tracing::{info, info_span, warn, Level, Span};
+use tracing::{debug, error, info, info_span, warn, Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use waddle_extensions::{
     host_tools as ext_host, CommandAction as ExtensionCommandAction, CommandSessionId,
@@ -132,6 +132,62 @@ impl AppState {
             server_owner_jids,
         }
     }
+}
+
+/// Maximum age a `pending_delivery` row can live before the aging
+/// janitor drops it. Reads `WADDLE_PENDING_DELIVERY_MAX_AGE_DAYS`
+/// (clamped to `[1, 365]`) and falls back to 30 days. Issue #209
+/// finding #5: without an upper age bound, a permanently-offline
+/// recipient (deleted account, lost device) eventually fills their
+/// per-recipient quota with stale rows that block future legitimate
+/// senders forever via `<service-unavailable/>`.
+fn pending_delivery_max_age_days_from_env() -> u32 {
+    const DEFAULT_DAYS: u32 = 30;
+    const MIN_DAYS: u32 = 1;
+    const MAX_DAYS: u32 = 365;
+    std::env::var("WADDLE_PENDING_DELIVERY_MAX_AGE_DAYS")
+        .ok()
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .map(|v| v.clamp(MIN_DAYS, MAX_DAYS))
+        .unwrap_or(DEFAULT_DAYS)
+}
+
+/// Threshold of consecutive Q6 promotion failures after which the
+/// SM-expiry janitor dead-letters the durable session row instead of
+/// preserving it for another retry pass.
+///
+/// Reads `WADDLE_SM_PROMOTION_MAX_ATTEMPTS` (clamped to `[2, 1024]`)
+/// and falls back to 5. Issue #209 finding #14: previously the
+/// preserve-and-retry path had no upper bound, so a permanent
+/// storage failure (disk full, schema corruption) would loop forever
+/// on every janitor pass and across restarts.
+fn max_promotion_attempts_from_env() -> u32 {
+    const DEFAULT_ATTEMPTS: u32 = 5;
+    const MIN_ATTEMPTS: u32 = 2;
+    const MAX_ATTEMPTS: u32 = 1024;
+    std::env::var("WADDLE_SM_PROMOTION_MAX_ATTEMPTS")
+        .ok()
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .map(|v| v.clamp(MIN_ATTEMPTS, MAX_ATTEMPTS))
+        .unwrap_or(DEFAULT_ATTEMPTS)
+}
+
+/// Maximum time to spend in the Q6 graceful-shutdown drain.
+///
+/// Reads `WADDLE_DRAIN_TIMEOUT_SECS` (clamped to `[1, 600]`) and
+/// falls back to 30s. Issue #209 finding #12: previously a hardcoded
+/// const so operators on mobile-heavy deployments couldn't extend
+/// the window when many sessions were still draining at SIGTERM.
+fn max_drain_duration_from_env() -> std::time::Duration {
+    const DEFAULT_SECS: u64 = 30;
+    const MIN_SECS: u64 = 1;
+    const MAX_SECS: u64 = 600;
+    let secs = std::env::var("WADDLE_DRAIN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .map(|v| v.clamp(MIN_SECS, MAX_SECS))
+        .unwrap_or(DEFAULT_SECS);
+    std::time::Duration::from_secs(secs)
 }
 
 /// Resolve `WADDLE_SERVER_OWNER_LOCALPARTS` localparts into bare JIDs against
@@ -1332,6 +1388,7 @@ async fn create_router(
                     {
                         Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
                         Err(error) => {
+                            waddle_xmpp::prometheus::increment_sm_promotion_blocklist_failed();
                             warn!(
                                 jid = %session.jid,
                                 error = %error,
@@ -1369,9 +1426,59 @@ async fn create_router(
                     // retry. Otherwise the unacked stanzas would be
                     // permanently lost on a transient storage error.
                     // (Copilot review on PR #346.)
+                    //
+                    // Issue #209 finding #14: track consecutive
+                    // failures via a durable counter so a permanent
+                    // failure (disk full, schema corruption) doesn't
+                    // loop forever. Dead-letter when attempts cross
+                    // the operator-defined threshold so the durable
+                    // row is removed and the unacked stanzas stop
+                    // re-tripping on every pass.
                     if summary.has_storage_failure() {
+                        waddle_xmpp::prometheus::add_sm_promotion_storage_failed(u64::from(
+                            summary.storage_failed,
+                        ));
+                        let attempts = match state
+                            .deps
+                            .protocol
+                            .sm_session_registry
+                            .record_promotion_failure(&session.stream_id)
+                            .await
+                        {
+                            Ok(n) => n,
+                            Err(error) => {
+                                warn!(
+                                    jid = %session.jid,
+                                    %error,
+                                    "SM janitor: record_promotion_failure failed; \
+                                     preserving session state for retry"
+                                );
+                                continue;
+                            }
+                        };
+                        if attempts >= max_promotion_attempts_from_env() {
+                            waddle_xmpp::prometheus::increment_sm_promotion_dead_lettered();
+                            error!(
+                                jid = %session.jid,
+                                stream_id = %session.stream_id,
+                                attempts,
+                                storage_failed = summary.storage_failed,
+                                "SM janitor: Q6 promotion has failed {attempts} times \
+                                 in a row for this session; dead-lettering the durable \
+                                 row to break the retry loop. Unacked stanzas are \
+                                 permanently lost (issue #209 finding #14)."
+                            );
+                            state
+                                .deps
+                                .protocol
+                                .sm_session_registry
+                                .confirm_drained(&session.stream_id)
+                                .await;
+                            continue;
+                        }
                         warn!(
                             jid = %session.jid,
+                            attempts,
                             storage_failed = summary.storage_failed,
                             "SM janitor: promotion had storage failures; \
                              preserving session state for retry"
@@ -1547,6 +1654,55 @@ async fn create_router(
                     count,
                     "claim-expiry janitor: released orphaned pending_delivery claims"
                 );
+                waddle_xmpp::prometheus::add_pending_delivery_orphan_claims_released(count as u64);
+                // Issue #209 finding #4: piggy-back the per-recipient
+                // insert-lock GC on the same ticker. Backends that
+                // don't track these (in-memory) return 0; the libSQL/
+                // Postgres backend prunes entries with
+                // `Arc::strong_count == 1` so the map can't accumulate
+                // permanently across the process lifetime.
+                let swept = state
+                    .deps
+                    .protocol
+                    .pending_delivery_storage
+                    .sweep_internal_bookkeeping();
+                if swept > 0 {
+                    debug!(
+                        swept,
+                        "claim-expiry janitor: pruned idle per-recipient insert locks"
+                    );
+                }
+                // Issue #209 finding #5: drop pending_delivery rows
+                // older than the configured max age so a permanently-
+                // offline recipient can't wedge their per-recipient
+                // quota and bounce future legitimate senders forever.
+                let max_age_days = i64::from(pending_delivery_max_age_days_from_env());
+                let cutoff = chrono::Utc::now() - chrono::Duration::days(max_age_days);
+                match state
+                    .deps
+                    .protocol
+                    .pending_delivery_storage
+                    .delete_older_than(cutoff)
+                    .await
+                {
+                    Ok(0) => {}
+                    Ok(removed) => {
+                        waddle_xmpp::prometheus::add_pending_delivery_aged_out(removed);
+                        info!(
+                            removed,
+                            cutoff = %cutoff,
+                            max_age_days,
+                            "pending_delivery aging janitor: dropped expired rows"
+                        );
+                    }
+                    Err(error) => {
+                        warn!(
+                            %error,
+                            "pending_delivery aging janitor: delete_older_than failed; \
+                             will retry on next sweep"
+                        );
+                    }
+                }
             }
         });
     }
@@ -1588,7 +1744,11 @@ async fn create_router(
             // elapses. (Copilot review on PR #346: a single-pass drain
             // missed sessions detaching mid-shutdown.)
             const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
-            const MAX_DRAIN_DURATION: std::time::Duration = std::time::Duration::from_secs(30);
+            // Drain deadline: WADDLE_DRAIN_TIMEOUT_SECS overrides the
+            // default 30s. Mobile-heavy deployments may need longer
+            // for the full unacked-queue promotion to finish before
+            // the runtime exits. Issue #209 finding #12.
+            let drain_deadline = std::time::Instant::now() + max_drain_duration_from_env();
             // Quiet window: 8 consecutive empty polls × 250ms = ~2s
             // of registry stability before we declare the drain
             // complete. Two passes (~500ms) was too aggressive —
@@ -1596,11 +1756,11 @@ async fn create_router(
             // to detach + store_session() its sessions during a busy
             // shutdown. (Qodo review on PR #346.)
             const QUIET_WINDOW_PASSES: u32 = 8;
-            let drain_deadline = std::time::Instant::now() + MAX_DRAIN_DURATION;
             let mut empty_passes = 0u32;
             let mut total_drained = 0usize;
             loop {
                 if std::time::Instant::now() >= drain_deadline {
+                    waddle_xmpp::prometheus::increment_sm_drain_timeout();
                     warn!(
                         total_drained,
                         "Graceful shutdown: drain timeout reached. Remaining sessions \

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -1087,6 +1087,7 @@ async fn interpret_with_depth(
                         );
                     }
                     Ok(waddle_xmpp::pending_delivery::InsertOutcome::QuotaExceeded) => {
+                        waddle_xmpp::prometheus::increment_pending_delivery_quota_exceeded();
                         // XEP-0160 §3 step 3 + RFC 6120 §8.3 — return a
                         // typed `<service-unavailable/>` bounce that
                         // echoes the original payload (RFC 6120 §8.3.4

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -1571,6 +1571,33 @@ pub(crate) fn build_iq_error_xml_typed(
     element_to_xml(iq)
 }
 
+/// Server-side maximum XEP-0198 resume window in seconds.
+///
+/// Reads `WADDLE_SM_MAX_RESUME_SECS` (clamped to `[60, 86400]`) and
+/// falls back to 300 (5 min). Issue #209 finding #12: mobile-heavy
+/// deployments routinely use 600s+ resume windows; the previous
+/// hardcoded 300s silently rewrote larger client requests. Operators
+/// can override via env without recompile; absurd values get clamped
+/// rather than rejected so a typo doesn't take the server down.
+fn max_resume_secs_from_env() -> u32 {
+    const DEFAULT_MAX_RESUME_SECS: u32 = 300;
+    const MIN_MAX_RESUME_SECS: u32 = 60;
+    const MAX_MAX_RESUME_SECS: u32 = 86_400;
+    match std::env::var("WADDLE_SM_MAX_RESUME_SECS") {
+        Ok(raw) => match raw.parse::<u32>() {
+            Ok(secs) => secs.clamp(MIN_MAX_RESUME_SECS, MAX_MAX_RESUME_SECS),
+            Err(_) => {
+                warn!(
+                    raw = %raw,
+                    "WADDLE_SM_MAX_RESUME_SECS not parseable; using default {DEFAULT_MAX_RESUME_SECS}s"
+                );
+                DEFAULT_MAX_RESUME_SECS
+            }
+        },
+        Err(_) => DEFAULT_MAX_RESUME_SECS,
+    }
+}
+
 fn build_handled_count_too_high_stream_error(acknowledged: u32, send_count: u32) -> String {
     let mut writer = Writer::new(Vec::new());
     let mut stream_error = BytesStart::new("stream:error");
@@ -1813,14 +1840,22 @@ fn handle_sm_enable(
     }
 
     let stream_id = uuid::Uuid::new_v4().to_string();
-    // Clamp resumption window to our server-side maximum (5 minutes) — this
-    // is also the registry TTL. Clients that asked for less get what they
-    // asked for; clients that asked for more or didn't specify get 300s.
-    const MAX_RESUME_SECS: u32 = 300;
-    let max = enable
-        .max
-        .map(|m| m.min(MAX_RESUME_SECS))
-        .unwrap_or(MAX_RESUME_SECS);
+    // Clamp resumption window to our server-side maximum. Default 300s
+    // (5 min) matches XEP-0198 §5 prose; mobile-heavy deployments
+    // routinely use 600s+ resume windows (Conversations defaults to
+    // 5–10 min) and can override via WADDLE_SM_MAX_RESUME_SECS.
+    // Clients that asked for less get what they asked for; clients
+    // that asked for more or didn't specify get the (possibly
+    // configured) max. Issue #209 finding #12.
+    let max_resume_secs = max_resume_secs_from_env();
+    let max = match enable.max {
+        Some(m) if m > max_resume_secs => {
+            waddle_xmpp::prometheus::increment_sm_resume_window_clamped();
+            max_resume_secs
+        }
+        Some(m) => m,
+        None => max_resume_secs,
+    };
     sm_state.enable(stream_id.clone(), enable.resume, Some(max));
 
     // Publish the stream id onto the registry's ConnectionEntry so

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use jid::FullJid;
-use tracing::{info, instrument};
+use tracing::{debug, info, instrument};
 use waddle_xmpp::pending_delivery::SmSessionId;
 use waddle_xmpp::stream_management::persistence::{
     PersistedSession, PersistedUnackedStanza, SmPersistenceError, SmPersistenceStorage,
@@ -118,6 +118,39 @@ impl DatabaseSmPersistence {
         Ok(storage)
     }
 
+    /// Add a column to an existing table idempotently across libSQL
+    /// and Postgres. Mirrors the established pattern in
+    /// `pending_delivery::DatabasePendingDeliveryStorage::initialize`:
+    /// Postgres has `ADD COLUMN IF NOT EXISTS` natively; older SQLite
+    /// builds error with "duplicate column", which we treat as a
+    /// no-op. Issue #209 finding #13: the previous schema had no
+    /// migration affordance, so any future column addition would
+    /// silently no-op the `CREATE TABLE IF NOT EXISTS` then crash on
+    /// first SELECT/INSERT against an upgraded deployment. This
+    /// helper is the building block; adding a column becomes one call
+    /// alongside the `CREATE TABLE` block.
+    async fn add_column_if_missing(
+        &self,
+        table: &str,
+        column_def: &str,
+    ) -> Result<(), SmPersistenceError> {
+        let alter_sql = match self.db.driver() {
+            DatabaseDriver::Postgres => {
+                format!("ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {column_def}")
+            }
+            DatabaseDriver::Sqlite => format!("ALTER TABLE {table} ADD COLUMN {column_def}"),
+        };
+        if let Err(error) = self.execute(&alter_sql, ()).await {
+            let msg = error.to_string().to_lowercase();
+            if msg.contains("duplicate column") || msg.contains("already exists") {
+                debug!(table, column_def, "column already present; skipping ALTER");
+                return Ok(());
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
     async fn initialize(&self) -> Result<(), SmPersistenceError> {
         // Driver-aware bigint type: Postgres INTEGER is i32 (overflows
         // for `timestamp_millis()` after Jan 2038); BIGINT is i64.
@@ -144,7 +177,8 @@ impl DatabaseSmPersistence {
                     presence_available INTEGER NOT NULL,
                     presence_show TEXT,
                     presence_status TEXT,
-                    presence_priority INTEGER NOT NULL
+                    presence_priority INTEGER NOT NULL,
+                    promotion_attempts INTEGER NOT NULL DEFAULT 0
                 )
                 "#
             ),
@@ -174,6 +208,26 @@ impl DatabaseSmPersistence {
             "CREATE INDEX IF NOT EXISTS idx_sm_sessions_detached \
              ON sm_sessions (detached_at_ms)",
             (),
+        )
+        .await?;
+        // Idempotent column-add migrations (issue #209 finding #13:
+        // schema previously had no migration affordance — any future
+        // column addition would crash on first use against an upgraded
+        // deployment). Add new migrations as one call each below;
+        // pre-existing deployments whose tables predate the column
+        // see the column added, freshly-created tables (where
+        // CREATE TABLE above already declares the column) see the
+        // duplicate-column error and skip.
+        //
+        // `promotion_attempts` (issue #209 finding #14): tracks the
+        // number of consecutive Q6-promotion failures for this
+        // session so the SM-expiry janitor can dead-letter durable
+        // rows that fail promotion repeatedly (e.g. permanent disk-
+        // full or schema-corruption scenarios) instead of retrying
+        // forever. `DEFAULT 0` so existing rows compare cleanly.
+        self.add_column_if_missing(
+            "sm_sessions",
+            "promotion_attempts INTEGER NOT NULL DEFAULT 0",
         )
         .await?;
         Ok(())
@@ -210,6 +264,22 @@ impl DatabaseSmPersistence {
             .entry(stream_id.clone())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+
+    /// Drop the per-stream lock entry once a session is terminally
+    /// done (delete_session). Without this, every distinct stream id
+    /// the process has ever seen leaks an `Arc<Mutex<()>>` for the
+    /// lifetime of the runtime — issue #209 finding #4.
+    ///
+    /// Race-safe: DashMap's `remove_if` only removes the entry when
+    /// the predicate returns true, evaluated while holding the
+    /// shard's write lock. We check `Arc::strong_count == 1` so we
+    /// only remove when no other task currently holds a clone of the
+    /// lock; if another caller is mid-acquire, we leave the entry
+    /// alone and the next terminal cleanup retries.
+    fn drop_stream_lock(&self, stream_id: &SmSessionId) {
+        self.stream_locks
+            .remove_if(stream_id, |_, lock| Arc::strong_count(lock) == 1);
     }
 
     fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, SmPersistenceError> {
@@ -437,6 +507,46 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
     }
 
     #[instrument(skip(self), fields(stream_id = %stream_id))]
+    async fn record_promotion_failure(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<u32, SmPersistenceError> {
+        let lock = self.lock_for(stream_id);
+        let _guard = lock.lock().await;
+        // Increment in place; rows_affected = 0 means the session was
+        // already deleted (raced with a concurrent expire path),
+        // which we surface as count = 0 so the caller doesn't trigger
+        // a dead-letter on a row that no longer exists.
+        let updated = self
+            .execute(
+                "UPDATE sm_sessions SET promotion_attempts = promotion_attempts + 1 \
+                 WHERE stream_id = ?",
+                crate::db_params![stream_id.as_str().to_string()],
+            )
+            .await?;
+        if updated == 0 {
+            return Ok(0);
+        }
+        let mut rows = self
+            .query(
+                "SELECT promotion_attempts FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![stream_id.as_str().to_string()],
+            )
+            .await?;
+        let count = match rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?
+        {
+            Some(row) => row
+                .get::<i64>(0)
+                .map_err(|e| SmPersistenceError::Other(e.to_string()))?,
+            None => 0,
+        };
+        Ok(u32::try_from(count).unwrap_or(u32::MAX))
+    }
+
+    #[instrument(skip(self), fields(stream_id = %stream_id))]
     async fn delete_session(&self, stream_id: &SmSessionId) -> Result<(), SmPersistenceError> {
         let lock = self.lock_for(stream_id);
         let _guard = lock.lock().await;
@@ -452,6 +562,13 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             crate::db_params![stream_id.as_str().to_string()],
         )
         .await?;
+        // Drop guard then attempt to free the per-stream lock entry.
+        // We have to release the lock first so `Arc::strong_count`
+        // can settle to 1 (only the DashMap entry holds a clone).
+        // Issue #209 finding #4 — the StreamLockMap was previously
+        // append-only and grew with every distinct session id seen.
+        drop(_guard);
+        self.drop_stream_lock(stream_id);
         Ok(())
     }
 

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -562,12 +562,15 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             crate::db_params![stream_id.as_str().to_string()],
         )
         .await?;
-        // Drop guard then attempt to free the per-stream lock entry.
-        // We have to release the lock first so `Arc::strong_count`
+        // Drop guard AND the local Arc clone so `Arc::strong_count`
         // can settle to 1 (only the DashMap entry holds a clone).
-        // Issue #209 finding #4 — the StreamLockMap was previously
-        // append-only and grew with every distinct session id seen.
+        // Without dropping `lock` here as well, `drop_stream_lock`'s
+        // `strong_count == 1` predicate could never fire (the local
+        // clone keeps the count at ≥2), defeating the StreamLockMap
+        // GC entirely. Issue #209 finding #4 + Qodo finding on PR
+        // #410.
         drop(_guard);
+        drop(lock);
         self.drop_stream_lock(stream_id);
         Ok(())
     }
@@ -1134,6 +1137,42 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    /// Issue #209 finding #4 + Qodo finding on PR #410:
+    /// `delete_session` MUST drop its local `Arc` clone of the
+    /// per-stream lock before calling `drop_stream_lock`, or the
+    /// `Arc::strong_count == 1` predicate can never fire and the
+    /// `StreamLockMap` grows unbounded.
+    #[tokio::test]
+    async fn delete_session_releases_stream_lock_entry() {
+        let storage = DatabaseSmPersistence::open(None).await.unwrap();
+        storage
+            .upsert_session(fixture_session("stream-leaky"))
+            .await
+            .unwrap();
+        // Force a lock entry by walking the same path the writers do.
+        storage
+            .append_unacked(fixture_unacked("stream-leaky", 1))
+            .await
+            .unwrap();
+        assert!(
+            storage
+                .stream_locks
+                .contains_key(&SmSessionId::new("stream-leaky")),
+            "append_unacked must populate the stream_locks entry"
+        );
+
+        storage
+            .delete_session(&SmSessionId::new("stream-leaky"))
+            .await
+            .unwrap();
+        assert!(
+            !storage
+                .stream_locks
+                .contains_key(&SmSessionId::new("stream-leaky")),
+            "delete_session must drop its local Arc clone so drop_stream_lock can GC the entry"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -323,6 +323,7 @@ async fn insert_pending(
             // typed StanzaError builder the routing layer uses for
             // intake-time quota overflow so the wire shape is
             // identical.
+            waddle_xmpp::prometheus::increment_pending_delivery_quota_exceeded();
             send_quota_bounce(original_message, &recipient, registry).await;
             PromotedOutcome::Bounced
         }
@@ -1006,6 +1007,12 @@ mod tests {
                 Ok(vec![])
             }
             async fn count(&self, _recipient: &BareJid) -> Result<u32, PendingStorageError> {
+                Ok(0)
+            }
+            async fn delete_older_than(
+                &self,
+                _cutoff: chrono::DateTime<chrono::Utc>,
+            ) -> Result<u64, PendingStorageError> {
                 Ok(0)
             }
         }

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -122,6 +122,30 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// Current row count for `recipient` (used by the quota check;
     /// also exposed for metrics).
     async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError>;
+
+    /// Delete every row whose `original_receipt_at < cutoff`.
+    /// Returns the number of rows removed.
+    ///
+    /// Used by the pending_delivery aging janitor (issue #209
+    /// finding #5): without an upper age bound, a permanently-
+    /// offline recipient (deleted account, lost device) eventually
+    /// fills their per-recipient quota with stale rows that block
+    /// future legitimate senders forever via the
+    /// `<service-unavailable/>` bounce. Rows older than the
+    /// operator-defined threshold (default 30 days) are dropped.
+    async fn delete_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, PendingStorageError>;
+
+    /// Periodically GC backend-internal bookkeeping that grows with
+    /// distinct keys seen by the process — e.g. per-recipient
+    /// insert-serialization locks (issue #209 finding #4). Default
+    /// impl is a no-op for backends that don't need it (in-memory).
+    /// Returns the number of entries removed for observability.
+    fn sweep_internal_bookkeeping(&self) -> usize {
+        0
+    }
 }
 
 /// In-memory implementation suitable for handler tests.
@@ -369,6 +393,24 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             .lock()
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
         Ok(guard.get(recipient).map(|q| q.len() as u32).unwrap_or(0))
+    }
+
+    async fn delete_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, PendingStorageError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let mut removed = 0u64;
+        for queue in guard.values_mut() {
+            let before = queue.len();
+            queue.retain(|row| row.original_receipt_at >= cutoff);
+            removed += (before - queue.len()) as u64;
+        }
+        guard.retain(|_, q| !q.is_empty());
+        Ok(removed)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -27,6 +27,50 @@ static BROADCAST_DROPPED_CLOSED: AtomicU64 = AtomicU64::new(0);
 // later `<resumed/>` will silently drop that stanza.
 static SM_UNACKED_EVICTED: AtomicU64 = AtomicU64::new(0);
 
+// Issue #209 finding #11 — observability for the offline-DM /
+// SM-expiry surface. None of these existed before; the entire
+// runtime behavior described by issue #209 was previously
+// unobservable beyond grep'ing log lines.
+//
+// `pending_delivery_quota_exceeded`: per-recipient cap hit at intake
+// (XEP-0160 §3 step 3 bounce). Sustained non-zero indicates a
+// recipient queue saturated by a single sender or a permanently-
+// offline target.
+static PENDING_DELIVERY_QUOTA_EXCEEDED: AtomicU64 = AtomicU64::new(0);
+// `pending_delivery_orphan_claims_released`: claim-expiry janitor
+// activity — non-zero is normal (sessions die without acks); a
+// growing rate signals broken SM lifecycle.
+static PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED: AtomicU64 = AtomicU64::new(0);
+// `pending_delivery_aged_out`: aging janitor (issue #209 finding #5)
+// drops rows older than the configured max age. Sustained non-zero
+// indicates recipients with permanently-stale queues.
+static PENDING_DELIVERY_AGED_OUT: AtomicU64 = AtomicU64::new(0);
+// `pending_delivery_unresolved_poison_pill`: flush could not
+// materialize a row's MAM payload and dropped it. Should be ~0 on a
+// healthy deployment; non-zero signals MAM corruption.
+static PENDING_DELIVERY_UNRESOLVED_POISON_PILL: AtomicU64 = AtomicU64::new(0);
+// `sm_promotion_storage_failed`: Q6 promotion encountered a
+// pending_delivery insert error and preserved the durable SM row for
+// retry (issue #209 PR #346 + finding #14 dead-letter cap).
+static SM_PROMOTION_STORAGE_FAILED: AtomicU64 = AtomicU64::new(0);
+// `sm_promotion_blocklist_failed`: blocklist storage load failed
+// during Q6 promotion; the session was skipped fail-closed.
+static SM_PROMOTION_BLOCKLIST_FAILED: AtomicU64 = AtomicU64::new(0);
+// `sm_promotion_dead_lettered`: a session crossed the configured
+// promotion-attempt threshold and was dead-lettered (issue #209
+// finding #14). Each event is a permanent loss of unacked stanzas
+// from one session.
+static SM_PROMOTION_DEAD_LETTERED: AtomicU64 = AtomicU64::new(0);
+// `sm_drain_timeout`: graceful-shutdown drain hit the configured
+// deadline with sessions still pending. Each event implies durable
+// rows surviving for restart-time retry.
+static SM_DRAIN_TIMEOUT: AtomicU64 = AtomicU64::new(0);
+// `sm_resume_window_clamped`: a client requested a resume window
+// larger than the server-side cap (`WADDLE_SM_MAX_RESUME_SECS`) and
+// was silently lowered. Sustained non-zero indicates the cap is too
+// tight for the client population.
+static SM_RESUME_WINDOW_CLAMPED: AtomicU64 = AtomicU64::new(0);
+
 fn unix_timestamp_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -96,6 +140,42 @@ pub fn increment_sm_unacked_evicted() {
     SM_UNACKED_EVICTED.fetch_add(1, Ordering::Relaxed);
 }
 
+pub fn increment_pending_delivery_quota_exceeded() {
+    PENDING_DELIVERY_QUOTA_EXCEEDED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn add_pending_delivery_orphan_claims_released(n: u64) {
+    PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.fetch_add(n, Ordering::Relaxed);
+}
+
+pub fn add_pending_delivery_aged_out(n: u64) {
+    PENDING_DELIVERY_AGED_OUT.fetch_add(n, Ordering::Relaxed);
+}
+
+pub fn increment_pending_delivery_unresolved_poison_pill() {
+    PENDING_DELIVERY_UNRESOLVED_POISON_PILL.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn add_sm_promotion_storage_failed(n: u64) {
+    SM_PROMOTION_STORAGE_FAILED.fetch_add(n, Ordering::Relaxed);
+}
+
+pub fn increment_sm_promotion_blocklist_failed() {
+    SM_PROMOTION_BLOCKLIST_FAILED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn increment_sm_promotion_dead_lettered() {
+    SM_PROMOTION_DEAD_LETTERED.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn increment_sm_drain_timeout() {
+    SM_DRAIN_TIMEOUT.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn increment_sm_resume_window_clamped() {
+    SM_RESUME_WINDOW_CLAMPED.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn render_metrics() -> String {
     let now = unix_timestamp_secs();
     rotate_second_bucket(now);
@@ -109,6 +189,15 @@ pub fn render_metrics() -> String {
     let broadcast_dropped_full = BROADCAST_DROPPED_FULL.load(Ordering::Relaxed);
     let broadcast_dropped_closed = BROADCAST_DROPPED_CLOSED.load(Ordering::Relaxed);
     let sm_unacked_evicted = SM_UNACKED_EVICTED.load(Ordering::Relaxed);
+    let pending_quota_exceeded = PENDING_DELIVERY_QUOTA_EXCEEDED.load(Ordering::Relaxed);
+    let pending_orphan_released = PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.load(Ordering::Relaxed);
+    let pending_aged_out = PENDING_DELIVERY_AGED_OUT.load(Ordering::Relaxed);
+    let pending_poison_pill = PENDING_DELIVERY_UNRESOLVED_POISON_PILL.load(Ordering::Relaxed);
+    let sm_promotion_storage_failed = SM_PROMOTION_STORAGE_FAILED.load(Ordering::Relaxed);
+    let sm_promotion_blocklist_failed = SM_PROMOTION_BLOCKLIST_FAILED.load(Ordering::Relaxed);
+    let sm_promotion_dead_lettered = SM_PROMOTION_DEAD_LETTERED.load(Ordering::Relaxed);
+    let sm_drain_timeout = SM_DRAIN_TIMEOUT.load(Ordering::Relaxed);
+    let sm_resume_window_clamped = SM_RESUME_WINDOW_CLAMPED.load(Ordering::Relaxed);
 
     format!(
         concat!(
@@ -139,6 +228,33 @@ pub fn render_metrics() -> String {
             "# HELP waddle_sm_unacked_evicted_total XEP-0198 unacked-queue entries evicted because the queue hit capacity; each eviction will be missing from a later <resumed/> replay.\n",
             "# TYPE waddle_sm_unacked_evicted_total counter\n",
             "waddle_sm_unacked_evicted_total {sm_unacked_evicted}\n",
+            "# HELP waddle_pending_delivery_quota_exceeded_total Inserts rejected because the per-recipient pending_delivery quota was full (XEP-0160 §3 step 3 bounce path).\n",
+            "# TYPE waddle_pending_delivery_quota_exceeded_total counter\n",
+            "waddle_pending_delivery_quota_exceeded_total {pending_quota_exceeded}\n",
+            "# HELP waddle_pending_delivery_orphan_claims_released_total Pending_delivery rows the claim-expiry janitor released because their session was no longer live.\n",
+            "# TYPE waddle_pending_delivery_orphan_claims_released_total counter\n",
+            "waddle_pending_delivery_orphan_claims_released_total {pending_orphan_released}\n",
+            "# HELP waddle_pending_delivery_aged_out_total Pending_delivery rows the aging janitor dropped because they exceeded WADDLE_PENDING_DELIVERY_MAX_AGE_DAYS.\n",
+            "# TYPE waddle_pending_delivery_aged_out_total counter\n",
+            "waddle_pending_delivery_aged_out_total {pending_aged_out}\n",
+            "# HELP waddle_pending_delivery_unresolved_poison_pill_total Pending_delivery flushes that dropped a row because its MAM payload could not be resolved (corruption signal).\n",
+            "# TYPE waddle_pending_delivery_unresolved_poison_pill_total counter\n",
+            "waddle_pending_delivery_unresolved_poison_pill_total {pending_poison_pill}\n",
+            "# HELP waddle_sm_promotion_storage_failed_total Q6 promotion encountered a transient pending_delivery insert error; durable SM row preserved for retry.\n",
+            "# TYPE waddle_sm_promotion_storage_failed_total counter\n",
+            "waddle_sm_promotion_storage_failed_total {sm_promotion_storage_failed}\n",
+            "# HELP waddle_sm_promotion_blocklist_failed_total Q6 promotion skipped a session because its blocklist load failed (fail-closed XEP-0191 policy).\n",
+            "# TYPE waddle_sm_promotion_blocklist_failed_total counter\n",
+            "waddle_sm_promotion_blocklist_failed_total {sm_promotion_blocklist_failed}\n",
+            "# HELP waddle_sm_promotion_dead_lettered_total Q6 promotion failed WADDLE_SM_PROMOTION_MAX_ATTEMPTS times in a row for a session; durable row deleted to break the retry loop. Each event is a permanent loss of unacked stanzas.\n",
+            "# TYPE waddle_sm_promotion_dead_lettered_total counter\n",
+            "waddle_sm_promotion_dead_lettered_total {sm_promotion_dead_lettered}\n",
+            "# HELP waddle_sm_drain_timeout_total Graceful-shutdown drain hit WADDLE_DRAIN_TIMEOUT_SECS with sessions still pending; remaining durable rows survive for restart-time retry.\n",
+            "# TYPE waddle_sm_drain_timeout_total counter\n",
+            "waddle_sm_drain_timeout_total {sm_drain_timeout}\n",
+            "# HELP waddle_sm_resume_window_clamped_total Client-requested XEP-0198 resume window exceeded WADDLE_SM_MAX_RESUME_SECS and was silently lowered.\n",
+            "# TYPE waddle_sm_resume_window_clamped_total counter\n",
+            "waddle_sm_resume_window_clamped_total {sm_resume_window_clamped}\n",
         ),
         connected_users = connected_users,
         room_count = room_count,
@@ -149,6 +265,15 @@ pub fn render_metrics() -> String {
         broadcast_dropped_full = broadcast_dropped_full,
         broadcast_dropped_closed = broadcast_dropped_closed,
         sm_unacked_evicted = sm_unacked_evicted,
+        pending_quota_exceeded = pending_quota_exceeded,
+        pending_orphan_released = pending_orphan_released,
+        pending_aged_out = pending_aged_out,
+        pending_poison_pill = pending_poison_pill,
+        sm_promotion_storage_failed = sm_promotion_storage_failed,
+        sm_promotion_blocklist_failed = sm_promotion_blocklist_failed,
+        sm_promotion_dead_lettered = sm_promotion_dead_lettered,
+        sm_drain_timeout = sm_drain_timeout,
+        sm_resume_window_clamped = sm_resume_window_clamped,
     )
 }
 
@@ -174,6 +299,15 @@ mod tests {
         BROADCAST_DROPPED_FULL.store(0, Ordering::Release);
         BROADCAST_DROPPED_CLOSED.store(0, Ordering::Release);
         SM_UNACKED_EVICTED.store(0, Ordering::Release);
+        PENDING_DELIVERY_QUOTA_EXCEEDED.store(0, Ordering::Release);
+        PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.store(0, Ordering::Release);
+        PENDING_DELIVERY_AGED_OUT.store(0, Ordering::Release);
+        PENDING_DELIVERY_UNRESOLVED_POISON_PILL.store(0, Ordering::Release);
+        SM_PROMOTION_STORAGE_FAILED.store(0, Ordering::Release);
+        SM_PROMOTION_BLOCKLIST_FAILED.store(0, Ordering::Release);
+        SM_PROMOTION_DEAD_LETTERED.store(0, Ordering::Release);
+        SM_DRAIN_TIMEOUT.store(0, Ordering::Release);
+        SM_RESUME_WINDOW_CLAMPED.store(0, Ordering::Release);
     }
 
     #[test]
@@ -263,6 +397,54 @@ mod tests {
         assert!(rendered.contains("waddle_broadcast_not_connected_total 1"));
         assert!(rendered.contains("waddle_broadcast_dropped_full_total 3"));
         assert!(rendered.contains("waddle_broadcast_dropped_closed_total 1"));
+    }
+
+    /// Issue #209 finding #11: every metric introduced for the
+    /// offline-DM / SM-expiry surface MUST appear in the rendered
+    /// output with HELP+TYPE headers. Without these headers, a
+    /// scraper accepts the line but dashboards lose the metric type.
+    #[test]
+    fn test_issue_209_finding_11_metric_families_render() {
+        let _guard = test_lock().lock().unwrap();
+        reset_metrics_for_test();
+
+        increment_pending_delivery_quota_exceeded();
+        add_pending_delivery_orphan_claims_released(7);
+        add_pending_delivery_aged_out(3);
+        increment_pending_delivery_unresolved_poison_pill();
+        add_sm_promotion_storage_failed(2);
+        increment_sm_promotion_blocklist_failed();
+        increment_sm_promotion_dead_lettered();
+        increment_sm_drain_timeout();
+        increment_sm_resume_window_clamped();
+
+        let rendered = render_metrics();
+
+        for family in [
+            "waddle_pending_delivery_quota_exceeded_total",
+            "waddle_pending_delivery_orphan_claims_released_total",
+            "waddle_pending_delivery_aged_out_total",
+            "waddle_pending_delivery_unresolved_poison_pill_total",
+            "waddle_sm_promotion_storage_failed_total",
+            "waddle_sm_promotion_blocklist_failed_total",
+            "waddle_sm_promotion_dead_lettered_total",
+            "waddle_sm_drain_timeout_total",
+            "waddle_sm_resume_window_clamped_total",
+        ] {
+            assert!(
+                rendered.contains(&format!("# HELP {family}")),
+                "missing HELP header for {family}"
+            );
+            assert!(
+                rendered.contains(&format!("# TYPE {family} counter")),
+                "missing TYPE header for {family}"
+            );
+        }
+        assert!(rendered.contains("waddle_pending_delivery_quota_exceeded_total 1"));
+        assert!(rendered.contains("waddle_pending_delivery_orphan_claims_released_total 7"));
+        assert!(rendered.contains("waddle_pending_delivery_aged_out_total 3"));
+        assert!(rendered.contains("waddle_sm_promotion_storage_failed_total 2"));
+        assert!(rendered.contains("waddle_sm_resume_window_clamped_total 1"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -219,6 +219,27 @@ pub trait SmPersistenceStorage: Send + Sync {
         }
         Ok(())
     }
+
+    /// Atomically increment the persistent promotion-failure counter
+    /// for `stream_id` and return the new value. Used by the SM-
+    /// expiry janitor (issue #209 finding #14) to break runaway retry
+    /// loops when Q6 promotion fails repeatedly for permanent reasons
+    /// (disk full, schema corruption, etc.) — once the count crosses a
+    /// threshold the caller dead-letters the durable row instead of
+    /// preserving it for yet another retry.
+    ///
+    /// Default impl returns `Ok(0)` — in-memory backends don't track
+    /// the counter durably, so the janitor's dead-letter path simply
+    /// never trips for them. Production backends override with a
+    /// `UPDATE … SET promotion_attempts = promotion_attempts + 1` plus
+    /// a follow-up SELECT.
+    async fn record_promotion_failure(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<u32, SmPersistenceError> {
+        let _ = stream_id;
+        Ok(0)
+    }
 }
 
 /// In-memory implementation suitable for tests and as the structural

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -980,6 +980,28 @@ impl InMemorySmSessionRegistry {
         }
     }
 
+    /// Increment the persistent promotion-failure counter for
+    /// `stream_id` and return the new value. Used by the SM-expiry
+    /// janitor (issue #209 finding #14) to detect runaway retry loops
+    /// on permanent storage failures (disk full, schema corruption,
+    /// blocklist storage permanently broken). Once the count crosses
+    /// the operator-defined threshold the caller dead-letters the
+    /// durable row via `confirm_drained` instead of preserving it for
+    /// yet another retry pass.
+    ///
+    /// Returns `Ok(0)` when no persistence backend is configured
+    /// (in-memory tests), so the dead-letter path simply never trips.
+    pub async fn record_promotion_failure(&self, stream_id: &str) -> Result<u32, SmRegistryError> {
+        let Some(persistence) = self.persistence.as_ref() else {
+            return Ok(0);
+        };
+        let session_id = crate::pending_delivery::SmSessionId::new(stream_id.to_string());
+        persistence
+            .record_promotion_failure(&session_id)
+            .await
+            .map_err(|e| SmRegistryError::Internal(e.to_string()))
+    }
+
     /// Drain expired sessions from the in-memory view. Returns the
     /// drained sessions for the caller to run Q6 promotion on.
     ///


### PR DESCRIPTION
## Summary

Six operability fixes uncovered by the issue #209 adversarial review (findings #4, #5, #11, #12, #13, #14):

- **Finding #4** — `StreamLockMap` (sm_persistence) and `RecipientLockMap` (pending_delivery) were both append-only DashMaps, leaking an `Arc<Mutex<()>>` per distinct session id / recipient bare-JID for the lifetime of the runtime. `StreamLockMap` now drops entries on `delete_session` via `remove_if(strong_count == 1)`. `RecipientLockMap` is GC'd by a periodic sweep on the claim-expiry janitor's ticker via the new `sweep_internal_bookkeeping` trait method (default no-op, libSQL/Postgres backend overrides).
- **Finding #5** — Per-recipient quota was the only stop on `pending_delivery` growth; a permanently-offline recipient (deleted account / lost device) could fill their queue with rows that never expire, bouncing future legitimate senders with `<service-unavailable/>` forever. New `delete_older_than(cutoff)` trait method invoked from the same janitor; default 30 days, configurable via `WADDLE_PENDING_DELIVERY_MAX_AGE_DAYS` (clamped `[1, 365]`).
- **Finding #11** — Zero Prometheus metrics existed for the offline-DM / SM-expiry surface beyond `sm_unacked_evicted`. Added 9 new counters covering quota bounces, orphan claim releases, aging janitor activity, poison-pill drops, promotion storage / blocklist failures, dead-letter events, drain timeouts, and resume-window clamps. Wired into every relevant call site.
- **Finding #12** — Hardcoded `MAX_DRAIN_DURATION = 30s` and `MAX_RESUME_SECS = 300` are now overridable via `WADDLE_DRAIN_TIMEOUT_SECS` (clamp `[1, 600]`) and `WADDLE_SM_MAX_RESUME_SECS` (clamp `[60, 86400]`). The resume-window clamp emits `waddle_sm_resume_window_clamped_total` when a client request is silently lowered.
- **Finding #13** — `sm_sessions` had no migration affordance; future column additions would silently no-op `CREATE TABLE IF NOT EXISTS` then crash on first SELECT against an upgraded deployment. Added `add_column_if_missing` helper mirroring `pending_delivery`'s idempotent ALTER pattern, exercised by the first real migration: `promotion_attempts INTEGER NOT NULL DEFAULT 0` (groundwork for finding #14).
- **Finding #14** — Promotion preserve-and-retry path had no upper bound; permanent failures (disk full, schema corruption) looped forever per janitor pass and across restarts. New `record_promotion_failure` trait method atomically bumps the durable counter and returns the new value. Janitor preserves below threshold, dead-letters at/above (default 5 attempts, configurable via `WADDLE_SM_PROMOTION_MAX_ATTEMPTS` clamp `[2, 1024]`). Each dead-letter event emits an error log + the new `waddle_sm_promotion_dead_lettered_total` counter for alerting.

## Test plan

- [x] `cargo test -p waddle-xmpp --features test-utils` — every test passes including new `test_issue_209_finding_11_metric_families_render`
- [x] `cargo test -p waddle-server` — every test passes
- [x] `cargo clippy --all-targets -- -D warnings` clean on both crates
- [x] `cargo fmt --all` clean

## New env vars (all clamped, no rejection on bad input)

| Variable | Default | Clamp |
|---|---|---|
| `WADDLE_DRAIN_TIMEOUT_SECS` | 30 | [1, 600] |
| `WADDLE_SM_MAX_RESUME_SECS` | 300 | [60, 86400] |
| `WADDLE_PENDING_DELIVERY_MAX_AGE_DAYS` | 30 | [1, 365] |
| `WADDLE_SM_PROMOTION_MAX_ATTEMPTS` | 5 | [2, 1024] |

## New Prometheus metrics

```
waddle_pending_delivery_quota_exceeded_total
waddle_pending_delivery_orphan_claims_released_total
waddle_pending_delivery_aged_out_total
waddle_pending_delivery_unresolved_poison_pill_total
waddle_sm_promotion_storage_failed_total
waddle_sm_promotion_blocklist_failed_total
waddle_sm_promotion_dead_lettered_total
waddle_sm_drain_timeout_total
waddle_sm_resume_window_clamped_total
```

## Adversarial review context

Third of three follow-up PRs from the issue #209 adversarial review:
- **PR-A** (#407, draft) — XEP/RFC conformance gaps (findings #1, #6, #7)
- **PR-B** (#409, draft) — concurrency / lifecycle (findings #2, #3, #8, #9, #10)
- **PR-C (this)** — operability (findings #4, #5, #11, #12, #13, #14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)