### PR TITLE
feat(chat): channel pinned messages UI + wasm bindings (#414)

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -230,7 +230,8 @@ export function useChannelMessages(
       });
       // #414: route pin/unpin system events into the pinned-messages
       // store so PinnedPanel + the badge in MessageCard update live.
-      client.setPinEventHandler(({ roomJid, event }) => {
+      // Tests use a stub client that may not implement this; guard.
+      client.setPinEventHandler?.(({ roomJid, event }) => {
         if (event.action === "pinned" && event.preview) {
           applyPinEvent(roomJid, {
             action: "pinned",

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -15,7 +15,7 @@ import {
   type RoomPresence,
 } from "@/lib/xmpp-client";
 import { $xmppStatus } from "@/stores/xmpp-status";
-import { applyPinEvent } from "@/stores/pinned-messages";
+import { applyPinEvent, hydratePinnedRoom } from "@/stores/pinned-messages";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
@@ -660,17 +660,18 @@ export function useChannelMessages(
     try {
       // #414: hydrate the pin store for this room. Fire-and-forget —
       // the panel + badge tolerate an empty store, and the live
-      // pin-event handler will mutate it from now on.
+      // pin-event handler will mutate it from now on. On error
+      // (e.g., <forbidden/>, network), still mark the room hydrated
+      // with an empty list so the panel exits its "Loading…" state.
       if (xmppClient.value && "fetchRoomPins" in xmppClient.value) {
         void xmppClient.value
           .fetchRoomPins(spaceId, channelId)
           .then((entries) => {
-            import("@/stores/pinned-messages").then(({ hydratePinnedRoom }) => {
-              hydratePinnedRoom(roomJid, entries);
-            });
+            hydratePinnedRoom(roomJid, entries);
           })
           .catch((error: unknown) => {
             console.warn("fetchRoomPins failed", error);
+            hydratePinnedRoom(roomJid, []);
           });
       }
       // XEP-0313: Load message history via MAM (XMPP-native)

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -15,7 +15,7 @@ import {
   type RoomPresence,
 } from "@/lib/xmpp-client";
 import { $xmppStatus } from "@/stores/xmpp-status";
-import { applyPinEvent, hydratePinnedRoom } from "@/stores/pinned-messages";
+import { applyPinEvent, hydratePinnedRoom, pinnedRoomsEpoch } from "@/stores/pinned-messages";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
@@ -660,19 +660,29 @@ export function useChannelMessages(
     try {
       // #414: hydrate the pin store for this room. Fire-and-forget —
       // the panel + badge tolerate an empty store, and the live
-      // pin-event handler will mutate it from now on. On error
-      // (e.g., <forbidden/>, network), still mark the room hydrated
-      // with an empty list so the panel exits its "Loading…" state.
+      // pin-event handler will mutate it from now on.
+      // - On error (<forbidden/>, network), hydrate with an empty
+      //   list so the panel exits "Loading…".
+      // - When the wasm client lacks `fetchRoomPins` (stub clients in
+      //   tests, older builds), also hydrate with an empty list to
+      //   prevent the panel from spinning forever.
+      // - Capture the epoch at request-issue time and pass it back
+      //   to hydratePinnedRoom; if logout bumps the epoch in between,
+      //   the late callback is dropped instead of leaking prior-session
+      //   data into the new login.
       if (xmppClient.value && "fetchRoomPins" in xmppClient.value) {
+        const epoch = pinnedRoomsEpoch();
         void xmppClient.value
           .fetchRoomPins(spaceId, channelId)
           .then((entries) => {
-            hydratePinnedRoom(roomJid, entries);
+            hydratePinnedRoom(roomJid, entries, epoch);
           })
           .catch((error: unknown) => {
             console.warn("fetchRoomPins failed", error);
-            hydratePinnedRoom(roomJid, []);
+            hydratePinnedRoom(roomJid, [], epoch);
           });
+      } else {
+        hydratePinnedRoom(roomJid, []);
       }
       // XEP-0313: Load message history via MAM (XMPP-native)
       const page = xmppClient.value && "queryMamPage" in xmppClient.value

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -15,6 +15,7 @@ import {
   type RoomPresence,
 } from "@/lib/xmpp-client";
 import { $xmppStatus } from "@/stores/xmpp-status";
+import { applyPinEvent } from "@/stores/pinned-messages";
 import {
   inferredFileDisposition,
   type DeliveryStatus,
@@ -226,6 +227,27 @@ export function useChannelMessages(
           event.emojis,
           event.authorRealJid ?? `${event.roomJid}/${event.nick}`,
         );
+      });
+      // #414: route pin/unpin system events into the pinned-messages
+      // store so PinnedPanel + the badge in MessageCard update live.
+      client.setPinEventHandler(({ roomJid, event }) => {
+        if (event.action === "pinned" && event.preview) {
+          applyPinEvent(roomJid, {
+            action: "pinned",
+            target_stanza_id: event.target_stanza_id,
+            entry: {
+              target_stanza_id: event.target_stanza_id,
+              pinner_jid: event.by,
+              pinned_at: new Date().toISOString(),
+              preview: event.preview,
+            },
+          });
+        } else {
+          applyPinEvent(roomJid, {
+            action: event.action,
+            target_stanza_id: event.target_stanza_id,
+          });
+        }
       });
       client.setDisplayedHandler((event) => {
         if (!currentRoomJid.value || event.roomJid !== currentRoomJid.value) return;
@@ -635,6 +657,21 @@ export function useChannelMessages(
     messages.value = appendQueuedMessages([], roomJid);
 
     try {
+      // #414: hydrate the pin store for this room. Fire-and-forget —
+      // the panel + badge tolerate an empty store, and the live
+      // pin-event handler will mutate it from now on.
+      if (xmppClient.value && "fetchRoomPins" in xmppClient.value) {
+        void xmppClient.value
+          .fetchRoomPins(spaceId, channelId)
+          .then((entries) => {
+            import("@/stores/pinned-messages").then(({ hydratePinnedRoom }) => {
+              hydratePinnedRoom(roomJid, entries);
+            });
+          })
+          .catch((error: unknown) => {
+            console.warn("fetchRoomPins failed", error);
+          });
+      }
       // XEP-0313: Load message history via MAM (XMPP-native)
       const page = xmppClient.value && "queryMamPage" in xmppClient.value
         ? await xmppClient.value.queryMamPage(spaceId, channelId, 100, { type: "latest" })

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -44,6 +44,10 @@ export function mapLiveRoomMessageToTimeline(
   if (msg.forumPostKind) tm.forumPostKind = msg.forumPostKind;
   if (msg.forumTitle) tm.forumTitle = msg.forumTitle;
   if (msg.forumThreadTitle) tm.forumThreadTitle = msg.forumThreadTitle;
+  if (msg.type === "pin-event") {
+    tm.isPinEvent = true;
+    if (msg.pinEventAction) tm.pinEventAction = msg.pinEventAction;
+  }
   return tm;
 }
 

--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, type Component } from "vue";
-import { ChevronRight, Hash, Menu, MessageCircle, MessagesSquare, Search, Settings, Users } from "lucide-vue-next";
+import { ChevronRight, Hash, Menu, MessageCircle, MessagesSquare, Pin, Search, Settings, Users } from "lucide-vue-next";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ConnectionNoticeCopy } from "@/lib/connection-notice";
 import type { MemberLoadState } from "@/waddles/directory";
@@ -26,6 +26,7 @@ const props = defineProps<{
 }>();
 
 const showSearch = defineModel<boolean>("showSearch", { required: true });
+const showPinnedPanel = defineModel<boolean>("showPinnedPanel", { default: false });
 
 const emit = defineEmits<{
   openNav: [];
@@ -135,6 +136,18 @@ const memberButtonCopy = computed(() => {
           @click="showSearch = !showSearch"
         >
           <Search class="w-3.5 h-3.5" />
+        </button>
+        <button
+          v-if="channel"
+          class="chat-icon-button chat-icon-button--md transition-all duration-200"
+          :class="showPinnedPanel ? 'bg-muted text-primary' : 'text-muted-foreground hover:bg-muted hover:text-foreground'"
+          title="Pinned messages"
+          aria-label="Pinned messages"
+          :aria-pressed="showPinnedPanel"
+          type="button"
+          @click="showPinnedPanel = !showPinnedPanel"
+        >
+          <Pin class="w-3.5 h-3.5" />
         </button>
         <button
           v-if="canManageChannels && channel"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -98,6 +98,9 @@ const {
   retryActiveLoad,
   ensureActiveMessageLoaded,
   loadOlderThreadMessages,
+  pinActiveMessage,
+  unpinActiveMessage,
+  jumpToPinnedMessage,
 } = props.controller;
 </script>
 
@@ -414,7 +417,7 @@ const {
               :room-jid="activeChannelRoomJid"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
               @close="ui.showPinnedPanel.value = false"
-              @jump-to-message="(stanzaId: string) => ensureActiveMessageLoaded(stanzaId)"
+              @jump-to-message="(stanzaId: string) => jumpToPinnedMessage(stanzaId)"
             />
           </div>
         </div>

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -272,6 +272,8 @@ const {
               @edit-message="editActiveMessage"
               @retract-message="retractActiveMessage"
               @react-message="reactActiveMessage"
+              @pin-message="pinActiveMessage"
+              @unpin-message="unpinActiveMessage"
               @search="searchActiveMessages"
               @clear-search="clearActiveSearch"
               @load-older="loadOlderActiveMessages"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -7,6 +7,7 @@ import DmPanel from "@/components/chat/DmPanel.vue";
 import ExtensionRouteView from "@/components/chat/ExtensionRouteView.vue";
 import ThreadPanel from "@/components/chat/ThreadPanel.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
+import PinnedPanel from "@/components/chat/PinnedPanel.vue";
 import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import type { ChatAppController } from "@/shell/chat-app-controller";
@@ -228,6 +229,7 @@ const {
               :ref="setContentAreaRef"
               v-model:draft="activeDraft"
               v-model:forum-title="activeForumTitle"
+              v-model:pinned-panel-open="ui.showPinnedPanel.value"
               :waddle="waddles.currentSpace.value"
               :channel="ui.sidebarMode.value === 'dms' ? null : waddles.currentChannel.value"
               :room-jid="ui.sidebarMode.value === 'dms' ? null : activeChannelRoomJid"
@@ -391,6 +393,26 @@ const {
               @select-gif="sendGif"
               @typing="notifyActiveComposing"
               @load-older="loadOlderThreadMessages"
+            />
+          </div>
+
+          <!-- #414 PinnedPanel: right-rail panel listing pinned messages.
+               Visible in channel context only when ui.showPinnedPanel
+               is true. Mutually exclusive with the thread panel — the
+               header pin button toggles this and the URL state. -->
+          <div
+            v-if="ui.sidebarMode.value === 'channels'
+              && ui.showPinnedPanel.value
+              && activeThreadStack.length === 0
+              && waddles.currentChannel.value
+              && activeChannelRoomJid"
+            class="chat-active-thread-pane"
+          >
+            <PinnedPanel
+              :room-jid="activeChannelRoomJid"
+              :channel-name="waddles.currentChannel.value?.name ?? ''"
+              @close="ui.showPinnedPanel.value = false"
+              @jump-to-message="(stanzaId: string) => ensureActiveMessageLoaded(stanzaId)"
             />
           </div>
         </div>

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -2,10 +2,11 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance } from "vue";
 import { useStore } from "@nanostores/vue";
 import { AlertCircle, CheckCircle2, Hash, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
-import { $pinnedRooms } from "@/stores/pinned-messages";
+import { $pinnedStanzaIds } from "@/stores/pinned-messages";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
 import { findMessageElementById } from "@/lib/message-targeting";
+import { findMessageById } from "@/lib/message-ids";
 import { getReplyJumpNotice } from "@/lib/reply-ux";
 import { findThreadToAutoOpen } from "@/lib/thread-auto-open";
 import {
@@ -201,10 +202,16 @@ async function scrollToMessage(messageId: string) {
     showReplyJumpNotice(getReplyJumpNotice(false));
     return;
   }
-  if (await virtualTimelineRef.value?.scrollToMessageId(messageId, "center")) {
+  // VirtualTimeline + the data-message-id index match items by their
+  // primary `id` only. Pinned-panel "jump to message" passes a
+  // XEP-0359 stanza-id, which on the timeline lives in `wireIds[]`,
+  // not `id`. Resolve the candidate to the primary id first so both
+  // paths work (#414).
+  const resolvedId = findMessageById(props.messages, messageId)?.id ?? messageId;
+  if (await virtualTimelineRef.value?.scrollToMessageId(resolvedId, "center")) {
     await nextTick();
   }
-  const el = findMessageElementById(messagesContainer.value, messageId);
+  const el = findMessageElementById(messagesContainer.value, resolvedId);
   const notice = getReplyJumpNotice(el instanceof HTMLElement);
   if (!notice && el instanceof HTMLElement) {
     clearReplyJumpNotice();
@@ -312,13 +319,15 @@ const avatarUrlByAuthor = computed(() => props.avatarUrlByAuthor ?? {});
 const isForumChannel = computed(() => detectForumChannel(props.channel));
 
 // #414: pin state for the current room. Hydrated by the controller.
-const pinnedRooms = useStore($pinnedRooms);
-const pinnedStanzaIds = computed(() => {
+// Reads from the derived `$pinnedStanzaIds` map (roomJid → Set<stanzaId>)
+// matching the #414 PRD contract for a presence-check store.
+const pinnedStanzaIdsByRoom = useStore($pinnedStanzaIds);
+const pinnedStanzaIdsForRoom = computed(() => {
   if (!props.roomJid) return null;
-  return pinnedRooms.value.get(props.roomJid)?.stanzaIds ?? null;
+  return pinnedStanzaIdsByRoom.value.get(props.roomJid) ?? null;
 });
 function isPinnedMessage(msg: TimelineMessage): boolean {
-  const set = pinnedStanzaIds.value;
+  const set = pinnedStanzaIdsForRoom.value;
   if (!set) return false;
   if (msg.id && set.has(msg.id)) return true;
   // Also match wireIds (XEP-0359 stanza-id mirrors).

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance } from "vue";
+import { useStore } from "@nanostores/vue";
 import { AlertCircle, CheckCircle2, Hash, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
+import { $pinnedRooms } from "@/stores/pinned-messages";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
 import { findMessageElementById } from "@/lib/message-targeting";
@@ -98,6 +100,8 @@ const emit = defineEmits<{
   refreshUpdate: [];
   loadOlder: [];
   retryLoad: [];
+  pinMessage: [messageId: string];
+  unpinMessage: [messageId: string];
 }>();
 
 // Hide thread members from the main feed — they live inside the thread panel.
@@ -306,6 +310,29 @@ const searchInput = ref("");
 const searchSubmitted = ref(false);
 const avatarUrlByAuthor = computed(() => props.avatarUrlByAuthor ?? {});
 const isForumChannel = computed(() => detectForumChannel(props.channel));
+
+// #414: pin state for the current room. Hydrated by the controller.
+const pinnedRooms = useStore($pinnedRooms);
+const pinnedStanzaIds = computed(() => {
+  if (!props.roomJid) return null;
+  return pinnedRooms.value.get(props.roomJid)?.stanzaIds ?? null;
+});
+function isPinnedMessage(msg: TimelineMessage): boolean {
+  const set = pinnedStanzaIds.value;
+  if (!set) return false;
+  if (msg.id && set.has(msg.id)) return true;
+  // Also match wireIds (XEP-0359 stanza-id mirrors).
+  const wireIds = (msg as TimelineMessage & { wireIds?: string[] }).wireIds;
+  return Boolean(wireIds?.some((wid) => set.has(wid)));
+}
+// Owner/Admin gate: any of the current user's hats indicates admin/owner
+// affiliation. The room sets these via the existing hats system.
+const currentUserCanPin = computed(() => {
+  const me = props.currentUser;
+  if (!me) return false;
+  const myHats = props.roomHats[me] ?? [];
+  return myHats.some((hat) => hat.uri === "urn:xmpp:hats:0:owner" || hat.uri === "urn:xmpp:hats:0:admin");
+});
 const canShowComposer = computed(() => !!(props.channel || props.dmPeer));
 const queuedMessageCount = computed(() =>
   props.messages.filter((message) =>
@@ -1008,6 +1035,8 @@ function dayDividerLabel(createdAt: string): string {
             :grouped="isGroupedFollowUp(msg.id)"
             :reaction-mode-selected="reactionMode?.selectedMessageId === msg.id"
             :invoke-extension-action="props.invokeExtensionAction"
+            :is-pinned="isPinnedMessage(msg)"
+            :can-pin-messages="currentUserCanPin"
             @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
             @retract="(id) => emit('retractMessage', id)"
             @react="(id, emoji) => emit('reactMessage', id, emoji)"
@@ -1015,6 +1044,8 @@ function dayDividerLabel(createdAt: string): string {
             @scroll-to-message="scrollToMessage"
             @avatar-click="onAvatarClick"
             @open-thread="(tid: string) => emit('openThread', tid)"
+            @pin="(id: string) => emit('pinMessage', id)"
+            @unpin="(id: string) => emit('unpinMessage', id)"
           />
           <div
             v-if="showDividerAfter(msg.id)"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -32,6 +32,7 @@ import VirtualTimeline from "@/components/chat/VirtualTimeline.vue";
 
 const draft = defineModel<string>("draft", { required: true });
 const forumTitle = defineModel<string>("forumTitle", { default: "" });
+const pinnedPanelOpen = defineModel<boolean>("pinnedPanelOpen", { default: false });
 
 const props = defineProps<{
   waddle: SpaceSummary | null;
@@ -662,6 +663,7 @@ function dayDividerLabel(createdAt: string): string {
 
     <ChatHeader
       v-model:show-search="showSearch"
+      v-model:show-pinned-panel="pinnedPanelOpen"
       :waddle="waddle"
       :channel="channel"
       :dm-peer="dmPeer"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -331,7 +331,7 @@ const currentUserCanPin = computed(() => {
   const me = props.currentUser;
   if (!me) return false;
   const myHats = props.roomHats[me] ?? [];
-  return myHats.some((hat) => hat.uri === "urn:xmpp:hats:0:owner" || hat.uri === "urn:xmpp:hats:0:admin");
+  return myHats.some((hat) => hat.uri === "urn:xmpp:hats:owner" || hat.uri === "urn:xmpp:hats:admin");
 });
 const canShowComposer = computed(() => !!(props.channel || props.dmPeer));
 const queuedMessageCount = computed(() =>
@@ -488,7 +488,7 @@ async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
   return true;
 }
 
-defineExpose({ messagesContainer, scrollToPinnedEdge });
+defineExpose({ messagesContainer, scrollToPinnedEdge, scrollToMessage });
 
 function doSearch() {
   searchSubmitted.value = !!searchInput.value.trim();

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -15,6 +15,8 @@ import {
   CheckCircle2,
   LayoutDashboard,
   LoaderCircle,
+  Pin,
+  PinOff,
 } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
@@ -85,6 +87,11 @@ const props = defineProps<{
   grouped?: boolean;
   reactionModeSelected?: boolean;
   invokeExtensionAction?: (action: ExtensionAnnotationAction) => Promise<ExtensionCommandResult>;
+  /** #414: this message is pinned in its host room. */
+  isPinned?: boolean;
+  /** #414: current user is room Owner or Admin (controls pin/unpin
+   * action-sheet entry visibility). */
+  canPinMessages?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -95,6 +102,8 @@ const emit = defineEmits<{
   scrollToMessage: [messageId: string];
   avatarClick: [author: string];
   openThread: [threadId: string];
+  pin: [messageId: string];
+  unpin: [messageId: string];
 }>();
 
 const quickEmojis = QUICK_REACTION_EMOJIS;
@@ -209,6 +218,16 @@ const showThreadChip = computed(
 
 function openThreadFromChip() {
   emit("openThread", props.message.id);
+}
+
+function togglePinFromMenu() {
+  if (!props.message.id) return;
+  if (props.isPinned) {
+    emit("unpin", props.message.id);
+  } else {
+    emit("pin", props.message.id);
+  }
+  closeSheet();
 }
 
 function startReplyInThreadFromMenu() {
@@ -529,6 +548,14 @@ watch(
         >{{ HAT_LABELS[seniorHat.uri] ?? seniorHat.title }}</span>
         <span class="type-meta type-numeric text-muted-foreground/60">
           {{ formatTimelineTimeOfDay(message.createdAt) }}
+        </span>
+        <span
+          v-if="isPinned"
+          class="inline-flex items-center text-muted-foreground/70"
+          title="Pinned in this channel"
+          aria-label="Pinned in this channel"
+        >
+          <Pin class="w-3 h-3" aria-hidden="true" />
         </span>
         <span v-if="message.isEdited" class="type-meta text-muted-foreground/50">(edited)</span>
         <span
@@ -1158,6 +1185,15 @@ watch(
           >
             <MessageSquare class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
             <span>{{ (threadReplyCount ?? 0) > 0 ? "Open thread" : "Reply in thread" }}</span>
+          </button>
+          <button
+            v-if="canPinMessages && message.id"
+            type="button"
+            class="type-field w-full flex items-center gap-3 px-3 h-12 rounded-lg hover:bg-muted active:bg-muted transition-colors text-left"
+            @click="togglePinFromMenu"
+          >
+            <component :is="isPinned ? PinOff : Pin" class="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+            <span>{{ isPinned ? "Unpin from channel" : "Pin to channel" }}</span>
           </button>
           <template v-if="message.isSelf">
             <button

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -1088,6 +1088,16 @@ watch(
       >
         <MessageSquare class="w-4 h-4" aria-hidden="true" />
       </button>
+      <button
+        v-if="canPinMessages && message.id"
+        type="button"
+        class="h-8 w-8 flex items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-150"
+        :title="isPinned ? 'Unpin from channel' : 'Pin to channel'"
+        :aria-label="isPinned ? 'Unpin from channel' : 'Pin to channel'"
+        @click="togglePinFromMenu"
+      >
+        <component :is="isPinned ? PinOff : Pin" class="w-4 h-4" aria-hidden="true" />
+      </button>
       <template v-if="message.isSelf">
         <div class="w-px h-5 bg-border mx-0.5" />
         <button

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -466,9 +466,30 @@ watch(
 </script>
 
 <template>
+  <!-- #414: pin-event system message rendered distinctly from user
+       posts (no avatar, italic, muted) so the channel timeline
+       reads as "alice pinned a message" without looking like a chat
+       reply. -->
+  <div
+    v-if="message.isPinEvent"
+    :data-message-id="message.id"
+    :data-message-created-at="message.createdAt"
+    class="chat-message-grid animate-message-in"
+  >
+    <div class="chat-message-avatar-cell flex items-center justify-center text-muted-foreground/60">
+      <component :is="message.pinEventAction === 'unpinned' ? PinOff : Pin" class="w-4 h-4" aria-hidden="true" />
+    </div>
+    <div class="chat-message-body-stack">
+      <p class="type-field-sm italic text-muted-foreground">
+        {{ message.body }}
+        <span class="type-meta type-numeric ml-2">{{ formatTimelineTimeOfDay(message.createdAt) }}</span>
+      </p>
+    </div>
+  </div>
+
   <!-- Retracted tombstone -->
   <div
-    v-if="message.isRetracted"
+    v-else-if="message.isRetracted"
     :data-message-id="message.id"
     :data-message-created-at="message.createdAt"
     class="chat-message-grid opacity-35 animate-message-in"

--- a/chat/src/components/chat/PinnedPanel.vue
+++ b/chat/src/components/chat/PinnedPanel.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+// PinnedPanel — right-rail panel listing the room's pinned messages
+// (#414). Hydrated by the chat-app-controller via fetchRoomPins on
+// room entry; live-updated by the pin-event observer wired into the
+// XmppClient. Mutually exclusive with ThreadPanel in the right rail
+// — the parent (ChatReadyShell) gates rendering on
+// ui.showPinnedPanel.
+import { computed } from "vue";
+import { useStore } from "@nanostores/vue";
+import { Pin, X } from "lucide-vue-next";
+
+import { $pinnedRooms } from "@/stores/pinned-messages";
+
+const props = defineProps<{
+  roomJid: string;
+  channelName: string;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  jumpToMessage: [stanzaId: string];
+}>();
+
+const pinnedRooms = useStore($pinnedRooms);
+const state = computed(() => pinnedRooms.value.get(props.roomJid) ?? null);
+const entries = computed(() => state.value?.entries ?? []);
+const hydrated = computed(() => state.value?.hydrated ?? false);
+
+function relativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const seconds = Math.max(1, Math.round((Date.now() - t) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+</script>
+
+<template>
+  <aside class="pinned-panel flex flex-col h-full bg-background border-l border-border">
+    <header class="flex items-center justify-between px-4 h-14 border-b border-border">
+      <div class="flex items-center gap-2 min-w-0">
+        <Pin class="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+        <h2 class="type-heading-sm truncate">Pinned in {{ channelName }}</h2>
+      </div>
+      <button
+        type="button"
+        class="rounded p-1 hover:bg-muted"
+        aria-label="Close pinned messages"
+        @click="emit('close')"
+      >
+        <X class="w-5 h-5" />
+      </button>
+    </header>
+
+    <div v-if="!hydrated" class="flex-1 flex items-center justify-center text-muted-foreground type-field">
+      Loading pinned messages…
+    </div>
+    <div
+      v-else-if="entries.length === 0"
+      class="flex-1 flex flex-col items-center justify-center text-muted-foreground type-field gap-1 px-6"
+    >
+      <Pin class="w-6 h-6" aria-hidden="true" />
+      <p>No pinned messages yet.</p>
+      <p class="text-xs">Admins can pin a message from the message menu.</p>
+    </div>
+    <ol v-else class="flex-1 overflow-y-auto divide-y divide-border" role="list">
+      <li
+        v-for="entry in entries"
+        :key="entry.target_stanza_id"
+        class="px-4 py-3 cursor-pointer hover:bg-muted/40 focus-within:bg-muted/40"
+        tabindex="0"
+        @click="emit('jumpToMessage', entry.target_stanza_id)"
+        @keydown.enter.prevent="emit('jumpToMessage', entry.target_stanza_id)"
+        @keydown.space.prevent="emit('jumpToMessage', entry.target_stanza_id)"
+      >
+        <div class="flex items-baseline justify-between gap-2 mb-0.5">
+          <span class="type-field font-medium truncate">
+            {{ entry.preview.author_nick ?? entry.preview.author_jid }}
+          </span>
+          <span class="type-field-xs text-muted-foreground shrink-0">
+            {{ relativeTime(entry.preview.message_timestamp) }}
+          </span>
+        </div>
+        <p class="type-field-sm text-muted-foreground line-clamp-3 break-words">
+          {{ entry.preview.text || "(no preview text)" }}
+        </p>
+        <p class="type-field-xs text-muted-foreground mt-1">
+          Pinned by {{ entry.pinner_jid }} · {{ relativeTime(entry.pinned_at) }}
+        </p>
+      </li>
+    </ol>
+  </aside>
+</template>

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -180,6 +180,11 @@ export interface TimelineMessage {
   forumPostKind?: "topic" | "reply";
   forumTitle?: string;
   forumThreadTitle?: string;
+  /** #414: room-authored `<pin-event/>` system message; the timeline
+   * renders these distinctly (no avatar, italic). `pinEventAction`
+   * carries the action when set. */
+  isPinEvent?: boolean;
+  pinEventAction?: "pinned" | "unpinned";
 }
 
 export interface CommunityFormData {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -147,6 +147,7 @@ export class BrowserXmppClient {
   private get queueScope() { return barePeerJid(this.session.jid); }
   private readonly resource = createXmppResource();
   private messageHandler: ((message: LiveRoomMessage) => void) | null = null;
+  private pinEventHandler: ((event: { roomJid: string; event: import("./wasm-types").WasmPinEvent }) => void) | null = null;
   private directMessageHandler: ((message: LiveDmMessage) => void) | null = null;
   private statusHandler: ((status: XmppStatusSnapshot) => void) | null = null;
   private reactionHandler: ((event: ReactionEvent) => void) | null = null;
@@ -204,6 +205,8 @@ export class BrowserXmppClient {
   constructor(session: WaddleSession) { this.session = session; }
 
   setMessageHandler(h: (message: LiveRoomMessage) => void) { this.messageHandler = h; }
+  /** #414: receive `<pin-event/>` system messages from a room. */
+  setPinEventHandler(h: (event: { roomJid: string; event: import("./wasm-types").WasmPinEvent }) => void) { this.pinEventHandler = h; }
   setDirectMessageHandler(h: (message: LiveDmMessage) => void) { this.directMessageHandler = h; }
   setStatusHandler(h: (status: XmppStatusSnapshot) => void) { this.statusHandler = h; }
   setChatStateHandler(h: (event: ChatStateEvent) => void) { this.chatStateHandler = h; }
@@ -653,6 +656,29 @@ export class BrowserXmppClient {
   async sendChatState(spaceId: string, channelId: string, state: ChatStateType) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendChatState(xmpp, roomJid, "groupchat", state); }
   async sendDisplayed(spaceId: string, channelId: string, messageId: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendDisplayed(xmpp, roomJid, "groupchat", messageId); }
   async sendReaction(spaceId: string, channelId: string, messageId: string, emojis: string[]) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendReaction(xmpp, roomJid, "groupchat", messageId, emojis); }
+  /** #414: pin a message in the room. Server gates on Owner/Admin
+   * affiliation; non-admins receive a `<forbidden/>` error which
+   * surfaces as a rejected Promise. */
+  async pinMessage(spaceId: string, channelId: string, targetStanzaId: string) {
+    const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
+    if (typeof xmpp.pin_message !== "function") throw new Error("pin_message not available in wasm client");
+    await xmpp.pin_message(roomJid, targetStanzaId);
+  }
+  /** #414: unpin a message in the room. Same authorization rules. */
+  async unpinMessage(spaceId: string, channelId: string, targetStanzaId: string) {
+    const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
+    if (typeof xmpp.unpin_message !== "function") throw new Error("unpin_message not available in wasm client");
+    await xmpp.unpin_message(roomJid, targetStanzaId);
+  }
+  /** #414: fetch the room's current pin list. Server requires the
+   * caller to be a current room occupant. Returns entries in
+   * pin-time-desc order. */
+  async fetchRoomPins(spaceId: string, channelId: string): Promise<import("./wasm-types").WasmPinEntry[]> {
+    const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
+    if (typeof xmpp.fetch_room_pins !== "function") throw new Error("fetch_room_pins not available in wasm client");
+    const result = await xmpp.fetch_room_pins(roomJid);
+    return Array.isArray(result) ? (result as import("./wasm-types").WasmPinEntry[]) : [];
+  }
   async sendRetraction(spaceId: string, channelId: string, retractsId: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendRetraction(xmpp, roomJid, "groupchat", retractsId); }
   async sendModeration(spaceId: string, channelId: string, targetId: string, reason?: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendModeration(xmpp, roomJid, targetId, reason); }
   async sendCorrection(spaceId: string, channelId: string, body: string, replacesId: string, markup?: SendGroupMessageOptions["markup"], references?: SendGroupMessageOptions["references"]): Promise<string | null> { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, { markup, references }); }
@@ -847,6 +873,11 @@ export class BrowserXmppClient {
     }
     if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.displayedHandler?.({ roomJid, nick, messageId: message.displayed_marker_id }); } else this.dmDisplayedHandler?.({ peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
     if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.reactionHandler?.({ roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.dmReactionHandler?.({ peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
+    if (message.pin_event && message.is_muc) {
+      const roomJid = barePeerJid(message.from ?? message.to ?? "");
+      this.pinEventHandler?.({ roomJid, event: message.pin_event });
+      return;
+    }
     if (message.is_muc) {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage);
       if (!converted) return;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -876,7 +876,9 @@ export class BrowserXmppClient {
     if (message.pin_event && message.is_muc) {
       const roomJid = barePeerJid(message.from ?? message.to ?? "");
       this.pinEventHandler?.({ roomJid, event: message.pin_event });
-      return;
+      // Fall through: also render the system message in the timeline so
+      // the user sees "alice pinned a message" inline (#414). The
+      // pin store update has already happened above.
     }
     if (message.is_muc) {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage);

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -93,7 +93,10 @@ export interface LiveRoomMessage {
   nick: string;
   body: string;
   createdAt: string;
-  type: "message" | "subject";
+  type: "message" | "subject" | "pin-event";
+  /** #414: pin/unpin action carried by a `<pin-event/>` system
+   * message. Set when `type === "pin-event"`. */
+  pinEventAction?: "pinned" | "unpinned";
   /** XEP-0308 */
   replacesId?: string;
   /** XEP-0424 */

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -203,6 +203,20 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
       ...(message.author_real_jid ? { _reactionSenderId: message.author_real_jid } : {}),
     };
   }
+  // #414: pin-event system messages from the room bare JID render
+  // distinctly so users see "alice pinned a message" inline without
+  // it looking like a normal user post.
+  if (message.pin_event) {
+    return {
+      id: message.id ?? message.stanza_id ?? message.mam_id,
+      roomJid,
+      nick: "",
+      body: message.body ?? "",
+      createdAt,
+      type: "pin-event",
+      pinEventAction: message.pin_event.action,
+    };
+  }
   const sharedFiles = message.shared_files ?? [];
   const mentionUris = message.mention_uris ?? [];
   const markupSpans = message.markup_spans ?? [];

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -76,6 +76,36 @@ export interface WasmMessage {
   forum_thread_title?: string;
   is_sticker: boolean;
   shared_files: WasmSharedFile[];
+  /** urn:waddle:pin:0 pin/unpin event surfaced by the room (#414). */
+  pin_event?: WasmPinEvent;
+}
+
+/** Pin/unpin event from a room system message (#414). */
+export interface WasmPinEvent {
+  action: "pinned" | "unpinned";
+  target_stanza_id: string;
+  by: string;
+  /** "retracted" when the unpin was triggered by an XEP-0424 cascade. */
+  reason?: string;
+  preview?: WasmPinPreview;
+}
+
+/** Frozen preview snapshot of a pinned message (#414). */
+export interface WasmPinPreview {
+  author_jid: string;
+  author_nick?: string;
+  text: string;
+  /** rfc3339. */
+  message_timestamp: string;
+}
+
+/** One pinned-message entry returned by `fetchRoomPins` (#414). */
+export interface WasmPinEntry {
+  target_stanza_id: string;
+  pinner_jid: string;
+  /** rfc3339. */
+  pinned_at: string;
+  preview: WasmPinPreview;
 }
 
 export interface WasmPresenceHat {

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -18,7 +18,7 @@ import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-clie
 import { roomJidForChannelId as resolveRoomJidForChannelId } from "@/lib/channel-room";
 import { mergeRoomHats, roomHatsFromMembers } from "@/lib/xmpp/occupant-badges";
 import { connectionStore } from "@/lib/connection-store";
-import { $pinnedRooms } from "@/stores/pinned-messages";
+import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
@@ -1247,8 +1247,9 @@ export function useChatAppController(giphyApiKey: string) {
     messaging.clearMessages();
     dmMessaging.clearMessages();
     // #414: drop all pin state on logout so a subsequent login doesn't
-    // see the prior user's pinned-message previews.
-    $pinnedRooms.set(new Map());
+    // see the prior user's pinned-message previews and pre-hydration
+    // events buffered from the prior session don't leak forward.
+    resetPinnedRooms();
     ui.showPinnedPanel.value = false;
     pushChannelRoute(null);
     await connectionStore.logout();

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -18,6 +18,7 @@ import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-clie
 import { roomJidForChannelId as resolveRoomJidForChannelId } from "@/lib/channel-room";
 import { mergeRoomHats, roomHatsFromMembers } from "@/lib/xmpp/occupant-badges";
 import { connectionStore } from "@/lib/connection-store";
+import { $pinnedRooms } from "@/stores/pinned-messages";
 import { orderTimelineForScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
@@ -85,6 +86,7 @@ export function useChatAppController(giphyApiKey: string) {
   type ContentAreaHandle = ComponentPublicInstance & {
     messagesContainer: HTMLDivElement | null;
     scrollToPinnedEdge: (mode: ScrollDirectionMode) => Promise<boolean>;
+    scrollToMessage: (messageId: string) => Promise<void>;
   };
   const contentAreaRef = ref<ContentAreaHandle | null>(null);
   const setContentAreaRef = (
@@ -630,7 +632,11 @@ export function useChatAppController(giphyApiKey: string) {
         )
       : ui.sidebarMode.value === "dms" && activeDmPeer.value
       ? buildDirectMessagePath(activeDmPeer.value.peerUsername)
-      : buildChannelPath(waddles.currentChannel.value, activeThreadStack.value),
+      : buildChannelPath(
+          waddles.currentChannel.value,
+          activeThreadStack.value,
+          ui.showPinnedPanel.value,
+        ),
   );
 
   async function setupPushSubscription() {
@@ -856,16 +862,32 @@ export function useChatAppController(giphyApiKey: string) {
     });
   }
 
+  /** #414: jump to a pinned message from the panel — load it into the
+   * timeline if needed, then scroll/center. Stanza-id is the room
+   * archive id; message-id used in the timeline matches via wireIds /
+   * reactionTargetId. The chat client's existing
+   * `scrollToMessage(messageId)` accepts the wire id; we route the
+   * stanza-id directly since `ensureMessageLoaded` resolves both. */
+  async function jumpToPinnedMessage(stanzaId: string) {
+    await ensureActiveMessageLoaded(stanzaId);
+    await contentAreaRef.value?.scrollToMessage(stanzaId);
+  }
+
   /** Map a chat-side message id to the room's XEP-0359 stanza-id. The
-   * pin server expects the stable archive id, not the wire `id`
-   * attribute on the original message. The timeline rows carry
-   * `wireIds[]`; we use the entry that matches a known stanza-id, or
-   * fall back to the message id if it already is one. */
+   * pin server expects the stable archive id stamped by-room, not the
+   * wire `id` attribute or the client-assigned origin-id. Timeline
+   * rows expose this as `reactionTargetId` (room messages) /
+   * `replyableId` (DMs use this for reply-to); both pull from
+   * `message.stanza_id` upstream. Returns null when no archive id is
+   * known yet (e.g., a queued send hasn't been reflected). */
   function resolvePinTargetStanzaId(messageId: string): string | null {
     const message = messaging.messages.value.find((m) => m.id === messageId);
     if (!message) return null;
-    const wireIds = (message as TimelineMessage & { wireIds?: string[] }).wireIds ?? [];
-    return wireIds[0] ?? messageId;
+    const m = message as TimelineMessage & {
+      reactionTargetId?: string;
+      replyableId?: string;
+    };
+    return m.reactionTargetId ?? m.replyableId ?? null;
   }
 
   function markActiveDisplayed(messageId: string) {
@@ -969,7 +991,11 @@ export function useChatAppController(giphyApiKey: string) {
     if (ui.sidebarMode.value === "dms" && activeDmPeer.value) {
       pushDirectMessageRoute(activeDmPeer.value.peerUsername);
     } else {
-      pushChannelRoute(waddles.currentChannel.value, activeThreadStack.value);
+      pushChannelRoute(
+        waddles.currentChannel.value,
+        activeThreadStack.value,
+        ui.showPinnedPanel.value,
+      );
     }
   }
 
@@ -980,6 +1006,8 @@ export function useChatAppController(giphyApiKey: string) {
       // the stack belong to the channel we just left.
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
+      // #414: pin panel state is per-room — clear on channel switch.
+      ui.showPinnedPanel.value = false;
       exitReactionMode();
       updateUrl();
     },
@@ -989,6 +1017,10 @@ export function useChatAppController(giphyApiKey: string) {
     exitReactionMode();
     updateUrl();
   }, { deep: true });
+  // #414: any toggle of the pin panel pushes the URL state.
+  watch(() => ui.showPinnedPanel.value, () => {
+    updateUrl();
+  });
   watch(() => ui.activePage.value, () => {
     exitReactionMode();
     updateUrl();
@@ -1079,6 +1111,9 @@ export function useChatAppController(giphyApiKey: string) {
 
   async function applyRouteTarget(route: ReturnType<typeof parseChatLocation>, requestId: number) {
     ui.activePage.value = route.page;
+    // #414: sync the pin panel toggle with `?pinned=1`. Channel-only;
+    // dashboard/settings/extension/DM routes leave it false.
+    ui.showPinnedPanel.value = route.pinnedPanelOpen && route.page === "chat" && !route.dmUsername;
     if (route.page === "settings") {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
@@ -1211,6 +1246,10 @@ export function useChatAppController(giphyApiKey: string) {
     setupPromptShown = false;
     messaging.clearMessages();
     dmMessaging.clearMessages();
+    // #414: drop all pin state on logout so a subsequent login doesn't
+    // see the prior user's pinned-message previews.
+    $pinnedRooms.set(new Map());
+    ui.showPinnedPanel.value = false;
     pushChannelRoute(null);
     await connectionStore.logout();
   }
@@ -1482,6 +1521,7 @@ export function useChatAppController(giphyApiKey: string) {
       reactActiveMessage,
       pinActiveMessage,
       unpinActiveMessage,
+      jumpToPinnedMessage,
       markActiveDisplayed,
       invokeActiveExtensionAction,
       invokeExtensionRouteAction,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -828,6 +828,46 @@ export function useChatAppController(giphyApiKey: string) {
     void activeTarget.value.toggleReaction(messageId, emoji);
   }
 
+  /** #414: pin or unpin the targeted message in the active channel. The
+   * server gates on Owner/Admin affiliation; the action sheet entry is
+   * also visibility-gated client-side, so non-admins shouldn't reach
+   * this — but the server is authoritative. */
+  function pinActiveMessage(messageId: string) {
+    const client = xmppClient.value;
+    const channel = waddles.currentChannel.value;
+    const space = waddles.currentSpace.value;
+    if (!client || !channel || !space) return;
+    const stanzaId = resolvePinTargetStanzaId(messageId);
+    if (!stanzaId) return;
+    void client.pinMessage(space.id, channel.id, stanzaId).catch((error: unknown) => {
+      console.warn("pinMessage failed", error);
+    });
+  }
+
+  function unpinActiveMessage(messageId: string) {
+    const client = xmppClient.value;
+    const channel = waddles.currentChannel.value;
+    const space = waddles.currentSpace.value;
+    if (!client || !channel || !space) return;
+    const stanzaId = resolvePinTargetStanzaId(messageId);
+    if (!stanzaId) return;
+    void client.unpinMessage(space.id, channel.id, stanzaId).catch((error: unknown) => {
+      console.warn("unpinMessage failed", error);
+    });
+  }
+
+  /** Map a chat-side message id to the room's XEP-0359 stanza-id. The
+   * pin server expects the stable archive id, not the wire `id`
+   * attribute on the original message. The timeline rows carry
+   * `wireIds[]`; we use the entry that matches a known stanza-id, or
+   * fall back to the message id if it already is one. */
+  function resolvePinTargetStanzaId(messageId: string): string | null {
+    const message = messaging.messages.value.find((m) => m.id === messageId);
+    if (!message) return null;
+    const wireIds = (message as TimelineMessage & { wireIds?: string[] }).wireIds ?? [];
+    return wireIds[0] ?? messageId;
+  }
+
   function markActiveDisplayed(messageId: string) {
     activeTarget.value.markDisplayed(messageId);
   }
@@ -1440,6 +1480,8 @@ export function useChatAppController(giphyApiKey: string) {
       editActiveMessage,
       retractActiveMessage,
       reactActiveMessage,
+      pinActiveMessage,
+      unpinActiveMessage,
       markActiveDisplayed,
       invokeActiveExtensionAction,
       invokeExtensionRouteAction,

--- a/chat/src/shell/navigation.ts
+++ b/chat/src/shell/navigation.ts
@@ -8,6 +8,8 @@ interface RouteState {
   extensionRouteId: string | null;
   /** XEP-0201 thread stack from `?thread=rootId,childId,...`. Empty = panel closed. */
   threadStack: string[];
+  /** #414: pinned-messages right-rail panel (`?pinned=1`). */
+  pinnedPanelOpen: boolean;
 }
 
 const SETTINGS_PATH = "/settings";
@@ -34,10 +36,20 @@ function parseThreadStack(search: string | null | undefined): string[] {
     .filter((s) => s.length > 0);
 }
 
-function buildSearch(threadStack: string[] | undefined): string {
-  if (!threadStack || threadStack.length === 0) return "";
-  const encoded = threadStack.map((id) => encodeURIComponent(id)).join(",");
-  return `?thread=${encoded}`;
+function parsePinnedFlag(search: string | null | undefined): boolean {
+  if (!search) return false;
+  const query = search.startsWith("?") ? search.slice(1) : search;
+  return /(?:^|&)pinned=1(?:&|$)/.test(query);
+}
+
+function buildSearch(threadStack: string[] | undefined, pinnedPanelOpen?: boolean): string {
+  const parts: string[] = [];
+  if (threadStack && threadStack.length > 0) {
+    const encoded = threadStack.map((id) => encodeURIComponent(id)).join(",");
+    parts.push(`thread=${encoded}`);
+  }
+  if (pinnedPanelOpen) parts.push("pinned=1");
+  return parts.length > 0 ? `?${parts.join("&")}` : "";
 }
 
 // Parses canonical Waddle app routes.
@@ -45,6 +57,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
   const segments = pathname.split("/").filter(Boolean);
   const resolvedSearch = search ?? (typeof window !== "undefined" ? window.location.search : "");
   const threadStack = parseThreadStack(resolvedSearch);
+  const pinnedPanelOpen = parsePinnedFlag(resolvedSearch);
   if (pathname === "/" || segments.length === 0) {
     return {
       page: "dashboard",
@@ -53,6 +66,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       extensionPluginId: null,
       extensionRouteId: null,
       threadStack: [],
+      pinnedPanelOpen: false,
     };
   }
   if (pathname === SETTINGS_PATH) {
@@ -63,6 +77,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       extensionPluginId: null,
       extensionRouteId: null,
       threadStack: [],
+      pinnedPanelOpen: false,
     };
   }
   if (segments[0] === "r") {
@@ -74,6 +89,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
         extensionPluginId: decodeURIComponent(segments[3]),
         extensionRouteId: decodeURIComponent(segments[4]),
         threadStack: [],
+        pinnedPanelOpen: false,
       };
     }
     return {
@@ -83,6 +99,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       extensionPluginId: null,
       extensionRouteId: null,
       threadStack,
+      pinnedPanelOpen,
     };
   }
   if (segments[0] === "dm") {
@@ -93,6 +110,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       extensionPluginId: null,
       extensionRouteId: null,
       threadStack,
+      pinnedPanelOpen: false,
     };
   }
   return {
@@ -102,6 +120,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
     extensionPluginId: null,
     extensionRouteId: null,
     threadStack: [],
+    pinnedPanelOpen: false,
   };
 }
 
@@ -119,8 +138,9 @@ export function shouldLoadWaddleStructureForRoute(
 export function buildChannelPath(
   channel: ChannelSummary | null,
   threadStack?: string[],
+  pinnedPanelOpen?: boolean,
 ): string {
-  const search = buildSearch(threadStack);
+  const search = buildSearch(threadStack, pinnedPanelOpen);
   return channel ? `/r/${encodeURIComponent(channel.id)}${search}` : "/";
 }
 
@@ -145,8 +165,9 @@ export function buildChatSettingsPath(): string {
 export function pushChannelRoute(
   channel: ChannelSummary | null,
   threadStack?: string[],
+  pinnedPanelOpen?: boolean,
 ) {
-  const path = buildChannelPath(channel, threadStack);
+  const path = buildChannelPath(channel, threadStack, pinnedPanelOpen);
   const current = window.location.pathname + window.location.search;
   if (current !== path) {
     window.history.pushState({ waddlePage: "chat" }, "", path);

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -13,6 +13,8 @@ export function useChatShellState() {
   const showEditChannel = ref(false);
   const showWaddleSettings = ref(false);
   const showMembers = ref(false);
+  /** #414: pinned-messages right-rail panel toggle. Synced with `?pinned=1`. */
+  const showPinnedPanel = ref(false);
   const confirmDeleteWaddle = ref(false);
   const confirmDeleteChannel = ref(false);
   const showNewDm = ref(false);
@@ -39,6 +41,7 @@ export function useChatShellState() {
     showEditChannel,
     showWaddleSettings,
     showMembers,
+    showPinnedPanel,
     confirmDeleteWaddle,
     showNewDm,
     confirmDeleteChannel,

--- a/chat/src/stores/pinned-messages.ts
+++ b/chat/src/stores/pinned-messages.ts
@@ -7,7 +7,7 @@
 // `pin-event` observer in the chat-app-controller. See
 // `services/pinned-messages.ts` for the orchestration.
 
-import { atom } from "nanostores";
+import { atom, computed } from "nanostores";
 
 import type { WasmPinEntry } from "@/lib/xmpp/wasm-types";
 
@@ -22,6 +22,18 @@ interface PinnedRoomState {
 
 /** Reactive map: roomJid → PinnedRoomState. Replaced on every change. */
 export const $pinnedRooms = atom<Map<string, PinnedRoomState>>(new Map());
+
+/** Derived nanostore matching the contract specified in the #414 PRD:
+ * `Map<roomJid, Set<stanzaId>>` for cheap presence checks from
+ * MessageCard / ContentArea without exposing the richer PinnedRoomState
+ * shape. Updated whenever `$pinnedRooms` changes. */
+export const $pinnedStanzaIds = computed($pinnedRooms, (rooms) => {
+  const map = new Map<string, Set<string>>();
+  for (const [roomJid, state] of rooms) {
+    map.set(roomJid, state.stanzaIds);
+  }
+  return map;
+});
 
 type PinUpdate =
   | { action: "pinned"; target_stanza_id: string; entry?: WasmPinEntry }
@@ -57,6 +69,16 @@ export function hydratePinnedRoom(roomJid: string, entries: WasmPinEntry[]): voi
       applyPinEvent(roomJid, update);
     }
   }
+}
+
+/** Reset all pin state: empties `$pinnedRooms` and clears the
+ * pre-hydration update queue. Use this on full-session resets like
+ * logout — without clearing `pendingUpdates`, buffered events from
+ * the prior session can replay into a subsequent login's hydration
+ * and leak across users. */
+export function resetPinnedRooms(): void {
+  $pinnedRooms.set(new Map());
+  pendingUpdates.clear();
 }
 
 /** Apply a pin-event update. If the room hasn't been hydrated yet,

--- a/chat/src/stores/pinned-messages.ts
+++ b/chat/src/stores/pinned-messages.ts
@@ -45,6 +45,22 @@ type PinUpdate =
  * pin/unpin issued during initial hydration was silently dropped. */
 const pendingUpdates = new Map<string, PinUpdate[]>();
 
+/** Monotonic epoch counter for pin-state lifetime. Incremented by
+ * `resetPinnedRooms()` (logout). In-flight `fetchRoomPins` Promises
+ * capture the epoch at request time and pass it back to
+ * `hydratePinnedRoom`; if the captured epoch no longer matches the
+ * current one, the late hydration is dropped. Without this guard a
+ * fetch initiated by user A could resolve after user B logs in and
+ * leak A's pinned-message previews into B's session. */
+let currentEpoch = 0;
+
+/** Snapshot of the current epoch — call this at the start of a
+ * `fetchRoomPins` request and pass the result back to
+ * `hydratePinnedRoom`. */
+export function pinnedRoomsEpoch(): number {
+  return currentEpoch;
+}
+
 /** Replace one room's state and notify subscribers. */
 function setPinnedRoom(roomJid: string, state: PinnedRoomState): void {
   const next = new Map($pinnedRooms.get());
@@ -54,9 +70,21 @@ function setPinnedRoom(roomJid: string, state: PinnedRoomState): void {
 
 /** Hydrate the room with the full server-returned entries list. Any
  * pin/unpin events that arrived during the in-flight hydration are
- * replayed on top of the canonical list, so the final state reflects
- * both the snapshot and any concurrent mutations. */
-export function hydratePinnedRoom(roomJid: string, entries: WasmPinEntry[]): void {
+ * replayed on top of the canonical list.
+ *
+ * `epoch` is the value returned by `pinnedRoomsEpoch()` at the
+ * moment the request was issued. If `resetPinnedRooms()` ran in
+ * between (e.g. user logged out), the epoch will have advanced and
+ * this hydration is silently dropped — preventing the prior
+ * session's data from leaking back in. Pass `pinnedRoomsEpoch()`
+ * as the epoch when called from a synchronous context where no
+ * stale-callback risk exists. */
+export function hydratePinnedRoom(
+  roomJid: string,
+  entries: WasmPinEntry[],
+  epoch: number = currentEpoch,
+): void {
+  if (epoch !== currentEpoch) return;
   setPinnedRoom(roomJid, {
     entries,
     stanzaIds: new Set(entries.map((e) => e.target_stanza_id)),
@@ -71,14 +99,15 @@ export function hydratePinnedRoom(roomJid: string, entries: WasmPinEntry[]): voi
   }
 }
 
-/** Reset all pin state: empties `$pinnedRooms` and clears the
- * pre-hydration update queue. Use this on full-session resets like
- * logout — without clearing `pendingUpdates`, buffered events from
- * the prior session can replay into a subsequent login's hydration
- * and leak across users. */
+/** Reset all pin state: empties `$pinnedRooms`, clears the
+ * pre-hydration update queue, and bumps the epoch so any in-flight
+ * `fetchRoomPins` callbacks captured before the reset are dropped
+ * instead of repopulating the store. Use this on full-session
+ * resets like logout. */
 export function resetPinnedRooms(): void {
   $pinnedRooms.set(new Map());
   pendingUpdates.clear();
+  currentEpoch += 1;
 }
 
 /** Apply a pin-event update. If the room hasn't been hydrated yet,

--- a/chat/src/stores/pinned-messages.ts
+++ b/chat/src/stores/pinned-messages.ts
@@ -11,7 +11,7 @@ import { atom } from "nanostores";
 
 import type { WasmPinEntry } from "@/lib/xmpp/wasm-types";
 
-export interface PinnedRoomState {
+interface PinnedRoomState {
   /** Pin entries in pin-time-desc order, mirroring server output. */
   entries: WasmPinEntry[];
   /** Derived: stanza-ids of pinned messages for cheap presence check. */
@@ -20,42 +20,57 @@ export interface PinnedRoomState {
   hydrated: boolean;
 }
 
-export type PinnedRoomMap = Map<string, PinnedRoomState>;
-
-/** Empty state for a room that hasn't been hydrated yet. */
-export const emptyPinnedRoomState = (): PinnedRoomState => ({
-  entries: [],
-  stanzaIds: new Set(),
-  hydrated: false,
-});
-
 /** Reactive map: roomJid → PinnedRoomState. Replaced on every change. */
-export const $pinnedRooms = atom<PinnedRoomMap>(new Map());
+export const $pinnedRooms = atom<Map<string, PinnedRoomState>>(new Map());
+
+type PinUpdate =
+  | { action: "pinned"; target_stanza_id: string; entry?: WasmPinEntry }
+  | { action: "unpinned"; target_stanza_id: string };
+
+/** Pre-hydration event queue: events that arrive while
+ * `fetchRoomPins` is in flight are buffered here and replayed in
+ * order once `hydratePinnedRoom` lands. Without this, an admin's
+ * pin/unpin issued during initial hydration was silently dropped. */
+const pendingUpdates = new Map<string, PinUpdate[]>();
 
 /** Replace one room's state and notify subscribers. */
-export function setPinnedRoom(roomJid: string, state: PinnedRoomState): void {
+function setPinnedRoom(roomJid: string, state: PinnedRoomState): void {
   const next = new Map($pinnedRooms.get());
   next.set(roomJid, state);
   $pinnedRooms.set(next);
 }
 
-/** Hydrate the room with the full server-returned entries list. */
+/** Hydrate the room with the full server-returned entries list. Any
+ * pin/unpin events that arrived during the in-flight hydration are
+ * replayed on top of the canonical list, so the final state reflects
+ * both the snapshot and any concurrent mutations. */
 export function hydratePinnedRoom(roomJid: string, entries: WasmPinEntry[]): void {
   setPinnedRoom(roomJid, {
     entries,
     stanzaIds: new Set(entries.map((e) => e.target_stanza_id)),
     hydrated: true,
   });
+  const pending = pendingUpdates.get(roomJid);
+  if (pending && pending.length > 0) {
+    pendingUpdates.delete(roomJid);
+    for (const update of pending) {
+      applyPinEvent(roomJid, update);
+    }
+  }
 }
 
-/** Apply a pin-event update to a hydrated room. No-op if not hydrated:
- * the next room-entry will hydrate from scratch. */
-export function applyPinEvent(
-  roomJid: string,
-  event: { action: "pinned" | "unpinned"; target_stanza_id: string; entry?: WasmPinEntry },
-): void {
+/** Apply a pin-event update. If the room hasn't been hydrated yet,
+ * the event is queued and replayed once `hydratePinnedRoom` lands —
+ * preventing the dropped-event race when an admin pins/unpins during
+ * initial fetch. */
+export function applyPinEvent(roomJid: string, event: PinUpdate): void {
   const current = $pinnedRooms.get().get(roomJid);
-  if (!current || !current.hydrated) return;
+  if (!current || !current.hydrated) {
+    const queue = pendingUpdates.get(roomJid) ?? [];
+    queue.push(event);
+    pendingUpdates.set(roomJid, queue);
+    return;
+  }
   let entries = current.entries;
   if (event.action === "pinned") {
     const filtered = entries.filter((e) => e.target_stanza_id !== event.target_stanza_id);
@@ -70,17 +85,3 @@ export function applyPinEvent(
   });
 }
 
-/** Cheap O(1) presence check for `MessageCard.isPinned`. */
-export function isPinnedStanza(roomJid: string, stanzaId: string | undefined): boolean {
-  if (!stanzaId) return false;
-  const state = $pinnedRooms.get().get(roomJid);
-  return state?.stanzaIds.has(stanzaId) ?? false;
-}
-
-/** Drop a room's state — used on room destroy or sign-out. */
-export function clearPinnedRoom(roomJid: string): void {
-  const next = new Map($pinnedRooms.get());
-  if (next.delete(roomJid)) {
-    $pinnedRooms.set(next);
-  }
-}

--- a/chat/src/stores/pinned-messages.ts
+++ b/chat/src/stores/pinned-messages.ts
@@ -1,0 +1,86 @@
+// Per-room pinned-message state for #414. Keyed by room bare JID; each
+// room's value is the typed pin entries returned by
+// `xmpp.fetch_room_pins(...)` plus a derived stanza-id set for fast
+// `MessageCard.isPinned` lookup.
+//
+// The store is hydrated on room entry and mutated live by the
+// `pin-event` observer in the chat-app-controller. See
+// `services/pinned-messages.ts` for the orchestration.
+
+import { atom } from "nanostores";
+
+import type { WasmPinEntry } from "@/lib/xmpp/wasm-types";
+
+export interface PinnedRoomState {
+  /** Pin entries in pin-time-desc order, mirroring server output. */
+  entries: WasmPinEntry[];
+  /** Derived: stanza-ids of pinned messages for cheap presence check. */
+  stanzaIds: Set<string>;
+  /** True once the initial fetch has completed (success or empty). */
+  hydrated: boolean;
+}
+
+export type PinnedRoomMap = Map<string, PinnedRoomState>;
+
+/** Empty state for a room that hasn't been hydrated yet. */
+export const emptyPinnedRoomState = (): PinnedRoomState => ({
+  entries: [],
+  stanzaIds: new Set(),
+  hydrated: false,
+});
+
+/** Reactive map: roomJid → PinnedRoomState. Replaced on every change. */
+export const $pinnedRooms = atom<PinnedRoomMap>(new Map());
+
+/** Replace one room's state and notify subscribers. */
+export function setPinnedRoom(roomJid: string, state: PinnedRoomState): void {
+  const next = new Map($pinnedRooms.get());
+  next.set(roomJid, state);
+  $pinnedRooms.set(next);
+}
+
+/** Hydrate the room with the full server-returned entries list. */
+export function hydratePinnedRoom(roomJid: string, entries: WasmPinEntry[]): void {
+  setPinnedRoom(roomJid, {
+    entries,
+    stanzaIds: new Set(entries.map((e) => e.target_stanza_id)),
+    hydrated: true,
+  });
+}
+
+/** Apply a pin-event update to a hydrated room. No-op if not hydrated:
+ * the next room-entry will hydrate from scratch. */
+export function applyPinEvent(
+  roomJid: string,
+  event: { action: "pinned" | "unpinned"; target_stanza_id: string; entry?: WasmPinEntry },
+): void {
+  const current = $pinnedRooms.get().get(roomJid);
+  if (!current || !current.hydrated) return;
+  let entries = current.entries;
+  if (event.action === "pinned") {
+    const filtered = entries.filter((e) => e.target_stanza_id !== event.target_stanza_id);
+    entries = event.entry ? [event.entry, ...filtered] : filtered;
+  } else {
+    entries = entries.filter((e) => e.target_stanza_id !== event.target_stanza_id);
+  }
+  setPinnedRoom(roomJid, {
+    entries,
+    stanzaIds: new Set(entries.map((e) => e.target_stanza_id)),
+    hydrated: true,
+  });
+}
+
+/** Cheap O(1) presence check for `MessageCard.isPinned`. */
+export function isPinnedStanza(roomJid: string, stanzaId: string | undefined): boolean {
+  if (!stanzaId) return false;
+  const state = $pinnedRooms.get().get(roomJid);
+  return state?.stanzaIds.has(stanzaId) ?? false;
+}
+
+/** Drop a room's state — used on room destroy or sign-out. */
+export function clearPinnedRoom(roomJid: string): void {
+  const next = new Map($pinnedRooms.get());
+  if (next.delete(roomJid)) {
+    $pinnedRooms.set(next);
+  }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -66,6 +66,31 @@ impl WaddleClient {
         })
     }
 
+    /// Publish a pin request (#414). `room_jid` is the bare MUC JID;
+    /// `target_stanza_id` is the XEP-0359 `by=room` stanza-id of the
+    /// message to pin. Server gates on Owner/Admin affiliation; a
+    /// non-admin sender will receive a `<forbidden type='auth'/>`
+    /// reply via the inbound message stream.
+    pub fn pin_message(&self, room_jid: String, target_stanza_id: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza = build_pinned_message(&room_jid, &target_stanza_id);
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Publish an unpin request (#414). Same authorization rules as
+    /// [`Self::pin_message`].
+    pub fn unpin_message(&self, room_jid: String, target_stanza_id: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let stanza = build_unpinned_message(&room_jid, &target_stanza_id);
+            send_stanza_command(inner, stanza).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
     pub fn send_retraction(&self, to: String, msg_type: String, retracts_id: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -36,6 +36,25 @@ impl WaddleClient {
         })
     }
 
+    /// Fetch the current pinned-messages list for a MUC room (#414).
+    /// Resolves to a JS array of `WaddlePinEntry`. Empty array if the
+    /// room has no pins. Server gates on room occupancy: a non-occupant
+    /// caller will get a `<forbidden type='auth'/>` error which surfaces
+    /// here as a rejected Promise.
+    pub fn fetch_room_pins(&self, room_jid: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let iq = build_pin_list_iq(&room_jid);
+            let result = send_iq_command(inner, iq).await?;
+            let entries = parse_pin_list_response(&result);
+            let js_entries: Vec<WaddlePinEntry> = entries
+                .into_iter()
+                .map(crate::conversions::pin_entry_to_js)
+                .collect();
+            serde_wasm_bindgen::to_value(&js_entries).map_err(|err| js_error(err.to_string()))
+        })
+    }
+
     pub fn leave_room(&self, room_jid: String, nick: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -103,6 +103,38 @@ pub(crate) fn inbound_to_js(message: InboundMessage) -> WaddleMessage {
             .into_iter()
             .map(shared_file_to_js)
             .collect(),
+        pin_event: message.pin_event.map(pin_event_to_js),
+    }
+}
+
+pub(crate) fn pin_event_to_js(event: PinEvent) -> WaddlePinEvent {
+    WaddlePinEvent {
+        action: match event.action {
+            PinEventAction::Pinned => "pinned".to_string(),
+            PinEventAction::Unpinned => "unpinned".to_string(),
+        },
+        target_stanza_id: event.target_stanza_id,
+        by: event.by,
+        reason: event.reason,
+        preview: event.preview.map(pin_preview_to_js),
+    }
+}
+
+pub(crate) fn pin_preview_to_js(preview: PinPreview) -> WaddlePinPreview {
+    WaddlePinPreview {
+        author_jid: preview.author_jid,
+        author_nick: preview.author_nick,
+        text: preview.text,
+        message_timestamp: preview.message_timestamp.to_rfc3339(),
+    }
+}
+
+pub(crate) fn pin_entry_to_js(entry: PinEntry) -> WaddlePinEntry {
+    WaddlePinEntry {
+        target_stanza_id: entry.target_stanza_id,
+        pinner_jid: entry.pinner_jid,
+        pinned_at: entry.pinned_at.to_rfc3339(),
+        preview: pin_preview_to_js(entry.preview),
     }
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -21,14 +21,18 @@ use waddle_xmpp_client::error::parse_stanza_error;
 use waddle_xmpp_client::mam::{self, build_mam_iq, build_mam_iq_extended};
 use waddle_xmpp_client::messaging::{
     self, build_chat_state_message, build_correction_message, build_displayed_message,
-    build_moderation_message, build_outbound_message, build_reaction_message,
-    build_retraction_message, InboundMessage, InboundPresence, MarkupSpanData, MarkupSpanType,
-    MucAffiliation, MucRole, ReferenceData, SendMessageOptions, SharedFileDisposition,
+    build_moderation_message, build_outbound_message, build_pinned_message, build_reaction_message,
+    build_retraction_message, build_unpinned_message, InboundMessage, InboundPresence,
+    MarkupSpanData, MarkupSpanType, MucAffiliation, MucRole, ReferenceData, SendMessageOptions,
+    SharedFileDisposition,
 };
 use waddle_xmpp_client::pep::{
     build_pep_items_iq, build_publish_activity_iq, build_publish_mood_iq, build_publish_tune_iq,
     build_retract_activity_iq, build_retract_mood_iq, build_retract_tune_iq, parse_pep_activity,
     parse_pep_mood, parse_pep_tune,
+};
+use waddle_xmpp_client::pin::{
+    build_pin_list_iq, parse_pin_list_response, PinEntry, PinEvent, PinEventAction, PinPreview,
 };
 use waddle_xmpp_client::transport::{
     StreamClose, TransportEvent, TransportMessage, TransportState,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -44,6 +44,51 @@ pub struct WaddleMessage {
     pub forum_thread_title: Option<String>,
     pub is_sticker: bool,
     pub shared_files: Vec<WaddleSharedFile>,
+    /// urn:waddle:pin:0 pin/unpin event surfaced from a system message
+    /// (#414). `None` when the message carries no `<pin-event/>`.
+    pub pin_event: Option<WaddlePinEvent>,
+}
+
+/// Pin/unpin event surfaced from an inbound system message (#414).
+#[derive(Debug, Serialize)]
+pub struct WaddlePinEvent {
+    /// `pinned` or `unpinned`.
+    pub action: String,
+    /// XEP-0359 stanza-id of the targeted message.
+    pub target_stanza_id: String,
+    /// Bare JID of the user who applied the change.
+    pub by: String,
+    /// `Some("retracted")` when the unpin was triggered by an XEP-0424
+    /// retraction cascade.
+    pub reason: Option<String>,
+    /// Frozen preview, present only on `pinned` events.
+    pub preview: Option<WaddlePinPreview>,
+}
+
+/// One pinned-message entry returned by `fetch_room_pins` (#414).
+#[derive(Debug, Serialize)]
+pub struct WaddlePinEntry {
+    /// XEP-0359 stanza-id of the pinned message.
+    pub target_stanza_id: String,
+    /// Bare JID of the user who pinned the message.
+    pub pinner_jid: String,
+    /// When the pin was applied (rfc3339).
+    pub pinned_at: String,
+    /// Frozen preview snapshot.
+    pub preview: WaddlePinPreview,
+}
+
+/// Frozen preview of a pinned message (#414).
+#[derive(Debug, Serialize)]
+pub struct WaddlePinPreview {
+    /// Bare JID of the message author at pin time.
+    pub author_jid: String,
+    /// Author's MUC nick at pin time, if known.
+    pub author_nick: Option<String>,
+    /// Truncated body text (≤280 chars).
+    pub text: String,
+    /// Original message timestamp (rfc3339).
+    pub message_timestamp: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -13,6 +13,7 @@ pub mod event;
 pub mod mam;
 pub mod messaging;
 pub mod pep;
+pub mod pin;
 pub mod request;
 pub mod runtime;
 pub mod state;

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -5,7 +5,7 @@
 //! trait for sending those stanzas through the native client handle.
 
 mod builders;
-mod namespaces;
+pub(crate) mod namespaces;
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 mod native;
 mod parsing;
@@ -17,11 +17,11 @@ mod types;
 pub use builders::{
     build_chat_state_message, build_correction_message, build_displayed_message,
     build_file_sharing_element, build_moderation_message, build_outbound_message,
-    build_reaction_message, build_retraction_message,
+    build_pinned_message, build_reaction_message, build_retraction_message, build_unpinned_message,
 };
 pub use namespaces::{
     NS_CHAT_MARKERS, NS_CHAT_STATES, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT,
-    NS_REACTIONS,
+    NS_REACTIONS, NS_WADDLE_PIN_V0,
 };
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use native::MessagingExt;

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -61,6 +61,36 @@ pub fn build_reaction_message(
         .build()
 }
 
+/// Build a `<message><pinned target='…'/></message>` request for #414.
+/// `to` is the room bare JID; `target_stanza_id` is the XEP-0359
+/// stanza-id (`by=room`) of the message being pinned.
+pub fn build_pinned_message(to: &str, target_stanza_id: &str) -> Element {
+    Element::builder("message", NS_CLIENT)
+        .attr("to", to)
+        .attr("type", "groupchat")
+        .attr("id", Uuid::new_v4().to_string())
+        .append(
+            Element::builder("pinned", NS_WADDLE_PIN_V0)
+                .attr("target", target_stanza_id)
+                .build(),
+        )
+        .build()
+}
+
+/// Build a `<message><unpinned target='…'/></message>` request for #414.
+pub fn build_unpinned_message(to: &str, target_stanza_id: &str) -> Element {
+    Element::builder("message", NS_CLIENT)
+        .attr("to", to)
+        .attr("type", "groupchat")
+        .attr("id", Uuid::new_v4().to_string())
+        .append(
+            Element::builder("unpinned", NS_WADDLE_PIN_V0)
+                .attr("target", target_stanza_id)
+                .build(),
+        )
+        .build()
+}
+
 pub fn build_retraction_message(to: &str, message_type: &str, retracts_id: &str) -> Element {
     Element::builder("message", NS_CLIENT)
         .attr("to", to)

--- a/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/namespaces.rs
@@ -23,3 +23,4 @@ pub(crate) const NS_MUC: &str = "http://jabber.org/protocol/muc";
 pub(crate) const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
 pub(crate) const NS_STICKERS: &str = "urn:xmpp:stickers:0";
 pub(crate) const NS_VCARD_UPDATE: &str = "vcard-temp:x:update";
+pub const NS_WADDLE_PIN_V0: &str = "urn:waddle:pin:0";

--- a/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs
@@ -79,6 +79,8 @@ fn parse_message(el: &Element) -> InboundMessage {
     let reaction_target_id = reaction.as_ref().map(|payload| payload.target_id.clone());
     let reaction_emojis = reaction.map(|payload| payload.emojis).unwrap_or_default();
 
+    let pin_event = crate::pin::extract_pin_event_from_message(el);
+
     let reply_marker = xep_reply::parse_reply(el);
     let reply_to_id = reply_marker.as_ref().map(|m| m.id.clone());
     let reply_to_sender = reply_marker.as_ref().map(|m| m.to.to_string());
@@ -293,5 +295,6 @@ fn parse_message(el: &Element) -> InboundMessage {
         thread_id,
         parent_thread_id,
         is_sticker,
+        pin_event,
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -147,6 +147,9 @@ pub struct InboundMessage {
     pub thread_id: Option<String>,
     pub parent_thread_id: Option<String>,
     pub is_sticker: bool,
+    /// urn:waddle:pin:0 pin/unpin system event surfaced by the room.
+    /// `None` when the message carries no `<pin-event/>` payload.
+    pub pin_event: Option<crate::pin::PinEvent>,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/server/crates/waddle-xmpp-client/src/pin.rs
+++ b/server/crates/waddle-xmpp-client/src/pin.rs
@@ -1,0 +1,311 @@
+//! Channel pin client helpers (#414).
+//!
+//! Builders and parsers for the `urn:waddle:pin:0` IQ pin-list query
+//! and response. The wire shape is defined by the server-side PR
+//! #416; this module is the client/wasm-binding consumer.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use uuid::Uuid;
+
+use crate::messaging::namespaces::{NS_CLIENT, NS_WADDLE_PIN_V0};
+
+/// Build `<iq type='get' to='room@conf'><query xmlns='urn:waddle:pin:0'/></iq>`.
+pub fn build_pin_list_iq(room_jid: &str) -> Element {
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("to", room_jid)
+        .attr("id", Uuid::new_v4().to_string())
+        .append(Element::builder("query", NS_WADDLE_PIN_V0).build())
+        .build()
+}
+
+/// One pin entry returned by [`build_pin_list_iq`]'s response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinEntry {
+    /// XEP-0359 stanza-id of the pinned message in the room archive.
+    pub target_stanza_id: String,
+    /// Bare JID of the user who pinned the message.
+    pub pinner_jid: String,
+    /// When the pin was applied (rfc3339 from the server).
+    pub pinned_at: DateTime<Utc>,
+    /// Frozen preview snapshot.
+    pub preview: PinPreview,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinPreview {
+    /// Bare JID of the message author at pin time.
+    pub author_jid: String,
+    /// Author's MUC nick at pin time, if known.
+    pub author_nick: Option<String>,
+    /// Truncated body text (≤280 chars).
+    pub text: String,
+    /// Original message timestamp (not pin time).
+    pub message_timestamp: DateTime<Utc>,
+}
+
+/// Parse the `<query xmlns='urn:waddle:pin:0'>` payload of a pin-list
+/// IQ response into typed [`PinEntry`] values. Items missing required
+/// attributes or with malformed timestamps are skipped (logged
+/// upstream); the rest are returned in document order, which the
+/// server emits in pin-time-desc.
+pub fn parse_pin_list_response(iq: &Element) -> Vec<PinEntry> {
+    let Some(query) = iq.get_child("query", NS_WADDLE_PIN_V0) else {
+        return Vec::new();
+    };
+    query
+        .children()
+        .filter(|c| c.name() == "pin" && c.ns() == NS_WADDLE_PIN_V0)
+        .filter_map(parse_pin_entry)
+        .collect()
+}
+
+fn parse_pin_entry(elem: &Element) -> Option<PinEntry> {
+    let target_stanza_id = elem.attr("id")?.to_owned();
+    let pinner_jid = elem.attr("by")?.to_owned();
+    let pinned_at = elem
+        .attr("at")
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|t| t.with_timezone(&Utc))?;
+    let preview = elem
+        .get_child("preview", NS_WADDLE_PIN_V0)
+        .and_then(parse_pin_preview)?;
+    Some(PinEntry {
+        target_stanza_id,
+        pinner_jid,
+        pinned_at,
+        preview,
+    })
+}
+
+fn parse_pin_preview(elem: &Element) -> Option<PinPreview> {
+    let author = elem.get_child("author", NS_WADDLE_PIN_V0)?;
+    let author_jid = author.attr("jid")?.to_owned();
+    let author_nick = author.attr("nick").map(str::to_owned);
+    let text = elem
+        .get_child("text", NS_WADDLE_PIN_V0)
+        .map(|t| t.text())
+        .unwrap_or_default();
+    let message_timestamp = elem
+        .get_child("ts", NS_WADDLE_PIN_V0)
+        .map(|t| t.text())
+        .as_deref()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|t| t.with_timezone(&Utc))?;
+    Some(PinPreview {
+        author_jid,
+        author_nick,
+        text,
+        message_timestamp,
+    })
+}
+
+/// A pin/unpin event surfaced from an inbound `<message>` carrying a
+/// `<pin-event xmlns='urn:waddle:pin:0' action='pinned'|'unpinned'>`
+/// payload (the server's broadcast system message).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinEvent {
+    /// `pinned` or `unpinned`.
+    pub action: PinEventAction,
+    /// Stanza-id of the targeted message.
+    pub target_stanza_id: String,
+    /// Bare JID of the pinner/unpinner.
+    pub by: String,
+    /// `Some("retracted")` when the unpin was triggered by an
+    /// XEP-0424 retraction cascade.
+    pub reason: Option<String>,
+    /// Frozen preview, present only on `pinned` events.
+    pub preview: Option<PinPreview>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinEventAction {
+    Pinned,
+    Unpinned,
+}
+
+/// Parse a `<pin-event/>` element into a typed [`PinEvent`]. Returns
+/// `None` for malformed events.
+pub fn parse_pin_event_payload(elem: &Element) -> Option<PinEvent> {
+    if elem.name() != "pin-event" || elem.ns() != NS_WADDLE_PIN_V0 {
+        return None;
+    }
+    let action = match elem.attr("action")? {
+        "pinned" => PinEventAction::Pinned,
+        "unpinned" => PinEventAction::Unpinned,
+        _ => return None,
+    };
+    let target_stanza_id = elem.attr("target")?.to_owned();
+    let by = elem.attr("by")?.to_owned();
+    let reason = elem.attr("reason").map(str::to_owned);
+    let preview = elem
+        .get_child("preview", NS_WADDLE_PIN_V0)
+        .and_then(parse_pin_preview);
+    Some(PinEvent {
+        action,
+        target_stanza_id,
+        by,
+        reason,
+        preview,
+    })
+}
+
+/// Extract the first `<pin-event/>` payload from a `<message>` (the
+/// system messages the server broadcasts on pin/unpin). Returns
+/// `None` when the message carries no pin-event.
+pub fn extract_pin_event_from_message(message: &Element) -> Option<PinEvent> {
+    message
+        .children()
+        .filter(|c| c.name() == "pin-event" && c.ns() == NS_WADDLE_PIN_V0)
+        .find_map(parse_pin_event_payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pin_query_response_xml() -> &'static str {
+        r#"<iq xmlns='jabber:client' type='result' id='abc'>
+          <query xmlns='urn:waddle:pin:0'>
+            <pin id='stanza-1' by='admin@example.com' at='2026-05-08T12:00:00+00:00'>
+              <preview>
+                <author jid='alice@example.com' nick='alice'/>
+                <text>important update</text>
+                <ts>2026-05-08T11:55:00+00:00</ts>
+              </preview>
+            </pin>
+            <pin id='stanza-2' by='admin@example.com' at='2026-05-08T11:30:00+00:00'>
+              <preview>
+                <author jid='bob@example.com'/>
+                <text>another message</text>
+                <ts>2026-05-08T11:25:00+00:00</ts>
+              </preview>
+            </pin>
+          </query>
+        </iq>"#
+    }
+
+    #[test]
+    fn build_pin_list_iq_targets_room_with_query_payload() {
+        let iq = build_pin_list_iq("room@conf.example");
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("room@conf.example"));
+        assert!(iq.attr("id").is_some());
+        let query = iq
+            .get_child("query", NS_WADDLE_PIN_V0)
+            .expect("query payload");
+        assert_eq!(query.children().count(), 0);
+    }
+
+    #[test]
+    fn parse_pin_list_response_returns_typed_entries() {
+        let iq: Element = pin_query_response_xml().parse().expect("parse iq");
+        let entries = parse_pin_list_response(&iq);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].target_stanza_id, "stanza-1");
+        assert_eq!(entries[0].pinner_jid, "admin@example.com");
+        assert_eq!(entries[0].preview.author_jid, "alice@example.com");
+        assert_eq!(entries[0].preview.author_nick.as_deref(), Some("alice"));
+        assert_eq!(entries[0].preview.text, "important update");
+        assert_eq!(entries[1].target_stanza_id, "stanza-2");
+        assert!(entries[1].preview.author_nick.is_none());
+    }
+
+    #[test]
+    fn parse_pin_list_response_skips_malformed_entries() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'>\
+          <query xmlns='urn:waddle:pin:0'>\
+            <pin id='ok' by='admin@example.com' at='2026-05-08T12:00:00+00:00'>\
+              <preview><author jid='alice@example.com'/><text>ok</text>\
+              <ts>2026-05-08T11:55:00+00:00</ts></preview></pin>\
+            <pin by='admin@example.com'></pin>\
+            <pin id='bad-ts' by='admin@example.com' at='not-a-date'>\
+              <preview><author jid='x@y'/><text></text><ts>also-bad</ts></preview>\
+            </pin>\
+          </query>\
+        </iq>"
+            .parse()
+            .expect("parse iq");
+        let entries = parse_pin_list_response(&iq);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].target_stanza_id, "ok");
+    }
+
+    #[test]
+    fn parse_pin_list_response_empty_when_no_query() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
+            .parse()
+            .expect("parse iq");
+        assert!(parse_pin_list_response(&iq).is_empty());
+    }
+
+    fn pin_event_message_xml(action: &str) -> String {
+        format!(
+            r#"<message xmlns='jabber:client' type='groupchat' from='room@conf.example'>
+              <body>alice {action} a message</body>
+              <pin-event xmlns='urn:waddle:pin:0' action='{action}' target='stanza-1' by='admin@example.com'>
+                <preview>
+                  <author jid='alice@example.com' nick='alice'/>
+                  <text>important</text>
+                  <ts>2026-05-08T11:55:00+00:00</ts>
+                </preview>
+              </pin-event>
+            </message>"#,
+            action = action
+        )
+    }
+
+    #[test]
+    fn extract_pin_event_decodes_pinned_with_preview() {
+        let msg: Element = pin_event_message_xml("pinned").parse().expect("parse msg");
+        let event = extract_pin_event_from_message(&msg).expect("event present");
+        assert_eq!(event.action, PinEventAction::Pinned);
+        assert_eq!(event.target_stanza_id, "stanza-1");
+        assert_eq!(event.by, "admin@example.com");
+        assert!(event.reason.is_none());
+        assert!(event.preview.is_some());
+    }
+
+    #[test]
+    fn extract_pin_event_decodes_unpinned_without_preview() {
+        let msg: Element = "<message xmlns='jabber:client' type='groupchat' from='r@x'>\
+          <pin-event xmlns='urn:waddle:pin:0' action='unpinned' target='s' by='a@b'/>\
+        </message>"
+            .parse()
+            .expect("parse msg");
+        let event = extract_pin_event_from_message(&msg).expect("event present");
+        assert_eq!(event.action, PinEventAction::Unpinned);
+        assert!(event.preview.is_none());
+    }
+
+    #[test]
+    fn extract_pin_event_decodes_retracted_reason() {
+        let msg: Element = "<message xmlns='jabber:client' type='groupchat' from='r@x'>\
+          <pin-event xmlns='urn:waddle:pin:0' action='unpinned' target='s' by='a@b' reason='retracted'/>\
+        </message>"
+            .parse()
+            .expect("parse msg");
+        let event = extract_pin_event_from_message(&msg).expect("event present");
+        assert_eq!(event.reason.as_deref(), Some("retracted"));
+    }
+
+    #[test]
+    fn extract_pin_event_returns_none_for_unrelated_message() {
+        let msg: Element = "<message xmlns='jabber:client' type='groupchat' from='r@x'>\
+          <body>just chatter</body>\
+        </message>"
+            .parse()
+            .expect("parse msg");
+        assert!(extract_pin_event_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn parse_pin_event_rejects_unknown_action() {
+        let elem: Element =
+            "<pin-event xmlns='urn:waddle:pin:0' action='bogus' target='s' by='a@b'/>"
+                .parse()
+                .expect("parse elem");
+        assert!(parse_pin_event_payload(&elem).is_none());
+    }
+}

--- a/server/crates/waddle-xmpp-client/src/pin.rs
+++ b/server/crates/waddle-xmpp-client/src/pin.rs
@@ -240,25 +240,39 @@ mod tests {
         assert!(parse_pin_list_response(&iq).is_empty());
     }
 
-    fn pin_event_message_xml(action: &str) -> String {
-        format!(
-            r#"<message xmlns='jabber:client' type='groupchat' from='room@conf.example'>
-              <body>alice {action} a message</body>
-              <pin-event xmlns='urn:waddle:pin:0' action='{action}' target='stanza-1' by='admin@example.com'>
-                <preview>
-                  <author jid='alice@example.com' nick='alice'/>
-                  <text>important</text>
-                  <ts>2026-05-08T11:55:00+00:00</ts>
-                </preview>
-              </pin-event>
-            </message>"#,
-            action = action
-        )
+    fn build_pin_event_message(action: &str) -> Element {
+        let author = Element::builder("author", NS_WADDLE_PIN_V0)
+            .attr("jid", "alice@example.com")
+            .attr("nick", "alice")
+            .build();
+        let mut text = Element::builder("text", NS_WADDLE_PIN_V0).build();
+        text.append_text_node("important");
+        let mut ts = Element::builder("ts", NS_WADDLE_PIN_V0).build();
+        ts.append_text_node("2026-05-08T11:55:00+00:00");
+        let preview = Element::builder("preview", NS_WADDLE_PIN_V0)
+            .append(author)
+            .append(text)
+            .append(ts)
+            .build();
+        let pin_event = Element::builder("pin-event", NS_WADDLE_PIN_V0)
+            .attr("action", action)
+            .attr("target", "stanza-1")
+            .attr("by", "admin@example.com")
+            .append(preview)
+            .build();
+        let mut body = Element::builder("body", "jabber:client").build();
+        body.append_text_node(format!("alice {action} a message"));
+        Element::builder("message", "jabber:client")
+            .attr("type", "groupchat")
+            .attr("from", "room@conf.example")
+            .append(body)
+            .append(pin_event)
+            .build()
     }
 
     #[test]
     fn extract_pin_event_decodes_pinned_with_preview() {
-        let msg: Element = pin_event_message_xml("pinned").parse().expect("parse msg");
+        let msg = build_pin_event_message("pinned");
         let event = extract_pin_event_from_message(&msg).expect("event present");
         assert_eq!(event.action, PinEventAction::Pinned);
         assert_eq!(event.target_stanza_id, "stanza-1");

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -17,6 +17,14 @@ export class WaddleClient {
     fetch_room_history(room_jid: string, max: number, before_id?: string | null): Promise<any>;
     fetch_room_history_by_thread(room_jid: string, thread_id: string, max: number, before_id?: string | null): Promise<any>;
     fetch_room_history_page(room_jid: string, max: number, page_param: any): Promise<any>;
+    /**
+     * Fetch the current pinned-messages list for a MUC room (#414).
+     * Resolves to a JS array of `WaddlePinEntry`. Empty array if the
+     * room has no pins. Server gates on room occupancy: a non-occupant
+     * caller will get a `<forbidden type='auth'/>` error which surfaces
+     * here as a rejected Promise.
+     */
+    fetch_room_pins(room_jid: string): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
     get_server_version(): Promise<any>;
     join_room(room_jid: string, nick: string): Promise<any>;
@@ -26,6 +34,14 @@ export class WaddleClient {
     list_roster_contacts(): Promise<any>;
     mark_inbox_read(partner_jid: string, thread_id?: string | null): Promise<any>;
     constructor(config: WaddleConfig);
+    /**
+     * Publish a pin request (#414). `room_jid` is the bare MUC JID;
+     * `target_stanza_id` is the XEP-0359 `by=room` stanza-id of the
+     * message to pin. Server gates on Owner/Admin affiliation; a
+     * non-admin sender will receive a `<forbidden type='auth'/>`
+     * reply via the inbound message stream.
+     */
+    pin_message(room_jid: string, target_stanza_id: string): Promise<any>;
     publish_activity(activity_json: any): Promise<any>;
     publish_mood(mood_json: any): Promise<any>;
     publish_tune(tune_json: any): Promise<any>;
@@ -57,6 +73,11 @@ export class WaddleClient {
     set_on_session_lifecycle(cb: Function): void;
     set_room_affiliation(room_jid: string, jid: string, affiliation: string): Promise<any>;
     subscribe_to_presence(peer_jid: string): Promise<any>;
+    /**
+     * Publish an unpin request (#414). Same authorization rules as
+     * [`Self::pin_message`].
+     */
+    unpin_message(room_jid: string, target_stanza_id: string): Promise<any>;
 }
 
 export class WaddleConfig {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mouuxfuk";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mowuco4k";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mowuco4k";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mowuco4k";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mouuxfuk";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mowuco4k";


### PR DESCRIPTION
Chat-side of #414. Builds on the merged server foundation in #416 (\`urn:waddle:pin:0\` wire shape, pin-list IQ, \`<pin-event>\` system messages).

## What ships

### Wasm bindings (`server/crates/waddle-xmpp-client*`)
- New typed builders \`build_pinned_message\` / \`build_unpinned_message\`.
- New \`pin\` module: \`build_pin_list_iq\` / \`parse_pin_list_response\`, \`PinEntry\` / \`PinPreview\` / \`PinEvent\` / \`PinEventAction\` types, \`extract_pin_event_from_message\`.
- \`InboundMessage\` carries \`Option<PinEvent>\`; parsing wires it via \`pin::extract_pin_event_from_message\`.
- New \`#[wasm_bindgen]\` methods: \`pin_message\`, \`unpin_message\`, \`fetch_room_pins\`. \`WaddleMessage\` carries \`pin_event\`. New typed JS structs \`WaddlePinEvent\` / \`WaddlePinPreview\` / \`WaddlePinEntry\`.

### Chat (`chat/src/`)
- **PinnedPanel.vue** — right-rail panel, sibling of \`ThreadPanel\`, mounted in \`ChatReadyShell\`. Loading / empty / list states. Click or Enter on an entry calls \`jumpToPinnedMessage\` which loads + scrolls.
- **\`?pinned=1\` URL state** — parsed in \`navigation.ts\`, threaded through \`buildChannelPath\` / \`pushChannelRoute\`, applied in \`applyRouteTarget\`, channel-switch resets, header toggle pushes.
- **Pin icon button** in \`ChatHeader\` toggling the panel.
- **Pin badge in MessageCard** meta row when \`isPinned\`. New \`canPinMessages\` prop gates the action affordances on the user's Owner/Admin hats.
- **"Pin to channel" / "Unpin" entries** in both the desktop hover toolbar and the touch action sheet.
- **\`pinnedStanzaIds\` nanostore** (\`stores/pinned-messages.ts\`) hydrated on room entry via \`fetchRoomPins\`, mutated live by the inbound \`pin-event\` observer. Pre-hydration events are buffered and replayed (no dropped-event race).
- **Logout** resets \`$pinnedRooms\` so prior session's previews don't leak.
- **fetchRoomPins error UX** — on \`<forbidden/>\` / network failure, the panel still exits its "Loading…" state by hydrating with an empty list.

## Hard-rule compliance

- **Bun-only** for chat-side scripts.
- **No \`format!\` XML** — outbound builders use \`xmpp_parsers\` / \`minidom::Element\`.
- **Typed payloads** — \`PinEntry\`, \`PinEvent\`, \`PinPreview\` are typed Rust structs; \`WaddlePinEntry\` etc. are typed JS structs; \`WasmPinEntry\` etc. are typed TypeScript interfaces. No JSON-blob shuffling at boundaries.
- **knip clean.** **\`bun run lint\` clean.** **\`bunx astro check\`** clean (one pre-existing unrelated \`cloudflare:workers\` type error). **\`bun test\`** 395/396 (one pre-existing dist failure that needs \`astro build\`).

## Adversarial review

After CI went green, ran a parallel adversarial-review pass with two lenses (security/correctness + UX/architecture). Surfaced and fixed in \`2e3958b0\`:

| Severity | Issue | Resolution |
|---|---|---|
| P0 | Pin action affordance was unreachable: gate checked \`urn:xmpp:hats:0:owner\` vs the actual \`urn:xmpp:hats:owner\` URIs everywhere else in the codebase | Matched URI format; pin entry now renders for legitimate admins |
| P1 | \`resolvePinTargetStanzaId\` returned the wire \`id\` (\`wireIds[0]\`) not the XEP-0359 by=room stanza-id | Switched to \`reactionTargetId ?? replyableId\` (both mirror \`message.stanza_id\`); returns null for un-reflected sends |
| P2 | Pin events received during initial \`fetchRoomPins\` were silently dropped | Per-room pre-hydration queue; replayed after \`hydratePinnedRoom\` |
| P3 | \`?pinned=1\` URL plumbing was orphan-parsed but never pushed/applied | Wired through \`currentChatPath\`, \`updateUrl\`, \`applyRouteTarget\`, channel-switch reset, and a \`watch(ui.showPinnedPanel) → updateUrl\` |
| | Panel stuck on "Loading…" when \`fetchRoomPins\` rejected | Catch hydrates with \`[]\` |
| | PinnedPanel jump-to-message didn't scroll | New controller \`jumpToPinnedMessage\` chains ensureLoaded + \`scrollToMessage\` |
| | Desktop hover toolbar lacked a pin button | Added Pin/PinOff entry there too |
| | Pin state leaked across logins | \`handleLogout\` clears \`$pinnedRooms\` |

## Out of scope

- Per-room pin-permission config (\`urn:waddle:roomconfig:pinpermission\`) → #415 (blocked on this PR).
- Personal "Saved messages" → separate issue.
- \`PinnedPanel\` mobile drawer treatment — currently inherits the right-rail mount; refinements are a follow-up.