### PR TITLE
fix(chat): repair AI extension public channel flow

### DIFF
--- a/chat/src/channels/extension-launcher.ts
+++ b/chat/src/channels/extension-launcher.ts
@@ -15,11 +15,13 @@ import type { SlashInvocation } from "@/lib/slash-dispatch";
 type ExtensionLauncherState = "idle" | "loading" | "error";
 type ExtensionCommandUiState = "loading" | "success" | "warning" | "error";
 type ReadonlyRef<T> = Readonly<Ref<T>>;
+const AI_CHATBOT_COMMAND_NODE = "urn:waddle:extension:1:ai-chatbot";
 
 export function useExtensionLauncher(input: {
   xmppClient: ReadonlyRef<BrowserXmppClient | null | undefined>;
   roomJid: ReadonlyRef<string | null | undefined>;
   invokeExtensionAction: ReadonlyRef<((action: ExtensionAnnotationAction) => Promise<ExtensionCommandResult>) | undefined>;
+  sendPublicChannelMessage?: ReadonlyRef<((body: string) => Promise<void>) | undefined>;
   focusPalette: () => void;
   focusComposerExtensions: () => void;
 }) {
@@ -170,22 +172,31 @@ export function useExtensionLauncher(input: {
     discoveryAttempted = false;
   }
 
-  async function submitForm(command: DiscoveredExtensionCommand, action: ExtensionCommandAction = "complete") {
+  async function submitForm(
+    command: DiscoveredExtensionCommand,
+    action: ExtensionCommandAction = "complete",
+    options: { skipPublicPrompt?: boolean } = {},
+  ): Promise<boolean> {
     const client = input.xmppClient.value;
-    if (!client) return;
+    if (!client) return false;
     const key = command.node;
     const form = commandForms.value[key];
-    if (!form) return;
+    if (!form) return false;
     commandStates.value = { ...commandStates.value, [key]: { state: "loading" } };
     try {
+      if (!options.skipPublicPrompt) {
+        await sendPublicPromptIfRequested(command, form.fields, action);
+      }
       const result = await client.submitExtensionCommandForm(command, form.sessionId, form.fields, action, input.roomJid.value ?? undefined);
       storeResultSurfaces(key, result);
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
+      return true;
     } catch (error) {
       commandStates.value = {
         ...commandStates.value,
         [key]: { state: "error", detail: error instanceof Error ? error.message : "Extension form submission failed." },
       };
+      return false;
     }
   }
 
@@ -231,8 +242,8 @@ export function useExtensionLauncher(input: {
       const allowed = form?.actions ?? [];
       if (form && allowed.includes("complete")) {
         updateField(key, invocation.fieldName, [invocation.value]);
-        await submitForm(command, "complete");
-        return true;
+        forceChannelOutputForSlashAi(command);
+        return await submitForm(command, "complete");
       }
 
       commandStates.value = { ...commandStates.value, [key]: extensionCommandOutcome(result) };
@@ -249,6 +260,42 @@ export function useExtensionLauncher(input: {
       };
       return false;
     }
+  }
+
+  async function sendPublicPromptIfRequested(
+    command: DiscoveredExtensionCommand,
+    fields: ExtensionCommandFormField[],
+    action: ExtensionCommandAction,
+  ) {
+    if (command.node !== AI_CHATBOT_COMMAND_NODE) return;
+    if (action === "cancel" || action === "prev") return;
+    if (formFieldValue(fields, "output") !== "channel") return;
+    if (!input.roomJid.value) return;
+    const prompt = formFieldValue(fields, "prompt")?.trim();
+    if (!prompt) return;
+    const sendPublicChannelMessage = input.sendPublicChannelMessage?.value;
+    if (!sendPublicChannelMessage) {
+      throw new Error("Cannot post the AI prompt to this channel.");
+    }
+    await sendPublicChannelMessage(prompt);
+  }
+
+  function forceChannelOutputForSlashAi(command: DiscoveredExtensionCommand) {
+    if (!input.roomJid.value || command.node !== AI_CHATBOT_COMMAND_NODE) return;
+    const form = commandForms.value[command.node];
+    const output = form?.fields.find((field) => field.name === "output");
+    if (!output) return;
+    const supportsChannelOutput = output.options.length === 0
+      || output.options.some((option) => option.value === "channel");
+    if (supportsChannelOutput) updateField(command.node, "output", ["channel"]);
+  }
+
+  function formFieldValue(
+    fields: ExtensionCommandFormField[],
+    name: string,
+  ): string | undefined {
+    const field = fields.find((candidate) => candidate.name === name);
+    return field?.values.find((value) => value.trim().length > 0) ?? field?.value;
   }
 
   async function invokeResultAction(command: DiscoveredExtensionCommand, action: ExtensionAnnotationAction) {

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -84,6 +84,7 @@ const {
   openCreateChannelDialog,
   openChannelEdit,
   sendActiveMessage,
+  sendPublicChannelMessage,
   sendThreadMessage,
   sendGif,
   openThread,
@@ -297,6 +298,7 @@ function setPinnedPanelOpen(isOpen: boolean) {
               :xmpp-client="xmppClient"
               :reaction-mode="reactionModeTarget === 'main' ? reactionModeState : null"
               :ensure-message-loaded="ensureActiveMessageLoaded"
+              :send-public-channel-message="sendPublicChannelMessage"
               @send="sendActiveMessage"
               @typing="notifyActiveComposing"
               @edit-message="editActiveMessage"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -77,6 +77,7 @@ const props = defineProps<{
   reactionMode?: { selectedMessageId: string | null } | null;
   ensureMessageLoaded?: (messageId: string) => Promise<boolean>;
   invokeExtensionAction?: (action: ExtensionAnnotationAction) => Promise<ExtensionCommandResult>;
+  sendPublicChannelMessage?: (body: string) => Promise<void>;
 }>();
 
 const emit = defineEmits<{
@@ -297,6 +298,7 @@ const extensionLauncher = useExtensionLauncher({
   xmppClient: computed(() => props.xmppClient),
   roomJid: computed(() => props.roomJid),
   invokeExtensionAction: computed(() => props.invokeExtensionAction),
+  sendPublicChannelMessage: computed(() => props.sendPublicChannelMessage),
   focusPalette: () => extensionPaletteRef.value?.focus(),
   focusComposerExtensions: () => composerRef.value?.focusExtensions(),
 });

--- a/chat/src/lib/xmpp/extension-commands/disco.ts
+++ b/chat/src/lib/xmpp/extension-commands/disco.ts
@@ -161,9 +161,10 @@ async function rawDiscoInfoFull(xmpp: XmppSendIq, jid: string, node?: string): P
   if (typeof xmpp.getDiscoInfo === "function") {
     try {
       const info = await xmpp.getDiscoInfo(jid, node);
-      return { features: info.features ?? [], extensions: info.extensions ?? [] };
+      const parsed = { features: info.features ?? [], extensions: info.extensions ?? [] };
+      if (parsed.extensions.length > 0 || typeof xmpp.send_raw_iq !== "function") return parsed;
     } catch {
-      return { features: [], extensions: [] };
+      if (typeof xmpp.send_raw_iq !== "function") return { features: [], extensions: [] };
     }
   }
   if (typeof xmpp.send_raw_iq !== "function") return { features: [], extensions: [] };

--- a/chat/src/lib/xmpp/extension-commands/invoke.ts
+++ b/chat/src/lib/xmpp/extension-commands/invoke.ts
@@ -43,12 +43,17 @@ export async function submitExtensionCommandForm(
   sessionId: string,
   fields: ExtensionCommandFormField[],
   action: ExtensionCommandAction = "complete",
-  _roomJid?: string,
+  roomJid?: string,
 ): Promise<ExtensionCommandResult> {
   const sendRawIq = requireRawIq(xmpp);
-  const dataFields: DataFormField[] = (action === "cancel" || action === "prev") ? [] : fields
-    .filter((field) => field.type !== "fixed")
-    .map((field) => ({ name: field.name, value: dataFormFieldValue(field) }));
+  const dataFields: DataFormField[] = (action === "cancel" || action === "prev") ? [] : [
+    ...fields
+      .filter((field) => field.type !== "fixed")
+      .map((field) => ({ name: field.name, value: dataFormFieldValue(field) })),
+    ...(roomJid && !fields.some((field) => field.name === "waddle#room_jid")
+      ? [{ name: "waddle#room_jid", value: roomJid }]
+      : []),
+  ];
   const responseXml = await sendRawIq(buildCommandIqXml(command.serviceJid, command.node, action, dataFields, sessionId));
   return parseCommandIqResponse(responseXml);
 }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -780,6 +780,17 @@ export function useChatAppController(giphyApiKey: string) {
     await messaging.sendMessage(body, markup, references, files, replyTo, forumTitle);
   }
 
+  async function sendPublicChannelMessage(body: string) {
+    if (ui.sidebarMode.value !== "channels" || !xmppClient.value || !waddles.activeChannelId.value) {
+      throw new Error("Public AI prompts require an active channel.");
+    }
+    ui.clearActionError();
+    await messaging.sendMessage(body);
+    if (ui.actionError.value) {
+      throw new Error(ui.actionError.value);
+    }
+  }
+
   async function sendThreadMessage(
     body: string,
     markup: MarkupSpan[],
@@ -1608,6 +1619,7 @@ export function useChatAppController(giphyApiKey: string) {
       confirmRemoveMember,
       openChannelEdit,
       sendActiveMessage,
+      sendPublicChannelMessage,
       sendThreadMessage,
       sendGif,
       openThread,

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -682,6 +682,37 @@ describe("optimistic UI waits for successful sends", () => {
     expect(actionError.value).toBe("");
   });
 
+  test("room programmatic sends do not clear the composer draft", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "public-prompt-1", state: "queued" as const }));
+    const sendChatState = mock(async () => undefined);
+    const actionError = ref("");
+    const messaging = useChannelMessages(
+      ref(session()),
+      ref(null),
+      ref({ ...handlerStubs(), sendGroupMessage, sendChatState } as never),
+      ref("w1"),
+      ref("c1"),
+      ref({ id: "c1", name: "general", channel_type: "text" }),
+      normalizeError,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+    );
+    messaging.draft.value = "/ai tell the room";
+
+    await messaging.sendMessage("tell the room");
+
+    expect(sendGroupMessage).toHaveBeenCalledWith(
+      "w1",
+      "c1",
+      "tell the room",
+      expect.any(Object),
+    );
+    expect(messaging.draft.value).toBe("/ai tell the room");
+    expect(actionError.value).toBe("");
+  });
+
   test("room composer allows bodyless standard MUC thread metadata", async () => {
     const sendGroupMessage = mock(async () => ({ id: "thread-marker-1", state: "sending" as const }));
     const sendChatState = mock(async () => undefined);

--- a/chat/tests/extension-command.test.ts
+++ b/chat/tests/extension-command.test.ts
@@ -123,6 +123,46 @@ describe("extension command invocation", () => {
     ]);
   });
 
+  test("falls back to raw disco XML when typed command info omits metadata forms", async () => {
+    const xmpp = {
+      async getDiscoItems(jid: string, node?: string) {
+        if (jid === "example.com" && !node) return { items: [{ jid: "extensions.example.com" }] };
+        if (jid === "extensions.example.com" && node === "http://jabber.org/protocol/commands") {
+          return {
+            items: [{
+              jid: "extensions.example.com",
+              node: "urn:waddle:extension:1:ai-chatbot",
+              name: "Ask AI Chatbot",
+            }],
+          };
+        }
+        return { items: [] };
+      },
+      async getDiscoInfo(_jid: string, node?: string) {
+        if (!node) {
+          return {
+            features: ["urn:waddle:extension:1", "http://jabber.org/protocol/commands"],
+            extensions: [],
+          };
+        }
+        return { features: ["http://jabber.org/protocol/commands"], extensions: [] };
+      },
+      async send_raw_iq(xml: string) {
+        expect(xml).toContain('node="urn:waddle:extension:1:ai-chatbot"');
+        return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info"><x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE"><value>urn:waddle:extension:1:command</value></field><field var="waddle#command_scope"><value>global</value></field><field var="waddle#composer_prefix"><value>ai</value></field><field var="waddle#inline_field"><value>prompt</value></field></x></query></iq>`;
+      },
+    };
+
+    expect(await discoverExtensionCommands(xmpp as any, "alice@example.com/web")).toEqual([{
+      serviceJid: "extensions.example.com",
+      node: "urn:waddle:extension:1:ai-chatbot",
+      name: "Ask AI Chatbot",
+      scope: "global",
+      composerPrefix: "ai",
+      inlineField: "prompt",
+    }]);
+  });
+
   test("treats an empty composer_prefix value as absent rather than a zero-length match", async () => {
     const xmpp = {
       async send_raw_iq(xml: string) {
@@ -691,6 +731,7 @@ describe("extension command invocation", () => {
     expect(sent).toContain('<field var="payload#choices"><value>yes</value><value>maybe</value></field>');
     expect(sent).toContain('<field var="payload#notify" type="boolean"><value>false</value></field>');
     expect(sent).toContain('<field var="hidden#multi"><value>alpha</value><value>beta</value></field>');
+    expect(sent).toContain('<field var="waddle#room_jid"><value>pub@muc.example.com</value></field>');
     expect(sent).not.toContain('fixed:Do not send me');
   });
 });

--- a/chat/tests/extension-launcher-slash.test.ts
+++ b/chat/tests/extension-launcher-slash.test.ts
@@ -26,6 +26,15 @@ const pollCommand: DiscoveredExtensionCommand = {
   composerPrefix: "poll",
 };
 
+const genericCommand: DiscoveredExtensionCommand = {
+  serviceJid: "extensions.example.com",
+  node: "urn:waddle:extension:1:generic",
+  name: "Generic Extension",
+  scope: "channel",
+  composerPrefix: "generic",
+  inlineField: "prompt",
+};
+
 interface SubmitCall {
   command: DiscoveredExtensionCommand;
   sessionId: string;
@@ -63,12 +72,16 @@ function executingResult(fields: ExtensionCommandFormField[], allowed: Extension
         required: f.required,
         values: f.values,
         rawValues: f.values,
+        options: f.options,
       })),
     },
   };
 }
 
-function fakeClient(executeResults: ExtensionCommandResult[]): {
+function fakeClient(executeResults: ExtensionCommandResult[], options: {
+  events?: string[] | undefined;
+  submitError?: Error | undefined;
+} = {}): {
   client: Ref<unknown>;
   submitCalls: SubmitCall[];
   invokeCalls: DiscoveredExtensionCommand[];
@@ -88,7 +101,9 @@ function fakeClient(executeResults: ExtensionCommandResult[]): {
       action?: ExtensionCommandAction,
       roomJid?: string,
     ): Promise<ExtensionCommandResult> {
+      options.events?.push("submit");
       submitCalls.push({ command, sessionId, fields, action, roomJid });
+      if (options.submitError) throw options.submitError;
       return { status: "completed", notes: [] };
     },
     async discoverExtensionCommands(): Promise<DiscoveredExtensionCommand[]> {
@@ -98,12 +113,24 @@ function fakeClient(executeResults: ExtensionCommandResult[]): {
   return { client: ref(fake), submitCalls, invokeCalls };
 }
 
-function createLauncher(executeResults: ExtensionCommandResult[]) {
-  const fake = fakeClient(executeResults);
+function createLauncher(
+  executeResults: ExtensionCommandResult[],
+  options: {
+    roomJid?: string | null;
+    sendPublicChannelMessage?: (body: string) => Promise<void>;
+    events?: string[] | undefined;
+    submitError?: Error | undefined;
+  } = {},
+) {
+  const fake = fakeClient(executeResults, {
+    events: options.events,
+    submitError: options.submitError,
+  });
   const launcher = useExtensionLauncher({
     xmppClient: fake.client as never,
-    roomJid: ref(null),
+    roomJid: ref(options.roomJid ?? null),
     invokeExtensionAction: ref(undefined),
+    sendPublicChannelMessage: ref(options.sendPublicChannelMessage),
     focusPalette: () => {},
     focusComposerExtensions: () => {},
   });
@@ -132,6 +159,98 @@ describe("dispatchSlashInvocation: inline-submit", () => {
       "tell me a joke",
     ]);
     expect(launcher.open.value).toBe(false);
+  });
+
+  test("passes the active room into XEP-0050 inline command submissions", async () => {
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([field("prompt", { required: true })], ["complete", "cancel"]),
+    ], { roomJid: "pub@muc.example.com" });
+
+    await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell the room",
+    });
+
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].roomJid).toBe("pub@muc.example.com");
+  });
+
+  test("makes inline /ai public in channel context", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", {
+          type: "list-single",
+          value: "private",
+          values: ["private"],
+          options: [
+            { label: "Private", value: "private" },
+            { label: "Post to channel", value: "channel" },
+          ],
+        }),
+      ], ["complete", "cancel"]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      sendPublicChannelMessage: async (body) => {
+        events.push(`public:${body}`);
+      },
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell the room",
+    });
+
+    expect(ok).toBe(true);
+    expect(events).toEqual(["public:tell the room", "submit"]);
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].fields.find((f) => f.name === "output")?.values).toEqual([
+      "channel",
+    ]);
+  });
+
+  test("does not submit inline /ai when the public prompt fails to send", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", {
+          type: "list-single",
+          value: "private",
+          values: ["private"],
+          options: [
+            { label: "Private", value: "private" },
+            { label: "Post to channel", value: "channel" },
+          ],
+        }),
+      ], ["complete", "cancel"]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      sendPublicChannelMessage: async () => {
+        events.push("public-failed");
+        throw new Error("channel send failed");
+      },
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell the room",
+    });
+
+    expect(ok).toBe(false);
+    expect(events).toEqual(["public-failed"]);
+    expect(submitCalls).toEqual([]);
+    expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("error");
+    expect(launcher.commandStates.value[aiCommand.node]?.detail).toBe("channel send failed");
   });
 
   test("returns false and surfaces an error state when the XMPP client is null", async () => {
@@ -188,6 +307,64 @@ describe("dispatchSlashInvocation: inline-submit", () => {
     expect(submitCalls).toEqual([]);
     expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("success");
   });
+
+  test("returns false when inline command submission fails", async () => {
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([field("prompt", { required: true })], ["complete", "cancel"]),
+    ], {
+      submitError: new Error("submit failed"),
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell me a joke",
+    });
+
+    expect(ok).toBe(false);
+    expect(submitCalls).toHaveLength(1);
+    expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("error");
+    expect(launcher.commandStates.value[aiCommand.node]?.detail).toBe("submit failed");
+  });
+
+  test("returns false after posting public /ai prompt when command submission fails", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", {
+          type: "list-single",
+          value: "private",
+          values: ["private"],
+          options: [
+            { label: "Private", value: "private" },
+            { label: "Post to channel", value: "channel" },
+          ],
+        }),
+      ], ["complete", "cancel"]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      submitError: new Error("submit failed"),
+      sendPublicChannelMessage: async (body) => {
+        events.push(`public:${body}`);
+      },
+    });
+
+    const ok = await launcher.dispatchSlashInvocation({
+      kind: "inline-submit",
+      command: aiCommand,
+      fieldName: "prompt",
+      value: "tell the room",
+    });
+
+    expect(ok).toBe(false);
+    expect(events).toEqual(["public:tell the room", "submit"]);
+    expect(submitCalls).toHaveLength(1);
+    expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("error");
+    expect(launcher.commandStates.value[aiCommand.node]?.detail).toBe("submit failed");
+  });
 });
 
 describe("dispatchSlashInvocation: open-palette", () => {
@@ -239,5 +416,86 @@ describe("dispatchSlashInvocation: open-palette", () => {
     expect(launcher.open.value).toBe(true);
     const stored = launcher.commandForms.value[pollCommand.node]?.fields.find((f) => f.name === "question");
     expect(stored?.values).toEqual([]);
+  });
+});
+
+describe("submitForm: public channel output", () => {
+  test("posts the user's prompt to the room before submitting the command", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", { required: true, value: "private", values: ["private"] }),
+      ]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      sendPublicChannelMessage: async (body) => {
+        events.push(`public:${body}`);
+      },
+    });
+    await launcher.invokeCommand(aiCommand);
+    launcher.updateField(aiCommand.node, "prompt", ["what changed?"]);
+    launcher.updateField(aiCommand.node, "output", ["channel"]);
+
+    const ok = await launcher.submitForm(aiCommand, "complete");
+
+    expect(ok).toBe(true);
+    expect(events).toEqual(["public:what changed?", "submit"]);
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].roomJid).toBe("pub@muc.example.com");
+  });
+
+  test("does not submit the command when posting the public prompt fails", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", { required: true, value: "private", values: ["private"] }),
+      ]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      sendPublicChannelMessage: async () => {
+        events.push("public-failed");
+        throw new Error("could not send prompt");
+      },
+    });
+    await launcher.invokeCommand(aiCommand);
+    launcher.updateField(aiCommand.node, "prompt", ["what changed?"]);
+    launcher.updateField(aiCommand.node, "output", ["channel"]);
+
+    const ok = await launcher.submitForm(aiCommand, "complete");
+
+    expect(ok).toBe(false);
+    expect(events).toEqual(["public-failed"]);
+    expect(submitCalls).toEqual([]);
+    expect(launcher.commandStates.value[aiCommand.node]?.state).toBe("error");
+    expect(launcher.commandStates.value[aiCommand.node]?.detail).toBe("could not send prompt");
+  });
+
+  test("does not echo non-AI extension prompts with output=channel", async () => {
+    const events: string[] = [];
+    const { launcher, submitCalls } = createLauncher([
+      executingResult([
+        field("prompt", { required: true }),
+        field("output", { required: true, value: "channel", values: ["channel"] }),
+      ]),
+    ], {
+      roomJid: "pub@muc.example.com",
+      events,
+      sendPublicChannelMessage: async (body) => {
+        events.push(`public:${body}`);
+      },
+    });
+    await launcher.invokeCommand(genericCommand);
+    launcher.updateField(genericCommand.node, "prompt", ["generic public text"]);
+
+    const ok = await launcher.submitForm(genericCommand, "complete");
+
+    expect(ok).toBe(true);
+    expect(events).toEqual(["submit"]);
+    expect(submitCalls).toHaveLength(1);
+    expect(submitCalls[0].command).toBe(genericCommand);
   });
 });

--- a/server/crates/waddle-server/src/server/extension_commands/pubsub.rs
+++ b/server/crates/waddle-server/src/server/extension_commands/pubsub.rs
@@ -246,3 +246,53 @@ fn extension_pubsub_node_config() -> NodeConfig {
     config.max_items = MAX_EXTENSION_PUBSUB_ITEMS;
     config
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_extensions::types::{
+        DisplayText, EnrichmentId, ExtensionCapability, ExtensionEnvelope, MessageEnrichment,
+        PayloadNamespace, PluginId, TextBlock, TextStyle, Timestamp, UiBlock, UiView, UiViewId,
+    };
+    use waddle_xmpp::commands::CommandResult;
+    use waddle_xmpp::xep::xep0050::NoteType;
+
+    #[tokio::test]
+    async fn enrichment_command_result_completes_without_noop_warning() {
+        let result =
+            extension_command_result(vec![ExtensionEffect::EnrichMessage(envelope())], None).await;
+
+        let CommandResult::Completed {
+            form: Some(_),
+            notes,
+        } = result
+        else {
+            panic!("expected completed command result with visible form");
+        };
+        assert!(notes.iter().all(|note| note.note_type != NoteType::Warn));
+        assert!(notes.iter().any(|note| {
+            note.note_type == NoteType::Info && note.text == "AI answer posted to channel."
+        }));
+    }
+
+    fn envelope() -> ExtensionEnvelope {
+        ExtensionEnvelope::new(vec![MessageEnrichment {
+            id: EnrichmentId::new("ai-command-posted").expect("enrichment id"),
+            plugin: PluginId::new("ai-chatbot").expect("plugin id"),
+            capability: ExtensionCapability::MessageEnrich,
+            payload_namespace: PayloadNamespace::framework(),
+            created_at: Timestamp::new("2026-05-09T00:00:00Z").expect("timestamp"),
+            source: None,
+            ui: vec![UiView {
+                id: UiViewId::new("ai-command-posted").expect("view id"),
+                title: Some(DisplayText::new("AI answer posted").expect("title")),
+                blocks: vec![UiBlock::Text(TextBlock {
+                    text: DisplayText::new("AI answer posted to channel.").expect("body"),
+                    style: TextStyle::Body,
+                })],
+            }],
+            payloads: vec![],
+            launches: vec![],
+        }])
+    }
+}

--- a/server/extensions/ai-chatbot/src/command.rs
+++ b/server/extensions/ai-chatbot/src/command.rs
@@ -183,7 +183,7 @@ fn response_effect(
         return Ok(command_answer_effect(answer));
     };
     send_room_message(&target, display(answer.text.as_str()))?;
-    Ok(types::ExtensionEffect::Noop)
+    Ok(channel_posted_effect())
 }
 
 fn room_message_request(
@@ -228,12 +228,33 @@ fn sent_room_messages() -> &'static std::sync::Mutex<Vec<types::SendMessageReque
     SENT_ROOM_MESSAGES.get_or_init(|| std::sync::Mutex::new(Vec::new()))
 }
 
+#[cfg(test)]
+pub(crate) fn take_sent_room_messages() -> Vec<types::SendMessageRequest> {
+    std::mem::take(
+        &mut *sent_room_messages()
+            .lock()
+            .expect("sent room messages lock"),
+    )
+}
+
 fn command_answer_effect(answer: ProviderAnswer) -> types::ExtensionEffect {
+    command_text_effect("ai-command-answer", "AI answer", answer.text.as_str())
+}
+
+fn channel_posted_effect() -> types::ExtensionEffect {
+    command_text_effect(
+        "ai-command-posted",
+        "AI answer posted",
+        "AI answer posted to channel.",
+    )
+}
+
+fn command_text_effect(id: &str, title: &str, text: &str) -> types::ExtensionEffect {
     types::ExtensionEffect::EnrichMessage(types::ExtensionEnvelope {
         version: 1,
         enrichments: vec![types::MessageEnrichment {
             id: types::EnrichmentId {
-                value: "ai-command-answer".to_string(),
+                value: id.to_string(),
             },
             plugin: plugin_id(),
             capability: types::ExtensionCapability::MessageEnrich,
@@ -242,11 +263,11 @@ fn command_answer_effect(answer: ProviderAnswer) -> types::ExtensionEffect {
             source: None,
             ui: vec![types::UiView {
                 id: types::UiViewId {
-                    value: "ai-command-answer".to_string(),
+                    value: id.to_string(),
                 },
-                title: Some(display("AI answer")),
+                title: Some(display(title)),
                 blocks: vec![types::UiBlock::Text(types::TextBlock {
-                    text: display(answer.text.as_str()),
+                    text: display(text),
                     style: types::TextStyle::Body,
                 })],
             }],

--- a/server/extensions/ai-chatbot/src/lib.rs
+++ b/server/extensions/ai-chatbot/src/lib.rs
@@ -102,7 +102,7 @@ fn provider_config() -> Result<RuntimeProviderConfig, types::ExtensionError> {
 }
 
 #[cfg(test)]
-pub(crate) use command::command_response_with_config;
+pub(crate) use command::{command_response_with_config, take_sent_room_messages};
 #[cfg(test)]
 pub(crate) use constants::{
     BASELINE_SYSTEM_PROMPT, COMMAND_NODE, MAX_CONTEXT_BYTES, MAX_CONTEXT_LINE_BYTES,

--- a/server/extensions/ai-chatbot/src/tests.rs
+++ b/server/extensions/ai-chatbot/src/tests.rs
@@ -3,11 +3,11 @@ use super::{
     execute_provider_request_with_runtime, extension_error, format_archived_messages, manifest,
     parse_provider_answer, provider_execution_error, provider_request_headers,
     provider_request_json, provider_request_json_from_parts, provider_tool_mam_query,
-    select_host_tools, types, CleanPrompt, ExecutionContext, HostTool, NonEmptyString,
-    ProviderAnswer, ProviderConfig, ProviderExecutionError, ProviderExecutor, ProviderRequest,
-    ProviderRole, ResponseTarget, BASELINE_SYSTEM_PROMPT, COMMAND_NODE, MAX_CONTEXT_BYTES,
-    MAX_CONTEXT_LINE_BYTES, MAX_PROVIDER_TOOL_CALLS_PER_ROUND, OPENROUTER_REFERER,
-    OPENROUTER_TITLE,
+    select_host_tools, take_sent_room_messages, types, CleanPrompt, ExecutionContext, HostTool,
+    NonEmptyString, ProviderAnswer, ProviderConfig, ProviderExecutionError, ProviderExecutor,
+    ProviderRequest, ProviderRole, ResponseTarget, BASELINE_SYSTEM_PROMPT, COMMAND_NODE,
+    MAX_CONTEXT_BYTES, MAX_CONTEXT_LINE_BYTES, MAX_PROVIDER_TOOL_CALLS_PER_ROUND,
+    OPENROUTER_REFERER, OPENROUTER_TITLE,
 };
 
 struct FakeExecutor {
@@ -673,6 +673,67 @@ fn command_success_returns_visible_result_enrichment() {
         panic!("expected text block");
     };
     assert_eq!(text.text.value, "answer");
+}
+
+#[test]
+fn channel_public_command_posts_answer_to_active_room() {
+    let _ = take_sent_room_messages();
+    let mut command = command_invocation("summarize release blockers");
+    command.room = Some(types::RoomJid {
+        value: "chat@muc.example.com".to_string(),
+    });
+    command.fields.push(types::FormFieldValue {
+        name: types::UiActionId {
+            value: "output".to_string(),
+        },
+        values: vec![types::DataFormValue {
+            value: "channel".to_string(),
+        }],
+    });
+    let executor = success_executor("there are no blockers");
+
+    let effect = command_response_with_config(command, &executor, test_config())
+        .expect("command succeeds")
+        .expect("visible command result");
+
+    let types::ExtensionEffect::EnrichMessage(envelope) = effect else {
+        panic!("expected visible posted confirmation");
+    };
+    let block = &envelope.enrichments[0].ui[0].blocks[0];
+    let types::UiBlock::Text(text) = block else {
+        panic!("expected text block");
+    };
+    assert_eq!(text.text.value, "AI answer posted to channel.");
+    let sent = take_sent_room_messages();
+    assert_eq!(sent.len(), 1);
+    assert_eq!(sent[0].body.value, "there are no blockers");
+    assert!(sent.iter().all(|request| matches!(
+        &request.target,
+        types::MessageTarget::Muc(room) if room.value == "chat@muc.example.com"
+    )));
+}
+
+#[test]
+fn channel_public_command_requires_active_room() {
+    let mut command = command_invocation("summarize release blockers");
+    command.fields.push(types::FormFieldValue {
+        name: types::UiActionId {
+            value: "output".to_string(),
+        },
+        values: vec![types::DataFormValue {
+            value: "channel".to_string(),
+        }],
+    });
+    let executor = success_executor("unused");
+
+    let error = command_response_with_config(command, &executor, test_config())
+        .expect_err("channel output without room fails");
+
+    assert_eq!(error.code, types::ExtensionErrorCode::InvalidRequest);
+    assert_eq!(
+        error.message.value,
+        "posting an AI answer to a channel requires an active channel"
+    );
 }
 
 fn success_executor(answer: &str) -> FakeExecutor {


### PR DESCRIPTION
## Summary

Fixes the AI extension public-channel command flow end to end.

## Plan and completed work

- Preserve XEP-0128 command metadata discovery for `/ai` by falling back to raw disco#info parsing when the typed Rust client response omits metadata forms.
- Include the active channel JID as the Waddle-specific `waddle#room_jid` data-form field when submitting XEP-0050 extension command forms from a room.
- Make inline `/ai <prompt>` in a channel public by forcing the AI command form's `output` field to `channel`.
- Post the user's public AI prompt to the channel before submitting the AI command, using the normal XMPP message path.
- Keep the form path private by default unless the user explicitly chooses `Post to channel`.
- Restrict public prompt echoing to the AI chatbot command only, so generic extension forms with `prompt` and `output=channel` do not gain unintended side effects.
- Do not submit the bot command when the public prompt send fails.
- Return failure from slash dispatch when command submission fails, so the composer draft is not cleared.
- Use a programmatic channel send for the public prompt so the draft is preserved if the subsequent command submission fails.
- Change the AI extension's successful public-channel result from `Noop` to a visible completion confirmation, avoiding the command wrapper's no-visible-result warning without leaking the AI answer privately.
- Add regression coverage for discovery fallback, active-room form submission, inline public `/ai`, failure ordering, draft preservation, non-AI negative behavior, and server command-result warning avoidance.

## Validation

- `cd chat && bun test tests/extension-launcher-slash.test.ts tests/client-send-readiness.test.ts tests/extension-command.test.ts`
- `cd chat && bun run lint`
- `cd chat && bun run build`
- `cd chat && bun test`
- `cd server && cargo fmt --check -p ai-chatbot -p waddle-server`
- `cd server && cargo test -p ai-chatbot`
- `cd server && cargo test -p waddle-server enrichment_command_result_completes_without_noop_warning --lib`
- `git diff --check`

## Notes

- `bun run build` required filesystem approval for Wrangler/Miniflare writes under `~/Library/Preferences/.wrangler`.
- The build still reports existing TypeScript hint-level unused declarations and Vite chunk-size warnings; it completes successfully.
