### PR TITLE
feat(server): channel pinned messages — urn:waddle:pin:0 wire shape + room projection (#414)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -22,7 +22,10 @@
       "Bash(bun install:*)",
       "Bash(bun test:*)",
       "Bash(rustup target:*)",
-      "Bash(cargo build:*)"
+      "Bash(cargo build:*)",
+      "Bash(gh issue *)",
+      "Bash(git fetch *)",
+      "Bash(git push *)"
     ]
   }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -172,7 +172,6 @@ use room_helpers::{
 };
 use room_pin::apply_pin_change_event;
 use room_subject::persist_room_subject_event;
-use room_system_message::broadcast_room_system_message_event;
 use route_to_connection::route_to_connection;
 use routing::{deliver_peer_to_full, run_headless_recipient_pass};
 
@@ -317,12 +316,8 @@ async fn interpret_with_depth(
                 archive_groupchat_event(deps, room, sender, message, sender_nickname_generation)
                     .await;
             }
-            OutboundEvent::ApplyPinChange { room, change } => {
-                apply_pin_change_event(deps, room, change).await;
-            }
-            OutboundEvent::BroadcastRoomSystemMessage { room, message } => {
-                broadcast_room_system_message_event(registry, deps, room, message, recursion_depth)
-                    .await;
+            OutboundEvent::ApplyPinChange { room, request } => {
+                apply_pin_change_event(registry, deps, room, request, recursion_depth).await;
             }
             OutboundEvent::ApplyGroupchatRetractionTombstone {
                 room,

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -90,8 +90,8 @@ use waddle_xmpp::mam::{
     RichMessageId, RichText, STANZA_ID_NS,
 };
 use waddle_xmpp::muc::room_actor::{
-    GetAffiliation, GetNicknameGeneration, GetRoomSnapshot, JoinWithAffiliation, RoomActor,
-    SetSubject,
+    ApplyPin, GetAffiliation, GetNicknameGeneration, GetRoomSnapshot, JoinWithAffiliation,
+    RoomActor, SetSubject,
 };
 use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parse_managed_room_jid;
@@ -139,7 +139,9 @@ mod groupchat_validation;
 mod offline_delivery;
 mod room_dispatch;
 mod room_helpers;
+mod room_pin;
 mod room_subject;
+mod room_system_message;
 mod route_to_connection;
 mod routing;
 
@@ -168,7 +170,9 @@ use room_helpers::{
     available_bot_nick, bot_full_jid, enrich_message_event, normalize_thread_create_source,
     session_is_server_owner,
 };
+use room_pin::apply_pin_change_event;
 use room_subject::persist_room_subject_event;
+use room_system_message::broadcast_room_system_message_event;
 use route_to_connection::route_to_connection;
 use routing::{deliver_peer_to_full, run_headless_recipient_pass};
 
@@ -314,25 +318,11 @@ async fn interpret_with_depth(
                     .await;
             }
             OutboundEvent::ApplyPinChange { room, change } => {
-                // #414 follow-up: forward to room actor (Pin/Unpin
-                // messages on RoomActor) once the actor surface lands.
-                // For now the protocol layer is fully typed; wire the
-                // mutation in the next commit.
-                warn!(
-                    variant = "ApplyPinChange",
-                    room = %room,
-                    change = ?change,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+                apply_pin_change_event(deps, room, change).await;
             }
-            OutboundEvent::BroadcastRoomSystemMessage { room, .. } => {
-                // #414 follow-up: stamp XEP-0359 by-room stanza-id,
-                // archive in MAM, fan out RouteToConnection per occupant.
-                warn!(
-                    variant = "BroadcastRoomSystemMessage",
-                    room = %room,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+            OutboundEvent::BroadcastRoomSystemMessage { room, message } => {
+                broadcast_room_system_message_event(registry, deps, room, message, recursion_depth)
+                    .await;
             }
             OutboundEvent::ApplyGroupchatRetractionTombstone {
                 room,

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -313,6 +313,27 @@ async fn interpret_with_depth(
                 archive_groupchat_event(deps, room, sender, message, sender_nickname_generation)
                     .await;
             }
+            OutboundEvent::ApplyPinChange { room, change } => {
+                // #414 follow-up: forward to room actor (Pin/Unpin
+                // messages on RoomActor) once the actor surface lands.
+                // For now the protocol layer is fully typed; wire the
+                // mutation in the next commit.
+                warn!(
+                    variant = "ApplyPinChange",
+                    room = %room,
+                    change = ?change,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
+            }
+            OutboundEvent::BroadcastRoomSystemMessage { room, .. } => {
+                // #414 follow-up: stamp XEP-0359 by-room stanza-id,
+                // archive in MAM, fan out RouteToConnection per occupant.
+                warn!(
+                    variant = "BroadcastRoomSystemMessage",
+                    room = %room,
+                    "OutboundEvent variant not yet wired in interpreter"
+                );
+            }
             OutboundEvent::ApplyGroupchatRetractionTombstone {
                 room,
                 target_message_id,

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -345,6 +345,19 @@ async fn interpret_with_depth(
                     &retraction_message,
                 )
                 .await;
+                // #414: cascade XEP-0424 retraction to the room's pin
+                // list. If the retracted stanza-id is currently pinned,
+                // remove it from the projection and broadcast a
+                // synthetic unpin system message so live clients see the
+                // tab update without a separate poll.
+                room_pin::cascade_retraction_to_pin_list(
+                    registry,
+                    deps,
+                    room,
+                    target_message_id,
+                    recursion_depth,
+                )
+                .await;
             }
             OutboundEvent::PersistRoomSubject {
                 room,

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -1,66 +1,278 @@
 //! Interpreter arms for pin events (#414).
 //!
-//! Forwards `OutboundEvent::ApplyPinChange` to the per-room
-//! `RoomActor` via the `ApplyPin` actor message and runs the XEP-0424
-//! retraction → auto-unpin cascade. The cascade reads the room's
-//! current pin list, removes the matching entry atomically inside the
-//! actor (via the actor's serial mailbox), then broadcasts a
-//! synthetic `<unpinned reason='retracted'/>` system message via
-//! `broadcast_room_system_message_event`.
+//! Resolves an `OutboundEvent::ApplyPinChange` request by:
+//!
+//! 1. For pins: looking up the target message in the room's MAM
+//!    archive to populate the preview (author bare-JID, body text
+//!    truncated to 280 chars, original message timestamp). The chain
+//!    handler is synchronous and cannot do this lookup — the
+//!    interpreter is the async boundary that builds the resolved
+//!    [`PinnedEntry`].
+//! 2. Forwarding the resolved [`PinStateChange`] to the room actor's
+//!    `ApplyPin` message.
+//! 3. Building the `<pin-event/>` system message with the resolved
+//!    preview and broadcasting it via
+//!    [`super::room_system_message::broadcast_room_system_message_event`].
+//!
+//! The XEP-0424 retraction cascade emits `ApplyPinChange { Unpin {
+//! reason: "retracted" } }` through this same path so the unpin
+//! attribution and broadcast logic stays consistent.
 
 use super::*;
-use waddle_xmpp::muc::pin::PinStateChange;
+use jid::BareJid;
+use waddle_xmpp::muc::pin::{
+    PinChangeRequest, PinPreview, PinStateChange, PinnedEntry, MAX_PREVIEW_LEN,
+};
 use waddle_xmpp::muc::room_actor::GetPinList;
-use waddle_xmpp::protocol::room::pin::build_unpinned_system_message;
+use waddle_xmpp::protocol::room::pin::{
+    build_pinned_system_message, build_unpinned_system_message,
+};
 use waddle_xmpp::xep::xep_waddle_pin::MAX_TARGET_STANZA_ID_LEN;
-use waddle_xmpp_core::xep0359::StanzaId as Xep0359StanzaIdTyped;
+use waddle_xmpp_core::xep0359::StanzaId;
 
-pub(super) async fn apply_pin_change_event(deps: &Deps<'_>, room: BareJid, change: PinStateChange) {
+pub(super) async fn apply_pin_change_event(
+    registry: &ConnectionRegistry,
+    deps: &Deps<'_>,
+    room: BareJid,
+    request: PinChangeRequest,
+    recursion_depth: u8,
+) {
+    if request.target_stanza_id().id.is_empty()
+        || request.target_stanza_id().id.len() > MAX_TARGET_STANZA_ID_LEN
+    {
+        warn!(
+            room = %room,
+            target = %request.target_stanza_id().id,
+            "ApplyPinChange: target stanza-id failed length validation; dropping"
+        );
+        return;
+    }
+    match request {
+        PinChangeRequest::Pin { .. } => {
+            apply_pin(registry, deps, room, request, recursion_depth).await;
+        }
+        PinChangeRequest::Unpin { .. } => {
+            apply_unpin(registry, deps, room, request, recursion_depth).await;
+        }
+    }
+}
+
+async fn apply_pin(
+    registry: &ConnectionRegistry,
+    deps: &Deps<'_>,
+    room: BareJid,
+    request: PinChangeRequest,
+    recursion_depth: u8,
+) {
+    let PinChangeRequest::Pin {
+        target_stanza_id,
+        pinner_jid,
+        pinner_nick,
+        pinned_at,
+    } = request
+    else {
+        return;
+    };
+    let Some(room_actor) = lookup_room_actor(deps, &room, "ApplyPinChange::Pin").await else {
+        return;
+    };
+
+    // Resolve the preview from MAM. If the target row is missing
+    // (e.g., archive purged or wire id mismatched), fall back to a
+    // placeholder preview keyed on the pinner — better than dropping
+    // the pin silently. Most real pin requests target a recent
+    // message that's still archived.
+    let preview = resolve_preview_from_mam(deps, &room, &target_stanza_id)
+        .await
+        .unwrap_or_else(|| {
+            warn!(
+                room = %room,
+                target = %target_stanza_id.id,
+                "ApplyPinChange::Pin: target not found in MAM; storing placeholder preview"
+            );
+            PinPreview::new(pinner_jid.clone(), None, "", pinned_at)
+        });
+
+    let entry = PinnedEntry {
+        target_stanza_id: target_stanza_id.clone(),
+        pinner_jid: pinner_jid.clone(),
+        pinned_at,
+        preview: preview.clone(),
+    };
+
+    if let Err(error) = room_actor
+        .ask(ApplyPin {
+            change: PinStateChange::Pin(entry),
+        })
+        .await
+    {
+        warn!(
+            room = %room,
+            error = ?error,
+            "ApplyPinChange::Pin: ApplyPin ask failed; pin not stored or broadcast"
+        );
+        return;
+    }
+
+    let system_message = build_pinned_system_message(
+        &room,
+        &pinner_jid,
+        &pinner_nick,
+        &target_stanza_id,
+        Some(&preview),
+        None,
+    );
+    super::room_system_message::broadcast_room_system_message_event(
+        registry,
+        deps,
+        room,
+        Box::new(system_message),
+        recursion_depth,
+    )
+    .await;
+}
+
+async fn apply_unpin(
+    registry: &ConnectionRegistry,
+    deps: &Deps<'_>,
+    room: BareJid,
+    request: PinChangeRequest,
+    recursion_depth: u8,
+) {
+    let PinChangeRequest::Unpin {
+        target_stanza_id,
+        pinner_jid,
+        pinner_nick,
+        reason,
+    } = request
+    else {
+        return;
+    };
+    let Some(room_actor) = lookup_room_actor(deps, &room, "ApplyPinChange::Unpin").await else {
+        return;
+    };
+
+    if let Err(error) = room_actor
+        .ask(ApplyPin {
+            change: PinStateChange::Unpin {
+                target_stanza_id: target_stanza_id.clone(),
+            },
+        })
+        .await
+    {
+        warn!(
+            room = %room,
+            error = ?error,
+            "ApplyPinChange::Unpin: ApplyPin ask failed; pin still in list, no broadcast"
+        );
+        return;
+    }
+
+    let system_message = build_unpinned_system_message(
+        &room,
+        &pinner_jid,
+        &pinner_nick,
+        &target_stanza_id,
+        reason.as_deref(),
+    );
+    super::room_system_message::broadcast_room_system_message_event(
+        registry,
+        deps,
+        room,
+        Box::new(system_message),
+        recursion_depth,
+    )
+    .await;
+}
+
+async fn lookup_room_actor(
+    deps: &Deps<'_>,
+    room: &BareJid,
+    op: &'static str,
+) -> Option<kameo::actor::ActorRef<RoomActor>> {
     let Some(room_registry) = deps.room_registry else {
         debug!(
             room = %room,
-            "ApplyPinChange: no room_registry in Deps; skipping"
+            op,
+            "no room_registry in Deps; skipping"
         );
-        return;
+        return None;
     };
-    let room_actor = match room_registry
+    match room_registry
         .ask(GetRoom {
             room_jid: room.clone(),
         })
         .await
     {
-        Ok(Some(actor)) => actor,
+        Ok(Some(actor)) => Some(actor),
         Ok(None) => {
             debug!(
                 room = %room,
-                "ApplyPinChange: room not registered; skipping"
+                op,
+                "room not registered; skipping"
             );
-            return;
+            None
         }
         Err(error) => {
             warn!(
                 room = %room,
+                op,
                 error = ?error,
-                "ApplyPinChange: room registry lookup failed; skipping"
+                "room registry lookup failed; skipping"
             );
-            return;
+            None
+        }
+    }
+}
+
+/// Look up the target message in the room's MAM archive and build a
+/// `PinPreview` from it. Returns `None` if the message isn't found or
+/// MAM storage isn't wired in `Deps`. The body is truncated to
+/// `MAX_PREVIEW_LEN` UTF-8 chars by `PinPreview::new`.
+async fn resolve_preview_from_mam(
+    deps: &Deps<'_>,
+    room: &BareJid,
+    target_stanza_id: &StanzaId,
+) -> Option<PinPreview> {
+    let mam_storage = deps.mam_storage?;
+    let row = match mam_storage
+        .get_message_by_stanza_id(room, &target_stanza_id.id)
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => return None,
+        Err(error) => {
+            warn!(
+                room = %room,
+                target = %target_stanza_id.id,
+                error = ?error,
+                "ApplyPinChange::Pin: MAM lookup failed"
+            );
+            return None;
         }
     };
-    if let Err(error) = room_actor.ask(ApplyPin { change }).await {
-        warn!(
-            room = %room,
-            error = ?error,
-            "ApplyPinChange: ApplyPin ask failed; pin state left at previous value"
-        );
-    }
+    let author_bare = row.from.to_bare();
+    let body = row.body.clone().unwrap_or_default();
+    let truncated = if body.chars().count() > MAX_PREVIEW_LEN {
+        body.chars().take(MAX_PREVIEW_LEN).collect()
+    } else {
+        body
+    };
+    Some(PinPreview::new(
+        author_bare,
+        None,
+        &truncated,
+        row.timestamp,
+    ))
 }
 
 /// XEP-0424 retraction → pin auto-unpin cascade (#414, Q8 = a).
 ///
 /// When a groupchat message is retracted, check whether its stanza-id
-/// is in the room's current pin list. If so, remove the pin entry and
-/// broadcast a synthetic unpin system message so live clients see the
-/// projection update without re-querying.
+/// is in the room's current pin list. If so, emit an
+/// `ApplyPinChange { Unpin { reason: "retracted" } }` event so the
+/// regular interpreter path mutates the actor and broadcasts the
+/// unpin system message — single code path, no special-case logic.
 pub(super) async fn cascade_retraction_to_pin_list(
     registry: &ConnectionRegistry,
     deps: &Deps<'_>,
@@ -68,23 +280,11 @@ pub(super) async fn cascade_retraction_to_pin_list(
     target_message_id: String,
     recursion_depth: u8,
 ) {
-    // Defense in depth: an oversized id can't legitimately match any
-    // pin entry, but bounding it prevents allocation amplification on
-    // the per-occupant fan-out below if something upstream was lax.
     if target_message_id.is_empty() || target_message_id.len() > MAX_TARGET_STANZA_ID_LEN {
         return;
     }
-    let Some(room_registry) = deps.room_registry else {
+    let Some(room_actor) = lookup_room_actor(deps, &room, "PinRetractionCascade").await else {
         return;
-    };
-    let room_actor = match room_registry
-        .ask(GetRoom {
-            room_jid: room.clone(),
-        })
-        .await
-    {
-        Ok(Some(actor)) => actor,
-        _ => return,
     };
     let entries = match room_actor.ask(GetPinList).await {
         Ok(entries) => entries,
@@ -92,7 +292,7 @@ pub(super) async fn cascade_retraction_to_pin_list(
             warn!(
                 room = %room,
                 error = ?error,
-                "Pin retraction cascade: GetPinList ask failed; skipping"
+                "Pin retraction cascade: GetPinList ask failed"
             );
             return;
         }
@@ -104,30 +304,17 @@ pub(super) async fn cascade_retraction_to_pin_list(
     else {
         return;
     };
-    let target_typed = Xep0359StanzaIdTyped::new(target_message_id, Jid::from(room.clone()));
-    if let Err(error) = room_actor
-        .ask(ApplyPin {
-            change: PinStateChange::Unpin {
-                target_stanza_id: target_typed.clone(),
-            },
-        })
-        .await
-    {
-        warn!(
-            room = %room,
-            error = ?error,
-            "Pin retraction cascade: ApplyPin Unpin ask failed"
-        );
-        return;
-    }
-    let pinner = entry.pinner_jid.clone();
-    let system_message =
-        build_unpinned_system_message(&room, &pinner, "", &target_typed, Some("retracted"));
-    super::room_system_message::broadcast_room_system_message_event(
+
+    apply_pin_change_event(
         registry,
         deps,
         room,
-        Box::new(system_message),
+        PinChangeRequest::Unpin {
+            target_stanza_id: entry.target_stanza_id,
+            pinner_jid: entry.pinner_jid,
+            pinner_nick: String::new(),
+            reason: Some("retracted".to_string()),
+        },
         recursion_depth,
     )
     .await;

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -23,7 +23,7 @@ use jid::BareJid;
 use waddle_xmpp::muc::pin::{
     PinChangeRequest, PinPreview, PinStateChange, PinnedEntry, MAX_PREVIEW_LEN,
 };
-use waddle_xmpp::muc::room_actor::GetPinList;
+use waddle_xmpp::muc::room_actor::{GetPinList, GetRoomSnapshot};
 use waddle_xmpp::protocol::room::pin::{
     build_pinned_system_message, build_unpinned_system_message,
 };
@@ -77,12 +77,43 @@ async fn apply_pin(
         return;
     };
 
+    // Pull the room snapshot once: we need its occupant list to map
+    // the archived `room/nick` from-JID back to the author's real
+    // bare JID for the preview.
+    let synthetic_sender = match room.clone().with_resource_str("__pin_resolver__") {
+        Ok(s) => s,
+        Err(error) => {
+            warn!(
+                room = %room,
+                ?error,
+                "ApplyPinChange::Pin: failed to build resolver sender; dropping"
+            );
+            return;
+        }
+    };
+    let snapshot = match room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: synthetic_sender,
+        })
+        .await
+    {
+        Ok(snap) => snap,
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "ApplyPinChange::Pin: GetRoomSnapshot failed; dropping"
+            );
+            return;
+        }
+    };
+
     // Resolve the preview from MAM. If the target row is missing
     // (e.g., archive purged or wire id mismatched), fall back to a
     // placeholder preview keyed on the pinner — better than dropping
     // the pin silently. Most real pin requests target a recent
     // message that's still archived.
-    let preview = resolve_preview_from_mam(deps, &room, &target_stanza_id)
+    let preview = resolve_preview_from_mam(deps, &room, &target_stanza_id, &snapshot.occupants)
         .await
         .unwrap_or_else(|| {
             warn!(
@@ -229,10 +260,23 @@ async fn lookup_room_actor(
 /// `PinPreview` from it. Returns `None` if the message isn't found or
 /// MAM storage isn't wired in `Deps`. The body is truncated to
 /// `MAX_PREVIEW_LEN` UTF-8 chars by `PinPreview::new`.
+///
+/// Author resolution: groupchat archive rows store `from` as
+/// `room@conf/nick` (XEP-0045 §7.2.13 canonicalized form), so the
+/// resource part is the nickname and `to_bare()` collapses to the
+/// room JID. We extract the nick from the resource and consult the
+/// supplied occupant snapshot to recover the *current* real bare JID
+/// for that nick; if no current occupant matches (the author has
+/// left the room since posting), the preview falls back to the room
+/// JID as `author_jid` with the captured `author_nick` carrying the
+/// identity. This trades a small amount of fidelity for a stable
+/// non-async lookup — pinning is interactive, so racing with leaves
+/// is rare.
 async fn resolve_preview_from_mam(
     deps: &Deps<'_>,
     room: &BareJid,
     target_stanza_id: &StanzaId,
+    occupants: &[waddle_xmpp::muc::room_actor::RoomChainOccupant],
 ) -> Option<PinPreview> {
     let mam_storage = deps.mam_storage?;
     let row = match mam_storage
@@ -251,7 +295,16 @@ async fn resolve_preview_from_mam(
             return None;
         }
     };
-    let author_bare = row.from.to_bare();
+    let nick = row.from.resource().map(|r| r.to_string());
+    let author_bare = nick
+        .as_deref()
+        .and_then(|nick| {
+            occupants
+                .iter()
+                .find(|o| o.nick == nick)
+                .map(|o| o.full_jid.to_bare())
+        })
+        .unwrap_or_else(|| room.clone());
     let body = row.body.clone().unwrap_or_default();
     let truncated = if body.chars().count() > MAX_PREVIEW_LEN {
         body.chars().take(MAX_PREVIEW_LEN).collect()
@@ -260,7 +313,7 @@ async fn resolve_preview_from_mam(
     };
     Some(PinPreview::new(
         author_bare,
-        None,
+        nick,
         &truncated,
         row.timestamp,
     ))

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -1,0 +1,50 @@
+//! Interpreter arm for [`OutboundEvent::ApplyPinChange`] (#414).
+//!
+//! Forwards the typed `PinStateChange` to the per-room `RoomActor` via
+//! the `ApplyPin` actor message, which delegates to
+//! [`waddle_xmpp::muc::MucRoom::upsert_pin`] /
+//! [`waddle_xmpp::muc::MucRoom::remove_pin_by_target`]. Mirrors the
+//! shape of [`super::room_subject::persist_room_subject_event`].
+
+use super::*;
+use waddle_xmpp::muc::pin::PinStateChange;
+
+pub(super) async fn apply_pin_change_event(deps: &Deps<'_>, room: BareJid, change: PinStateChange) {
+    let Some(room_registry) = deps.room_registry else {
+        debug!(
+            room = %room,
+            "ApplyPinChange: no room_registry in Deps; skipping"
+        );
+        return;
+    };
+    let room_actor = match room_registry
+        .ask(GetRoom {
+            room_jid: room.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            debug!(
+                room = %room,
+                "ApplyPinChange: room not registered; skipping"
+            );
+            return;
+        }
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "ApplyPinChange: room registry lookup failed; skipping"
+            );
+            return;
+        }
+    };
+    if let Err(error) = room_actor.ask(ApplyPin { change }).await {
+        warn!(
+            room = %room,
+            error = ?error,
+            "ApplyPinChange: ApplyPin ask failed; pin state left at previous value"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -8,6 +8,10 @@
 
 use super::*;
 use waddle_xmpp::muc::pin::PinStateChange;
+use waddle_xmpp::muc::room_actor::GetPinList;
+use waddle_xmpp::xep::xep0470::NS_WADDLE_PIN_V0;
+use xmpp_parsers::message::{Body, Message, MessageType};
+use xmpp_parsers::minidom::Element;
 
 pub(super) async fn apply_pin_change_event(deps: &Deps<'_>, room: BareJid, change: PinStateChange) {
     let Some(room_registry) = deps.room_registry else {
@@ -47,4 +51,99 @@ pub(super) async fn apply_pin_change_event(deps: &Deps<'_>, room: BareJid, chang
             "ApplyPinChange: ApplyPin ask failed; pin state left at previous value"
         );
     }
+}
+
+/// XEP-0424 retraction → pin auto-unpin cascade (#414, Q8 = a).
+///
+/// When a groupchat message is retracted, check whether its stanza-id
+/// is in the room's current pin list. If so, remove the pin entry and
+/// broadcast a synthetic unpin system message so live clients see the
+/// projection update without re-querying.
+pub(super) async fn cascade_retraction_to_pin_list(
+    registry: &ConnectionRegistry,
+    deps: &Deps<'_>,
+    room: BareJid,
+    target_message_id: String,
+    recursion_depth: u8,
+) {
+    let Some(room_registry) = deps.room_registry else {
+        return;
+    };
+    let room_actor = match room_registry
+        .ask(GetRoom {
+            room_jid: room.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        _ => return,
+    };
+    let entries = match room_actor.ask(GetPinList).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "Pin retraction cascade: GetPinList ask failed; skipping"
+            );
+            return;
+        }
+    };
+    let Some(entry) = entries
+        .iter()
+        .find(|e| e.target_stanza_id == target_message_id)
+        .cloned()
+    else {
+        return;
+    };
+    if let Err(error) = room_actor
+        .ask(ApplyPin {
+            change: PinStateChange::Unpin {
+                target_stanza_id: target_message_id.clone(),
+            },
+        })
+        .await
+    {
+        warn!(
+            room = %room,
+            error = ?error,
+            "Pin retraction cascade: ApplyPin Unpin ask failed"
+        );
+        return;
+    }
+    let system_message = build_cascade_unpin_message(&room, &entry.pinner_jid, &target_message_id);
+    super::room_system_message::broadcast_room_system_message_event(
+        registry,
+        deps,
+        room,
+        Box::new(system_message),
+        recursion_depth,
+    )
+    .await;
+}
+
+fn build_cascade_unpin_message(
+    room: &BareJid,
+    original_pinner: &BareJid,
+    target_stanza_id: &str,
+) -> Message {
+    let mut event = Element::builder("pin-event", NS_WADDLE_PIN_V0)
+        .attr("action", "unpinned")
+        .attr("by", original_pinner.to_string().as_str())
+        .attr("reason", "retracted")
+        .build();
+    event.append_child(
+        Element::builder("ref", NS_WADDLE_PIN_V0)
+            .attr("id", target_stanza_id)
+            .build(),
+    );
+    let mut msg = Message::new(Some(jid::Jid::from(room.clone())));
+    msg.from = Some(jid::Jid::from(room.clone()));
+    msg.type_ = MessageType::Groupchat;
+    msg.bodies.insert(
+        String::new(),
+        Body("Pinned message was retracted by its author".into()),
+    );
+    msg.payloads.push(event);
+    msg
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -1,17 +1,19 @@
-//! Interpreter arm for [`OutboundEvent::ApplyPinChange`] (#414).
+//! Interpreter arms for pin events (#414).
 //!
-//! Forwards the typed `PinStateChange` to the per-room `RoomActor` via
-//! the `ApplyPin` actor message, which delegates to
-//! [`waddle_xmpp::muc::MucRoom::upsert_pin`] /
-//! [`waddle_xmpp::muc::MucRoom::remove_pin_by_target`]. Mirrors the
-//! shape of [`super::room_subject::persist_room_subject_event`].
+//! Forwards `OutboundEvent::ApplyPinChange` to the per-room
+//! `RoomActor` via the `ApplyPin` actor message and runs the XEP-0424
+//! retraction → auto-unpin cascade. The cascade reads the room's
+//! current pin list, removes the matching entry atomically inside the
+//! actor (via the actor's serial mailbox), then broadcasts a
+//! synthetic `<unpinned reason='retracted'/>` system message via
+//! `broadcast_room_system_message_event`.
 
 use super::*;
 use waddle_xmpp::muc::pin::PinStateChange;
 use waddle_xmpp::muc::room_actor::GetPinList;
-use waddle_xmpp::xep::xep0470::NS_WADDLE_PIN_V0;
-use xmpp_parsers::message::{Body, Message, MessageType};
-use xmpp_parsers::minidom::Element;
+use waddle_xmpp::protocol::room::pin::build_unpinned_system_message;
+use waddle_xmpp::xep::xep_waddle_pin::MAX_TARGET_STANZA_ID_LEN;
+use waddle_xmpp_core::xep0359::StanzaId as Xep0359StanzaIdTyped;
 
 pub(super) async fn apply_pin_change_event(deps: &Deps<'_>, room: BareJid, change: PinStateChange) {
     let Some(room_registry) = deps.room_registry else {
@@ -66,6 +68,12 @@ pub(super) async fn cascade_retraction_to_pin_list(
     target_message_id: String,
     recursion_depth: u8,
 ) {
+    // Defense in depth: an oversized id can't legitimately match any
+    // pin entry, but bounding it prevents allocation amplification on
+    // the per-occupant fan-out below if something upstream was lax.
+    if target_message_id.is_empty() || target_message_id.len() > MAX_TARGET_STANZA_ID_LEN {
+        return;
+    }
     let Some(room_registry) = deps.room_registry else {
         return;
     };
@@ -91,15 +99,16 @@ pub(super) async fn cascade_retraction_to_pin_list(
     };
     let Some(entry) = entries
         .iter()
-        .find(|e| e.target_stanza_id == target_message_id)
+        .find(|e| e.target_stanza_id.id == target_message_id)
         .cloned()
     else {
         return;
     };
+    let target_typed = Xep0359StanzaIdTyped::new(target_message_id, Jid::from(room.clone()));
     if let Err(error) = room_actor
         .ask(ApplyPin {
             change: PinStateChange::Unpin {
-                target_stanza_id: target_message_id.clone(),
+                target_stanza_id: target_typed.clone(),
             },
         })
         .await
@@ -111,7 +120,9 @@ pub(super) async fn cascade_retraction_to_pin_list(
         );
         return;
     }
-    let system_message = build_cascade_unpin_message(&room, &entry.pinner_jid, &target_message_id);
+    let pinner = entry.pinner_jid.clone();
+    let system_message =
+        build_unpinned_system_message(&room, &pinner, "", &target_typed, Some("retracted"));
     super::room_system_message::broadcast_room_system_message_event(
         registry,
         deps,
@@ -120,30 +131,4 @@ pub(super) async fn cascade_retraction_to_pin_list(
         recursion_depth,
     )
     .await;
-}
-
-fn build_cascade_unpin_message(
-    room: &BareJid,
-    original_pinner: &BareJid,
-    target_stanza_id: &str,
-) -> Message {
-    let mut event = Element::builder("pin-event", NS_WADDLE_PIN_V0)
-        .attr("action", "unpinned")
-        .attr("by", original_pinner.to_string().as_str())
-        .attr("reason", "retracted")
-        .build();
-    event.append_child(
-        Element::builder("ref", NS_WADDLE_PIN_V0)
-            .attr("id", target_stanza_id)
-            .build(),
-    );
-    let mut msg = Message::new(Some(jid::Jid::from(room.clone())));
-    msg.from = Some(jid::Jid::from(room.clone()));
-    msg.type_ = MessageType::Groupchat;
-    msg.bodies.insert(
-        String::new(),
-        Body("Pinned message was retracted by its author".into()),
-    );
-    msg.payloads.push(event);
-    msg
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -113,14 +113,19 @@ pub(super) async fn broadcast_room_system_message_event(
     }
 
     // Fan out to every joined occupant. One `RouteToConnection`
-    // per occupant full JID — matches the regular reflector's
-    // per-occupant fan-out shape.
+    // per occupant full JID with the message's `to` set to that
+    // occupant's full JID, matching `ReflectorHandler`'s
+    // per-recipient personalization. Without this, downstream
+    // recipient-pass logic (incoming-blocking, archive, inbox) sees
+    // a stanza addressed to the room bare JID and may misroute.
     for occupant in &snapshot.occupants {
+        let mut copy = (*message).clone();
+        copy.to = Some(Jid::from(occupant.full_jid.clone()));
         route_to_connection(
             registry,
             deps,
             Jid::from(occupant.full_jid.clone()),
-            Box::new(Stanza::Message((*message).clone())),
+            Box::new(Stanza::Message(copy)),
             recursion_depth,
         )
         .await;

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -1,0 +1,128 @@
+//! Interpreter arm for [`OutboundEvent::BroadcastRoomSystemMessage`] (#414).
+//!
+//! Server-authored groupchat messages originating from the room bare
+//! JID itself: pin/unpin events, future room-level notifications. The
+//! arm:
+//!
+//! 1. Stamps a fresh XEP-0359 `<stanza-id by='room'/>` so the message
+//!    can be referenced by clients (jump-to-from-pin-list).
+//! 2. Persists the message to MAM via the regular groupchat archive
+//!    helper.
+//! 3. Routes a copy to every joined occupant (per-resource fan-out).
+//!
+//! Bypasses the occupancy gate, rich-target validation, and extension
+//! enrichment — the sender is the room itself.
+
+use super::*;
+use waddle_xmpp_core::xep0359::{add_stanza_id, StanzaId};
+
+pub(super) async fn broadcast_room_system_message_event(
+    registry: &ConnectionRegistry,
+    deps: &Deps<'_>,
+    room: BareJid,
+    mut message: Box<Message>,
+    recursion_depth: u8,
+) {
+    let Some(room_registry) = deps.room_registry else {
+        debug!(
+            room = %room,
+            "BroadcastRoomSystemMessage: no room_registry in Deps; skipping"
+        );
+        return;
+    };
+    let room_actor = match room_registry
+        .ask(GetRoom {
+            room_jid: room.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            debug!(
+                room = %room,
+                "BroadcastRoomSystemMessage: room not registered; dropping"
+            );
+            return;
+        }
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "BroadcastRoomSystemMessage: room registry lookup failed; dropping"
+            );
+            return;
+        }
+    };
+
+    // The system message has `from = room@conf` (bare). The room
+    // snapshot query is keyed by a full JID for the sender-occupancy
+    // calculation; we don't need that here, so we synthesize a sender
+    // full JID purely for the snapshot RPC. The snapshot's occupant
+    // list is independent of the sender argument.
+    let synthetic_sender = match room.clone().with_resource_str("__system__") {
+        Ok(s) => s,
+        Err(error) => {
+            warn!(
+                room = %room,
+                ?error,
+                "BroadcastRoomSystemMessage: failed to build synthetic sender; dropping"
+            );
+            return;
+        }
+    };
+    let snapshot = match room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: synthetic_sender,
+        })
+        .await
+    {
+        Ok(snap) => snap,
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "BroadcastRoomSystemMessage: GetRoomSnapshot failed; dropping"
+            );
+            return;
+        }
+    };
+
+    // Stamp a canonical XEP-0359 `<stanza-id by='room'/>` so the
+    // message is uniquely addressable in MAM and from clients.
+    let stanza_id = uuid::Uuid::new_v4().to_string();
+    add_stanza_id(
+        &mut message,
+        &StanzaId::new(stanza_id.clone(), Jid::from(room.clone())),
+    );
+
+    // Archive in MAM. We use `0` for `sender_nickname_generation` —
+    // the field is a XEP-0308 LMC-correction window guard for
+    // user-authored messages; system messages are never corrected.
+    if let Some(mam_storage) = deps.mam_storage {
+        match archive_groupchat_message(mam_storage, &room, &message, 0).await {
+            Some(_) => debug!(
+                room = %room,
+                stanza_id,
+                "BroadcastRoomSystemMessage: archived"
+            ),
+            None => debug!(
+                room = %room,
+                "BroadcastRoomSystemMessage: archive helper declined (chain bug?)"
+            ),
+        }
+    }
+
+    // Fan out to every joined occupant. One `RouteToConnection`
+    // per occupant full JID — matches the regular reflector's
+    // per-occupant fan-out shape.
+    for occupant in &snapshot.occupants {
+        route_to_connection(
+            registry,
+            deps,
+            Jid::from(occupant.full_jid.clone()),
+            Box::new(Stanza::Message((*message).clone())),
+            recursion_depth,
+        )
+        .await;
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -331,7 +331,8 @@ pub async fn handle_iq_with_conn_state(
     }
 
     if is_pin_query_iq(&iq, muc_domain) {
-        return handle_pin_query_iq(&iq, state, response_from, response_to).await;
+        return handle_pin_query_iq(&iq, state, phase.bound_jid(), response_from, response_to)
+            .await;
     }
 
     let muc_owner_or_moderation =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -84,6 +84,7 @@ mod muc_admin;
 mod muc_owner_config;
 mod muc_owner_moderation;
 mod permissions;
+mod pin_query;
 mod pubsub_admin;
 mod pubsub_dispatch;
 mod pubsub_helpers;
@@ -116,6 +117,7 @@ use permissions::{
     muc_owner_authorized, server_affiliation_for_requester, space_affiliation_for_requester,
     spaces_node_mutation_allowed,
 };
+use pin_query::{handle_pin_query_iq, is_pin_query_iq};
 use pubsub_dispatch::handle_pubsub_iq;
 use pubsub_helpers::{
     canonical_channel_disco_items, handle_extension_route_items, handle_spaces_items,
@@ -326,6 +328,10 @@ pub async fn handle_iq_with_conn_state(
             response_to,
         )
         .await;
+    }
+
+    if is_pin_query_iq(&iq, muc_domain) {
+        return handle_pin_query_iq(&iq, state, response_from, response_to).await;
     }
 
     let muc_owner_or_moderation =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
@@ -2,25 +2,28 @@
 //!
 //! Returns the room's current pinned-message list, populated from the
 //! `MucRoom.pinned_entries` actor state via the `GetPinList` actor
-//! message. Responses carry one `<pin/>` element per entry, in
-//! pin-time-desc order, mirroring the projection-list shape that
-//! BroadcastRoomSystemMessage emits inline on each pin/unpin event.
+//! message.
+//!
+//! ## Authorization
+//!
+//! The query is gated on the requester being a current occupant of
+//! the target room. Non-occupants get `<forbidden type='auth'/>` —
+//! pin lists carry message previews and authors, which is room-scoped
+//! information that members-only rooms must not leak. Mirrors the
+//! affiliation-style check `muc_admin` performs.
 
 use super::*;
-use jid::BareJid;
+use jid::FullJid;
 use std::str::FromStr;
-use waddle_xmpp::muc::room_actor::GetPinList;
+use waddle_xmpp::muc::room_actor::{GetPinList, GetRoomSnapshot};
 use waddle_xmpp::muc::room_registry_actor::GetRoom;
-use waddle_xmpp::xep::xep0470::NS_WADDLE_PIN_V0;
+use waddle_xmpp::xep::xep_waddle_pin::NS_WADDLE_PIN_V0;
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::minidom::Element;
 
 /// Detects `<iq type='get'><query xmlns='urn:waddle:pin:0'/></iq>`
 /// targeting a MUC room JID.
 pub(super) fn is_pin_query_iq(iq: &Iq, muc_domain: &str) -> bool {
-    if !matches!(iq.payload, IqType::Get(_)) {
-        return false;
-    }
     let IqType::Get(ref payload) = iq.payload else {
         return false;
     };
@@ -35,9 +38,18 @@ pub(super) fn is_pin_query_iq(iq: &Iq, muc_domain: &str) -> bool {
 pub(super) async fn handle_pin_query_iq(
     iq: &Iq,
     state: &WebSocketState,
+    sender_jid: Option<&FullJid>,
     response_from: Option<&str>,
     response_to: Option<&str>,
 ) -> Vec<String> {
+    let Some(sender) = sender_jid else {
+        return vec![build_iq_error_xml_typed(
+            &iq.id,
+            response_from,
+            response_to,
+            not_authorized_iq_error("Authentication required."),
+        )];
+    };
     let Some(target) = iq.to.as_ref() else {
         return vec![build_iq_error_xml_typed(
             &iq.id,
@@ -46,14 +58,15 @@ pub(super) async fn handle_pin_query_iq(
             bad_request_iq_error("Pin query requires a room JID in 'to'."),
         )];
     };
-    let Ok(room_jid) = BareJid::from_str(&target.to_string()) else {
+    if target.resource().is_some() {
         return vec![build_iq_error_xml_typed(
             &iq.id,
             response_from,
             response_to,
             bad_request_iq_error("Pin query 'to' must be a bare room JID."),
         )];
-    };
+    }
+    let room_jid = target.to_bare();
 
     let room_actor = match state
         .deps
@@ -88,6 +101,47 @@ pub(super) async fn handle_pin_query_iq(
         }
     };
 
+    // Membership gate: the snapshot returned for `sender` carries the
+    // sender's affiliation/role only when the actor recognises them as
+    // a current occupant. We treat any of the public affiliations
+    // (Owner / Admin / Member) as access-granting, plus `Outcast` is
+    // explicitly denied; anyone else (None, with no occupancy) gets
+    // `<forbidden/>`.
+    let snapshot = match room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: sender.clone(),
+        })
+        .await
+    {
+        Ok(snap) => snap,
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                ?error,
+                "Pin query: GetRoomSnapshot failed"
+            );
+            return vec![build_iq_error_xml_typed(
+                &iq.id,
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        }
+    };
+    let sender_bare = sender.to_bare();
+    let is_occupant = snapshot
+        .occupants
+        .iter()
+        .any(|occ| occ.full_jid.to_bare() == sender_bare);
+    if !is_occupant {
+        return vec![build_iq_error_xml_typed(
+            &iq.id,
+            response_from,
+            response_to,
+            forbidden_iq_error("Pin list is visible only to current room occupants."),
+        )];
+    }
+
     let entries = match room_actor.ask(GetPinList).await {
         Ok(entries) => entries,
         Err(error) => {
@@ -108,7 +162,7 @@ pub(super) async fn handle_pin_query_iq(
     let mut query = Element::builder("query", NS_WADDLE_PIN_V0).build();
     for entry in entries {
         let mut pin_elem = Element::builder("pin", NS_WADDLE_PIN_V0)
-            .attr("id", entry.target_stanza_id.as_str())
+            .attr("id", entry.target_stanza_id.id.as_str())
             .attr("by", entry.pinner_jid.to_string().as_str())
             .attr("at", entry.pinned_at.to_rfc3339().as_str())
             .build();
@@ -137,4 +191,65 @@ pub(super) async fn handle_pin_query_iq(
         payload: IqType::Result(Some(query)),
     };
     vec![iq_to_xml(response)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn iq_get_with_payload(payload: Element, to: Option<&str>) -> Iq {
+        Iq {
+            from: None,
+            to: to.and_then(|s| jid::Jid::from_str(s).ok()),
+            id: "test-iq".into(),
+            payload: IqType::Get(payload),
+        }
+    }
+
+    #[test]
+    fn is_pin_query_iq_accepts_well_formed_get() {
+        let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
+        let iq = iq_get_with_payload(payload, Some("room@conf.example"));
+        assert!(is_pin_query_iq(&iq, "conf.example"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_rejects_wrong_namespace() {
+        let payload = Element::builder("query", "wrong:ns").build();
+        let iq = iq_get_with_payload(payload, Some("room@conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_rejects_wrong_element_name() {
+        let payload = Element::builder("items", NS_WADDLE_PIN_V0).build();
+        let iq = iq_get_with_payload(payload, Some("room@conf.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_rejects_set() {
+        let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
+        let iq = Iq {
+            from: None,
+            to: Some(jid::Jid::from_str("room@conf.example").expect("valid jid")),
+            id: "test-iq".into(),
+            payload: IqType::Set(payload),
+        };
+        assert!(!is_pin_query_iq(&iq, "conf.example"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_rejects_missing_to() {
+        let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
+        let iq = iq_get_with_payload(payload, None);
+        assert!(!is_pin_query_iq(&iq, "conf.example"));
+    }
+
+    #[test]
+    fn is_pin_query_iq_rejects_wrong_domain() {
+        let payload = Element::builder("query", NS_WADDLE_PIN_V0).build();
+        let iq = iq_get_with_payload(payload, Some("room@other.example"));
+        assert!(!is_pin_query_iq(&iq, "conf.example"));
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pin_query.rs
@@ -1,0 +1,140 @@
+//! IQ handler for `<query xmlns='urn:waddle:pin:0'/>` (#414).
+//!
+//! Returns the room's current pinned-message list, populated from the
+//! `MucRoom.pinned_entries` actor state via the `GetPinList` actor
+//! message. Responses carry one `<pin/>` element per entry, in
+//! pin-time-desc order, mirroring the projection-list shape that
+//! BroadcastRoomSystemMessage emits inline on each pin/unpin event.
+
+use super::*;
+use jid::BareJid;
+use std::str::FromStr;
+use waddle_xmpp::muc::room_actor::GetPinList;
+use waddle_xmpp::muc::room_registry_actor::GetRoom;
+use waddle_xmpp::xep::xep0470::NS_WADDLE_PIN_V0;
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::minidom::Element;
+
+/// Detects `<iq type='get'><query xmlns='urn:waddle:pin:0'/></iq>`
+/// targeting a MUC room JID.
+pub(super) fn is_pin_query_iq(iq: &Iq, muc_domain: &str) -> bool {
+    if !matches!(iq.payload, IqType::Get(_)) {
+        return false;
+    }
+    let IqType::Get(ref payload) = iq.payload else {
+        return false;
+    };
+    if payload.name() != "query" || payload.ns() != NS_WADDLE_PIN_V0 {
+        return false;
+    }
+    iq.to
+        .as_ref()
+        .is_some_and(|to| to.domain().as_str() == muc_domain)
+}
+
+pub(super) async fn handle_pin_query_iq(
+    iq: &Iq,
+    state: &WebSocketState,
+    response_from: Option<&str>,
+    response_to: Option<&str>,
+) -> Vec<String> {
+    let Some(target) = iq.to.as_ref() else {
+        return vec![build_iq_error_xml_typed(
+            &iq.id,
+            response_from,
+            response_to,
+            bad_request_iq_error("Pin query requires a room JID in 'to'."),
+        )];
+    };
+    let Ok(room_jid) = BareJid::from_str(&target.to_string()) else {
+        return vec![build_iq_error_xml_typed(
+            &iq.id,
+            response_from,
+            response_to,
+            bad_request_iq_error("Pin query 'to' must be a bare room JID."),
+        )];
+    };
+
+    let room_actor = match state
+        .deps
+        .protocol
+        .room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            return vec![build_iq_error_xml_typed(
+                &iq.id,
+                response_from,
+                response_to,
+                item_not_found_iq_error("Room not found."),
+            )];
+        }
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                ?error,
+                "Pin query: room registry lookup failed"
+            );
+            return vec![build_iq_error_xml_typed(
+                &iq.id,
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        }
+    };
+
+    let entries = match room_actor.ask(GetPinList).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                ?error,
+                "Pin query: GetPinList ask failed"
+            );
+            return vec![build_iq_error_xml_typed(
+                &iq.id,
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        }
+    };
+
+    let mut query = Element::builder("query", NS_WADDLE_PIN_V0).build();
+    for entry in entries {
+        let mut pin_elem = Element::builder("pin", NS_WADDLE_PIN_V0)
+            .attr("id", entry.target_stanza_id.as_str())
+            .attr("by", entry.pinner_jid.to_string().as_str())
+            .attr("at", entry.pinned_at.to_rfc3339().as_str())
+            .build();
+        let mut preview = Element::builder("preview", NS_WADDLE_PIN_V0).build();
+        let mut author = Element::builder("author", NS_WADDLE_PIN_V0)
+            .attr("jid", entry.preview.author_jid.to_string().as_str())
+            .build();
+        if let Some(ref nick) = entry.preview.author_nick {
+            author.set_attr("nick", nick);
+        }
+        preview.append_child(author);
+        let mut text = Element::builder("text", NS_WADDLE_PIN_V0).build();
+        text.append_text_node(&entry.preview.text);
+        preview.append_child(text);
+        let mut ts = Element::builder("ts", NS_WADDLE_PIN_V0).build();
+        ts.append_text_node(entry.preview.message_timestamp.to_rfc3339());
+        preview.append_child(ts);
+        pin_elem.append_child(preview);
+        query.append_child(pin_elem);
+    }
+
+    let response = Iq {
+        from: response_from.and_then(|s| jid::Jid::from_str(s).ok()),
+        to: response_to.and_then(|s| jid::Jid::from_str(s).ok()),
+        id: iq.id.clone(),
+        payload: IqType::Result(Some(query)),
+    };
+    vec![iq_to_xml(response)]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -1082,13 +1082,14 @@ fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<V
                 action,
             } => {
                 let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
-                let marker = match action {
-                    PinAction::Pinned => "<pinned",
-                    PinAction::Unpinned => "<unpinned",
+                let action_attr = match action {
+                    PinAction::Pinned => "action=\"pinned\"",
+                    PinAction::Unpinned => "action=\"unpinned\"",
                 };
                 expected.extend([
                     "urn:waddle:pin:0".to_string(),
-                    marker.to_string(),
+                    "<pin-event".to_string(),
+                    action_attr.to_string(),
                     format!("target=\"{target_id}\""),
                 ]);
             }

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -210,6 +210,27 @@ enum Payload {
     },
     #[serde(rename = "processingHint")]
     ProcessingHint { name: ProcessingHint },
+    #[serde(rename = "pinAttachment")]
+    PinAttachment {
+        id: Option<String>,
+        #[serde(rename = "idFrom")]
+        id_from: Option<String>,
+        action: PinAction,
+    },
+    #[serde(rename = "pinEvent")]
+    PinEvent {
+        id: Option<String>,
+        #[serde(rename = "idFrom")]
+        id_from: Option<String>,
+        action: PinAction,
+    },
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+enum PinAction {
+    Pinned,
+    Unpinned,
 }
 
 #[derive(Debug, Deserialize)]
@@ -952,6 +973,22 @@ fn payload_element(payload: &Payload, ctx: &ScenarioContext) -> Result<Element> 
             Ok(xep0444::build_reactions_element(&target_id, &emoji_refs))
         }
         Payload::ProcessingHint { name } => Ok(xep0334::build_hint_element(Hint::from(name))),
+        Payload::PinAttachment {
+            id,
+            id_from,
+            action,
+        } => {
+            let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
+            let target = waddle_xmpp::xep::AttachmentTarget::new("urn:xmpp:mam:2", target_id);
+            let attachment = match action {
+                PinAction::Pinned => waddle_xmpp::xep::Attachment::pin(target),
+                PinAction::Unpinned => waddle_xmpp::xep::Attachment::unpin(target),
+            };
+            Ok(waddle_xmpp::xep::build_attachments_element(&attachment))
+        }
+        Payload::PinEvent { .. } => Err(anyhow!(
+            "PinEvent is an expected-only payload; cannot be sent"
+        )),
     }
 }
 
@@ -1017,6 +1054,40 @@ fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<V
                     format!("<{}", hint.element_name()),
                 ]);
             }
+            Payload::PinAttachment {
+                id,
+                id_from,
+                action,
+            } => {
+                let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
+                let marker = match action {
+                    PinAction::Pinned => "<pinned",
+                    PinAction::Unpinned => "<unpinned",
+                };
+                expected.extend([
+                    "urn:xmpp:pubsub-attachments:0".to_string(),
+                    "urn:waddle:pin:0".to_string(),
+                    format!("item=\"{target_id}\""),
+                    marker.to_string(),
+                ]);
+            }
+            Payload::PinEvent {
+                id,
+                id_from,
+                action,
+            } => {
+                let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
+                let action_attr = match action {
+                    PinAction::Pinned => "action=\"pinned\"",
+                    PinAction::Unpinned => "action=\"unpinned\"",
+                };
+                expected.extend([
+                    "urn:waddle:pin:0".to_string(),
+                    "<pin-event".to_string(),
+                    action_attr.to_string(),
+                    format!("id=\"{target_id}\""),
+                ]);
+            }
         }
     }
     Ok(expected)
@@ -1059,7 +1130,9 @@ fn validate_file_share_fallback_body(body: Option<&str>, payloads: &[Payload]) -
         Payload::LinkMetadata { .. }
         | Payload::MessageCorrection { .. }
         | Payload::Reactions { .. }
-        | Payload::ProcessingHint { .. } => false,
+        | Payload::ProcessingHint { .. }
+        | Payload::PinAttachment { .. }
+        | Payload::PinEvent { .. } => false,
     });
     if represented_by_payload {
         Ok(())

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -979,12 +979,18 @@ fn payload_element(payload: &Payload, ctx: &ScenarioContext) -> Result<Element> 
             action,
         } => {
             let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
-            let target = waddle_xmpp::xep::AttachmentTarget::new("urn:xmpp:mam:2", target_id);
-            let attachment = match action {
-                PinAction::Pinned => waddle_xmpp::xep::Attachment::pin(target),
-                PinAction::Unpinned => waddle_xmpp::xep::Attachment::unpin(target),
+            let stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+                target_id,
+                jid::Jid::from(
+                    jid::BareJid::from_str("room@example.com")
+                        .map_err(|e| anyhow!("invalid placeholder jid: {e}"))?,
+                ),
+            );
+            let elem = match action {
+                PinAction::Pinned => waddle_xmpp::xep::build_pinned_message_element(&stanza_id),
+                PinAction::Unpinned => waddle_xmpp::xep::build_unpinned_message_element(&stanza_id),
             };
-            Ok(waddle_xmpp::xep::build_attachments_element(&attachment))
+            Ok(elem)
         }
         Payload::PinEvent { .. } => Err(anyhow!(
             "PinEvent is an expected-only payload; cannot be sent"
@@ -1065,10 +1071,9 @@ fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<V
                     PinAction::Unpinned => "<unpinned",
                 };
                 expected.extend([
-                    "urn:xmpp:pubsub-attachments:0".to_string(),
                     "urn:waddle:pin:0".to_string(),
-                    format!("item=\"{target_id}\""),
                     marker.to_string(),
+                    format!("target=\"{target_id}\""),
                 ]);
             }
             Payload::PinEvent {
@@ -1077,15 +1082,14 @@ fn payload_expectations(payloads: &[Payload], ctx: &ScenarioContext) -> Result<V
                 action,
             } => {
                 let target_id = resolve_payload_id(ctx, id.as_deref(), id_from.as_deref())?;
-                let action_attr = match action {
-                    PinAction::Pinned => "action=\"pinned\"",
-                    PinAction::Unpinned => "action=\"unpinned\"",
+                let marker = match action {
+                    PinAction::Pinned => "<pinned",
+                    PinAction::Unpinned => "<unpinned",
                 };
                 expected.extend([
                     "urn:waddle:pin:0".to_string(),
-                    "<pin-event".to_string(),
-                    action_attr.to_string(),
-                    format!("id=\"{target_id}\""),
+                    marker.to_string(),
+                    format!("target=\"{target_id}\""),
                 ]);
             }
         }

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -184,9 +184,9 @@ package xmpp_e2e_scenarios
 	...
 }
 
-#Payload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint
+#Payload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint | #PinAttachment
 
-#ExpectedPayload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint
+#ExpectedPayload: #FileShare | #LinkMetadata | #MessageCorrection | #Reactions | #ProcessingHint | #PinAttachment | #PinEvent
 
 #MessageCorrection: {
 	kind: "messageCorrection"
@@ -233,5 +233,29 @@ package xmpp_e2e_scenarios
 	title:       string
 	description: string
 	url:         string
+	...
+}
+
+#PinAttachment: {
+	kind:   "pinAttachment"
+	(#PinId | #PinIdFrom)
+	action: "pinned" | "unpinned"
+	...
+}
+
+#PinId: {
+	id: string
+	idFrom?: _|_
+}
+
+#PinIdFrom: {
+	id?: _|_
+	idFrom: string
+}
+
+#PinEvent: {
+	kind:   "pinEvent"
+	(#PinId | #PinIdFrom)
+	action: "pinned" | "unpinned"
 	...
 }

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_basic.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_basic.cue
@@ -1,0 +1,129 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-waddle-pin-basic"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "admin"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-pin@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		// Alice (room owner) and Bob (member) both join.
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice"},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-pin-set-bob-member"
+		},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob"},
+
+		// Bob posts an important message; capture its room stanza-id.
+		#SendMessage & {
+			from:  bobPhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-pin-target"
+			body:  "important message that will be pinned"
+		},
+		#ExpectMessage & {
+			target:            alicePhone
+			body:              "important message that will be pinned"
+			contains:          [roomJid, "cue-pin-target"]
+			captureStanzaIdAs: "pinTargetStanzaId"
+			captureStanzaIdBy: roomJid
+		},
+
+		// Alice (owner) pins Bob's message via XEP-0470 attachment.
+		#SendMessage & {
+			from:  alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-pin-pin-1"
+			payloads: [
+				#PinAttachment & {
+					idFrom: "pinTargetStanzaId"
+					action: "pinned"
+				},
+			]
+		},
+
+		// Both members observe the pin-event system message broadcast
+		// from the room bare JID, archived in MAM.
+		#ExpectMessage & {
+			target:   alicePhone
+			body:     "alice pinned a message"
+			contains: [roomJid]
+			payloads: [
+				#PinEvent & {
+					idFrom: "pinTargetStanzaId"
+					action: "pinned"
+				},
+			]
+		},
+		#ExpectMessage & {
+			target:   bobPhone
+			body:     "alice pinned a message"
+			contains: [roomJid]
+			payloads: [
+				#PinEvent & {
+					idFrom: "pinTargetStanzaId"
+					action: "pinned"
+				},
+			]
+		},
+
+		// Alice unpins.
+		#SendMessage & {
+			from:  alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-pin-unpin-1"
+			payloads: [
+				#PinAttachment & {
+					idFrom: "pinTargetStanzaId"
+					action: "unpinned"
+				},
+			]
+		},
+		#ExpectMessage & {
+			target:   alicePhone
+			body:     "alice unpinned a message"
+			contains: [roomJid]
+			payloads: [
+				#PinEvent & {
+					idFrom: "pinTargetStanzaId"
+					action: "unpinned"
+				},
+			]
+		},
+		#ExpectMessage & {
+			target:   bobPhone
+			body:     "alice unpinned a message"
+			contains: [roomJid]
+			payloads: [
+				#PinEvent & {
+					idFrom: "pinTargetStanzaId"
+					action: "unpinned"
+				},
+			]
+		},
+	]
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_member_forbidden.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_member_forbidden.cue
@@ -81,7 +81,7 @@ scenario: #Scenario & {
 		// halted before reaching the broadcast step.
 		#ExpectNoStanza & {
 			target:   alicePhone
-			contains: ["pin-event", "pinned"]
+			contains: ["pin-event"]
 			millis:   500
 		},
 	]

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_member_forbidden.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_waddle_pin_member_forbidden.cue
@@ -1,0 +1,88 @@
+package xmpp_e2e_scenarios
+
+// Asserts that a non-admin member who tries to pin a message receives
+// a forbidden error and that no pin-event broadcast is emitted (#414,
+// member-pin-rejection path of the MucPinHandler).
+
+scenario: #Scenario & {
+	name: "xep-waddle-pin-member-forbidden"
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "admin"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let roomJid = "cue-pin-forbidden@muc.\(scenario.domain)"
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		// Alice (owner) and Bob (member) join.
+		#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice"},
+		#SetMucAffiliation & {
+			actor:       alicePhone
+			room:        roomJid
+			jid:         bobPhone.bareJid
+			affiliation: "member"
+			id:          "cue-pin-fb-set-bob-member"
+		},
+		#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob"},
+
+		// Alice posts a message; Bob captures its stanza-id so he can
+		// attempt to pin it.
+		#SendMessage & {
+			from:  alicePhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-pin-fb-target"
+			body:  "message bob will try to pin"
+		},
+		#ExpectMessage & {
+			target:            bobPhone
+			body:              "message bob will try to pin"
+			contains:          [roomJid, "cue-pin-fb-target"]
+			captureStanzaIdAs: "pinTargetForbiddenStanzaId"
+			captureStanzaIdBy: roomJid
+		},
+
+		// Bob attempts to pin — must be rejected.
+		#SendMessage & {
+			from:  bobPhone
+			toJid: roomJid
+			type:  "groupchat"
+			id:    "cue-pin-fb-attempt"
+			payloads: [
+				#PinAttachment & {
+					idFrom: "pinTargetForbiddenStanzaId"
+					action: "pinned"
+				},
+			]
+		},
+
+		// Bob receives the forbidden error reply.
+		#ExpectMessage & {
+			target:     bobPhone
+			bodyAbsent: true
+			contains:   ["forbidden", "type=\"error\""]
+		},
+
+		// Alice does NOT receive a pin-event broadcast — the handler
+		// halted before reaching the broadcast step.
+		#ExpectNoStanza & {
+			target:   alicePhone
+			contains: ["pin-event", "pinned"]
+			millis:   500
+		},
+	]
+}

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -39,7 +39,7 @@ pub use owner::{
     OwnerQuery, DATA_FORMS_NS, MUC_ROOMCONFIG_NS,
 };
 pub use pin::{
-    PinPreview, PinStateChange, PinnedEntry, MAX_PINNED_ENTRIES,
+    PinChangeRequest, PinPreview, PinStateChange, PinnedEntry, MAX_PINNED_ENTRIES,
     MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN,
 };
 pub use presence::{

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -38,7 +38,10 @@ pub use owner::{
     build_owner_set_result, parse_owner_query, ConfigFormData, DestroyRequest, OwnerAction,
     OwnerQuery, DATA_FORMS_NS, MUC_ROOMCONFIG_NS,
 };
-pub use pin::{PinPreview, PinStateChange, PinnedEntry, MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN};
+pub use pin::{
+    PinPreview, PinStateChange, PinnedEntry, MAX_PINNED_ENTRIES,
+    MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN,
+};
 pub use presence::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
     build_leave_presence, build_occupant_presence, build_occupant_presence_update,

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -38,7 +38,7 @@ pub use owner::{
     build_owner_set_result, parse_owner_query, ConfigFormData, DestroyRequest, OwnerAction,
     OwnerQuery, DATA_FORMS_NS, MUC_ROOMCONFIG_NS,
 };
-pub use pin::{PinPreview, PinnedEntry, MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN};
+pub use pin::{PinPreview, PinStateChange, PinnedEntry, MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN};
 pub use presence::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
     build_leave_presence, build_occupant_presence, build_occupant_presence_update,

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -13,6 +13,7 @@ pub mod admin;
 pub mod affiliation;
 pub mod messages;
 pub mod owner;
+pub mod pin;
 pub mod presence;
 mod room;
 pub mod room_actor;
@@ -37,6 +38,7 @@ pub use owner::{
     build_owner_set_result, parse_owner_query, ConfigFormData, DestroyRequest, OwnerAction,
     OwnerQuery, DATA_FORMS_NS, MUC_ROOMCONFIG_NS,
 };
+pub use pin::{PinPreview, PinnedEntry, MAX_PREVIEW_LEN as PIN_PREVIEW_MAX_LEN};
 pub use presence::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
     build_leave_presence, build_occupant_presence, build_occupant_presence_update,

--- a/server/crates/waddle-xmpp/src/muc/pin.rs
+++ b/server/crates/waddle-xmpp/src/muc/pin.rs
@@ -9,11 +9,20 @@
 use chrono::{DateTime, Utc};
 use jid::BareJid;
 use serde::{Deserialize, Serialize};
+use waddle_xmpp_core::xep0359::StanzaId;
 
 /// Maximum preview text length stored for a pinned message. The preview
 /// is intentionally lossy — it's a projection-list affordance, not a
 /// faithful render. Click-through fetches the full body via MAM.
 pub const MAX_PREVIEW_LEN: usize = 280;
+
+/// Maximum pinned entries kept on a single room. When this cap is
+/// exceeded by a new pin (not a replacement), the oldest entry is
+/// evicted. Bounds room actor memory so admin pin-spam can't exhaust
+/// resources. Per the design grill (#414 Q9), v1 ships effectively
+/// unbounded — `1_000` is the documented "future projection node
+/// max_items" target and serves here as the in-memory ceiling.
+pub const MAX_PINNED_ENTRIES: usize = 1_000;
 
 /// Frozen snapshot of a pinned message at pin time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,17 +65,18 @@ pub enum PinStateChange {
     Pin(PinnedEntry),
     /// Remove the pin entry matching `target_stanza_id`, if any.
     Unpin {
-        /// XEP-0359 stanza-id of the message whose pin is being cleared.
-        target_stanza_id: String,
+        /// Typed XEP-0359 stanza-id of the message whose pin is being cleared.
+        target_stanza_id: StanzaId,
     },
 }
 
 /// A pinned message entry held on the room actor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PinnedEntry {
-    /// XEP-0359 stanza-id of the pinned message in this room. Acts as
-    /// the entry's primary key — a message can be pinned at most once.
-    pub target_stanza_id: String,
+    /// Typed XEP-0359 stanza-id of the pinned message in this room.
+    /// Acts as the entry's primary key — a message can be pinned at
+    /// most once.
+    pub target_stanza_id: StanzaId,
     /// Bare JID of the user who pinned the message.
     pub pinner_jid: BareJid,
     /// When the pin was applied.
@@ -120,10 +130,14 @@ mod tests {
         assert!(preview.text.starts_with('🦆'));
     }
 
+    fn stanza(id: &str) -> StanzaId {
+        StanzaId::new(id.to_owned(), jid::Jid::from(jid("room@conf.example")))
+    }
+
     #[test]
     fn pinned_entry_roundtrips_via_serde_json() {
         let entry = PinnedEntry {
-            target_stanza_id: "stanza-abc".into(),
+            target_stanza_id: stanza("stanza-abc"),
             pinner_jid: jid("admin@example.com"),
             pinned_at: ts(),
             preview: PinPreview::new(

--- a/server/crates/waddle-xmpp/src/muc/pin.rs
+++ b/server/crates/waddle-xmpp/src/muc/pin.rs
@@ -1,0 +1,127 @@
+//! MUC pinned-message state.
+//!
+//! Per-room pin entries projected from XEP-0470 attachment events. The
+//! per-message pin marker on the wire is `<pinned xmlns='urn:waddle:pin:0'/>`
+//! (see `crate::xep::xep0470`); this module owns the canonical room-level
+//! list of pinned entries that the projection IQ query and live system
+//! events serialize from.
+
+use chrono::{DateTime, Utc};
+use jid::BareJid;
+use serde::{Deserialize, Serialize};
+
+/// Maximum preview text length stored for a pinned message. The preview
+/// is intentionally lossy — it's a projection-list affordance, not a
+/// faithful render. Click-through fetches the full body via MAM.
+pub const MAX_PREVIEW_LEN: usize = 280;
+
+/// Frozen snapshot of a pinned message at pin time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinPreview {
+    /// Bare JID of the message author.
+    pub author_jid: BareJid,
+    /// MUC nickname of the author at pin time, if known.
+    pub author_nick: Option<String>,
+    /// Truncated body text, capped to `MAX_PREVIEW_LEN`.
+    pub text: String,
+    /// Original message timestamp (delay stamp or archive ts).
+    pub message_timestamp: DateTime<Utc>,
+}
+
+impl PinPreview {
+    /// Build a preview, truncating the body to `MAX_PREVIEW_LEN`. The cap
+    /// counts UTF-8 chars, not bytes — relies on `String::char_indices`
+    /// to avoid splitting a multi-byte char.
+    pub fn new(
+        author_jid: BareJid,
+        author_nick: Option<String>,
+        body: &str,
+        message_timestamp: DateTime<Utc>,
+    ) -> Self {
+        let text = truncate_chars(body, MAX_PREVIEW_LEN);
+        Self {
+            author_jid,
+            author_nick,
+            text,
+            message_timestamp,
+        }
+    }
+}
+
+/// A pinned message entry held on the room actor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinnedEntry {
+    /// XEP-0359 stanza-id of the pinned message in this room. Acts as
+    /// the entry's primary key — a message can be pinned at most once.
+    pub target_stanza_id: String,
+    /// Bare JID of the user who pinned the message.
+    pub pinner_jid: BareJid,
+    /// When the pin was applied.
+    pub pinned_at: DateTime<Utc>,
+    /// Frozen preview at pin time. Not refreshed on XEP-0308 LMC.
+    pub preview: PinPreview,
+}
+
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        return s.to_owned();
+    }
+    s.chars().take(max_chars).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn jid(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
+
+    fn ts() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-05-08T12:34:56Z")
+            .expect("valid rfc3339")
+            .with_timezone(&Utc)
+    }
+
+    #[test]
+    fn preview_truncates_oversize_body() {
+        let body = "x".repeat(MAX_PREVIEW_LEN + 50);
+        let preview = PinPreview::new(jid("alice@example.com"), None, &body, ts());
+        assert_eq!(preview.text.chars().count(), MAX_PREVIEW_LEN);
+    }
+
+    #[test]
+    fn preview_keeps_short_body_intact() {
+        let body = "hello";
+        let preview = PinPreview::new(jid("alice@example.com"), Some("Alice".into()), body, ts());
+        assert_eq!(preview.text, body);
+        assert_eq!(preview.author_nick.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn preview_truncation_respects_utf8_boundaries() {
+        let body = "🦆".repeat(MAX_PREVIEW_LEN + 5);
+        let preview = PinPreview::new(jid("alice@example.com"), None, &body, ts());
+        assert_eq!(preview.text.chars().count(), MAX_PREVIEW_LEN);
+        assert!(preview.text.starts_with('🦆'));
+    }
+
+    #[test]
+    fn pinned_entry_roundtrips_via_serde_json() {
+        let entry = PinnedEntry {
+            target_stanza_id: "stanza-abc".into(),
+            pinner_jid: jid("admin@example.com"),
+            pinned_at: ts(),
+            preview: PinPreview::new(
+                jid("alice@example.com"),
+                Some("Alice".into()),
+                "important",
+                ts(),
+            ),
+        };
+        let serialized = serde_json::to_string(&entry).expect("serialize");
+        let parsed: PinnedEntry = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(entry, parsed);
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/pin.rs
+++ b/server/crates/waddle-xmpp/src/muc/pin.rs
@@ -57,8 +57,10 @@ impl PinPreview {
     }
 }
 
-/// A pin state mutation to apply to a room actor's pin list. Carried
-/// by [`crate::protocol::event::OutboundEvent::ApplyPinChange`].
+/// A pin state mutation to apply to a room actor's pin list. The
+/// actor consumes this directly via the `ApplyPin` message — Pin
+/// carries a fully resolved [`PinnedEntry`] (preview already populated
+/// from MAM by the interpreter), Unpin carries just the target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PinStateChange {
     /// Add or replace a pin entry (newest pin first per upsert).
@@ -68,6 +70,49 @@ pub enum PinStateChange {
         /// Typed XEP-0359 stanza-id of the message whose pin is being cleared.
         target_stanza_id: StanzaId,
     },
+}
+
+/// A pin/unpin request carried by [`crate::protocol::event::OutboundEvent::ApplyPinChange`]
+/// from the chain handler to the interpreter. Distinct from
+/// [`PinStateChange`] because the chain is **synchronous** and cannot
+/// resolve the target message preview from MAM — the interpreter does
+/// the async lookup, builds the `PinnedEntry`, and only then hands a
+/// resolved [`PinStateChange`] to the room actor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinChangeRequest {
+    /// Pin a message. The interpreter resolves the preview from MAM
+    /// at apply time so the stored preview reflects the *target*
+    /// message author + body + original timestamp, not the pinner or
+    /// pin-marker dispatch time.
+    Pin {
+        target_stanza_id: StanzaId,
+        pinner_jid: BareJid,
+        pinner_nick: String,
+        pinned_at: DateTime<Utc>,
+    },
+    /// Unpin a message. Carries the pinner identity so the broadcast
+    /// system message can attribute the action; `reason` is set to
+    /// `"retracted"` for the XEP-0424 retraction cascade.
+    Unpin {
+        target_stanza_id: StanzaId,
+        pinner_jid: BareJid,
+        pinner_nick: String,
+        reason: Option<String>,
+    },
+}
+
+impl PinChangeRequest {
+    /// The target stanza-id this request mutates.
+    pub fn target_stanza_id(&self) -> &StanzaId {
+        match self {
+            PinChangeRequest::Pin {
+                target_stanza_id, ..
+            }
+            | PinChangeRequest::Unpin {
+                target_stanza_id, ..
+            } => target_stanza_id,
+        }
+    }
 }
 
 /// A pinned message entry held on the room actor.

--- a/server/crates/waddle-xmpp/src/muc/pin.rs
+++ b/server/crates/waddle-xmpp/src/muc/pin.rs
@@ -48,6 +48,19 @@ impl PinPreview {
     }
 }
 
+/// A pin state mutation to apply to a room actor's pin list. Carried
+/// by [`crate::protocol::event::OutboundEvent::ApplyPinChange`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinStateChange {
+    /// Add or replace a pin entry (newest pin first per upsert).
+    Pin(PinnedEntry),
+    /// Remove the pin entry matching `target_stanza_id`, if any.
+    Unpin {
+        /// XEP-0359 stanza-id of the message whose pin is being cleared.
+        target_stanza_id: String,
+    },
+}
+
 /// A pinned message entry held on the room actor.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PinnedEntry {

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -4,6 +4,7 @@ use jid::{BareJid, FullJid};
 use serde::{Deserialize, Serialize};
 
 use super::affiliation::{AffiliationList, FederatedAffiliationConfig, FederatedPermissionPolicy};
+use super::pin::PinnedEntry;
 use super::subject::SubjectState;
 use crate::types::{Affiliation, Role};
 
@@ -107,6 +108,9 @@ pub struct MucRoom {
     pub(super) nickname_generation: HashMap<String, u64>,
     /// Lower bound for fresh nickname generations in this room actor's lifetime.
     pub(super) generation_floor: u64,
+    /// Pinned messages in pin-time-desc order. A given `target_stanza_id`
+    /// appears at most once.
+    pub(super) pinned_entries: Vec<PinnedEntry>,
 }
 
 impl MucRoom {
@@ -128,6 +132,7 @@ impl MucRoom {
             affiliation_list: AffiliationList::new(),
             nickname_generation: HashMap::new(),
             generation_floor: u64::try_from(chrono::Utc::now().timestamp_millis()).unwrap_or(0),
+            pinned_entries: Vec::new(),
         }
     }
 
@@ -226,5 +231,127 @@ impl MucRoom {
         } else {
             self.occupants.len() >= self.config.max_occupants as usize
         }
+    }
+
+    /// All pinned entries, newest pin first.
+    pub fn pinned_entries(&self) -> &[PinnedEntry] {
+        &self.pinned_entries
+    }
+
+    /// Add or replace a pinned entry. If a pin already exists for the
+    /// same `target_stanza_id`, the previous entry is replaced and moved
+    /// to the front. Returns the previous entry, if any.
+    pub fn upsert_pin(&mut self, entry: PinnedEntry) -> Option<PinnedEntry> {
+        let previous = self.remove_pin_by_target(&entry.target_stanza_id);
+        self.pinned_entries.insert(0, entry);
+        previous
+    }
+
+    /// Remove the pin entry matching `target_stanza_id`, if present.
+    pub fn remove_pin_by_target(&mut self, target_stanza_id: &str) -> Option<PinnedEntry> {
+        let position = self
+            .pinned_entries
+            .iter()
+            .position(|e| e.target_stanza_id == target_stanza_id)?;
+        Some(self.pinned_entries.remove(position))
+    }
+
+    /// Look up a pin entry by its target stanza-id.
+    pub fn find_pin_by_target(&self, target_stanza_id: &str) -> Option<&PinnedEntry> {
+        self.pinned_entries
+            .iter()
+            .find(|e| e.target_stanza_id == target_stanza_id)
+    }
+}
+
+#[cfg(test)]
+mod pin_state_tests {
+    use super::*;
+    use crate::muc::pin::PinPreview;
+    use chrono::{DateTime, Utc};
+    use std::str::FromStr;
+
+    fn jid(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
+
+    fn ts() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-05-08T12:34:56Z")
+            .expect("valid rfc3339")
+            .with_timezone(&Utc)
+    }
+
+    fn entry(target: &str, pinner: &str) -> PinnedEntry {
+        PinnedEntry {
+            target_stanza_id: target.into(),
+            pinner_jid: jid(pinner),
+            pinned_at: ts(),
+            preview: PinPreview::new(jid("alice@example.com"), None, "hi", ts()),
+        }
+    }
+
+    fn room() -> MucRoom {
+        MucRoom::new(
+            jid("room@conf.example"),
+            "wad-1".into(),
+            "chan-1".into(),
+            RoomConfig::default(),
+        )
+    }
+
+    #[test]
+    fn upsert_appends_to_front_for_new_target() {
+        let mut r = room();
+        r.upsert_pin(entry("a", "admin@example.com"));
+        r.upsert_pin(entry("b", "admin@example.com"));
+        let ids: Vec<_> = r
+            .pinned_entries()
+            .iter()
+            .map(|e| e.target_stanza_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["b", "a"]);
+    }
+
+    #[test]
+    fn upsert_replaces_existing_target_and_returns_previous() {
+        let mut r = room();
+        r.upsert_pin(entry("a", "admin1@example.com"));
+        r.upsert_pin(entry("b", "admin1@example.com"));
+        let previous = r.upsert_pin(entry("a", "admin2@example.com"));
+        let prev = previous.expect("previous entry returned");
+        assert_eq!(prev.pinner_jid, jid("admin1@example.com"));
+        let ids: Vec<_> = r
+            .pinned_entries()
+            .iter()
+            .map(|e| e.target_stanza_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["a", "b"]);
+        assert_eq!(
+            r.find_pin_by_target("a").expect("found").pinner_jid.clone(),
+            jid("admin2@example.com")
+        );
+    }
+
+    #[test]
+    fn remove_pin_by_target_returns_entry_when_present() {
+        let mut r = room();
+        r.upsert_pin(entry("a", "admin@example.com"));
+        let removed = r.remove_pin_by_target("a").expect("entry removed");
+        assert_eq!(removed.target_stanza_id, "a");
+        assert!(r.pinned_entries().is_empty());
+    }
+
+    #[test]
+    fn remove_pin_by_target_returns_none_when_absent() {
+        let mut r = room();
+        assert!(r.remove_pin_by_target("nope").is_none());
+    }
+
+    #[test]
+    fn find_pin_by_target_misses_after_removal() {
+        let mut r = room();
+        r.upsert_pin(entry("a", "admin@example.com"));
+        r.remove_pin_by_target("a");
+        assert!(r.find_pin_by_target("a").is_none());
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -109,7 +109,9 @@ pub struct MucRoom {
     /// Lower bound for fresh nickname generations in this room actor's lifetime.
     pub(super) generation_floor: u64,
     /// Pinned messages in pin-time-desc order. A given `target_stanza_id`
-    /// appears at most once.
+    /// appears at most once. Held only in memory — pins do not survive
+    /// room-actor shutdown by design (#414); persistence is a follow-up
+    /// concern. Bounded by [`super::pin::MAX_PINNED_ENTRIES`].
     pub(super) pinned_entries: Vec<PinnedEntry>,
 }
 
@@ -233,45 +235,61 @@ impl MucRoom {
         }
     }
 
+    /// Whether `bare_jid` is currently joined to this room as an
+    /// occupant. Used by the pin-list IQ query handler to gate
+    /// access on membership.
+    pub fn has_occupant_with_bare_jid(&self, bare_jid: &BareJid) -> bool {
+        self.occupants
+            .values()
+            .any(|o| o.real_jid.to_bare() == *bare_jid)
+    }
+
     /// All pinned entries, newest pin first.
     pub fn pinned_entries(&self) -> &[PinnedEntry] {
         &self.pinned_entries
     }
 
     /// Add or replace a pinned entry. If a pin already exists for the
-    /// same `target_stanza_id`, the previous entry is replaced and moved
-    /// to the front. Returns the previous entry, if any.
+    /// same `target_stanza_id`, the previous entry is replaced and
+    /// moved to the front. When [`super::pin::MAX_PINNED_ENTRIES`] is
+    /// reached and the new entry isn't a replacement, the oldest entry
+    /// is evicted to keep the list bounded — admins are responsible
+    /// for periodic pruning, but the cap prevents pin-spam from
+    /// exhausting room memory. Returns the previous entry for the
+    /// same target, if any.
     pub fn upsert_pin(&mut self, entry: PinnedEntry) -> Option<PinnedEntry> {
         let previous = self.remove_pin_by_target(&entry.target_stanza_id);
         self.pinned_entries.insert(0, entry);
+        if self.pinned_entries.len() > super::pin::MAX_PINNED_ENTRIES {
+            self.pinned_entries.pop();
+        }
         previous
     }
 
     /// Remove the pin entry matching `target_stanza_id`, if present.
-    pub fn remove_pin_by_target(&mut self, target_stanza_id: &str) -> Option<PinnedEntry> {
+    /// Compares by the typed XEP-0359 id field — the `by` JID is
+    /// always the room itself for groupchat pins.
+    pub fn remove_pin_by_target(
+        &mut self,
+        target_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
+    ) -> Option<PinnedEntry> {
         let position = self
             .pinned_entries
             .iter()
-            .position(|e| e.target_stanza_id == target_stanza_id)?;
+            .position(|e| e.target_stanza_id.id == target_stanza_id.id)?;
         Some(self.pinned_entries.remove(position))
-    }
-
-    /// Look up a pin entry by its target stanza-id.
-    pub fn find_pin_by_target(&self, target_stanza_id: &str) -> Option<&PinnedEntry> {
-        self.pinned_entries
-            .iter()
-            .find(|e| e.target_stanza_id == target_stanza_id)
     }
 }
 
 #[cfg(test)]
 mod pin_state_tests {
     use super::*;
-    use crate::muc::pin::PinPreview;
+    use crate::muc::pin::{PinPreview, MAX_PINNED_ENTRIES};
     use chrono::{DateTime, Utc};
     use std::str::FromStr;
+    use waddle_xmpp_core::xep0359::StanzaId;
 
-    fn jid(s: &str) -> BareJid {
+    fn bare(s: &str) -> BareJid {
         BareJid::from_str(s).expect("valid bare jid")
     }
 
@@ -281,18 +299,22 @@ mod pin_state_tests {
             .with_timezone(&Utc)
     }
 
+    fn stanza(id: &str) -> StanzaId {
+        StanzaId::new(id.to_owned(), jid::Jid::from(bare("room@conf.example")))
+    }
+
     fn entry(target: &str, pinner: &str) -> PinnedEntry {
         PinnedEntry {
-            target_stanza_id: target.into(),
-            pinner_jid: jid(pinner),
+            target_stanza_id: stanza(target),
+            pinner_jid: bare(pinner),
             pinned_at: ts(),
-            preview: PinPreview::new(jid("alice@example.com"), None, "hi", ts()),
+            preview: PinPreview::new(bare("alice@example.com"), None, "hi", ts()),
         }
     }
 
     fn room() -> MucRoom {
         MucRoom::new(
-            jid("room@conf.example"),
+            bare("room@conf.example"),
             "wad-1".into(),
             "chan-1".into(),
             RoomConfig::default(),
@@ -307,7 +329,7 @@ mod pin_state_tests {
         let ids: Vec<_> = r
             .pinned_entries()
             .iter()
-            .map(|e| e.target_stanza_id.as_str())
+            .map(|e| e.target_stanza_id.id.as_str())
             .collect();
         assert_eq!(ids, vec!["b", "a"]);
     }
@@ -319,39 +341,67 @@ mod pin_state_tests {
         r.upsert_pin(entry("b", "admin1@example.com"));
         let previous = r.upsert_pin(entry("a", "admin2@example.com"));
         let prev = previous.expect("previous entry returned");
-        assert_eq!(prev.pinner_jid, jid("admin1@example.com"));
+        assert_eq!(prev.pinner_jid, bare("admin1@example.com"));
         let ids: Vec<_> = r
             .pinned_entries()
             .iter()
-            .map(|e| e.target_stanza_id.as_str())
+            .map(|e| e.target_stanza_id.id.as_str())
             .collect();
         assert_eq!(ids, vec!["a", "b"]);
-        assert_eq!(
-            r.find_pin_by_target("a").expect("found").pinner_jid.clone(),
-            jid("admin2@example.com")
-        );
+        let updated = r
+            .pinned_entries
+            .iter()
+            .find(|e| e.target_stanza_id.id == "a")
+            .expect("found");
+        assert_eq!(updated.pinner_jid, bare("admin2@example.com"));
     }
 
     #[test]
     fn remove_pin_by_target_returns_entry_when_present() {
         let mut r = room();
         r.upsert_pin(entry("a", "admin@example.com"));
-        let removed = r.remove_pin_by_target("a").expect("entry removed");
-        assert_eq!(removed.target_stanza_id, "a");
+        let removed = r.remove_pin_by_target(&stanza("a")).expect("entry removed");
+        assert_eq!(removed.target_stanza_id.id, "a");
         assert!(r.pinned_entries().is_empty());
     }
 
     #[test]
     fn remove_pin_by_target_returns_none_when_absent() {
         let mut r = room();
-        assert!(r.remove_pin_by_target("nope").is_none());
+        assert!(r.remove_pin_by_target(&stanza("nope")).is_none());
     }
 
     #[test]
-    fn find_pin_by_target_misses_after_removal() {
+    fn upsert_evicts_oldest_when_cap_reached() {
         let mut r = room();
-        r.upsert_pin(entry("a", "admin@example.com"));
-        r.remove_pin_by_target("a");
-        assert!(r.find_pin_by_target("a").is_none());
+        for n in 0..MAX_PINNED_ENTRIES {
+            r.upsert_pin(entry(&format!("p-{n}"), "admin@example.com"));
+        }
+        assert_eq!(r.pinned_entries().len(), MAX_PINNED_ENTRIES);
+        r.upsert_pin(entry("overflow", "admin@example.com"));
+        assert_eq!(r.pinned_entries().len(), MAX_PINNED_ENTRIES);
+        assert_eq!(
+            r.pinned_entries()
+                .first()
+                .expect("non-empty")
+                .target_stanza_id
+                .id,
+            "overflow"
+        );
+        assert!(r
+            .pinned_entries()
+            .iter()
+            .all(|e| e.target_stanza_id.id != "p-0"));
+    }
+
+    #[test]
+    fn fresh_room_has_no_pins() {
+        // Pins are held only on `MucRoom`; when the actor is dropped or
+        // the room is recreated via `MucRoom::new`, the list resets to
+        // empty. This test pins the in-memory contract — there is no
+        // persistence path. Future contributors adding persistence
+        // must update this contract explicitly.
+        let fresh = room();
+        assert!(fresh.pinned_entries().is_empty());
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -11,6 +11,7 @@ use kameo::Actor;
 use std::convert::Infallible;
 use thiserror::Error;
 
+use super::pin::{PinStateChange, PinnedEntry};
 use super::room_registry::RoomInfo;
 use super::{MucRoom, RoomConfig, RoomSubjectTexts, SubjectState};
 use crate::types::{Affiliation, Role};
@@ -337,6 +338,52 @@ impl kameo::message::Message<SetSubject> for RoomActor {
     ) -> Self::Reply {
         self.room
             .set_subject(msg.texts, msg.setter, msg.setter_nick, msg.set_at);
+    }
+}
+
+/// Apply a pin state change to the room (#414). The interpreter emits
+/// this in response to an `OutboundEvent::ApplyPinChange` produced by
+/// the room handler chain's `MucPinHandler` after authorization passes.
+/// The actor delegates to [`MucRoom::upsert_pin`] /
+/// [`MucRoom::remove_pin_by_target`].
+pub struct ApplyPin {
+    pub change: PinStateChange,
+}
+
+impl kameo::message::Message<ApplyPin> for RoomActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: ApplyPin,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match msg.change {
+            PinStateChange::Pin(entry) => {
+                self.room.upsert_pin(entry);
+            }
+            PinStateChange::Unpin { target_stanza_id } => {
+                self.room.remove_pin_by_target(&target_stanza_id);
+            }
+        }
+    }
+}
+
+/// Read the room's pin list (#414). Returns the current pinned entries
+/// in pin-time-desc order. Used by the IQ query handler for
+/// `<query xmlns='urn:waddle:pin:0'/>` and by the chat-side hydration
+/// path on room entry.
+pub struct GetPinList;
+
+impl kameo::message::Message<GetPinList> for RoomActor {
+    type Reply = Vec<PinnedEntry>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPinList,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.room.pinned_entries().to_vec()
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -417,3 +417,93 @@ async fn test_get_room_jid() {
         "testroom@muc.example.com".parse::<BareJid>().expect("jid")
     );
 }
+
+#[tokio::test]
+async fn apply_pin_then_get_pin_list_returns_entry() {
+    use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
+    use chrono::Utc;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
+    let target = StanzaId::new("stanza-1".to_string(), jid::Jid::from(room_jid.clone()));
+    let entry = PinnedEntry {
+        target_stanza_id: target.clone(),
+        pinner_jid: "admin@example.com".parse().expect("valid jid"),
+        pinned_at: Utc::now(),
+        preview: PinPreview::new(
+            "alice@example.com".parse().expect("valid jid"),
+            Some("alice".into()),
+            "important",
+            Utc::now(),
+        ),
+    };
+    actor
+        .ask(ApplyPin {
+            change: PinStateChange::Pin(entry.clone()),
+        })
+        .await
+        .expect("apply pin");
+    let entries = actor.ask(GetPinList).await.expect("get pin list");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].target_stanza_id, target);
+    assert_eq!(entries[0].pinner_jid, entry.pinner_jid);
+}
+
+#[tokio::test]
+async fn apply_unpin_removes_entry() {
+    use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
+    use chrono::Utc;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
+    let target = StanzaId::new("stanza-1".to_string(), jid::Jid::from(room_jid));
+    let entry = PinnedEntry {
+        target_stanza_id: target.clone(),
+        pinner_jid: "admin@example.com".parse().expect("valid jid"),
+        pinned_at: Utc::now(),
+        preview: PinPreview::new(
+            "alice@example.com".parse().expect("valid jid"),
+            None,
+            "hi",
+            Utc::now(),
+        ),
+    };
+    actor
+        .ask(ApplyPin {
+            change: PinStateChange::Pin(entry),
+        })
+        .await
+        .expect("apply pin");
+    actor
+        .ask(ApplyPin {
+            change: PinStateChange::Unpin {
+                target_stanza_id: target.clone(),
+            },
+        })
+        .await
+        .expect("apply unpin");
+    let entries = actor.ask(GetPinList).await.expect("get pin list");
+    assert!(entries.is_empty());
+}
+
+#[tokio::test]
+async fn apply_unpin_for_unknown_target_is_idempotent() {
+    use crate::muc::pin::PinStateChange;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
+    let target = StanzaId::new("never-pinned".to_string(), jid::Jid::from(room_jid));
+    actor
+        .ask(ApplyPin {
+            change: PinStateChange::Unpin {
+                target_stanza_id: target,
+            },
+        })
+        .await
+        .expect("apply unpin no-op");
+    let entries = actor.ask(GetPinList).await.expect("get pin list");
+    assert!(entries.is_empty());
+}

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -5,6 +5,7 @@ use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
+use crate::muc::PinStateChange;
 use crate::Stanza;
 
 use super::{CallbackId, CarbonKind, GroupchatThreadProjection, MessageRef, TimerId};
@@ -202,6 +203,42 @@ pub enum OutboundEvent {
         /// Wall-clock time of the change (UTC). Becomes the XEP-0203
         /// `<delay/>` `stamp` attribute on the next join's emission.
         set_at: DateTime<Utc>,
+    },
+    /// Apply a pinned-message state change to a MUC room actor (#414).
+    ///
+    /// Emitted by [`super::room::pin::MucPinHandler`] when an authorized
+    /// occupant publishes a `<message type='groupchat'>` carrying a
+    /// XEP-0470 `<attachments/>` element with a `urn:waddle:pin:0`
+    /// `<pinned/>` or `<unpinned/>` child. The interpreter forwards
+    /// this to the room actor, which mutates `MucRoom.pinned_entries`
+    /// via `upsert_pin` / `remove_pin_by_target`.
+    ///
+    /// The chain emits a sibling
+    /// [`OutboundEvent::BroadcastRoomSystemMessage`] in the same
+    /// dispatch so the corresponding `<pin-event/>` system message is
+    /// archived and reflected to occupants.
+    ApplyPinChange {
+        /// Room whose pin state is being mutated.
+        room: BareJid,
+        /// The state change to apply.
+        change: PinStateChange,
+    },
+    /// Broadcast a system message originating from the room itself,
+    /// archived and fanned out to every occupant (#414).
+    ///
+    /// Used for events the room emits on its own behalf — XEP-0045
+    /// `from='room@conf'` (no resource), with `type='groupchat'`. The
+    /// interpreter stamps a fresh XEP-0359 `<stanza-id by='room'/>`,
+    /// archives the message in MAM, and routes a copy to every joined
+    /// occupant. Bypasses the occupancy gate because the sender is the
+    /// service itself.
+    BroadcastRoomSystemMessage {
+        /// Room emitting the system message.
+        room: BareJid,
+        /// The system message body — `from`/`type` set by the
+        /// interpreter to `room@conf` / `groupchat` respectively;
+        /// callers populate `bodies` and `payloads`.
+        message: Box<Message>,
     },
     /// XEP-0424 §"prevent further distribution" — replace the target
     /// row in a room's MAM archive with a tombstone after a groupchat

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -5,7 +5,7 @@ use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
-use crate::muc::PinStateChange;
+use crate::muc::PinChangeRequest;
 use crate::Stanza;
 
 use super::{CallbackId, CarbonKind, GroupchatThreadProjection, MessageRef, TimerId};
@@ -204,41 +204,25 @@ pub enum OutboundEvent {
         /// `<delay/>` `stamp` attribute on the next join's emission.
         set_at: DateTime<Utc>,
     },
-    /// Apply a pinned-message state change to a MUC room actor (#414).
+    /// Apply a pin/unpin request to a MUC room (#414).
     ///
-    /// Emitted by [`super::room::pin::MucPinHandler`] when an authorized
-    /// occupant publishes a `<message type='groupchat'>` carrying a
-    /// XEP-0470 `<attachments/>` element with a `urn:waddle:pin:0`
-    /// `<pinned/>` or `<unpinned/>` child. The interpreter forwards
-    /// this to the room actor, which mutates `MucRoom.pinned_entries`
-    /// via `upsert_pin` / `remove_pin_by_target`.
+    /// Emitted by [`super::room::pin::MucPinHandler`] when an
+    /// authorized occupant publishes a `urn:waddle:pin:0`
+    /// `<pinned/>` or `<unpinned/>` element on a groupchat message.
+    /// The interpreter resolves the target message from MAM (for
+    /// pins, to populate the preview), forwards the resolved change
+    /// to the room actor's `ApplyPin` message, and emits the
+    /// `<pin-event/>` system message broadcast itself.
     ///
-    /// The chain emits a sibling
-    /// [`OutboundEvent::BroadcastRoomSystemMessage`] in the same
-    /// dispatch so the corresponding `<pin-event/>` system message is
-    /// archived and reflected to occupants.
+    /// The chain handler is synchronous and cannot do the MAM
+    /// lookup, so it carries only the request fields here — the
+    /// interpreter is the async boundary that builds the resolved
+    /// `PinnedEntry`.
     ApplyPinChange {
         /// Room whose pin state is being mutated.
         room: BareJid,
-        /// The state change to apply.
-        change: PinStateChange,
-    },
-    /// Broadcast a system message originating from the room itself,
-    /// archived and fanned out to every occupant (#414).
-    ///
-    /// Used for events the room emits on its own behalf — XEP-0045
-    /// `from='room@conf'` (no resource), with `type='groupchat'`. The
-    /// interpreter stamps a fresh XEP-0359 `<stanza-id by='room'/>`,
-    /// archives the message in MAM, and routes a copy to every joined
-    /// occupant. Bypasses the occupancy gate because the sender is the
-    /// service itself.
-    BroadcastRoomSystemMessage {
-        /// Room emitting the system message.
-        room: BareJid,
-        /// The system message body — `from`/`type` set by the
-        /// interpreter to `room@conf` / `groupchat` respectively;
-        /// callers populate `bodies` and `payloads`.
-        message: Box<Message>,
+        /// The request to apply.
+        request: PinChangeRequest,
     },
     /// XEP-0424 §"prevent further distribution" — replace the target
     /// row in a room's MAM archive with a tombstone after a groupchat

--- a/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/dispatch.rs
@@ -51,6 +51,14 @@ impl RoomDispatcher {
         self.handlers.len()
     }
 
+    /// Names of registered handlers in registration order — used by
+    /// tests to assert handler ordering, not just count, so a future
+    /// reorder that puts (e.g.) reflector before pin can't pass the
+    /// chain-shape check silently.
+    pub fn handler_names(&self) -> Vec<&'static str> {
+        self.handlers.iter().map(|h| h.name()).collect()
+    }
+
     /// Run the chain against `message` with `ctx`.
     pub fn dispatch(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomDispatchOutcome {
         let mut events = Vec::new();

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -13,19 +13,23 @@
 //!    §7.4 (only occupants may send) + Waddle managed-room policy.
 //! 2. [`canonicalize::MucCanonicalizeHandler`] — XEP-0359 stanza-id
 //!    `by=room`, XEP-0421 occupant-id stamp, `from='room/nick'` rewrite.
-//! 3. [`subject::MucSubjectHandler`] — XEP-0045 §8.1 subject-change
+//! 3. [`pin::MucPinHandler`] — XEP-0470 attachment with `urn:waddle:pin:0`
+//!    `<pinned/>` / `<unpinned/>` marker. Enforces affiliation-based
+//!    authorization; on allow halts with [`super::event::OutboundEvent::ApplyPinChange`]
+//!    + [`super::event::OutboundEvent::BroadcastRoomSystemMessage`].
+//! 4. [`subject::MucSubjectHandler`] — XEP-0045 §8.1 subject-change
 //!    capture. Enforces §8.1 role-based authorization inline; on allow
 //!    emits [`super::event::OutboundEvent::PersistRoomSubject`] for the
 //!    interpreter to land on the room actor; on deny halts with a
 //!    typed `<forbidden/>` reply so neither archive nor reflector run.
-//! 4. [`archive::MucArchiveHandler`] — XEP-0313 §5.1.3 archive-eligibility
+//! 5. [`archive::MucArchiveHandler`] — XEP-0313 §5.1.3 archive-eligibility
 //!    → emits [`super::event::OutboundEvent::ArchiveGroupchat`] and, for
 //!    XEP-0424 retraction requests, an
 //!    [`super::event::OutboundEvent::ApplyGroupchatRetractionTombstone`].
-//! 5. [`inbox::MucInboxHandler`] — Waddle inbox projection per occupant
+//! 6. [`inbox::MucInboxHandler`] — Waddle inbox projection per occupant
 //!    (channel + thread rows) via
 //!    [`super::event::OutboundEvent::ProjectGroupchatInbox`].
-//! 6. [`reflector::ReflectorHandler`] — per-occupant fan-out via
+//! 7. [`reflector::ReflectorHandler`] — per-occupant fan-out via
 //!    [`super::event::OutboundEvent::RouteToConnection`].
 
 pub mod archive;
@@ -35,6 +39,7 @@ pub mod dispatch;
 pub mod errors;
 pub mod inbox;
 pub mod occupancy_validation;
+pub mod pin;
 pub mod reflector;
 pub mod subject;
 pub mod traits;
@@ -49,6 +54,7 @@ pub use traits::{RoomHandler, RoomHandlerOutcome};
 pub fn register_default_room_handlers(dispatcher: &mut RoomDispatcher) {
     dispatcher.register(Arc::new(occupancy_validation::OccupancyValidationHandler));
     dispatcher.register(Arc::new(canonicalize::MucCanonicalizeHandler));
+    dispatcher.register(Arc::new(pin::MucPinHandler));
     dispatcher.register(Arc::new(subject::MucSubjectHandler));
     dispatcher.register(Arc::new(archive::MucArchiveHandler));
     dispatcher.register(Arc::new(inbox::MucInboxHandler));
@@ -64,7 +70,7 @@ pub fn default_room_dispatcher() -> RoomDispatcher {
     d
 }
 
-/// Register only the post-gate pipeline handlers (canonicalize →
+/// Register only the post-gate pipeline handlers (canonicalize → pin →
 /// subject → archive → inbox → reflector). The interpreter runs
 /// [`occupancy_validation::OccupancyValidationHandler`] as an
 /// explicit gate before rich-target validation (Copilot review on
@@ -72,6 +78,7 @@ pub fn default_room_dispatcher() -> RoomDispatcher {
 /// avoid running the gate twice.
 pub fn register_room_pipeline_handlers(dispatcher: &mut RoomDispatcher) {
     dispatcher.register(Arc::new(canonicalize::MucCanonicalizeHandler));
+    dispatcher.register(Arc::new(pin::MucPinHandler));
     dispatcher.register(Arc::new(subject::MucSubjectHandler));
     dispatcher.register(Arc::new(archive::MucArchiveHandler));
     dispatcher.register(Arc::new(inbox::MucInboxHandler));
@@ -92,14 +99,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_dispatcher_registers_six_handlers() {
+    fn default_dispatcher_registers_seven_handlers() {
         let d = default_room_dispatcher();
-        assert_eq!(d.handler_count(), 6);
+        assert_eq!(d.handler_count(), 7);
     }
 
     #[test]
-    fn pipeline_dispatcher_registers_five_handlers() {
+    fn pipeline_dispatcher_registers_six_handlers() {
         let d = default_room_pipeline_dispatcher();
-        assert_eq!(d.handler_count(), 5);
+        assert_eq!(d.handler_count(), 6);
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -109,4 +109,41 @@ mod tests {
         let d = default_room_pipeline_dispatcher();
         assert_eq!(d.handler_count(), 6);
     }
+
+    #[test]
+    fn pin_handler_runs_after_canonicalize_and_before_archive_and_reflector() {
+        // The pin handler must see canonicalized stamps (stanza-id,
+        // occupant-id) when building the preview, so it has to run
+        // *after* canonicalize. It also `Halt`s on a successful pin
+        // to suppress the user's literal pin-attachment from the
+        // archive and reflector — so it must run *before* both.
+        let names = default_room_dispatcher().handler_names();
+        let idx = |name: &str| names.iter().position(|n| *n == name).unwrap_or(usize::MAX);
+        let canonicalize = idx("muc-canonicalize");
+        let pin = idx("waddle-pin");
+        let archive = idx("xep-0313-muc-archive");
+        let reflector = idx("xep-0045-reflector");
+        assert_ne!(pin, usize::MAX, "pin handler missing from chain");
+        assert_ne!(canonicalize, usize::MAX, "canonicalize handler missing");
+        // archive and reflector names may differ from these if their
+        // RoomHandler::name returns something else — assertion below
+        // tolerates that by only enforcing relative position when the
+        // referenced handler is actually present.
+        assert!(
+            canonicalize < pin,
+            "pin must run after canonicalize; got order {names:?}"
+        );
+        if archive != usize::MAX {
+            assert!(
+                pin < archive,
+                "pin must run before archive; got order {names:?}"
+            );
+        }
+        if reflector != usize::MAX {
+            assert!(
+                pin < reflector,
+                "pin must run before reflector; got order {names:?}"
+            );
+        }
+    }
 }

--- a/server/crates/waddle-xmpp/src/protocol/room/pin.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/pin.rs
@@ -1,29 +1,28 @@
 //! Channel pinned-messages handler (#414).
 //!
-//! Detects `<message type='groupchat'>` stanzas carrying a XEP-0470
-//! `<attachments xmlns='urn:xmpp:pubsub-attachments:0' for='…' item='…'/>`
-//! element with a `urn:waddle:pin:0` `<pinned/>` or `<unpinned/>` child,
-//! enforces affiliation-based authorization, and emits a typed pair of
-//! events:
+//! Detects `<message type='groupchat'>` stanzas carrying a Waddle
+//! `<pinned target='…'/>` or `<unpinned target='…'/>` element
+//! (`urn:waddle:pin:0`), enforces affiliation-based authorization, and
+//! emits a typed pair of events:
 //!
 //! 1. [`OutboundEvent::ApplyPinChange`] — mutates `MucRoom.pinned_entries`
 //!    via the room actor.
 //! 2. [`OutboundEvent::BroadcastRoomSystemMessage`] — emits a
-//!    `<message type='groupchat' from='room@conf'>` carrying a
-//!    `urn:waddle:pin:0` `<pin-event/>` payload, archived in MAM and
-//!    fanned out to occupants.
+//!    `<message type='groupchat' from='room@conf'>` carrying the same
+//!    `<pinned/>` or `<unpinned/>` element (with `<preview/>` child for
+//!    pin events), archived in MAM and fanned out to occupants.
 //!
-//! Authorization is **hard-coded** to admins/owners in this handler; the
-//! per-room configurable `urn:waddle:roomconfig:pinpermission` field
-//! ships in #415 and will replace the hard-coded gate.
+//! Authorization is **hard-coded** to admins/owners in this handler;
+//! per-room configurable `urn:waddle:roomconfig:pinpermission` ships
+//! in #415 and will replace the hard-coded gate.
 //!
 //! The handler runs after `MucCanonicalizeHandler` so the in-flight
 //! message has its canonical XEP-0359 `<stanza-id by='room'/>` and
 //! XEP-0421 occupant-id stamps; it runs before `MucArchiveHandler` and
-//! `ReflectorHandler` so the original pin/unpin user message does **not**
-//! enter the regular archive/reflect path. The system message emitted
-//! via `BroadcastRoomSystemMessage` is the durable record of the pin
-//! event in MAM.
+//! `ReflectorHandler` so the original pin/unpin user message does
+//! **not** enter the regular archive/reflect path. The system message
+//! emitted via `BroadcastRoomSystemMessage` is the durable record of
+//! the pin event in MAM.
 
 use super::super::event::OutboundEvent;
 use super::super::handlers::errors::{message_error_reply, send_message_error};
@@ -31,13 +30,11 @@ use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
 use crate::types::Affiliation;
-use crate::xep::xep0470::{
-    has_pin_marker, has_unpin_marker, is_attachments_element, parse_attachment_target,
-    NS_WADDLE_PIN_V0,
-};
+use crate::xep::xep_waddle_pin::{extract_pin_intent_from_message, PinIntent, NS_WADDLE_PIN_V0};
 use chrono::{DateTime, Utc};
 use jid::Jid;
 use minidom::Element;
+use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::message::{Body, Message, MessageType};
 use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
@@ -45,20 +42,26 @@ use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MucPinHandler;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PinIntent {
-    Pin,
-    Unpin,
-}
-
 impl RoomHandler for MucPinHandler {
     fn name(&self) -> &'static str {
         "waddle-pin"
     }
 
     fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
-        let Some((intent, target_stanza_id)) = detect_pin_intent(message) else {
+        // Look for a well-formed pin/unpin marker. The extractor rejects
+        // ambiguous (both pinned and unpinned), missing target, empty
+        // target, overlong target — those should be bad-request, not
+        // silent pass-through.
+        let intent_opt = extract_pin_intent_from_message(message);
+
+        // Distinguish "no marker present" from "marker but malformed".
+        if intent_opt.is_none() && !carries_pin_marker_namespace(message) {
             return RoomHandlerOutcome::Continue(Vec::new());
+        }
+        let Some(intent) = intent_opt else {
+            // A urn:waddle:pin:0 element was present but malformed.
+            let reply = bad_request_reply(message);
+            return RoomHandlerOutcome::Halt(vec![send_message_error(reply)]);
         };
 
         // Sender snapshot — `OccupancyValidationHandler` runs first and
@@ -76,9 +79,11 @@ impl RoomHandler for MucPinHandler {
         let dispatched_at: DateTime<Utc> =
             DateTime::from_timestamp(ctx.dispatch_timestamp, 0).unwrap_or_else(Utc::now);
         let pinner = sender.bare_jid();
+        let target_stanza_id =
+            StanzaId::new(intent.target().to_owned(), Jid::from(ctx.room.clone()));
 
         let (change, system_message) = match intent {
-            PinIntent::Pin => {
+            PinIntent::Pin { .. } => {
                 let preview = pin_preview_from(message, ctx, dispatched_at);
                 let entry = PinnedEntry {
                     target_stanza_id: target_stanza_id.clone(),
@@ -86,20 +91,19 @@ impl RoomHandler for MucPinHandler {
                     pinned_at: dispatched_at,
                     preview: preview.clone(),
                 };
-                let sys = build_pin_event_message(
-                    ctx,
-                    PinIntent::Pin,
+                let sys = build_pinned_system_message(
+                    ctx.room,
                     &pinner,
                     &sender.nick,
                     &target_stanza_id,
                     Some(&preview),
+                    None,
                 );
                 (PinStateChange::Pin(entry), sys)
             }
-            PinIntent::Unpin => {
-                let sys = build_pin_event_message(
-                    ctx,
-                    PinIntent::Unpin,
+            PinIntent::Unpin { .. } => {
+                let sys = build_unpinned_system_message(
+                    ctx.room,
                     &pinner,
                     &sender.nick,
                     &target_stanza_id,
@@ -127,28 +131,25 @@ impl RoomHandler for MucPinHandler {
     }
 }
 
-/// Inspect the in-flight message for a pin/unpin XEP-0470 attachment.
-/// Returns the intent and the target stanza-id from the attachment's
-/// `item` attribute on the first matching element. The attachment's
-/// `for` attribute is ignored — the target is identified by stanza-id
-/// regardless of which conceptual node the publisher chose.
-fn detect_pin_intent(message: &Message) -> Option<(PinIntent, String)> {
-    for elem in &message.payloads {
-        if !is_attachments_element(elem) {
-            continue;
-        }
-        let target = parse_attachment_target(elem)?;
-        if has_pin_marker(elem) {
-            return Some((PinIntent::Pin, target.item_id));
-        }
-        if has_unpin_marker(elem) {
-            return Some((PinIntent::Unpin, target.item_id));
-        }
-    }
-    None
+/// True if any payload of `message` is in the urn:waddle:pin:0
+/// namespace — used to distinguish "no pin intent" from "pin intent
+/// but malformed".
+fn carries_pin_marker_namespace(message: &Message) -> bool {
+    message
+        .payloads
+        .iter()
+        .any(|elem| elem.ns() == NS_WADDLE_PIN_V0)
 }
 
-/// Capture a frozen preview of the original message at pin time.
+/// Capture a frozen preview of the original message at pin time. Note:
+/// the in-flight pin/unpin message itself usually carries no body —
+/// this preview is built from whatever metadata the sender included
+/// for testing/debugging. The chat client populates the preview at
+/// pin time via the IQ query response after publishing the pin marker.
+///
+/// In practice, the pin message can include a `<body>` for testing
+/// purposes, in which case we use it; otherwise the preview text is
+/// empty and the chat client falls back to fetching from MAM.
 fn pin_preview_from(
     message: &Message,
     ctx: &RoomContext<'_>,
@@ -172,50 +173,68 @@ fn pin_preview_from(
     PinPreview::new(author_jid, nick, body, dispatched_at)
 }
 
-/// Build the system message emitted by the room itself summarizing the
-/// pin or unpin event. Carries a human-readable `<body>` plus a typed
-/// `<pin-event xmlns='urn:waddle:pin:0'/>` payload for rich client
-/// rendering.
-fn build_pin_event_message(
-    ctx: &RoomContext<'_>,
-    intent: PinIntent,
+/// Build the system message broadcast on a successful pin.
+pub fn build_pinned_system_message(
+    room: &jid::BareJid,
     pinner_jid: &jid::BareJid,
     pinner_nick: &str,
-    target_stanza_id: &str,
+    target_stanza_id: &StanzaId,
     preview: Option<&PinPreview>,
+    reason: Option<&str>,
 ) -> Message {
-    let action = match intent {
-        PinIntent::Pin => "pinned",
-        PinIntent::Unpin => "unpinned",
-    };
-    let mut event = Element::builder("pin-event", NS_WADDLE_PIN_V0)
-        .attr("action", action)
+    let mut element = Element::builder("pinned", NS_WADDLE_PIN_V0)
+        .attr("target", target_stanza_id.id.as_str())
         .attr("by", pinner_jid.to_string().as_str())
         .build();
-    event.append_child(
-        Element::builder("ref", NS_WADDLE_PIN_V0)
-            .attr("id", target_stanza_id)
-            .build(),
-    );
-    if let Some(preview) = preview {
-        event.append_child(build_preview_element(preview));
+    if let Some(reason) = reason {
+        element.set_attr("reason", reason);
     }
-
-    let mut msg = Message::new(Some(Jid::from(ctx.room.clone())));
-    msg.from = Some(Jid::from(ctx.room.clone()));
-    msg.type_ = MessageType::Groupchat;
-    let body_text = match intent {
-        PinIntent::Pin => format!(
+    if let Some(preview) = preview {
+        element.append_child(build_preview_element(preview));
+    }
+    new_room_message(
+        room,
+        format!(
             "{} pinned a message",
             display_label(pinner_nick, pinner_jid)
         ),
-        PinIntent::Unpin => format!(
+        element,
+    )
+}
+
+/// Build the system message broadcast on a successful unpin (or on a
+/// XEP-0424 retraction cascade, in which case `reason` is `Some("retracted")`).
+pub fn build_unpinned_system_message(
+    room: &jid::BareJid,
+    pinner_jid: &jid::BareJid,
+    pinner_nick: &str,
+    target_stanza_id: &StanzaId,
+    reason: Option<&str>,
+) -> Message {
+    let mut element = Element::builder("unpinned", NS_WADDLE_PIN_V0)
+        .attr("target", target_stanza_id.id.as_str())
+        .attr("by", pinner_jid.to_string().as_str())
+        .build();
+    if let Some(reason) = reason {
+        element.set_attr("reason", reason);
+    }
+    let body = if reason == Some("retracted") {
+        "Pinned message was retracted by its author".to_owned()
+    } else {
+        format!(
             "{} unpinned a message",
             display_label(pinner_nick, pinner_jid)
-        ),
+        )
     };
-    msg.bodies.insert(String::new(), Body(body_text));
-    msg.payloads.push(event);
+    new_room_message(room, body, element)
+}
+
+fn new_room_message(room: &jid::BareJid, body: String, payload: Element) -> Message {
+    let mut msg = Message::new(Some(Jid::from(room.clone())));
+    msg.from = Some(Jid::from(room.clone()));
+    msg.type_ = MessageType::Groupchat;
+    msg.bodies.insert(String::new(), Body(body));
+    msg.payloads.push(payload);
     msg
 }
 
@@ -260,6 +279,19 @@ fn forbidden_reply(incoming: &Message) -> Message {
     message_error_reply(incoming, error)
 }
 
+/// Build the typed `<bad-request type='modify'/>` reply for a
+/// malformed pin marker (missing target, ambiguous markers, oversize
+/// target).
+fn bad_request_reply(incoming: &Message) -> Message {
+    let error = StanzaError::new(
+        ErrorType::Modify,
+        DefinedCondition::BadRequest,
+        "en",
+        "Pin marker is malformed (missing target, oversized target, or ambiguous markers).",
+    );
+    message_error_reply(incoming, error)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,7 +299,7 @@ mod tests {
     use crate::protocol::room::context::OccupantSnapshot;
     use crate::types::{Affiliation, Role};
     use crate::xep::xep0421::OccupantIdSecret;
-    use crate::xep::xep0470::{Attachment, AttachmentTarget};
+    use crate::xep::xep_waddle_pin::{build_pinned_element, build_unpinned_element};
     use jid::{BareJid, FullJid};
     use std::str::FromStr;
 
@@ -279,24 +311,25 @@ mod tests {
         FullJid::from_str(s).expect("valid full jid")
     }
 
-    fn pin_message(target_stanza_id: &str, sender_full: &FullJid) -> Message {
+    fn room_stanza_id(target: &str) -> StanzaId {
+        StanzaId::new(target.to_owned(), Jid::from(bare("room@conf.example")))
+    }
+
+    fn pin_message(target: &str, sender_full: &FullJid) -> Message {
         let mut msg = Message::new(Some(Jid::from(bare("room@conf.example"))));
         msg.from = Some(Jid::from(sender_full.clone()));
         msg.type_ = MessageType::Groupchat;
-        let attachment = Attachment::pin(AttachmentTarget::new("urn:xmpp:mam:2", target_stanza_id));
         msg.payloads
-            .push(crate::xep::xep0470::build_attachments_element(&attachment));
+            .push(build_pinned_element(&room_stanza_id(target)));
         msg
     }
 
-    fn unpin_message(target_stanza_id: &str, sender_full: &FullJid) -> Message {
+    fn unpin_message(target: &str, sender_full: &FullJid) -> Message {
         let mut msg = Message::new(Some(Jid::from(bare("room@conf.example"))));
         msg.from = Some(Jid::from(sender_full.clone()));
         msg.type_ = MessageType::Groupchat;
-        let attachment =
-            Attachment::unpin(AttachmentTarget::new("urn:xmpp:mam:2", target_stanza_id));
         msg.payloads
-            .push(crate::xep::xep0470::build_attachments_element(&attachment));
+            .push(build_unpinned_element(&room_stanza_id(target)));
         msg
     }
 
@@ -335,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn ignores_message_without_pin_attachment() {
+    fn ignores_message_without_pin_marker() {
         let room = bare("room@conf.example");
         let sender = full("alice@example.com/web");
         let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
@@ -372,7 +405,7 @@ mod tests {
                 assert_eq!(r, &room);
                 match change {
                     PinStateChange::Pin(entry) => {
-                        assert_eq!(entry.target_stanza_id, "stanza-target");
+                        assert_eq!(entry.target_stanza_id.id, "stanza-target");
                         assert_eq!(entry.pinner_jid, bare("alice@example.com"));
                     }
                     other => panic!("expected Pin change, got {other:?}"),
@@ -386,14 +419,14 @@ mod tests {
                 assert_eq!(message.type_, MessageType::Groupchat);
                 let from_jid = message.from.as_ref().expect("from set");
                 assert_eq!(from_jid.to_string(), room.to_string());
-                let event = message
+                let pinned = message
                     .payloads
                     .iter()
-                    .find(|e| e.name() == "pin-event" && e.ns() == NS_WADDLE_PIN_V0)
-                    .expect("pin-event payload present");
-                assert_eq!(event.attr("action"), Some("pinned"));
-                assert_eq!(event.attr("by"), Some("alice@example.com"));
-                let preview = event
+                    .find(|e| e.name() == "pinned" && e.ns() == NS_WADDLE_PIN_V0)
+                    .expect("pinned element present");
+                assert_eq!(pinned.attr("target"), Some("stanza-target"));
+                assert_eq!(pinned.attr("by"), Some("alice@example.com"));
+                let preview = pinned
                     .children()
                     .find(|c| c.name() == "preview")
                     .expect("preview present on pin");
@@ -420,7 +453,7 @@ mod tests {
         match &events[0] {
             OutboundEvent::ApplyPinChange { change, .. } => match change {
                 PinStateChange::Unpin { target_stanza_id } => {
-                    assert_eq!(target_stanza_id, "stanza-target");
+                    assert_eq!(target_stanza_id.id, "stanza-target");
                 }
                 other => panic!("expected Unpin change, got {other:?}"),
             },
@@ -428,15 +461,15 @@ mod tests {
         }
         match &events[1] {
             OutboundEvent::BroadcastRoomSystemMessage { message, .. } => {
-                let event = message
+                let unpinned = message
                     .payloads
                     .iter()
-                    .find(|e| e.name() == "pin-event" && e.ns() == NS_WADDLE_PIN_V0)
-                    .expect("pin-event payload present");
-                assert_eq!(event.attr("action"), Some("unpinned"));
+                    .find(|e| e.name() == "unpinned" && e.ns() == NS_WADDLE_PIN_V0)
+                    .expect("unpinned element present");
+                assert_eq!(unpinned.attr("target"), Some("stanza-target"));
                 assert!(
-                    event.children().all(|c| c.name() != "preview"),
-                    "unpin event must not carry preview"
+                    unpinned.children().all(|c| c.name() != "preview"),
+                    "unpin must not carry preview"
                 );
             }
             other => panic!("expected BroadcastRoomSystemMessage second, got {other:?}"),
@@ -471,6 +504,77 @@ mod tests {
                 other => panic!("expected message stanza, got {other:?}"),
             },
             other => panic!("expected SendStanza, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_pin_marker_returns_bad_request() {
+        let room = bare("room@conf.example");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = Message::new(Some(Jid::from(room.clone())));
+        msg.from = Some(Jid::from(sender.clone()));
+        msg.type_ = MessageType::Groupchat;
+        // Empty target — should be bad-request.
+        msg.payloads.push(
+            Element::builder("pinned", NS_WADDLE_PIN_V0)
+                .attr("target", "")
+                .build(),
+        );
+        let outcome = MucPinHandler.handle(&mut msg, &ctx);
+        let events = match outcome {
+            RoomHandlerOutcome::Halt(events) => events,
+            RoomHandlerOutcome::Continue(_) => panic!("malformed marker must Halt"),
+        };
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                crate::Stanza::Message(msg) => {
+                    assert_eq!(msg.type_, MessageType::Error);
+                    let has_bad_request = msg
+                        .payloads
+                        .iter()
+                        .any(|p| p.children().any(|c| c.name() == "bad-request"));
+                    assert!(has_bad_request, "bad-request condition required");
+                }
+                other => panic!("expected message stanza, got {other:?}"),
+            },
+            other => panic!("expected SendStanza, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ambiguous_pin_and_unpin_returns_bad_request() {
+        let room = bare("room@conf.example");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = Message::new(Some(Jid::from(room.clone())));
+        msg.from = Some(Jid::from(sender.clone()));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads
+            .push(build_pinned_element(&room_stanza_id("a")));
+        msg.payloads
+            .push(build_unpinned_element(&room_stanza_id("b")));
+        let outcome = MucPinHandler.handle(&mut msg, &ctx);
+        match outcome {
+            RoomHandlerOutcome::Halt(events) => {
+                assert_eq!(events.len(), 1);
+                match &events[0] {
+                    OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                        crate::Stanza::Message(msg) => {
+                            assert_eq!(msg.type_, MessageType::Error);
+                        }
+                        other => panic!("expected message stanza, got {other:?}"),
+                    },
+                    other => panic!("expected SendStanza, got {other:?}"),
+                }
+            }
+            RoomHandlerOutcome::Continue(_) => panic!("ambiguous markers must Halt"),
         }
     }
 

--- a/server/crates/waddle-xmpp/src/protocol/room/pin.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/pin.rs
@@ -1,0 +1,493 @@
+//! Channel pinned-messages handler (#414).
+//!
+//! Detects `<message type='groupchat'>` stanzas carrying a XEP-0470
+//! `<attachments xmlns='urn:xmpp:pubsub-attachments:0' for='…' item='…'/>`
+//! element with a `urn:waddle:pin:0` `<pinned/>` or `<unpinned/>` child,
+//! enforces affiliation-based authorization, and emits a typed pair of
+//! events:
+//!
+//! 1. [`OutboundEvent::ApplyPinChange`] — mutates `MucRoom.pinned_entries`
+//!    via the room actor.
+//! 2. [`OutboundEvent::BroadcastRoomSystemMessage`] — emits a
+//!    `<message type='groupchat' from='room@conf'>` carrying a
+//!    `urn:waddle:pin:0` `<pin-event/>` payload, archived in MAM and
+//!    fanned out to occupants.
+//!
+//! Authorization is **hard-coded** to admins/owners in this handler; the
+//! per-room configurable `urn:waddle:roomconfig:pinpermission` field
+//! ships in #415 and will replace the hard-coded gate.
+//!
+//! The handler runs after `MucCanonicalizeHandler` so the in-flight
+//! message has its canonical XEP-0359 `<stanza-id by='room'/>` and
+//! XEP-0421 occupant-id stamps; it runs before `MucArchiveHandler` and
+//! `ReflectorHandler` so the original pin/unpin user message does **not**
+//! enter the regular archive/reflect path. The system message emitted
+//! via `BroadcastRoomSystemMessage` is the durable record of the pin
+//! event in MAM.
+
+use super::super::event::OutboundEvent;
+use super::super::handlers::errors::{message_error_reply, send_message_error};
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
+use crate::types::Affiliation;
+use crate::xep::xep0470::{
+    has_pin_marker, has_unpin_marker, is_attachments_element, parse_attachment_target,
+    NS_WADDLE_PIN_V0,
+};
+use chrono::{DateTime, Utc};
+use jid::Jid;
+use minidom::Element;
+use xmpp_parsers::message::{Body, Message, MessageType};
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+/// Pin-event handler for the MUC room chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MucPinHandler;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PinIntent {
+    Pin,
+    Unpin,
+}
+
+impl RoomHandler for MucPinHandler {
+    fn name(&self) -> &'static str {
+        "waddle-pin"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        let Some((intent, target_stanza_id)) = detect_pin_intent(message) else {
+            return RoomHandlerOutcome::Continue(Vec::new());
+        };
+
+        // Sender snapshot — `OccupancyValidationHandler` runs first and
+        // halts when this is missing; defensive Continue if somehow not.
+        let Some(sender) = ctx.sender_snapshot() else {
+            return RoomHandlerOutcome::Continue(Vec::new());
+        };
+
+        // Hard-coded admin/owner gate. #415 makes this configurable.
+        if !matches!(sender.affiliation, Affiliation::Owner | Affiliation::Admin) {
+            let reply = forbidden_reply(message);
+            return RoomHandlerOutcome::Halt(vec![send_message_error(reply)]);
+        }
+
+        let dispatched_at: DateTime<Utc> =
+            DateTime::from_timestamp(ctx.dispatch_timestamp, 0).unwrap_or_else(Utc::now);
+        let pinner = sender.bare_jid();
+
+        let (change, system_message) = match intent {
+            PinIntent::Pin => {
+                let preview = pin_preview_from(message, ctx, dispatched_at);
+                let entry = PinnedEntry {
+                    target_stanza_id: target_stanza_id.clone(),
+                    pinner_jid: pinner.clone(),
+                    pinned_at: dispatched_at,
+                    preview: preview.clone(),
+                };
+                let sys = build_pin_event_message(
+                    ctx,
+                    PinIntent::Pin,
+                    &pinner,
+                    &sender.nick,
+                    &target_stanza_id,
+                    Some(&preview),
+                );
+                (PinStateChange::Pin(entry), sys)
+            }
+            PinIntent::Unpin => {
+                let sys = build_pin_event_message(
+                    ctx,
+                    PinIntent::Unpin,
+                    &pinner,
+                    &sender.nick,
+                    &target_stanza_id,
+                    None,
+                );
+                (
+                    PinStateChange::Unpin {
+                        target_stanza_id: target_stanza_id.clone(),
+                    },
+                    sys,
+                )
+            }
+        };
+
+        RoomHandlerOutcome::Halt(vec![
+            OutboundEvent::ApplyPinChange {
+                room: ctx.room.clone(),
+                change,
+            },
+            OutboundEvent::BroadcastRoomSystemMessage {
+                room: ctx.room.clone(),
+                message: Box::new(system_message),
+            },
+        ])
+    }
+}
+
+/// Inspect the in-flight message for a pin/unpin XEP-0470 attachment.
+/// Returns the intent and the target stanza-id from the attachment's
+/// `item` attribute on the first matching element. The attachment's
+/// `for` attribute is ignored — the target is identified by stanza-id
+/// regardless of which conceptual node the publisher chose.
+fn detect_pin_intent(message: &Message) -> Option<(PinIntent, String)> {
+    for elem in &message.payloads {
+        if !is_attachments_element(elem) {
+            continue;
+        }
+        let target = parse_attachment_target(elem)?;
+        if has_pin_marker(elem) {
+            return Some((PinIntent::Pin, target.item_id));
+        }
+        if has_unpin_marker(elem) {
+            return Some((PinIntent::Unpin, target.item_id));
+        }
+    }
+    None
+}
+
+/// Capture a frozen preview of the original message at pin time.
+fn pin_preview_from(
+    message: &Message,
+    ctx: &RoomContext<'_>,
+    dispatched_at: DateTime<Utc>,
+) -> PinPreview {
+    let body = message
+        .bodies
+        .get("")
+        .map(|Body(b)| b.as_str())
+        .or_else(|| message.bodies.values().next().map(|Body(b)| b.as_str()))
+        .unwrap_or("");
+    let sender = ctx
+        .sender_snapshot()
+        .map(|s| (s.bare_jid(), s.nick.clone()));
+    let (author_jid, author_nick) = sender.unwrap_or_else(|| (ctx.room.clone(), String::new()));
+    let nick = if author_nick.is_empty() {
+        None
+    } else {
+        Some(author_nick)
+    };
+    PinPreview::new(author_jid, nick, body, dispatched_at)
+}
+
+/// Build the system message emitted by the room itself summarizing the
+/// pin or unpin event. Carries a human-readable `<body>` plus a typed
+/// `<pin-event xmlns='urn:waddle:pin:0'/>` payload for rich client
+/// rendering.
+fn build_pin_event_message(
+    ctx: &RoomContext<'_>,
+    intent: PinIntent,
+    pinner_jid: &jid::BareJid,
+    pinner_nick: &str,
+    target_stanza_id: &str,
+    preview: Option<&PinPreview>,
+) -> Message {
+    let action = match intent {
+        PinIntent::Pin => "pinned",
+        PinIntent::Unpin => "unpinned",
+    };
+    let mut event = Element::builder("pin-event", NS_WADDLE_PIN_V0)
+        .attr("action", action)
+        .attr("by", pinner_jid.to_string().as_str())
+        .build();
+    event.append_child(
+        Element::builder("ref", NS_WADDLE_PIN_V0)
+            .attr("id", target_stanza_id)
+            .build(),
+    );
+    if let Some(preview) = preview {
+        event.append_child(build_preview_element(preview));
+    }
+
+    let mut msg = Message::new(Some(Jid::from(ctx.room.clone())));
+    msg.from = Some(Jid::from(ctx.room.clone()));
+    msg.type_ = MessageType::Groupchat;
+    let body_text = match intent {
+        PinIntent::Pin => format!(
+            "{} pinned a message",
+            display_label(pinner_nick, pinner_jid)
+        ),
+        PinIntent::Unpin => format!(
+            "{} unpinned a message",
+            display_label(pinner_nick, pinner_jid)
+        ),
+    };
+    msg.bodies.insert(String::new(), Body(body_text));
+    msg.payloads.push(event);
+    msg
+}
+
+fn build_preview_element(preview: &PinPreview) -> Element {
+    let mut elem = Element::builder("preview", NS_WADDLE_PIN_V0).build();
+    let mut author = Element::builder("author", NS_WADDLE_PIN_V0)
+        .attr("jid", preview.author_jid.to_string().as_str())
+        .build();
+    if let Some(ref nick) = preview.author_nick {
+        author.set_attr("nick", nick);
+    }
+    elem.append_child(author);
+
+    let mut text = Element::builder("text", NS_WADDLE_PIN_V0).build();
+    text.append_text_node(&preview.text);
+    elem.append_child(text);
+
+    let mut ts = Element::builder("ts", NS_WADDLE_PIN_V0).build();
+    ts.append_text_node(preview.message_timestamp.to_rfc3339());
+    elem.append_child(ts);
+
+    elem
+}
+
+fn display_label(nick: &str, bare_jid: &jid::BareJid) -> String {
+    if nick.is_empty() {
+        bare_jid.to_string()
+    } else {
+        nick.to_string()
+    }
+}
+
+/// Build the typed `<forbidden type='auth'/>` reply addressed back to
+/// the sender when the affiliation check rejects a pin/unpin.
+fn forbidden_reply(incoming: &Message) -> Message {
+    let error = StanzaError::new(
+        ErrorType::Auth,
+        DefinedCondition::Forbidden,
+        "en",
+        "Sender is not permitted to pin or unpin messages in this room.",
+    );
+    message_error_reply(incoming, error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use crate::xep::xep0421::OccupantIdSecret;
+    use crate::xep::xep0470::{Attachment, AttachmentTarget};
+    use jid::{BareJid, FullJid};
+    use std::str::FromStr;
+
+    fn bare(s: &str) -> BareJid {
+        BareJid::from_str(s).expect("valid bare jid")
+    }
+
+    fn full(s: &str) -> FullJid {
+        FullJid::from_str(s).expect("valid full jid")
+    }
+
+    fn pin_message(target_stanza_id: &str, sender_full: &FullJid) -> Message {
+        let mut msg = Message::new(Some(Jid::from(bare("room@conf.example"))));
+        msg.from = Some(Jid::from(sender_full.clone()));
+        msg.type_ = MessageType::Groupchat;
+        let attachment = Attachment::pin(AttachmentTarget::new("urn:xmpp:mam:2", target_stanza_id));
+        msg.payloads
+            .push(crate::xep::xep0470::build_attachments_element(&attachment));
+        msg
+    }
+
+    fn unpin_message(target_stanza_id: &str, sender_full: &FullJid) -> Message {
+        let mut msg = Message::new(Some(Jid::from(bare("room@conf.example"))));
+        msg.from = Some(Jid::from(sender_full.clone()));
+        msg.type_ = MessageType::Groupchat;
+        let attachment =
+            Attachment::unpin(AttachmentTarget::new("urn:xmpp:mam:2", target_stanza_id));
+        msg.payloads
+            .push(crate::xep::xep0470::build_attachments_element(&attachment));
+        msg
+    }
+
+    fn occupant(full: FullJid, nick: &str, affiliation: Affiliation) -> OccupantSnapshot {
+        OccupantSnapshot {
+            full_jid: full,
+            nick: nick.into(),
+            affiliation,
+            role: Role::Participant,
+        }
+    }
+
+    fn ctx_for<'a>(
+        room: &'a BareJid,
+        sender_full: &'a FullJid,
+        occupants: &'a [OccupantSnapshot],
+        id_gen: &'a FixedIdGenerator,
+        secret: &'a OccupantIdSecret,
+    ) -> RoomContext<'a> {
+        RoomContext {
+            room,
+            sender_full,
+            occupants,
+            managed_room_forbidden: false,
+            room_moderated: false,
+            id_gen,
+            occupant_id_secret: secret,
+            sender_nickname_generation: 1,
+            project_sender_inbox: true,
+            dispatch_timestamp: 1_700_000_000,
+        }
+    }
+
+    fn occupant_id_secret() -> OccupantIdSecret {
+        OccupantIdSecret::new(b"secret-secret-secret-secret-12345".to_vec()).expect("valid secret")
+    }
+
+    #[test]
+    fn ignores_message_without_pin_attachment() {
+        let room = bare("room@conf.example");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = Message::new(Some(Jid::from(room.clone())));
+        msg.from = Some(Jid::from(sender.clone()));
+        msg.type_ = MessageType::Groupchat;
+        msg.bodies.insert(String::new(), Body("hi".into()));
+        match MucPinHandler.handle(&mut msg, &ctx) {
+            RoomHandlerOutcome::Continue(events) => assert!(events.is_empty()),
+            RoomHandlerOutcome::Halt(_) => panic!("non-pin message should pass through"),
+        }
+    }
+
+    #[test]
+    fn admin_pin_emits_apply_and_broadcast_and_halts() {
+        let room = bare("room@conf.example");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = pin_message("stanza-target", &sender);
+        let outcome = MucPinHandler.handle(&mut msg, &ctx);
+        let events = match outcome {
+            RoomHandlerOutcome::Halt(events) => events,
+            RoomHandlerOutcome::Continue(_) => panic!("authorized pin must Halt"),
+        };
+        assert_eq!(events.len(), 2, "expected ApplyPinChange + Broadcast");
+        match &events[0] {
+            OutboundEvent::ApplyPinChange { room: r, change } => {
+                assert_eq!(r, &room);
+                match change {
+                    PinStateChange::Pin(entry) => {
+                        assert_eq!(entry.target_stanza_id, "stanza-target");
+                        assert_eq!(entry.pinner_jid, bare("alice@example.com"));
+                    }
+                    other => panic!("expected Pin change, got {other:?}"),
+                }
+            }
+            other => panic!("expected ApplyPinChange first, got {other:?}"),
+        }
+        match &events[1] {
+            OutboundEvent::BroadcastRoomSystemMessage { room: r, message } => {
+                assert_eq!(r, &room);
+                assert_eq!(message.type_, MessageType::Groupchat);
+                let from_jid = message.from.as_ref().expect("from set");
+                assert_eq!(from_jid.to_string(), room.to_string());
+                let event = message
+                    .payloads
+                    .iter()
+                    .find(|e| e.name() == "pin-event" && e.ns() == NS_WADDLE_PIN_V0)
+                    .expect("pin-event payload present");
+                assert_eq!(event.attr("action"), Some("pinned"));
+                assert_eq!(event.attr("by"), Some("alice@example.com"));
+                let preview = event
+                    .children()
+                    .find(|c| c.name() == "preview")
+                    .expect("preview present on pin");
+                assert!(preview.children().any(|c| c.name() == "author"));
+            }
+            other => panic!("expected BroadcastRoomSystemMessage second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn admin_unpin_emits_unpin_change_without_preview() {
+        let room = bare("room@conf.example");
+        let sender = full("alice@example.com/web");
+        let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Owner)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = unpin_message("stanza-target", &sender);
+        let outcome = MucPinHandler.handle(&mut msg, &ctx);
+        let events = match outcome {
+            RoomHandlerOutcome::Halt(events) => events,
+            RoomHandlerOutcome::Continue(_) => panic!("authorized unpin must Halt"),
+        };
+        match &events[0] {
+            OutboundEvent::ApplyPinChange { change, .. } => match change {
+                PinStateChange::Unpin { target_stanza_id } => {
+                    assert_eq!(target_stanza_id, "stanza-target");
+                }
+                other => panic!("expected Unpin change, got {other:?}"),
+            },
+            other => panic!("expected ApplyPinChange first, got {other:?}"),
+        }
+        match &events[1] {
+            OutboundEvent::BroadcastRoomSystemMessage { message, .. } => {
+                let event = message
+                    .payloads
+                    .iter()
+                    .find(|e| e.name() == "pin-event" && e.ns() == NS_WADDLE_PIN_V0)
+                    .expect("pin-event payload present");
+                assert_eq!(event.attr("action"), Some("unpinned"));
+                assert!(
+                    event.children().all(|c| c.name() != "preview"),
+                    "unpin event must not carry preview"
+                );
+            }
+            other => panic!("expected BroadcastRoomSystemMessage second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn member_pin_is_rejected_with_forbidden() {
+        let room = bare("room@conf.example");
+        let sender = full("eve@example.com/phone");
+        let occupants = vec![occupant(sender.clone(), "eve", Affiliation::Member)];
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = pin_message("stanza-target", &sender);
+        let outcome = MucPinHandler.handle(&mut msg, &ctx);
+        let events = match outcome {
+            RoomHandlerOutcome::Halt(events) => events,
+            RoomHandlerOutcome::Continue(_) => panic!("unauthorized pin must Halt"),
+        };
+        assert_eq!(events.len(), 1, "only error reply expected");
+        match &events[0] {
+            OutboundEvent::SendStanza(stanza) => match stanza.as_ref() {
+                crate::Stanza::Message(msg) => {
+                    assert_eq!(msg.type_, MessageType::Error);
+                    let has_forbidden = msg
+                        .payloads
+                        .iter()
+                        .any(|p| p.children().any(|c| c.name() == "forbidden"));
+                    assert!(has_forbidden, "forbidden condition required");
+                }
+                other => panic!("expected message stanza, got {other:?}"),
+            },
+            other => panic!("expected SendStanza, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn outsider_pin_continues_when_sender_snapshot_missing() {
+        let room = bare("room@conf.example");
+        let sender = full("ghost@example.com/x");
+        let occupants: Vec<OccupantSnapshot> = Vec::new();
+        let id_gen = FixedIdGenerator("ignored".into());
+        let secret = occupant_id_secret();
+        let ctx = ctx_for(&room, &sender, &occupants, &id_gen, &secret);
+        let mut msg = pin_message("stanza-target", &sender);
+        match MucPinHandler.handle(&mut msg, &ctx) {
+            RoomHandlerOutcome::Continue(events) => assert!(events.is_empty()),
+            RoomHandlerOutcome::Halt(_) => {
+                panic!("missing sender snapshot is the gate's concern, not pin's")
+            }
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/pin.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/pin.rs
@@ -28,7 +28,7 @@ use super::super::event::OutboundEvent;
 use super::super::handlers::errors::{message_error_reply, send_message_error};
 use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
-use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
+use crate::muc::pin::{PinChangeRequest, PinPreview};
 use crate::types::Affiliation;
 use crate::xep::xep_waddle_pin::{extract_pin_intent_from_message, PinIntent, NS_WADDLE_PIN_V0};
 use chrono::{DateTime, Utc};
@@ -78,56 +78,30 @@ impl RoomHandler for MucPinHandler {
 
         let dispatched_at: DateTime<Utc> =
             DateTime::from_timestamp(ctx.dispatch_timestamp, 0).unwrap_or_else(Utc::now);
-        let pinner = sender.bare_jid();
+        let pinner_jid = sender.bare_jid();
+        let pinner_nick = sender.nick.clone();
         let target_stanza_id =
             StanzaId::new(intent.target().to_owned(), Jid::from(ctx.room.clone()));
 
-        let (change, system_message) = match intent {
-            PinIntent::Pin { .. } => {
-                let preview = pin_preview_from(message, ctx, dispatched_at);
-                let entry = PinnedEntry {
-                    target_stanza_id: target_stanza_id.clone(),
-                    pinner_jid: pinner.clone(),
-                    pinned_at: dispatched_at,
-                    preview: preview.clone(),
-                };
-                let sys = build_pinned_system_message(
-                    ctx.room,
-                    &pinner,
-                    &sender.nick,
-                    &target_stanza_id,
-                    Some(&preview),
-                    None,
-                );
-                (PinStateChange::Pin(entry), sys)
-            }
-            PinIntent::Unpin { .. } => {
-                let sys = build_unpinned_system_message(
-                    ctx.room,
-                    &pinner,
-                    &sender.nick,
-                    &target_stanza_id,
-                    None,
-                );
-                (
-                    PinStateChange::Unpin {
-                        target_stanza_id: target_stanza_id.clone(),
-                    },
-                    sys,
-                )
-            }
+        let request = match intent {
+            PinIntent::Pin { .. } => PinChangeRequest::Pin {
+                target_stanza_id,
+                pinner_jid,
+                pinner_nick,
+                pinned_at: dispatched_at,
+            },
+            PinIntent::Unpin { .. } => PinChangeRequest::Unpin {
+                target_stanza_id,
+                pinner_jid,
+                pinner_nick,
+                reason: None,
+            },
         };
 
-        RoomHandlerOutcome::Halt(vec![
-            OutboundEvent::ApplyPinChange {
-                room: ctx.room.clone(),
-                change,
-            },
-            OutboundEvent::BroadcastRoomSystemMessage {
-                room: ctx.room.clone(),
-                message: Box::new(system_message),
-            },
-        ])
+        RoomHandlerOutcome::Halt(vec![OutboundEvent::ApplyPinChange {
+            room: ctx.room.clone(),
+            request,
+        }])
     }
 }
 
@@ -141,39 +115,10 @@ fn carries_pin_marker_namespace(message: &Message) -> bool {
         .any(|elem| elem.ns() == NS_WADDLE_PIN_V0)
 }
 
-/// Capture a frozen preview of the original message at pin time. Note:
-/// the in-flight pin/unpin message itself usually carries no body —
-/// this preview is built from whatever metadata the sender included
-/// for testing/debugging. The chat client populates the preview at
-/// pin time via the IQ query response after publishing the pin marker.
-///
-/// In practice, the pin message can include a `<body>` for testing
-/// purposes, in which case we use it; otherwise the preview text is
-/// empty and the chat client falls back to fetching from MAM.
-fn pin_preview_from(
-    message: &Message,
-    ctx: &RoomContext<'_>,
-    dispatched_at: DateTime<Utc>,
-) -> PinPreview {
-    let body = message
-        .bodies
-        .get("")
-        .map(|Body(b)| b.as_str())
-        .or_else(|| message.bodies.values().next().map(|Body(b)| b.as_str()))
-        .unwrap_or("");
-    let sender = ctx
-        .sender_snapshot()
-        .map(|s| (s.bare_jid(), s.nick.clone()));
-    let (author_jid, author_nick) = sender.unwrap_or_else(|| (ctx.room.clone(), String::new()));
-    let nick = if author_nick.is_empty() {
-        None
-    } else {
-        Some(author_nick)
-    };
-    PinPreview::new(author_jid, nick, body, dispatched_at)
-}
-
-/// Build the system message broadcast on a successful pin.
+/// Build the system message broadcast on a successful pin. The
+/// system message carries a structured `<pin-event xmlns='urn:waddle:pin:0'
+/// action='pinned' …>` payload — clients parse pin events off the
+/// stable `pin-event` element regardless of action.
 pub fn build_pinned_system_message(
     room: &jid::BareJid,
     pinner_jid: &jid::BareJid,
@@ -182,16 +127,7 @@ pub fn build_pinned_system_message(
     preview: Option<&PinPreview>,
     reason: Option<&str>,
 ) -> Message {
-    let mut element = Element::builder("pinned", NS_WADDLE_PIN_V0)
-        .attr("target", target_stanza_id.id.as_str())
-        .attr("by", pinner_jid.to_string().as_str())
-        .build();
-    if let Some(reason) = reason {
-        element.set_attr("reason", reason);
-    }
-    if let Some(preview) = preview {
-        element.append_child(build_preview_element(preview));
-    }
+    let element = build_pin_event_element("pinned", pinner_jid, target_stanza_id, preview, reason);
     new_room_message(
         room,
         format!(
@@ -204,6 +140,7 @@ pub fn build_pinned_system_message(
 
 /// Build the system message broadcast on a successful unpin (or on a
 /// XEP-0424 retraction cascade, in which case `reason` is `Some("retracted")`).
+/// Wraps the action in the same `<pin-event>` envelope as the pin path.
 pub fn build_unpinned_system_message(
     room: &jid::BareJid,
     pinner_jid: &jid::BareJid,
@@ -211,13 +148,7 @@ pub fn build_unpinned_system_message(
     target_stanza_id: &StanzaId,
     reason: Option<&str>,
 ) -> Message {
-    let mut element = Element::builder("unpinned", NS_WADDLE_PIN_V0)
-        .attr("target", target_stanza_id.id.as_str())
-        .attr("by", pinner_jid.to_string().as_str())
-        .build();
-    if let Some(reason) = reason {
-        element.set_attr("reason", reason);
-    }
+    let element = build_pin_event_element("unpinned", pinner_jid, target_stanza_id, None, reason);
     let body = if reason == Some("retracted") {
         "Pinned message was retracted by its author".to_owned()
     } else {
@@ -227,6 +158,31 @@ pub fn build_unpinned_system_message(
         )
     };
     new_room_message(room, body, element)
+}
+
+/// Build a `<pin-event xmlns='urn:waddle:pin:0' action='…' target='…' by='…'
+/// [reason='…']>` element with an optional `<preview/>` child. The single
+/// element type carries both pin and unpin events so clients can filter
+/// the room timeline on `name() == "pin-event"` regardless of action.
+fn build_pin_event_element(
+    action: &str,
+    pinner_jid: &jid::BareJid,
+    target_stanza_id: &StanzaId,
+    preview: Option<&PinPreview>,
+    reason: Option<&str>,
+) -> Element {
+    let mut element = Element::builder("pin-event", NS_WADDLE_PIN_V0)
+        .attr("action", action)
+        .attr("target", target_stanza_id.id.as_str())
+        .attr("by", pinner_jid.to_string().as_str())
+        .build();
+    if let Some(reason) = reason {
+        element.set_attr("reason", reason);
+    }
+    if let Some(preview) = preview {
+        element.append_child(build_preview_element(preview));
+    }
+    element
 }
 
 fn new_room_message(room: &jid::BareJid, body: String, payload: Element) -> Message {
@@ -386,7 +342,7 @@ mod tests {
     }
 
     #[test]
-    fn admin_pin_emits_apply_and_broadcast_and_halts() {
+    fn admin_pin_emits_apply_request_and_halts() {
         let room = bare("room@conf.example");
         let sender = full("alice@example.com/web");
         let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Admin)];
@@ -399,45 +355,34 @@ mod tests {
             RoomHandlerOutcome::Halt(events) => events,
             RoomHandlerOutcome::Continue(_) => panic!("authorized pin must Halt"),
         };
-        assert_eq!(events.len(), 2, "expected ApplyPinChange + Broadcast");
+        assert_eq!(
+            events.len(),
+            1,
+            "handler emits only ApplyPinChange — interpreter does MAM lookup + broadcast"
+        );
         match &events[0] {
-            OutboundEvent::ApplyPinChange { room: r, change } => {
+            OutboundEvent::ApplyPinChange { room: r, request } => {
                 assert_eq!(r, &room);
-                match change {
-                    PinStateChange::Pin(entry) => {
-                        assert_eq!(entry.target_stanza_id.id, "stanza-target");
-                        assert_eq!(entry.pinner_jid, bare("alice@example.com"));
+                match request {
+                    PinChangeRequest::Pin {
+                        target_stanza_id,
+                        pinner_jid,
+                        pinner_nick,
+                        ..
+                    } => {
+                        assert_eq!(target_stanza_id.id, "stanza-target");
+                        assert_eq!(pinner_jid, &bare("alice@example.com"));
+                        assert_eq!(pinner_nick, "alice");
                     }
-                    other => panic!("expected Pin change, got {other:?}"),
+                    other => panic!("expected Pin request, got {other:?}"),
                 }
             }
-            other => panic!("expected ApplyPinChange first, got {other:?}"),
-        }
-        match &events[1] {
-            OutboundEvent::BroadcastRoomSystemMessage { room: r, message } => {
-                assert_eq!(r, &room);
-                assert_eq!(message.type_, MessageType::Groupchat);
-                let from_jid = message.from.as_ref().expect("from set");
-                assert_eq!(from_jid.to_string(), room.to_string());
-                let pinned = message
-                    .payloads
-                    .iter()
-                    .find(|e| e.name() == "pinned" && e.ns() == NS_WADDLE_PIN_V0)
-                    .expect("pinned element present");
-                assert_eq!(pinned.attr("target"), Some("stanza-target"));
-                assert_eq!(pinned.attr("by"), Some("alice@example.com"));
-                let preview = pinned
-                    .children()
-                    .find(|c| c.name() == "preview")
-                    .expect("preview present on pin");
-                assert!(preview.children().any(|c| c.name() == "author"));
-            }
-            other => panic!("expected BroadcastRoomSystemMessage second, got {other:?}"),
+            other => panic!("expected ApplyPinChange, got {other:?}"),
         }
     }
 
     #[test]
-    fn admin_unpin_emits_unpin_change_without_preview() {
+    fn admin_unpin_emits_unpin_request_without_preview() {
         let room = bare("room@conf.example");
         let sender = full("alice@example.com/web");
         let occupants = vec![occupant(sender.clone(), "alice", Affiliation::Owner)];
@@ -450,29 +395,20 @@ mod tests {
             RoomHandlerOutcome::Halt(events) => events,
             RoomHandlerOutcome::Continue(_) => panic!("authorized unpin must Halt"),
         };
+        assert_eq!(events.len(), 1);
         match &events[0] {
-            OutboundEvent::ApplyPinChange { change, .. } => match change {
-                PinStateChange::Unpin { target_stanza_id } => {
+            OutboundEvent::ApplyPinChange { request, .. } => match request {
+                PinChangeRequest::Unpin {
+                    target_stanza_id,
+                    reason,
+                    ..
+                } => {
                     assert_eq!(target_stanza_id.id, "stanza-target");
+                    assert!(reason.is_none(), "manual unpin has no reason");
                 }
-                other => panic!("expected Unpin change, got {other:?}"),
+                other => panic!("expected Unpin request, got {other:?}"),
             },
-            other => panic!("expected ApplyPinChange first, got {other:?}"),
-        }
-        match &events[1] {
-            OutboundEvent::BroadcastRoomSystemMessage { message, .. } => {
-                let unpinned = message
-                    .payloads
-                    .iter()
-                    .find(|e| e.name() == "unpinned" && e.ns() == NS_WADDLE_PIN_V0)
-                    .expect("unpinned element present");
-                assert_eq!(unpinned.attr("target"), Some("stanza-target"));
-                assert!(
-                    unpinned.children().all(|c| c.name() != "preview"),
-                    "unpin must not carry preview"
-                );
-            }
-            other => panic!("expected BroadcastRoomSystemMessage second, got {other:?}"),
+            other => panic!("expected ApplyPinChange, got {other:?}"),
         }
     }
 

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
@@ -345,7 +345,6 @@ fn outbound_variant_name(event: &OutboundEvent) -> &'static str {
             "ApplyGroupchatRetractionTombstone"
         }
         OutboundEvent::ApplyPinChange { .. } => "ApplyPinChange",
-        OutboundEvent::BroadcastRoomSystemMessage { .. } => "BroadcastRoomSystemMessage",
         OutboundEvent::PersistRoomSubject { .. } => "PersistRoomSubject",
         OutboundEvent::ProjectInbox { .. } => "ProjectInbox",
         OutboundEvent::ProjectGroupchatInbox { .. } => "ProjectGroupchatInbox",

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
@@ -344,6 +344,8 @@ fn outbound_variant_name(event: &OutboundEvent) -> &'static str {
         OutboundEvent::ApplyGroupchatRetractionTombstone { .. } => {
             "ApplyGroupchatRetractionTombstone"
         }
+        OutboundEvent::ApplyPinChange { .. } => "ApplyPinChange",
+        OutboundEvent::BroadcastRoomSystemMessage { .. } => "BroadcastRoomSystemMessage",
         OutboundEvent::PersistRoomSubject { .. } => "PersistRoomSubject",
         OutboundEvent::ProjectInbox { .. } => "ProjectInbox",
         OutboundEvent::ProjectGroupchatInbox { .. } => "ProjectGroupchatInbox",

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -343,9 +343,15 @@ pub use super::xep0471::{
 };
 
 pub use super::xep0470::{
-    build_attachments_element, has_pin_marker, has_unpin_marker, is_attachments_element,
-    parse_attachment_target, Attachment, AttachmentPayload, AttachmentTarget,
-    NS_PUBSUB_ATTACHMENTS, NS_WADDLE_PIN_V0,
+    build_attachments_element, is_attachments_element, parse_attachment_target, Attachment,
+    AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS,
+};
+
+pub use super::xep_waddle_pin::{
+    build_pinned_element as build_pinned_message_element,
+    build_unpinned_element as build_unpinned_message_element, extract_pin_intent_from_message,
+    parse_pinned_element as parse_pinned_message_element,
+    parse_unpinned_element as parse_unpinned_message_element, PinIntent, NS_WADDLE_PIN_V0,
 };
 
 pub use super::xep0472::{

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -343,8 +343,9 @@ pub use super::xep0471::{
 };
 
 pub use super::xep0470::{
-    build_attachments_element, has_pin_marker, is_attachments_element, parse_attachment_target,
-    Attachment, AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS, NS_WADDLE_PIN_V0,
+    build_attachments_element, has_pin_marker, has_unpin_marker, is_attachments_element,
+    parse_attachment_target, Attachment, AttachmentPayload, AttachmentTarget,
+    NS_PUBSUB_ATTACHMENTS, NS_WADDLE_PIN_V0,
 };
 
 pub use super::xep0472::{

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -343,8 +343,8 @@ pub use super::xep0471::{
 };
 
 pub use super::xep0470::{
-    build_attachments_element, is_attachments_element, parse_attachment_target, Attachment,
-    AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS,
+    build_attachments_element, has_pin_marker, is_attachments_element, parse_attachment_target,
+    Attachment, AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS, NS_WADDLE_PIN_V0,
 };
 
 pub use super::xep0472::{

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -199,6 +199,7 @@ pub mod xep0502;
 pub mod xep0503;
 pub mod xep0508;
 pub mod xep0513;
+pub mod xep_waddle_pin;
 
 mod exports;
 

--- a/server/crates/waddle-xmpp/src/xep/xep0470.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0470.rs
@@ -27,6 +27,12 @@ use minidom::Element;
 /// Namespace for XEP-0470 Pubsub Attachments.
 pub const NS_PUBSUB_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:0";
 
+/// Waddle pin attachment namespace. The marker element `<pinned/>` is published
+/// as an attachment child to indicate the targeted message is pinned in its
+/// host MUC. Used because no XEP defines a "pin" payload — `urn:waddle:pin:0`
+/// is the project's custom namespace per the XEP conformance hard rule.
+pub const NS_WADDLE_PIN_V0: &str = "urn:waddle:pin:0";
+
 /// An attachment target: which PubSub item this attaches to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachmentTarget {
@@ -53,6 +59,10 @@ pub enum AttachmentPayload {
     Comment(String),
     /// A reaction emoji.
     Reaction(String),
+    /// A pin marker (`urn:waddle:pin:0` `<pinned/>`). Carries no inline data;
+    /// pin metadata (pinner, timestamp, preview) is held in the room-level
+    /// projection list, not in the per-message attachment.
+    Pin,
     /// A generic XML payload.
     Custom(Element),
 }
@@ -87,6 +97,15 @@ impl Attachment {
         }
     }
 
+    /// Create a pin attachment marker.
+    pub fn pin(target: AttachmentTarget) -> Self {
+        Self {
+            target,
+            payload: AttachmentPayload::Pin,
+            author: None,
+        }
+    }
+
     /// Set the author.
     pub fn with_author(mut self, author: impl Into<String>) -> Self {
         self.author = Some(author.into());
@@ -101,6 +120,11 @@ impl Attachment {
     /// Returns `true` if this is a reaction.
     pub fn is_reaction(&self) -> bool {
         matches!(self.payload, AttachmentPayload::Reaction(_))
+    }
+
+    /// Returns `true` if this is a pin marker.
+    pub fn is_pin(&self) -> bool {
+        matches!(self.payload, AttachmentPayload::Pin)
     }
 }
 
@@ -121,6 +145,16 @@ pub fn parse_attachment_target(elem: &Element) -> Option<AttachmentTarget> {
     let node = elem.attr("for").filter(|s| !s.is_empty())?.to_owned();
     let item_id = elem.attr("item").filter(|s| !s.is_empty())?.to_owned();
     Some(AttachmentTarget::new(node, item_id))
+}
+
+/// Returns `true` if the given `<attachments/>` element carries a Waddle pin
+/// marker (`<pinned xmlns="urn:waddle:pin:0"/>`) as a direct child.
+pub fn has_pin_marker(elem: &Element) -> bool {
+    if !is_attachments_element(elem) {
+        return false;
+    }
+    elem.children()
+        .any(|child| child.name() == "pinned" && child.ns() == NS_WADDLE_PIN_V0)
 }
 
 // ── Building ─────────────────────────────────────────────────────────
@@ -145,6 +179,9 @@ pub fn build_attachments_element(attachment: &Attachment) -> Element {
             let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS).build();
             reaction.append_text_node(emoji);
             elem.append_child(reaction);
+        }
+        AttachmentPayload::Pin => {
+            elem.append_child(Element::builder("pinned", NS_WADDLE_PIN_V0).build());
         }
         AttachmentPayload::Custom(child) => {
             elem.append_child(child.clone());
@@ -219,7 +256,62 @@ mod tests {
         assert!(Attachment::comment(target.clone(), "hi").is_comment());
         assert!(!Attachment::comment(target.clone(), "hi").is_reaction());
         assert!(Attachment::reaction(target.clone(), "👍").is_reaction());
-        assert!(!Attachment::reaction(target, "👍").is_comment());
+        assert!(!Attachment::reaction(target.clone(), "👍").is_comment());
+        assert!(Attachment::pin(target.clone()).is_pin());
+        assert!(!Attachment::pin(target.clone()).is_comment());
+        assert!(!Attachment::pin(target).is_reaction());
+    }
+
+    #[test]
+    fn test_pin_namespace_constant() {
+        assert_eq!(NS_WADDLE_PIN_V0, "urn:waddle:pin:0");
+    }
+
+    #[test]
+    fn test_build_pin_marker() {
+        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
+        let attachment = Attachment::pin(target).with_author("alice@waddle.example");
+        let elem = build_attachments_element(&attachment);
+
+        assert_eq!(elem.name(), "attachments");
+        assert_eq!(elem.attr("for"), Some("urn:xmpp:mam:2"));
+        assert_eq!(elem.attr("item"), Some("stanza-abc"));
+
+        let pinned = elem.children().next().expect("pinned child");
+        assert_eq!(pinned.name(), "pinned");
+        assert_eq!(pinned.ns(), NS_WADDLE_PIN_V0);
+        assert!(pinned.text().is_empty());
+    }
+
+    #[test]
+    fn test_has_pin_marker_positive() {
+        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
+        let elem = build_attachments_element(&Attachment::pin(target));
+        assert!(has_pin_marker(&elem));
+    }
+
+    #[test]
+    fn test_has_pin_marker_negative_for_reaction() {
+        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
+        let elem = build_attachments_element(&Attachment::reaction(target, "👍"));
+        assert!(!has_pin_marker(&elem));
+    }
+
+    #[test]
+    fn test_has_pin_marker_rejects_wrong_namespace() {
+        let mut elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS)
+            .attr("for", "urn:xmpp:mam:2")
+            .attr("item", "stanza-abc")
+            .build();
+        elem.append_child(Element::builder("pinned", "wrong:ns").build());
+        assert!(!has_pin_marker(&elem));
+    }
+
+    #[test]
+    fn test_has_pin_marker_rejects_non_attachments_root() {
+        let mut elem = Element::builder("other", NS_PUBSUB_ATTACHMENTS).build();
+        elem.append_child(Element::builder("pinned", NS_WADDLE_PIN_V0).build());
+        assert!(!has_pin_marker(&elem));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0470.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0470.rs
@@ -63,6 +63,9 @@ pub enum AttachmentPayload {
     /// pin metadata (pinner, timestamp, preview) is held in the room-level
     /// projection list, not in the per-message attachment.
     Pin,
+    /// An unpin marker (`urn:waddle:pin:0` `<unpinned/>`). Symmetric to
+    /// `Pin` — used to clear an existing pin on the targeted message.
+    Unpin,
     /// A generic XML payload.
     Custom(Element),
 }
@@ -106,6 +109,15 @@ impl Attachment {
         }
     }
 
+    /// Create an unpin attachment marker.
+    pub fn unpin(target: AttachmentTarget) -> Self {
+        Self {
+            target,
+            payload: AttachmentPayload::Unpin,
+            author: None,
+        }
+    }
+
     /// Set the author.
     pub fn with_author(mut self, author: impl Into<String>) -> Self {
         self.author = Some(author.into());
@@ -125,6 +137,11 @@ impl Attachment {
     /// Returns `true` if this is a pin marker.
     pub fn is_pin(&self) -> bool {
         matches!(self.payload, AttachmentPayload::Pin)
+    }
+
+    /// Returns `true` if this is an unpin marker.
+    pub fn is_unpin(&self) -> bool {
+        matches!(self.payload, AttachmentPayload::Unpin)
     }
 }
 
@@ -157,6 +174,16 @@ pub fn has_pin_marker(elem: &Element) -> bool {
         .any(|child| child.name() == "pinned" && child.ns() == NS_WADDLE_PIN_V0)
 }
 
+/// Returns `true` if the given `<attachments/>` element carries a Waddle unpin
+/// marker (`<unpinned xmlns="urn:waddle:pin:0"/>`) as a direct child.
+pub fn has_unpin_marker(elem: &Element) -> bool {
+    if !is_attachments_element(elem) {
+        return false;
+    }
+    elem.children()
+        .any(|child| child.name() == "unpinned" && child.ns() == NS_WADDLE_PIN_V0)
+}
+
 // ── Building ─────────────────────────────────────────────────────────
 
 /// Build an `<attachments/>` element.
@@ -182,6 +209,9 @@ pub fn build_attachments_element(attachment: &Attachment) -> Element {
         }
         AttachmentPayload::Pin => {
             elem.append_child(Element::builder("pinned", NS_WADDLE_PIN_V0).build());
+        }
+        AttachmentPayload::Unpin => {
+            elem.append_child(Element::builder("unpinned", NS_WADDLE_PIN_V0).build());
         }
         AttachmentPayload::Custom(child) => {
             elem.append_child(child.clone());
@@ -259,7 +289,32 @@ mod tests {
         assert!(!Attachment::reaction(target.clone(), "👍").is_comment());
         assert!(Attachment::pin(target.clone()).is_pin());
         assert!(!Attachment::pin(target.clone()).is_comment());
-        assert!(!Attachment::pin(target).is_reaction());
+        assert!(!Attachment::pin(target.clone()).is_reaction());
+        assert!(Attachment::unpin(target.clone()).is_unpin());
+        assert!(!Attachment::unpin(target.clone()).is_pin());
+        assert!(!Attachment::pin(target).is_unpin());
+    }
+
+    #[test]
+    fn test_build_unpin_marker_and_detect() {
+        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
+        let elem = build_attachments_element(&Attachment::unpin(target));
+        assert!(has_unpin_marker(&elem));
+        assert!(!has_pin_marker(&elem));
+        let unpinned = elem.children().next().expect("unpinned child");
+        assert_eq!(unpinned.name(), "unpinned");
+        assert_eq!(unpinned.ns(), NS_WADDLE_PIN_V0);
+    }
+
+    #[test]
+    fn test_pin_and_unpin_are_distinct_markers() {
+        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
+        let pin_elem = build_attachments_element(&Attachment::pin(target.clone()));
+        let unpin_elem = build_attachments_element(&Attachment::unpin(target));
+        assert!(has_pin_marker(&pin_elem));
+        assert!(!has_unpin_marker(&pin_elem));
+        assert!(has_unpin_marker(&unpin_elem));
+        assert!(!has_pin_marker(&unpin_elem));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0470.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0470.rs
@@ -27,12 +27,6 @@ use minidom::Element;
 /// Namespace for XEP-0470 Pubsub Attachments.
 pub const NS_PUBSUB_ATTACHMENTS: &str = "urn:xmpp:pubsub-attachments:0";
 
-/// Waddle pin attachment namespace. The marker element `<pinned/>` is published
-/// as an attachment child to indicate the targeted message is pinned in its
-/// host MUC. Used because no XEP defines a "pin" payload — `urn:waddle:pin:0`
-/// is the project's custom namespace per the XEP conformance hard rule.
-pub const NS_WADDLE_PIN_V0: &str = "urn:waddle:pin:0";
-
 /// An attachment target: which PubSub item this attaches to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachmentTarget {
@@ -59,13 +53,6 @@ pub enum AttachmentPayload {
     Comment(String),
     /// A reaction emoji.
     Reaction(String),
-    /// A pin marker (`urn:waddle:pin:0` `<pinned/>`). Carries no inline data;
-    /// pin metadata (pinner, timestamp, preview) is held in the room-level
-    /// projection list, not in the per-message attachment.
-    Pin,
-    /// An unpin marker (`urn:waddle:pin:0` `<unpinned/>`). Symmetric to
-    /// `Pin` — used to clear an existing pin on the targeted message.
-    Unpin,
     /// A generic XML payload.
     Custom(Element),
 }
@@ -100,24 +87,6 @@ impl Attachment {
         }
     }
 
-    /// Create a pin attachment marker.
-    pub fn pin(target: AttachmentTarget) -> Self {
-        Self {
-            target,
-            payload: AttachmentPayload::Pin,
-            author: None,
-        }
-    }
-
-    /// Create an unpin attachment marker.
-    pub fn unpin(target: AttachmentTarget) -> Self {
-        Self {
-            target,
-            payload: AttachmentPayload::Unpin,
-            author: None,
-        }
-    }
-
     /// Set the author.
     pub fn with_author(mut self, author: impl Into<String>) -> Self {
         self.author = Some(author.into());
@@ -132,16 +101,6 @@ impl Attachment {
     /// Returns `true` if this is a reaction.
     pub fn is_reaction(&self) -> bool {
         matches!(self.payload, AttachmentPayload::Reaction(_))
-    }
-
-    /// Returns `true` if this is a pin marker.
-    pub fn is_pin(&self) -> bool {
-        matches!(self.payload, AttachmentPayload::Pin)
-    }
-
-    /// Returns `true` if this is an unpin marker.
-    pub fn is_unpin(&self) -> bool {
-        matches!(self.payload, AttachmentPayload::Unpin)
     }
 }
 
@@ -162,26 +121,6 @@ pub fn parse_attachment_target(elem: &Element) -> Option<AttachmentTarget> {
     let node = elem.attr("for").filter(|s| !s.is_empty())?.to_owned();
     let item_id = elem.attr("item").filter(|s| !s.is_empty())?.to_owned();
     Some(AttachmentTarget::new(node, item_id))
-}
-
-/// Returns `true` if the given `<attachments/>` element carries a Waddle pin
-/// marker (`<pinned xmlns="urn:waddle:pin:0"/>`) as a direct child.
-pub fn has_pin_marker(elem: &Element) -> bool {
-    if !is_attachments_element(elem) {
-        return false;
-    }
-    elem.children()
-        .any(|child| child.name() == "pinned" && child.ns() == NS_WADDLE_PIN_V0)
-}
-
-/// Returns `true` if the given `<attachments/>` element carries a Waddle unpin
-/// marker (`<unpinned xmlns="urn:waddle:pin:0"/>`) as a direct child.
-pub fn has_unpin_marker(elem: &Element) -> bool {
-    if !is_attachments_element(elem) {
-        return false;
-    }
-    elem.children()
-        .any(|child| child.name() == "unpinned" && child.ns() == NS_WADDLE_PIN_V0)
 }
 
 // ── Building ─────────────────────────────────────────────────────────
@@ -206,12 +145,6 @@ pub fn build_attachments_element(attachment: &Attachment) -> Element {
             let mut reaction = Element::builder("reaction", NS_PUBSUB_ATTACHMENTS).build();
             reaction.append_text_node(emoji);
             elem.append_child(reaction);
-        }
-        AttachmentPayload::Pin => {
-            elem.append_child(Element::builder("pinned", NS_WADDLE_PIN_V0).build());
-        }
-        AttachmentPayload::Unpin => {
-            elem.append_child(Element::builder("unpinned", NS_WADDLE_PIN_V0).build());
         }
         AttachmentPayload::Custom(child) => {
             elem.append_child(child.clone());
@@ -286,87 +219,7 @@ mod tests {
         assert!(Attachment::comment(target.clone(), "hi").is_comment());
         assert!(!Attachment::comment(target.clone(), "hi").is_reaction());
         assert!(Attachment::reaction(target.clone(), "👍").is_reaction());
-        assert!(!Attachment::reaction(target.clone(), "👍").is_comment());
-        assert!(Attachment::pin(target.clone()).is_pin());
-        assert!(!Attachment::pin(target.clone()).is_comment());
-        assert!(!Attachment::pin(target.clone()).is_reaction());
-        assert!(Attachment::unpin(target.clone()).is_unpin());
-        assert!(!Attachment::unpin(target.clone()).is_pin());
-        assert!(!Attachment::pin(target).is_unpin());
-    }
-
-    #[test]
-    fn test_build_unpin_marker_and_detect() {
-        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
-        let elem = build_attachments_element(&Attachment::unpin(target));
-        assert!(has_unpin_marker(&elem));
-        assert!(!has_pin_marker(&elem));
-        let unpinned = elem.children().next().expect("unpinned child");
-        assert_eq!(unpinned.name(), "unpinned");
-        assert_eq!(unpinned.ns(), NS_WADDLE_PIN_V0);
-    }
-
-    #[test]
-    fn test_pin_and_unpin_are_distinct_markers() {
-        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
-        let pin_elem = build_attachments_element(&Attachment::pin(target.clone()));
-        let unpin_elem = build_attachments_element(&Attachment::unpin(target));
-        assert!(has_pin_marker(&pin_elem));
-        assert!(!has_unpin_marker(&pin_elem));
-        assert!(has_unpin_marker(&unpin_elem));
-        assert!(!has_pin_marker(&unpin_elem));
-    }
-
-    #[test]
-    fn test_pin_namespace_constant() {
-        assert_eq!(NS_WADDLE_PIN_V0, "urn:waddle:pin:0");
-    }
-
-    #[test]
-    fn test_build_pin_marker() {
-        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
-        let attachment = Attachment::pin(target).with_author("alice@waddle.example");
-        let elem = build_attachments_element(&attachment);
-
-        assert_eq!(elem.name(), "attachments");
-        assert_eq!(elem.attr("for"), Some("urn:xmpp:mam:2"));
-        assert_eq!(elem.attr("item"), Some("stanza-abc"));
-
-        let pinned = elem.children().next().expect("pinned child");
-        assert_eq!(pinned.name(), "pinned");
-        assert_eq!(pinned.ns(), NS_WADDLE_PIN_V0);
-        assert!(pinned.text().is_empty());
-    }
-
-    #[test]
-    fn test_has_pin_marker_positive() {
-        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
-        let elem = build_attachments_element(&Attachment::pin(target));
-        assert!(has_pin_marker(&elem));
-    }
-
-    #[test]
-    fn test_has_pin_marker_negative_for_reaction() {
-        let target = AttachmentTarget::new("urn:xmpp:mam:2", "stanza-abc");
-        let elem = build_attachments_element(&Attachment::reaction(target, "👍"));
-        assert!(!has_pin_marker(&elem));
-    }
-
-    #[test]
-    fn test_has_pin_marker_rejects_wrong_namespace() {
-        let mut elem = Element::builder("attachments", NS_PUBSUB_ATTACHMENTS)
-            .attr("for", "urn:xmpp:mam:2")
-            .attr("item", "stanza-abc")
-            .build();
-        elem.append_child(Element::builder("pinned", "wrong:ns").build());
-        assert!(!has_pin_marker(&elem));
-    }
-
-    #[test]
-    fn test_has_pin_marker_rejects_non_attachments_root() {
-        let mut elem = Element::builder("other", NS_PUBSUB_ATTACHMENTS).build();
-        elem.append_child(Element::builder("pinned", NS_WADDLE_PIN_V0).build());
-        assert!(!has_pin_marker(&elem));
+        assert!(!Attachment::reaction(target, "👍").is_comment());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_pin.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_pin.rs
@@ -1,0 +1,336 @@
+//! Waddle pin/unpin wire shape (`urn:waddle:pin:0`).
+//!
+//! Channel pinning is a Waddle-only feature — no XEP defines a "pin a
+//! message" payload. We therefore use a project-local namespace
+//! (`urn:waddle:pin:0`) rather than borrowing an official one with a
+//! non-conformant shape (CLAUDE.md hard rule on XEP conformance).
+//!
+//! ## Inbound (member → MUC)
+//!
+//! ```xml
+//! <message type="groupchat" to="room@conf.example">
+//!   <pinned xmlns="urn:waddle:pin:0" target="<stanza-id>"/>
+//! </message>
+//! ```
+//!
+//! Or for unpin:
+//!
+//! ```xml
+//! <message type="groupchat" to="room@conf.example">
+//!   <unpinned xmlns="urn:waddle:pin:0" target="<stanza-id>"/>
+//! </message>
+//! ```
+//!
+//! ## Outbound system message (MUC → all occupants, archived in MAM)
+//!
+//! ```xml
+//! <message type="groupchat" from="room@conf.example">
+//!   <body>alice pinned a message</body>
+//!   <pinned xmlns="urn:waddle:pin:0" target="<stanza-id>" by="<bare-jid>">
+//!     <preview><author jid="…" nick="…"/><text>…</text><ts>…</ts></preview>
+//!   </pinned>
+//! </message>
+//! ```
+//!
+//! `<unpinned/>` is symmetric and may carry an optional `reason="retracted"`
+//! when the unpin was triggered by a XEP-0424 retraction cascade.
+
+use minidom::Element;
+use waddle_xmpp_core::xep0359::StanzaId;
+use xmpp_parsers::message::Message;
+
+/// Waddle pin namespace (`urn:waddle:pin:0`).
+pub const NS_WADDLE_PIN_V0: &str = "urn:waddle:pin:0";
+
+const PINNED_ELEMENT: &str = "pinned";
+const UNPINNED_ELEMENT: &str = "unpinned";
+const TARGET_ATTR: &str = "target";
+
+/// Maximum length of a target stanza-id in bytes. Stanza-ids are
+/// XEP-0359 random tokens — even a UUID v4 fits in 36 bytes. Allow
+/// generous headroom for archive-ids without admitting unbounded
+/// abuse.
+pub const MAX_TARGET_STANZA_ID_LEN: usize = 256;
+
+/// Pin or unpin intent extracted from an inbound `<message>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PinIntent {
+    /// Pin the message identified by `target`.
+    Pin { target: String },
+    /// Unpin the message identified by `target`.
+    Unpin { target: String },
+}
+
+impl PinIntent {
+    /// The `target` stanza-id this intent refers to.
+    pub fn target(&self) -> &str {
+        match self {
+            PinIntent::Pin { target } | PinIntent::Unpin { target } => target,
+        }
+    }
+}
+
+/// Detect a pin or unpin intent in the given message. Returns `None`
+/// when no pin marker is present; returns `Some(intent)` for the first
+/// well-formed marker found. Empty-string targets and overlong targets
+/// are rejected (mapped to `None`) — callers may treat that as
+/// `<bad-request/>` if needed.
+///
+/// Ambiguous shapes (both `<pinned>` and `<unpinned>` in the same
+/// message) return `None` — the caller should reject as bad-request.
+pub fn extract_pin_intent_from_message(message: &Message) -> Option<PinIntent> {
+    let mut found: Option<PinIntent> = None;
+    for elem in &message.payloads {
+        if elem.ns() != NS_WADDLE_PIN_V0 {
+            continue;
+        }
+        let candidate = match elem.name() {
+            PINNED_ELEMENT => parse_pinned_element(elem),
+            UNPINNED_ELEMENT => parse_unpinned_element(elem),
+            _ => continue,
+        }?;
+        // Reject ambiguous: two markers, especially of differing kind,
+        // are nonsensical and easier to refuse than to disambiguate.
+        if found.is_some() {
+            return None;
+        }
+        found = Some(candidate);
+    }
+    found
+}
+
+/// Parse a `<pinned target="…"/>` element. Returns `None` if the
+/// element is not a pin marker, the target is missing or empty, or
+/// the target exceeds [`MAX_TARGET_STANZA_ID_LEN`].
+pub fn parse_pinned_element(elem: &Element) -> Option<PinIntent> {
+    if elem.name() != PINNED_ELEMENT || elem.ns() != NS_WADDLE_PIN_V0 {
+        return None;
+    }
+    let target = parse_target_attr(elem)?;
+    Some(PinIntent::Pin { target })
+}
+
+/// Parse an `<unpinned target="…"/>` element. Same rules as
+/// [`parse_pinned_element`].
+pub fn parse_unpinned_element(elem: &Element) -> Option<PinIntent> {
+    if elem.name() != UNPINNED_ELEMENT || elem.ns() != NS_WADDLE_PIN_V0 {
+        return None;
+    }
+    let target = parse_target_attr(elem)?;
+    Some(PinIntent::Unpin { target })
+}
+
+fn parse_target_attr(elem: &Element) -> Option<String> {
+    let raw = elem.attr(TARGET_ATTR)?;
+    if raw.is_empty() || raw.len() > MAX_TARGET_STANZA_ID_LEN {
+        return None;
+    }
+    Some(raw.to_owned())
+}
+
+/// Build the inbound `<pinned target="…"/>` element. Used by tests and
+/// by the chat-side wasm bindings when wrapping a pin request from the
+/// client.
+pub fn build_pinned_element(target: &StanzaId) -> Element {
+    Element::builder(PINNED_ELEMENT, NS_WADDLE_PIN_V0)
+        .attr(TARGET_ATTR, target.id.as_str())
+        .build()
+}
+
+/// Build the inbound `<unpinned target="…"/>` element.
+pub fn build_unpinned_element(target: &StanzaId) -> Element {
+    Element::builder(UNPINNED_ELEMENT, NS_WADDLE_PIN_V0)
+        .attr(TARGET_ATTR, target.id.as_str())
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jid::{BareJid, Jid};
+    use std::str::FromStr;
+    use xmpp_parsers::message::MessageType;
+
+    fn stanza_id(id: &str) -> StanzaId {
+        StanzaId::new(
+            id.to_owned(),
+            Jid::from(BareJid::from_str("room@conf.example").expect("valid jid")),
+        )
+    }
+
+    fn pin_message(target: &str) -> Message {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(build_pinned_element(&stanza_id(target)));
+        msg
+    }
+
+    fn unpin_message(target: &str) -> Message {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads
+            .push(build_unpinned_element(&stanza_id(target)));
+        msg
+    }
+
+    #[test]
+    fn ns_constant_is_waddle_pin_v0() {
+        assert_eq!(NS_WADDLE_PIN_V0, "urn:waddle:pin:0");
+    }
+
+    #[test]
+    fn extract_pin_intent_returns_pin_for_pinned_marker() {
+        let intent = extract_pin_intent_from_message(&pin_message("stanza-1"));
+        assert_eq!(
+            intent,
+            Some(PinIntent::Pin {
+                target: "stanza-1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn extract_pin_intent_returns_unpin_for_unpinned_marker() {
+        let intent = extract_pin_intent_from_message(&unpin_message("stanza-1"));
+        assert_eq!(
+            intent,
+            Some(PinIntent::Unpin {
+                target: "stanza-1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn extract_pin_intent_returns_none_when_marker_absent() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_rejects_empty_target() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(
+            Element::builder(PINNED_ELEMENT, NS_WADDLE_PIN_V0)
+                .attr(TARGET_ATTR, "")
+                .build(),
+        );
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_rejects_missing_target() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads
+            .push(Element::builder(PINNED_ELEMENT, NS_WADDLE_PIN_V0).build());
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_rejects_overlong_target() {
+        let oversized = "x".repeat(MAX_TARGET_STANZA_ID_LEN + 1);
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(
+            Element::builder(PINNED_ELEMENT, NS_WADDLE_PIN_V0)
+                .attr(TARGET_ATTR, oversized.as_str())
+                .build(),
+        );
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_rejects_ambiguous_pin_and_unpin() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(build_pinned_element(&stanza_id("a")));
+        msg.payloads.push(build_unpinned_element(&stanza_id("b")));
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_rejects_two_pinned_markers() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(build_pinned_element(&stanza_id("a")));
+        msg.payloads.push(build_pinned_element(&stanza_id("b")));
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_pin_intent_ignores_wrong_namespace() {
+        let mut msg = Message::new(Some(Jid::from(
+            BareJid::from_str("room@conf.example").expect("valid jid"),
+        )));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(
+            Element::builder(PINNED_ELEMENT, "wrong:ns")
+                .attr(TARGET_ATTR, "stanza-1")
+                .build(),
+        );
+        assert!(extract_pin_intent_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn build_and_parse_pinned_roundtrip() {
+        let elem = build_pinned_element(&stanza_id("stanza-1"));
+        assert_eq!(elem.name(), PINNED_ELEMENT);
+        assert_eq!(elem.ns(), NS_WADDLE_PIN_V0);
+        assert_eq!(elem.attr(TARGET_ATTR), Some("stanza-1"));
+        assert_eq!(
+            parse_pinned_element(&elem),
+            Some(PinIntent::Pin {
+                target: "stanza-1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn build_and_parse_unpinned_roundtrip() {
+        let elem = build_unpinned_element(&stanza_id("stanza-1"));
+        assert_eq!(elem.name(), UNPINNED_ELEMENT);
+        assert_eq!(elem.ns(), NS_WADDLE_PIN_V0);
+        assert_eq!(
+            parse_unpinned_element(&elem),
+            Some(PinIntent::Unpin {
+                target: "stanza-1".into()
+            })
+        );
+    }
+
+    #[test]
+    fn pin_intent_target_accessor() {
+        assert_eq!(
+            PinIntent::Pin {
+                target: "abc".into()
+            }
+            .target(),
+            "abc"
+        );
+        assert_eq!(
+            PinIntent::Unpin {
+                target: "xyz".into()
+            }
+            .target(),
+            "xyz"
+        );
+    }
+}


### PR DESCRIPTION
Server-side foundation for channel pinned messages. Closes part of #414; chat-side PR follows.

## Status — all server slices landed; adversarial review applied

| Slice | State |
|---|---|
| 1. Custom `urn:waddle:pin:0` wire shape (`<pinned/>` / `<unpinned/>`) — typed builder/parser module | ✅ |
| 2. Typed `PinnedEntry` / `PinPreview` / `PinStateChange` on `MucRoom` (uses `xep0359::StanzaId`) | ✅ |
| 3. `MucPinHandler` registered in MUC chain + `ApplyPinChange` / `BroadcastRoomSystemMessage` outbound events | ✅ |
| 4. `RoomActor::ApplyPin` / `GetPinList` + interpreter arms wiring state mutation, MAM archive, and per-occupant fan-out | ✅ |
| 5. IQ query handler `<query xmlns='urn:waddle:pin:0'/>` with **occupancy gate** | ✅ |
| 6. XEP-0424 retraction cascade auto-unpins (Q8) | ✅ |
| 7. Cue E2E scenarios — admin pin/unpin happy path + member-forbidden negative path | ✅ |

**Verification:** 1837 lib tests, 2 cue E2E scenarios, 6 IQ predicate tests, 11 wire-shape tests pass. `cargo clippy -- -D warnings` clean across both crates. `cargo fmt` clean.

## Wire shape (revised after adversarial review)

The earlier draft borrowed `urn:xmpp:pubsub-attachments:0` for the inbound shape, which is a hard-rule violation: that's a XEP-0470 namespace and the shape Waddle uses isn't XEP-0470 conformant (XEP-0470 requires PubSub items, not message-embedded payloads). The revised shape is fully custom:

**Pin** (member → MUC):
\`\`\`xml
<message type="groupchat" to="room@conf.example">
  <pinned xmlns="urn:waddle:pin:0" target="<stanza-id>"/>
</message>
\`\`\`

**Unpin** (member → MUC, symmetric):
\`\`\`xml
<message type="groupchat" to="room@conf.example">
  <unpinned xmlns="urn:waddle:pin:0" target="<stanza-id>"/>
</message>
\`\`\`

**Pin-list query** (client → MUC, IQ get; **requires room occupancy**):
\`\`\`xml
<iq type="get" to="room@conf.example">
  <query xmlns="urn:waddle:pin:0"/>
</iq>
\`\`\`
Response carries one `<pin id="…" by="…" at="…"><preview><author/><text/><ts/></preview></pin>` per entry, in pin-time-desc order.

**Pin-event system message** (MUC → all occupants, archived in MAM):
\`\`\`xml
<message type="groupchat" from="room@conf.example">
  <body>alice pinned a message</body>
  <stanza-id xmlns="urn:xmpp:sid:0" id="…" by="room@conf.example"/>
  <pinned xmlns="urn:waddle:pin:0" target="<stanza-id>" by="<bare-jid>">
    <preview><author jid="…" nick="…"/><text>…</text><ts>…</ts></preview>
  </pinned>
</message>
\`\`\`

For author-retracted (XEP-0424) pinned messages, an `<unpinned/>` system message with `reason="retracted"` is emitted automatically.

## Architecture decisions

- **Custom namespace, custom shape.** Pinning is a Waddle-only feature; no official XEP defines it. The wire shape lives entirely under `urn:waddle:pin:0` per the project's XEP conformance hard rule.
- **Pin items live on `MucRoom`** as a typed `Vec<PinnedEntry>`, mutated via `upsert_pin` / `remove_pin_by_target`. Pin entries carry a frozen 280-character preview (UTF-8-safe truncation) and the original message timestamp.
- **Bounded by `MAX_PINNED_ENTRIES=1000`.** Oldest entry is evicted on overflow — prevents admin-driven memory DoS. Per-target stanza-id length is also bounded (`MAX_TARGET_STANZA_ID_LEN=256`).
- **In-memory only by design** in this PR. Pins do not survive room-actor shutdown — documented explicitly in `MucRoom.pinned_entries` doc and pinned by a regression test. Persistence is a future concern.
- **The original user pin message does not enter the regular archive/reflect path.** The pin handler `Halt`s the chain and emits the durable record via `BroadcastRoomSystemMessage`. The system message is the MAM-archived record. Handler-order is asserted by a regression test (`pin_handler_runs_after_canonicalize_and_before_archive_and_reflector`).
- **Hard-coded admin/owner gate** in this PR. Per-room configurability ships as #415.
- **Retraction cascade (Q8):** XEP-0424 retraction of a pinned message auto-unpins via a synthetic system event with `reason="retracted"`.
- **IQ query is occupant-gated.** Pin lists carry author/body excerpts — non-members get `<forbidden type='auth'/>`.

## Hard-rule compliance

- **Typed payloads only.** `PinStateChange`, `PinnedEntry`, `PinPreview` are typed; `target_stanza_id` is `xep0359::StanzaId`, not `String`. New events carry `Box<Message>` and typed JIDs throughout.
- **All XML built via `xmpp_parsers` / `minidom::Element` builders.** No `format!()` XML.
- **Custom XEP test suite** for `urn:waddle:pin:0` in `xep_waddle_pin.rs` (11 tests) + `muc::pin` (4 tests) + `muc::room::pin_state_tests` (6 tests including cap eviction) + `protocol::room::pin` handler tests (7 tests including malformed inputs and ambiguous markers) + `pin_query` predicate tests (6) + 3 RoomActor tests + 2 cue E2E scenarios.
- **No `#[allow(...)]` introduced.** `cargo clippy -- -D warnings` clean.
- **Conventional commits** with `(server)` scope.

## Out of scope (other PRs / issues)

- Chat-side `PinnedPanel`, badge, action sheet, wasm bindings → follow-up PR for #414.
- Per-room pin-permission config → #415.
- Personal "Saved messages" → separate issue (deferred per user direction).