### PR TITLE
feat(chat): restore slash command entry point (#399)

### DIFF
--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -189,47 +189,49 @@ export function useExtensionLauncher(input: {
   async function dispatchSlashInvocation(invocation: SlashInvocation) {
     const client = input.xmppClient.value;
     if (!client) return;
-    if (invocation.kind === "open-palette") {
-      open.value = true;
-      void nextTick(input.focusPalette);
-      const key = invocation.command.node;
-      clearCommandSurfaces(key);
-      commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
-      try {
-        const result = await client.invokeExtensionCommand(invocation.command);
-        storeResultSurfaces(key, result);
-        commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
-        if (invocation.prefillFirstRequired) {
-          const form = commandForms.value[key];
-          const target = form?.fields.find((field) => field.required && !field.hidden);
-          if (target) {
-            updateField(key, target.name, [invocation.prefillFirstRequired]);
-          }
-        }
-      } catch (error) {
-        commandStates.value = {
-          ...commandStates.value,
-          [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
-        };
-      }
-      return;
-    }
-
-    // inline-submit: invoke the command, set the inline field, submit.
     const command = invocation.command;
     const key = command.node;
+    const wantsPalette = invocation.kind === "open-palette";
+
     clearCommandSurfaces(key);
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
+    if (wantsPalette) {
+      open.value = true;
+      void nextTick(input.focusPalette);
+    }
+
     try {
       const result = await client.invokeExtensionCommand(command);
       storeResultSurfaces(key, result);
       const form = commandForms.value[key];
-      if (!form) {
+
+      if (invocation.kind === "open-palette") {
         commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
+        if (invocation.prefillFirstRequired && form) {
+          const target = form.fields.find((field) => field.required && !field.hidden);
+          if (target) {
+            updateField(key, target.name, [invocation.prefillFirstRequired]);
+          }
+        }
         return;
       }
-      updateField(key, invocation.fieldName, [invocation.value]);
-      await submitForm(command, "complete");
+
+      // inline-submit only stays inline if the server returned a single-stage
+      // form whose advertised XEP-0050 actions include `complete`. Otherwise
+      // fall back to the palette so the user can drive the multi-stage flow.
+      const allowed = form?.actions ?? [];
+      if (form && allowed.includes("complete")) {
+        updateField(key, invocation.fieldName, [invocation.value]);
+        await submitForm(command, "complete");
+        return;
+      }
+
+      commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
+      if (form) {
+        updateField(key, invocation.fieldName, [invocation.value]);
+        open.value = true;
+        void nextTick(input.focusPalette);
+      }
     } catch (error) {
       commandStates.value = {
         ...commandStates.value,

--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -85,8 +85,9 @@ export function useExtensionLauncher(input: {
   }
 
   let discoveryPromise: Promise<void> | null = null;
+  let discoveryAttempted = false;
   async function ensureDiscovered() {
-    if (commands.value.length > 0) return;
+    if (commands.value.length > 0 || discoveryAttempted) return;
     if (discoveryPromise) {
       await discoveryPromise;
       return;
@@ -98,6 +99,7 @@ export function useExtensionLauncher(input: {
     discoveryPromise = (async () => {
       try {
         commands.value = await client.discoverExtensionCommands();
+        discoveryAttempted = true;
         state.value = "idle";
         if (commands.value.length === 0) detail.value = "No extension commands discovered.";
       } catch (error) {
@@ -165,6 +167,7 @@ export function useExtensionLauncher(input: {
     commandStates.value = {};
     commandForms.value = {};
     commandActions.value = {};
+    discoveryAttempted = false;
   }
 
   async function submitForm(command: DiscoveredExtensionCommand, action: ExtensionCommandAction = "complete") {
@@ -186,9 +189,15 @@ export function useExtensionLauncher(input: {
     }
   }
 
-  async function dispatchSlashInvocation(invocation: SlashInvocation) {
+  async function dispatchSlashInvocation(invocation: SlashInvocation): Promise<boolean> {
     const client = input.xmppClient.value;
-    if (!client) return;
+    if (!client) {
+      state.value = "error";
+      detail.value = "Extensions are unavailable while XMPP is disconnected.";
+      open.value = true;
+      void nextTick(input.focusPalette);
+      return false;
+    }
     const command = invocation.command;
     const key = command.node;
     const wantsPalette = invocation.kind === "open-palette";
@@ -213,7 +222,7 @@ export function useExtensionLauncher(input: {
             updateField(key, target.name, [invocation.prefillFirstRequired]);
           }
         }
-        return;
+        return true;
       }
 
       // inline-submit only stays inline if the server returned a single-stage
@@ -223,7 +232,7 @@ export function useExtensionLauncher(input: {
       if (form && allowed.includes("complete")) {
         updateField(key, invocation.fieldName, [invocation.value]);
         await submitForm(command, "complete");
-        return;
+        return true;
       }
 
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
@@ -232,11 +241,13 @@ export function useExtensionLauncher(input: {
         open.value = true;
         void nextTick(input.focusPalette);
       }
+      return true;
     } catch (error) {
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
       };
+      return false;
     }
   }
 

--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -10,6 +10,7 @@ import {
   type ExtensionCommandFormField,
   type ExtensionCommandResult,
 } from "@/lib/xmpp/extension-commands";
+import type { SlashInvocation } from "@/lib/slash-dispatch";
 
 type ExtensionLauncherState = "idle" | "loading" | "error";
 type ExtensionCommandUiState = "loading" | "success" | "warning" | "error";
@@ -83,26 +84,43 @@ export function useExtensionLauncher(input: {
     commandForms.value = nextForms;
   }
 
+  let discoveryPromise: Promise<void> | null = null;
+  async function ensureDiscovered() {
+    if (commands.value.length > 0) return;
+    if (discoveryPromise) {
+      await discoveryPromise;
+      return;
+    }
+    const client = input.xmppClient.value;
+    if (!client) return;
+    state.value = "loading";
+    detail.value = "";
+    discoveryPromise = (async () => {
+      try {
+        commands.value = await client.discoverExtensionCommands();
+        state.value = "idle";
+        if (commands.value.length === 0) detail.value = "No extension commands discovered.";
+      } catch (error) {
+        state.value = "error";
+        detail.value = error instanceof Error ? error.message : "Could not discover extension commands.";
+      } finally {
+        discoveryPromise = null;
+      }
+    })();
+    await discoveryPromise;
+  }
+
   async function toggle() {
     open.value = !open.value;
     if (open.value) void nextTick(input.focusPalette);
-    if (!open.value || commands.value.length > 0) return;
+    if (!open.value) return;
     const client = input.xmppClient.value;
     if (!client) {
       state.value = "error";
       detail.value = "Extensions are unavailable while XMPP is disconnected.";
       return;
     }
-    state.value = "loading";
-    detail.value = "";
-    try {
-      commands.value = await client.discoverExtensionCommands();
-      state.value = "idle";
-      if (commands.value.length === 0) detail.value = "No extension commands discovered.";
-    } catch (error) {
-      state.value = "error";
-      detail.value = error instanceof Error ? error.message : "Could not discover extension commands.";
-    }
+    await ensureDiscovered();
   }
 
   async function invokeCommand(command: DiscoveredExtensionCommand) {
@@ -168,6 +186,58 @@ export function useExtensionLauncher(input: {
     }
   }
 
+  async function dispatchSlashInvocation(invocation: SlashInvocation) {
+    const client = input.xmppClient.value;
+    if (!client) return;
+    if (invocation.kind === "open-palette") {
+      open.value = true;
+      void nextTick(input.focusPalette);
+      const key = invocation.command.node;
+      clearCommandSurfaces(key);
+      commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
+      try {
+        const result = await client.invokeExtensionCommand(invocation.command);
+        storeResultSurfaces(key, result);
+        commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
+        if (invocation.prefillFirstRequired) {
+          const form = commandForms.value[key];
+          const target = form?.fields.find((field) => field.required && !field.hidden);
+          if (target) {
+            updateField(key, target.name, [invocation.prefillFirstRequired]);
+          }
+        }
+      } catch (error) {
+        commandStates.value = {
+          ...commandStates.value,
+          [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
+        };
+      }
+      return;
+    }
+
+    // inline-submit: invoke the command, set the inline field, submit.
+    const command = invocation.command;
+    const key = command.node;
+    clearCommandSurfaces(key);
+    commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
+    try {
+      const result = await client.invokeExtensionCommand(command);
+      storeResultSurfaces(key, result);
+      const form = commandForms.value[key];
+      if (!form) {
+        commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
+        return;
+      }
+      updateField(key, invocation.fieldName, [invocation.value]);
+      await submitForm(command, "complete");
+    } catch (error) {
+      commandStates.value = {
+        ...commandStates.value,
+        [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension command failed." },
+      };
+    }
+  }
+
   async function invokeResultAction(command: DiscoveredExtensionCommand, action: ExtensionAnnotationAction) {
     const invokeExtensionAction = input.invokeExtensionAction.value;
     if (!invokeExtensionAction) return;
@@ -196,10 +266,12 @@ export function useExtensionLauncher(input: {
     commandActions,
     close,
     toggle,
+    ensureDiscovered,
     invokeCommand,
     updateField,
     reset,
     submitForm,
     invokeResultAction,
+    dispatchSlashInvocation,
   };
 }

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -303,6 +303,7 @@ const extensionLauncher = useExtensionLauncher({
 const extensionLauncherOpen = extensionLauncher.open;
 const extensionLauncherState = extensionLauncher.state;
 const extensionLauncherDetail = extensionLauncher.detail;
+const allDiscoveredCommands = extensionLauncher.commands;
 const availableExtensionCommands = extensionLauncher.availableCommands;
 const extensionCommandStates = extensionLauncher.commandStates;
 const extensionCommandForms = extensionLauncher.commandForms;
@@ -313,6 +314,16 @@ const updateExtensionCommandField = extensionLauncher.updateField;
 const resetExtensionLauncherState = extensionLauncher.reset;
 const submitExtensionCommandForm = extensionLauncher.submitForm;
 const invokeCommandResultAction = extensionLauncher.invokeResultAction;
+const dispatchSlashCommand = extensionLauncher.dispatchSlashInvocation;
+const inMucContext = computed(() => !!props.roomJid);
+
+watch(
+  () => props.xmppClient,
+  (client) => {
+    if (client) void extensionLauncher.ensureDiscovered();
+  },
+  { immediate: true },
+);
 const showSearch = ref(false);
 const searchInput = ref("");
 const searchSubmitted = ref(false);
@@ -901,11 +912,14 @@ function dayDividerLabel(createdAt: string): string {
       :replying-to="replyingTo"
       :is-top-pinned="true"
       :extensions-open="extensionLauncherOpen"
+      :slash-commands="allDiscoveredCommands"
+      :in-muc="inMucContext"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="onSelectGif"
       @open-extensions="openExtensionLauncher"
+      @dispatch-slash="dispatchSlashCommand"
     />
 
     <ExtensionPalette
@@ -1120,11 +1134,14 @@ function dayDividerLabel(createdAt: string): string {
       :upload-progress="uploadProgress"
       :replying-to="replyingTo"
       :extensions-open="extensionLauncherOpen"
+      :slash-commands="allDiscoveredCommands"
+      :in-muc="inMucContext"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="onSelectGif"
       @open-extensions="openExtensionLauncher"
+      @dispatch-slash="dispatchSlashCommand"
     />
     <ExtensionPalette
       v-if="extensionLauncherOpen && !isTopPinned"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -314,7 +314,13 @@ const updateExtensionCommandField = extensionLauncher.updateField;
 const resetExtensionLauncherState = extensionLauncher.reset;
 const submitExtensionCommandForm = extensionLauncher.submitForm;
 const invokeCommandResultAction = extensionLauncher.invokeResultAction;
-const dispatchSlashCommand = extensionLauncher.dispatchSlashInvocation;
+async function dispatchSlashCommand(invocation: Parameters<typeof extensionLauncher.dispatchSlashInvocation>[0]) {
+  const ok = await extensionLauncher.dispatchSlashInvocation(invocation);
+  if (ok) {
+    draft.value = "";
+    if (isForumChannel.value) forumTitle.value = "";
+  }
+}
 const inMucContext = computed(() => !!props.roomJid);
 
 watch(

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -314,12 +314,15 @@ const updateExtensionCommandField = extensionLauncher.updateField;
 const resetExtensionLauncherState = extensionLauncher.reset;
 const submitExtensionCommandForm = extensionLauncher.submitForm;
 const invokeCommandResultAction = extensionLauncher.invokeResultAction;
-async function dispatchSlashCommand(invocation: Parameters<typeof extensionLauncher.dispatchSlashInvocation>[0]) {
+async function dispatchSlashCommand(
+  invocation: Parameters<typeof extensionLauncher.dispatchSlashInvocation>[0],
+): Promise<boolean> {
   const ok = await extensionLauncher.dispatchSlashInvocation(invocation);
   if (ok) {
     draft.value = "";
     if (isForumChannel.value) forumTitle.value = "";
   }
+  return ok;
 }
 const inMucContext = computed(() => !!props.roomJid);
 
@@ -920,12 +923,12 @@ function dayDividerLabel(createdAt: string): string {
       :extensions-open="extensionLauncherOpen"
       :slash-commands="allDiscoveredCommands"
       :in-muc="inMucContext"
+      :dispatch-slash-command="dispatchSlashCommand"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="onSelectGif"
       @open-extensions="openExtensionLauncher"
-      @dispatch-slash="dispatchSlashCommand"
     />
 
     <ExtensionPalette
@@ -1142,12 +1145,12 @@ function dayDividerLabel(createdAt: string): string {
       :extensions-open="extensionLauncherOpen"
       :slash-commands="allDiscoveredCommands"
       :in-muc="inMucContext"
+      :dispatch-slash-command="dispatchSlashCommand"
       @send="onSend"
       @cancel-reply="cancelReply"
       @typing="emit('typing')"
       @select-gif="onSelectGif"
       @open-extensions="openExtensionLauncher"
-      @dispatch-slash="dispatchSlashCommand"
     />
     <ExtensionPalette
       v-if="extensionLauncherOpen && !isTopPinned"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -76,7 +76,7 @@ const showEmoji = ref(false);
 const showSlash = ref(false);
 const slashPrefix = ref("");
 const slashTrailing = ref("");
-const slashDismissed = ref(false);
+const dismissedSlashPrefix = ref<string | null>(null);
 const mentionQuery = ref("");
 const emojiQuery = ref("");
 const selectedIndex = ref(0);
@@ -294,12 +294,19 @@ function checkAutocompleteFromEditor() {
   }
   showEmoji.value = false;
 
+  // Slash autocomplete is anchored to paragraph 0; if the cursor is in a
+  // later paragraph, an earlier `/word` must not arm the slash submit path.
+  const firstChild = doc.firstChild;
+  const cursorInFirstParagraph =
+    !!firstChild && firstChild.type?.name === "paragraph" && pos > 0 && pos <= firstChild.nodeSize - 1;
+
   const firstParagraph = firstParagraphTextFromDoc(doc);
-  const slash = parseSlashTrigger(firstParagraph);
+  const slash = cursorInFirstParagraph ? parseSlashTrigger(firstParagraph) : null;
   if (slash) {
-    if (slashDismissed.value) {
+    if (dismissedSlashPrefix.value !== null && dismissedSlashPrefix.value === slash.prefix) {
       showSlash.value = false;
     } else {
+      dismissedSlashPrefix.value = null;
       slashPrefix.value = slash.prefix;
       slashTrailing.value = slash.trailing;
       selectedIndex.value = 0;
@@ -311,7 +318,7 @@ function checkAutocompleteFromEditor() {
     return;
   }
 
-  slashDismissed.value = false;
+  dismissedSlashPrefix.value = null;
   showSlash.value = false;
   triggerRange.value = null;
 }
@@ -361,10 +368,12 @@ function expandSlashCandidate(command: DiscoveredExtensionCommand) {
 function dispatchSlashResolution(): boolean {
   const command = slashResolution.value;
   if (!command) return false;
+  // Forum channels demand a title; don't smuggle a slash dispatch past that gate.
+  if (showForumTitleInput.value && !forumTitle.value.trim()) return true;
   const invocation = buildSlashInvocation(command, slashTrailing.value);
   emit("dispatchSlash", invocation);
   showSlash.value = false;
-  slashDismissed.value = false;
+  dismissedSlashPrefix.value = null;
   triggerRange.value = null;
   // Caller resets the editor draft after the launcher accepts the invocation.
   return true;
@@ -466,7 +475,7 @@ function onEditorCancel() {
 
   if (action === "dismiss-slash") {
     showSlash.value = false;
-    slashDismissed.value = true;
+    dismissedSlashPrefix.value = slashPrefix.value;
     return;
   }
 

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -5,11 +5,16 @@ import type { JSONContent } from "@tiptap/core";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
+import SlashCommandPopover from "@/components/chat/SlashCommandPopover.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { getComposerAutocompleteAction, getComposerEscapeAction } from "@/lib/reply-ux";
 import { tiptapToRichMessage } from "@/lib/rich-message";
 import { extractImagesFromClipboardEvent } from "@/lib/xmpp/file-upload";
 import type { MentionCandidate } from "@/lib/mentions";
+import { parseSlashTrigger } from "@/lib/slash-trigger";
+import { filterSlashCandidates, resolveSlashCommand } from "@/lib/slash-match";
+import { buildSlashInvocation, type SlashInvocation } from "@/lib/slash-dispatch";
+import type { DiscoveredExtensionCommand } from "@/lib/xmpp/extension-commands";
 import {
   isAudioFile,
   isImageFile,
@@ -46,6 +51,8 @@ const props = defineProps<{
   replyingTo?: { id: string; author: string; preview?: string } | null;
   isTopPinned?: boolean;
   extensionsOpen?: boolean;
+  slashCommands?: DiscoveredExtensionCommand[];
+  inMuc?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -54,6 +61,7 @@ const emit = defineEmits<{
   selectGif: [url: string];
   cancelReply: [];
   openExtensions: [];
+  dispatchSlash: [invocation: SlashInvocation];
 }>();
 
 const replyAuthorName = computed(() => {
@@ -65,6 +73,10 @@ const replyAuthorName = computed(() => {
 const showGifPicker = ref(false);
 const showMentions = ref(false);
 const showEmoji = ref(false);
+const showSlash = ref(false);
+const slashPrefix = ref("");
+const slashTrailing = ref("");
+const slashDismissed = ref(false);
 const mentionQuery = ref("");
 const emojiQuery = ref("");
 const selectedIndex = ref(0);
@@ -163,9 +175,21 @@ const mentionResults = computed(() => {
 const emojiResults = computed(() => searchEmoji(emojiQuery.value));
 const showForumTitleInput = computed(() => props.isForumChannel && !props.replyingTo);
 
+const slashContext = computed(() => ({ inMuc: !!props.inMuc }));
+const slashCandidates = computed(() =>
+  filterSlashCandidates(slashPrefix.value, props.slashCommands ?? [], slashContext.value),
+);
+const slashResolution = computed(() =>
+  resolveSlashCommand(slashPrefix.value, props.slashCommands ?? [], slashContext.value),
+);
+const slashBlocked = computed(() =>
+  showSlash.value && slashPrefix.value.length > 0 && !slashResolution.value && slashCandidates.value.length === 0,
+);
+
 const activeResults = computed(() => {
   if (showMentions.value) return mentionResults.value;
   if (showEmoji.value) return emojiResults.value;
+  if (showSlash.value) return slashCandidates.value;
   return [];
 });
 
@@ -175,6 +199,9 @@ const autocompleteAction = computed(() =>
     mentionCount: mentionResults.value.length,
     showEmoji: showEmoji.value,
     emojiCount: emojiResults.value.length,
+    showSlash: showSlash.value,
+    slashCandidateCount: slashCandidates.value.length,
+    slashHasResolution: !!slashResolution.value,
   }),
 );
 
@@ -209,7 +236,14 @@ function onEditorUpdate(doc: JSONContent) {
 function clearAutocomplete() {
   showMentions.value = false;
   showEmoji.value = false;
+  showSlash.value = false;
   triggerRange.value = null;
+}
+
+function firstParagraphTextFromDoc(doc: any): string {
+  const firstChild = doc?.firstChild;
+  if (!firstChild || firstChild.type?.name !== "paragraph") return "";
+  return firstChild.textContent ?? "";
 }
 
 function checkAutocompleteFromEditor() {
@@ -237,6 +271,7 @@ function checkAutocompleteFromEditor() {
     selectedIndex.value = 0;
     showMentions.value = true;
     showEmoji.value = false;
+    showSlash.value = false;
     triggerRange.value = {
       from: pos - mentionMatch[0].trimStart().length,
       to: pos,
@@ -250,13 +285,35 @@ function checkAutocompleteFromEditor() {
     emojiQuery.value = emojiMatch[1];
     selectedIndex.value = 0;
     showEmoji.value = true;
+    showSlash.value = false;
     triggerRange.value = {
       from: pos - emojiMatch[0].trimStart().length,
       to: pos,
     };
     return;
   }
-  clearAutocomplete();
+  showEmoji.value = false;
+
+  const firstParagraph = firstParagraphTextFromDoc(doc);
+  const slash = parseSlashTrigger(firstParagraph);
+  if (slash) {
+    if (slashDismissed.value) {
+      showSlash.value = false;
+    } else {
+      slashPrefix.value = slash.prefix;
+      slashTrailing.value = slash.trailing;
+      selectedIndex.value = 0;
+      showSlash.value = true;
+      // The slash trigger spans the first paragraph from position 1 (after the
+      // leading <p> open tag) through the prefix length.
+      triggerRange.value = { from: 1, to: 1 + 1 + slash.prefix.length };
+    }
+    return;
+  }
+
+  slashDismissed.value = false;
+  showSlash.value = false;
+  triggerRange.value = null;
 }
 
 function insertMention(candidate: MentionCandidate) {
@@ -287,6 +344,32 @@ function insertEmoji(emoji: string) {
   triggerRange.value = null;
 }
 
+function expandSlashCandidate(command: DiscoveredExtensionCommand) {
+  const tiptapEditor = getTiptapEditor();
+  if (!tiptapEditor || !command.composerPrefix) return;
+  const replacement = `/${command.composerPrefix} `;
+  tiptapEditor.chain()
+    .focus()
+    .setTextSelection({ from: 1, to: 1 + 1 + slashPrefix.value.length })
+    .insertContent(replacement)
+    .run();
+  slashPrefix.value = command.composerPrefix;
+  slashTrailing.value = "";
+  showSlash.value = true;
+}
+
+function dispatchSlashResolution(): boolean {
+  const command = slashResolution.value;
+  if (!command) return false;
+  const invocation = buildSlashInvocation(command, slashTrailing.value);
+  emit("dispatchSlash", invocation);
+  showSlash.value = false;
+  slashDismissed.value = false;
+  triggerRange.value = null;
+  // Caller resets the editor draft after the launcher accepts the invocation.
+  return true;
+}
+
 function selectAutocompleteResult(action = autocompleteAction.value): boolean {
   if (action === "select-mention") {
     insertMention(mentionResults.value[selectedIndex.value]);
@@ -295,6 +378,21 @@ function selectAutocompleteResult(action = autocompleteAction.value): boolean {
 
   if (action === "select-emoji") {
     insertEmoji(emojiResults.value[selectedIndex.value].emoji);
+    return true;
+  }
+
+  if (action === "select-command") {
+    const candidate = slashCandidates.value[selectedIndex.value];
+    if (candidate) expandSlashCandidate(candidate);
+    return true;
+  }
+
+  if (action === "submit-slash") {
+    return dispatchSlashResolution();
+  }
+
+  if (action === "block-slash") {
+    // Hold the message; popover already shows an inline "no command" hint.
     return true;
   }
 
@@ -357,11 +455,18 @@ function onEditorCancel() {
   const action = getComposerEscapeAction({
     showMentions: showMentions.value,
     showEmoji: showEmoji.value,
+    showSlash: showSlash.value,
     isReplyingTo: !!props.replyingTo,
   });
 
   if (action === "dismiss-autocomplete") {
     clearAutocomplete();
+    return;
+  }
+
+  if (action === "dismiss-slash") {
+    showSlash.value = false;
+    slashDismissed.value = true;
     return;
   }
 
@@ -371,7 +476,7 @@ function onEditorCancel() {
 }
 
 function onKeydown(e: KeyboardEvent) {
-  if (activeResults.value.length > 0 && (showMentions.value || showEmoji.value)) {
+  if (activeResults.value.length > 0 && (showMentions.value || showEmoji.value || showSlash.value)) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
       e.stopPropagation();
@@ -632,6 +737,17 @@ watch(
         </button>
       </div>
     </div>
+
+    <!-- /slash command autocomplete -->
+    <SlashCommandPopover
+      v-if="showSlash && (slashCandidates.length > 0 || slashBlocked)"
+      :candidates="slashCandidates"
+      :selected-index="selectedIndex"
+      :prefix="slashPrefix"
+      :blocked="slashBlocked"
+      :is-top-pinned="isTopPinned"
+      @pick="expandSlashCandidate"
+    />
 
     <div
       class="chat-composer-input-shell flex min-w-0 flex-nowrap items-center gap-2 bg-muted p-1 transition-all duration-300 has-[:focus]:ring-2 has-[:focus]:ring-primary/20 has-[:focus]:shadow-[0_0_16px_var(--glow)]"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -200,6 +200,7 @@ const autocompleteAction = computed(() =>
     showEmoji: showEmoji.value,
     emojiCount: emojiResults.value.length,
     showSlash: showSlash.value,
+    slashHasPrefix: slashPrefix.value.length > 0,
     slashCandidateCount: slashCandidates.value.length,
     slashHasResolution: !!slashResolution.value,
   }),
@@ -354,10 +355,14 @@ function insertEmoji(emoji: string) {
 function expandSlashCandidate(command: DiscoveredExtensionCommand) {
   const tiptapEditor = getTiptapEditor();
   if (!tiptapEditor || !command.composerPrefix) return;
+  // If the user already typed a space after the partial prefix, swallow it
+  // so we don't end up with double spaces (e.g. `/p ` + `/poll ` → `/poll  `).
+  const firstParagraph = firstParagraphTextFromDoc(tiptapEditor.state.doc);
+  const consumedExtra = firstParagraph.charAt(1 + slashPrefix.value.length) === " " ? 1 : 0;
   const replacement = `/${command.composerPrefix} `;
   tiptapEditor.chain()
     .focus()
-    .setTextSelection({ from: 1, to: 1 + 1 + slashPrefix.value.length })
+    .setTextSelection({ from: 1, to: 1 + 1 + slashPrefix.value.length + consumedExtra })
     .insertContent(replacement)
     .run();
   slashPrefix.value = command.composerPrefix;
@@ -371,11 +376,13 @@ function dispatchSlashResolution(): boolean {
   // Forum channels demand a title; don't smuggle a slash dispatch past that gate.
   if (showForumTitleInput.value && !forumTitle.value.trim()) return true;
   const invocation = buildSlashInvocation(command, slashTrailing.value);
-  emit("dispatchSlash", invocation);
+  // Suppress the popover for this exact prefix until the parent resets the
+  // draft so a stray re-render between emit and draft-clear cannot re-arm
+  // the slash submit path on the same keystroke.
+  dismissedSlashPrefix.value = slashPrefix.value;
   showSlash.value = false;
-  dismissedSlashPrefix.value = null;
   triggerRange.value = null;
-  // Caller resets the editor draft after the launcher accepts the invocation.
+  emit("dispatchSlash", invocation);
   return true;
 }
 

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -53,6 +53,7 @@ const props = defineProps<{
   extensionsOpen?: boolean;
   slashCommands?: DiscoveredExtensionCommand[];
   inMuc?: boolean;
+  dispatchSlashCommand?: (invocation: SlashInvocation) => Promise<boolean>;
 }>();
 
 const emit = defineEmits<{
@@ -61,7 +62,6 @@ const emit = defineEmits<{
   selectGif: [url: string];
   cancelReply: [];
   openExtensions: [];
-  dispatchSlash: [invocation: SlashInvocation];
 }>();
 
 const replyAuthorName = computed(() => {
@@ -302,12 +302,16 @@ function checkAutocompleteFromEditor() {
     !!firstChild && firstChild.type?.name === "paragraph" && pos > 0 && pos <= firstChild.nodeSize - 1;
 
   const firstParagraph = firstParagraphTextFromDoc(doc);
-  const slash = cursorInFirstParagraph ? parseSlashTrigger(firstParagraph) : null;
+  const slash = parseSlashTrigger(firstParagraph);
   if (slash) {
-    if (dismissedSlashPrefix.value !== null && dismissedSlashPrefix.value === slash.prefix) {
+    // Hold the popover when the cursor is outside paragraph 0 — but keep the
+    // dismissedSlashPrefix intact so the user can navigate away and back
+    // without re-arming the same `/word` they already dismissed.
+    const suppressedByDismissal =
+      dismissedSlashPrefix.value !== null && dismissedSlashPrefix.value === slash.prefix;
+    if (!cursorInFirstParagraph || suppressedByDismissal) {
       showSlash.value = false;
     } else {
-      dismissedSlashPrefix.value = null;
       slashPrefix.value = slash.prefix;
       slashTrailing.value = slash.trailing;
       selectedIndex.value = 0;
@@ -319,6 +323,7 @@ function checkAutocompleteFromEditor() {
     return;
   }
 
+  // The leading `/word` is gone; safe to reset the dismissal too.
   dismissedSlashPrefix.value = null;
   showSlash.value = false;
   triggerRange.value = null;
@@ -376,13 +381,20 @@ function dispatchSlashResolution(): boolean {
   // Forum channels demand a title; don't smuggle a slash dispatch past that gate.
   if (showForumTitleInput.value && !forumTitle.value.trim()) return true;
   const invocation = buildSlashInvocation(command, slashTrailing.value);
-  // Suppress the popover for this exact prefix until the parent resets the
-  // draft so a stray re-render between emit and draft-clear cannot re-arm
-  // the slash submit path on the same keystroke.
-  dismissedSlashPrefix.value = slashPrefix.value;
+  const dispatcher = props.dispatchSlashCommand;
+  // Hide the popover for the round-trip; only commit the dismissal once the
+  // parent reports success, so a failed dispatch leaves slash mode armed for
+  // the user to retry, edit, or Esc.
   showSlash.value = false;
   triggerRange.value = null;
-  emit("dispatchSlash", invocation);
+  if (!dispatcher) return true;
+  const dispatchedPrefix = slashPrefix.value;
+  void (async () => {
+    const ok = await dispatcher(invocation);
+    if (ok) {
+      dismissedSlashPrefix.value = dispatchedPrefix;
+    }
+  })();
   return true;
 }
 

--- a/chat/src/components/chat/SlashCommandPopover.vue
+++ b/chat/src/components/chat/SlashCommandPopover.vue
@@ -22,7 +22,7 @@ const emit = defineEmits<{
   >
     <div v-if="blocked" class="type-caption flex items-center gap-2 px-3 py-2 text-destructive">
       <AlertCircle class="h-3.5 w-3.5" aria-hidden="true" />
-      <span>No command <span class="type-emphasis">/{{ prefix }}</span>. Press Esc to send as text.</span>
+      <span>No command <span class="type-emphasis">/{{ prefix }}</span>. Press Esc, then Enter to send as text.</span>
     </div>
     <div v-else class="flex flex-col gap-1">
       <button

--- a/chat/src/components/chat/SlashCommandPopover.vue
+++ b/chat/src/components/chat/SlashCommandPopover.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { Slash, AlertCircle } from "lucide-vue-next";
+import type { DiscoveredExtensionCommand } from "@/lib/xmpp/extension-commands";
+
+defineProps<{
+  candidates: DiscoveredExtensionCommand[];
+  selectedIndex: number;
+  prefix: string;
+  blocked: boolean;
+  isTopPinned?: boolean;
+}>();
+
+const emit = defineEmits<{
+  pick: [command: DiscoveredExtensionCommand];
+}>();
+</script>
+
+<template>
+  <div
+    class="z-popover chat-composer-popover absolute glass-panel border border-border rounded-lg max-h-56 overflow-auto min-w-0 shadow-xl animate-fade-in p-1"
+    :class="isTopPinned ? 'top-full mt-2' : 'bottom-full mb-2'"
+  >
+    <div v-if="blocked" class="type-caption flex items-center gap-2 px-3 py-2 text-destructive">
+      <AlertCircle class="h-3.5 w-3.5" aria-hidden="true" />
+      <span>No command <span class="type-emphasis">/{{ prefix }}</span>. Press Esc to send as text.</span>
+    </div>
+    <div v-else class="flex flex-col gap-1">
+      <button
+        v-for="(command, i) in candidates"
+        :key="command.node"
+        type="button"
+        class="type-control w-full h-9 px-3 py-0 text-left hover:bg-muted transition-colors flex items-center gap-2 rounded-lg"
+        :class="i === selectedIndex ? 'bg-muted' : ''"
+        @mousedown.prevent="emit('pick', command)"
+      >
+        <Slash class="h-4 w-4 text-primary" aria-hidden="true" />
+        <span class="type-emphasis">/{{ command.composerPrefix }}</span>
+        <span class="type-caption text-muted-foreground truncate">{{ command.name }}</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/chat/src/lib/reply-ux.ts
+++ b/chat/src/lib/reply-ux.ts
@@ -31,6 +31,7 @@ export function getComposerAutocompleteAction(state: {
   showEmoji: boolean;
   emojiCount: number;
   showSlash?: boolean;
+  slashHasPrefix?: boolean;
   slashCandidateCount?: number;
   slashHasResolution?: boolean;
 }): "select-mention" | "select-emoji" | "select-command" | "submit-slash" | "block-slash" | "dismiss-autocomplete" | "none" {
@@ -45,7 +46,10 @@ export function getComposerAutocompleteAction(state: {
   if (state.showSlash) {
     if (state.slashHasResolution) return "submit-slash";
     if ((state.slashCandidateCount ?? 0) > 0) return "select-command";
-    return "block-slash";
+    // Block only when the user typed an actual command attempt. A bare `/`
+    // with nothing matching falls through so the Enter sends as plain text.
+    if (state.slashHasPrefix) return "block-slash";
+    return "none";
   }
 
   return "none";

--- a/chat/src/lib/reply-ux.ts
+++ b/chat/src/lib/reply-ux.ts
@@ -7,10 +7,15 @@ export function getReplyJumpNotice(targetFound: boolean): string {
 export function getComposerEscapeAction(state: {
   showMentions: boolean;
   showEmoji: boolean;
+  showSlash?: boolean;
   isReplyingTo: boolean;
-}): "dismiss-autocomplete" | "cancel-reply" | "none" {
+}): "dismiss-autocomplete" | "dismiss-slash" | "cancel-reply" | "none" {
   if (state.showMentions || state.showEmoji) {
     return "dismiss-autocomplete";
+  }
+
+  if (state.showSlash) {
+    return "dismiss-slash";
   }
 
   if (state.isReplyingTo) {
@@ -25,13 +30,22 @@ export function getComposerAutocompleteAction(state: {
   mentionCount: number;
   showEmoji: boolean;
   emojiCount: number;
-}): "select-mention" | "select-emoji" | "dismiss-autocomplete" | "none" {
+  showSlash?: boolean;
+  slashCandidateCount?: number;
+  slashHasResolution?: boolean;
+}): "select-mention" | "select-emoji" | "select-command" | "submit-slash" | "block-slash" | "dismiss-autocomplete" | "none" {
   if (state.showMentions) {
     return state.mentionCount > 0 ? "select-mention" : "dismiss-autocomplete";
   }
 
   if (state.showEmoji) {
     return state.emojiCount > 0 ? "select-emoji" : "dismiss-autocomplete";
+  }
+
+  if (state.showSlash) {
+    if (state.slashHasResolution) return "submit-slash";
+    if ((state.slashCandidateCount ?? 0) > 0) return "select-command";
+    return "block-slash";
   }
 
   return "none";

--- a/chat/src/lib/slash-dispatch.ts
+++ b/chat/src/lib/slash-dispatch.ts
@@ -1,0 +1,28 @@
+import type { DiscoveredExtensionCommand } from "./xmpp/extension-commands";
+
+export type SlashInvocation =
+  | {
+      kind: "inline-submit";
+      command: DiscoveredExtensionCommand;
+      fieldName: string;
+      value: string;
+    }
+  | {
+      kind: "open-palette";
+      command: DiscoveredExtensionCommand;
+      prefillFirstRequired?: string;
+    };
+
+export function buildSlashInvocation(
+  command: DiscoveredExtensionCommand,
+  trailing: string,
+): SlashInvocation {
+  const value = trailing.trim();
+  if (command.inlineField && value.length > 0) {
+    return { kind: "inline-submit", command, fieldName: command.inlineField, value };
+  }
+  if (!command.inlineField && value.length > 0) {
+    return { kind: "open-palette", command, prefillFirstRequired: value };
+  }
+  return { kind: "open-palette", command };
+}

--- a/chat/src/lib/slash-match.ts
+++ b/chat/src/lib/slash-match.ts
@@ -24,9 +24,12 @@ export function resolveSlashCommand(
 ): DiscoveredExtensionCommand | null {
   if (!prefix) return null;
   const needle = prefix.toLowerCase();
-  return commands.find((command) => {
+  const matches = commands.filter((command) => {
     if (!command.composerPrefix) return false;
     if (command.scope === "channel" && !context.inMuc) return false;
     return command.composerPrefix.toLowerCase() === needle;
-  }) ?? null;
+  });
+  // Multiple extensions advertised the same prefix: refuse to auto-resolve
+  // so the user picks explicitly from the autocomplete popover.
+  return matches.length === 1 ? matches[0] : null;
 }

--- a/chat/src/lib/slash-match.ts
+++ b/chat/src/lib/slash-match.ts
@@ -1,6 +1,6 @@
 import type { DiscoveredExtensionCommand } from "./xmpp/extension-commands";
 
-export interface SlashMatchContext {
+interface SlashMatchContext {
   inMuc: boolean;
 }
 

--- a/chat/src/lib/slash-match.ts
+++ b/chat/src/lib/slash-match.ts
@@ -1,0 +1,32 @@
+import type { DiscoveredExtensionCommand } from "./xmpp/extension-commands";
+
+export interface SlashMatchContext {
+  inMuc: boolean;
+}
+
+export function filterSlashCandidates(
+  prefix: string,
+  commands: DiscoveredExtensionCommand[],
+  context: SlashMatchContext,
+): DiscoveredExtensionCommand[] {
+  const needle = prefix.toLowerCase();
+  return commands.filter((command) => {
+    if (!command.composerPrefix) return false;
+    if (command.scope === "channel" && !context.inMuc) return false;
+    return command.composerPrefix.toLowerCase().startsWith(needle);
+  });
+}
+
+export function resolveSlashCommand(
+  prefix: string,
+  commands: DiscoveredExtensionCommand[],
+  context: SlashMatchContext,
+): DiscoveredExtensionCommand | null {
+  if (!prefix) return null;
+  const needle = prefix.toLowerCase();
+  return commands.find((command) => {
+    if (!command.composerPrefix) return false;
+    if (command.scope === "channel" && !context.inMuc) return false;
+    return command.composerPrefix.toLowerCase() === needle;
+  }) ?? null;
+}

--- a/chat/src/lib/slash-trigger.ts
+++ b/chat/src/lib/slash-trigger.ts
@@ -1,0 +1,15 @@
+export interface SlashTriggerMatch {
+  prefix: string;
+  trailing: string;
+}
+
+const SLASH_TRIGGER_PATTERN = /^\/([a-zA-Z][a-zA-Z0-9_-]*)?(?:(\s)([\s\S]*))?$/;
+
+export function parseSlashTrigger(text: string): SlashTriggerMatch | null {
+  const match = SLASH_TRIGGER_PATTERN.exec(text);
+  if (!match) return null;
+  const [, rawPrefix, separator, rest] = match;
+  const prefix = rawPrefix ?? "";
+  if (separator === undefined) return { prefix, trailing: "" };
+  return { prefix, trailing: (rest ?? "").trimStart() };
+}

--- a/chat/src/lib/slash-trigger.ts
+++ b/chat/src/lib/slash-trigger.ts
@@ -1,4 +1,4 @@
-export interface SlashTriggerMatch {
+interface SlashTriggerMatch {
   prefix: string;
   trailing: string;
 }

--- a/chat/src/lib/xmpp/extension-commands/disco.ts
+++ b/chat/src/lib/xmpp/extension-commands/disco.ts
@@ -53,10 +53,14 @@ export async function discoverExtensionCommands(
     const itemServiceJid = item.jid ?? serviceJid;
     const node = item.node;
     let scope: ExtensionCommandScope = "global";
+    let composerPrefix: string | undefined;
+    let inlineField: string | undefined;
     try {
       const info = await rawDiscoInfoFull(xmpp, itemServiceJid, node);
-      const parsedScope = parseExtensionCommandScope(info.extensions);
-      if (parsedScope) scope = parsedScope;
+      const metadata = parseExtensionCommandMetadata(info.extensions);
+      if (metadata.scope) scope = metadata.scope;
+      composerPrefix = metadata.composerPrefix;
+      inlineField = metadata.inlineField;
     } catch {
       // If disco#info is unavailable, fall back to global scope.
     }
@@ -65,22 +69,35 @@ export async function discoverExtensionCommands(
       node,
       name: item.name || node,
       scope,
+      ...(composerPrefix !== undefined ? { composerPrefix } : {}),
+      ...(inlineField !== undefined ? { inlineField } : {}),
     });
   }
   return commands;
 }
 
-function parseExtensionCommandScope(extensions: unknown[] | undefined): ExtensionCommandScope | null {
-  if (!Array.isArray(extensions)) return null;
+interface ExtensionCommandMetadata {
+  scope: ExtensionCommandScope | null;
+  composerPrefix?: string;
+  inlineField?: string;
+}
+
+function parseExtensionCommandMetadata(extensions: unknown[] | undefined): ExtensionCommandMetadata {
+  const result: ExtensionCommandMetadata = { scope: null };
+  if (!Array.isArray(extensions)) return result;
   for (const form of extensions) {
     const fields = (form as { fields?: unknown[] } | undefined)?.fields;
     if (!Array.isArray(fields)) continue;
     const formType = formFieldValue(fields, "FORM_TYPE");
     if (formType !== NS_WADDLE_EXTENSION_1 && formType !== EXTENSION_COMMAND_FORM_TYPE) continue;
-    const value = formFieldValue(fields, "waddle#command_scope");
-    if (value === "global" || value === "channel") return value;
+    const scopeValue = formFieldValue(fields, "waddle#command_scope");
+    if (scopeValue === "global" || scopeValue === "channel") result.scope = scopeValue;
+    const composerPrefix = formFieldValue(fields, "waddle#composer_prefix");
+    if (composerPrefix) result.composerPrefix = composerPrefix;
+    const inlineField = formFieldValue(fields, "waddle#inline_field");
+    if (inlineField) result.inlineField = inlineField;
   }
-  return null;
+  return result;
 }
 
 export async function discoverExtensionCommandService(xmpp: XmppSendIq, userJid: string): Promise<string> {

--- a/chat/src/lib/xmpp/extension-commands/types.ts
+++ b/chat/src/lib/xmpp/extension-commands/types.ts
@@ -63,6 +63,8 @@ export interface DiscoveredExtensionCommand {
   node: string;
   name: string;
   scope: ExtensionCommandScope;
+  composerPrefix?: string;
+  inlineField?: string;
 }
 
 export type ExtensionRouteScope = "channel";

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -83,6 +83,46 @@ describe("extension command invocation", () => {
     ]);
   });
 
+  test("reads composer-prefix and inline-field from XEP-0128 disco metadata", async () => {
+    const xmpp = {
+      async send_raw_iq(xml: string) {
+        if (xml.includes('to="example.com"') && xml.includes("disco#items")) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" name="Extensions" /></query></iq>`;
+        }
+        if (xml.includes('to="extensions.example.com"') && xml.includes("disco#info") && !xml.includes(" node=")) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><feature var="urn:waddle:extension:1" /><feature var="http://jabber.org/protocol/commands" /></query></iq>`;
+        }
+        if (xml.includes('node="http://jabber.org/protocol/commands"')) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" node="urn:waddle:extension:1:ai-chatbot" name="Ask AI Chatbot" /><item jid="extensions.example.com" node="urn:waddle:extension:1:decision-polls" name="Create Decision Poll" /></query></iq>`;
+        }
+        if (xml.includes('node="urn:waddle:extension:1:ai-chatbot"')) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>global</value></field><field var="waddle#composer_prefix"><value>ai</value></field><field var="waddle#inline_field"><value>prompt</value></field></x></query></iq>`;
+        }
+        expect(xml).toContain('node="urn:waddle:extension:1:decision-polls"');
+        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>channel</value></field><field var="waddle#composer_prefix"><value>poll</value></field></x></query></iq>`;
+      },
+    };
+
+    const commands = await discoverExtensionCommands(xmpp as any, "alice@example.com/web");
+    expect(commands).toEqual([
+      {
+        serviceJid: "extensions.example.com",
+        node: "urn:waddle:extension:1:ai-chatbot",
+        name: "Ask AI Chatbot",
+        scope: "global",
+        composerPrefix: "ai",
+        inlineField: "prompt",
+      },
+      {
+        serviceJid: "extensions.example.com",
+        node: "urn:waddle:extension:1:decision-polls",
+        name: "Create Decision Poll",
+        scope: "channel",
+        composerPrefix: "poll",
+      },
+    ]);
+  });
+
   test("prefers the advertised Waddle extension service over generic command services", async () => {
     const commandItemTargets: string[] = [];
     const xmpp = {

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -123,6 +123,34 @@ describe("extension command invocation", () => {
     ]);
   });
 
+  test("treats an empty composer_prefix value as absent rather than a zero-length match", async () => {
+    const xmpp = {
+      async send_raw_iq(xml: string) {
+        if (xml.includes('to="example.com"') && xml.includes("disco#items")) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" name="Extensions" /></query></iq>`;
+        }
+        if (xml.includes('to="extensions.example.com"') && xml.includes("disco#info") && !xml.includes(" node=")) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><feature var="urn:waddle:extension:1" /><feature var="http://jabber.org/protocol/commands" /></query></iq>`;
+        }
+        if (xml.includes('node="http://jabber.org/protocol/commands"')) {
+          return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items"><item jid="extensions.example.com" node="urn:waddle:extension:1:noprefix" name="No Prefix" /></query></iq>`;
+        }
+        expect(xml).toContain('node="urn:waddle:extension:1:noprefix"');
+        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>global</value></field><field var="waddle#composer_prefix"><value></value></field><field var="waddle#inline_field" /></x></query></iq>`;
+      },
+    };
+
+    const commands = await discoverExtensionCommands(xmpp as any, "alice@example.com/web");
+    expect(commands).toEqual([
+      {
+        serviceJid: "extensions.example.com",
+        node: "urn:waddle:extension:1:noprefix",
+        name: "No Prefix",
+        scope: "global",
+      },
+    ]);
+  });
+
   test("prefers the advertised Waddle extension service over generic command services", async () => {
     const commandItemTargets: string[] = [];
     const xmpp = {

--- a/chat/tests/extension-launcher-slash.test.ts
+++ b/chat/tests/extension-launcher-slash.test.ts
@@ -122,8 +122,9 @@ describe("dispatchSlashInvocation: inline-submit", () => {
       fieldName: "prompt",
       value: "tell me a joke",
     };
-    await launcher.dispatchSlashInvocation(invocation);
+    const ok = await launcher.dispatchSlashInvocation(invocation);
 
+    expect(ok).toBe(true);
     expect(invokeCalls).toEqual([aiCommand]);
     expect(submitCalls).toHaveLength(1);
     expect(submitCalls[0].action).toBe("complete");
@@ -131,6 +132,27 @@ describe("dispatchSlashInvocation: inline-submit", () => {
       "tell me a joke",
     ]);
     expect(launcher.open.value).toBe(false);
+  });
+
+  test("returns false and surfaces an error state when the XMPP client is null", async () => {
+    const launcher = useExtensionLauncher({
+      xmppClient: ref(null) as never,
+      roomJid: ref(null),
+      invokeExtensionAction: ref(undefined),
+      focusPalette: () => {},
+      focusComposerExtensions: () => {},
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell me a joke",
+    });
+
+    expect(ok).toBe(false);
+    expect(launcher.state.value).toBe("error");
+    expect(launcher.detail.value).toContain("disconnected");
   });
 
   test("falls back to the palette when the executing form does not allow `complete`", async () => {

--- a/chat/tests/extension-launcher-slash.test.ts
+++ b/chat/tests/extension-launcher-slash.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, test } from "bun:test";
+import { ref, type Ref } from "vue";
+import { useExtensionLauncher } from "../src/channels/extension-launcher";
+import type {
+  DiscoveredExtensionCommand,
+  ExtensionCommandAction,
+  ExtensionCommandFormField,
+  ExtensionCommandResult,
+} from "../src/lib/xmpp/extension-commands";
+import type { SlashInvocation } from "../src/lib/slash-dispatch";
+
+const aiCommand: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:ai-chatbot",
+  name: "Ask AI Chatbot",
+  scope: "global",
+  composerPrefix: "ai",
+  inlineField: "prompt",
+};
+
+const pollCommand: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:decision-polls",
+  name: "Create Decision Poll",
+  scope: "channel",
+  composerPrefix: "poll",
+};
+
+interface SubmitCall {
+  command: DiscoveredExtensionCommand;
+  sessionId: string;
+  fields: ExtensionCommandFormField[];
+  action?: ExtensionCommandAction;
+  roomJid?: string;
+}
+
+function field(name: string, overrides: Partial<ExtensionCommandFormField> = {}): ExtensionCommandFormField {
+  return {
+    name,
+    label: name,
+    type: "text-single",
+    value: "",
+    values: [],
+    options: [],
+    required: false,
+    blocked: false,
+    hidden: false,
+    ...overrides,
+  };
+}
+
+function executingResult(fields: ExtensionCommandFormField[], allowed: ExtensionCommandAction[] = ["complete", "cancel"]): ExtensionCommandResult {
+  return {
+    status: "executing",
+    sessionId: "session-1",
+    actions: { allowed },
+    notes: [],
+    form: {
+      fields: fields.map((f) => ({
+        var: f.name,
+        type: f.type,
+        label: f.label,
+        required: f.required,
+        values: f.values,
+        rawValues: f.values,
+      })),
+    },
+  };
+}
+
+function fakeClient(executeResults: ExtensionCommandResult[]): {
+  client: Ref<unknown>;
+  submitCalls: SubmitCall[];
+  invokeCalls: DiscoveredExtensionCommand[];
+} {
+  const submitCalls: SubmitCall[] = [];
+  const invokeCalls: DiscoveredExtensionCommand[] = [];
+  const queue = [...executeResults];
+  const fake = {
+    async invokeExtensionCommand(command: DiscoveredExtensionCommand): Promise<ExtensionCommandResult> {
+      invokeCalls.push(command);
+      return queue.shift() ?? { status: "completed", notes: [] };
+    },
+    async submitExtensionCommandForm(
+      command: DiscoveredExtensionCommand,
+      sessionId: string,
+      fields: ExtensionCommandFormField[],
+      action?: ExtensionCommandAction,
+      roomJid?: string,
+    ): Promise<ExtensionCommandResult> {
+      submitCalls.push({ command, sessionId, fields, action, roomJid });
+      return { status: "completed", notes: [] };
+    },
+    async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
+      return [];
+    },
+  };
+  return { client: ref(fake), submitCalls, invokeCalls };
+}
+
+function createLauncher(executeResults: ExtensionCommandResult[]) {
+  const fake = fakeClient(executeResults);
+  const launcher = useExtensionLauncher({
+    xmppClient: fake.client as never,
+    roomJid: ref(null),
+    invokeExtensionAction: ref(undefined),
+    focusPalette: () => {},
+    focusComposerExtensions: () => {},
+  });
+  return { ...fake, launcher };
+}
+
+describe("dispatchSlashInvocation: inline-submit", () => {
+  test("auto-submits with the inline field set when the form advertises `complete`", async () => {
+    const { launcher, submitCalls, invokeCalls } = createLauncher([
+      executingResult([field("prompt", { required: true })], ["complete", "cancel"]),
+    ]);
+
+    const invocation: SlashInvocation = {
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell me a joke",
+    };
+    await launcher.dispatchSlashInvocation(invocation);
+
+    expect(invokeCalls).toEqual([aiCommand]);
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].action).toBe("complete");
+    expect(submitCalls[0].fields.find((f) => f.name === "prompt")?.values).toEqual([
+      "tell me a joke",
+    ]);
+    expect(launcher.open.value).toBe(false);
+  });
+
+  test("falls back to the palette when the executing form does not allow `complete`", async () => {
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([field("prompt", { required: true })], ["next", "cancel"]),
+    ]);
+
+    await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell me a joke",
+    });
+
+    expect(submitCalls).toEqual([]);
+    expect(launcher.open.value).toBe(true);
+    const stored = launcher.commandForms.value[aiCommand.node]?.fields.find((f) => f.name === "prompt");
+    expect(stored?.values).toEqual(["tell me a joke"]);
+  });
+
+  test("does not submit when the server returns no executing form", async () => {
+    const { launcher, submitCalls } = createLauncher([
+      { status: "completed", notes: [] },
+    ]);
+
+    await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "stale prompt",
+    });
+
+    expect(submitCalls).toEqual([]);
+    expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("success");
+  });
+});
+
+describe("dispatchSlashInvocation: open-palette", () => {
+  test("opens the palette and prefills the first required visible field", async () => {
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("question", { required: true }),
+        field("options", { required: true }),
+      ]),
+    ]);
+
+    await launcher.dispatchSlashInvocation({
+      kind: "open-palette",
+      command: pollCommand,
+      prefillFirstRequired: "Best mascot?",
+    });
+
+    expect(submitCalls).toEqual([]);
+    expect(launcher.open.value).toBe(true);
+    const stored = launcher.commandForms.value[pollCommand.node]?.fields.find((f) => f.name === "question");
+    expect(stored?.values).toEqual(["Best mascot?"]);
+  });
+
+  test("skips prefill when the form has no required visible field", async () => {
+    const { launcher } = createLauncher([
+      executingResult([field("note", { required: false })]),
+    ]);
+
+    await launcher.dispatchSlashInvocation({
+      kind: "open-palette",
+      command: pollCommand,
+      prefillFirstRequired: "ignored",
+    });
+
+    const stored = launcher.commandForms.value[pollCommand.node]?.fields.find((f) => f.name === "note");
+    expect(stored?.values).toEqual([]);
+  });
+
+  test("opens the palette empty when there is no prefill", async () => {
+    const { launcher } = createLauncher([
+      executingResult([field("question", { required: true })]),
+    ]);
+
+    await launcher.dispatchSlashInvocation({
+      kind: "open-palette",
+      command: pollCommand,
+    });
+
+    expect(launcher.open.value).toBe(true);
+    const stored = launcher.commandForms.value[pollCommand.node]?.fields.find((f) => f.name === "question");
+    expect(stored?.values).toEqual([]);
+  });
+});

--- a/chat/tests/reply-ux.test.ts
+++ b/chat/tests/reply-ux.test.ts
@@ -136,10 +136,26 @@ describe("reply UX helpers", () => {
         showEmoji: false,
         emojiCount: 0,
         showSlash: true,
+        slashHasPrefix: true,
         slashCandidateCount: 0,
         slashHasResolution: false,
       }),
     ).toBe("block-slash");
+  });
+
+  test("Bare `/` with zero candidates falls through to plain-text send", () => {
+    expect(
+      getComposerAutocompleteAction({
+        showMentions: false,
+        mentionCount: 0,
+        showEmoji: false,
+        emojiCount: 0,
+        showSlash: true,
+        slashHasPrefix: false,
+        slashCandidateCount: 0,
+        slashHasResolution: false,
+      }),
+    ).toBe("none");
   });
 
   test("Mention autocomplete still wins over slash popover", () => {

--- a/chat/tests/reply-ux.test.ts
+++ b/chat/tests/reply-ux.test.ts
@@ -77,4 +77,82 @@ describe("reply UX helpers", () => {
     expect(getReplyJumpNotice(true)).toBe("");
     expect(getReplyJumpNotice(false)).toBe(REPLY_JUMP_TARGET_MISSING_MESSAGE);
   });
+
+  test("Escape dismisses the slash popover before cancelling a reply", () => {
+    expect(
+      getComposerEscapeAction({
+        showMentions: false,
+        showEmoji: false,
+        showSlash: true,
+        isReplyingTo: true,
+      }),
+    ).toBe("dismiss-slash");
+  });
+
+  test("Escape ignores slash popover when mention/emoji autocomplete is also showing", () => {
+    expect(
+      getComposerEscapeAction({
+        showMentions: true,
+        showEmoji: false,
+        showSlash: true,
+        isReplyingTo: false,
+      }),
+    ).toBe("dismiss-autocomplete");
+  });
+
+  test("Submit on `/word` that resolves to a command invokes the slash submit path", () => {
+    expect(
+      getComposerAutocompleteAction({
+        showMentions: false,
+        mentionCount: 0,
+        showEmoji: false,
+        emojiCount: 0,
+        showSlash: true,
+        slashCandidateCount: 1,
+        slashHasResolution: true,
+      }),
+    ).toBe("submit-slash");
+  });
+
+  test("Submit on slash popover with candidates but no exact resolution expands the highlighted candidate", () => {
+    expect(
+      getComposerAutocompleteAction({
+        showMentions: false,
+        mentionCount: 0,
+        showEmoji: false,
+        emojiCount: 0,
+        showSlash: true,
+        slashCandidateCount: 2,
+        slashHasResolution: false,
+      }),
+    ).toBe("select-command");
+  });
+
+  test("Submit on `/word` with no candidates and no resolution blocks", () => {
+    expect(
+      getComposerAutocompleteAction({
+        showMentions: false,
+        mentionCount: 0,
+        showEmoji: false,
+        emojiCount: 0,
+        showSlash: true,
+        slashCandidateCount: 0,
+        slashHasResolution: false,
+      }),
+    ).toBe("block-slash");
+  });
+
+  test("Mention autocomplete still wins over slash popover", () => {
+    expect(
+      getComposerAutocompleteAction({
+        showMentions: true,
+        mentionCount: 1,
+        showEmoji: false,
+        emojiCount: 0,
+        showSlash: true,
+        slashCandidateCount: 1,
+        slashHasResolution: true,
+      }),
+    ).toBe("select-mention");
+  });
 });

--- a/chat/tests/slash-dispatch.test.ts
+++ b/chat/tests/slash-dispatch.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import type { DiscoveredExtensionCommand } from "../src/lib/xmpp/extension-commands";
+import { buildSlashInvocation } from "../src/lib/slash-dispatch";
+
+const ai: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:ai-chatbot",
+  name: "Ask AI Chatbot",
+  scope: "global",
+  composerPrefix: "ai",
+  inlineField: "prompt",
+};
+
+const poll: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:decision-polls",
+  name: "Create Decision Poll",
+  scope: "channel",
+  composerPrefix: "poll",
+};
+
+describe("buildSlashInvocation", () => {
+  test("inline-submit when inlineField is declared and trailing has text", () => {
+    expect(buildSlashInvocation(ai, "tell me a joke")).toEqual({
+      kind: "inline-submit",
+      command: ai,
+      fieldName: "prompt",
+      value: "tell me a joke",
+    });
+  });
+
+  test("open-palette with no prefill when trailing is empty", () => {
+    expect(buildSlashInvocation(ai, "")).toEqual({
+      kind: "open-palette",
+      command: ai,
+    });
+  });
+
+  test("open-palette with first-required-field prefill when no inlineField but trailing exists", () => {
+    expect(buildSlashInvocation(poll, "Best mascot?")).toEqual({
+      kind: "open-palette",
+      command: poll,
+      prefillFirstRequired: "Best mascot?",
+    });
+  });
+
+  test("open-palette without prefill when no inlineField and no trailing", () => {
+    expect(buildSlashInvocation(poll, "")).toEqual({
+      kind: "open-palette",
+      command: poll,
+    });
+  });
+
+  test("trims surrounding whitespace from the value", () => {
+    expect(buildSlashInvocation(ai, "   hi there   ")).toEqual({
+      kind: "inline-submit",
+      command: ai,
+      fieldName: "prompt",
+      value: "hi there",
+    });
+  });
+
+  test("treats whitespace-only trailing as empty", () => {
+    expect(buildSlashInvocation(ai, "   ")).toEqual({
+      kind: "open-palette",
+      command: ai,
+    });
+  });
+});

--- a/chat/tests/slash-flow.test.ts
+++ b/chat/tests/slash-flow.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/core";
+import { createChatEditorExtensions } from "../src/lib/editor/chat-editor-extensions";
+import { parseSlashTrigger } from "../src/lib/slash-trigger";
+import { filterSlashCandidates, resolveSlashCommand } from "../src/lib/slash-match";
+import { buildSlashInvocation } from "../src/lib/slash-dispatch";
+import type { DiscoveredExtensionCommand } from "../src/lib/xmpp/extension-commands";
+
+if (typeof globalThis.requestAnimationFrame !== "function") {
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(performance.now());
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+}
+
+const ai: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:ai-chatbot",
+  name: "Ask AI Chatbot",
+  scope: "global",
+  composerPrefix: "ai",
+  inlineField: "prompt",
+};
+
+const poll: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:decision-polls",
+  name: "Create Decision Poll",
+  scope: "channel",
+  composerPrefix: "poll",
+};
+
+function createEditor(text: string, secondParagraph?: string): Editor {
+  const content: Record<string, unknown> = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: text.length > 0 ? [{ type: "text", text }] : [],
+      },
+      ...(secondParagraph !== undefined
+        ? [
+            {
+              type: "paragraph",
+              content: secondParagraph.length > 0 ? [{ type: "text", text: secondParagraph }] : [],
+            },
+          ]
+        : []),
+    ],
+  };
+  return new Editor({
+    enableCoreExtensions: { keymap: false },
+    extensions: createChatEditorExtensions({
+      includePlaceholder: false,
+      onSubmit: () => false,
+    }),
+    content,
+  });
+}
+
+function firstParagraphText(editor: Editor): string {
+  const firstChild = editor.state.doc.firstChild;
+  if (!firstChild || firstChild.type.name !== "paragraph") return "";
+  return firstChild.textContent;
+}
+
+describe("slash command flow against a live TipTap editor", () => {
+  test("`/ai hello world` resolves and dispatches as inline-submit", () => {
+    const editor = createEditor("/ai hello world");
+
+    const text = firstParagraphText(editor);
+    const trigger = parseSlashTrigger(text);
+    expect(trigger).toEqual({ prefix: "ai", trailing: "hello world" });
+
+    const matched = resolveSlashCommand(trigger!.prefix, [ai, poll], { inMuc: false });
+    expect(matched).toBe(ai);
+
+    const invocation = buildSlashInvocation(matched!, trigger!.trailing);
+    expect(invocation).toEqual({
+      kind: "inline-submit",
+      command: ai,
+      fieldName: "prompt",
+      value: "hello world",
+    });
+  });
+
+  test("`/poll Best mascot?` in a MUC opens the palette with first-required prefill", () => {
+    const editor = createEditor("/poll Best mascot?");
+
+    const text = firstParagraphText(editor);
+    const trigger = parseSlashTrigger(text);
+    expect(trigger).toEqual({ prefix: "poll", trailing: "Best mascot?" });
+
+    const matched = resolveSlashCommand(trigger!.prefix, [ai, poll], { inMuc: true });
+    expect(matched).toBe(poll);
+
+    const invocation = buildSlashInvocation(matched!, trigger!.trailing);
+    expect(invocation).toEqual({
+      kind: "open-palette",
+      command: poll,
+      prefillFirstRequired: "Best mascot?",
+    });
+  });
+
+  test("`/poll` outside a MUC shows no candidates (channel-scope filter)", () => {
+    const editor = createEditor("/poll");
+
+    const text = firstParagraphText(editor);
+    const trigger = parseSlashTrigger(text);
+    expect(trigger).toEqual({ prefix: "poll", trailing: "" });
+
+    expect(filterSlashCandidates(trigger!.prefix, [ai, poll], { inMuc: false })).toEqual([]);
+    expect(resolveSlashCommand(trigger!.prefix, [ai, poll], { inMuc: false })).toBeNull();
+  });
+
+  test("`/xyz` blocks: no candidates, no resolution", () => {
+    const editor = createEditor("/xyz");
+
+    const text = firstParagraphText(editor);
+    const trigger = parseSlashTrigger(text);
+    expect(trigger).toEqual({ prefix: "xyz", trailing: "" });
+
+    expect(filterSlashCandidates(trigger!.prefix, [ai, poll], { inMuc: true })).toEqual([]);
+    expect(resolveSlashCommand(trigger!.prefix, [ai, poll], { inMuc: true })).toBeNull();
+  });
+
+  test("plain text `hello` produces no slash trigger", () => {
+    const editor = createEditor("hello");
+
+    const text = firstParagraphText(editor);
+    expect(parseSlashTrigger(text)).toBeNull();
+  });
+
+  test("`/ai` in the first paragraph does not pull trailing text from a second paragraph", () => {
+    const editor = createEditor("/ai", "hello");
+
+    // Trigger looks at the first paragraph only; the second paragraph's text
+    // is not pulled into `trailing`.
+    const text = firstParagraphText(editor);
+    const trigger = parseSlashTrigger(text);
+    expect(trigger).toEqual({ prefix: "ai", trailing: "" });
+  });
+});

--- a/chat/tests/slash-match.test.ts
+++ b/chat/tests/slash-match.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { DiscoveredExtensionCommand } from "../src/lib/xmpp/extension-commands";
+import { filterSlashCandidates, resolveSlashCommand } from "../src/lib/slash-match";
+
+const ai: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:ai-chatbot",
+  name: "Ask AI Chatbot",
+  scope: "global",
+  composerPrefix: "ai",
+  inlineField: "prompt",
+};
+
+const poll: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:decision-polls",
+  name: "Create Decision Poll",
+  scope: "channel",
+  composerPrefix: "poll",
+};
+
+const link: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:link-board",
+  name: "Add Link",
+  scope: "channel",
+  composerPrefix: "link",
+};
+
+const noPrefix: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:ops-panic",
+  name: "Panic Button",
+  scope: "global",
+};
+
+describe("filterSlashCandidates", () => {
+  test("returns nothing when commands list is empty", () => {
+    expect(filterSlashCandidates("ai", [], { inMuc: true })).toEqual([]);
+  });
+
+  test("skips commands without a composerPrefix (opt-in only)", () => {
+    expect(filterSlashCandidates("", [noPrefix, ai], { inMuc: true })).toEqual([ai]);
+  });
+
+  test("hides channel-scoped commands when not currently in a MUC", () => {
+    expect(filterSlashCandidates("", [ai, poll, link], { inMuc: false })).toEqual([ai]);
+  });
+
+  test("includes channel-scoped commands when in a MUC", () => {
+    expect(filterSlashCandidates("", [ai, poll, link], { inMuc: true })).toEqual([ai, poll, link]);
+  });
+
+  test("filters by startsWith on composerPrefix (case-insensitive)", () => {
+    expect(filterSlashCandidates("a", [ai, poll, link], { inMuc: true })).toEqual([ai]);
+    expect(filterSlashCandidates("AI", [ai, poll, link], { inMuc: true })).toEqual([ai]);
+    expect(filterSlashCandidates("l", [ai, poll, link], { inMuc: true })).toEqual([link]);
+  });
+
+  test("returns empty when nothing starts with the prefix", () => {
+    expect(filterSlashCandidates("z", [ai, poll, link], { inMuc: true })).toEqual([]);
+  });
+
+  test("empty prefix returns all eligible commands", () => {
+    expect(filterSlashCandidates("", [ai, poll, link], { inMuc: true })).toEqual([ai, poll, link]);
+  });
+});
+
+describe("resolveSlashCommand", () => {
+  test("returns null when prefix is empty (ambiguous)", () => {
+    expect(resolveSlashCommand("", [ai, poll, link], { inMuc: true })).toBeNull();
+  });
+
+  test("returns null when nothing exactly matches", () => {
+    expect(resolveSlashCommand("xyz", [ai, poll, link], { inMuc: true })).toBeNull();
+  });
+
+  test("ignores partial matches", () => {
+    expect(resolveSlashCommand("a", [ai, poll, link], { inMuc: true })).toBeNull();
+  });
+
+  test("returns the exact match (case-insensitive)", () => {
+    expect(resolveSlashCommand("ai", [ai, poll, link], { inMuc: true })).toBe(ai);
+    expect(resolveSlashCommand("AI", [ai, poll, link], { inMuc: true })).toBe(ai);
+  });
+
+  test("returns null for channel-scoped command outside a MUC", () => {
+    expect(resolveSlashCommand("poll", [ai, poll, link], { inMuc: false })).toBeNull();
+  });
+
+  test("ignores commands without a composerPrefix", () => {
+    expect(resolveSlashCommand("ops-panic", [noPrefix], { inMuc: true })).toBeNull();
+  });
+});

--- a/chat/tests/slash-match.test.ts
+++ b/chat/tests/slash-match.test.ts
@@ -91,4 +91,15 @@ describe("resolveSlashCommand", () => {
   test("ignores commands without a composerPrefix", () => {
     expect(resolveSlashCommand("ops-panic", [noPrefix], { inMuc: true })).toBeNull();
   });
+
+  test("returns null when two commands advertise the same composerPrefix", () => {
+    const dupe: DiscoveredExtensionCommand = {
+      serviceJid: "extensions.example.com",
+      node: "urn:waddle:extension:1:other-ai",
+      name: "Other AI",
+      scope: "global",
+      composerPrefix: "ai",
+    };
+    expect(resolveSlashCommand("ai", [ai, dupe], { inMuc: true })).toBeNull();
+  });
 });

--- a/chat/tests/slash-trigger.test.ts
+++ b/chat/tests/slash-trigger.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { parseSlashTrigger } from "../src/lib/slash-trigger";
+
+describe("parseSlashTrigger", () => {
+  test("returns null when text does not start with slash", () => {
+    expect(parseSlashTrigger("hello")).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(parseSlashTrigger("")).toBeNull();
+  });
+
+  test("returns empty prefix and trailing when text is just slash", () => {
+    expect(parseSlashTrigger("/")).toEqual({ prefix: "", trailing: "" });
+  });
+
+  test("captures prefix while user is typing", () => {
+    expect(parseSlashTrigger("/ai")).toEqual({ prefix: "ai", trailing: "" });
+  });
+
+  test("splits prefix and trailing on first whitespace", () => {
+    expect(parseSlashTrigger("/ai hello world")).toEqual({ prefix: "ai", trailing: "hello world" });
+  });
+
+  test("collapses leading whitespace before trailing text", () => {
+    expect(parseSlashTrigger("/ai   hello")).toEqual({ prefix: "ai", trailing: "hello" });
+  });
+
+  test("rejects non-letter first character after slash", () => {
+    expect(parseSlashTrigger("/123")).toBeNull();
+    expect(parseSlashTrigger("/-foo")).toBeNull();
+  });
+
+  test("rejects illegal characters within prefix", () => {
+    expect(parseSlashTrigger("/ai!")).toBeNull();
+  });
+
+  test("allows hyphen and underscore inside the prefix", () => {
+    expect(parseSlashTrigger("/quick-poll question")).toEqual({ prefix: "quick-poll", trailing: "question" });
+    expect(parseSlashTrigger("/my_cmd")).toEqual({ prefix: "my_cmd", trailing: "" });
+  });
+
+  test("treats slash plus whitespace as empty prefix with no trailing", () => {
+    expect(parseSlashTrigger("/ ")).toEqual({ prefix: "", trailing: "" });
+  });
+
+  test("does not match double slash", () => {
+    expect(parseSlashTrigger("//foo")).toBeNull();
+  });
+});

--- a/server/crates/waddle-extensions/src/lib.rs
+++ b/server/crates/waddle-extensions/src/lib.rs
@@ -19,8 +19,8 @@ pub use host_tools::{
 pub use manager::{ExtensionManager, MessageExtensionOutcome};
 pub use types::{
     message_has_framework_envelope, ArtifactReference, CommandAction, CommandDescriptor,
-    CommandInvocation, CommandScope, CommandSessionId, DataForm, DataFormField, DataFormType,
-    DataFormValue, DetectedLink, DisplayText, ExtensionCapability, ExtensionEffect,
+    CommandInvocation, CommandNode, CommandScope, CommandSessionId, DataForm, DataFormField,
+    DataFormType, DataFormValue, DetectedLink, DisplayText, ExtensionCapability, ExtensionEffect,
     ExtensionEnvelope, ExtensionEvent, ExtensionManifest, ExtensionPayload, ExtensionResponse,
     ExtensionRouteDescriptor, ExtensionRouteScope, ExtensionRouteSurface, FormFieldOption,
     FormFieldType, FormFieldValue, FrameworkTypeError, FullJidValue, LaunchContext,

--- a/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
+++ b/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
@@ -52,6 +52,8 @@ impl TryFrom<wit_types::CommandDescriptor> for CommandDescriptor {
             node: wit_newtype_to_domain!(value.node, CommandNode)?,
             name: wit_newtype_to_domain!(value.name, DisplayText)?,
             scope: value.scope.into(),
+            composer_prefix: value.composer_prefix,
+            inline_field: value.inline_field,
         })
     }
 }

--- a/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
+++ b/server/crates/waddle-extensions/src/runtime/wit_to_domain.rs
@@ -250,3 +250,49 @@ impl From<wit_types::ExtensionCapability> for ExtensionCapability {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wit_descriptor(
+        node: &str,
+        composer_prefix: Option<&str>,
+        inline_field: Option<&str>,
+    ) -> wit_types::CommandDescriptor {
+        wit_types::CommandDescriptor {
+            node: wit_types::CommandNode {
+                value: node.to_string(),
+            },
+            name: wit_types::DisplayText {
+                value: "Test Command".to_string(),
+            },
+            scope: wit_types::CommandScope::Global,
+            composer_prefix: composer_prefix.map(str::to_string),
+            inline_field: inline_field.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn command_descriptor_round_trip_carries_composer_prefix_and_inline_field() {
+        let descriptor: CommandDescriptor = wit_descriptor(
+            "urn:waddle:extension:1:ai-chatbot",
+            Some("ai"),
+            Some("prompt"),
+        )
+        .try_into()
+        .expect("convert");
+        assert_eq!(descriptor.composer_prefix.as_deref(), Some("ai"));
+        assert_eq!(descriptor.inline_field.as_deref(), Some("prompt"));
+    }
+
+    #[test]
+    fn command_descriptor_round_trip_preserves_none_when_absent() {
+        let descriptor: CommandDescriptor =
+            wit_descriptor("urn:waddle:extension:1:invoke", None, None)
+                .try_into()
+                .expect("convert");
+        assert!(descriptor.composer_prefix.is_none());
+        assert!(descriptor.inline_field.is_none());
+    }
+}

--- a/server/crates/waddle-extensions/src/types/manifest.rs
+++ b/server/crates/waddle-extensions/src/types/manifest.rs
@@ -119,6 +119,10 @@ pub struct CommandDescriptor {
     pub node: CommandNode,
     pub name: DisplayText,
     pub scope: CommandScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub composer_prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inline_field: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/server/crates/waddle-extensions/tests/framework_vocabulary.rs
+++ b/server/crates/waddle-extensions/tests/framework_vocabulary.rs
@@ -79,6 +79,8 @@ fn sample_manifest() -> ExtensionManifest {
             node: CommandNode::new("urn:waddle:extension:1:task-widget").expect("command node"),
             name: text("Task Widget"),
             scope: CommandScope::Global,
+            composer_prefix: None,
+            inline_field: None,
         }],
         routes: Vec::new(),
         pubsub_nodes: vec![id!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/extension_forms.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/extension_forms.rs
@@ -90,7 +90,7 @@ pub(super) fn extension_command_metadata_form(
 ) -> Element {
     use waddle_xmpp::xep::xep0004::{DataForm, Field, FormType, IntoElement};
 
-    DataForm::new(FormType::Result)
+    let mut form = DataForm::new(FormType::Result)
         .add_field(Field::form_type(EXTENSION_COMMAND_FORM_TYPE))
         .add_field(Field::text_single("waddle#plugin_id", plugin.as_str()))
         .add_field(Field::text_single(
@@ -104,6 +104,113 @@ pub(super) fn extension_command_metadata_form(
         .add_field(Field::text_single(
             "waddle#command_scope",
             descriptor.scope.as_str(),
-        ))
-        .into_element()
+        ));
+    if let Some(prefix) = descriptor.composer_prefix.as_deref() {
+        form = form.add_field(Field::text_single("waddle#composer_prefix", prefix));
+    }
+    if let Some(field_name) = descriptor.inline_field.as_deref() {
+        form = form.add_field(Field::text_single("waddle#inline_field", field_name));
+    }
+    form.into_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn descriptor(
+        node: &str,
+        scope: waddle_extensions::CommandScope,
+        composer_prefix: Option<&str>,
+        inline_field: Option<&str>,
+    ) -> waddle_extensions::CommandDescriptor {
+        waddle_extensions::CommandDescriptor {
+            node: waddle_extensions::CommandNode::new(node).expect("command node"),
+            name: waddle_extensions::DisplayText::new("Test Command").expect("display text"),
+            scope,
+            composer_prefix: composer_prefix.map(str::to_string),
+            inline_field: inline_field.map(str::to_string),
+        }
+    }
+
+    fn plugin(id: &str) -> waddle_extensions::PluginId {
+        waddle_extensions::PluginId::new(id).expect("plugin id")
+    }
+
+    fn field_value(form: &Element, var: &str) -> Option<String> {
+        form.children()
+            .filter(|c| c.name() == "field")
+            .find_map(|field| {
+                (field.attr("var") == Some(var)).then(|| {
+                    field
+                        .get_child("value", "jabber:x:data")
+                        .map(|v| v.text())
+                        .unwrap_or_default()
+                })
+            })
+    }
+
+    fn has_field(form: &Element, var: &str) -> bool {
+        form.children()
+            .filter(|c| c.name() == "field")
+            .any(|field| field.attr("var") == Some(var))
+    }
+
+    #[test]
+    fn command_metadata_form_omits_composer_prefix_when_descriptor_has_none() {
+        let form = extension_command_metadata_form(
+            &plugin("decision-polls"),
+            &descriptor(
+                "urn:waddle:extension:1:invoke",
+                waddle_extensions::CommandScope::Channel,
+                None,
+                None,
+            ),
+        );
+        assert!(!has_field(&form, "waddle#composer_prefix"));
+        assert!(!has_field(&form, "waddle#inline_field"));
+        assert_eq!(
+            field_value(&form, "waddle#command_scope").as_deref(),
+            Some("channel"),
+        );
+    }
+
+    #[test]
+    fn command_metadata_form_serializes_composer_prefix_and_inline_field() {
+        let form = extension_command_metadata_form(
+            &plugin("ai-chatbot"),
+            &descriptor(
+                "urn:waddle:extension:1:ai-chatbot",
+                waddle_extensions::CommandScope::Global,
+                Some("ai"),
+                Some("prompt"),
+            ),
+        );
+        assert_eq!(
+            field_value(&form, "waddle#composer_prefix").as_deref(),
+            Some("ai"),
+        );
+        assert_eq!(
+            field_value(&form, "waddle#inline_field").as_deref(),
+            Some("prompt"),
+        );
+    }
+
+    #[test]
+    fn command_metadata_form_includes_composer_prefix_without_inline_field() {
+        let form = extension_command_metadata_form(
+            &plugin("decision-polls"),
+            &descriptor(
+                "urn:waddle:extension:1:decision-polls",
+                waddle_extensions::CommandScope::Channel,
+                Some("poll"),
+                None,
+            ),
+        );
+        assert_eq!(
+            field_value(&form, "waddle#composer_prefix").as_deref(),
+            Some("poll"),
+        );
+        assert!(!has_field(&form, "waddle#inline_field"));
+    }
 }

--- a/server/extensions/ai-chatbot/src/manifest.rs
+++ b/server/extensions/ai-chatbot/src/manifest.rs
@@ -29,6 +29,8 @@ pub(crate) fn manifest() -> types::ExtensionManifest {
             COMMAND_NODE,
             AI_COMMAND,
             types::CommandScope::Global,
+            Some("ai"),
+            Some("prompt"),
         )],
         routes: vec![],
         pubsub_nodes: vec![],
@@ -50,6 +52,8 @@ fn command_descriptor(
     node: &str,
     name: &str,
     scope: types::CommandScope,
+    composer_prefix: Option<&str>,
+    inline_field: Option<&str>,
 ) -> types::CommandDescriptor {
     types::CommandDescriptor {
         node: types::CommandNode {
@@ -57,5 +61,7 @@ fn command_descriptor(
         },
         name: display(name),
         scope,
+        composer_prefix: composer_prefix.map(str::to_string),
+        inline_field: inline_field.map(str::to_string),
     }
 }

--- a/server/extensions/decision-polls/src/helpers.rs
+++ b/server/extensions/decision-polls/src/helpers.rs
@@ -151,6 +151,8 @@ pub(super) fn command_descriptor(
     node: &str,
     name: &str,
     scope: types::CommandScope,
+    composer_prefix: Option<&str>,
+    inline_field: Option<&str>,
 ) -> types::CommandDescriptor {
     types::CommandDescriptor {
         node: types::CommandNode {
@@ -158,6 +160,8 @@ pub(super) fn command_descriptor(
         },
         name: display(name),
         scope,
+        composer_prefix: composer_prefix.map(str::to_string),
+        inline_field: inline_field.map(str::to_string),
     }
 }
 

--- a/server/extensions/decision-polls/src/manifest.rs
+++ b/server/extensions/decision-polls/src/manifest.rs
@@ -28,11 +28,15 @@ pub(super) fn manifest() -> types::ExtensionManifest {
                 COMMAND_NODE,
                 "Create Decision Poll",
                 types::CommandScope::Channel,
+                Some("poll"),
+                None,
             ),
             command_descriptor(
                 INVOKE_NODE,
                 "Run Decision Poll action",
                 types::CommandScope::Channel,
+                None,
+                None,
             ),
         ],
         routes: vec![types::ExtensionRouteDescriptor {

--- a/server/extensions/link-board/src/helpers.rs
+++ b/server/extensions/link-board/src/helpers.rs
@@ -28,6 +28,8 @@ pub(super) fn command_descriptor(
     node: &str,
     name: &str,
     scope: types::CommandScope,
+    composer_prefix: Option<&str>,
+    inline_field: Option<&str>,
 ) -> types::CommandDescriptor {
     types::CommandDescriptor {
         node: types::CommandNode {
@@ -35,6 +37,8 @@ pub(super) fn command_descriptor(
         },
         name: display(name),
         scope,
+        composer_prefix: composer_prefix.map(str::to_string),
+        inline_field: inline_field.map(str::to_string),
     }
 }
 

--- a/server/extensions/link-board/src/manifest.rs
+++ b/server/extensions/link-board/src/manifest.rs
@@ -22,6 +22,8 @@ pub(super) fn manifest() -> types::ExtensionManifest {
             INVOKE_NODE,
             "Run Link Board action",
             types::CommandScope::Channel,
+            None,
+            None,
         )],
         routes: vec![types::ExtensionRouteDescriptor {
             plugin: plugin_id(),

--- a/server/wit/waddle-extension.wit
+++ b/server/wit/waddle-extension.wit
@@ -186,6 +186,15 @@ interface types {
         node: command-node,
         name: display-text,
         scope: command-scope,
+        /// Optional `/`-prefix string declared by the extension. When present,
+        /// the chat client surfaces this command in its keyboard-first slash
+        /// autocomplete (XEP-0128 form var `waddle#composer_prefix`).
+        composer-prefix: option<string>,
+        /// Form-field name that captures the trailing text from the slash
+        /// composer (`/<prefix> <text>`). Only meaningful when the command's
+        /// XEP-0004 form has a single user-fillable field. (XEP-0128 form var
+        /// `waddle#inline_field`.)
+        inline-field: option<string>,
     }
 
     record extension-route-descriptor {


### PR DESCRIPTION
Closes #399.

## Background

PR #326 (`f4fd3edd`) intentionally tore out slash-like message-body workflows as part of the extension boundary cleanup ("No workflows are triggered by ordinary slash-like chat message bodies after this cleanup."). It also incidentally removed the keyboard-first slash autocomplete that commit `94d089ad` shipped — leaving the `ExtensionPalette` button as the only way to invoke a command.

This PR restores keyboard-first command invocation **without** re-introducing slash-message-body interception. Slash autocomplete in the composer dispatches via XEP-0050 ad-hoc commands; nothing is ever sent as a chat-body workflow trigger.

## Design

| # | Decision |
|---|---|
| 1 | Slash autocomplete in the composer opens or directly invokes the existing XEP-0050 command — never sends a slash body as a workflow. |
| 2 | Each command opts in by declaring `composer-prefix` (and optionally `inline-field`) on its per-command `disco#info` via XEP-0128 extended info, on the same `urn:waddle:extension:1:command` form that already carries `waddle#command_scope`. |
| 3 | Single-field commands declare `inline-field`: `/<prefix> <text>` builds an XEP-0050 invoke IQ with that field set and submits directly. Multi-field commands open the existing `ExtensionPalette.vue` form. |
| 4 | Trigger only fires when `/` is the first character of the composer's first paragraph. No mid-sentence trigger. |
| 5 | Submitting `/word` that doesn't match any declared `composer-prefix` is **blocked** with a non-modal "No command `/word`" hint. Esc converts the buffer to plain text; Enter retries. Satisfies AC: "Unsupported slash commands produce clear feedback instead of silent failure." |
| 6 | Autocomplete surfaces every command declaring `composer-prefix`, scope-filtered by `waddle#command_scope` (channel-scoped commands hidden outside MUCs). Admin/non-admin is **not** pre-filtered — server enforces capability checks on submit. |
| 7 | Trailing text after a multi-field prefix (e.g. `/poll Best mascot?`) pre-fills the first required field of the XEP-0004 form when the palette opens. |

## What landed

### Pure modules (TS)

- `chat/src/lib/slash-trigger.ts` — `parseSlashTrigger(text)`: only matches a `/` at the start of the first paragraph, allows hyphens/underscores in the prefix, splits prefix from trailing on the first whitespace.
- `chat/src/lib/slash-match.ts` — `filterSlashCandidates(prefix, commands, { inMuc })` (live autocomplete) and `resolveSlashCommand(prefix, commands, { inMuc })` (submit-time exact match). Both opt-in via declared `composerPrefix`, scope-filter by `command_scope`.
- `chat/src/lib/slash-dispatch.ts` — `buildSlashInvocation(command, trailing)`: returns either `{ kind: "inline-submit", fieldName, value }` or `{ kind: "open-palette", prefillFirstRequired? }`. Whitespace-only trailing is treated as empty.
- `chat/src/lib/reply-ux.ts` — `getComposerAutocompleteAction` learns `submit-slash`, `select-command`, `block-slash`. `getComposerEscapeAction` learns `dismiss-slash`. Mention/emoji autocomplete still take precedence over slash so the existing keyboard contract is unchanged in those modes.

### Disco parser (TS)

- `chat/src/lib/xmpp/extension-commands/disco.ts` — extended `parseExtensionCommandScope` into a single `parseExtensionCommandMetadata` reading `waddle#command_scope` plus the new `waddle#composer_prefix` and `waddle#inline_field`.
- `DiscoveredExtensionCommand` gains optional `composerPrefix` and `inlineField`.

### Composer wiring (Vue)

- New `chat/src/components/chat/SlashCommandPopover.vue` renders the candidate list and the blocked-state hint when `/word` matches no declared prefix.
- `MessageComposer.vue` detects a `/`-prefix on the first paragraph, derives candidates and resolution from the pure modules, routes Enter through the new actions. Esc dismisses the slash mode for the current draft so a literal `/word` can be sent as text.
- `ContentArea.vue` eagerly discovers commands when the XMPP client is ready, then passes the discovered list and an inMuc flag to the composer; the composer's `dispatchSlash` event drops into the launcher.
- `useExtensionLauncher` gains:
  - `ensureDiscovered()` — populates commands without opening the palette.
  - `dispatchSlashInvocation(invocation)` — for `inline-submit`, runs the XEP-0050 execute → set field → submit dance; for `open-palette`, opens the palette and pre-fills the first required field from `prefillFirstRequired`.

### Server (Rust + WIT)

- WIT `command-descriptor` gains optional `composer-prefix` and `inline-field`.
- Domain `CommandDescriptor` mirrors them as `Option<String>` (skipped during serde when None).
- `wit_to_domain::TryFrom` carries the values through.
- `extension_command_metadata_form` adds `waddle#composer_prefix` and `waddle#inline_field` to the per-command XEP-0128 disco#info form when set, omits them when not. All XML built via `xmpp_parsers` / typed builders.

### Extension opt-ins

- `ai-chatbot` — `composer_prefix=ai`, `inline_field=prompt`. Slash type-then-Enter goes straight to XEP-0050.
- `decision-polls` — `composer_prefix=poll` on the create command. Trailing text pre-fills the `question` field on palette open.
- `link-board` — **deferred to a follow-up.** It currently has no standalone create command suitable for a slash entry; adding one is meaningful new functionality and lives outside this PR's scope.

## Tests

Per the **XEP custom test-suite hard rule**, every implemented XEP touched here gets a dedicated test update.

- **Rust** (`extension_forms.rs#tests` — XEP-0030 / XEP-0050 / XEP-0128):
  - `command_metadata_form_omits_composer_prefix_when_descriptor_has_none`
  - `command_metadata_form_serializes_composer_prefix_and_inline_field`
  - `command_metadata_form_includes_composer_prefix_without_inline_field`
- **TypeScript (chat/tests/)**:
  - `slash-trigger.test.ts` — 11 cases for the parser.
  - `slash-match.test.ts` — 13 cases for filter + exact resolver, including scope filter and case-insensitivity.
  - `slash-dispatch.test.ts` — 6 cases for the inline / palette-with-prefill / open-palette decision.
  - `reply-ux.test.ts` — 5 new cases for the slash actions in autocomplete/escape helpers.
  - `extension-command.test.ts` — added a case for the new disco#info form fields end-to-end through `discoverExtensionCommands`.
  - `slash-flow.test.ts` — live `@tiptap/core` Editor integration covering the six end-to-end flows (inline-submit, palette-with-prefill, scope filter, no-match, plain text, multi-paragraph).

## Boundary check

- Extension-boundary contract from #326 preserved — chat client never invents per-extension semantics; everything flows through XEP-0050 + XEP-0128 + XEP-0004.
- XML generation hard rule — all stanzas via typed builders.
- Typed-payloads hard rule — new typed fields on the descriptor + typed match/invocation values; no stringly-typed payloads.
- Acceptance criteria from #399:
  - Typing a supported slash command works (inline or palette path).
  - Unsupported slash commands produce explicit feedback with an Esc escape hatch.
  - Deterministic parser/dispatch tests added.

## Follow-ups (out of scope here)

- Add a standalone "save link" command to `link-board` and declare its `composer-prefix=link` in a follow-up PR.
- The stale UX-review note `Slash command was removed. Only the extension button works atm` lives outside this repo (likely the UX review doc). After this lands, that note becomes false and should be removed at the source.