### PR TITLE
fix(xmpp): preserve direct reaction target ids in MAM DTOs

### DIFF
--- a/.github/workflows/waddle-chat-pullrequest.yml
+++ b/.github/workflows/waddle-chat-pullrequest.yml
@@ -13,6 +13,7 @@ on:
     - chat/../server/crates/waddle-xmpp-client-wasm/**
     - chat/../server/crates/waddle-xmpp-client/**
     - chat/astro.config.mjs
+    - chat/dist/**
     - chat/env.cue
     - chat/knip.json
     - chat/package.json

--- a/apps/apple/Waddle/App/AppModel.swift
+++ b/apps/apple/Waddle/App/AppModel.swift
@@ -1741,7 +1741,8 @@ final class AppModel: ObservableObject {
             size: UInt64(data.count),
             width: nil,
             height: nil,
-            disposition: sharedFileDisposition(for: mediaType)
+            disposition: sharedFileDisposition(for: mediaType),
+            encrypted: nil
         )
     }
 

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -932,7 +932,9 @@ public func FfiConverterTypeWaddleClient_lower(_ value: WaddleClient) -> UnsafeM
 public struct WaddleArchivedMessage {
     public var mamId: String
     public var queryId: String?
+    public var id: String?
     public var stanzaId: String?
+    public var originId: String?
     public var timestamp: String?
     public var from: String?
     public var to: String?
@@ -950,10 +952,12 @@ public struct WaddleArchivedMessage {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(mamId: String, queryId: String?, stanzaId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?, sharedFiles: [WaddleSharedFile]) {
+    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?, sharedFiles: [WaddleSharedFile]) {
         self.mamId = mamId
         self.queryId = queryId
+        self.id = id
         self.stanzaId = stanzaId
+        self.originId = originId
         self.timestamp = timestamp
         self.from = from
         self.to = to
@@ -984,7 +988,13 @@ extension WaddleArchivedMessage: Equatable, Hashable {
         if lhs.queryId != rhs.queryId {
             return false
         }
+        if lhs.id != rhs.id {
+            return false
+        }
         if lhs.stanzaId != rhs.stanzaId {
+            return false
+        }
+        if lhs.originId != rhs.originId {
             return false
         }
         if lhs.timestamp != rhs.timestamp {
@@ -1035,7 +1045,9 @@ extension WaddleArchivedMessage: Equatable, Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(mamId)
         hasher.combine(queryId)
+        hasher.combine(id)
         hasher.combine(stanzaId)
+        hasher.combine(originId)
         hasher.combine(timestamp)
         hasher.combine(from)
         hasher.combine(to)
@@ -1064,7 +1076,9 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
             try WaddleArchivedMessage(
                 mamId: FfiConverterString.read(from: &buf),
                 queryId: FfiConverterOptionString.read(from: &buf),
+                id: FfiConverterOptionString.read(from: &buf),
                 stanzaId: FfiConverterOptionString.read(from: &buf),
+                originId: FfiConverterOptionString.read(from: &buf),
                 timestamp: FfiConverterOptionString.read(from: &buf),
                 from: FfiConverterOptionString.read(from: &buf),
                 to: FfiConverterOptionString.read(from: &buf),
@@ -1085,7 +1099,9 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
     public static func write(_ value: WaddleArchivedMessage, into buf: inout [UInt8]) {
         FfiConverterString.write(value.mamId, into: &buf)
         FfiConverterOptionString.write(value.queryId, into: &buf)
+        FfiConverterOptionString.write(value.id, into: &buf)
         FfiConverterOptionString.write(value.stanzaId, into: &buf)
+        FfiConverterOptionString.write(value.originId, into: &buf)
         FfiConverterOptionString.write(value.timestamp, into: &buf)
         FfiConverterOptionString.write(value.from, into: &buf)
         FfiConverterOptionString.write(value.to, into: &buf)
@@ -1443,6 +1459,201 @@ public func FfiConverterTypeWaddleConfig_lift(_ buf: RustBuffer) throws -> Waddl
 #endif
 public func FfiConverterTypeWaddleConfig_lower(_ value: WaddleConfig) -> RustBuffer {
     return FfiConverterTypeWaddleConfig.lower(value)
+}
+
+
+/**
+ * XEP-0448 cipher/key/iv/hashes envelope for encrypted Stateless File
+ * Sharing payloads.
+ */
+public struct WaddleEncryptedFile {
+    /**
+     * Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
+     */
+    public var cipher: String
+    /**
+     * Base64-encoded symmetric key.
+     */
+    public var keyB64: String
+    /**
+     * Base64-encoded initialization vector / nonce.
+     */
+    public var ivB64: String
+    public var hashes: [WaddleEncryptedFileHash]
+    /**
+     * Source URLs the ciphertext can be fetched from. Always non-empty.
+     */
+    public var sources: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Cipher URN, e.g. `urn:xmpp:ciphers:aes-256-gcm-nopadding:0`.
+         */cipher: String,
+        /**
+         * Base64-encoded symmetric key.
+         */keyB64: String,
+        /**
+         * Base64-encoded initialization vector / nonce.
+         */ivB64: String, hashes: [WaddleEncryptedFileHash],
+        /**
+         * Source URLs the ciphertext can be fetched from. Always non-empty.
+         */sources: [String]) {
+        self.cipher = cipher
+        self.keyB64 = keyB64
+        self.ivB64 = ivB64
+        self.hashes = hashes
+        self.sources = sources
+    }
+}
+
+#if compiler(>=6)
+extension WaddleEncryptedFile: Sendable {}
+#endif
+
+
+extension WaddleEncryptedFile: Equatable, Hashable {
+    public static func ==(lhs: WaddleEncryptedFile, rhs: WaddleEncryptedFile) -> Bool {
+        if lhs.cipher != rhs.cipher {
+            return false
+        }
+        if lhs.keyB64 != rhs.keyB64 {
+            return false
+        }
+        if lhs.ivB64 != rhs.ivB64 {
+            return false
+        }
+        if lhs.hashes != rhs.hashes {
+            return false
+        }
+        if lhs.sources != rhs.sources {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(cipher)
+        hasher.combine(keyB64)
+        hasher.combine(ivB64)
+        hasher.combine(hashes)
+        hasher.combine(sources)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleEncryptedFile: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleEncryptedFile {
+        return
+            try WaddleEncryptedFile(
+                cipher: FfiConverterString.read(from: &buf),
+                keyB64: FfiConverterString.read(from: &buf),
+                ivB64: FfiConverterString.read(from: &buf),
+                hashes: FfiConverterSequenceTypeWaddleEncryptedFileHash.read(from: &buf),
+                sources: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleEncryptedFile, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.cipher, into: &buf)
+        FfiConverterString.write(value.keyB64, into: &buf)
+        FfiConverterString.write(value.ivB64, into: &buf)
+        FfiConverterSequenceTypeWaddleEncryptedFileHash.write(value.hashes, into: &buf)
+        FfiConverterSequenceString.write(value.sources, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleEncryptedFile_lift(_ buf: RustBuffer) throws -> WaddleEncryptedFile {
+    return try FfiConverterTypeWaddleEncryptedFile.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleEncryptedFile_lower(_ value: WaddleEncryptedFile) -> RustBuffer {
+    return FfiConverterTypeWaddleEncryptedFile.lower(value)
+}
+
+
+/**
+ * XEP-0300 hash entry nested under an `<encrypted/>` envelope.
+ */
+public struct WaddleEncryptedFileHash {
+    public var algo: String
+    public var valueB64: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(algo: String, valueB64: String) {
+        self.algo = algo
+        self.valueB64 = valueB64
+    }
+}
+
+#if compiler(>=6)
+extension WaddleEncryptedFileHash: Sendable {}
+#endif
+
+
+extension WaddleEncryptedFileHash: Equatable, Hashable {
+    public static func ==(lhs: WaddleEncryptedFileHash, rhs: WaddleEncryptedFileHash) -> Bool {
+        if lhs.algo != rhs.algo {
+            return false
+        }
+        if lhs.valueB64 != rhs.valueB64 {
+            return false
+        }
+        return true
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(algo)
+        hasher.combine(valueB64)
+    }
+}
+
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleEncryptedFileHash: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleEncryptedFileHash {
+        return
+            try WaddleEncryptedFileHash(
+                algo: FfiConverterString.read(from: &buf),
+                valueB64: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleEncryptedFileHash, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.algo, into: &buf)
+        FfiConverterString.write(value.valueB64, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleEncryptedFileHash_lift(_ buf: RustBuffer) throws -> WaddleEncryptedFileHash {
+    return try FfiConverterTypeWaddleEncryptedFileHash.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleEncryptedFileHash_lower(_ value: WaddleEncryptedFileHash) -> RustBuffer {
+    return FfiConverterTypeWaddleEncryptedFileHash.lower(value)
 }
 
 
@@ -2233,10 +2444,21 @@ public struct WaddleSharedFile {
     public var width: UInt32?
     public var height: UInt32?
     public var disposition: String
+    /**
+     * XEP-0448 envelope when the bytes at `url` are ciphertext rather than
+     * the plaintext file. Recipients MUST use these values to decrypt before
+     * rendering.
+     */
+    public var encrypted: WaddleEncryptedFile?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(url: String, name: String?, mediaType: String?, size: UInt64?, width: UInt32?, height: UInt32?, disposition: String) {
+    public init(url: String, name: String?, mediaType: String?, size: UInt64?, width: UInt32?, height: UInt32?, disposition: String,
+        /**
+         * XEP-0448 envelope when the bytes at `url` are ciphertext rather than
+         * the plaintext file. Recipients MUST use these values to decrypt before
+         * rendering.
+         */encrypted: WaddleEncryptedFile?) {
         self.url = url
         self.name = name
         self.mediaType = mediaType
@@ -2244,6 +2466,7 @@ public struct WaddleSharedFile {
         self.width = width
         self.height = height
         self.disposition = disposition
+        self.encrypted = encrypted
     }
 }
 
@@ -2275,6 +2498,9 @@ extension WaddleSharedFile: Equatable, Hashable {
         if lhs.disposition != rhs.disposition {
             return false
         }
+        if lhs.encrypted != rhs.encrypted {
+            return false
+        }
         return true
     }
 
@@ -2286,6 +2512,7 @@ extension WaddleSharedFile: Equatable, Hashable {
         hasher.combine(width)
         hasher.combine(height)
         hasher.combine(disposition)
+        hasher.combine(encrypted)
     }
 }
 
@@ -2304,7 +2531,8 @@ public struct FfiConverterTypeWaddleSharedFile: FfiConverterRustBuffer {
                 size: FfiConverterOptionUInt64.read(from: &buf),
                 width: FfiConverterOptionUInt32.read(from: &buf),
                 height: FfiConverterOptionUInt32.read(from: &buf),
-                disposition: FfiConverterString.read(from: &buf)
+                disposition: FfiConverterString.read(from: &buf),
+                encrypted: FfiConverterOptionTypeWaddleEncryptedFile.read(from: &buf)
         )
     }
 
@@ -2316,6 +2544,7 @@ public struct FfiConverterTypeWaddleSharedFile: FfiConverterRustBuffer {
         FfiConverterOptionUInt32.write(value.width, into: &buf)
         FfiConverterOptionUInt32.write(value.height, into: &buf)
         FfiConverterString.write(value.disposition, into: &buf)
+        FfiConverterOptionTypeWaddleEncryptedFile.write(value.encrypted, into: &buf)
     }
 }
 
@@ -3285,6 +3514,30 @@ fileprivate struct FfiConverterOptionTypeWaddleAvatar: FfiConverterRustBuffer {
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWaddleEncryptedFile: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleEncryptedFile?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleEncryptedFile.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleEncryptedFile.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWaddleFallbackRange: FfiConverterRustBuffer {
     typealias SwiftType = WaddleFallbackRange?
 
@@ -3520,6 +3773,31 @@ fileprivate struct FfiConverterSequenceTypeWaddleChannel: FfiConverterRustBuffer
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeWaddleChannel.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeWaddleEncryptedFileHash: FfiConverterRustBuffer {
+    typealias SwiftType = [WaddleEncryptedFileHash]
+
+    public static func write(_ value: [WaddleEncryptedFileHash], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWaddleEncryptedFileHash.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WaddleEncryptedFileHash] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WaddleEncryptedFileHash]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWaddleEncryptedFileHash.read(from: &buf))
         }
         return seq
     }

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -220,7 +220,8 @@ final class RustXmppClient: ObservableObject {
             size: UInt64(size),
             width: nil,
             height: nil,
-            disposition: inferredDisposition(for: mediaType)
+            disposition: inferredDisposition(for: mediaType),
+            encrypted: nil
         )
         let options = WaddleSendOptions(
             stanzaId: nil,
@@ -382,6 +383,18 @@ private func parseRFC3339(_ string: String) -> Date? {
     return formatter.date(from: string)
 }
 
+private func makeEncryptedSource(
+    _ encrypted: WaddleEncryptedFile,
+    fallbackURL: String
+) -> XMPPEncryptedSource {
+    XMPPEncryptedSource(
+        url: encrypted.sources.first ?? fallbackURL,
+        keyBase64: encrypted.keyB64,
+        ivBase64: encrypted.ivB64,
+        cipher: encrypted.cipher
+    )
+}
+
 private func makeSharedFile(_ file: WaddleSharedFile) -> XMPPSharedFile {
     XMPPSharedFile(
         url: file.url,
@@ -391,7 +404,7 @@ private func makeSharedFile(_ file: WaddleSharedFile) -> XMPPSharedFile {
         width: file.width.flatMap(Int.init),
         height: file.height.flatMap(Int.init),
         disposition: file.disposition,
-        encryptedSource: nil
+        encryptedSource: file.encrypted.map { makeEncryptedSource($0, fallbackURL: file.url) }
     )
 }
 
@@ -409,11 +422,14 @@ private extension WaddleMamPage {
     func toXMPPArchivePage() -> XMPPArchivePage {
         let converted = messages.map { archived -> XMPPArchiveMessage in
             let timestamp = archived.timestamp.flatMap { parseRFC3339($0) }
+            let eventID = archived.messageType == "groupchat"
+                ? archived.stanzaId
+                : (archived.originId ?? archived.id ?? archived.stanzaId)
             let msgEvent = XMPPMessageEvent(
                 from: archived.from,
                 to: archived.to,
                 type: archived.messageType,
-                id: archived.stanzaId,
+                id: eventID,
                 stanzaID: archived.stanzaId,
                 body: archived.body,
                 subject: nil,

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -24,6 +24,7 @@ export function fromLiveDmMessage(
     isSelf: barePeerJid(msg.fromJid) === barePeerJid(session.jid),
   };
   if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
+  if (msg.replyableId) tm.replyableId = msg.replyableId;
   if (msg.wireIds?.length) tm.wireIds = msg.wireIds;
   if (msg.mentions?.length) tm.mentions = msg.mentions;
   if (msg.markup?.length) tm.markup = msg.markup;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -600,7 +600,7 @@ export function useDirectMessages(
   async function toggleReaction(messageId: string, emoji: string) {
     if (!xmppClient.value || !activePeerJid.value || !session.value) return;
     const msg = findMessageById(messages.value, messageId);
-    const targetId = msg?.id ?? messageId;
+    const targetId = msg?.replyableId ?? msg?.id ?? messageId;
     const myNick = session.value.username;
     const currentReactions = msg?.reactions ?? {};
     const previousEmojis: string[] = [];

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -4,7 +4,7 @@ import type { WaddleSession } from "../src/lib/server-auth";
 import { roomBareJidFor, type LiveDmMessage, type LiveRoomMessage } from "../src/lib/xmpp-client";
 import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
-import { roomMessageFromArchived } from "../src/lib/xmpp/client";
+import { dmMessageFromArchived, roomMessageFromArchived } from "../src/lib/xmpp/client";
 import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
@@ -505,6 +505,93 @@ describe("XEP-0198 delivery status (DM)", () => {
 
     const original = dm.messages.value.find((m) => m.id === "dm-original");
     expect(original?.reactions).toEqual({ "🔥": ["bob"] });
+  });
+
+  test("MAM-replayed DM reactions survive when archived DTOs expose the conformant direct ID", async () => {
+    const originalWireId = "dm-original-wire-id";
+    const archivedOriginal: WasmArchivedMessage = {
+      mam_id: "mam-dm-original",
+      message_type: "chat",
+      from: "alice@example.com/desktop",
+      to: "bob@example.com",
+      id: originalWireId,
+      body: "react to me in dm after refresh",
+      reaction_emojis: [],
+      is_muc: false,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    const archivedReaction: WasmArchivedMessage = {
+      mam_id: "mam-dm-reaction",
+      message_type: "chat",
+      from: "bob@example.com/desktop",
+      to: "alice@example.com",
+      reaction_target_id: originalWireId,
+      reaction_emojis: ["🔥"],
+      is_muc: false,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      timestamp: "2024-01-01T00:01:00Z",
+    };
+    const liveMessages = [archivedOriginal, archivedReaction]
+      .map((message) => dmMessageFromArchived(message, "alice@example.com"))
+      .filter((message): message is LiveDmMessage => !!message);
+    const client = makeDmClient(liveMessages);
+    const { dm } = makeDmMessaging(client);
+
+    await dm.loadMessages("bob@example.com");
+    await nextTick();
+
+    const original = dm.messages.value.find((m) => m.body === "react to me in dm after refresh");
+    expect(original).toBeDefined();
+    expect(original?.reactions).toEqual({ "🔥": ["bob"] });
+  });
+
+  test("DM reactions sent after MAM refresh target the archived origin-id before message id", async () => {
+    const messageId = "dm-message-id";
+    const originId = "dm-origin-id";
+    const archivedOriginal: WasmArchivedMessage = {
+      mam_id: "mam-dm-origin-original",
+      message_type: "chat",
+      from: "bob@example.com/desktop",
+      to: "alice@example.com",
+      id: messageId,
+      origin_id: originId,
+      body: "react to origin-id",
+      reaction_emojis: [],
+      is_muc: false,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+      timestamp: "2024-01-01T00:00:00Z",
+    };
+    const liveMessages = [archivedOriginal]
+      .map((message) => dmMessageFromArchived(message, "alice@example.com"))
+      .filter((message): message is LiveDmMessage => !!message);
+    const sendDmReaction = mock(async () => undefined);
+    const client = makeDmClient(liveMessages);
+    (client as unknown as { value: Record<string, unknown> }).value = {
+      ...(client as unknown as { value: Record<string, unknown> }).value,
+      sendDmReaction,
+    };
+    const { dm } = makeDmMessaging(client);
+
+    await dm.loadMessages("bob@example.com");
+    await nextTick();
+    await dm.toggleReaction(messageId, "👍");
+
+    expect(sendDmReaction).toHaveBeenCalledWith("bob@example.com", originId, ["👍"]);
+    const original = dm.messages.value.find((m) => m.body === "react to origin-id");
+    expect(original?.reactions).toEqual({ "👍": ["alice"] });
   });
 
   test("DM toggleReaction optimistically updates the local timeline (the sender device gets no carbon)", async () => {

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5971,6 +5971,7 @@ dependencies = [
  "minidom",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "uuid",

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -270,7 +270,9 @@ fn archived_to_ffi(archived: waddle_xmpp_client::ArchivedMessage) -> WaddleArchi
     WaddleArchivedMessage {
         mam_id: archived.mam_id,
         query_id: archived.query_id,
-        stanza_id: archived.stanza_id,
+        id: archived.id.map(|id| id.to_string()),
+        stanza_id: archived.stanza_id.map(|id| id.to_string()),
+        origin_id: archived.origin_id.map(|id| id.to_string()),
         timestamp: archived.timestamp.map(|t| t.to_rfc3339()),
         from: archived.from,
         to: archived.to,

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -41,7 +41,9 @@ pub struct WaddleMessage {
 pub struct WaddleArchivedMessage {
     pub mam_id: String,
     pub query_id: Option<String>,
+    pub id: Option<String>,
     pub stanza_id: Option<String>,
+    pub origin_id: Option<String>,
     pub timestamp: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,

--- a/server/crates/waddle-xmpp-client-ffi/src/waddle_xmpp_client.udl
+++ b/server/crates/waddle-xmpp-client-ffi/src/waddle_xmpp_client.udl
@@ -36,7 +36,9 @@ dictionary WaddleMessage {
 dictionary WaddleArchivedMessage {
     string mam_id;
     string? query_id;
+    string? id;
     string? stanza_id;
+    string? origin_id;
     string? timestamp;
     string? from;
     string? to;

--- a/server/crates/waddle-xmpp-client-wasm/Cargo.toml
+++ b/server/crates/waddle-xmpp-client-wasm/Cargo.toml
@@ -28,5 +28,8 @@ serde = { workspace = true, features = ["derive"] }
 serde-wasm-bindgen = "0.6"
 getrandom = { version = "0.2", features = ["js"] }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -130,7 +130,9 @@ pub(crate) fn archived_to_js(archived: ArchivedMessage) -> WaddleArchivedMessage
     WaddleArchivedMessage {
         mam_id: archived.mam_id,
         query_id: archived.query_id,
-        stanza_id: archived.stanza_id,
+        id: archived.id.map(|id| id.to_string()),
+        stanza_id: archived.stanza_id.map(|id| id.to_string()),
+        origin_id: archived.origin_id.map(|id| id.to_string()),
         timestamp: archived.timestamp.map(|timestamp| timestamp.to_rfc3339()),
         from: archived.from,
         to: archived.to,
@@ -365,6 +367,36 @@ mod inbound_to_js_tests {
         assert_eq!(reference.begin, 4);
         assert_eq!(reference.end, 23);
         assert!(reference.anchor.is_none());
+    }
+
+    #[test]
+    fn archived_to_js_preserves_direct_message_business_ids_for_xep0444_refresh() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-dm-original' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='chat' id='dm-original-wire-id' \
+                            from='alice@example.com/desktop' to='bob@example.com'>\
+                     <origin-id xmlns='urn:xmpp:sid:0' id='dm-original-origin-id'/>\
+                     <body>direct reaction survives refresh</body>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let value =
+            serde_json::to_value(archived_to_js(archived)).expect("archived DTO should serialize");
+
+        assert_eq!(
+            value.get("id").and_then(serde_json::Value::as_str),
+            Some("dm-original-wire-id")
+        );
+        assert_eq!(
+            value.get("origin_id").and_then(serde_json::Value::as_str),
+            Some("dm-original-origin-id")
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -50,7 +50,9 @@ pub struct WaddleMessage {
 pub struct WaddleArchivedMessage {
     pub mam_id: String,
     pub query_id: Option<String>,
+    pub id: Option<String>,
     pub stanza_id: Option<String>,
+    pub origin_id: Option<String>,
     pub timestamp: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,

--- a/server/crates/waddle-xmpp-client/src/mam.rs
+++ b/server/crates/waddle-xmpp-client/src/mam.rs
@@ -10,6 +10,7 @@ use minidom::Element;
 use waddle_xmpp_core::mam::{
     DELAY_NS, FORWARD_NS, FULLTEXT_MAM_FIELD, MAM_NS, RSM_NS, WADDLE_MAM_THREAD_FIELD,
 };
+use waddle_xmpp_core::xep0359::{OriginId, StanzaId as StableStanzaId, NS_SID as XEP0359_NS};
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 use std::time::Duration;
@@ -48,7 +49,11 @@ pub struct MamPage {
 pub struct ArchivedMessage {
     pub mam_id: String,
     pub query_id: Option<String>,
-    pub stanza_id: Option<String>,
+    /// Inner forwarded `<message id='...'/>` value.
+    pub id: Option<ArchivedMessageId>,
+    pub stanza_id: Option<StableStanzaId>,
+    /// XEP-0359 `<origin-id/>` from the inner forwarded message.
+    pub origin_id: Option<OriginId>,
     pub timestamp: Option<DateTime<Utc>>,
     pub from: Option<String>,
     pub to: Option<String>,
@@ -64,6 +69,30 @@ pub struct ArchivedMessage {
     pub author_real_jid: Option<String>,
     /// Raw inner `<message>` element for full parsing by the messaging module.
     pub inner: Element,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ArchivedMessageId(String);
+
+impl ArchivedMessageId {
+    pub fn new(id: impl Into<String>) -> Option<Self> {
+        let id = id.into();
+        if id.is_empty() {
+            None
+        } else {
+            Some(Self(id))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ArchivedMessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// RSM (XEP-0059) pagination info from a MAM `<fin/>`.
@@ -376,6 +405,7 @@ pub fn parse_mam_result(element: &Element) -> Option<ArchivedMessage> {
     let from = inner.attr("from").map(str::to_string);
     let to = inner.attr("to").map(str::to_string);
     let message_type = inner.attr("type").unwrap_or("normal").to_string();
+    let id = inner.attr("id").and_then(ArchivedMessageId::new);
 
     let body = inner
         .get_child("body", CLIENT_NS)
@@ -392,15 +422,21 @@ pub fn parse_mam_result(element: &Element) -> Option<ArchivedMessage> {
 
     // XEP-0359 stanza-id embedded in the inner message.
     let stanza_id = inner
-        .get_child("stanza-id", "urn:xmpp:sid:0")
+        .get_child("stanza-id", XEP0359_NS)
+        .and_then(parse_archived_stanza_id);
+    let origin_id = inner
+        .get_child("origin-id", XEP0359_NS)
         .and_then(|s| s.attr("id"))
-        .map(str::to_string);
+        .filter(|id| !id.is_empty())
+        .map(OriginId::new);
     let author_real_jid = parse_archived_author_real_jid(&inner);
 
     Some(ArchivedMessage {
         mam_id,
         query_id,
+        id,
         stanza_id,
+        origin_id,
         timestamp,
         from,
         to,
@@ -411,6 +447,16 @@ pub fn parse_mam_result(element: &Element) -> Option<ArchivedMessage> {
         author_real_jid,
         inner,
     })
+}
+
+fn parse_archived_stanza_id(element: &Element) -> Option<StableStanzaId> {
+    let id = element.attr("id").filter(|id| !id.is_empty())?;
+    let by = element
+        .attr("by")
+        .filter(|by| !by.is_empty())?
+        .parse::<jid::Jid>()
+        .ok()?;
+    Some(StableStanzaId::new(id, by))
 }
 
 /// Parse a MAM `<fin/>` element into [`RsmPageInfo`] and a completeness flag.

--- a/server/crates/waddle-xmpp-client/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/mam/tests.rs
@@ -83,9 +83,54 @@ fn parse_mam_result_happy_path() {
     assert_eq!(archived.message_type, "chat");
     assert_eq!(archived.body.as_deref(), Some("Hello world"));
     assert_eq!(archived.from.as_deref(), Some("alice@example.com/res"));
+    assert!(archived.id.is_none());
+    assert!(archived.origin_id.is_none());
     assert!(archived.timestamp.is_some());
     let ts = archived.timestamp.unwrap();
     assert_eq!(ts.year(), 2024);
+}
+
+#[test]
+fn parse_mam_result_preserves_inner_message_and_origin_ids() {
+    let inner = Element::builder("message", CLIENT_NS)
+        .attr("from", "alice@example.com/desktop")
+        .attr("to", "bob@example.com")
+        .attr("type", "chat")
+        .attr("id", "direct-message-id")
+        .append(
+            Element::builder("origin-id", XEP0359_NS)
+                .attr("id", "direct-origin-id")
+                .build(),
+        )
+        .append(Element::builder("body", CLIENT_NS).append("hi").build())
+        .build();
+    let forwarded = Element::builder("forwarded", FORWARD_NS)
+        .append(
+            Element::builder("delay", DELAY_NS)
+                .attr("stamp", "2024-01-01T12:00:00Z")
+                .build(),
+        )
+        .append(inner)
+        .build();
+    let result = Element::builder("result", MAM_NS)
+        .attr("id", "mam-id-with-business-id")
+        .attr("queryid", "qid-business")
+        .append(forwarded)
+        .build();
+    let el = Element::builder("message", CLIENT_NS)
+        .append(result)
+        .build();
+
+    let archived = parse_mam_result(&el).expect("should parse");
+
+    assert_eq!(
+        archived.id.as_ref().map(|id| id.as_str()),
+        Some("direct-message-id")
+    );
+    assert_eq!(
+        archived.origin_id.as_ref().map(|id| id.as_str()),
+        Some("direct-origin-id")
+    );
 }
 
 #[test]
@@ -389,7 +434,12 @@ mod query {
         ArchivedMessage {
             mam_id: mam_id.to_string(),
             query_id: Some(query_id.to_string()),
-            stanza_id: Some(mam_id.to_string()),
+            id: None,
+            stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+                mam_id,
+                "room@muc.example.com".parse().expect("valid archive jid"),
+            )),
+            origin_id: None,
             timestamp: None,
             from: Some("room@muc.example.com/alice".to_string()),
             to: Some("alice@example.com/res".to_string()),

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -1,6 +1,6 @@
 pub(crate) const NS_DELAY: &str = "urn:xmpp:delay";
 pub(crate) const NS_STANZA_ID: &str = "urn:xmpp:sid:0";
-pub(crate) const NS_ORIGIN_ID: &str = "urn:xmpp:origin-id:0";
+pub(crate) const NS_ORIGIN_ID: &str = "urn:xmpp:sid:0";
 pub const NS_REACTIONS: &str = "urn:xmpp:reactions:0";
 pub(crate) const NS_MARKUP: &str = "urn:xmpp:markup:0";
 pub(crate) const NS_WADDLE_MARKUP: &str = "urn:waddle:markup:0";

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -55,6 +55,24 @@ fn parse_message_with_stanza_id() {
 }
 
 #[test]
+fn parse_message_with_origin_id() {
+    let e = Element::builder("message", NS_CLIENT)
+        .attr("type", "chat")
+        .attr("id", "m4")
+        .append(Element::builder("body", NS_CLIENT).append("hi").build())
+        .append(
+            Element::builder("origin-id", NS_ORIGIN_ID)
+                .attr("id", "client-origin-42")
+                .build(),
+        )
+        .build();
+    let MessagingEvent::Message(msg) = parse(&e).unwrap() else {
+        panic!("expected Message");
+    };
+    assert_eq!(msg.origin_id.as_deref(), Some("client-origin-42"));
+}
+
+#[test]
 fn parse_message_with_chat_state() {
     let e = el(
         "<message xmlns='jabber:client' type='chat' to='alice@example.com'>\


### PR DESCRIPTION
## Summary

Fixes the reaction-refresh regression after the large XMPP/chat refactor.

- Preserves the forwarded direct-message `<message id/>` and XEP-0359 `<origin-id/>` from MAM results through the Rust archive parser, WASM DTO, and UniFFI DTO.
- Uses the correct XEP-0359 namespace, `urn:xmpp:sid:0`, for `origin-id`.
- Keeps Rust-side archive payloads typed: XEP-0359 `stanza-id` and `origin-id` use the workspace XEP-0359 types, and forwarded message ids use a dedicated typed wrapper before flattening at FFI/WASM boundaries.
- Keeps groupchat reaction refresh keyed by XEP-0359 `stanza-id`, while direct-message refresh and post-refresh reaction sends prefer `origin-id`, then forwarded message id, then stanza id.
- Refreshes the Apple UniFFI binding and maps the now-exposed encrypted shared-file metadata into the native `XMPPEncryptedSource`.
- Commits the generated chat PR workflow path-filter drift from `cuenv sync -A`.

## Plan / Completed

1. Confirm the refresh failure with the websocket E2E scenario and focused DTO regression.
2. Compare the fix against local XEP-0444/XEP-0359 behavior: MUC reactions target stanza-id; direct reactions target origin-id when present, otherwise message id.
3. Preserve direct-message business ids in the Rust MAM parser and expose them to browser/native clients.
4. Preserve refreshed direct-message `replyableId` in chat timeline state so new reactions after reload target the conformant id.
5. Regenerate and compile the Apple Rust client binding after UniFFI DTO changes.
6. Run adversarial review and address the real findings.
7. Re-run generated CI sync after the CI drift check exposed stale workflow output.

## Validation

- `bun test tests/sm-delivery.test.ts`
- `bun run lint`
- `cargo fmt -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi --check`
- `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi`
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm -p waddle-xmpp-client-ffi --tests -- -D warnings`
- `cargo test -p waddle-server --test xmpp_e2e_cue cue_scenarios_run_over_websocket -- --nocapture`
- `cargo check -p waddle-xmpp-client-wasm --target wasm32-unknown-unknown`
- `./scripts/build-xcframework.sh --debug`
- `xcodebuild -project apps/apple/Waddle.xcodeproj -scheme Waddle-macOS -configuration Debug -derivedDataPath /private/tmp/waddle-xcode-derived4 build`
- `cuenv sync -A`
- `cuenv task checkCiDrift --skip-dependencies`
- `git diff --check`

The ignored `apps/apple/Generated/` XCFramework was generated locally for the Apple build check and is not committed.
