### PR TITLE
feat(chat): add extension route rail

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -20,8 +20,6 @@ const {
   channelUnread,
   notifications,
   version,
-  extensionRoutes,
-  activeExtensionRouteKey,
   displayedMemberCount,
   displayedMemberState,
   memberCountLabel,
@@ -32,7 +30,6 @@ const {
   handleToggleNotifications,
   selectChannel,
   onSelectThread,
-  selectExtensionRoute,
   selectDm,
   openCreateChannelDialog,
   openChannelEdit,
@@ -79,12 +76,9 @@ const {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
-          :extension-routes="extensionRoutes"
-          :active-extension-route="ui.activePage.value === 'extension' ? activeExtensionRouteKey : null"
           class="!w-full !border-r-0 !flex-1"
           @select-channel="selectChannel"
           @select-thread="onSelectThread"
-          @select-extension-route="selectExtensionRoute"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -5,6 +5,7 @@ import ChatAppModals from "@/components/chat/ChatAppModals.vue";
 import ChatMobileDrawers from "@/components/chat/ChatMobileDrawers.vue";
 import ContentArea from "@/components/chat/ContentArea.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
+import ExtensionRouteRail from "@/components/chat/ExtensionRouteRail.vue";
 import ExtensionRouteView from "@/components/chat/ExtensionRouteView.vue";
 import ThreadPanel from "@/components/chat/ThreadPanel.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
@@ -13,6 +14,7 @@ import UserSettingsPage from "@/components/chat/UserSettingsPage.vue";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
 import type { ChatAppController } from "@/shell/chat-app-controller";
+import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 
 const props = defineProps<{
   controller: ChatAppController;
@@ -32,12 +34,13 @@ const {
   xmppClient,
   activeMessages,
   activeFirstUnseenId,
-  extensionRoutes,
+  channelExtensionRoutes,
   activeExtensionRouteKey,
   activeExtensionRoute,
   activeChannelRoomJid,
   activeThreadStack,
   activeThreadTargetMessageId,
+  activeRightPanel,
   threads,
   reactionModeTarget,
   reactionModeState,
@@ -87,6 +90,9 @@ const {
   pushThread,
   popThreadTo,
   closeThreadPanel,
+  activateRightPanel,
+  closeExtensionRoutePanel,
+  closePinnedPanel,
   notifyActiveComposing,
   editActiveMessage,
   retractActiveMessage,
@@ -115,6 +121,32 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
   activeChannelJids: messaging.activeChannels.value,
   dmConversations: dmConversations.conversations.value,
 }));
+
+const contentPaneClass = computed(() => {
+  if (ui.sidebarMode.value !== "channels") return "";
+  if (activeRightPanel.value === "thread") {
+    if (activeThreadStack.value.length === 0) return "";
+    return activeThreadStack.value.length === 1
+      ? "chat-content-pane--desktop-split"
+      : "chat-content-pane--hidden";
+  }
+  return activeRightPanel.value ? "chat-content-pane--desktop-split" : "";
+});
+
+function selectCurrentChannelExtensionRoute(route: DiscoveredExtensionRoute) {
+  const channel = waddles.currentChannel.value;
+  if (!channel) return;
+  void selectExtensionRoute(channel.id, route);
+}
+
+function setPinnedPanelOpen(isOpen: boolean) {
+  if (!isOpen) {
+    closePinnedPanel();
+    return;
+  }
+  ui.showPinnedPanel.value = true;
+  activateRightPanel("pinned");
+}
 </script>
 
 <template>
@@ -163,11 +195,8 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
-          :extension-routes="extensionRoutes"
-          :active-extension-route="ui.activePage.value === 'extension' ? activeExtensionRouteKey : null"
           @select-channel="selectChannel"
           @select-thread="onSelectThread"
-          @select-extension-route="selectExtensionRoute"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"
@@ -199,18 +228,6 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
         :server-version="version.serverVersion.value"
         @close="closeUserSettings"
       />
-      <ExtensionRouteView
-        v-else-if="ui.activePage.value === 'extension'"
-        :waddle="waddles.currentSpace.value"
-        :channel="waddles.currentChannel.value"
-        :route="activeExtensionRoute"
-        :requested-route="activeExtensionRouteKey"
-        :room-jid="activeChannelRoomJid"
-        :xmpp-client="xmppClient"
-        :action-error="activeActionError"
-        @open-nav="ui.showMobileNav.value = true"
-        @invoke-action="invokeExtensionRouteAction"
-      />
       <template v-else>
         <!--
           Accordion thread layout
@@ -227,22 +244,21 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
              - depth 0: visible and flex-1 (full remaining width)
              - depth 1: hidden on mobile, flex-1 on desktop (left pane)
              - depth 2+: hidden entirely (parent thread pane takes its place) -->
-        <div class="chat-workspace">
+        <div
+          class="chat-workspace"
+          :class="activeRightPanel ? 'chat-workspace--right-panel-active' : ''"
+        >
           <div
             :class="[
               'chat-content-pane',
-              activeThreadStack.length === 0
-                ? ''
-                : activeThreadStack.length === 1
-                  ? 'chat-content-pane--desktop-split'
-                  : 'chat-content-pane--hidden',
+              contentPaneClass,
             ]"
           >
             <ContentArea
               :ref="setContentAreaRef"
               v-model:draft="activeDraft"
               v-model:forum-title="activeForumTitle"
-              v-model:pinned-panel-open="ui.showPinnedPanel.value"
+              :pinned-panel-open="activeRightPanel === 'pinned' && ui.showPinnedPanel.value"
               :waddle="waddles.currentSpace.value"
               :channel="ui.sidebarMode.value === 'dms' ? null : waddles.currentChannel.value"
               :room-jid="ui.sidebarMode.value === 'dms' ? null : activeChannelRoomJid"
@@ -288,6 +304,7 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
               @react-message="reactActiveMessage"
               @pin-message="pinActiveMessage"
               @unpin-message="unpinActiveMessage"
+              @update:pinned-panel-open="setPinnedPanelOpen"
               @search="searchActiveMessages"
               @clear-search="clearActiveSearch"
               @load-older="loadOlderActiveMessages"
@@ -302,11 +319,22 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
             />
           </div>
 
-          <!-- Collapsed accordion bars: one per hidden ancestor level (desktop only, depth >= 2).
-               Each bar is a thin vertical strip with a rotated label; clicking
-               navigates to that level. The channel bar returns to the main feed,
-               thread bars collapse levels older than the parent context pane. -->
-          <template v-if="ui.sidebarMode.value === 'channels' && activeThreadStack.length >= 2">
+          <!-- Collapsed accordion bars: one per inactive right-side panel. -->
+          <button
+            v-if="ui.sidebarMode.value === 'channels'
+              && activeRightPanel !== 'thread'
+              && activeThreadStack.length >= 1"
+            type="button"
+            class="chat-accordion-bar bg-muted/20 hover:bg-muted/50"
+            :title="getThreadLabel(activeThreadStack[activeThreadStack.length - 1] ?? '')"
+            @click="activateRightPanel('thread')"
+          >
+            <span class="accordion-bar-label text-muted-foreground/70">
+              {{ getThreadLabel(activeThreadStack[activeThreadStack.length - 1] ?? '') }}
+            </span>
+          </button>
+
+          <template v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 2">
             <!-- Channel / main-feed bar -->
             <button
               type="button"
@@ -333,10 +361,40 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
             </button>
           </template>
 
+          <button
+            v-if="ui.sidebarMode.value === 'channels'
+              && activeRightPanel !== 'pinned'
+              && ui.showPinnedPanel.value
+              && waddles.currentChannel.value
+              && activeChannelRoomJid"
+            type="button"
+            class="chat-accordion-bar bg-muted/20 hover:bg-muted/50"
+            title="Pinned messages"
+            @click="activateRightPanel('pinned')"
+          >
+            <span class="accordion-bar-label text-muted-foreground/70">
+              Pinned
+            </span>
+          </button>
+
+          <button
+            v-if="ui.sidebarMode.value === 'channels'
+              && activeRightPanel !== 'extension'
+              && activeExtensionRouteKey"
+            type="button"
+            class="chat-accordion-bar bg-muted/20 hover:bg-muted/50"
+            :title="activeExtensionRoute?.label ?? 'Extensions'"
+            @click="activateRightPanel('extension')"
+          >
+            <span class="accordion-bar-label text-muted-foreground/70">
+              {{ activeExtensionRoute?.label ?? 'Extensions' }}
+            </span>
+          </button>
+
           <!-- Parent thread pane: desktop-only context when depth >= 2.
                Shows the second-to-last thread in read-only mode (no composer). -->
           <div
-            v-if="ui.sidebarMode.value === 'channels' && activeThreadStack.length >= 2"
+            v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 2"
             class="chat-parent-thread-pane"
           >
             <ThreadPanel
@@ -375,7 +433,7 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
           <!-- Active thread pane: shown when any thread is open.
                Full-width on mobile; shares space with parent context on desktop. -->
           <div
-            v-if="ui.sidebarMode.value === 'channels' && activeThreadStack.length >= 1"
+            v-if="ui.sidebarMode.value === 'channels' && activeRightPanel === 'thread' && activeThreadStack.length >= 1"
             class="chat-active-thread-pane"
           >
             <ThreadPanel
@@ -414,14 +472,10 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
             />
           </div>
 
-          <!-- #414 PinnedPanel: right-rail panel listing pinned messages.
-               Visible in channel context only when ui.showPinnedPanel
-               is true. Mutually exclusive with the thread panel — the
-               header pin button toggles this and the URL state. -->
           <div
             v-if="ui.sidebarMode.value === 'channels'
+              && activeRightPanel === 'pinned'
               && ui.showPinnedPanel.value
-              && activeThreadStack.length === 0
               && waddles.currentChannel.value
               && activeChannelRoomJid"
             class="chat-active-thread-pane"
@@ -429,10 +483,38 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
             <PinnedPanel
               :room-jid="activeChannelRoomJid"
               :channel-name="waddles.currentChannel.value?.name ?? ''"
-              @close="ui.showPinnedPanel.value = false"
+              @close="closePinnedPanel"
               @jump-to-message="(stanzaId: string) => jumpToPinnedMessage(stanzaId)"
             />
           </div>
+
+          <div
+            v-if="ui.sidebarMode.value === 'channels'
+              && activeRightPanel === 'extension'
+              && activeExtensionRouteKey"
+            class="chat-active-thread-pane"
+          >
+            <ExtensionRouteView
+              :waddle="waddles.currentSpace.value"
+              :channel="waddles.currentChannel.value"
+              :route="activeExtensionRoute"
+              :requested-route="activeExtensionRouteKey"
+              :room-jid="activeChannelRoomJid"
+              :xmpp-client="xmppClient"
+              :action-error="activeActionError"
+              @open-nav="ui.showMobileNav.value = true"
+              @close="closeExtensionRoutePanel"
+              @invoke-action="invokeExtensionRouteAction"
+            />
+          </div>
+
+          <ExtensionRouteRail
+            v-if="ui.sidebarMode.value === 'channels' && waddles.currentChannel.value"
+            :routes="channelExtensionRoutes"
+            :active-route="activeExtensionRouteKey"
+            :active="activeRightPanel === 'extension'"
+            @select-route="selectCurrentChannelExtensionRoute"
+          />
         </div>
       </template>
     </div>

--- a/chat/src/components/chat/ExtensionRouteRail.vue
+++ b/chat/src/components/chat/ExtensionRouteRail.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { Grid3X3, Link2, ListChecks } from "lucide-vue-next";
+import { computed } from "vue";
+import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+import { extensionRouteRailItems, type ExtensionRouteRailIcon } from "./extension-route-rail-model";
+
+const props = defineProps<{
+  routes: DiscoveredExtensionRoute[];
+  activeRoute?: { pluginId: string; routeId: string } | null;
+  active?: boolean;
+}>();
+
+const emit = defineEmits<{
+  selectRoute: [route: DiscoveredExtensionRoute];
+}>();
+
+const items = computed(() => extensionRouteRailItems(props.routes, props.activeRoute, !!props.active));
+
+function routeIcon(icon: ExtensionRouteRailIcon) {
+  if (icon === "links") return Link2;
+  if (icon === "gallery") return Grid3X3;
+  return ListChecks;
+}
+</script>
+
+<template>
+  <aside
+    v-if="routes.length > 0"
+    class="extension-route-rail"
+    aria-label="Channel extension routes"
+  >
+    <button
+      v-for="item in items"
+      :key="item.key"
+      type="button"
+      class="extension-route-rail__button"
+      :class="item.isActive ? 'extension-route-rail__button--active' : ''"
+      :title="item.label"
+      :aria-label="item.label"
+      :aria-current="item.isActive ? 'page' : undefined"
+      @click="emit('selectRoute', item.route)"
+    >
+      <component :is="routeIcon(item.icon)" class="h-4 w-4" aria-hidden="true" />
+    </button>
+  </aside>
+</template>

--- a/chat/src/components/chat/ExtensionRouteView.vue
+++ b/chat/src/components/chat/ExtensionRouteView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
-import { ExternalLink, Grid3X3, List, RefreshCw, WifiOff } from "lucide-vue-next";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
+import { ExternalLink, Grid3X3, List, RefreshCw, WifiOff, X } from "lucide-vue-next";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ExtensionAnnotationAction } from "@/lib/chat-ui";
@@ -18,12 +18,14 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   openNav: [];
+  close: [];
   invokeAction: [action: ExtensionAnnotationAction];
 }>();
 
 const items = ref<ExtensionRouteItem[]>([]);
 const state = ref<"idle" | "loading" | "error">("idle");
 const detail = ref("");
+const panelRef = ref<HTMLElement | null>(null);
 
 const routeKey = computed(() =>
   props.route && props.roomJid
@@ -84,13 +86,25 @@ function safeUrl(href: string | undefined): string | null {
   }
 }
 
+function focusPanel() {
+  void nextTick(() => panelRef.value?.focus({ preventScroll: true }));
+}
+
 watch(routeKey, () => {
+  focusPanel();
   void refreshItems();
 }, { immediate: true });
+
+onMounted(focusPanel);
 </script>
 
 <template>
-  <div class="flex min-w-0 flex-1 flex-col bg-background">
+  <aside
+    ref="panelRef"
+    class="extension-route-panel flex min-w-0 flex-1 flex-col bg-background border-l border-border"
+    tabindex="-1"
+    :aria-label="route?.label ? `${route.label} extension route` : 'Extension route'"
+  >
     <header class="chat-pane-header border-b border-border px-[var(--chat-content-inline)] py-0 flex flex-shrink-0 items-center justify-between gap-3 glass-panel">
       <div class="chat-message-lane flex min-w-0 items-center gap-2">
         <button
@@ -109,18 +123,28 @@ watch(routeKey, () => {
           </div>
         </div>
       </div>
-      <button
-        class="chat-icon-button"
-        type="button"
-        aria-label="Refresh"
-        :disabled="state === 'loading'"
-        @click="refreshItems"
-      >
-        <RefreshCw class="h-4 w-4" :class="state === 'loading' ? 'animate-spin' : ''" />
-      </button>
+      <div class="flex items-center gap-1.5">
+        <button
+          class="chat-icon-button"
+          type="button"
+          aria-label="Refresh"
+          :disabled="state === 'loading'"
+          @click="refreshItems"
+        >
+          <RefreshCw class="h-4 w-4" :class="state === 'loading' ? 'animate-spin' : ''" />
+        </button>
+        <button
+          class="chat-icon-button"
+          type="button"
+          aria-label="Close extension route"
+          @click="emit('close')"
+        >
+          <X class="h-4 w-4" />
+        </button>
+      </div>
     </header>
 
-    <main class="chat-pane-scroll flex-1 px-[var(--chat-content-inline)] py-4">
+    <div class="chat-pane-scroll flex-1 px-[var(--chat-content-inline)] py-4">
       <div v-if="state === 'loading'" class="type-caption flex h-full items-center justify-center text-muted-foreground">
         Loading…
       </div>
@@ -190,7 +214,7 @@ watch(routeKey, () => {
               v-for="action in item.actions"
               :key="action.launchId"
               type="button"
-              class="chat-icon-button chat-icon-button--sm"
+              class="type-caption inline-flex min-h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-foreground transition-colors hover:bg-muted"
               @click="emit('invokeAction', { label: action.label, route: action.launchId, launch: action.launch })"
             >
               {{ action.label }}
@@ -198,6 +222,6 @@ watch(routeKey, () => {
           </div>
         </article>
       </div>
-    </main>
-  </div>
+    </div>
+  </aside>
 </template>

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { Hash, LayoutDashboard, MessagesSquare, Plus, Settings, Users, ChevronDown, MessageCircle } from "lucide-vue-next";
+import { Hash, MessagesSquare, Plus, Settings, Users, ChevronDown, MessageCircle } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
-import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import type { MemberLoadState } from "@/waddles/directory";
 
 const props = defineProps<{
@@ -23,8 +22,6 @@ const props = defineProps<{
   channelUnreadMap?: Record<string, { unread: number; mentions: number }>;
   threadEntriesFn?: (roomJid: string) => ChannelThreadInboxEntry[];
   roomAvatarHashes?: Record<string, string>;
-  extensionRoutes?: DiscoveredExtensionRoute[];
-  activeExtensionRoute?: { channelId: string; pluginId: string; routeId: string } | null;
 }>();
 
 function hasActivity(channelId: string): boolean {
@@ -122,23 +119,8 @@ function channelThreads(channel: ChannelSummary): ChannelThreadInboxEntry[] {
   return [];
 }
 
-function channelExtensionRoutes(_channel: ChannelSummary): DiscoveredExtensionRoute[] {
-  return props.extensionRoutes?.filter((route) => route.scope === "channel") ?? [];
-}
-
-function isActiveExtensionRoute(channel: ChannelSummary, route: DiscoveredExtensionRoute): boolean {
-  return props.activeExtensionRoute?.channelId === channel.id
-    && props.activeExtensionRoute.pluginId === route.pluginId
-    && props.activeExtensionRoute.routeId === route.routeId;
-}
-
 function isActiveChannelPage(channel: ChannelSummary): boolean {
-  return props.activeChannelId === channel.id && !props.activeExtensionRoute;
-}
-
-function extensionRouteRowLabel(channel: ChannelSummary, route: DiscoveredExtensionRoute): string {
-  const state = isActiveExtensionRoute(channel, route) ? "selected" : "not selected";
-  return `${route.label}, ${channel.name}, extension route, ${state}`;
+  return props.activeChannelId === channel.id;
 }
 
 function truncateTitle(title: string | undefined, maxLen = 28): string {
@@ -149,7 +131,6 @@ function truncateTitle(title: string | undefined, maxLen = 28): string {
 const emit = defineEmits<{
   selectChannel: [id: string];
   selectThread: [channelId: string, threadId: string];
-  selectExtensionRoute: [channelId: string, route: DiscoveredExtensionRoute];
   createChannel: [];
   createChannelInSpace: [spaceId: string | null];
   openSettings: [];
@@ -347,24 +328,6 @@ watch(
                   class="w-2 h-2 bg-primary rounded-full flex-shrink-0 shadow-[0_0_6px_var(--glow-strong)]"
                   aria-hidden="true"
                 />
-              </button>
-
-              <!-- Channel extension routes -->
-              <button
-                v-for="route in channelExtensionRoutes(channel)"
-                :key="`${channel.id}:${route.pluginId}:${route.routeId}`"
-                class="chat-channel-thread-row chat-list-row flex items-center gap-2 px-2.5 py-2 text-left text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground group"
-                :class="isActiveExtensionRoute(channel, route) ? 'bg-sidebar-accent text-sidebar-foreground' : ''"
-                type="button"
-                :aria-current="isActiveExtensionRoute(channel, route) ? 'page' : undefined"
-                :aria-label="extensionRouteRowLabel(channel, route)"
-                @click="emit('selectExtensionRoute', channel.id, route)"
-              >
-                <LayoutDashboard
-                  class="w-3 h-3 flex-shrink-0 opacity-40 group-hover:opacity-70"
-                  :class="isActiveExtensionRoute(channel, route) ? 'text-primary opacity-90' : ''"
-                />
-                <span class="type-caption truncate flex-1">{{ route.label }}</span>
               </button>
 
               <!-- Active threads for this channel -->

--- a/chat/src/components/chat/extension-route-rail-model.ts
+++ b/chat/src/components/chat/extension-route-rail-model.ts
@@ -1,0 +1,38 @@
+import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+
+export type ExtensionRouteRailIcon = "gallery" | "links" | "list";
+
+interface ExtensionRouteRailItem {
+  key: string;
+  label: string;
+  icon: ExtensionRouteRailIcon;
+  isActive: boolean;
+  route: DiscoveredExtensionRoute;
+}
+
+interface ActiveExtensionRouteKey {
+  pluginId: string;
+  routeId: string;
+}
+
+function routeIcon(route: DiscoveredExtensionRoute): ExtensionRouteRailIcon {
+  if (route.routeId.includes("link")) return "links";
+  if (route.surface === "gallery") return "gallery";
+  return "list";
+}
+
+export function extensionRouteRailItems(
+  routes: DiscoveredExtensionRoute[],
+  activeRoute: ActiveExtensionRouteKey | null | undefined,
+  isRailActive = false,
+): ExtensionRouteRailItem[] {
+  return routes.map((route) => ({
+    key: `${route.pluginId}:${route.routeId}`,
+    label: route.label,
+    icon: routeIcon(route),
+    isActive: isRailActive
+      && activeRoute?.pluginId === route.pluginId
+      && activeRoute?.routeId === route.routeId,
+    route,
+  }));
+}

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -127,6 +127,11 @@ export function useChatAppController(giphyApiKey: string) {
       route.pluginId === key.pluginId && route.routeId === key.routeId,
     ) ?? null;
   });
+  const channelExtensionRoutes = computed(() =>
+    ui.sidebarMode.value === "channels" && waddles.currentChannel.value
+      ? extensionRoutes.value.filter((route) => route.scope === "channel")
+      : [],
+  );
   const activeChannelRoomJid = computed(() => {
     const channel = waddles.currentChannel.value;
     if (!channel || !session.value) return null;
@@ -139,6 +144,8 @@ export function useChatAppController(giphyApiKey: string) {
   const activeThreadStack = ref<string[]>([]);
   const activeThreadTargetMessageId = ref<string | null>(null);
   const threads = useMessageThreads(activeMessages);
+  type ActiveRightPanel = "thread" | "pinned" | "extension";
+  const activeRightPanel = ref<ActiveRightPanel | null>(null);
   type ReactionModeTarget = "main" | "thread";
   const reactionModeTarget = ref<ReactionModeTarget | null>(null);
   const reactionModeSelectedMessageId = ref<string | null>(null);
@@ -150,6 +157,37 @@ export function useChatAppController(giphyApiKey: string) {
     const entry = threads.resolveEntry(threadId);
     const body = entry?.root?.body?.trim() ?? "";
     return body.length > 0 ? body.slice(0, 40) : threadId.slice(0, 8);
+  }
+
+  function isRightPanelAvailable(panel: ActiveRightPanel): boolean {
+    if (ui.sidebarMode.value !== "channels" || ui.activePage.value !== "chat") return false;
+    if (panel === "thread") return activeThreadStack.value.length > 0;
+    if (panel === "pinned") return ui.showPinnedPanel.value && !!waddles.currentChannel.value && !!activeChannelRoomJid.value;
+    return !!activeExtensionRouteKey.value && !!waddles.currentChannel.value;
+  }
+
+  function bestAvailableRightPanel(exclude?: ActiveRightPanel): ActiveRightPanel | null {
+    const candidates: ActiveRightPanel[] = ["thread", "pinned", "extension"];
+    return candidates.find((candidate) => candidate !== exclude && isRightPanelAvailable(candidate)) ?? null;
+  }
+
+  function activateRightPanel(panel: ActiveRightPanel) {
+    if (isRightPanelAvailable(panel)) activeRightPanel.value = panel;
+  }
+
+  function normalizeActiveRightPanel(exclude?: ActiveRightPanel) {
+    if (activeRightPanel.value && activeRightPanel.value !== exclude && isRightPanelAvailable(activeRightPanel.value)) return;
+    activeRightPanel.value = bestAvailableRightPanel(exclude);
+  }
+
+  function closeExtensionRoutePanel() {
+    activeExtensionRouteKey.value = null;
+    normalizeActiveRightPanel("extension");
+  }
+
+  function closePinnedPanel() {
+    ui.showPinnedPanel.value = false;
+    normalizeActiveRightPanel("pinned");
   }
 
   const orderedMainReactionMessages = computed(() =>
@@ -189,7 +227,7 @@ export function useChatAppController(giphyApiKey: string) {
 
   function activeReactionTarget(): ReactionModeTarget | null {
     if (ui.activePage.value !== "chat") return null;
-    if (ui.sidebarMode.value === "channels" && activeThreadStack.value.length > 0) return "thread";
+    if (ui.sidebarMode.value === "channels" && activeRightPanel.value === "thread" && activeThreadStack.value.length > 0) return "thread";
     if (ui.sidebarMode.value === "dms" && activeDmPeer.value) return "main";
     if (ui.sidebarMode.value === "channels" && waddles.currentChannel.value) return "main";
     return null;
@@ -625,11 +663,13 @@ export function useChatAppController(giphyApiKey: string) {
   const settingsPath = buildChatSettingsPath();
 
   const currentChatPath = computed(() =>
-    ui.activePage.value === "extension" && activeExtensionRouteKey.value
+    ui.activePage.value === "chat" && activeRightPanel.value === "extension" && activeExtensionRouteKey.value
       ? buildChannelExtensionPath(
           waddles.currentChannel.value,
           activeExtensionRouteKey.value.pluginId,
           activeExtensionRouteKey.value.routeId,
+          activeThreadStack.value,
+          ui.showPinnedPanel.value,
         )
       : ui.sidebarMode.value === "dms" && activeDmPeer.value
       ? buildDirectMessagePath(activeDmPeer.value.peerUsername)
@@ -757,6 +797,7 @@ export function useChatAppController(giphyApiKey: string) {
 
   function openThread(threadId: string, targetMessageId?: string) {
     if (!threadId) return;
+    activeRightPanel.value = "thread";
     activeThreadTargetMessageId.value = targetMessageId ?? null;
     if (
       activeThreadStack.value.length > 0 &&
@@ -790,6 +831,7 @@ export function useChatAppController(giphyApiKey: string) {
 
   function pushThread(threadId: string) {
     if (!threadId) return;
+    activeRightPanel.value = "thread";
     activeThreadTargetMessageId.value = null;
     if (
       activeThreadStack.value.length > 0 &&
@@ -805,14 +847,17 @@ export function useChatAppController(giphyApiKey: string) {
     activeThreadTargetMessageId.value = null;
     if (index < 0) {
       activeThreadStack.value = [];
+      normalizeActiveRightPanel("thread");
       return;
     }
     activeThreadStack.value = activeThreadStack.value.slice(0, index + 1);
+    activeRightPanel.value = "thread";
   }
 
   function closeThreadPanel() {
     activeThreadTargetMessageId.value = null;
     activeThreadStack.value = [];
+    normalizeActiveRightPanel("thread");
   }
 
   function notifyActiveComposing() {
@@ -945,10 +990,21 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   function handleChatEscape(event: KeyboardEvent) {
-    if (activeThreadStack.value.length === 0) return;
     // Don't intercept Escape when any dialog/drawer is open so they can close first.
     if (anyModalOpen()) return;
+    if (activeRightPanel.value === "extension" && activeExtensionRouteKey.value) {
+      closeExtensionRoutePanel();
+      consumeKeystrokEvent(event);
+      return;
+    }
+    if (activeRightPanel.value === "pinned" && ui.showPinnedPanel.value) {
+      closePinnedPanel();
+      consumeKeystrokEvent(event);
+      return;
+    }
+    if (activeThreadStack.value.length === 0) return;
     activeThreadStack.value = activeThreadStack.value.slice(0, -1);
+    normalizeActiveRightPanel();
     consumeKeystrokEvent(event);
   }
 
@@ -981,11 +1037,13 @@ export function useChatAppController(giphyApiKey: string) {
       pushChannelRoute(null);
       return;
     }
-    if (ui.activePage.value === "extension") {
+    if (ui.activePage.value === "chat" && activeRightPanel.value === "extension") {
       pushChannelExtensionRoute(
         waddles.currentChannel.value,
         activeExtensionRouteKey.value?.pluginId,
         activeExtensionRouteKey.value?.routeId,
+        activeThreadStack.value,
+        ui.showPinnedPanel.value,
       );
       return;
     }
@@ -1009,20 +1067,33 @@ export function useChatAppController(giphyApiKey: string) {
       activeThreadStack.value = [];
       // #414: pin panel state is per-room — clear on channel switch.
       ui.showPinnedPanel.value = false;
+      activeExtensionRouteKey.value = null;
+      activeRightPanel.value = null;
       exitReactionMode();
       updateUrl();
     },
   );
 
   watch(activeThreadStack, () => {
+    normalizeActiveRightPanel();
     exitReactionMode();
     updateUrl();
   }, { deep: true });
   // #414: any toggle of the pin panel pushes the URL state.
   watch(() => ui.showPinnedPanel.value, () => {
+    if (!ui.showPinnedPanel.value && activeRightPanel.value === "pinned") {
+      normalizeActiveRightPanel("pinned");
+    }
+    updateUrl();
+  });
+  watch(activeExtensionRouteKey, () => {
+    normalizeActiveRightPanel();
+  }, { deep: true });
+  watch(activeRightPanel, () => {
     updateUrl();
   });
   watch(() => ui.activePage.value, () => {
+    normalizeActiveRightPanel();
     exitReactionMode();
     updateUrl();
   });
@@ -1061,17 +1132,17 @@ export function useChatAppController(giphyApiKey: string) {
       window.history.back();
       return;
     }
-    ui.activePage.value = activeExtensionRouteKey.value && waddles.currentChannel.value
-      ? "extension"
-      : waddles.currentChannel.value || activeDmPeer.value
+    ui.activePage.value = waddles.currentChannel.value || activeDmPeer.value
         ? "chat"
         : "dashboard";
     if (window.location.pathname + window.location.search !== currentChatPath.value) {
-      if (ui.activePage.value === "extension") {
+      if (activeRightPanel.value === "extension") {
         pushChannelExtensionRoute(
           waddles.currentChannel.value,
           activeExtensionRouteKey.value?.pluginId,
           activeExtensionRouteKey.value?.routeId,
+          activeThreadStack.value,
+          ui.showPinnedPanel.value,
         );
       } else if (ui.sidebarMode.value === "dms" && activeDmPeer.value) {
         pushDirectMessageRoute(activeDmPeer.value.peerUsername);
@@ -1083,7 +1154,7 @@ export function useChatAppController(giphyApiKey: string) {
 
   function onPopState() {
     const route = parseChatLocation(window.location.pathname, window.location.search);
-    ui.activePage.value = route.page;
+    ui.activePage.value = route.page === "extension" ? "chat" : route.page;
     if (route.page === "settings") {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
@@ -1111,10 +1182,10 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   async function applyRouteTarget(route: ReturnType<typeof parseChatLocation>, requestId: number) {
-    ui.activePage.value = route.page;
-    // #414: sync the pin panel toggle with `?pinned=1`. Channel-only;
-    // dashboard/settings/extension/DM routes leave it false.
-    ui.showPinnedPanel.value = route.pinnedPanelOpen && route.page === "chat" && !route.dmUsername;
+    ui.activePage.value = route.page === "extension" ? "chat" : route.page;
+    // #414: sync the pin panel toggle with `?pinned=1`. Channel routes,
+    // including extension panels, can keep pinned collapsed beside another panel.
+    ui.showPinnedPanel.value = route.pinnedPanelOpen && (route.page === "chat" || route.page === "extension") && !route.dmUsername;
     if (route.page === "settings") {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
@@ -1153,7 +1224,7 @@ export function useChatAppController(giphyApiKey: string) {
       ui.sidebarMode.value = "channels";
       dmConversations.closeDm();
       activeThreadTargetMessageId.value = null;
-      activeThreadStack.value = [];
+      activeThreadStack.value = route.threadStack;
       if (route.channelSlug) {
         const ch = resolveChannelBySlug(route.channelSlug, waddles.channels.value);
         if (!ch) {
@@ -1163,9 +1234,20 @@ export function useChatAppController(giphyApiKey: string) {
         }
         waddles.activeChannelId.value = ch.id;
         void waddles.reloadChannelMembers(ch.id);
-        activeExtensionRouteKey.value = route.extensionPluginId && route.extensionRouteId
+        const nextExtensionRouteKey = route.extensionPluginId && route.extensionRouteId
           ? { channelId: ch.id, pluginId: route.extensionPluginId, routeId: route.extensionRouteId }
           : null;
+        messaging.clearMessages();
+        await messaging.loadMessages(ch.spaceId ?? "", ch.id);
+        if (requestId !== routeRequestId) return;
+        activeThreadTargetMessageId.value = null;
+        activeThreadStack.value = route.threadStack;
+        ui.showPinnedPanel.value = route.pinnedPanelOpen;
+        for (const threadId of route.threadStack) {
+          void messaging.backfillThread(threadId);
+        }
+        activeExtensionRouteKey.value = nextExtensionRouteKey;
+        activeRightPanel.value = activeExtensionRouteKey.value ? "extension" : null;
       }
       return;
     }
@@ -1190,8 +1272,16 @@ export function useChatAppController(giphyApiKey: string) {
     // Restore the thread panel from the URL and initialize paging for every
     // visible thread pane. Dedupe in the messaging composable keeps already
     // loaded roots/replies stable.
+    ui.showPinnedPanel.value = route.pinnedPanelOpen;
     activeThreadTargetMessageId.value = null;
     activeThreadStack.value = route.threadStack;
+    if (route.pinnedPanelOpen) {
+      activeRightPanel.value = "pinned";
+    } else if (route.threadStack.length > 0) {
+      activeRightPanel.value = "thread";
+    } else {
+      activeRightPanel.value = null;
+    }
     for (const threadId of route.threadStack) {
       void messaging.backfillThread(threadId);
     }
@@ -1244,6 +1334,7 @@ export function useChatAppController(giphyApiKey: string) {
     rosterContacts.clearRosterContacts();
     extensionRoutes.value = [];
     activeExtensionRouteKey.value = null;
+    activeRightPanel.value = null;
     setupPromptShown = false;
     messaging.clearMessages();
     dmMessaging.clearMessages();
@@ -1280,14 +1371,18 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   async function selectExtensionRoute(channelId: string, route: DiscoveredExtensionRoute) {
-    ui.activePage.value = "extension";
+    ui.activePage.value = "chat";
     ui.sidebarMode.value = "channels";
     dmConversations.closeDm();
-    activeThreadTargetMessageId.value = null;
-    activeThreadStack.value = [];
-    activeExtensionRouteKey.value = { channelId, pluginId: route.pluginId, routeId: route.routeId };
     memberJidByNick.value = {};
-    waddles.activeChannelId.value = channelId;
+    if (waddles.activeChannelId.value !== channelId) {
+      waddles.activeChannelId.value = channelId;
+      messaging.clearMessages();
+      await messaging.loadMessages(waddles.currentChannel.value?.spaceId ?? "", channelId);
+    }
+    activeExtensionRouteKey.value = { channelId, pluginId: route.pluginId, routeId: route.routeId };
+    activeRightPanel.value = "extension";
+    updateUrl();
     void waddles.reloadChannelMembers(channelId);
     ui.showMobileNav.value = false;
   }
@@ -1448,11 +1543,13 @@ export function useChatAppController(giphyApiKey: string) {
       activeMessages,
       activeFirstUnseenId,
       extensionRoutes,
+      channelExtensionRoutes,
       activeExtensionRouteKey,
       activeExtensionRoute,
       activeChannelRoomJid,
       activeThreadStack,
       activeThreadTargetMessageId,
+      activeRightPanel,
       threads,
       reactionModeTarget,
       reactionModeState,
@@ -1517,6 +1614,9 @@ export function useChatAppController(giphyApiKey: string) {
       pushThread,
       popThreadTo,
       closeThreadPanel,
+      activateRightPanel,
+      closeExtensionRoutePanel,
+      closePinnedPanel,
       notifyActiveComposing,
       editActiveMessage,
       retractActiveMessage,

--- a/chat/src/shell/navigation.ts
+++ b/chat/src/shell/navigation.ts
@@ -88,8 +88,8 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
         dmUsername: null,
         extensionPluginId: decodeURIComponent(segments[3]),
         extensionRouteId: decodeURIComponent(segments[4]),
-        threadStack: [],
-        pinnedPanelOpen: false,
+        threadStack,
+        pinnedPanelOpen,
       };
     }
     return {
@@ -148,9 +148,12 @@ export function buildChannelExtensionPath(
   channel: ChannelSummary | null,
   pluginId: string | null | undefined,
   routeId: string | null | undefined,
+  threadStack?: string[],
+  pinnedPanelOpen?: boolean,
 ): string {
   if (!channel || !pluginId || !routeId) return "/";
-  return `/r/${encodeURIComponent(channel.id)}/x/${encodeURIComponent(pluginId)}/${encodeURIComponent(routeId)}`;
+  const search = buildSearch(threadStack, pinnedPanelOpen);
+  return `/r/${encodeURIComponent(channel.id)}/x/${encodeURIComponent(pluginId)}/${encodeURIComponent(routeId)}${search}`;
 }
 
 export function buildDirectMessagePath(username: string | null, threadStack?: string[]): string {
@@ -193,8 +196,10 @@ export function pushChannelExtensionRoute(
   channel: ChannelSummary | null,
   pluginId: string | null | undefined,
   routeId: string | null | undefined,
+  threadStack?: string[],
+  pinnedPanelOpen?: boolean,
 ) {
-  const path = buildChannelExtensionPath(channel, pluginId, routeId);
+  const path = buildChannelExtensionPath(channel, pluginId, routeId, threadStack, pinnedPanelOpen);
   const current = window.location.pathname + window.location.search;
   if (current !== path) {
     window.history.pushState({ waddlePage: "extension" }, "", path);

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -2,7 +2,7 @@ import { ref } from "vue";
 import type { AdminTab } from "@/lib/chat-ui";
 
 export function useChatShellState() {
-  const activePage = ref<"dashboard" | "chat" | "settings" | "extension">("dashboard");
+  const activePage = ref<"dashboard" | "chat" | "settings">("dashboard");
   const adminTab = ref<AdminTab>("rooms");
   const sidebarMode = ref<"channels" | "dms">("channels");
   const collapsedSpaceGroupIds = ref<Set<string>>(new Set());

--- a/chat/src/styles/global/shell.css
+++ b/chat/src/styles/global/shell.css
@@ -169,6 +169,49 @@
   flex-direction: column;
 }
 
+.extension-route-rail {
+  display: flex;
+  width: calc(var(--control-lg) + (var(--space-xs) * 2));
+  min-height: 0;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-left: 1px solid var(--border);
+  background: var(--rail);
+  padding-block: var(--space-sm);
+  padding-inline: var(--space-xs);
+}
+
+@media (max-width: 63.999rem) {
+  .chat-workspace--right-panel-active .extension-route-rail {
+    display: none;
+  }
+}
+
+.extension-route-rail__button {
+  display: inline-flex;
+  width: var(--control-lg);
+  height: var(--control-lg);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  color: var(--rail-foreground);
+  transition: background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.extension-route-rail__button:hover,
+.extension-route-rail__button--active {
+  background: var(--rail-hover);
+  color: var(--primary);
+}
+
+.extension-route-rail__button--active {
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--primary) 18%, transparent);
+}
+
 .chat-rail {
   display: flex;
   flex-shrink: 0;

--- a/chat/tests/extension-route-rail-ui.test.ts
+++ b/chat/tests/extension-route-rail-ui.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { extensionRouteRailItems } from "../src/components/chat/extension-route-rail-model";
+import type { DiscoveredExtensionRoute } from "../src/lib/xmpp/extension-commands";
+
+const routes: DiscoveredExtensionRoute[] = [
+  {
+    serviceJid: "extensions.waddle.test",
+    pluginId: "link-board",
+    routeId: "saved-links",
+    label: "Saved Links",
+    scope: "channel",
+    surface: "list",
+    stateNode: "urn:waddle:link-board",
+    payloadNamespace: "urn:waddle:link-board:payload",
+  },
+  {
+    serviceJid: "extensions.waddle.test",
+    pluginId: "polls",
+    routeId: "active-polls",
+    label: "Polls",
+    scope: "channel",
+    surface: "gallery",
+    stateNode: "urn:waddle:polls",
+    payloadNamespace: "urn:waddle:polls:payload",
+  },
+];
+
+describe("extension route rail UI contract", () => {
+  test("keeps extension routes out of the channel list", () => {
+    const topicsPanel = readFileSync(new URL("../src/components/chat/TopicsPanel.vue", import.meta.url), "utf8");
+
+    expect(topicsPanel).not.toContain("channelExtensionRoutes");
+    expect(topicsPanel).not.toContain("selectExtensionRoute");
+    expect(topicsPanel).not.toContain("extension route");
+  });
+
+  test("builds rail button state from discovered extension routes", () => {
+    const items = extensionRouteRailItems(routes, { pluginId: "polls", routeId: "active-polls" }, true);
+
+    expect(items).toEqual([
+      {
+        key: "link-board:saved-links",
+        label: "Saved Links",
+        icon: "links",
+        isActive: false,
+        route: routes[0],
+      },
+      {
+        key: "polls:active-polls",
+        label: "Polls",
+        icon: "gallery",
+        isActive: true,
+        route: routes[1],
+      },
+    ]);
+  });
+
+  test("does not mark a route active when the extension panel is collapsed", () => {
+    const items = extensionRouteRailItems(routes, { pluginId: "polls", routeId: "active-polls" }, false);
+
+    expect(items.map((item) => item.isActive)).toEqual([false, false]);
+  });
+
+  test("keeps direct extension routes in chat with a right-side panel", () => {
+    const readyShell = readFileSync(new URL("../src/components/chat/ChatReadyShell.vue", import.meta.url), "utf8");
+    const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
+    const state = readFileSync(new URL("../src/shell/state.ts", import.meta.url), "utf8");
+
+    expect(state).toContain('ref<"dashboard" | "chat" | "settings">');
+    expect(readyShell).toContain("<ExtensionRouteRail");
+    expect(readyShell).toContain("@close=\"closeExtensionRoutePanel\"");
+    expect(readyShell).toContain("@update:pinned-panel-open=\"setPinnedPanelOpen\"");
+    expect(readyShell).toContain("chat-workspace--right-panel-active");
+    expect(readyShell).not.toContain("v-else-if=\"ui.activePage.value === 'extension'\"");
+
+    const rail = readFileSync(new URL("../src/components/chat/ExtensionRouteRail.vue", import.meta.url), "utf8");
+    const routeView = readFileSync(new URL("../src/components/chat/ExtensionRouteView.vue", import.meta.url), "utf8");
+    expect(rail).toContain(":aria-current=\"item.isActive ? 'page' : undefined\"");
+    expect(rail).not.toContain(":aria-pressed");
+    expect(routeView).toContain(":aria-label=\"route?.label ? `${route.label} extension route` : 'Extension route'\"");
+    expect(routeView).toContain('ref="panelRef"');
+    expect(routeView).toContain('tabindex="-1"');
+    expect(routeView).not.toContain("<main");
+    expect(routeView).toContain("type-caption inline-flex min-h-8");
+    expect(controller).toContain('route.page === "extension" ? "chat" : route.page');
+    const extensionStart = controller.indexOf('if (route.page === "extension") {');
+    const loadIndex = controller.indexOf("await messaging.loadMessages(ch.spaceId ?? \"\", ch.id);", extensionStart);
+    const guardIndex = controller.indexOf("if (requestId !== routeRequestId) return;", loadIndex);
+    const pinnedIndex = controller.indexOf("ui.showPinnedPanel.value = route.pinnedPanelOpen;", guardIndex);
+    const panelIndex = controller.indexOf("activeRightPanel.value = activeExtensionRouteKey.value ? \"extension\" : null", pinnedIndex);
+    expect(extensionStart).toBeGreaterThan(-1);
+    expect(loadIndex).toBeGreaterThan(extensionStart);
+    expect(guardIndex).toBeGreaterThan(loadIndex);
+    expect(pinnedIndex).toBeGreaterThan(guardIndex);
+    expect(panelIndex).toBeGreaterThan(pinnedIndex);
+  });
+});

--- a/chat/tests/use-routing.test.ts
+++ b/chat/tests/use-routing.test.ts
@@ -74,6 +74,17 @@ describe("parseChatLocation / buildChannelPath threadStack", () => {
     });
   });
 
+  test("buildChannelExtensionPath preserves collapsed right-panel state", () => {
+    const path = buildChannelExtensionPath(channel, "link-board", "saved-links", ["root,1", "child%2"], true);
+    expect(path).toBe("/r/room-id-1/x/link-board/saved-links?thread=root%2C1,child%252&pinned=1");
+    const route = parseChatLocation("/r/room-id-1/x/link-board/saved-links", "?thread=root%2C1,child%252&pinned=1");
+    expect(route).toMatchObject({
+      page: "extension",
+      threadStack: ["root,1", "child%2"],
+      pinnedPanelOpen: true,
+    });
+  });
+
   test("resolveChannelBySlug uses channel ids only", () => {
     const channels = [
       { ...channel, id: "space-a-general", name: "general" },


### PR DESCRIPTION
## Summary
- moves channel extension routes out of the channel list into a fixed right-side rail
- renders extension route content as an accordion-style right panel alongside threads and pinned messages
- preserves channel feed loading, collapsed thread/pinned panel URL state, and direct extension-route refresh behavior
- adds focused rail/routing tests and keeps the change inside the chat UI/controller boundary

## Plan
- Remove extension route rows from TopicsPanel and mobile channel drawers.
- Add a right-side ExtensionRouteRail for the current channel.
- Treat extension routes as a chat right panel instead of a full page.
- Preserve canonical /r/:channel/x/:plugin/:route URLs, including thread and pinned query state.
- Validate with focused tests, full chat tests, lint, type check, and adversarial review.

## XEP Review
- Reviewed local XEP-0030 and XEP-0050 relevance before implementation.
- No XMPP wire-shape changes; discovery, command execution, and route item loading remain on the existing XMPP paths.

## Validation
- cd chat && bun test tests/use-routing.test.ts tests/extension-route-rail-ui.test.ts
- cd chat && bun test
- cd chat && bun run lint
- cd chat && bun run astro check

## Review Notes
- Fixed adversarial findings around brittle source assertions, mobile rail layout, pinned panel activation, extension URL query preservation, stale route hydration, rail overflow, landmark semantics, active route ARIA, hidden-focus transfer, and normal channel pinned URL restoration.
