### PR TITLE
fix(infra): bump waddle-server memory limit to 1Gi

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -27,6 +27,13 @@ spec:
       repository: ghcr.io/waddle-social/waddle
       tag: main
       digest: ""
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: "1"
+        memory: 1Gi
     config:
       baseUrl: https://xmpp.waddle.social
       corsOrigins: https://waddle.chat,http://localhost:4321


### PR DESCRIPTION
## Summary
- Override the chart-default `resources` block in the waddle-server `HelmRelease` so the container gets `requests: 100m / 512Mi` and `limits: 1 / 1Gi`.
- The new server build (`sha-bebfd53`, image digest `sha256:d0f212e2…`) was OOMKilled at startup under the chart-default 512Mi limit, blocking every Flux upgrade attempt.

## Context
- Production was stuck on `sha-dce783f` (May 7) for ~2.5 days. Chart 0.3.0 (which removes the broken `bitnami/kubectl:1.31` bootstrap hook) cleared the first blocker.
- Once 0.3.0 reconciled, the new pod reached "SM persistence storage initialized" then died with exit 137.
- An emergency in-cluster patch was applied to unblock prod immediately (`flux suspend kustomization infra-waddle-server`, then `kubectl patch helmrelease`); this PR makes that change durable so we can resume the kustomization without drift reverting it.

## Plan
- [x] Override `resources` in `infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml`.
- [ ] Merge so CI republishes `oci://ghcr.io/waddle-social/waddle/gitops-waddle-server:latest`.
- [ ] After Flux pulls the new artifact, `flux resume kustomization -n flux-system infra-waddle-server`.
- [ ] Confirm the running pod still has `limits.memory: 1Gi` after resume (i.e., values came from git, not the hot patch).

## Test plan
- [ ] CI green on this branch.
- [ ] After merge, watch `kubectl -n waddle get helmrelease waddle-server` reconcile cleanly with the new chart values.
- [ ] `kubectl -n waddle describe pod -l app.kubernetes.io/name=waddle-server | grep -A3 Limits` shows `memory: 1Gi`.
- [ ] No OOMKills in pod events for ≥10 minutes after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)