### PR TITLE
feat(server): XEP-0163 §3 PEP fan-out by roster + CAPS

### DIFF
--- a/docs/rfc/363-avatar-vcard-pep-sync.md
+++ b/docs/rfc/363-avatar-vcard-pep-sync.md
@@ -1,0 +1,321 @@
+# RFC 363: Avatar and vCard PEP Sync
+
+**Issue:** [#363](https://github.com/waddle-social/waddle/issues/363)
+**Status:** Design ratified, implementation pending
+**Follow-ups:** [#435](https://github.com/waddle-social/waddle/issues/435) (workspace roster bridge), [#436](https://github.com/waddle-social/waddle/issues/436) (XMPP-native user deletion), [#437](https://github.com/waddle-social/waddle/issues/437) (binary-payload object storage)
+**Date:** 2026-05-09
+
+## Summary
+
+Make profile and avatar updates reliable across web, native, and standard XMPP clients using XMPP-native PEP/vCard flows. The user-visible symptom motivating this work: avatars don't appear in the chat client for other users, especially in DM views and member lists. The root causes span both the server (no bridge from `users.avatar_url` to PEP/vCard) and the client (no PEP push handler, iterate-and-pull misses DM peers).
+
+The design is **push-driven**, not pull-driven. Avatars and display names propagate via XEP-0163 §3 PEP fan-out triggered by presence exchange. The chat client advertises `+notify` filters in CAPS and receives `<message><event>` notifications from the server; it does not iterate JID lists and pull avatars by IQ.
+
+## Problem
+
+Today:
+
+- Self avatar comes from `/api/auth/session.avatar_url` in `chat/src/shell/chat-app-controller.ts:504`.
+- Other users' avatars are loaded with `avatar_url: null` (`chat/src/lib/xmpp/client.ts:819`); the chat then calls `fetchUserAvatar(jid)` (`chat/src/lib/xmpp/client.ts:828`).
+- `fetchUserAvatar` calls the Rust XMPP avatar path, which tries XEP-0084 PEP first then XEP-0054 vCard fallback (`server/crates/waddle-xmpp-client/src/avatar.rs:214`).
+- Server-side PEP avatar reads only from `pubsub_storage` (`server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs:184`).
+- Server-side vCard reads only from `vcard_storage` (`server/crates/waddle-server/src/server/routes/websocket/handlers/iq/vcard_private.rs:33`).
+- `get_user_avatar_url()` exists at `server/crates/waddle-server/src/server/xmpp_profile_state.rs:41` and is wired into the `XmppState` trait but **has zero callers under `server/crates/waddle-server/src/server/routes/`**. Dead at the route layer.
+- Client `avatarLookupCandidates` consumes `messaging.messages.value` only (`chat/src/shell/chat-app-controller.ts:496-503`), so DM peers from `dmMessaging.messages.value` never trigger a fetch.
+- Workspace members are merged into `avatarUrlByAuthor` with their cached `member.avatar_url` (which is `null` from `list_room_members`); the watch at `chat-app-controller.ts:547-568` only iterates `avatarCandidates`, so workspace members who aren't active room authors never trigger a fetch either.
+
+Net effect: a user resolves their own avatar via the REST session response; everybody else shows blank.
+
+## Design overview
+
+### Push, not pull
+
+XEP-0163 §3 specifies presence-driven PEP fan-out: when a user publishes an item, the server delivers `<message><event>` to every entity that (a) has roster `subscription = from/both` to the publisher AND (b) has cached CAPS advertising `+notify` for the node. There is no explicit pubsub subscription record involved — roster + CAPS is the filter.
+
+The server already advertises `urn:xmpp:avatar:metadata+notify` (`server/crates/waddle-xmpp-core/src/disco/info/features.rs:267`) and `pubsub#auto-subscribe` (`features.rs:258`), and the typed `CapsCache` exists at `server/crates/waddle-xmpp/src/xep/xep0115.rs:114`. The disco/CAPS advertisement currently does not match runtime behavior because the inbound presence handler doesn't wire the `<c hash ver node>` element through the cache, and the publish/fanout path doesn't filter by per-resource CAPS. This RFC closes both gaps.
+
+### XMPP-native, no `url` shortcut
+
+XEP-0084 §4 defines the data node as the authoritative retrieval path for avatar bytes. The optional `url` attribute on `<info>` is a permitted HTTP shortcut, but using it propagates an out-of-band retrieval expectation to every client. We omit `url` and serve everything from the data node, keeping retrieval entirely in-band.
+
+### Conformant SHA-1 from fetched bytes
+
+XEP-0084 §4.1.1 requires the metadata `<info id="...">` attribute to be the SHA-1 of the actual image bytes — not a hash of the URL string. The OIDC bridge fetches the bytes once at publish time, computes the real SHA-1 via the existing typed primitive (`HashValue` from `server/crates/waddle-xmpp/src/xep/xep0300.rs`), and uses `HashValue::to_hex()` as the item id.
+
+### Mirror to legacy and modern vCard
+
+XEP-0398 §3 requires server-side consistency between the PEP avatar and the XEP-0054 vcard-temp PHOTO so legacy clients (XEP-0153) stay in sync. We additionally mirror to XEP-0292 vCard4 (`urn:xmpp:vcard4` PEP node) so modern clients have first-class vCard4 access. Display name (FN) flows alongside PHOTO into both vCard surfaces.
+
+### Independent PHOTO/FN sync
+
+OIDC claims `picture` and `name` have independent provenance. The publish helper handles them as independent flows — either subset can run alone, both can run together, neither runs as no-op.
+
+## Detailed design
+
+### Typed helper signature
+
+```rust
+// server/crates/waddle-server/src/<profile module>/mod.rs
+pub async fn ensure_pep_profile_published(
+    state: &XmppState,
+    jid: &BareJid,
+    source: ProfileSource,
+) -> Result<(), ProfileSyncError>
+
+pub enum ProfileSource {
+    Oidc {
+        avatar_url: Option<url::Url>,        // typed URL, not &str
+        display_name: Option<String>,        // boundary type for free-form unicode
+    },
+    // Future variants out of scope: User { ... }, Scim { ... }, etc.
+}
+```
+
+`url::Url` rather than `&str` honors the typed-payloads hard rule. Parsing happens once at the OIDC boundary, never re-parsed downstream. `ProfileSource::Oidc { None, None }` short-circuits as a no-op.
+
+### Wiring into OIDC login
+
+Call sites:
+
+- `server/crates/waddle-server/src/auth/identity.rs:262-269` (`provision_new_user` — new user insert)
+- `server/crates/waddle-server/src/auth/identity.rs:329-337` (`reconcile_existing_user` — existing user update)
+
+The reconcile path runs the helper only when `existing.avatar_url != claims.avatar_url` OR `existing.display_name != claims.name`. The helper internally decides which subset of steps to run based on what's set/changed.
+
+The OIDC login response returns immediately. The helper runs in a background `tokio::spawn` task so a slow CDN or unreachable avatar URL does not stall login.
+
+### Outbound HTTP fetch policy
+
+The OIDC `picture` claim is user-controlled in many real-world IdPs (notably GitHub OAuth). SSRF defense is mandatory.
+
+| Knob | Setting | Rationale |
+|---|---|---|
+| Scheme | `https://` only | Reject `http://`, `data:`, `file:`. |
+| SSRF block | After DNS resolution, refuse RFC 1918, link-local (incl. `169.254/16` for AWS/GCP metadata), loopback, non-global IPv6. Re-resolve before connect (DNS rebinding defense). | Closes SSRF without a brittle domain allowlist. |
+| Size cap | **100 KB raw (transitional).** Lifts to 1 MB after [#437](https://github.com/waddle-social/waddle/issues/437) ships and binary-payload object storage is available. | Fits comfortably in `pubsub_items.payload_xml TEXT` on D1 (~135 KB serialized). Typical OIDC avatars (GitHub/Google/Bluesky thumbnails) are well under this. |
+| MIME allowlist | `image/png`, `image/jpeg`, `image/gif`, `image/webp` | Reject anything else; log and skip publish. |
+| Timeouts | 5s connect, 10s total | Short — background bridge, not a critical path. |
+| Retries | 1 on transient (5xx, connect timeout, network error). No backoff. | Background bridge; failure cache handles permanence. |
+| Failure cache | `users.last_avatar_fetch_attempt_at` + typed `users.last_avatar_fetch_error` (`permanent_4xx | transient_5xx | timeout | mime_rejected | size_exceeded | ssrf_blocked | network`) | Skip re-attempt for 24h after a 4xx; retry sooner after transient failures. |
+
+### Publish chain (set path)
+
+The chain is XEP-prescribed and conditional. PHOTO steps run only if `users.avatar_url` is present; FN steps run only if `users.display_name` is present.
+
+| Step | XEP | Action |
+|---|---|---|
+| 1 | XEP-0084 §4.1.1 | **(PHOTO)** Fetch URL bytes per the policy above. |
+| 2 | XEP-0300 | **(PHOTO)** `compute_hash(HashAlgo::Sha1, &bytes) -> HashValue`. Item id is `HashValue::to_hex()`. |
+| 3 | XEP-0084 §4.1.1 | **(PHOTO)** Publish to `urn:xmpp:avatar:data` (item id = SHA-1, payload = base64-encoded bytes). No fan-out — data node has no `+notify`. |
+| 4 | XEP-0084 §4.1.2 | **(PHOTO)** Publish to `urn:xmpp:avatar:metadata` with `<metadata><info id="<sha1>" type="<mime>" bytes="<len>"/></metadata>` — exactly one `<info>`, no `url`. Triggers `pubsub_fanout::fan_out_publish` so XEP-0163 §3 push fires. Subscribers immediately follow up with a data-item IQ get and find the data already in storage from step 3. |
+| 5 | XEP-0398 §3 / XEP-0054 | **(PHOTO and/or FN)** Read-modify-write vcard-temp via `VCardStore::get(jid)` → mutate → `VCardStore::set(jid, &elem)`. Replace/insert `<PHOTO>` if PHOTO ran; replace/insert `<FN>` if FN sync is in scope. Preserve all other elements (EMAIL, NICKNAME, NOTE, custom). |
+| 6 | XEP-0292 / XEP-0163 | **(PHOTO and/or FN)** Read-modify-write XEP-0292 vCard4 PEP item via `pubsub_storage.get_items(jid, "urn:xmpp:vcard4", Some(1), &[])`. Replace/insert `<photo><uri>data:image/png;base64,...</uri></photo>` if PHOTO ran; replace/insert `<fn><text>...</text></fn>` if FN. Preserve other fields. Publish back to `urn:xmpp:vcard4`; fan-out fires for `urn:xmpp:vcard4+notify` subscribers. |
+| 7 | XEP-0153 §4 | **(PHOTO only)** Emit fresh self-presence broadcast carrying `<x xmlns="vcard-temp:x:update"><photo>SHA1</photo></x>`. SHA-1 matches the bytes in vcard-temp from step 5. Skipped if PHOTO step did not run. |
+
+**Why this order?** XEP-0084 §4.1.2 opens with: *"Once the data is published, the user publishes the metadata..."* — explicit XEP prescription. Metadata is what triggers fan-out; data must be in storage first so subscribers' immediate follow-up retrieve succeeds. Otherwise contacts get `<item-not-found/>` per XEP-0060 §5.5 and interpret it as a broken avatar.
+
+### Removal chain (XEP-0084 §4.3)
+
+When OIDC re-login arrives with `avatar_url = None` and the user previously had an OIDC-sourced avatar:
+
+- **Guard:** `avatar_source = 'oidc'` AND a previous metadata item exists. If `avatar_source = 'user'`, PHOTO removal is skipped — OIDC's "no avatar" view does not override a deliberate self-publish.
+- **Steps:**
+  1. Publish empty `<metadata xmlns="urn:xmpp:avatar:metadata"/>` to `urn:xmpp:avatar:metadata` with item id `current` per XEP-0084 §4.3 example. Triggers fan-out; subscribers receive `<message><event>` and drop their cached avatars.
+  2. RMW vcard-temp: remove `<PHOTO>`. Other fields untouched.
+  3. RMW vCard4 PEP item: remove `<photo>`. Other fields untouched.
+  4. Self-presence broadcast carrying empty `<x xmlns="vcard-temp:x:update"><photo/></x>` per XEP-0153 §4.2.
+  5. Optionally retract the orphaned `urn:xmpp:avatar:data` item (storage cleanup; not required by XEP).
+
+**FN removal mirror:** when `users.display_name` transitions to None, RMW removes `<FN>` from vcard-temp and `<fn>` from vCard4. No guard — FN has no user-self-managed analog.
+
+**Trigger discipline:** removal fires only on actual transition (Some → None) when a published item exists. Repeated OIDC re-logins with `avatar_url = None` after the removal already fired are idempotent skips. Fetch failure (per the policy above) is **not** a removal — `claims.avatar_url = Some(url)` with a fetch error leaves PEP state alone.
+
+### Schema additions
+
+```sql
+ALTER TABLE users ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'oidc';
+-- typed enum on the Rust side: AvatarSource { Oidc, User }
+ALTER TABLE users ADD COLUMN last_avatar_fetch_attempt_at TEXT;  -- RFC 3339
+ALTER TABLE users ADD COLUMN last_avatar_fetch_error TEXT;       -- typed error enum serialized
+```
+
+The XEP-0084 publish handler in `pubsub_dispatch.rs` flips `avatar_source` to `'user'` when a publishing JID matches the target_jid of `urn:xmpp:avatar:metadata` (i.e., the user is publishing their own avatar via XEP-0084 from a client). The OIDC bridge respects this guard.
+
+### Access control
+
+On first publish, set `NodeConfig::public()` on:
+
+- `urn:xmpp:avatar:metadata`
+- `urn:xmpp:avatar:data`
+- `urn:xmpp:vcard4`
+
+`AccessModel::Open` matches XEP-0084 / XEP-0292 design (avatars and profile data are semi-public) and means any authenticated requester can read. "Unauthorized" then means unauthenticated, already blocked at the websocket auth layer.
+
+`send_last_published_item = OnSub` (already the default in `NodeConfig` at `server/crates/waddle-xmpp-core/src/pubsub/node.rs:153`) ensures new subscribers get the current item pushed immediately.
+
+vcard-temp authorization is already consistent: `vcard_private.rs:33-65` lets any authenticated user read any user's vCard, and `vcard_private.rs:67-76` restricts writes to the owner. No changes needed to the vcard-temp IQ handler.
+
+### XEP-0115 CAPS resolution wire-up
+
+The typed `CapsCache` exists in `waddle-xmpp` but is not wired into the server. This RFC adds:
+
+- **Inbound presence handler:** parse `<c xmlns="http://jabber.org/protocol/caps" hash="..." node="..." ver="..."/>` to typed `EntityCaps { node, hash, ver }`.
+- **Cache lookup:** if `(node, ver)` is in `CapsCache`, record session-scoped `(full_jid → caps_ver)` mapping. If not, issue typed `disco#info` query to the resource's full JID, validate response hash matches `ver` (XEP-0115 §5), insert into `CapsCache`, then record the mapping.
+- **Disconnect cleanup:** drop the resource→caps mapping. The hash-keyed cache itself stays warm for cross-session reuse.
+
+All caps storage uses typed `EntityCaps`, `Identity`, `Feature`. No stringly-typed feature lists at any boundary.
+
+### XEP-0163 §3 fan-out
+
+Extend `pubsub_fanout::fan_out_publish` (after the existing iteration over explicit pubsub subscribers):
+
+1. Iterate roster contacts of the publisher (`subscription = from/both`).
+2. For each contact, look up online resources.
+3. For each resource, look up its caps hash from the session-scoped mapping.
+4. Look up the feature list in `CapsCache`.
+5. If features include the matching `+notify` filter for the published node, send `<message><event>` to that full JID.
+
+**Per-resource semantics:** only resources with the matching `+notify` receive the event. Resources without it receive nothing. Resources mid-resolution (disco#info in flight) are skipped for this publish; they pick up the current item via `send_last_published_item = OnSub` on their next presence broadcast.
+
+### Startup backfill
+
+One-shot migration on server boot:
+
+```sql
+SELECT id, xmpp_localpart, avatar_url, display_name, avatar_source FROM users
+WHERE (avatar_url IS NOT NULL AND avatar_source = 'oidc')
+   OR display_name IS NOT NULL
+   OR (avatar_url IS NULL AND avatar_source = 'oidc' AND <a published metadata item exists>)
+```
+
+For each row, call `ensure_pep_profile_published`. Bounded concurrency (4 in-flight fetches), continue-on-error, marker recorded in `schema_migrations` to prevent re-run. Failed users are eligible for retry on next startup or via a CLI subcommand. Idempotent per-step (skip if PEP item / vCard field already matches).
+
+### Failure modes and idempotence
+
+The chain is sequential and each step commits independently:
+
+- Step 3 succeeds, step 4 fails → orphaned data item, harmless (no advertising metadata, nobody resolves it).
+- Step 4 succeeds, step 5 fails → PEP avatar is correct, vcard-temp PHOTO is stale; XEP-0153 hash advertisement reflects the stale state until next publish. PEP-aware clients see the correct avatar.
+- Step 5 succeeds, step 6 fails → vCard4 PEP subscribers get the old item; legacy vcard-temp consumers see the right one.
+- Re-running the helper completes idempotently.
+
+**Empty-bytes guard:** the helper refuses to spuriously publish empty metadata when fetched bytes are empty. XEP-0084 §4.3 reserves the empty `<metadata/>` shape for the explicit removal flow above.
+
+## Client design
+
+### WASM client outbound CAPS
+
+Add to the WASM client's outbound CAPS (`server/crates/waddle-xmpp-client/src/`):
+
+- `urn:xmpp:avatar:metadata+notify` (already advertised server-side, must match)
+- `urn:xmpp:vcard4+notify` (new — needed for FN updates to push)
+
+Adding new `+notify` filters changes the CAPS verification string and therefore the CAPS hash. Other servers' CAPS caches will re-resolve once on next presence — harmless but worth noting in the PR description.
+
+### Typed PEP event handler
+
+Add to `chat/src/lib/xmpp/client.ts` a typed handler dispatching on event node:
+
+- `urn:xmpp:avatar:metadata`: extract typed `<info id type bytes/>`, IQ-retrieve `urn:xmpp:avatar:data` items by id from the publisher, decode bytes, render as `data:` URL, update `fetchedAvatarUrlByJid[publisherJid]`.
+- `urn:xmpp:vcard4`: extract typed `VCard4`, surface FN as the displayed name for the publisher.
+- On receipt of a push for either node, the JID is added to a "push-served" set so subsequent iterate-and-pull skips it.
+
+### Transitional iterate-and-pull
+
+This RFC ships before [#435](https://github.com/waddle-social/waddle/issues/435) (workspace roster bridge). Until #435 lands, push delivery only reaches roster-explicit contacts; workspace colleagues need the iterate-and-pull fallback.
+
+So this RFC **adds the push path but does not remove iterate-and-pull**:
+
+- Fix the original observed gap: extend `avatarLookupCandidates` at `chat/src/shell/chat-app-controller.ts:496-503` to also consume `dmMessaging.messages.value` so DM peers are queued for IQ pull.
+- The watch at `chat/src/shell/chat-app-controller.ts:547-568` stays in place but becomes a fallback: triggers IQ pull only for JIDs not already served by push.
+- After #435 ships, a small follow-up PR removes the watch entirely.
+
+## XEPs and conformance considerations
+
+- **XEP-0060 PubSub** — base mechanism for publish/retrieve/notify.
+- **XEP-0163 PEP** — auto-discovery via CAPS, presence-driven fan-out (§3).
+- **XEP-0084 User Avatar** — data and metadata nodes (§4.1), `url` is optional and we omit it, removal via empty metadata (§4.3).
+- **XEP-0292 vCard4 Over XMPP** — modern profile in PEP at `urn:xmpp:vcard4`.
+- **XEP-0153 vCard-Based Avatars** — presence advertises SHA-1 hash of vCard PHOTO bytes (§4); empty `<photo/>` signals "no avatar" (§4.2).
+- **XEP-0398 PEP/vCard Conversion** — server-side consistency between PEP avatar and vCard PHOTO (§3).
+- **XEP-0054 vcard-temp** — legacy vCard storage; remains the source for XEP-0153.
+- **XEP-0115 Entity Capabilities** — CAPS hash advertisement and verification (§5).
+- **XEP-0300 Cryptographic Hashes** — typed `HashValue`/`HashAlgo` primitive.
+
+## Out of scope
+
+- **Synthesize-on-read fallback.** Rejected as non-conformant — would require a fake SHA-1 id and would never fire PEP notifications.
+- **Including `url` attribute in published metadata.** Rejected to keep retrieval entirely XMPP-native.
+- **Per-render lazy fetch in the client as the primary mechanism.** Replaced by the push-based design; lazy is fallback only.
+- **Federated peers (s2s avatar push, remote CAPS resolution).** s2s subsystem doesn't yet exist (see `server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs:31,104` — cross-domain JIDs are dropped). Code is written route-agnostically (typed `Jid`, dispatch through existing routing) so explicit federation tests can be added when s2s lands.
+- **Workspace roster bridge** — tracked in [#435](https://github.com/waddle-social/waddle/issues/435).
+- **Conformant user-deletion semantics** (XEP-0084 §4.3 empty publish + RFC 6121 §3.4 presence-unavailable + roster `subscription="remove"` cascade) — tracked in [#436](https://github.com/waddle-social/waddle/issues/436). This RFC verifies FK cascade so writes don't orphan rows; the wire effects on deletion are #436's job.
+- **Binary-payload object storage** — tracked in [#437](https://github.com/waddle-social/waddle/issues/437). Until that lands, the avatar fetch policy enforces a 100 KB inline cap.
+- **EMAIL, NICKNAME, ORG, and other vCard fields** — only PHOTO and FN are populated by the OIDC bridge in this RFC.
+- **Per-user opt-out of presence/avatar sharing within a workspace** — workspace-level settings concern, not in this RFC.
+- **Periodic re-fetch of unchanged URLs** to catch upstream content changes — login-only fetch is sufficient.
+- **Concurrency control on vCard writes** — last-write-wins for now; typed concurrency is a separate concern, filed if it bites in practice.
+
+## Implementation plan (PR breakdown)
+
+This RFC lands as 6 sequential PRs. Each builds on the previous and ships in a working, independently-testable state. No feature flags (per the project's no-backwards-compat rule).
+
+| # | PR title | Scope | Working state at end |
+|---|---|---|---|
+| 1 | `feat(server): wire XEP-0115 CAPS resolution into presence handler` | Inbound presence handler parses `<c hash ver node>`, resolves via `CapsCache` (hit) or disco#info (miss with hash verification per XEP-0115 §5), records per-resource caps mapping; disconnect cleans up the mapping while leaving the hash-keyed cache warm. New `xep0115_caps_ws.rs`. | CAPS conformance tests pass. No fan-out behavior change yet (no consumer). |
+| 2 | `feat(server): XEP-0163 §3 PEP fan-out by roster + CAPS` | Extend `pubsub_fanout` to iterate roster `from/both` contacts of the publisher, consult per-resource cached CAPS, deliver `<message><event>` to matching resources. Per-resource semantics. Updates `xep0163_pep_ws.rs`. | Existing PEP nodes (mood, activity, microblogging, nick, tune) now fan out per XEP-0163 §3. Avatars not yet involved. |
+| 3 | `feat(server): typed ProfileSource + OIDC avatar/FN publish chain` | Adds typed `ProfileSource` enum, `ensure_pep_profile_published` happy-path branches (steps 1–7 for set), `users.avatar_source` schema column, fetch policy with SSRF + 100 KB cap + MIME allowlist + retry + failure cache columns, `NodeConfig::public()` on the three nodes. Wire into OIDC `provision_new_user` and `reconcile_existing_user` (background `tokio::spawn`, login non-blocking). New `xep0084_avatar_ws.rs` covering the set path + vCard mirror RMW + vCard4 PEP push + presence refresh. Updates `xep0054_0049_0191_ws.rs` and `rfc6121_presence_ws.rs`. New `xep0084_avatar.rs` core-protocol unit tests. | OIDC login publishes a conformant avatar + FN; subscribers receive push (works because PRs 1+2 already landed); user-managed avatar guard works. No removal yet, no backfill. |
+| 4 | `feat(server): XEP-0084 §4.3 avatar removal + FN removal mirror` | Adds removal branches to `ensure_pep_profile_published`: empty `<metadata/>` publish per XEP-0084 §4.3, vCard PHOTO/FN removal RMW, empty `<photo/>` presence per XEP-0153 §4.2. User-managed avatar exception preserved. Extends `xep0084_avatar_ws.rs` with removal tests. | OIDC re-login with `picture` claim disappearing fires the conformant removal flow; subscribers' caches invalidate. |
+| 5 | `feat(server): startup backfill for OIDC profile sync` | One-shot startup migration with bounded concurrency (4 in-flight fetches), idempotence marker in `schema_migrations`, failure cache columns. Backfill query covers set, FN-only, and removal-needed cases. Continue-on-error. CLI subcommand for retry. Extends `xep0084_avatar_ws.rs`. | Existing users with `users.avatar_url` set get conformant PEP/vCard state on next server boot; OIDC-sourced no-avatar transitions get the conformant removal applied. |
+| 6 | `feat(chat): PEP event handler + DM peer iterate-and-pull fix` | WASM client outbound CAPS adds `urn:xmpp:avatar:metadata+notify` and `urn:xmpp:vcard4+notify`. Chat client adds typed PEP event handler dispatching on node — avatar metadata triggers data IQ retrieve and updates `fetchedAvatarUrlByJid`; vCard4 surfaces FN as displayed name. Push-served JIDs added to a set so iterate-and-pull skips them. DM peer extension: `avatarLookupCandidates` consumes `dmMessaging.messages.value`. | Avatars resolve in chat for roster contacts (push) and DM peers (pull); workspace colleagues continue using pull until #435 lands. After #435, a small follow-up PR removes the iterate-and-pull mechanism. |
+
+## Test strategy
+
+All server-side tests follow the project's WebSocket-driven XEP conformance pattern (`server/crates/waddle-server/tests/*_ws.rs`). Per the CLAUDE.md hard rule, every implemented XEP must have a dedicated Rust custom test suite — this RFC adds one for XEP-0084 and extends the existing XEP-0163, XEP-0054, and RFC 6121 suites.
+
+| New / Edit | Path | Coverage |
+|---|---|---|
+| New | `server/crates/waddle-server/tests/xep0084_avatar_ws.rs` | `ensure_pep_profile_published` happy path; XEP-prescribed publish order (data before metadata, fan-out fires only after metadata); OIDC re-login no-op when URL unchanged; OIDC re-login republish when URL changed; user self-publish flips `avatar_source = 'user'` and protects subsequent OIDC re-login; XEP-0084 §4.3 removal flow; user-managed exception during removal; FN-only sync; FN removal mirror; failure-mode idempotence; startup backfill; access control (open read for any authenticated requester, forbidden cross-user publish with typed stanza error); restart persistence; vCard mirror RMW preserves user-set fields. |
+| Edit | `server/crates/waddle-server/tests/xep0163_pep_ws.rs` | XEP-0163 §3 fan-out: roster + CAPS filter; per-resource semantics; multi-resource case (one resource with `+notify`, one without — only the first receives). |
+| New | `server/crates/waddle-server/tests/xep0115_caps_ws.rs` | Presence with `<c hash ver node>` triggers cache lookup or disco#info; hash verification rejects mismatched responses (XEP-0115 §5); cache hit avoids the disco query; multi-resource independent tracking; disconnect cleans up resource→caps mapping while leaving the hash-keyed cache warm. |
+| Edit | `server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs` | PEP avatar publish mirrors to vcard-temp PHOTO and FN; vCard4 PEP carries equivalent photo (data: URI) and FN; vCard4 publish triggers fan-out; RMW preserves user-set fields. |
+| Edit | `server/crates/waddle-server/tests/rfc6121_presence_ws.rs` | After avatar publish, the user's next presence broadcast carries `<x xmlns="vcard-temp:x:update"><photo>SHA1</photo></x>` matching the published bytes. After avatar removal, presence carries empty `<photo/>`. |
+| New | `server/crates/waddle-xmpp/tests/xep0084_avatar.rs` | Core-protocol unit tests: metadata stanza shape, `<info>` attribute requirements (id required, type required, bytes required, no `url` emitted), data item base64 round-trip, parser rejects malformed metadata. |
+
+### Client coverage
+
+- PEP event handler updates `fetchedAvatarUrlByJid` when a `urn:xmpp:avatar:metadata` event arrives, then IQ-retrieves data and renders a `data:` URL.
+- vCard4 event handler surfaces FN as displayed name.
+- Iterate-and-pull fallback at `chat-app-controller.ts:547-568` fires only for JIDs not already push-served.
+- DM open queues the peer for IQ pull via the extended `avatarLookupCandidates`.
+- `fetchUserAvatar(jid)` fallback resolves for stranger JIDs on demand.
+
+### Validation
+
+- `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt`.
+- `bun test && bun run lint` (knip clean).
+
+## Acceptance criteria
+
+- A user can publish a profile/avatar update and another subscribed/contact client receives it without reload-only behavior — delivered via PEP push.
+- A fresh client retrieves the last published avatar/profile through the XMPP path; first presence exchange triggers `send_last_published_item = OnSub` delivery.
+- A user who has only ever set their avatar via OIDC login (never via XMPP publish) is resolvable by other users through XEP-0084 — the OIDC bridge materializes a real conformant PEP item with SHA-1 derived from fetched bytes.
+- vCard fallback (XEP-0054) and PEP avatar metadata/data stay consistent; XEP-0153 presence-hash matches published bytes.
+- A user who self-published a custom avatar via XEP-0084 is not overwritten by subsequent OIDC re-login.
+- DM views show peer avatars without opening a profile or visiting a shared room first. While #435 is pending, satisfied by iterate-and-pull on `dmMessaging.messages`. After #435, satisfied by push.
+- Workspace member listings show member avatars. While #435 is pending, satisfied by iterate-and-pull. After #435, satisfied by push.
+- Unauthorized cross-user publishes are rejected with typed stanza errors. Reads on the open avatar nodes succeed for any authenticated requester.
+- Disco/advertised support matches runtime behavior — `urn:xmpp:avatar:metadata+notify`, `urn:xmpp:vcard4+notify`, `pubsub#auto-subscribe` all advertised AND functional.
+- Inbound presence with `<c xmlns="http://jabber.org/protocol/caps">` populates `CapsCache` (hit) or triggers typed disco#info with hash verification (miss). Resource→caps mappings recorded on presence, dropped on disconnect.
+- A PEP publish from user Y is delivered as `<message><event>` to exactly the online resources of Y's roster `from/both` contacts whose cached CAPS include the matching `+notify` filter.
+- Per-resource semantics: contacts with multiple resources only see push on resources advertising `+notify`. Resources mid-resolution are skipped for this publish but pick up via `OnSub` later.
+- Avatar removal: `users.avatar_url` Some → None for `avatar_source = 'oidc'` users publishes empty `<metadata/>`, removes PHOTO from vCards, emits empty `<photo/>` presence. User-managed avatars are unaffected.
+- FN removal: `users.display_name` → None removes `<FN>` from vcard-temp and `<fn>` from vCard4; vCard4 fan-out fires.
+
+## Cross-references
+
+- **Issue:** [#363](https://github.com/waddle-social/waddle/issues/363)
+- **Followed by:** [#435](https://github.com/waddle-social/waddle/issues/435) (workspace roster bridge — required for push delivery to workspace co-members; until it lands, iterate-and-pull covers them)
+- **Touched by:** [#436](https://github.com/waddle-social/waddle/issues/436) (conformant XMPP-native user deletion semantics — wire effects on deletion live there)
+- **Unblocked by:** [#437](https://github.com/waddle-social/waddle/issues/437) (binary-payload object storage — lifts the 100 KB transitional cap)
+- **Parent backlog:** [#208](https://github.com/waddle-social/waddle/issues/208), [#212](https://github.com/waddle-social/waddle/issues/212), [#215](https://github.com/waddle-social/waddle/issues/215)

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5896,6 +5896,7 @@ dependencies = [
  "html-escape",
  "jid",
  "kameo",
+ "lru 0.12.5",
  "minidom",
  "opentelemetry",
  "pbkdf2",

--- a/server/crates/waddle-server/src/db/roster/query.rs
+++ b/server/crates/waddle-server/src/db/roster/query.rs
@@ -244,27 +244,43 @@ impl DatabaseRosterStorage {
 
     /// Get all roster items where the user should send presence updates.
     ///
-    /// Returns contacts with subscription=from or subscription=both.
+    /// Returns contacts with subscription=from or subscription=both as
+    /// typed `BareJid` values — per the typed-payloads hard rule, the
+    /// untyped `String` form from storage is parsed exactly once at the
+    /// boundary so handler code never touches raw JID strings. Rows
+    /// that fail to parse are dropped with a debug log rather than
+    /// surfaced as a per-row error, since corrupted JIDs in the roster
+    /// are unactionable for the caller.
     #[instrument(skip(self), fields(user = %user_jid))]
     pub async fn get_presence_subscribers(
         &self,
         user_jid: &BareJid,
-    ) -> Result<Vec<String>, RosterStorageError> {
+    ) -> Result<Vec<BareJid>, RosterStorageError> {
         let mut rows = self.query_with_persistent(
             "SELECT contact_jid FROM roster_items WHERE user_jid = ? AND subscription IN ('from', 'both')",
             crate::db_params![user_jid.to_string()],
         ).await?;
 
-        let mut jids = Vec::new();
+        let mut jids: Vec<BareJid> = Vec::new();
         while let Some(row) = rows
             .next()
             .await
             .map_err(|e| RosterStorageError::QueryFailed(format!("Failed to read row: {}", e)))?
         {
-            let jid: String = row.get(0).map_err(|e| {
+            let raw: String = row.get(0).map_err(|e| {
                 RosterStorageError::QueryFailed(format!("Failed to get jid: {}", e))
             })?;
-            jids.push(jid);
+            match raw.parse::<BareJid>() {
+                Ok(jid) => jids.push(jid),
+                Err(error) => {
+                    debug!(
+                        error = %error,
+                        raw = %raw,
+                        user = %user_jid,
+                        "Skipping un-parseable contact_jid row in get_presence_subscribers"
+                    );
+                }
+            }
         }
 
         debug!(count = jids.len(), "Retrieved presence subscribers");

--- a/server/crates/waddle-server/src/db/roster/tests.rs
+++ b/server/crates/waddle-server/src/db/roster/tests.rs
@@ -162,8 +162,10 @@ async fn test_presence_queries() {
 
     let subscribers = storage.get_presence_subscribers(&user_jid).await.unwrap();
     assert_eq!(subscribers.len(), 2);
-    assert!(subscribers.contains(&"carol@example.com".to_string()));
-    assert!(subscribers.contains(&"dan@example.com".to_string()));
+    let carol: BareJid = "carol@example.com".parse().unwrap();
+    let dan: BareJid = "dan@example.com".parse().unwrap();
+    assert!(subscribers.contains(&carol));
+    assert!(subscribers.contains(&dan));
 
     let subscriptions = storage.get_presence_subscriptions(&user_jid).await.unwrap();
     assert_eq!(subscriptions.len(), 2);

--- a/server/crates/waddle-server/src/server/caps_resolution.rs
+++ b/server/crates/waddle-server/src/server/caps_resolution.rs
@@ -5,15 +5,22 @@
 //!
 //! - **Cache hit:** records `(full_jid → ver)` so XEP-0163 §3 fan-out
 //!   (PR 2) can filter notifications by per-resource feature lists.
-//! - **Cache miss:** sends a typed `disco#info` IQ get to the resource
-//!   with `node="<NODE>#<VER>"` (XEP-0115 §6.2). The reply is verified
-//!   per §5.4 — the recipient MUST recompute the verification string
-//!   from the disco#info response (identities + features + XEP-0128
-//!   forms) and only cache when the recomputed hash matches the
-//!   advertised `ver`.
+//! - **Cache miss with supported `hash`:** sends a typed `disco#info`
+//!   IQ get to the resource with `node="<NODE>#<VER>"` (XEP-0115 §6.2).
+//!   The reply is verified per §5.4 — the recipient MUST recompute the
+//!   verification string from the disco#info response (identities +
+//!   features + XEP-0128 forms) and only cache when the recomputed
+//!   hash matches the advertised `ver`.
+//! - **Unsupported `hash` value (e.g. `sha-256` advertised but server
+//!   only implements SHA-1):** XEP-0115 §5.4 step 2 forbids global
+//!   caching but does NOT forbid per-session knowledge. We currently
+//!   skip both the disco#info round-trip and the cache write; the
+//!   resource's caps are simply unknown to fan-out for that session.
+//!
+//! Cache keying is per `(hash algorithm, ver)` per XEP-0115 §6.
 //!
 //! On disconnect, the per-resource mapping AND any in-flight pending
-//! resolution for that resource are dropped while the hash-keyed
+//! resolution for that resource are dropped while the bounded LRU
 //! `CapsCache` itself stays warm so the next session can reuse
 //! cross-session knowledge (XEP-0115 §6).
 
@@ -23,10 +30,22 @@ use dashmap::DashMap;
 use jid::{FullJid, Jid};
 use waddle_xmpp::disco::info::{Feature, Identity, DISCO_INFO_NS};
 use waddle_xmpp::xep::xep0115::{
-    compute_caps_hash_with_extensions, CachedDiscoInfo, Caps, CapsCache,
+    compute_caps_hash_with_extensions, CachedDiscoInfo, Caps, CapsCache, CapsCacheKey,
 };
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::minidom::Element;
+
+/// XEP-0115 §8.1: SHA-1 is mandatory-to-implement and is the only
+/// hash family this server validates today. Per §5.4 step 2, an
+/// advertised hash outside this set means "do NOT cache globally,
+/// do NOT invent a verification" — see `is_supported_hash`.
+const SUPPORTED_HASHES: &[&str] = &["sha-1"];
+
+pub fn is_supported_hash(hash: &str) -> bool {
+    SUPPORTED_HASHES
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(hash))
+}
 
 /// Outcome of recomputing and verifying a disco#info reply against an
 /// advertised `ver` per XEP-0115 §5.4.
@@ -36,8 +55,13 @@ pub enum CapsVerification {
     /// the resource→ver mapping recorded.
     Match,
     /// Recomputed hash did not match `ver`; the result MUST NOT be
-    /// cached (poisoning defense).
+    /// cached (poisoning defense, §8.1).
     Mismatch,
+    /// The disco#info reply is ill-formed per §5.4 step 2.4
+    /// (e.g. duplicate identity, duplicate feature, multiple
+    /// FORM_TYPE values in one form). The whole response MUST be
+    /// discarded.
+    IllFormed,
 }
 
 /// Pending state for an outstanding disco#info IQ get the server has
@@ -58,7 +82,7 @@ pub struct PendingCapsResolution {
 #[derive(Clone)]
 pub struct CapsResolver {
     cache: Arc<CapsCache>,
-    resource_to_ver: Arc<DashMap<FullJid, String>>,
+    resource_to_ver: Arc<DashMap<FullJid, CapsCacheKey>>,
     pending: Arc<DashMap<String, PendingCapsResolution>>,
 }
 
@@ -81,11 +105,10 @@ impl CapsResolver {
         &self.cache
     }
 
-    /// Record that `full_jid` is advertising `ver`. Used both on a
-    /// cache hit and after a successful verification.
-    pub fn record_resource(&self, full_jid: &FullJid, ver: &str) {
-        self.resource_to_ver
-            .insert(full_jid.clone(), ver.to_string());
+    /// Record that `full_jid` is advertising `(hash, ver)`. Used both
+    /// on a cache hit and after a successful verification.
+    pub fn record_resource(&self, full_jid: &FullJid, key: CapsCacheKey) {
+        self.resource_to_ver.insert(full_jid.clone(), key);
     }
 
     /// Drop the per-resource mapping AND any in-flight pending
@@ -97,16 +120,16 @@ impl CapsResolver {
         self.pending.retain(|_, v| v.full_jid != *full_jid);
     }
 
-    /// Return the ver advertised by `full_jid`, if any.
-    pub fn ver_for_resource(&self, full_jid: &FullJid) -> Option<String> {
+    /// Return the (hash, ver) advertised by `full_jid`, if any.
+    pub fn key_for_resource(&self, full_jid: &FullJid) -> Option<CapsCacheKey> {
         self.resource_to_ver
             .get(full_jid)
             .map(|v| v.value().clone())
     }
 
-    /// Look up the cached identity+features for a ver.
-    pub fn cached(&self, ver: &str) -> Option<CachedDiscoInfo> {
-        self.cache.get(ver)
+    /// Look up the cached identity+features for a (hash, ver) tuple.
+    pub fn cached(&self, key: &CapsCacheKey) -> Option<CachedDiscoInfo> {
+        self.cache.get(key)
     }
 
     /// Begin tracking a pending disco#info resolution for `caps`
@@ -124,9 +147,12 @@ impl CapsResolver {
     }
 
     /// Verify a disco#info reply for a previously-pending resolution
-    /// per XEP-0115 §5.4. On match, the (hash, ver) is cached and the
-    /// resource→ver mapping recorded. On mismatch, neither side
-    /// effect occurs.
+    /// per XEP-0115 §5.4.
+    ///
+    /// - On Match, the (hash, ver) is cached and the resource→key
+    ///   mapping recorded.
+    /// - On Mismatch, neither side effect occurs (poisoning defense).
+    /// - On IllFormed, neither side effect occurs (§5.4 step 2.4).
     ///
     /// `extensions` MUST include any XEP-0128 `<x xmlns="jabber:x:data"
     /// type="result"/>` forms returned alongside identities/features —
@@ -138,40 +164,61 @@ impl CapsResolver {
         identities: Vec<Identity>,
         features: Vec<Feature>,
         extensions: Vec<Element>,
+        ill_formed: bool,
     ) -> CapsVerification {
+        if ill_formed {
+            return CapsVerification::IllFormed;
+        }
+        if !is_supported_hash(&pending.caps.hash) {
+            // §5.4 step 2: unsupported hash → MUST NOT cache.
+            return CapsVerification::Mismatch;
+        }
         let recomputed = compute_caps_hash_with_extensions(&identities, &features, &extensions);
         if recomputed != pending.caps.ver {
             return CapsVerification::Mismatch;
         }
-        self.cache.insert(
-            &pending.caps.ver,
-            CachedDiscoInfo::new(identities, features),
-        );
-        self.record_resource(&pending.full_jid, &pending.caps.ver);
+        let key = CapsCacheKey::from_caps(&pending.caps);
+        self.cache
+            .insert(key.clone(), CachedDiscoInfo::new(identities, features));
+        self.record_resource(&pending.full_jid, key);
         CapsVerification::Match
+    }
+}
+
+/// Typed wrapper around the server's authoritative XMPP domain. Parsed
+/// once at startup so downstream call sites that need a `Jid` value
+/// (e.g. server-issued IQ `from`) cannot panic on bad input —
+/// validation is concentrated at the boundary per the typed-payloads
+/// hard rule.
+#[derive(Debug, Clone)]
+pub struct ServerDomainJid(Jid);
+
+impl ServerDomainJid {
+    /// Parse and validate `domain` as a `Jid` once. Returns `Err` if
+    /// the configured XMPP domain is not a valid JID — startup MUST
+    /// fail loudly rather than reach a runtime panic.
+    pub fn parse(domain: &str) -> Result<Self, jid::Error> {
+        Ok(Self(domain.parse::<Jid>()?))
+    }
+
+    pub fn as_jid(&self) -> &Jid {
+        &self.0
     }
 }
 
 /// Build a typed disco#info IQ get for caps resolution.
 /// Per XEP-0115 §6.2 the query MUST carry `node="<NODE>#<VER>"`.
-///
-/// `server_domain` is the validated XMPP domain configured at server
-/// boot — `Jid::Domain` construction is infallible for a non-empty
-/// validated domain string, so the helper never fails at runtime.
 pub fn build_caps_disco_info_query(
-    server_domain: &str,
+    server_domain: &ServerDomainJid,
     target: &FullJid,
     caps: &Caps,
     iq_id: &str,
 ) -> Iq {
-    let from = server_domain
-        .parse::<Jid>()
-        .expect("waddle xmpp_domain is validated as a JID at startup");
     let query = Element::builder("query", DISCO_INFO_NS)
         .attr("node", caps.node_ver())
         .build();
     Iq {
-        from: Some(from),
+        from: Some(server_domain.as_jid().clone()),
         to: Some(Jid::from(target.clone())),
         id: iq_id.to_string(),
         payload: IqType::Get(query),
@@ -243,11 +290,12 @@ mod tests {
         let pending = resolver.take_pending("iq-1").expect("pending entry");
 
         let outcome =
-            resolver.complete_pending(pending, identities.clone(), features.clone(), vec![]);
+            resolver.complete_pending(pending, identities.clone(), features.clone(), vec![], false);
 
         assert_eq!(outcome, CapsVerification::Match);
-        assert!(resolver.cached(&ver).is_some());
-        assert_eq!(resolver.ver_for_resource(&full_jid), Some(ver));
+        let key = CapsCacheKey::new("sha-1", &ver);
+        assert!(resolver.cached(&key).is_some());
+        assert_eq!(resolver.key_for_resource(&full_jid), Some(key));
     }
 
     #[test]
@@ -261,11 +309,62 @@ mod tests {
         resolver.begin_pending("iq-2".into(), full_jid.clone(), caps);
         let pending = resolver.take_pending("iq-2").expect("pending entry");
 
-        let outcome = resolver.complete_pending(pending, identities, features, vec![]);
+        let outcome = resolver.complete_pending(pending, identities, features, vec![], false);
 
         assert_eq!(outcome, CapsVerification::Mismatch);
-        assert!(resolver.cached(advertised).is_none());
-        assert_eq!(resolver.ver_for_resource(&full_jid), None);
+        assert!(resolver
+            .cached(&CapsCacheKey::new("sha-1", advertised))
+            .is_none());
+        assert_eq!(resolver.key_for_resource(&full_jid), None);
+    }
+
+    #[test]
+    fn complete_pending_with_unsupported_hash_does_not_cache() {
+        // PR #438 adversarial review issue #1: an unsupported `hash`
+        // attribute MUST NOT be cached even if the recomputed value
+        // happens to match by accident. We always reject when the
+        // advertised hash isn't in our SUPPORTED_HASHES set.
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let ver = compute_caps_hash(&identities, &features);
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let caps = Caps {
+            hash: "sha-256".to_string(),
+            node: "https://example.test/caps".to_string(),
+            ver: ver.clone(),
+        };
+        resolver.begin_pending("iq-unsupp".into(), full_jid.clone(), caps);
+        let pending = resolver.take_pending("iq-unsupp").expect("pending");
+
+        let outcome = resolver.complete_pending(pending, identities, features, vec![], false);
+
+        assert_eq!(outcome, CapsVerification::Mismatch);
+        assert!(resolver
+            .cached(&CapsCacheKey::new("sha-256", &ver))
+            .is_none());
+        assert!(resolver.cached(&CapsCacheKey::new("sha-1", &ver)).is_none());
+        assert_eq!(resolver.key_for_resource(&full_jid), None);
+    }
+
+    #[test]
+    fn complete_pending_ill_formed_response_is_rejected() {
+        // §5.4 step 2.4: ill-formed disco#info response MUST be
+        // discarded (no caching, no mapping).
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let ver = compute_caps_hash(&identities, &features);
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let caps = Caps::new("https://example.test/caps", &ver);
+        resolver.begin_pending("iq-bad".into(), full_jid.clone(), caps);
+        let pending = resolver.take_pending("iq-bad").expect("pending");
+
+        let outcome = resolver.complete_pending(pending, identities, features, vec![], true);
+
+        assert_eq!(outcome, CapsVerification::IllFormed);
+        assert!(resolver.cached(&CapsCacheKey::new("sha-1", &ver)).is_none());
+        assert_eq!(resolver.key_for_resource(&full_jid), None);
     }
 
     #[test]
@@ -292,10 +391,14 @@ mod tests {
             identities.clone(),
             features.clone(),
             vec![extension],
+            false,
         );
 
         assert_eq!(outcome, CapsVerification::Match);
-        assert_eq!(resolver.ver_for_resource(&full_jid), Some(ver));
+        assert_eq!(
+            resolver.key_for_resource(&full_jid),
+            Some(CapsCacheKey::new("sha-1", &ver))
+        );
     }
 
     #[test]
@@ -306,10 +409,11 @@ mod tests {
         let ver = compute_caps_hash(&identities, &features);
         let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
         let other_jid: FullJid = "bob@localhost/r1".parse().expect("jid");
+        let key = CapsCacheKey::new("sha-1", &ver);
         resolver
             .cache()
-            .insert(&ver, CachedDiscoInfo::new(identities, features));
-        resolver.record_resource(&full_jid, &ver);
+            .insert(key.clone(), CachedDiscoInfo::new(identities, features));
+        resolver.record_resource(&full_jid, key.clone());
         // Pending entry for the resource that's about to disconnect AND
         // an unrelated entry that MUST survive.
         resolver.begin_pending(
@@ -325,7 +429,7 @@ mod tests {
 
         resolver.drop_resource(&full_jid);
 
-        assert_eq!(resolver.ver_for_resource(&full_jid), None);
+        assert_eq!(resolver.key_for_resource(&full_jid), None);
         assert!(
             resolver.take_pending("iq-leak").is_none(),
             "drop_resource MUST also evict the pending entry to bound memory growth"
@@ -334,6 +438,13 @@ mod tests {
             resolver.take_pending("iq-keep").is_some(),
             "drop_resource MUST not touch unrelated pending entries"
         );
-        assert!(resolver.cached(&ver).is_some());
+        assert!(resolver.cached(&key).is_some());
+    }
+
+    #[test]
+    fn server_domain_jid_parses_at_boundary() {
+        assert!(ServerDomainJid::parse("localhost").is_ok());
+        assert!(ServerDomainJid::parse("waddle.social").is_ok());
+        assert!(ServerDomainJid::parse("").is_err());
     }
 }

--- a/server/crates/waddle-server/src/server/caps_resolution.rs
+++ b/server/crates/waddle-server/src/server/caps_resolution.rs
@@ -1,0 +1,241 @@
+//! XEP-0115 entity-capabilities resolution for inbound presence.
+//!
+//! When a connected resource advertises `<c hash node ver/>` on a
+//! presence stanza, the server either:
+//!
+//! - **Cache hit:** records `(full_jid → ver)` so XEP-0163 §3 fan-out
+//!   (PR 2) can filter notifications by per-resource feature lists.
+//! - **Cache miss:** sends a typed `disco#info` IQ get to the resource
+//!   with `node="<NODE>#<VER>"` (XEP-0115 §6.2). The reply is verified
+//!   per §5.4 — the recipient MUST recompute the verification string
+//!   from the disco#info response and only cache when the recomputed
+//!   hash matches the advertised `ver`.
+//!
+//! On disconnect, the per-resource mapping is dropped while the
+//! hash-keyed `CapsCache` itself stays warm so the next session can
+//! reuse cross-session knowledge (XEP-0115 §6).
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use jid::{FullJid, Jid};
+use waddle_xmpp::disco::info::{Feature, Identity};
+use waddle_xmpp::xep::xep0115::{compute_caps_hash, CachedDiscoInfo, Caps, CapsCache};
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::minidom::Element;
+
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+/// Outcome of recomputing and verifying a disco#info reply against an
+/// advertised `ver` per XEP-0115 §5.4.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CapsVerification {
+    /// Recomputed hash matched `ver`; the result MUST be cached and
+    /// the resource→ver mapping recorded.
+    Match,
+    /// Recomputed hash did not match `ver`; the result MUST NOT be
+    /// cached (poisoning defense).
+    Mismatch,
+}
+
+/// Pending state for an outstanding disco#info IQ get the server has
+/// sent to a resource that advertised an unknown `ver`.
+#[derive(Debug, Clone)]
+pub struct PendingCapsResolution {
+    pub full_jid: FullJid,
+    pub caps: Caps,
+}
+
+/// Server-side resolver for XEP-0115 entity capabilities.
+///
+/// The `cache` is process-wide and survives individual sessions
+/// (XEP-0115 §6 — caching across sessions is RECOMMENDED).
+/// `resource_to_ver` is per-session and cleared on disconnect.
+/// `pending` tracks outstanding disco#info queries by IQ id so the
+/// inbound IQ result handler can match a reply to the original ver.
+#[derive(Clone)]
+pub struct CapsResolver {
+    cache: Arc<CapsCache>,
+    resource_to_ver: Arc<DashMap<String, String>>,
+    pending: Arc<DashMap<String, PendingCapsResolution>>,
+}
+
+impl Default for CapsResolver {
+    fn default() -> Self {
+        Self::new(Arc::new(CapsCache::new()))
+    }
+}
+
+impl CapsResolver {
+    pub fn new(cache: Arc<CapsCache>) -> Self {
+        Self {
+            cache,
+            resource_to_ver: Arc::new(DashMap::new()),
+            pending: Arc::new(DashMap::new()),
+        }
+    }
+
+    pub fn cache(&self) -> &Arc<CapsCache> {
+        &self.cache
+    }
+
+    /// Record that `full_jid` is advertising `ver`. Used both on a
+    /// cache hit and after a successful verification.
+    pub fn record_resource(&self, full_jid: &FullJid, ver: &str) {
+        self.resource_to_ver
+            .insert(full_jid.to_string(), ver.to_string());
+    }
+
+    /// Drop the per-resource mapping. Called on resource disconnect.
+    /// Leaves the hash-keyed cache warm.
+    pub fn drop_resource(&self, full_jid: &FullJid) {
+        self.resource_to_ver.remove(&full_jid.to_string());
+    }
+
+    /// Return the ver advertised by `full_jid`, if any.
+    pub fn ver_for_resource(&self, full_jid: &FullJid) -> Option<String> {
+        self.resource_to_ver
+            .get(&full_jid.to_string())
+            .map(|v| v.value().clone())
+    }
+
+    /// Look up the cached identity+features for a ver.
+    pub fn cached(&self, ver: &str) -> Option<CachedDiscoInfo> {
+        self.cache.get(ver)
+    }
+
+    /// Begin tracking a pending disco#info resolution for `caps`
+    /// keyed by `iq_id`. Used for cache misses where the server
+    /// just sent the disco#info IQ get.
+    pub fn begin_pending(&self, iq_id: String, full_jid: FullJid, caps: Caps) {
+        self.pending
+            .insert(iq_id, PendingCapsResolution { full_jid, caps });
+    }
+
+    /// Take a pending entry by IQ id. Returns `None` if no resolution
+    /// is in flight under that id (a stray result; ignore per §5.4).
+    pub fn take_pending(&self, iq_id: &str) -> Option<PendingCapsResolution> {
+        self.pending.remove(iq_id).map(|(_, v)| v)
+    }
+
+    /// Verify a disco#info reply for a previously-pending resolution
+    /// per XEP-0115 §5.4. On match, the (hash, ver) is cached and the
+    /// resource→ver mapping recorded. On mismatch, neither side
+    /// effect occurs.
+    pub fn complete_pending(
+        &self,
+        pending: PendingCapsResolution,
+        identities: Vec<Identity>,
+        features: Vec<Feature>,
+    ) -> CapsVerification {
+        let recomputed = compute_caps_hash(&identities, &features);
+        if recomputed != pending.caps.ver {
+            return CapsVerification::Mismatch;
+        }
+        self.cache.insert(
+            &pending.caps.ver,
+            CachedDiscoInfo::new(identities, features),
+        );
+        self.record_resource(&pending.full_jid, &pending.caps.ver);
+        CapsVerification::Match
+    }
+}
+
+/// Build a typed disco#info IQ get for caps resolution.
+/// Per XEP-0115 §6.2 the query MUST carry `node="<NODE>#<VER>"`.
+pub fn build_caps_disco_info_query(
+    server_domain: &str,
+    target: &FullJid,
+    caps: &Caps,
+    iq_id: &str,
+) -> Result<Iq, String> {
+    let from = Jid::from_str(server_domain)
+        .map_err(|e| format!("server domain is not a valid JID: {e}"))?;
+    let query = Element::builder("query", NS_DISCO_INFO)
+        .attr("node", caps.node_ver())
+        .build();
+    Ok(Iq {
+        from: Some(from),
+        to: Some(Jid::from(target.clone())),
+        id: iq_id.to_string(),
+        payload: IqType::Get(query),
+    })
+}
+
+/// Extract a `<c hash node ver/>` payload from a typed `Presence`.
+pub fn extract_caps_payload(presence: &xmpp_parsers::presence::Presence) -> Option<Caps> {
+    for child in &presence.payloads {
+        if child.name() == "c" && child.ns() == waddle_xmpp::xep::xep0115::NS_CAPS {
+            return Caps::from_element(child);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_identities() -> Vec<Identity> {
+        vec![Identity::server(Some("Waddle Test"))]
+    }
+
+    fn sample_features() -> Vec<Feature> {
+        vec![Feature::disco_info(), Feature::disco_items()]
+    }
+
+    #[test]
+    fn complete_pending_with_matching_hash_caches_and_records() {
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let ver = compute_caps_hash(&identities, &features);
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let caps = Caps::new("https://example.test/caps", &ver);
+        resolver.begin_pending("iq-1".into(), full_jid.clone(), caps.clone());
+        let pending = resolver.take_pending("iq-1").expect("pending entry");
+
+        let outcome = resolver.complete_pending(pending, identities.clone(), features.clone());
+
+        assert_eq!(outcome, CapsVerification::Match);
+        assert!(resolver.cached(&ver).is_some());
+        assert_eq!(resolver.ver_for_resource(&full_jid), Some(ver));
+    }
+
+    #[test]
+    fn complete_pending_with_mismatched_hash_rejects_and_skips_cache() {
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let advertised = "ZZZdefinitely-not-the-real-hashZZZ";
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let caps = Caps::new("https://example.test/caps", advertised);
+        resolver.begin_pending("iq-2".into(), full_jid.clone(), caps);
+        let pending = resolver.take_pending("iq-2").expect("pending entry");
+
+        let outcome = resolver.complete_pending(pending, identities, features);
+
+        assert_eq!(outcome, CapsVerification::Mismatch);
+        assert!(resolver.cached(advertised).is_none());
+        assert_eq!(resolver.ver_for_resource(&full_jid), None);
+    }
+
+    #[test]
+    fn drop_resource_clears_mapping_but_not_hash_cache() {
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let ver = compute_caps_hash(&identities, &features);
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        resolver
+            .cache()
+            .insert(&ver, CachedDiscoInfo::new(identities, features));
+        resolver.record_resource(&full_jid, &ver);
+
+        resolver.drop_resource(&full_jid);
+
+        assert_eq!(resolver.ver_for_resource(&full_jid), None);
+        assert!(resolver.cached(&ver).is_some());
+    }
+}

--- a/server/crates/waddle-server/src/server/caps_resolution.rs
+++ b/server/crates/waddle-server/src/server/caps_resolution.rs
@@ -8,24 +8,25 @@
 //! - **Cache miss:** sends a typed `disco#info` IQ get to the resource
 //!   with `node="<NODE>#<VER>"` (XEP-0115 §6.2). The reply is verified
 //!   per §5.4 — the recipient MUST recompute the verification string
-//!   from the disco#info response and only cache when the recomputed
-//!   hash matches the advertised `ver`.
+//!   from the disco#info response (identities + features + XEP-0128
+//!   forms) and only cache when the recomputed hash matches the
+//!   advertised `ver`.
 //!
-//! On disconnect, the per-resource mapping is dropped while the
-//! hash-keyed `CapsCache` itself stays warm so the next session can
-//! reuse cross-session knowledge (XEP-0115 §6).
+//! On disconnect, the per-resource mapping AND any in-flight pending
+//! resolution for that resource are dropped while the hash-keyed
+//! `CapsCache` itself stays warm so the next session can reuse
+//! cross-session knowledge (XEP-0115 §6).
 
-use std::str::FromStr;
 use std::sync::Arc;
 
 use dashmap::DashMap;
 use jid::{FullJid, Jid};
-use waddle_xmpp::disco::info::{Feature, Identity};
-use waddle_xmpp::xep::xep0115::{compute_caps_hash, CachedDiscoInfo, Caps, CapsCache};
+use waddle_xmpp::disco::info::{Feature, Identity, DISCO_INFO_NS};
+use waddle_xmpp::xep::xep0115::{
+    compute_caps_hash_with_extensions, CachedDiscoInfo, Caps, CapsCache,
+};
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::minidom::Element;
-
-const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
 
 /// Outcome of recomputing and verifying a disco#info reply against an
 /// advertised `ver` per XEP-0115 §5.4.
@@ -57,7 +58,7 @@ pub struct PendingCapsResolution {
 #[derive(Clone)]
 pub struct CapsResolver {
     cache: Arc<CapsCache>,
-    resource_to_ver: Arc<DashMap<String, String>>,
+    resource_to_ver: Arc<DashMap<FullJid, String>>,
     pending: Arc<DashMap<String, PendingCapsResolution>>,
 }
 
@@ -84,19 +85,22 @@ impl CapsResolver {
     /// cache hit and after a successful verification.
     pub fn record_resource(&self, full_jid: &FullJid, ver: &str) {
         self.resource_to_ver
-            .insert(full_jid.to_string(), ver.to_string());
+            .insert(full_jid.clone(), ver.to_string());
     }
 
-    /// Drop the per-resource mapping. Called on resource disconnect.
-    /// Leaves the hash-keyed cache warm.
+    /// Drop the per-resource mapping AND any in-flight pending
+    /// disco#info resolution for that resource. Called on resource
+    /// disconnect (live or detached-session expiry). Leaves the
+    /// hash-keyed cache warm.
     pub fn drop_resource(&self, full_jid: &FullJid) {
-        self.resource_to_ver.remove(&full_jid.to_string());
+        self.resource_to_ver.remove(full_jid);
+        self.pending.retain(|_, v| v.full_jid != *full_jid);
     }
 
     /// Return the ver advertised by `full_jid`, if any.
     pub fn ver_for_resource(&self, full_jid: &FullJid) -> Option<String> {
         self.resource_to_ver
-            .get(&full_jid.to_string())
+            .get(full_jid)
             .map(|v| v.value().clone())
     }
 
@@ -123,13 +127,19 @@ impl CapsResolver {
     /// per XEP-0115 §5.4. On match, the (hash, ver) is cached and the
     /// resource→ver mapping recorded. On mismatch, neither side
     /// effect occurs.
+    ///
+    /// `extensions` MUST include any XEP-0128 `<x xmlns="jabber:x:data"
+    /// type="result"/>` forms returned alongside identities/features —
+    /// dropping them silently breaks verification for any client that
+    /// emits a software-info form.
     pub fn complete_pending(
         &self,
         pending: PendingCapsResolution,
         identities: Vec<Identity>,
         features: Vec<Feature>,
+        extensions: Vec<Element>,
     ) -> CapsVerification {
-        let recomputed = compute_caps_hash(&identities, &features);
+        let recomputed = compute_caps_hash_with_extensions(&identities, &features, &extensions);
         if recomputed != pending.caps.ver {
             return CapsVerification::Mismatch;
         }
@@ -144,23 +154,28 @@ impl CapsResolver {
 
 /// Build a typed disco#info IQ get for caps resolution.
 /// Per XEP-0115 §6.2 the query MUST carry `node="<NODE>#<VER>"`.
+///
+/// `server_domain` is the validated XMPP domain configured at server
+/// boot — `Jid::Domain` construction is infallible for a non-empty
+/// validated domain string, so the helper never fails at runtime.
 pub fn build_caps_disco_info_query(
     server_domain: &str,
     target: &FullJid,
     caps: &Caps,
     iq_id: &str,
-) -> Result<Iq, String> {
-    let from = Jid::from_str(server_domain)
-        .map_err(|e| format!("server domain is not a valid JID: {e}"))?;
-    let query = Element::builder("query", NS_DISCO_INFO)
+) -> Iq {
+    let from = server_domain
+        .parse::<Jid>()
+        .expect("waddle xmpp_domain is validated as a JID at startup");
+    let query = Element::builder("query", DISCO_INFO_NS)
         .attr("node", caps.node_ver())
         .build();
-    Ok(Iq {
+    Iq {
         from: Some(from),
         to: Some(Jid::from(target.clone())),
         id: iq_id.to_string(),
         payload: IqType::Get(query),
-    })
+    }
 }
 
 /// Extract a `<c hash node ver/>` payload from a typed `Presence`.
@@ -176,6 +191,7 @@ pub fn extract_caps_payload(presence: &xmpp_parsers::presence::Presence) -> Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+    use waddle_xmpp::xep::xep0115::compute_caps_hash;
 
     fn sample_identities() -> Vec<Identity> {
         vec![Identity::server(Some("Waddle Test"))]
@@ -183,6 +199,36 @@ mod tests {
 
     fn sample_features() -> Vec<Feature> {
         vec![Feature::disco_info(), Feature::disco_items()]
+    }
+
+    /// Build a XEP-0128 `<x xmlns="jabber:x:data" type="result">` form
+    /// with a single FORM_TYPE field and one extra var. Used to
+    /// exercise the extension path through `compute_caps_hash_with_extensions`.
+    fn sample_extension_form(form_type: &str, software: &str) -> Element {
+        Element::builder("x", "jabber:x:data")
+            .attr("type", "result")
+            .append(
+                Element::builder("field", "jabber:x:data")
+                    .attr("var", "FORM_TYPE")
+                    .attr("type", "hidden")
+                    .append(
+                        Element::builder("value", "jabber:x:data")
+                            .append(form_type)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .append(
+                Element::builder("field", "jabber:x:data")
+                    .attr("var", "software")
+                    .append(
+                        Element::builder("value", "jabber:x:data")
+                            .append(software)
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
     }
 
     #[test]
@@ -196,7 +242,8 @@ mod tests {
         resolver.begin_pending("iq-1".into(), full_jid.clone(), caps.clone());
         let pending = resolver.take_pending("iq-1").expect("pending entry");
 
-        let outcome = resolver.complete_pending(pending, identities.clone(), features.clone());
+        let outcome =
+            resolver.complete_pending(pending, identities.clone(), features.clone(), vec![]);
 
         assert_eq!(outcome, CapsVerification::Match);
         assert!(resolver.cached(&ver).is_some());
@@ -214,7 +261,7 @@ mod tests {
         resolver.begin_pending("iq-2".into(), full_jid.clone(), caps);
         let pending = resolver.take_pending("iq-2").expect("pending entry");
 
-        let outcome = resolver.complete_pending(pending, identities, features);
+        let outcome = resolver.complete_pending(pending, identities, features, vec![]);
 
         assert_eq!(outcome, CapsVerification::Mismatch);
         assert!(resolver.cached(advertised).is_none());
@@ -222,20 +269,71 @@ mod tests {
     }
 
     #[test]
-    fn drop_resource_clears_mapping_but_not_hash_cache() {
+    fn complete_pending_includes_xep0128_form_in_recomputed_hash() {
+        let resolver = CapsResolver::default();
+        let identities = sample_identities();
+        let features = sample_features();
+        let extension = sample_extension_form("urn:xmpp:dataforms:softwareinfo", "Waddle");
+        // ver was computed *with* the form. Without feeding the form
+        // back into recomputation the verification would mismatch —
+        // see Issue 1 in the PR 1 adversarial review.
+        let ver = compute_caps_hash_with_extensions(
+            &identities,
+            &features,
+            std::slice::from_ref(&extension),
+        );
+        let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let caps = Caps::new("https://example.test/caps", &ver);
+        resolver.begin_pending("iq-3".into(), full_jid.clone(), caps);
+        let pending = resolver.take_pending("iq-3").expect("pending entry");
+
+        let outcome = resolver.complete_pending(
+            pending,
+            identities.clone(),
+            features.clone(),
+            vec![extension],
+        );
+
+        assert_eq!(outcome, CapsVerification::Match);
+        assert_eq!(resolver.ver_for_resource(&full_jid), Some(ver));
+    }
+
+    #[test]
+    fn drop_resource_clears_mapping_and_pending_but_not_hash_cache() {
         let resolver = CapsResolver::default();
         let identities = sample_identities();
         let features = sample_features();
         let ver = compute_caps_hash(&identities, &features);
         let full_jid: FullJid = "alice@localhost/r1".parse().expect("jid");
+        let other_jid: FullJid = "bob@localhost/r1".parse().expect("jid");
         resolver
             .cache()
             .insert(&ver, CachedDiscoInfo::new(identities, features));
         resolver.record_resource(&full_jid, &ver);
+        // Pending entry for the resource that's about to disconnect AND
+        // an unrelated entry that MUST survive.
+        resolver.begin_pending(
+            "iq-leak".into(),
+            full_jid.clone(),
+            Caps::new("https://example.test/caps", &ver),
+        );
+        resolver.begin_pending(
+            "iq-keep".into(),
+            other_jid.clone(),
+            Caps::new("https://example.test/caps", "other-ver"),
+        );
 
         resolver.drop_resource(&full_jid);
 
         assert_eq!(resolver.ver_for_resource(&full_jid), None);
+        assert!(
+            resolver.take_pending("iq-leak").is_none(),
+            "drop_resource MUST also evict the pending entry to bound memory growth"
+        );
+        assert!(
+            resolver.take_pending("iq-keep").is_some(),
+            "drop_resource MUST not touch unrelated pending entries"
+        );
         assert!(resolver.cached(&ver).is_some());
     }
 }

--- a/server/crates/waddle-server/src/server/caps_resolution.rs
+++ b/server/crates/waddle-server/src/server/caps_resolution.rs
@@ -140,6 +140,24 @@ impl CapsResolver {
             .insert(iq_id, PendingCapsResolution { full_jid, caps });
     }
 
+    /// True iff there is already a pending disco#info resolution for
+    /// this `(full_jid, hash, ver)` tuple. Callers use this to avoid
+    /// queuing a second outbound query while the first is still in
+    /// flight, which a malicious client could exploit by spamming
+    /// presence updates with random `ver` values.
+    pub fn has_pending_for(&self, full_jid: &FullJid, caps: &Caps) -> bool {
+        self.pending.iter().any(|entry| {
+            let v = entry.value();
+            v.full_jid == *full_jid && v.caps.hash == caps.hash && v.caps.ver == caps.ver
+        })
+    }
+
+    /// Number of currently-pending resolutions. Test/telemetry hook.
+    #[doc(hidden)]
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
     /// Take a pending entry by IQ id. Returns `None` if no resolution
     /// is in flight under that id (a stray result; ignore per §5.4).
     pub fn take_pending(&self, iq_id: &str) -> Option<PendingCapsResolution> {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -259,6 +259,8 @@ async fn create_websocket_state(
     );
     let pending_delivery_storage = create_pending_delivery_storage(xmpp_config).await;
 
+    let caps_resolver = Arc::new(crate::server::caps_resolution::CapsResolver::default());
+
     let websocket_state = Arc::new(WebSocketState {
         deps: WebSocketDeps {
             app_state: state.clone(),
@@ -279,6 +281,7 @@ async fn create_websocket_state(
                 isr_token_store: waddle_xmpp::isr::create_shared_store(),
                 sm_session_registry,
                 resumable_sessions,
+                caps_resolver,
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
         },

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -1,4 +1,5 @@
 mod acme;
+pub(crate) mod caps_resolution;
 mod config;
 mod extension_commands;
 pub mod extension_host_adapter;

--- a/server/crates/waddle-server/src/server/routes/auth/state.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/state.rs
@@ -7,6 +7,11 @@ pub struct AuthState {
     pub providers: ProviderRegistry,
     pub base_url: String,
     pub xmpp_domain: String,
+    /// Pre-parsed XMPP domain JID for server-issued IQ stanzas
+    /// (e.g. XEP-0115 caps disco#info queries). Validated at startup
+    /// so downstream construction sites cannot panic on a malformed
+    /// `WADDLE_XMPP_DOMAIN` value at runtime.
+    pub caps_server_domain: crate::server::caps_resolution::ServerDomainJid,
     pub http_client: reqwest::Client,
     pub pending_auth: Arc<DashMap<String, PendingAuthorization>>,
     pub device_auth: Arc<DashMap<String, DeviceAuthorization>>,
@@ -29,13 +34,21 @@ impl AuthState {
         let providers = ProviderRegistry::new(server_config.auth.providers.clone())
             .unwrap_or_else(|e| panic!("invalid provider config at startup: {}", e));
 
+        let xmpp_domain =
+            std::env::var("WADDLE_XMPP_DOMAIN").unwrap_or_else(|_| "localhost".to_string());
+        let caps_server_domain = crate::server::caps_resolution::ServerDomainJid::parse(
+            &xmpp_domain,
+        )
+        .unwrap_or_else(|error| {
+            panic!("WADDLE_XMPP_DOMAIN={xmpp_domain:?} is not a valid JID at startup: {error}")
+        });
         Self {
             session_manager,
             identity_service,
             providers,
             base_url: server_config.base_url.trim_end_matches('/').to_string(),
-            xmpp_domain: std::env::var("WADDLE_XMPP_DOMAIN")
-                .unwrap_or_else(|_| "localhost".to_string()),
+            xmpp_domain,
+            caps_server_domain,
             http_client: reqwest::Client::new(),
             pending_auth: Arc::new(DashMap::new()),
             device_auth: Arc::new(DashMap::new()),

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -175,6 +175,12 @@ pub(super) async fn cleanup_connection_shutdown(
                         .protocol
                         .connection_registry
                         .unregister_if_owner(&jid, owner);
+                    // PR #438 review (Copilot): when SM detachment
+                    // fails we fall back to a full unregister, so the
+                    // caps resource→ver mapping AND any pending
+                    // disco#info resolution must be cleared too —
+                    // otherwise stale state lingers indefinitely.
+                    state.deps.protocol.caps_resolver.drop_resource(&jid);
                     cleanup_muc_presence(state, &jid).await;
                 }
             }

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -259,6 +259,14 @@ pub(super) async fn cleanup_invalidated_detached_session(
             .protocol
             .connection_registry
             .unregister(&detached.jid);
+        // XEP-0115 §6: clear the resource→ver mapping AND any stuck
+        // pending disco#info resolution for this resource so an
+        // unresumed detached session doesn't leak indefinitely.
+        state
+            .deps
+            .protocol
+            .caps_resolver
+            .drop_resource(&detached.jid);
     }
     if detached.presence_available && !replacement_is_current_owner {
         handlers::presence::broadcast_unavailable_for_expired_detached_session(

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -191,6 +191,11 @@ pub(super) async fn cleanup_connection_shutdown(
             .is_some()
     });
     if removed {
+        // XEP-0115 §6: drop the per-resource caps mapping for this
+        // resource. The hash-keyed `CapsCache` itself stays warm so
+        // a future session reusing the same `(hash, ver)` short-
+        // circuits the disco#info round-trip.
+        state.deps.protocol.caps_resolver.drop_resource(&jid);
         info!(jid = %jid, "WebSocket connection unregistered");
         cleanup_muc_presence(state, &jid).await;
     } else {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
@@ -172,16 +172,7 @@ async fn send_blocking_presence_side_effects(
         }
     };
 
-    let subscriber_bares: HashSet<BareJid> = subscribers
-        .into_iter()
-        .filter_map(|jid| match jid.parse::<Jid>() {
-            Ok(jid) => Some(jid.to_bare()),
-            Err(error) => {
-                warn!(jid, %error, "Skipping invalid stored roster subscriber JID");
-                None
-            }
-        })
-        .collect();
+    let subscriber_bares: HashSet<BareJid> = subscribers.into_iter().collect();
 
     let mut targets = Vec::new();
     let mut seen = HashSet::new();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
@@ -14,12 +14,10 @@
 
 use jid::FullJid;
 use tracing::{debug, warn};
-use waddle_xmpp::disco::info::parse_disco_info_response;
+use waddle_xmpp::disco::info::{parse_disco_info_response, DISCO_INFO_NS};
 
 use crate::server::caps_resolution::CapsVerification;
 use crate::server::routes::websocket::WebSocketState;
-
-const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
 
 pub(super) fn handle_caps_disco_info_result(
     iq: &xmpp_parsers::iq::Iq,
@@ -54,7 +52,7 @@ pub(super) fn handle_caps_disco_info_result(
         _ => return,
     };
 
-    if query.name() != "query" || query.ns() != NS_DISCO_INFO {
+    if query.name() != "query" || query.ns() != DISCO_INFO_NS {
         debug!(id = %iq.id, "caps disco#info reply payload is not a disco#info query element");
         return;
     }
@@ -67,7 +65,12 @@ pub(super) fn handle_caps_disco_info_result(
         }
     };
 
-    match resolver.complete_pending(pending, parsed.identities, parsed.features) {
+    match resolver.complete_pending(
+        pending,
+        parsed.identities,
+        parsed.features,
+        parsed.extensions,
+    ) {
         CapsVerification::Match => {
             debug!(id = %iq.id, jid = %sender, "Cached XEP-0115 caps after hash verification");
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
@@ -1,0 +1,82 @@
+//! Inbound IQ result/error matcher for outstanding XEP-0115 caps
+//! disco#info queries.
+//!
+//! When the server has issued a disco#info query because a resource
+//! advertised an unknown `(hash, ver)`, the reply travels back over
+//! the same websocket. This module peels off that reply *before* the
+//! generic IQ-result-ignored path swallows it.
+//!
+//! The reply is verified per **XEP-0115 §5.4**: the server recomputes
+//! the verification string from the response's identities + features
+//! and only caches when the recomputed hash matches the advertised
+//! `ver`. A mismatch is treated as a poisoning attempt and silently
+//! dropped — the caller may re-resolve on a later presence.
+
+use jid::FullJid;
+use tracing::{debug, warn};
+use waddle_xmpp::disco::info::parse_disco_info_response;
+
+use crate::server::caps_resolution::CapsVerification;
+use crate::server::routes::websocket::WebSocketState;
+
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+pub(super) fn handle_caps_disco_info_result(
+    iq: &xmpp_parsers::iq::Iq,
+    sender: &FullJid,
+    state: &WebSocketState,
+) {
+    let resolver = &state.deps.protocol.caps_resolver;
+    let Some(pending) = resolver.take_pending(&iq.id) else {
+        return;
+    };
+
+    if pending.full_jid != *sender {
+        debug!(
+            id = %iq.id,
+            expected = %pending.full_jid,
+            got = %sender,
+            "caps disco#info reply arrived from a different resource than the one queried — dropping"
+        );
+        return;
+    }
+
+    let query = match &iq.payload {
+        xmpp_parsers::iq::IqType::Result(Some(elem)) => elem,
+        xmpp_parsers::iq::IqType::Result(None) => {
+            debug!(id = %iq.id, "caps disco#info reply has empty result body");
+            return;
+        }
+        xmpp_parsers::iq::IqType::Error(_) => {
+            debug!(id = %iq.id, "caps disco#info reply was an IQ error — not caching");
+            return;
+        }
+        _ => return,
+    };
+
+    if query.name() != "query" || query.ns() != NS_DISCO_INFO {
+        debug!(id = %iq.id, "caps disco#info reply payload is not a disco#info query element");
+        return;
+    }
+
+    let parsed = match parse_disco_info_response(query) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            warn!(error = %error, id = %iq.id, "Failed to parse caps disco#info reply");
+            return;
+        }
+    };
+
+    match resolver.complete_pending(pending, parsed.identities, parsed.features) {
+        CapsVerification::Match => {
+            debug!(id = %iq.id, jid = %sender, "Cached XEP-0115 caps after hash verification");
+        }
+        CapsVerification::Mismatch => {
+            warn!(
+                id = %iq.id,
+                jid = %sender,
+                "XEP-0115 §5.4: recomputed hash did not match advertised ver — discarding"
+            );
+        }
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/caps_result.rs
@@ -70,6 +70,7 @@ pub(super) fn handle_caps_disco_info_result(
         parsed.identities,
         parsed.features,
         parsed.extensions,
+        parsed.ill_formed,
     ) {
         CapsVerification::Match => {
             debug!(id = %iq.id, jid = %sender, "Cached XEP-0115 caps after hash verification");
@@ -78,7 +79,14 @@ pub(super) fn handle_caps_disco_info_result(
             warn!(
                 id = %iq.id,
                 jid = %sender,
-                "XEP-0115 §5.4: recomputed hash did not match advertised ver — discarding"
+                "XEP-0115 §5.4: recomputed hash did not match advertised ver (or unsupported algo) — discarding"
+            );
+        }
+        CapsVerification::IllFormed => {
+            warn!(
+                id = %iq.id,
+                jid = %sender,
+                "XEP-0115 §5.4 step 2.4: ill-formed disco#info response — discarding entire reply"
             );
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -72,6 +72,7 @@ use xmpp_parsers::minidom::Element;
 
 mod archive_inbox_upload;
 mod blocking;
+mod caps_result;
 mod commands;
 mod conn_state;
 mod disco_info;
@@ -99,6 +100,7 @@ mod vcard_private;
 
 use archive_inbox_upload::handle_archive_inbox_upload_iq;
 use blocking::handle_blocking_iq;
+use caps_result::handle_caps_disco_info_result;
 use commands::handle_command_iq;
 pub use conn_state::IqConnState;
 use disco_info::handle_disco_info_iq;
@@ -216,6 +218,9 @@ pub async fn handle_iq_with_conn_state(
         &iq.payload,
         xmpp_parsers::iq::IqType::Result(_) | xmpp_parsers::iq::IqType::Error(_)
     ) {
+        if let Some(full) = phase.bound_jid() {
+            handle_caps_disco_info_result(&iq, full, state);
+        }
         debug!(id = %id, "Ignoring IQ result/error stanza");
         return vec![];
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -132,6 +132,7 @@ pub(super) async fn handle_pubsub_iq(
                             &item,
                             &publish_result.item_id,
                             Some(&user_jid),
+                            phase.bound_jid(),
                         )
                         .await;
                         let response =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -127,12 +127,15 @@ pub(super) async fn handle_pubsub_iq(
                         );
                         pubsub_fanout::fan_out_publish(
                             state,
-                            &target_jid,
-                            &node,
-                            &item,
-                            &publish_result.item_id,
-                            Some(&user_jid),
-                            phase.bound_jid(),
+                            pubsub_fanout::FanOutRequest {
+                                owner: &target_jid,
+                                node: &node,
+                                published_item: &item,
+                                item_id: &publish_result.item_id,
+                                publisher: Some(&user_jid),
+                                publisher_full: phase.bound_jid(),
+                                is_pep,
+                            },
                         )
                         .await;
                         let response =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -386,16 +386,21 @@ pub(super) async fn handle_spaces_publish(
             // compensating-retract path above must NOT emit events for
             // a publish that gets rolled back.
             // Spaces publishes are owned by the spaces service domain,
-            // not a user JID, so there is no per-resource publisher to
-            // exclude from the §3 owner-self pass.
+            // not a user JID. `is_pep = false` skips the §3 roster +
+            // owner-self passes (PR #439 review): the publisher's
+            // roster has no authorization relationship to a Spaces
+            // node, so running those passes would leak the event.
             pubsub_fanout::fan_out_publish(
                 state,
-                &spaces_jid,
-                node,
-                &item,
-                &result.item_id,
-                None,
-                None,
+                pubsub_fanout::FanOutRequest {
+                    owner: &spaces_jid,
+                    node,
+                    published_item: &item,
+                    item_id: &result.item_id,
+                    publisher: None,
+                    publisher_full: None,
+                    is_pep: false,
+                },
             )
             .await;
             vec![iq_to_xml(build_pubsub_publish_result(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -385,8 +385,19 @@ pub(super) async fn handle_spaces_publish(
             // Fan-out only after the parent-tuple write succeeds: the
             // compensating-retract path above must NOT emit events for
             // a publish that gets rolled back.
-            pubsub_fanout::fan_out_publish(state, &spaces_jid, node, &item, &result.item_id, None)
-                .await;
+            // Spaces publishes are owned by the spaces service domain,
+            // not a user JID, so there is no per-resource publisher to
+            // exclude from the §3 owner-self pass.
+            pubsub_fanout::fan_out_publish(
+                state,
+                &spaces_jid,
+                node,
+                &item,
+                &result.item_id,
+                None,
+                None,
+            )
+            .await;
             vec![iq_to_xml(build_pubsub_publish_result(
                 iq,
                 node,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -3,6 +3,8 @@ use super::subscription::{
     roster_storage,
 };
 use super::*;
+use crate::server::caps_resolution::{build_caps_disco_info_query, extract_caps_payload};
+use waddle_xmpp::Stanza;
 
 pub(super) async fn handle_regular_presence_update(
     state: &WebSocketState,
@@ -22,6 +24,7 @@ pub(super) async fn handle_regular_presence_update(
             .protocol
             .connection_registry
             .update_presence(sender_jid, true, priority);
+        resolve_caps_for_presence(state, sender_jid, &presence).await;
         // XEP-0160 §3 step 5 (locked Q7a/Q7d): on the first non-negative-
         // priority presence of a fresh session, drain pending_delivery
         // for the recipient. `claim_offline_flush` ensures this fires at
@@ -211,6 +214,48 @@ async fn broadcast_presence_to_subscribers(
         )
         .await;
     }
+}
+
+/// XEP-0115: drive caps resolution for an inbound `<presence>`
+/// carrying `<c hash node ver/>`.
+///
+/// - Cache hit: record the per-resource ver mapping so the next
+///   PEP fan-out (PR 2) can filter by feature list.
+/// - Cache miss: send the resource a typed disco#info IQ get with
+///   `node="<NODE>#<VER>"` per §6.2 and remember the in-flight ver.
+async fn resolve_caps_for_presence(
+    state: &WebSocketState,
+    sender_jid: &FullJid,
+    presence: &xmpp_parsers::presence::Presence,
+) {
+    let Some(caps) = extract_caps_payload(presence) else {
+        return;
+    };
+    let resolver = &state.deps.protocol.caps_resolver;
+    if resolver.cache().contains(&caps.ver) {
+        resolver.record_resource(sender_jid, &caps.ver);
+        return;
+    }
+    let iq_id = format!("waddle-caps-disco-{}", uuid::Uuid::new_v4());
+    let iq = match build_caps_disco_info_query(
+        &state.deps.auth_state.xmpp_domain,
+        sender_jid,
+        &caps,
+        &iq_id,
+    ) {
+        Ok(iq) => iq,
+        Err(error) => {
+            warn!(error = %error, "Failed to build caps disco#info query");
+            return;
+        }
+    };
+    resolver.begin_pending(iq_id, sender_jid.clone(), caps);
+    let _ = state
+        .deps
+        .protocol
+        .connection_registry
+        .send_to(sender_jid, Stanza::Iq(iq))
+        .await;
 }
 
 pub(super) fn show_name(show: &xmpp_parsers::presence::Show) -> &'static str {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -219,10 +219,17 @@ async fn broadcast_presence_to_subscribers(
 /// XEP-0115: drive caps resolution for an inbound `<presence>`
 /// carrying `<c hash node ver/>`.
 ///
-/// - Cache hit: record the per-resource ver mapping so the next
-///   PEP fan-out (PR 2) can filter by feature list.
-/// - Cache miss: send the resource a typed disco#info IQ get with
-///   `node="<NODE>#<VER>"` per §6.2 and remember the in-flight ver.
+/// - Cache hit on `(hash, ver)`: record the per-resource mapping so
+///   the next PEP fan-out (PR 2) can filter by feature list.
+/// - Cache miss with supported `hash`: send the resource a typed
+///   disco#info IQ get with `node="<NODE>#<VER>"` per §6.2 and remember
+///   the in-flight ver. If the outbound write fails (resource just
+///   went offline / channel closed) the pending entry is immediately
+///   evicted so the in-memory pending map cannot leak.
+/// - Cache miss with unsupported `hash` (e.g. `sha-256`): per §5.4
+///   step 2 the server MUST NOT cache. We additionally skip the
+///   round-trip entirely — fan-out will treat this resource as
+///   "caps unknown" until it next advertises with a supported algo.
 async fn resolve_caps_for_presence(
     state: &WebSocketState,
     sender_jid: &FullJid,
@@ -232,24 +239,46 @@ async fn resolve_caps_for_presence(
         return;
     };
     let resolver = &state.deps.protocol.caps_resolver;
-    if resolver.cache().contains(&caps.ver) {
-        resolver.record_resource(sender_jid, &caps.ver);
+    let cache_key = waddle_xmpp::xep::xep0115::CapsCacheKey::from_caps(&caps);
+    if resolver.cache().contains(&cache_key) {
+        resolver.record_resource(sender_jid, cache_key);
+        return;
+    }
+    if !crate::server::caps_resolution::is_supported_hash(&caps.hash) {
+        debug!(
+            jid = %sender_jid,
+            hash = %caps.hash,
+            "Skipping caps resolution: advertised hash algorithm not implemented (XEP-0115 §5.4 step 2)"
+        );
         return;
     }
     let iq_id = format!("waddle-caps-disco-{}", uuid::Uuid::new_v4());
     let iq = build_caps_disco_info_query(
-        &state.deps.auth_state.xmpp_domain,
+        &state.deps.auth_state.caps_server_domain,
         sender_jid,
         &caps,
         &iq_id,
     );
-    resolver.begin_pending(iq_id, sender_jid.clone(), caps);
-    let _ = state
+    resolver.begin_pending(iq_id.clone(), sender_jid.clone(), caps);
+    let send_outcome = state
         .deps
         .protocol
         .connection_registry
         .send_to(sender_jid, Stanza::Iq(iq))
         .await;
+    if !send_outcome.is_sent() {
+        // PR #438 review issue #5: if the recipient already
+        // disconnected between the presence-receipt and the
+        // disco#info IQ write, evict the orphan pending entry
+        // immediately rather than waiting for the next disconnect
+        // event.
+        debug!(
+            jid = %sender_jid,
+            iq_id = %iq_id,
+            "Caps disco#info send failed; evicting orphaned pending entry"
+        );
+        let _ = resolver.take_pending(&iq_id);
+    }
 }
 
 pub(super) fn show_name(show: &xmpp_parsers::presence::Show) -> &'static str {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -160,10 +160,7 @@ async fn broadcast_presence_to_subscribers(
             return;
         }
     };
-    for subscriber in subscribers {
-        let Ok(subscriber_bare) = subscriber.parse::<BareJid>() else {
-            continue;
-        };
+    for subscriber_bare in subscribers {
         if recipient_blocks_sender(state, &sender_jid.to_bare(), &subscriber_bare).await {
             continue;
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -237,18 +237,12 @@ async fn resolve_caps_for_presence(
         return;
     }
     let iq_id = format!("waddle-caps-disco-{}", uuid::Uuid::new_v4());
-    let iq = match build_caps_disco_info_query(
+    let iq = build_caps_disco_info_query(
         &state.deps.auth_state.xmpp_domain,
         sender_jid,
         &caps,
         &iq_id,
-    ) {
-        Ok(iq) => iq,
-        Err(error) => {
-            warn!(error = %error, "Failed to build caps disco#info query");
-            return;
-        }
-    };
+    );
     resolver.begin_pending(iq_id, sender_jid.clone(), caps);
     let _ = state
         .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -252,6 +252,21 @@ async fn resolve_caps_for_presence(
         );
         return;
     }
+    // Dedup in-flight resolutions per (full_jid, hash, ver). Without
+    // this guard, a client spamming presence updates with random
+    // `ver` values (or re-advertising the same uncached ver before
+    // its disco#info reply lands) could grow the pending map
+    // unboundedly and amplify outbound disco#info traffic. PR #438
+    // review issue (Qodo / Copilot).
+    if resolver.has_pending_for(sender_jid, &caps) {
+        debug!(
+            jid = %sender_jid,
+            hash = %caps.hash,
+            ver = %caps.ver,
+            "Skipping caps disco#info: a resolution is already in flight for this (jid, hash, ver)"
+        );
+        return;
+    }
     let iq_id = format!("waddle-caps-disco-{}", uuid::Uuid::new_v4());
     let iq = build_caps_disco_info_query(
         &state.deps.auth_state.caps_server_domain,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
@@ -153,13 +153,6 @@ pub async fn broadcast_unavailable_for_expired_detached_session(
     };
 
     for subscriber in subscribers {
-        let Ok(subscriber) = subscriber.parse::<BareJid>() else {
-            warn!(
-                subscriber,
-                "Skipping invalid stored presence subscriber JID"
-            );
-            continue;
-        };
         let mut presence =
             xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::Unavailable);
         presence.from = Some(Jid::from(from.clone()));

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -38,6 +38,7 @@ use waddle_xmpp::Stanza;
 
 use super::super::WebSocketState;
 use crate::db::actor::GetDatabase;
+use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::roster::DatabaseRosterStorage;
 
 /// Dispatch a §7.1 event notification to every deliverable subscriber.
@@ -224,20 +225,39 @@ pub async fn fan_out_publish(
         }
     }
 
-    // XEP-0163 §3: presence-driven fan-out to roster from/both contacts
-    // whose cached CAPS include `<node>+notify`. Per-resource semantics —
-    // we deliver only to resources whose ver is mapped (set by PR 1's
-    // caps resolver) AND whose cached features include the notify filter.
-    // Resources mid-resolution (no ver mapping yet) are skipped here and
-    // pick up via `send_last_published_item` on their next presence
-    // broadcast per XEP-0060.
+    // XEP-0163 §3: presence-driven fan-out. Two passes follow the
+    // explicit-subscribers loop:
+    //
+    // - Roster pass: every roster from/both contact of the publisher,
+    //   filtered by per-resource cached CAPS for `<node>+notify`. This
+    //   is the §3 mainline. XEP-0191 blocking is honored both directions
+    //   (publisher blocking contact, contact blocking publisher).
+    //
+    // - Self pass: the publisher's own *other* resources (PEP §3.4 —
+    //   account owner is among the appropriate subscribers). Same +notify
+    //   filter; the publishing resource is not specifically excluded
+    //   (it'll naturally drop the duplicate by item id, and we don't
+    //   thread the publishing FullJid through this function yet).
+    //
+    // Resources mid-resolution (presence with `<c/>` arrived but the
+    // disco#info round-trip hasn't completed) carry no ver mapping and
+    // are skipped here. Replaying the last item to such a resource on
+    // resolution-complete is `send_last_published_item` territory — not
+    // yet wired through the runtime; tracked for a follow-up PR.
+    let notify_filter = format!("{node}+notify");
+    let ctx = CapsFanOutCtx {
+        from: &from,
+        event: &event,
+        notify_filter: &notify_filter,
+    };
     let roster_metrics =
-        roster_caps_fan_out(state, owner, node, &from, &event, &mut already_delivered).await;
-    intended += roster_metrics.intended;
-    delivered += roster_metrics.delivered;
-    dropped_full += roster_metrics.dropped_full;
-    dropped_closed += roster_metrics.dropped_closed;
-    not_connected += roster_metrics.not_connected;
+        roster_caps_fan_out(state, owner, node, &ctx, &mut already_delivered).await;
+    let self_metrics = owner_self_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
+    intended += roster_metrics.intended + self_metrics.intended;
+    delivered += roster_metrics.delivered + self_metrics.delivered;
+    dropped_full += roster_metrics.dropped_full + self_metrics.dropped_full;
+    dropped_closed += roster_metrics.dropped_closed + self_metrics.dropped_closed;
+    not_connected += roster_metrics.not_connected + self_metrics.not_connected;
 
     debug_assert_eq!(
         intended,
@@ -255,6 +275,8 @@ pub async fn fan_out_publish(
         not_connected,
         roster_caps_intended = roster_metrics.intended,
         roster_caps_delivered = roster_metrics.delivered,
+        self_caps_intended = self_metrics.intended,
+        self_caps_delivered = self_metrics.delivered,
         "PubSub publish fan-out complete"
     );
 }
@@ -268,16 +290,23 @@ struct FanOutMetrics {
     not_connected: u32,
 }
 
+/// Constants threaded through both §3 fan-out passes.
+struct CapsFanOutCtx<'a> {
+    from: &'a Jid,
+    event: &'a PubSubEvent,
+    notify_filter: &'a str,
+}
+
 /// XEP-0163 §3 — iterate the publisher's roster from/both contacts and
 /// deliver `<message><event>` to each available resource whose cached
 /// CAPS include `<node>+notify`. Skips resources already reached via
 /// the explicit-subscribers loop (deduped through `already_delivered`).
+/// Honors XEP-0191 blocking in both directions.
 async fn roster_caps_fan_out(
     state: &WebSocketState,
     owner: &BareJid,
     node: &str,
-    from: &Jid,
-    event: &PubSubEvent,
+    ctx: &CapsFanOutCtx<'_>,
     already_delivered: &mut HashSet<FullJid>,
 ) -> FanOutMetrics {
     let mut metrics = FanOutMetrics::default();
@@ -319,61 +348,195 @@ async fn roster_caps_fan_out(
         return metrics;
     }
 
-    let notify_filter = format!("{node}+notify");
+    let blocking = blocking_storage(state).await;
 
     for subscriber in presence_subscribers {
-        let Ok(contact_bare) = subscriber.parse::<BareJid>() else {
-            continue;
+        let contact_bare = match subscriber.parse::<BareJid>() {
+            Ok(jid) => jid,
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    raw = %subscriber,
+                    owner = %owner,
+                    "Skipping invalid roster JID in §3 fan-out"
+                );
+                continue;
+            }
         };
 
-        let resources = state
-            .deps
-            .protocol
-            .connection_registry
-            .get_resources_for_user(&contact_bare);
-
-        for resource in resources {
-            if already_delivered.contains(&resource) {
-                continue;
-            }
-            // Skip resources mid-resolution — no ver mapping yet — per
-            // RFC 363 PR 2 contract. They pick up via send_last_published_item.
-            let Some(ver) = state
-                .deps
-                .protocol
-                .caps_resolver
-                .ver_for_resource(&resource)
-            else {
-                continue;
-            };
-            let Some(cached) = state.deps.protocol.caps_resolver.cached(&ver) else {
-                continue;
-            };
-            let advertises_notify = cached
-                .features
-                .iter()
-                .any(|feature| feature.0 == notify_filter);
-            if !advertises_notify {
-                continue;
-            }
-
-            metrics.intended += 1;
-            already_delivered.insert(resource.clone());
-            let message = build_pubsub_event(from, &Jid::from(resource.clone()), event);
-            let stanza = Stanza::Message(message);
-            match state
-                .deps
-                .protocol
-                .connection_registry
-                .try_send_to(&resource, stanza.clone())
+        // XEP-0191 §2: do not deliver if either party blocked the other.
+        if let Some(blocking) = blocking.as_ref() {
+            if is_blocked(blocking, owner, &contact_bare).await
+                || is_blocked(blocking, &contact_bare, owner).await
             {
-                BroadcastOutcome::Delivered => metrics.delivered += 1,
-                BroadcastOutcome::DroppedFull => metrics.dropped_full += 1,
-                BroadcastOutcome::DroppedClosed => metrics.dropped_closed += 1,
-                BroadcastOutcome::NotConnected => metrics.not_connected += 1,
+                continue;
             }
         }
+
+        deliver_to_user_resources(state, &contact_bare, ctx, already_delivered, &mut metrics).await;
     }
 
     metrics
+}
+
+/// XEP-0163 §3.4 / PEP §4.2 — the account owner is among the
+/// "appropriate subscribers" of their own publishes. Mirror to every
+/// online resource of `owner` whose cached CAPS include `<node>+notify`,
+/// skipping resources already reached. The publishing resource itself
+/// will receive a duplicate event (the publisher's `<iq result>` is
+/// independent of the headline event), but XMPP clients dedupe by item
+/// id so this is harmless and matches behavior of other PEP servers.
+async fn owner_self_caps_fan_out(
+    state: &WebSocketState,
+    owner: &BareJid,
+    ctx: &CapsFanOutCtx<'_>,
+    already_delivered: &mut HashSet<FullJid>,
+) -> FanOutMetrics {
+    let mut metrics = FanOutMetrics::default();
+    deliver_to_user_resources(state, owner, ctx, already_delivered, &mut metrics).await;
+    metrics
+}
+
+/// Deliver the event to every live + detached resource of `target`
+/// whose cached CAPS include `notify_filter`, skipping anything in
+/// `already_delivered`.
+async fn deliver_to_user_resources(
+    state: &WebSocketState,
+    target: &BareJid,
+    ctx: &CapsFanOutCtx<'_>,
+    already_delivered: &mut HashSet<FullJid>,
+    metrics: &mut FanOutMetrics,
+) {
+    let mut resources = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_resources_for_user(target);
+    match state
+        .deps
+        .protocol
+        .sm_session_registry
+        .detached_resources_for_user(target)
+        .await
+    {
+        Ok(detached) => resources.extend(detached),
+        Err(error) => {
+            warn!(
+                error = %error,
+                target = %target,
+                "Failed to enumerate detached resources for §3 fan-out"
+            );
+        }
+    }
+
+    for resource in resources {
+        if already_delivered.contains(&resource) {
+            continue;
+        }
+        let Some(ver) = state
+            .deps
+            .protocol
+            .caps_resolver
+            .ver_for_resource(&resource)
+        else {
+            continue;
+        };
+        let Some(cached) = state.deps.protocol.caps_resolver.cached(&ver) else {
+            continue;
+        };
+        if !cached
+            .features
+            .iter()
+            .any(|feature| feature.0 == ctx.notify_filter)
+        {
+            continue;
+        }
+
+        metrics.intended += 1;
+        already_delivered.insert(resource.clone());
+        let message = build_pubsub_event(ctx.from, &Jid::from(resource.clone()), ctx.event);
+        let stanza = Stanza::Message(message);
+        match state
+            .deps
+            .protocol
+            .connection_registry
+            .try_send_to(&resource, stanza.clone())
+        {
+            BroadcastOutcome::Delivered => metrics.delivered += 1,
+            BroadcastOutcome::DroppedFull => metrics.dropped_full += 1,
+            BroadcastOutcome::DroppedClosed => match state
+                .deps
+                .protocol
+                .sm_session_registry
+                .record_stanza_for_detached_bound_resource(&resource, &stanza, chrono::Utc::now())
+                .await
+            {
+                Ok(true) => metrics.delivered += 1,
+                Ok(false) => metrics.dropped_closed += 1,
+                Err(error) => {
+                    warn!(
+                        resource = %resource,
+                        error = %error,
+                        "Failed to stash §3 fan-out for detached resource after closed live send"
+                    );
+                    metrics.dropped_closed += 1;
+                }
+            },
+            BroadcastOutcome::NotConnected => match state
+                .deps
+                .protocol
+                .sm_session_registry
+                .record_stanza_for_detached_bound_resource(&resource, &stanza, chrono::Utc::now())
+                .await
+            {
+                Ok(true) => metrics.delivered += 1,
+                Ok(false) => metrics.not_connected += 1,
+                Err(error) => {
+                    warn!(
+                        resource = %resource,
+                        error = %error,
+                        "Failed to stash §3 fan-out for not-connected detached resource"
+                    );
+                    metrics.not_connected += 1;
+                }
+            },
+        }
+    }
+}
+
+async fn blocking_storage(state: &WebSocketState) -> Option<DatabaseBlockingStorage> {
+    match state
+        .deps
+        .app_state
+        .db_pool
+        .global_actor()
+        .clone()
+        .ask(GetDatabase)
+        .await
+    {
+        Ok(db) => Some(DatabaseBlockingStorage::new(db)),
+        Err(error) => {
+            warn!(error = %error, "Failed to access blocking storage for §3 fan-out");
+            None
+        }
+    }
+}
+
+async fn is_blocked(
+    storage: &DatabaseBlockingStorage,
+    recipient: &BareJid,
+    sender: &BareJid,
+) -> bool {
+    match storage.is_blocked(recipient, sender).await {
+        Ok(blocked) => blocked,
+        Err(error) => {
+            warn!(
+                error = %error,
+                recipient = %recipient,
+                sender = %sender,
+                "Blocking check failed during §3 fan-out; treating as blocked to fail closed"
+            );
+            true
+        }
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -49,6 +49,7 @@ pub async fn fan_out_publish(
     published_item: &PubSubItem,
     item_id: &str,
     publisher: Option<&BareJid>,
+    publisher_full: Option<&FullJid>,
 ) {
     let storage = &state.deps.protocol.pubsub_storage;
 
@@ -118,7 +119,14 @@ pub async fn fan_out_publish(
 
     // Track resources reached via the explicit-subscribers loop so the
     // roster + CAPS phase doesn't double-deliver to the same client.
+    // We also pre-seed the publishing resource itself (when known) so
+    // the §3.4 owner-self pass doesn't echo a headline event back to
+    // the same FullJid that just received the publish IQ result —
+    // matches Prosody/ejabberd behavior.
     let mut already_delivered: HashSet<FullJid> = HashSet::new();
+    if let Some(publisher_full) = publisher_full {
+        already_delivered.insert(publisher_full.clone());
+    }
 
     for sub in subscribers {
         let target_resources: Vec<FullJid> = match sub.subscriber.try_as_full() {
@@ -235,9 +243,9 @@ pub async fn fan_out_publish(
     //
     // - Self pass: the publisher's own *other* resources (PEP §3.4 —
     //   account owner is among the appropriate subscribers). Same +notify
-    //   filter; the publishing resource is not specifically excluded
-    //   (it'll naturally drop the duplicate by item id, and we don't
-    //   thread the publishing FullJid through this function yet).
+    //   filter. The publishing resource itself is pre-seeded into
+    //   `already_delivered` above so it does NOT receive a headline
+    //   echo of the item it just authored.
     //
     // Resources mid-resolution (presence with `<c/>` arrived but the
     // disco#info round-trip hasn't completed) carry no ver mapping and
@@ -250,8 +258,7 @@ pub async fn fan_out_publish(
         event: &event,
         notify_filter: &notify_filter,
     };
-    let roster_metrics =
-        roster_caps_fan_out(state, owner, node, &ctx, &mut already_delivered).await;
+    let roster_metrics = roster_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
     let self_metrics = owner_self_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
     intended += roster_metrics.intended + self_metrics.intended;
     delivered += roster_metrics.delivered + self_metrics.delivered;
@@ -301,11 +308,13 @@ struct CapsFanOutCtx<'a> {
 /// deliver `<message><event>` to each available resource whose cached
 /// CAPS include `<node>+notify`. Skips resources already reached via
 /// the explicit-subscribers loop (deduped through `already_delivered`).
-/// Honors XEP-0191 blocking in both directions.
+/// Honors XEP-0191 blocking in both directions, fail-closed: if the
+/// blocking-storage handle is unavailable the entire roster pass is
+/// aborted (failing OPEN would risk leaking PEP items to blocked
+/// contacts during a transient DB outage, which §3.3 forbids).
 async fn roster_caps_fan_out(
     state: &WebSocketState,
     owner: &BareJid,
-    node: &str,
     ctx: &CapsFanOutCtx<'_>,
     already_delivered: &mut HashSet<FullJid>,
 ) -> FanOutMetrics {
@@ -337,7 +346,7 @@ async fn roster_caps_fan_out(
             warn!(
                 error = %error,
                 owner = %owner,
-                node,
+                notify_filter = %ctx.notify_filter,
                 "Failed to load roster from/both contacts for §3 fan-out"
             );
             return metrics;
@@ -348,7 +357,22 @@ async fn roster_caps_fan_out(
         return metrics;
     }
 
-    let blocking = blocking_storage(state).await;
+    // XEP-0191 §2 + RFC 363 PR #439 review issue #2: fail CLOSED if
+    // the blocking storage handle is unavailable. Failing open would
+    // skip the both-direction block check on a transient DB outage,
+    // which is a §3.3 violation (MUST NOT deliver to blocked peers).
+    let blocking = match blocking_storage(state).await {
+        Some(b) => b,
+        None => {
+            warn!(
+                owner = %owner,
+                notify_filter = %ctx.notify_filter,
+                "Aborting §3 roster fan-out: blocking storage handle unavailable; \
+                 cannot honor XEP-0191 — failing closed"
+            );
+            return metrics;
+        }
+    };
 
     for subscriber in presence_subscribers {
         let contact_bare = match subscriber.parse::<BareJid>() {
@@ -365,12 +389,10 @@ async fn roster_caps_fan_out(
         };
 
         // XEP-0191 §2: do not deliver if either party blocked the other.
-        if let Some(blocking) = blocking.as_ref() {
-            if is_blocked(blocking, owner, &contact_bare).await
-                || is_blocked(blocking, &contact_bare, owner).await
-            {
-                continue;
-            }
+        if is_blocked(&blocking, owner, &contact_bare).await
+            || is_blocked(&blocking, &contact_bare, owner).await
+        {
+            continue;
         }
 
         deliver_to_user_resources(state, &contact_bare, ctx, already_delivered, &mut metrics).await;
@@ -383,9 +405,10 @@ async fn roster_caps_fan_out(
 /// "appropriate subscribers" of their own publishes. Mirror to every
 /// online resource of `owner` whose cached CAPS include `<node>+notify`,
 /// skipping resources already reached. The publishing resource itself
-/// will receive a duplicate event (the publisher's `<iq result>` is
-/// independent of the headline event), but XMPP clients dedupe by item
-/// id so this is harmless and matches behavior of other PEP servers.
+/// is pre-seeded into `already_delivered` by the caller, so the owner's
+/// other resources receive the headline event but the originator does
+/// not see an echo of the item it just authored — matching Prosody's
+/// `mod_pep` and ejabberd's `mod_pubsub`.
 async fn owner_self_caps_fan_out(
     state: &WebSocketState,
     owner: &BareJid,
@@ -397,9 +420,18 @@ async fn owner_self_caps_fan_out(
     metrics
 }
 
-/// Deliver the event to every live + detached resource of `target`
-/// whose cached CAPS include `notify_filter`, skipping anything in
-/// `already_delivered`.
+/// Deliver the event to every live resource of `target` whose cached
+/// CAPS include `notify_filter`, skipping anything in `already_delivered`.
+///
+/// Detached XEP-0198 resumable resources are NOT enumerated here:
+/// `caps_resolver.drop_resource` is called on every disconnect/expiry
+/// path (including SM detach) so a detached resource never has a caps
+/// mapping when the event is published, and the §3 filter would skip
+/// it regardless. Once the caps lifetime is extended to span SM detach
+/// windows (a separate PR), the iteration here should re-include
+/// `sm_session_registry.detached_resources_for_user(target)` and route
+/// through `record_stanza_for_detached_bound_resource` on
+/// `DroppedClosed`/`NotConnected` outcomes.
 async fn deliver_to_user_resources(
     state: &WebSocketState,
     target: &BareJid,
@@ -407,41 +439,25 @@ async fn deliver_to_user_resources(
     already_delivered: &mut HashSet<FullJid>,
     metrics: &mut FanOutMetrics,
 ) {
-    let mut resources = state
+    let resources = state
         .deps
         .protocol
         .connection_registry
         .get_resources_for_user(target);
-    match state
-        .deps
-        .protocol
-        .sm_session_registry
-        .detached_resources_for_user(target)
-        .await
-    {
-        Ok(detached) => resources.extend(detached),
-        Err(error) => {
-            warn!(
-                error = %error,
-                target = %target,
-                "Failed to enumerate detached resources for §3 fan-out"
-            );
-        }
-    }
 
     for resource in resources {
         if already_delivered.contains(&resource) {
             continue;
         }
-        let Some(ver) = state
+        let Some(caps_key) = state
             .deps
             .protocol
             .caps_resolver
-            .ver_for_resource(&resource)
+            .key_for_resource(&resource)
         else {
             continue;
         };
-        let Some(cached) = state.deps.protocol.caps_resolver.cached(&ver) else {
+        let Some(cached) = state.deps.protocol.caps_resolver.cached(&caps_key) else {
             continue;
         };
         if !cached

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -41,16 +41,41 @@ use crate::db::actor::GetDatabase;
 use crate::db::blocking::DatabaseBlockingStorage;
 use crate::db::roster::DatabaseRosterStorage;
 
+/// Typed bundle of `fan_out_publish` inputs — keeps the public
+/// signature compact (one `state` + one struct) while still letting
+/// the helper consume each field by reference.
+pub struct FanOutRequest<'a> {
+    pub owner: &'a BareJid,
+    pub node: &'a str,
+    pub published_item: &'a PubSubItem,
+    pub item_id: &'a str,
+    pub publisher: Option<&'a BareJid>,
+    /// The publishing resource's full JID, when known. Used to
+    /// suppress the §3.4 owner-self echo back to the originator.
+    pub publisher_full: Option<&'a FullJid>,
+    /// `true` when this is a XEP-0163 PEP publish (owner is a user
+    /// JID); `false` for generic PubSub / Spaces publishes where the
+    /// §3 roster + owner-self passes would be a leak.
+    pub is_pep: bool,
+}
+
 /// Dispatch a §7.1 event notification to every deliverable subscriber.
-pub async fn fan_out_publish(
-    state: &WebSocketState,
-    owner: &BareJid,
-    node: &str,
-    published_item: &PubSubItem,
-    item_id: &str,
-    publisher: Option<&BareJid>,
-    publisher_full: Option<&FullJid>,
-) {
+///
+/// `req.is_pep` distinguishes XEP-0163 PEP self-publishes (where
+/// `owner` is a user JID and the §3 roster + owner-self passes apply)
+/// from generic PubSub or Spaces publishes (where `owner` is a service
+/// component domain and the §3 passes are skipped). Without this
+/// guard, a non-PEP publish would leak to the publisher's roster
+/// contacts that happen to advertise `<node>+notify` for the
+/// (unrelated) generic node — a real authorization bypass.
+pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
+    let owner = req.owner;
+    let node = req.node;
+    let published_item = req.published_item;
+    let item_id = req.item_id;
+    let publisher = req.publisher;
+    let publisher_full = req.publisher_full;
+    let is_pep = req.is_pep;
     let storage = &state.deps.protocol.pubsub_storage;
 
     let node_cfg = match storage.get_node(owner, node).await {
@@ -258,8 +283,20 @@ pub async fn fan_out_publish(
         event: &event,
         notify_filter: &notify_filter,
     };
-    let roster_metrics = roster_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
-    let self_metrics = owner_self_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
+    // Codex P1 review (PR #439): the §3 roster + owner-self passes
+    // are XEP-0163 PEP-specific. For non-PEP publishes (generic
+    // PubSub on a service component, Spaces) `owner` is a service
+    // domain and the publisher's roster bears no authorization
+    // relationship to the published node — running the passes there
+    // would leak the event to roster contacts that advertise
+    // `<node>+notify` for an unrelated node URI.
+    let (roster_metrics, self_metrics) = if is_pep {
+        let roster = roster_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
+        let self_ = owner_self_caps_fan_out(state, owner, &ctx, &mut already_delivered).await;
+        (roster, self_)
+    } else {
+        (FanOutMetrics::default(), FanOutMetrics::default())
+    };
     intended += roster_metrics.intended + self_metrics.intended;
     delivered += roster_metrics.delivered + self_metrics.delivered;
     dropped_full += roster_metrics.dropped_full + self_metrics.dropped_full;
@@ -308,10 +345,18 @@ struct CapsFanOutCtx<'a> {
 /// deliver `<message><event>` to each available resource whose cached
 /// CAPS include `<node>+notify`. Skips resources already reached via
 /// the explicit-subscribers loop (deduped through `already_delivered`).
+///
 /// Honors XEP-0191 blocking in both directions, fail-closed: if the
-/// blocking-storage handle is unavailable the entire roster pass is
-/// aborted (failing OPEN would risk leaking PEP items to blocked
-/// contacts during a transient DB outage, which §3.3 forbids).
+/// shared DB handle is unavailable the entire roster pass is aborted
+/// (failing OPEN would risk leaking PEP items to blocked contacts
+/// during a transient DB outage, which §3.3 forbids).
+///
+/// The DB handle is acquired ONCE for both the roster query and the
+/// blocking lookups (PR #439 review: avoid two `GetDatabase` actor
+/// round-trips and the fail-open window between them). The
+/// publisher's own blocklist is loaded ONCE and consulted via a
+/// `HashSet` membership test (PR #439 review: cuts the per-roster-
+/// contact query count in half on the publisher→contact direction).
 async fn roster_caps_fan_out(
     state: &WebSocketState,
     owner: &BareJid,
@@ -320,7 +365,7 @@ async fn roster_caps_fan_out(
 ) -> FanOutMetrics {
     let mut metrics = FanOutMetrics::default();
 
-    let roster = match state
+    let db = match state
         .deps
         .app_state
         .db_pool
@@ -329,16 +374,20 @@ async fn roster_caps_fan_out(
         .ask(GetDatabase)
         .await
     {
-        Ok(db) => DatabaseRosterStorage::new(db),
+        Ok(db) => db,
         Err(error) => {
             warn!(
                 error = %error,
                 owner = %owner,
-                "Failed to access roster database for §3 fan-out"
+                notify_filter = %ctx.notify_filter,
+                "Aborting §3 roster fan-out: cannot acquire DB handle; \
+                 cannot honor XEP-0191 — failing closed"
             );
             return metrics;
         }
     };
+    let roster = DatabaseRosterStorage::new(db.clone());
+    let blocking = DatabaseBlockingStorage::new(db);
 
     let presence_subscribers = match roster.get_presence_subscribers(owner).await {
         Ok(subs) => subs,
@@ -357,39 +406,28 @@ async fn roster_caps_fan_out(
         return metrics;
     }
 
-    // XEP-0191 §2 + RFC 363 PR #439 review issue #2: fail CLOSED if
-    // the blocking storage handle is unavailable. Failing open would
-    // skip the both-direction block check on a transient DB outage,
-    // which is a §3.3 violation (MUST NOT deliver to blocked peers).
-    let blocking = match blocking_storage(state).await {
-        Some(b) => b,
-        None => {
+    // Pre-load the publisher's blocklist as a typed set so the
+    // owner→contact direction is checked in O(1) per roster entry,
+    // not via a round-trip per check (PR #439 review). The
+    // contact→owner direction still needs a per-contact query
+    // because we don't have the contacts' blocklists pre-loaded.
+    let owner_blocklist: HashSet<BareJid> = match blocking.list_blocked_jids(owner).await {
+        Ok(list) => list.into_iter().collect(),
+        Err(error) => {
             warn!(
+                error = %error,
                 owner = %owner,
                 notify_filter = %ctx.notify_filter,
-                "Aborting §3 roster fan-out: blocking storage handle unavailable; \
+                "Aborting §3 roster fan-out: failed to load publisher's blocklist; \
                  cannot honor XEP-0191 — failing closed"
             );
             return metrics;
         }
     };
 
-    for subscriber in presence_subscribers {
-        let contact_bare = match subscriber.parse::<BareJid>() {
-            Ok(jid) => jid,
-            Err(error) => {
-                warn!(
-                    error = %error,
-                    raw = %subscriber,
-                    owner = %owner,
-                    "Skipping invalid roster JID in §3 fan-out"
-                );
-                continue;
-            }
-        };
-
+    for contact_bare in presence_subscribers {
         // XEP-0191 §2: do not deliver if either party blocked the other.
-        if is_blocked(&blocking, owner, &contact_bare).await
+        if owner_blocklist.contains(&contact_bare)
             || is_blocked(&blocking, &contact_bare, owner).await
         {
             continue;
@@ -420,8 +458,16 @@ async fn owner_self_caps_fan_out(
     metrics
 }
 
-/// Deliver the event to every live resource of `target` whose cached
-/// CAPS include `notify_filter`, skipping anything in `already_delivered`.
+/// Deliver the event to every presence-AVAILABLE resource of `target`
+/// whose cached CAPS include `notify_filter`, skipping anything in
+/// `already_delivered`.
+///
+/// XEP-0163 §3 is presence-driven: a resource that has explicitly gone
+/// `<presence type="unavailable"/>` MUST NOT receive PEP notifications
+/// even if its CAPS still advertise `+notify` (PR #439 review issue
+/// Qodo #2). We use the `get_available_resources_for_user` helper
+/// rather than `get_resources_for_user`, which would return all
+/// connected sockets including unavailable/invisible ones.
 ///
 /// Detached XEP-0198 resumable resources are NOT enumerated here:
 /// `caps_resolver.drop_resource` is called on every disconnect/expiry
@@ -439,11 +485,14 @@ async fn deliver_to_user_resources(
     already_delivered: &mut HashSet<FullJid>,
     metrics: &mut FanOutMetrics,
 ) {
-    let resources = state
+    let resources: Vec<FullJid> = state
         .deps
         .protocol
         .connection_registry
-        .get_resources_for_user(target);
+        .get_available_resources_for_user(target)
+        .into_iter()
+        .map(|(jid, _priority)| jid)
+        .collect();
 
     for resource in resources {
         if already_delivered.contains(&resource) {
@@ -516,24 +565,6 @@ async fn deliver_to_user_resources(
                     metrics.not_connected += 1;
                 }
             },
-        }
-    }
-}
-
-async fn blocking_storage(state: &WebSocketState) -> Option<DatabaseBlockingStorage> {
-    match state
-        .deps
-        .app_state
-        .db_pool
-        .global_actor()
-        .clone()
-        .ask(GetDatabase)
-        .await
-    {
-        Ok(db) => Some(DatabaseBlockingStorage::new(db)),
-        Err(error) => {
-            warn!(error = %error, "Failed to access blocking storage for §3 fan-out");
-            None
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -30,12 +30,15 @@
 //! §7.1 and not worth holding a lock across fan-out to prevent.
 
 use jid::{BareJid, FullJid, Jid};
-use tracing::{debug, info, warn};
+use std::collections::HashSet;
+use tracing::{info, warn};
 use waddle_xmpp::pubsub::{build_pubsub_event, PubSubEvent, PubSubItem};
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Stanza;
 
 use super::super::WebSocketState;
+use crate::db::actor::GetDatabase;
+use crate::db::roster::DatabaseRosterStorage;
 
 /// Dispatch a §7.1 event notification to every deliverable subscriber.
 pub async fn fan_out_publish(
@@ -82,10 +85,10 @@ pub async fn fan_out_publish(
         }
     };
 
-    if subscribers.is_empty() {
-        debug!(owner = %owner, node, "No deliverable subscribers; nothing to fan out");
-        return;
-    }
+    // XEP-0163 §3 fan-out is presence-driven, not subscription-driven —
+    // an empty deliverable-subscriber list does NOT terminate fan-out.
+    // We still need to iterate the publisher's roster for from/both
+    // contacts whose CAPS advertise `<node>+notify`.
 
     // §7.1.5: include `publisher` only when it differs from the owner.
     let event_publisher = publisher.filter(|p| *p != owner).cloned();
@@ -111,6 +114,10 @@ pub async fn fan_out_publish(
     let mut dropped_full: u32 = 0;
     let mut dropped_closed: u32 = 0;
     let mut not_connected: u32 = 0;
+
+    // Track resources reached via the explicit-subscribers loop so the
+    // roster + CAPS phase doesn't double-deliver to the same client.
+    let mut already_delivered: HashSet<FullJid> = HashSet::new();
 
     for sub in subscribers {
         let target_resources: Vec<FullJid> = match sub.subscriber.try_as_full() {
@@ -157,6 +164,7 @@ pub async fn fan_out_publish(
 
         for resource in target_resources {
             intended += 1;
+            already_delivered.insert(resource.clone());
             let message = build_pubsub_event(&from, &Jid::from(resource.clone()), &event);
             let stanza = Stanza::Message(message);
 
@@ -216,6 +224,21 @@ pub async fn fan_out_publish(
         }
     }
 
+    // XEP-0163 §3: presence-driven fan-out to roster from/both contacts
+    // whose cached CAPS include `<node>+notify`. Per-resource semantics —
+    // we deliver only to resources whose ver is mapped (set by PR 1's
+    // caps resolver) AND whose cached features include the notify filter.
+    // Resources mid-resolution (no ver mapping yet) are skipped here and
+    // pick up via `send_last_published_item` on their next presence
+    // broadcast per XEP-0060.
+    let roster_metrics =
+        roster_caps_fan_out(state, owner, node, &from, &event, &mut already_delivered).await;
+    intended += roster_metrics.intended;
+    delivered += roster_metrics.delivered;
+    dropped_full += roster_metrics.dropped_full;
+    dropped_closed += roster_metrics.dropped_closed;
+    not_connected += roster_metrics.not_connected;
+
     debug_assert_eq!(
         intended,
         delivered + dropped_full + dropped_closed + not_connected,
@@ -230,6 +253,127 @@ pub async fn fan_out_publish(
         dropped_full,
         dropped_closed,
         not_connected,
+        roster_caps_intended = roster_metrics.intended,
+        roster_caps_delivered = roster_metrics.delivered,
         "PubSub publish fan-out complete"
     );
+}
+
+#[derive(Default)]
+struct FanOutMetrics {
+    intended: u32,
+    delivered: u32,
+    dropped_full: u32,
+    dropped_closed: u32,
+    not_connected: u32,
+}
+
+/// XEP-0163 §3 — iterate the publisher's roster from/both contacts and
+/// deliver `<message><event>` to each available resource whose cached
+/// CAPS include `<node>+notify`. Skips resources already reached via
+/// the explicit-subscribers loop (deduped through `already_delivered`).
+async fn roster_caps_fan_out(
+    state: &WebSocketState,
+    owner: &BareJid,
+    node: &str,
+    from: &Jid,
+    event: &PubSubEvent,
+    already_delivered: &mut HashSet<FullJid>,
+) -> FanOutMetrics {
+    let mut metrics = FanOutMetrics::default();
+
+    let roster = match state
+        .deps
+        .app_state
+        .db_pool
+        .global_actor()
+        .clone()
+        .ask(GetDatabase)
+        .await
+    {
+        Ok(db) => DatabaseRosterStorage::new(db),
+        Err(error) => {
+            warn!(
+                error = %error,
+                owner = %owner,
+                "Failed to access roster database for §3 fan-out"
+            );
+            return metrics;
+        }
+    };
+
+    let presence_subscribers = match roster.get_presence_subscribers(owner).await {
+        Ok(subs) => subs,
+        Err(error) => {
+            warn!(
+                error = %error,
+                owner = %owner,
+                node,
+                "Failed to load roster from/both contacts for §3 fan-out"
+            );
+            return metrics;
+        }
+    };
+
+    if presence_subscribers.is_empty() {
+        return metrics;
+    }
+
+    let notify_filter = format!("{node}+notify");
+
+    for subscriber in presence_subscribers {
+        let Ok(contact_bare) = subscriber.parse::<BareJid>() else {
+            continue;
+        };
+
+        let resources = state
+            .deps
+            .protocol
+            .connection_registry
+            .get_resources_for_user(&contact_bare);
+
+        for resource in resources {
+            if already_delivered.contains(&resource) {
+                continue;
+            }
+            // Skip resources mid-resolution — no ver mapping yet — per
+            // RFC 363 PR 2 contract. They pick up via send_last_published_item.
+            let Some(ver) = state
+                .deps
+                .protocol
+                .caps_resolver
+                .ver_for_resource(&resource)
+            else {
+                continue;
+            };
+            let Some(cached) = state.deps.protocol.caps_resolver.cached(&ver) else {
+                continue;
+            };
+            let advertises_notify = cached
+                .features
+                .iter()
+                .any(|feature| feature.0 == notify_filter);
+            if !advertises_notify {
+                continue;
+            }
+
+            metrics.intended += 1;
+            already_delivered.insert(resource.clone());
+            let message = build_pubsub_event(from, &Jid::from(resource.clone()), event);
+            let stanza = Stanza::Message(message);
+            match state
+                .deps
+                .protocol
+                .connection_registry
+                .try_send_to(&resource, stanza.clone())
+            {
+                BroadcastOutcome::Delivered => metrics.delivered += 1,
+                BroadcastOutcome::DroppedFull => metrics.dropped_full += 1,
+                BroadcastOutcome::DroppedClosed => metrics.dropped_closed += 1,
+                BroadcastOutcome::NotConnected => metrics.not_connected += 1,
+            }
+        }
+    }
+
+    metrics
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -76,6 +76,10 @@ pub struct ProtocolServices {
     /// XEP-0198 detached-session registry — holds state for clients whose
     /// WebSocket has closed but may still resume within the session timeout.
     pub sm_session_registry: Arc<InMemorySmSessionRegistry>,
+    /// XEP-0115 entity-capabilities resolver. Maintains the
+    /// process-wide hash-keyed `CapsCache` plus per-resource caps
+    /// mappings used by XEP-0163 §3 fan-out filtering.
+    pub caps_resolver: Arc<crate::server::caps_resolution::CapsResolver>,
     /// Sidecar map keyed by SM stream id, holding the authenticated `Session`
     /// so that a resumed stream doesn't lose its authorization context and
     /// can serve IQs that check channel membership, etc. Entries are

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -182,6 +182,9 @@ async fn create_test_websocket_state_with_extension_manager(
                     isr_token_store: waddle_xmpp::isr::create_shared_store(),
                     sm_session_registry: Arc::new(InMemorySmSessionRegistry::new()),
                     resumable_sessions: Arc::new(dashmap::DashMap::new()),
+                    caps_resolver: Arc::new(
+                        crate::server::caps_resolution::CapsResolver::default(),
+                    ),
                 },
                 occupant_id_secret: OccupantIdSecret::new(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -244,6 +244,18 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     .protocol
                     .connection_registry
                     .unregister(&session.jid);
+                // PR #438 review (Qodo issue #2): the periodic SM expiry
+                // janitor takes its own cleanup path; without this drop
+                // it leaks `resource_to_ver` and `pending` entries for
+                // every detached session that times out. The other
+                // disconnect/expiry paths already call this; mirror it
+                // here so the caps state is bounded across all five
+                // tear-down code paths.
+                state
+                    .deps
+                    .protocol
+                    .caps_resolver
+                    .drop_resource(&session.jid);
                 routes::websocket::cleanup_muc_presence_for_jid(&state, &session.jid).await;
             }
         }

--- a/server/crates/waddle-server/src/server/xmpp_roster_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_roster_state.rs
@@ -157,15 +157,10 @@ pub(crate) async fn get_presence_subscribers(
     debug!(jid = %user_jid, "Getting presence subscribers");
 
     let storage = DatabaseRosterStorage::new(db);
-    let jid_strings = storage
-        .get_presence_subscribers(user_jid)
-        .await
-        .map_err(|e| {
-            warn!(jid = %user_jid, error = %e, "Failed to get presence subscribers");
-            XmppError::internal(format!("Database error: {}", e))
-        })?;
-
-    parse_bare_jids(&jid_strings, user_jid, "presence subscriber")
+    storage.get_presence_subscribers(user_jid).await.map_err(|e| {
+        warn!(jid = %user_jid, error = %e, "Failed to get presence subscribers");
+        XmppError::internal(format!("Database error: {}", e))
+    })
 }
 
 pub(crate) async fn get_presence_subscriptions(

--- a/server/crates/waddle-server/src/server/xmpp_roster_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_roster_state.rs
@@ -157,10 +157,13 @@ pub(crate) async fn get_presence_subscribers(
     debug!(jid = %user_jid, "Getting presence subscribers");
 
     let storage = DatabaseRosterStorage::new(db);
-    storage.get_presence_subscribers(user_jid).await.map_err(|e| {
-        warn!(jid = %user_jid, error = %e, "Failed to get presence subscribers");
-        XmppError::internal(format!("Database error: {}", e))
-    })
+    storage
+        .get_presence_subscribers(user_jid)
+        .await
+        .map_err(|e| {
+            warn!(jid = %user_jid, error = %e, "Failed to get presence subscribers");
+            XmppError::internal(format!("Database error: {}", e))
+        })
 }
 
 pub(crate) async fn get_presence_subscriptions(

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -1,0 +1,380 @@
+//! XEP-0115 Entity Capabilities resolution wire-conformance tests.
+//!
+//! Tests cover the inbound `<c hash ver node/>` presence path:
+//! - Cache miss triggers an outbound disco#info IQ to the publishing
+//!   resource's full JID with `node="<NODE>#<VER>"` per §6.2.
+//! - A response whose recomputed hash matches `ver` populates the
+//!   server's cache and records the per-resource caps mapping (§5.4).
+//! - A response whose recomputed hash mismatches is rejected and not
+//!   cached (§5.4 — cache only on match).
+//! - Cache hit short-circuits the disco query.
+//! - Disconnect drops the per-resource mapping while the hash-keyed
+//!   cache stays warm for cross-session reuse (§6).
+
+mod ws_common;
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const ADMIN: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+const NS_CAPS: &str = "http://jabber.org/protocol/caps";
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
+    let password = server.fixed_account_password().to_string();
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, ADMIN, &password, resource)
+        .await
+        .expect("admin connect")
+}
+
+async fn extra_client(
+    server: &TestServer,
+    user: &str,
+    password: &str,
+    resource: &str,
+) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, user, password, resource)
+        .await
+        .expect("connect_and_auth")
+}
+
+/// Pull the IQ id off a server-issued `<iq type="get" .../>` frame so
+/// the test can mirror it into the result reply.
+fn extract_iq_id(frame: &str) -> String {
+    extract_attr_after(frame, "<iq", "id").expect("iq has id attribute")
+}
+
+/// Compute the XEP-0115 §5.1 verification string for a disco#info
+/// response with the given identity-category/type/name and feature
+/// vars. This MUST match the algorithm the server runs so the server
+/// accepts the round-tripped reply as valid.
+fn caps_verification_string(
+    identity_category: &str,
+    identity_type: &str,
+    identity_name: &str,
+    features: &[&str],
+) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash;
+
+    let identities = vec![Identity::new(
+        identity_category,
+        identity_type,
+        Some(identity_name),
+    )];
+    let features: Vec<Feature> = features.iter().map(|f| Feature::new(f)).collect();
+    compute_caps_hash(&identities, &features)
+}
+
+// ============================================================================
+// Test 1 — caps_unknown_ver_triggers_disco_info_to_full_jid
+// ============================================================================
+//
+// XEP-0115 §6.2: when a recipient sees a <c/> with an unknown (hash,
+// ver), it MUST request the entity's identity and supported features
+// via a disco#info request with `node="<NODE>#<VER>"`. Here the server
+// is the recipient, so receiving alice's presence with caps must
+// drive the server to send disco#info to alice's bound full JID.
+
+#[tokio::test]
+async fn caps_unknown_ver_triggers_disco_info_to_full_jid() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-trigger-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("bind populated full_jid");
+
+    let node = "https://example.test/caps";
+    let ver = "definitely-not-yet-cached-ver-1";
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send presence with caps");
+
+    // The server is required to issue a disco#info IQ get back to the
+    // resource that just advertised the unknown ver. The query MUST
+    // carry node="<NODE>#<VER>" per §6.2.
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server sends disco#info IQ to resource on cache miss");
+
+    let expected_node_attr = format!(r#"node="{node}#{ver}""#);
+    assert!(
+        disco_query.contains(&expected_node_attr),
+        "disco#info query MUST carry node=\"<NODE>#<VER>\" per XEP-0115 §6.2: {disco_query}"
+    );
+    assert!(
+        disco_query.contains(&format!(r#"to="{admin_full_jid}""#)),
+        "disco#info query MUST be addressed to the resource that advertised caps: {disco_query}"
+    );
+
+    let _ = admin.close().await;
+    let _ = server;
+    let _ = Duration::from_secs(1);
+}
+
+// ============================================================================
+// Test 2 — caps_verified_reply_populates_cache_and_subsequent_advert_is_hit
+// ============================================================================
+//
+// XEP-0115 §5.4: when the disco#info reply's recomputed hash matches
+// the advertised `ver`, the recipient MUST cache the result. This is
+// keyed on the (hash algo, ver) tuple, not on the entity. So a second
+// resource advertising the same `(hash, ver)` is a cache hit and MUST
+// NOT trigger another disco#info round-trip — that's the entire
+// efficiency win of XEP-0115.
+
+#[tokio::test]
+async fn caps_verified_reply_populates_cache_and_subsequent_advert_is_hit() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", &bob_password)]);
+
+    let mut admin = admin_client(&server, "caps-pop-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("admin full_jid");
+
+    let node = "https://example.test/caps#hit";
+    let features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let ver = caps_verification_string("client", "pc", "Test Client", &features);
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin sends caps");
+
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="Test Client"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("admin replies to disco#info");
+
+    // Wait for the server to settle the cache write. There's no wire
+    // signal for "cache populated", so we use a short delay before
+    // having bob advertise the same ver. If verification works the
+    // server will short-circuit on the second presence.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let mut bob = extra_client(&server, "bob", &bob_password, "caps-hit-1").await;
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob sends caps with same ver");
+
+    // The server must NOT issue a second disco#info, since the
+    // (hash, ver) is now cached. Wait a generous window for the
+    // *absence* of a query.
+    let timed = tokio::time::timeout(
+        Duration::from_millis(500),
+        bob.recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+
+    assert!(
+        timed.is_err(),
+        "cache hit MUST short-circuit disco#info; got an unexpected query: {timed:?}"
+    );
+
+    let _ = admin.close().await;
+    let _ = bob.close().await;
+}
+
+// ============================================================================
+// Test 3 — caps_mismatched_hash_reply_is_rejected_and_not_cached
+// ============================================================================
+//
+// XEP-0115 §5.4: when the recomputed hash does NOT match the
+// advertised `ver`, the recipient MUST NOT cache the result (defense
+// against "caps poisoning" — §8). Subsequent advertisements of the
+// same (hash, ver) MUST therefore re-resolve.
+
+#[tokio::test]
+async fn caps_mismatched_hash_reply_is_rejected_and_not_cached() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-poison-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("admin full_jid");
+
+    let node = "https://example.test/caps#poison";
+    // ver advertised — claims one set of features ...
+    let advertised_features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let advertised_ver =
+        caps_verification_string("client", "pc", "Honest Client", &advertised_features);
+    // ... but the reply will return a *different* feature set. Their
+    // recomputed hash MUST NOT match `advertised_ver`.
+    let reply_features = ["urn:xmpp:malicious-feature"];
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{advertised_ver}"/></presence>"#
+        ))
+        .await
+        .expect("send caps presence");
+
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+
+    let feature_xml: String = reply_features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{advertised_ver}"><identity category="client" type="pc" name="Honest Client"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("admin sends mismatched reply");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Re-advertise the same ver from a *fresh* resource on the same
+    // user. If the reply was correctly rejected, the server's cache
+    // is still empty for `advertised_ver` and a new disco#info MUST
+    // fire on the second resource.
+    let mut admin2 = admin_client(&server, "caps-poison-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{advertised_ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 sends caps");
+
+    let _re_query = admin2
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect(
+            "rejected (poisoned) reply MUST NOT be cached; the next advert MUST re-resolve via disco#info per XEP-0115 §5.4",
+        );
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+}
+
+// ============================================================================
+// Test 4 — caps_cache_survives_publisher_disconnect_for_cross_session_reuse
+// ============================================================================
+//
+// XEP-0115 §6: caching across presence sessions is RECOMMENDED — that
+// is the whole point of the verification string. So when the resource
+// that originally taught the server about a (hash, ver) disconnects,
+// the per-resource mapping is cleared (we no longer care which JID
+// advertises that ver) but the hash-keyed cache stays warm for any
+// future session.
+//
+// Wire-observable check: alice teaches the server about ver, alice
+// disconnects, alice reconnects on a fresh resource and re-advertises
+// the same ver. The server MUST hit the cache and skip disco#info.
+
+#[tokio::test]
+async fn caps_cache_survives_publisher_disconnect_for_cross_session_reuse() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-warm-1").await;
+    let admin_full_jid_1 = admin.full_jid.clone().expect("full jid 1");
+
+    let node = "https://example.test/caps#warm";
+    let features = ["http://jabber.org/protocol/disco#info"];
+    let ver = caps_verification_string("client", "pc", "Warm Client", &features);
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send caps presence");
+
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid_1}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="Warm Client"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("admin replies");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Disconnect — exercises the resource→ver cleanup path. The
+    // hash-keyed cache MUST persist.
+    let _ = admin.close().await;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Reconnect on a FRESH resource and re-advertise the same ver.
+    let mut admin2 = admin_client(&server, "caps-warm-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 sends caps");
+
+    let timed = tokio::time::timeout(
+        Duration::from_millis(500),
+        admin2.recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        timed.is_err(),
+        "after publisher disconnects, cache MUST stay warm; \
+         the next presence with the same ver should be a hit, got: {timed:?}"
+    );
+
+    let _ = admin2.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -293,6 +293,73 @@ async fn caps_mismatched_hash_reply_is_rejected_and_not_cached() {
 }
 
 // ============================================================================
+// Test 3b — caps_iq_error_reply_is_not_cached_and_re_resolves
+// ============================================================================
+//
+// XEP-0115 §5.4: a disco#info IQ-error reply is not a verifiable
+// caps assertion. The recipient MUST NOT cache anything and the next
+// advertisement of the same `(hash, ver)` MUST re-resolve.
+
+#[tokio::test]
+async fn caps_iq_error_reply_is_not_cached_and_re_resolves() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-iqerr-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("full jid");
+
+    let node = "https://example.test/caps#iq-error";
+    let features = ["urn:xmpp:ping"];
+    let ver = caps_verification_string("client", "pc", "Erroring Client", &features);
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send caps presence");
+
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+
+    // Reply with an IQ error instead of a result.
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="error" id="{iq_id}" from="{admin_full_jid}"><error type="cancel"><service-unavailable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/></error></iq>"#
+        ))
+        .await
+        .expect("admin replies with IQ error");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let mut admin2 = admin_client(&server, "caps-iqerr-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 sends caps");
+
+    let _re_query = admin2
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("IQ error MUST NOT populate cache; next advert MUST re-resolve");
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+}
+
+// ============================================================================
 // Test 4 — caps_cache_survives_publisher_disconnect_for_cross_session_reuse
 // ============================================================================
 //

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -70,6 +70,71 @@ fn caps_verification_string(
     compute_caps_hash(&identities, &features)
 }
 
+/// XEP-0115 §5.1 with one XEP-0128 form. The wire-test for the
+/// software-info form path needs the server's hash to incorporate
+/// the form so the verification matches.
+fn caps_verification_string_with_softwareinfo_form(
+    identity_category: &str,
+    identity_type: &str,
+    identity_name: &str,
+    features: &[&str],
+    form_type: &str,
+    software: &str,
+) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash_with_extensions;
+    use xmpp_parsers::minidom::Element;
+
+    let identities = vec![Identity::new(
+        identity_category,
+        identity_type,
+        Some(identity_name),
+    )];
+    let features: Vec<Feature> = features.iter().map(|f| Feature::new(f)).collect();
+    let form = Element::builder("x", "jabber:x:data")
+        .attr("type", "result")
+        .append(
+            Element::builder("field", "jabber:x:data")
+                .attr("var", "FORM_TYPE")
+                .attr("type", "hidden")
+                .append(
+                    Element::builder("value", "jabber:x:data")
+                        .append(form_type)
+                        .build(),
+                )
+                .build(),
+        )
+        .append(
+            Element::builder("field", "jabber:x:data")
+                .attr("var", "software")
+                .append(
+                    Element::builder("value", "jabber:x:data")
+                        .append(software)
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+    compute_caps_hash_with_extensions(&identities, &features, std::slice::from_ref(&form))
+}
+
+/// Send a ping IQ and wait for its result. Used as a deterministic
+/// FIFO anchor for "MUST NOT receive frame X" assertions: anything
+/// that would have arrived before the ping reply has been emitted
+/// by the server when the ping result lands.
+async fn ping_anchor(client: &mut WsXmppClient, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="get" id="{id}"><ping xmlns="urn:xmpp:ping"/></iq>"#
+        ))
+        .await
+        .expect("send ping");
+    let _ = client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("ping result");
+}
+
 // ============================================================================
 // Test 1 — caps_unknown_ver_triggers_disco_info_to_full_jid
 // ============================================================================
@@ -444,4 +509,240 @@ async fn caps_cache_survives_publisher_disconnect_for_cross_session_reuse() {
     );
 
     let _ = admin2.close().await;
+}
+
+// ============================================================================
+// Test 5 — caps_reply_with_xep0128_form_verifies_and_caches
+// ============================================================================
+//
+// XEP-0128 / XEP-0115 §5.1: disco#info responses MAY include
+// `<x xmlns="jabber:x:data" type="result">` extension forms whose
+// FORM_TYPE values participate in the verification string. Real-world
+// clients (Gajim, Dino, Conversations) emit a `urn:xmpp:dataforms:softwareinfo`
+// form by default. PR #438's adversarial review (issue #1) flagged
+// that the previous fix was unit-tested only — this test exercises
+// the same path end-to-end over the wire.
+#[tokio::test]
+async fn caps_reply_with_xep0128_form_verifies_and_caches() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-form-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("full jid");
+
+    let node = "https://example.test/caps#form";
+    let features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let form_type = "urn:xmpp:dataforms:softwareinfo";
+    let software = "Waddle Test Client";
+    let ver = caps_verification_string_with_softwareinfo_form(
+        "client",
+        "pc",
+        "Form Client",
+        &features,
+        form_type,
+        software,
+    );
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send presence with caps");
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    let form_xml = format!(
+        r#"<x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE" type="hidden"><value>{form_type}</value></field><field var="software"><value>{software}</value></field></x>"#
+    );
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="Form Client"/>{feature_xml}{form_xml}</query></iq>"#
+        ))
+        .await
+        .expect("admin replies with form-bearing disco#info");
+
+    // Anchor: ping result confirms the disco#info reply was processed
+    // by the server's frame loop in FIFO order.
+    ping_anchor(&mut admin, "caps-form-anchor-1").await;
+
+    // A second resource advertising the same ver MUST be a cache hit.
+    let mut admin2 = admin_client(&server, "caps-form-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 sends caps");
+    ping_anchor(&mut admin2, "caps-form-anchor-2").await;
+
+    let timed = tokio::time::timeout(
+        Duration::from_millis(50),
+        admin2.recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        timed.is_err(),
+        "form-bearing reply MUST recompute correctly per XEP-0128 + §5.1 \
+         and populate the cache; second advert should be a hit. Got: {timed:?}"
+    );
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+}
+
+// ============================================================================
+// Test 6 — caps_unsupported_hash_algorithm_skips_resolution
+// ============================================================================
+//
+// XEP-0115 §5.4 step 2 + §8.1: the recipient MUST NOT cache a
+// result it cannot verify. SHA-1 is the only mandatory-to-implement
+// algorithm; for any other `hash` attribute the server skips the
+// disco#info round-trip rather than produce an unverifiable cache
+// entry.
+#[tokio::test]
+async fn caps_unsupported_hash_algorithm_skips_resolution() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-unsupp-1").await;
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-256" node="https://example.test/caps#sha256" ver="some-base64-string"/></presence>"#
+        ))
+        .await
+        .expect("send presence with sha-256 caps");
+    ping_anchor(&mut admin, "caps-unsupp-anchor-1").await;
+
+    let timed = tokio::time::timeout(
+        Duration::from_millis(50),
+        admin.recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        timed.is_err(),
+        "advertised sha-256 hash MUST NOT trigger a disco#info round-trip; \
+         the server has no way to verify the reply per §5.4 step 2. Got: {timed:?}"
+    );
+
+    let _ = admin.close().await;
+}
+
+// ============================================================================
+// Test 7 — caps_cache_is_not_poisoned_after_mismatched_reply
+// ============================================================================
+//
+// PR #438 review issue #10 hardening: confirm Test 3's "the cache
+// wasn't populated" claim by driving a *third* resource through a
+// successful resolution and verifying the cache then carries the
+// CORRECT identity/feature set, not the earlier poisoned payload.
+#[tokio::test]
+async fn caps_cache_is_not_poisoned_after_mismatched_reply() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-poison2-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("full");
+
+    let node = "https://example.test/caps#poison2";
+    let features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let ver = caps_verification_string("client", "pc", "Honest Client", &features);
+
+    // Round 1: poisoned reply — features won't recompute to ver.
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send presence");
+    let q = admin
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("disco");
+    let id = extract_iq_id(&q);
+    let bogus_xml = r#"<feature var="urn:xmpp:malicious"/>"#;
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="Honest Client"/>{bogus_xml}</query></iq>"#
+        ))
+        .await
+        .expect("send poisoned reply");
+    ping_anchor(&mut admin, "caps-poison2-anchor-1").await;
+
+    // Round 2: a fresh resource advertises the same ver. Server MUST
+    // re-resolve (cache should be empty for this ver).
+    let mut admin2 = admin_client(&server, "caps-poison2-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send presence");
+    let q2 = admin2
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("re-resolve fired");
+    let id2 = extract_iq_id(&q2);
+
+    // This time send the CORRECT reply.
+    let admin2_full_jid = admin2.full_jid.clone().expect("admin2 full");
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    admin2
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{id2}" from="{admin2_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="Honest Client"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("send correct reply");
+    ping_anchor(&mut admin2, "caps-poison2-anchor-2").await;
+
+    // Round 3: verify the cache now carries the correct features by
+    // having yet another resource hit the cache (no disco#info).
+    let mut admin3 = admin_client(&server, "caps-poison2-3").await;
+    admin3
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send presence");
+    ping_anchor(&mut admin3, "caps-poison2-anchor-3").await;
+    let timed = tokio::time::timeout(
+        Duration::from_millis(50),
+        admin3.recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        timed.is_err(),
+        "after a poisoned reply followed by a CORRECT reply, the cache MUST \
+         carry the correct (non-poisoned) entry; subsequent advert is a hit. Got: {timed:?}"
+    );
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+    let _ = admin3.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -184,8 +184,6 @@ async fn caps_unknown_ver_triggers_disco_info_to_full_jid() {
     );
 
     let _ = admin.close().await;
-    let _ = server;
-    let _ = Duration::from_secs(1);
 }
 
 // ============================================================================
@@ -745,4 +743,142 @@ async fn caps_cache_is_not_poisoned_after_mismatched_reply() {
     let _ = admin.close().await;
     let _ = admin2.close().await;
     let _ = admin3.close().await;
+}
+
+// ============================================================================
+// Test 8 — caps_multi_resource_independent_tracking
+// ============================================================================
+//
+// PR description (PR 1) and CLAUDE.md hard rule require: per-resource
+// caps tracking is independent. Two resources of the same user
+// advertising DIFFERENT `ver` values MUST resolve independently and
+// neither resolution should pollute the other's cache entry. This is
+// the test the original PR description named but did not include.
+#[tokio::test]
+async fn caps_multi_resource_independent_tracking() {
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", &bob_password)]);
+
+    // Two resources of the SAME user, each advertising a distinct
+    // `(node, ver)` so their caps must be tracked separately.
+    let mut admin = admin_client(&server, "caps-multi-admin").await;
+    let admin_full = admin.full_jid.clone().expect("admin full");
+    let mut bob = extra_client(&server, "bob", &bob_password, "caps-multi-bob").await;
+    let bob_full = bob.full_jid.clone().expect("bob full");
+
+    let admin_features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let bob_features = [
+        "http://jabber.org/protocol/disco#info",
+        "urn:xmpp:carbons:2",
+    ];
+    let admin_node = "https://example.test/caps#admin";
+    let bob_node = "https://example.test/caps#bob";
+    let admin_ver = caps_verification_string("client", "pc", "Admin Client", &admin_features);
+    let bob_ver = caps_verification_string("client", "phone", "Bob Client", &bob_features);
+
+    // Each resource advertises its own caps. The server MUST issue a
+    // separate disco#info to each resource (no cross-pollution).
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{admin_node}" ver="{admin_ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin presence");
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{bob_node}" ver="{bob_ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob presence");
+
+    let admin_query = admin
+        .recv_matching(|f| {
+            f.contains("<iq")
+                && f.contains(r#"type="get""#)
+                && f.contains(NS_DISCO_INFO)
+                && f.contains(&format!(r#"node="{admin_node}#{admin_ver}""#))
+        })
+        .await
+        .expect("admin disco");
+    let admin_id = extract_iq_id(&admin_query);
+    let bob_query = bob
+        .recv_matching(|f| {
+            f.contains("<iq")
+                && f.contains(r#"type="get""#)
+                && f.contains(NS_DISCO_INFO)
+                && f.contains(&format!(r#"node="{bob_node}#{bob_ver}""#))
+        })
+        .await
+        .expect("bob disco");
+    let bob_id = extract_iq_id(&bob_query);
+
+    let admin_feature_xml: String = admin_features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    let bob_feature_xml: String = bob_features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{admin_id}" from="{admin_full}"><query xmlns="{NS_DISCO_INFO}" node="{admin_node}#{admin_ver}"><identity category="client" type="pc" name="Admin Client"/>{admin_feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("admin reply");
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{bob_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{bob_node}#{bob_ver}"><identity category="client" type="phone" name="Bob Client"/>{bob_feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob reply");
+
+    ping_anchor(&mut admin, "caps-multi-anchor-1").await;
+    ping_anchor(&mut bob, "caps-multi-anchor-2").await;
+
+    // Confirm independent caching: a third resource advertising the
+    // admin ver hits the cache (no disco#info), and a fourth resource
+    // advertising bob's ver also hits independently.
+    let mut admin2 = admin_client(&server, "caps-multi-admin2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{admin_node}" ver="{admin_ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 presence");
+    ping_anchor(&mut admin2, "caps-multi-anchor-3").await;
+    let admin2_timed = tokio::time::timeout(
+        Duration::from_millis(50),
+        admin2.recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        admin2_timed.is_err(),
+        "admin's ver MUST be independently cached (no second disco#info): {admin2_timed:?}"
+    );
+
+    let mut bob2 = extra_client(&server, "bob", &bob_password, "caps-multi-bob2").await;
+    bob2.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{bob_node}" ver="{bob_ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob2 presence");
+    ping_anchor(&mut bob2, "caps-multi-anchor-4").await;
+    let bob2_timed = tokio::time::timeout(
+        Duration::from_millis(50),
+        bob2.recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        }),
+    )
+    .await;
+    assert!(
+        bob2_timed.is_err(),
+        "bob's ver MUST be independently cached: {bob2_timed:?}"
+    );
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+    let _ = bob.close().await;
+    let _ = bob2.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0163_pep_ws.rs
+++ b/server/crates/waddle-server/tests/xep0163_pep_ws.rs
@@ -537,6 +537,26 @@ fn extract_iq_id(frame: &str) -> String {
     extract_attr_after(frame, "<iq", "id").expect("iq has id attribute")
 }
 
+/// Send a ping IQ and wait for its result. Used as a deterministic
+/// FIFO anchor in place of `tokio::time::sleep` for "the prior frame
+/// has been processed" assertions: anything the server emitted before
+/// the ping reply (e.g. caps-disco round-trip completion, fan-out
+/// dispatch) is already in the client's recv queue when the ping
+/// result lands. Mirrors the anchor pattern in
+/// `tests/xep0115_caps_ws.rs`.
+async fn ping_anchor(client: &mut WsXmppClient, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="get" id="{id}"><ping xmlns="urn:xmpp:ping"/></iq>"#
+        ))
+        .await
+        .expect("send ping");
+    let _ = client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("ping result");
+}
+
 /// Establish bob -> alice presence subscription so alice's roster
 /// has bob with `subscription = from` (alice's PEP fan-out target).
 async fn establish_bob_subscribes_to_alice(
@@ -644,7 +664,11 @@ async fn pep_publish_fans_to_roster_contacts_with_matching_caps_notify() {
     .await
     .expect("bob disco#info reply");
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    ping_anchor(
+        &mut bob,
+        &format!("pep-bob-anchor-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
 
     let pub_resp = iq_set_to(
         &mut alice,
@@ -754,7 +778,11 @@ async fn pep_publish_skips_roster_contact_without_caps_notify_filter() {
     .await
     .expect("bob disco#info reply");
 
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    ping_anchor(
+        &mut bob,
+        &format!("pep-bob-anchor-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
 
     let pub_resp = iq_set_to(
         &mut alice,
@@ -897,7 +925,16 @@ async fn pep_publish_targets_only_resources_advertising_notify_filter() {
         .await
         .expect("bob-B disco#info reply");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    ping_anchor(
+        &mut bob_a,
+        &format!("pep-multi-anchor-a-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
+    ping_anchor(
+        &mut bob_b,
+        &format!("pep-multi-anchor-b-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
 
     let pub_resp = iq_set_to(
         &mut alice,
@@ -1034,7 +1071,11 @@ async fn pep_publish_delivers_exactly_once_when_subscriber_also_in_roster() {
     .await
     .expect("bob disco#info reply");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    ping_anchor(
+        &mut bob,
+        &format!("pep-bob-anchor-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
 
     let pub_resp = iq_set_to(
         &mut alice,
@@ -1140,7 +1181,11 @@ async fn pep_publish_fans_to_owner_other_resources_with_caps_notify() {
         .await
         .expect("alice-B disco#info reply");
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    ping_anchor(
+        &mut alice_b,
+        &format!("pep-self-anchor-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
 
     let pub_resp = iq_set_to(
         &mut alice_a,
@@ -1162,4 +1207,292 @@ async fn pep_publish_fans_to_owner_other_resources_with_caps_notify() {
 
     let _ = alice_a.close().await;
     let _ = alice_b.close().await;
+}
+
+// ============================================================================
+// XEP-0163 §3 + XEP-0191 — blocking guards on PEP fan-out
+// ============================================================================
+//
+// XEP-0191 §2 + XEP-0163 §3.3: a PEP service MUST NOT deliver a
+// notification when either party has blocked the other. The fan-out
+// honors the block in BOTH directions.
+//
+// PR #439 review issue #4: the fixup commit added the both-direction
+// blocking check, but the test suite had no coverage for it.
+//
+// Helper: drive an XEP-0191 block from `blocker` (already connected
+// + roster-interested) targeting `target`. Returns once the IQ-set
+// result lands.
+async fn xep0191_block(client: &mut WsXmppClient, target_bare: &str, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="set" id="{id}"><block xmlns="urn:xmpp:blocking"><item jid="{target_bare}"/></block></iq>"#
+        ))
+        .await
+        .expect("send block IQ");
+    let _ = client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("block IQ result");
+}
+
+#[tokio::test]
+async fn pep_publish_skips_blocked_roster_contact() {
+    // alice publishes; bob is in alice's roster (subscription=from)
+    // and advertises +notify, but alice has explicitly blocked bob.
+    // §3.3 + XEP-0191 §2: bob MUST NOT receive the event.
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-block-1",
+    )
+    .await
+    .expect("alice");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-block-1",
+    )
+    .await
+    .expect("bob");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    // Bob advertises +notify so the only path that COULD deliver to
+    // him is the §3 roster pass — which the block must veto.
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{publish_node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://bob.example/blocked";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob caps");
+    let q = bob
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries bob");
+    let qid = extract_iq_id(&q);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{qid}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco reply");
+    ping_anchor(&mut bob, "pep-block-anchor-bob-caps").await;
+
+    // Alice blocks bob.
+    xep0191_block(&mut alice, &bob_bare, "pep-block-1").await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-block-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="blocked-1"><conference xmlns="{publish_node}" name="Blocked"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    // Use bob's own ping reply as the FIFO anchor: by the time the
+    // ping result arrives, the fan-out for the publish has already
+    // been emitted (or skipped).
+    ping_anchor(&mut bob, "pep-block-anchor-pub").await;
+    let event = wait_for_event_message(&mut bob, publish_node, Duration::from_millis(200)).await;
+    assert!(
+        event.is_none(),
+        "alice blocked bob: bob MUST NOT receive PEP event per §3.3 + XEP-0191 §2; got: {event:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn pep_publish_skips_when_contact_blocked_publisher() {
+    // bob blocks alice. Alice publishes. bob is in alice's roster
+    // (subscription=from) and advertises +notify. §3.3 + XEP-0191 §2:
+    // bob MUST NOT receive the event because the contact->publisher
+    // direction is also a block.
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-block-2",
+    )
+    .await
+    .expect("alice");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-block-2",
+    )
+    .await
+    .expect("bob");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{publish_node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://bob.example/contact-blocks";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob caps");
+    let q = bob
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries bob");
+    let qid = extract_iq_id(&q);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{qid}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco reply");
+    ping_anchor(&mut bob, "pep-block2-anchor-bob-caps").await;
+
+    // Bob blocks alice (the publisher).
+    xep0191_block(&mut bob, &alice_bare, "pep-block-2-rev").await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-block2-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="contact-blocks-1"><conference xmlns="{publish_node}" name="ContactBlocks"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    ping_anchor(&mut bob, "pep-block2-anchor-pub").await;
+    let event = wait_for_event_message(&mut bob, publish_node, Duration::from_millis(200)).await;
+    assert!(
+        event.is_none(),
+        "bob blocked alice: §3.3 + XEP-0191 §2 require skipping; got: {event:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+// ============================================================================
+// PR #439 review issue #3 — publishing resource MUST NOT receive a self-echo
+// ============================================================================
+#[tokio::test]
+async fn pep_publish_does_not_echo_to_publishing_resource() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-noecho-1",
+    )
+    .await
+    .expect("alice");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let alice_full = alice.full_jid.clone().expect("alice full jid");
+
+    // Alice advertises +notify on her publishing resource.
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{publish_node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://alice.example/noecho";
+    let ver = caps_verification_string("client", "pc", "Alice", &features);
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    alice
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("alice caps presence");
+    let q = alice
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries alice");
+    let qid = extract_iq_id(&q);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    alice
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{qid}" from="{alice_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Alice"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("alice disco reply");
+    ping_anchor(&mut alice, "pep-noecho-anchor-1").await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-noecho-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="echo-1"><conference xmlns="{publish_node}" name="Echo"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    ping_anchor(&mut alice, "pep-noecho-anchor-2").await;
+    let event = wait_for_event_message(&mut alice, publish_node, Duration::from_millis(200)).await;
+    assert!(
+        event.is_none(),
+        "publishing resource MUST NOT receive its own item back as a §3.4 self-echo; got: {event:?}"
+    );
+
+    let _ = alice.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0163_pep_ws.rs
+++ b/server/crates/waddle-server/tests/xep0163_pep_ws.rs
@@ -501,3 +501,431 @@ async fn pep_publish_fans_event_with_owner_jid_as_from() {
     let _ = bob.close().await;
     let _ = admin.close().await;
 }
+
+// ============================================================================
+// XEP-0163 §3 — presence-driven roster + CAPS fan-out (RFC 363 PR 2)
+// ============================================================================
+//
+// The §3 contract: when a user publishes a PEP item, the server
+// delivers <message><event> to every entity that has roster
+// `subscription = from` or `both` to the publisher AND advertises
+// `<node>+notify` in cached CAPS. There is NO explicit pubsub
+// <subscribe/> involved — roster + CAPS is the filter.
+
+const NS_CAPS: &str = "http://jabber.org/protocol/caps";
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+fn caps_verification_string(
+    identity_category: &str,
+    identity_type: &str,
+    identity_name: &str,
+    features: &[&str],
+) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash;
+    let identities = vec![Identity::new(
+        identity_category,
+        identity_type,
+        Some(identity_name),
+    )];
+    let features: Vec<Feature> = features.iter().map(|f| Feature::new(f)).collect();
+    compute_caps_hash(&identities, &features)
+}
+
+fn extract_iq_id(frame: &str) -> String {
+    use ws_common::extract_attr_after;
+    extract_attr_after(frame, "<iq", "id").expect("iq has id attribute")
+}
+
+/// Establish bob -> alice presence subscription so alice's roster
+/// has bob with `subscription = from` (alice's PEP fan-out target).
+async fn establish_bob_subscribes_to_alice(
+    alice: &mut WsXmppClient,
+    bob: &mut WsXmppClient,
+    alice_bare: &str,
+    bob_bare: &str,
+) {
+    alice
+        .send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-a"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("alice roster get");
+    let _ = alice
+        .recv_matching(|f| f.contains("roster-init-a"))
+        .await
+        .expect("alice roster result");
+    bob.send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-b"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("bob roster get");
+    let _ = bob
+        .recv_matching(|f| f.contains("roster-init-b"))
+        .await
+        .expect("bob roster result");
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client" type="subscribe" to="{alice_bare}"/>"#
+    ))
+    .await
+    .expect("bob subscribes");
+    let _subscribe = alice
+        .recv_matching(|f| f.contains(r#"type="subscribe""#))
+        .await
+        .expect("alice receives subscribe");
+    alice
+        .send(&format!(
+            r#"<presence xmlns="jabber:client" type="subscribed" to="{bob_bare}"/>"#
+        ))
+        .await
+        .expect("alice approves");
+    let _subscribed = bob
+        .recv_matching(|f| f.contains(r#"type="subscribed""#))
+        .await
+        .expect("bob receives approval");
+}
+
+#[tokio::test]
+async fn pep_publish_fans_to_roster_contacts_with_matching_caps_notify() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-r1",
+    )
+    .await
+    .expect("alice connect");
+    let mut bob =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "bob", &bob_password, "bob-r1")
+            .await
+            .expect("bob connect");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    let node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://bob.example/caps";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob presence with caps");
+    let disco_query = bob
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries bob caps");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco#info reply");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-roster-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{node}"><item id="bm-roster-1"><conference xmlns="{node}" name="Roster Fanout"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, node, Duration::from_secs(2))
+        .await
+        .expect(
+            "bob in alice's roster (subscription=from) and advertising +notify MUST receive the PEP event without explicit pubsub <subscribe/> per XEP-0163 §3",
+        );
+    assert!(
+        event.contains(&format!(r#"from="{alice_bare}""#))
+            || event.contains(&format!(r#"from='{alice_bare}'"#)),
+        "fan-out from MUST be alice's bare JID per XEP-0163 §4.3: {event}"
+    );
+    assert!(
+        event.contains(r#"id="bm-roster-1""#),
+        "item id must round-trip: {event}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+// ============================================================================
+// XEP-0163 §3 — roster contact without `+notify` MUST NOT receive
+// ============================================================================
+//
+// Roster `subscription = from/both` is necessary but not sufficient.
+// A contact whose cached CAPS do not include `<node>+notify` MUST NOT
+// receive the event. Without this filter the server would spam every
+// roster contact for every PEP node, defeating the entire point of
+// XEP-0115's selective subscription model.
+
+#[tokio::test]
+async fn pep_publish_skips_roster_contact_without_caps_notify_filter() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-no-notify-1",
+    )
+    .await
+    .expect("alice");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-no-notify-1",
+    )
+    .await
+    .expect("bob");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    // Bob advertises caps, but with NO `+notify` filter for the
+    // node alice will publish to.
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let features = [
+        "http://jabber.org/protocol/disco#info",
+        // Notice: no urn:xmpp:bookmarks:1+notify
+        "urn:xmpp:ping",
+    ];
+    let caps_node = "https://bob.example/caps-no-notify";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob presence with caps");
+    let disco_query = bob
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type="get""#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries bob caps");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco#info reply");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-no-notify-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="silent-1"><conference xmlns="{publish_node}" name="Should Not See"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, publish_node, Duration::from_millis(700)).await;
+    assert!(
+        event.is_none(),
+        "bob without `<node>+notify` MUST NOT receive the PEP event; got: {event:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+// ============================================================================
+// XEP-0163 §3 — per-resource semantics: only resources with the
+// matching +notify receive
+// ============================================================================
+//
+// A user with multiple resources MUST receive the event only on the
+// resources whose cached CAPS include the matching `+notify`. The
+// non-advertising resource is skipped, not delivered-to-and-ignored.
+// This matters because resources may legitimately advertise different
+// feature sets (web vs mobile vs CLI) — fan-out must respect each
+// resource's CAPS independently.
+
+#[tokio::test]
+async fn pep_publish_targets_only_resources_advertising_notify_filter() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-multi-1",
+    )
+    .await
+    .expect("alice");
+    let mut bob_a = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-resource-A",
+    )
+    .await
+    .expect("bob-A");
+    let mut bob_b = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-resource-B",
+    )
+    .await
+    .expect("bob-B");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_a_full = bob_a.full_jid.clone().expect("bob-A jid");
+    let bob_b_full = bob_b.full_jid.clone().expect("bob-B jid");
+
+    // Subscription handshake from bob-A (any resource is sufficient
+    // to make alice's roster have bob with subscription=from).
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob_a, &alice_bare, &bob_bare).await;
+    bob_b
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob-B presence");
+
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{publish_node}+notify");
+
+    // Resource A: advertises +notify
+    let a_features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let a_caps_node = "https://bob.example/A";
+    let a_ver = caps_verification_string("client", "pc", "Bob A", &a_features);
+    bob_a
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{a_caps_node}" ver="{a_ver}"/></presence>"#
+        ))
+        .await
+        .expect("bob-A presence with caps");
+    let a_query = bob_a
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("disco#info to bob-A");
+    let a_id = extract_iq_id(&a_query);
+    let a_features_xml: String = a_features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob_a
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{a_id}" from="{bob_a_full}"><query xmlns="{NS_DISCO_INFO}" node="{a_caps_node}#{a_ver}"><identity category="client" type="pc" name="Bob A"/>{a_features_xml}</query></iq>"#
+        ))
+        .await
+        .expect("bob-A disco#info reply");
+
+    // Resource B: NO +notify
+    let b_features = ["http://jabber.org/protocol/disco#info", "urn:xmpp:ping"];
+    let b_caps_node = "https://bob.example/B";
+    let b_ver = caps_verification_string("client", "pc", "Bob B", &b_features);
+    bob_b
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{b_caps_node}" ver="{b_ver}"/></presence>"#
+        ))
+        .await
+        .expect("bob-B presence with caps");
+    let b_query = bob_b
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("disco#info to bob-B");
+    let b_id = extract_iq_id(&b_query);
+    let b_features_xml: String = b_features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob_b
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{b_id}" from="{bob_b_full}"><query xmlns="{NS_DISCO_INFO}" node="{b_caps_node}#{b_ver}"><identity category="client" type="pc" name="Bob B"/>{b_features_xml}</query></iq>"#
+        ))
+        .await
+        .expect("bob-B disco#info reply");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-multi-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="multi-1"><conference xmlns="{publish_node}" name="Multi Resource"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let a_event = wait_for_event_message(&mut bob_a, publish_node, Duration::from_secs(2))
+        .await
+        .expect("resource A advertising +notify MUST receive the event");
+    assert!(
+        a_event.contains(r#"id="multi-1""#),
+        "item id must round-trip on A: {a_event}"
+    );
+
+    let b_event =
+        wait_for_event_message(&mut bob_b, publish_node, Duration::from_millis(700)).await;
+    assert!(
+        b_event.is_none(),
+        "resource B without +notify MUST NOT receive the event (per-resource §3 semantics): {b_event:?}"
+    );
+
+    let _ = bob_a.close().await;
+    let _ = bob_b.close().await;
+    let _ = alice.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0163_pep_ws.rs
+++ b/server/crates/waddle-server/tests/xep0163_pep_ws.rs
@@ -929,3 +929,237 @@ async fn pep_publish_targets_only_resources_advertising_notify_filter() {
     let _ = bob_b.close().await;
     let _ = alice.close().await;
 }
+
+// ============================================================================
+// XEP-0163 §3 — overlap dedup: explicit subscriber + roster + +notify
+// ============================================================================
+//
+// A roster contact who is also an explicit pubsub subscriber AND
+// advertises +notify must receive exactly ONE event, not two. The
+// already_delivered HashSet inside fan_out_publish is the dedup seam.
+
+#[tokio::test]
+async fn pep_publish_delivers_exactly_once_when_subscriber_also_in_roster() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-dedup-1",
+    )
+    .await
+    .expect("alice");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-dedup-1",
+    )
+    .await
+    .expect("bob");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+
+    // Alice opens an open-access PEP node so bob can both subscribe AND
+    // satisfy presence-driven §3 fan-out.
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let r1 = iq_set_to(
+        &mut alice,
+        "pep-dedup-create",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="seed"/></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(r1.contains(r#"type="result""#), "create: {r1}");
+    let cfg = iq_set_to(
+        &mut alice,
+        "pep-dedup-cfg",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{publish_node}"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>open</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(cfg.contains(r#"type="result""#), "configure: {cfg}");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    // Bob explicitly subscribes via XEP-0060.
+    let sub = iq_set_to(
+        &mut bob,
+        "pep-dedup-sub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="{publish_node}" jid="{bob_bare}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(sub.contains(r#"type="result""#), "subscribe: {sub}");
+
+    // Bob also advertises +notify in CAPS.
+    let notify_var = format!("{publish_node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://bob.example/dedup";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob caps presence");
+    let disco_query = bob
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("disco#info to bob");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco#info reply");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-dedup-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="dedup-1"><conference xmlns="{publish_node}" name="Dedup"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let first = wait_for_event_message(&mut bob, publish_node, Duration::from_secs(2))
+        .await
+        .expect("bob (subscriber+roster+notify) MUST receive at least one event");
+    assert!(
+        first.contains(r#"id="dedup-1""#),
+        "expected dedup-1: {first}"
+    );
+
+    let second = wait_for_event_message(&mut bob, publish_node, Duration::from_millis(700)).await;
+    assert!(
+        second.is_none(),
+        "MUST receive exactly one event when both subscriber AND roster paths apply; got duplicate: {second:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+// ============================================================================
+// XEP-0163 §3.4 / PEP §4.2 — owner's other resources receive too
+// ============================================================================
+//
+// "Sending the Last Published Item" reaches "all appropriate
+// subscribers", which includes the account owner itself: when alice
+// publishes from /r1, alice/r2 must also receive the event so it can
+// keep its UI in sync with the publishing resource.
+
+#[tokio::test]
+async fn pep_publish_fans_to_owner_other_resources_with_caps_notify() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+    let mut alice_a = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-self-A",
+    )
+    .await
+    .expect("alice-A");
+    let mut alice_b = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-self-B",
+    )
+    .await
+    .expect("alice-B");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let alice_b_full = alice_b.full_jid.clone().expect("alice-B full jid");
+
+    // Both resources go presence-available.
+    alice_a
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice-A presence");
+    alice_b
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice-B presence");
+
+    let publish_node = "urn:xmpp:bookmarks:1";
+    let notify_var = format!("{publish_node}+notify");
+    let features = ["http://jabber.org/protocol/disco#info", notify_var.as_str()];
+    let caps_node = "https://alice.example/caps";
+    let ver = caps_verification_string("client", "pc", "Alice B", &features);
+
+    alice_b
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("alice-B presence with caps");
+    let disco_query = alice_b
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type="get""#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("disco#info to alice-B");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    alice_b
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{alice_b_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Alice B"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("alice-B disco#info reply");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let pub_resp = iq_set_to(
+        &mut alice_a,
+        "pep-self-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{publish_node}"><item id="self-1"><conference xmlns="{publish_node}" name="Self Sync"/></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type="result""#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut alice_b, publish_node, Duration::from_secs(2))
+        .await
+        .expect(
+            "alice-B advertising +notify MUST receive PEP event from alice-A's publish per §3.4",
+        );
+    assert!(event.contains(r#"id="self-1""#), "item id: {event}");
+
+    let _ = alice_a.close().await;
+    let _ = alice_b.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -123,6 +123,82 @@ pub fn parse_disco_info_query(iq: &Iq) -> Result<DiscoInfoQuery, CoreError> {
     Ok(DiscoInfoQuery { target, node })
 }
 
+/// Parsed disco#info response payload.
+///
+/// The `<query xmlns="http://jabber.org/protocol/disco#info">` element
+/// returned in an IQ result. XEP-0030 lists `<identity/>` and
+/// `<feature/>` children; XEP-0128 adds `<x xmlns="jabber:x:data"/>`
+/// extension forms whose typed handling lives elsewhere — this parser
+/// surfaces only identities and features, sufficient for XEP-0115
+/// hash recomputation against the no-form fallback path.
+#[derive(Debug, Clone)]
+pub struct DiscoInfoResponse {
+    pub node: Option<String>,
+    pub identities: Vec<Identity>,
+    pub features: Vec<Feature>,
+}
+
+/// Parse the `<query/>` element of a disco#info IQ result into typed
+/// identities + features.
+pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, CoreError> {
+    if query.name() != "query" || query.ns() != DISCO_INFO_NS {
+        return Err(CoreError::bad_request(Some(
+            "disco#info response payload is not a <query/> element".to_string(),
+        )));
+    }
+
+    let node = query.attr("node").map(str::to_string);
+    let mut identities = Vec::new();
+    let mut features = Vec::new();
+
+    for child in query.children() {
+        if child.ns() != DISCO_INFO_NS {
+            continue;
+        }
+        match child.name() {
+            "identity" => {
+                let category = child
+                    .attr("category")
+                    .ok_or_else(|| {
+                        CoreError::bad_request(Some(
+                            "disco#info <identity/> missing category".to_string(),
+                        ))
+                    })?
+                    .to_string();
+                let type_ = child
+                    .attr("type")
+                    .ok_or_else(|| {
+                        CoreError::bad_request(Some(
+                            "disco#info <identity/> missing type".to_string(),
+                        ))
+                    })?
+                    .to_string();
+                let lang = child.attr("xml:lang").map(str::to_string);
+                let name = child.attr("name").map(str::to_string);
+                identities.push(Identity {
+                    category,
+                    type_,
+                    lang,
+                    name,
+                });
+            }
+            "feature" => {
+                let var = child.attr("var").ok_or_else(|| {
+                    CoreError::bad_request(Some("disco#info <feature/> missing var".to_string()))
+                })?;
+                features.push(Feature::new(var));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(DiscoInfoResponse {
+        node,
+        identities,
+        features,
+    })
+}
+
 /// Build a disco#info response IQ.
 pub fn build_disco_info_response(
     original_iq: &Iq,

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -123,23 +123,31 @@ pub fn parse_disco_info_query(iq: &Iq) -> Result<DiscoInfoQuery, CoreError> {
     Ok(DiscoInfoQuery { target, node })
 }
 
+/// XEP-0004/XEP-0128 jabber:x:data namespace. A disco#info response
+/// MAY include one or more `<x xmlns="jabber:x:data" type="result">`
+/// extension forms (XEP-0128); their FORM_TYPE values participate in
+/// the XEP-0115 §5.1 verification string. Failing to feed them into
+/// the recomputation breaks hash verification for clients that emit
+/// software-info or capabilities forms.
+const NS_DATA_FORMS: &str = "jabber:x:data";
+
 /// Parsed disco#info response payload.
 ///
-/// The `<query xmlns="http://jabber.org/protocol/disco#info">` element
-/// returned in an IQ result. XEP-0030 lists `<identity/>` and
-/// `<feature/>` children; XEP-0128 adds `<x xmlns="jabber:x:data"/>`
-/// extension forms whose typed handling lives elsewhere — this parser
-/// surfaces only identities and features, sufficient for XEP-0115
-/// hash recomputation against the no-form fallback path.
+/// Surfaces identities, features, and any XEP-0128 `<x/>` extension
+/// elements verbatim so XEP-0115 §5.4 hash recomputation can run
+/// against the full input that produced the advertised `ver`.
 #[derive(Debug, Clone)]
 pub struct DiscoInfoResponse {
     pub node: Option<String>,
     pub identities: Vec<Identity>,
     pub features: Vec<Feature>,
+    /// XEP-0128 service-discovery extension forms preserved verbatim
+    /// (typically `<x xmlns="jabber:x:data" type="result">…</x>`).
+    pub extensions: Vec<Element>,
 }
 
 /// Parse the `<query/>` element of a disco#info IQ result into typed
-/// identities + features.
+/// identities + features + verbatim XEP-0128 extension forms.
 pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, CoreError> {
     if query.name() != "query" || query.ns() != DISCO_INFO_NS {
         return Err(CoreError::bad_request(Some(
@@ -150,13 +158,12 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
     let node = query.attr("node").map(str::to_string);
     let mut identities = Vec::new();
     let mut features = Vec::new();
+    let mut extensions = Vec::new();
 
     for child in query.children() {
-        if child.ns() != DISCO_INFO_NS {
-            continue;
-        }
-        match child.name() {
-            "identity" => {
+        let child_ns = child.ns();
+        match (child.name(), child_ns.as_str()) {
+            ("identity", ns) if ns == DISCO_INFO_NS => {
                 let category = child
                     .attr("category")
                     .ok_or_else(|| {
@@ -182,11 +189,14 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
                     name,
                 });
             }
-            "feature" => {
+            ("feature", ns) if ns == DISCO_INFO_NS => {
                 let var = child.attr("var").ok_or_else(|| {
                     CoreError::bad_request(Some("disco#info <feature/> missing var".to_string()))
                 })?;
                 features.push(Feature::new(var));
+            }
+            ("x", NS_DATA_FORMS) => {
+                extensions.push(child.clone());
             }
             _ => {}
         }
@@ -196,6 +206,7 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
         node,
         identities,
         features,
+        extensions,
     })
 }
 

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -136,6 +136,13 @@ const NS_DATA_FORMS: &str = "jabber:x:data";
 /// Surfaces identities, features, and any XEP-0128 `<x/>` extension
 /// elements verbatim so XEP-0115 §5.4 hash recomputation can run
 /// against the full input that produced the advertised `ver`.
+///
+/// `ill_formed` is true when the response violates one of XEP-0115
+/// §5.4 step 2.4's well-formedness rules — duplicate identities,
+/// duplicate features, or multi-FORM_TYPE extension forms. The
+/// parser still surfaces what it could read so callers can log
+/// diagnostics, but XEP-0115 verification MUST treat such a reply
+/// as invalid (do not cache).
 #[derive(Debug, Clone)]
 pub struct DiscoInfoResponse {
     pub node: Option<String>,
@@ -144,6 +151,7 @@ pub struct DiscoInfoResponse {
     /// XEP-0128 service-discovery extension forms preserved verbatim
     /// (typically `<x xmlns="jabber:x:data" type="result">…</x>`).
     pub extensions: Vec<Element>,
+    pub ill_formed: bool,
 }
 
 /// Parse the `<query/>` element of a disco#info IQ result into typed
@@ -159,6 +167,13 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
     let mut identities = Vec::new();
     let mut features = Vec::new();
     let mut extensions = Vec::new();
+    // §5.4 step 2.4 well-formedness tracking: duplicate identity
+    // tuples (category, type, xml:lang, name), duplicate feature
+    // vars, or multi-FORM_TYPE forms invalidate the entire response.
+    let mut seen_identities: std::collections::HashSet<(String, String, String, String)> =
+        std::collections::HashSet::new();
+    let mut seen_features: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut ill_formed = false;
 
     for child in query.children() {
         let child_ns = child.ns();
@@ -182,6 +197,15 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
                     .to_string();
                 let lang = child.attr("xml:lang").map(str::to_string);
                 let name = child.attr("name").map(str::to_string);
+                let key = (
+                    category.clone(),
+                    type_.clone(),
+                    lang.clone().unwrap_or_default(),
+                    name.clone().unwrap_or_default(),
+                );
+                if !seen_identities.insert(key) {
+                    ill_formed = true;
+                }
                 identities.push(Identity {
                     category,
                     type_,
@@ -193,9 +217,15 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
                 let var = child.attr("var").ok_or_else(|| {
                     CoreError::bad_request(Some("disco#info <feature/> missing var".to_string()))
                 })?;
+                if !seen_features.insert(var.to_string()) {
+                    ill_formed = true;
+                }
                 features.push(Feature::new(var));
             }
             ("x", NS_DATA_FORMS) => {
+                if has_multiple_form_types(child) {
+                    ill_formed = true;
+                }
                 extensions.push(child.clone());
             }
             _ => {}
@@ -207,7 +237,30 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
         identities,
         features,
         extensions,
+        ill_formed,
     })
+}
+
+/// XEP-0115 §5.4 step 2.4: a `<x type="result"/>` form with more than
+/// one FORM_TYPE field — or one FORM_TYPE field carrying more than
+/// one `<value/>` — is malformed. Either case invalidates the whole
+/// disco#info response.
+fn has_multiple_form_types(form: &Element) -> bool {
+    let mut form_type_fields = 0;
+    let mut form_type_values = 0;
+    for field in form.children().filter(|c| {
+        c.name() == "field" && c.ns() == NS_DATA_FORMS && c.attr("var") == Some("FORM_TYPE")
+    }) {
+        form_type_fields += 1;
+        for value in field
+            .children()
+            .filter(|c| c.name() == "value" && c.ns() == NS_DATA_FORMS)
+        {
+            form_type_values += 1;
+            let _ = value;
+        }
+    }
+    form_type_fields > 1 || form_type_values > 1
 }
 
 /// Build a disco#info response IQ.

--- a/server/crates/waddle-xmpp/Cargo.toml
+++ b/server/crates/waddle-xmpp/Cargo.toml
@@ -26,6 +26,7 @@ rxml = { workspace = true }
 
 # Concurrent Data Structures
 dashmap = { workspace = true }
+lru = { workspace = true }
 
 # TLS
 rustls = { workspace = true, features = ["ring"] }

--- a/server/crates/waddle-xmpp/src/disco/info.rs
+++ b/server/crates/waddle-xmpp/src/disco/info.rs
@@ -2,8 +2,9 @@
 
 pub use waddle_xmpp_core::disco::info::{
     build_disco_info_response, build_disco_info_response_with_extensions, is_disco_info_query,
-    muc_room_features, muc_service_features, pubsub_service_features, spaces_service_features,
-    upload_service_features, DiscoInfoQuery, Feature, Identity, DISCO_INFO_NS,
+    muc_room_features, muc_service_features, parse_disco_info_response, pubsub_service_features,
+    spaces_service_features, upload_service_features, DiscoInfoQuery, DiscoInfoResponse, Feature,
+    Identity, DISCO_INFO_NS,
 };
 use xmpp_parsers::iq::Iq;
 

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -15,7 +15,6 @@
 //! - <https://xmpp.org/extensions/xep-0115.html>
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use dashmap::DashMap;
 use minidom::Element;
 use sha1::{Digest, Sha1};
 use std::sync::Arc;
@@ -107,13 +106,51 @@ impl CachedDiscoInfo {
     }
 }
 
+/// Composite cache key that XEP-0115 §6 mandates: caching is per
+/// `(hash algorithm, verification string)`. Two clients advertising
+/// the same opaque `ver` under different hash families MUST not
+/// collide in the cache.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CapsCacheKey {
+    pub hash: String,
+    pub ver: String,
+}
+
+impl CapsCacheKey {
+    pub fn new(hash: impl Into<String>, ver: impl Into<String>) -> Self {
+        Self {
+            hash: hash.into(),
+            ver: ver.into(),
+        }
+    }
+
+    pub fn from_caps(caps: &Caps) -> Self {
+        Self::new(caps.hash.clone(), caps.ver.clone())
+    }
+}
+
+/// Default soft cap on cached `(hash, ver)` entries before the
+/// least-recently-used entry is evicted. XEP-0115 §6 RECOMMENDS
+/// long-lived caching, but unbounded growth from rotating client
+/// versions is operationally untenable. 10k entries is generous
+/// for typical deployments and bounded.
+pub const DEFAULT_CAPS_CACHE_CAPACITY: usize = 10_000;
+
 /// Cache for entity capabilities.
 ///
-/// Maps verification hashes to disco#info responses for efficient lookups.
-#[derive(Debug, Clone)]
+/// Keyed on `(hash, ver)` per XEP-0115 §6. Bounded by an LRU policy
+/// so a long-lived server with rotating client populations doesn't
+/// grow without bound.
+#[derive(Clone)]
 pub struct CapsCache {
-    /// Map from verification hash to disco#info data
-    cache: Arc<DashMap<String, CachedDiscoInfo>>,
+    inner: Arc<std::sync::Mutex<lru::LruCache<CapsCacheKey, CachedDiscoInfo>>>,
+}
+
+impl std::fmt::Debug for CapsCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.inner.lock().map(|g| g.len()).unwrap_or_default();
+        f.debug_struct("CapsCache").field("len", &len).finish()
+    }
 }
 
 impl Default for CapsCache {
@@ -123,47 +160,73 @@ impl Default for CapsCache {
 }
 
 impl CapsCache {
-    /// Create a new empty capabilities cache.
+    /// Create a new empty capabilities cache with the default LRU
+    /// capacity (`DEFAULT_CAPS_CACHE_CAPACITY`).
     pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPS_CACHE_CAPACITY)
+    }
+
+    /// Create a new empty capabilities cache with a custom LRU
+    /// capacity. Use this in tests to exercise the eviction policy.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let cap =
+            std::num::NonZeroUsize::new(capacity.max(1)).expect("max(1) above guarantees nonzero");
         Self {
-            cache: Arc::new(DashMap::new()),
+            inner: Arc::new(std::sync::Mutex::new(lru::LruCache::new(cap))),
         }
     }
 
-    /// Store disco#info for a capabilities hash.
-    pub fn insert(&self, hash: &str, info: CachedDiscoInfo) {
-        debug!(hash = %hash, identities = info.identities.len(), features = info.features.len(), "Caching caps");
-        self.cache.insert(hash.to_string(), info);
+    /// Store disco#info for a (hash, ver) tuple. Evicts the LRU entry
+    /// if at capacity.
+    pub fn insert(&self, key: CapsCacheKey, info: CachedDiscoInfo) {
+        debug!(
+            hash = %key.hash,
+            ver = %key.ver,
+            identities = info.identities.len(),
+            features = info.features.len(),
+            "Caching caps"
+        );
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.put(key, info);
+        }
     }
 
-    /// Retrieve cached disco#info for a capabilities hash.
-    pub fn get(&self, hash: &str) -> Option<CachedDiscoInfo> {
-        self.cache.get(hash).map(|entry| entry.value().clone())
+    /// Retrieve cached disco#info, refreshing LRU recency.
+    pub fn get(&self, key: &CapsCacheKey) -> Option<CachedDiscoInfo> {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.get(key).cloned())
     }
 
-    /// Check if a capabilities hash is cached.
-    pub fn contains(&self, hash: &str) -> bool {
-        self.cache.contains_key(hash)
+    /// Non-recency-affecting presence check.
+    pub fn contains(&self, key: &CapsCacheKey) -> bool {
+        self.inner
+            .lock()
+            .ok()
+            .map(|guard| guard.contains(key))
+            .unwrap_or(false)
     }
 
     /// Remove a cached entry.
-    pub fn remove(&self, hash: &str) -> Option<CachedDiscoInfo> {
-        self.cache.remove(hash).map(|(_, v)| v)
+    pub fn remove(&self, key: &CapsCacheKey) -> Option<CachedDiscoInfo> {
+        self.inner.lock().ok().and_then(|mut guard| guard.pop(key))
     }
 
-    /// Get the number of cached entries.
+    /// Number of cached entries.
     pub fn len(&self) -> usize {
-        self.cache.len()
+        self.inner.lock().map(|guard| guard.len()).unwrap_or(0)
     }
 
-    /// Check if the cache is empty.
     pub fn is_empty(&self) -> bool {
-        self.cache.is_empty()
+        self.len() == 0
     }
 
     /// Clear all cached entries.
     pub fn clear(&self) {
-        self.cache.clear();
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.clear();
+        }
     }
 }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -106,6 +106,49 @@ impl CachedDiscoInfo {
     }
 }
 
+/// Typed wrapper for an XEP-0115 verification string. The `ver` is
+/// opaque base64-encoded ciphertext at the protocol layer; the
+/// newtype prevents accidental confusion with other strings (JIDs,
+/// node names, hash-algo identifiers) and satisfies the
+/// typed-payloads hard rule for protocol data carried past the I/O
+/// boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CapsVer(String);
+
+impl CapsVer {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for CapsVer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for CapsVer {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for CapsVer {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&String> for CapsVer {
+    fn from(s: &String) -> Self {
+        Self(s.clone())
+    }
+}
+
 /// Composite cache key that XEP-0115 §6 mandates: caching is per
 /// `(hash algorithm, verification string)`. Two clients advertising
 /// the same opaque `ver` under different hash families MUST not
@@ -113,11 +156,11 @@ impl CachedDiscoInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CapsCacheKey {
     pub hash: String,
-    pub ver: String,
+    pub ver: CapsVer,
 }
 
 impl CapsCacheKey {
-    pub fn new(hash: impl Into<String>, ver: impl Into<String>) -> Self {
+    pub fn new(hash: impl Into<String>, ver: impl Into<CapsVer>) -> Self {
         Self {
             hash: hash.into(),
             ver: ver.into(),

--- a/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
@@ -227,6 +227,10 @@ fn test_caps_from_element_missing_attrs() {
     assert!(Caps::from_element(&elem).is_none());
 }
 
+fn key(hash: &str, ver: &str) -> super::CapsCacheKey {
+    super::CapsCacheKey::new(hash, ver)
+}
+
 #[test]
 fn test_caps_cache_insert_and_get() {
     let cache = CapsCache::new();
@@ -235,11 +239,36 @@ fn test_caps_cache_insert_and_get() {
         vec![Feature::disco_info()],
     );
 
-    cache.insert("test-hash", info.clone());
+    cache.insert(key("sha-1", "test-hash"), info.clone());
 
-    let retrieved = cache.get("test-hash").unwrap();
+    let retrieved = cache.get(&key("sha-1", "test-hash")).unwrap();
     assert_eq!(retrieved.identities.len(), 1);
     assert_eq!(retrieved.features.len(), 1);
+}
+
+#[test]
+fn test_caps_cache_keys_are_per_hash_algo() {
+    // XEP-0115 §6: caching MUST be per `(hash algorithm, ver)`. Two
+    // entries with identical `ver` but different `hash` MUST coexist.
+    let cache = CapsCache::new();
+    let sha1_info = CachedDiscoInfo::new(vec![Identity::server(Some("sha-1"))], vec![]);
+    let sha256_info = CachedDiscoInfo::new(vec![Identity::server(Some("sha-256"))], vec![]);
+
+    cache.insert(key("sha-1", "samever"), sha1_info);
+    cache.insert(key("sha-256", "samever"), sha256_info);
+
+    assert_eq!(
+        cache.get(&key("sha-1", "samever")).unwrap().identities[0]
+            .name
+            .as_deref(),
+        Some("sha-1")
+    );
+    assert_eq!(
+        cache.get(&key("sha-256", "samever")).unwrap().identities[0]
+            .name
+            .as_deref(),
+        Some("sha-256")
+    );
 }
 
 #[test]
@@ -247,9 +276,9 @@ fn test_caps_cache_contains() {
     let cache = CapsCache::new();
     let info = CachedDiscoInfo::new(vec![], vec![]);
 
-    assert!(!cache.contains("hash1"));
-    cache.insert("hash1", info);
-    assert!(cache.contains("hash1"));
+    assert!(!cache.contains(&key("sha-1", "hash1")));
+    cache.insert(key("sha-1", "hash1"), info);
+    assert!(cache.contains(&key("sha-1", "hash1")));
 }
 
 #[test]
@@ -257,12 +286,12 @@ fn test_caps_cache_remove() {
     let cache = CapsCache::new();
     let info = CachedDiscoInfo::new(vec![], vec![]);
 
-    cache.insert("hash1", info);
-    assert!(cache.contains("hash1"));
+    cache.insert(key("sha-1", "hash1"), info);
+    assert!(cache.contains(&key("sha-1", "hash1")));
 
-    let removed = cache.remove("hash1");
+    let removed = cache.remove(&key("sha-1", "hash1"));
     assert!(removed.is_some());
-    assert!(!cache.contains("hash1"));
+    assert!(!cache.contains(&key("sha-1", "hash1")));
 }
 
 #[test]
@@ -272,14 +301,31 @@ fn test_caps_cache_len_and_clear() {
     assert_eq!(cache.len(), 0);
     assert!(cache.is_empty());
 
-    cache.insert("h1", CachedDiscoInfo::new(vec![], vec![]));
-    cache.insert("h2", CachedDiscoInfo::new(vec![], vec![]));
+    cache.insert(key("sha-1", "h1"), CachedDiscoInfo::new(vec![], vec![]));
+    cache.insert(key("sha-1", "h2"), CachedDiscoInfo::new(vec![], vec![]));
 
     assert_eq!(cache.len(), 2);
     assert!(!cache.is_empty());
 
     cache.clear();
     assert!(cache.is_empty());
+}
+
+#[test]
+fn test_caps_cache_lru_eviction_at_capacity() {
+    // Bounded LRU prevents unbounded memory growth (PR 438 review #15).
+    let cache = CapsCache::with_capacity(2);
+    cache.insert(key("sha-1", "a"), CachedDiscoInfo::new(vec![], vec![]));
+    cache.insert(key("sha-1", "b"), CachedDiscoInfo::new(vec![], vec![]));
+    // Touch "a" so "b" becomes LRU.
+    let _ = cache.get(&key("sha-1", "a"));
+    cache.insert(key("sha-1", "c"), CachedDiscoInfo::new(vec![], vec![]));
+    assert!(cache.contains(&key("sha-1", "a")));
+    assert!(
+        !cache.contains(&key("sha-1", "b")),
+        "LRU eviction MUST drop b"
+    );
+    assert!(cache.contains(&key("sha-1", "c")));
 }
 
 #[test]


### PR DESCRIPTION
PR 2 of 6 implementing [RFC 363](https://github.com/waddle-social/waddle/blob/main/docs/rfc/363-avatar-vcard-pep-sync.md). Stacked on top of #438 (PR 1).

## What changed

Extends \`pubsub_fanout::fan_out_publish\` with two new passes after the existing explicit-subscribers loop:

1. **Roster pass** — every roster from/both contact of the publisher, filtered by per-resource cached CAPS for \`<node>+notify\`. Honors XEP-0191 blocking in both directions. Enumerates both live + detached XEP-0198 resumable resources.
2. **Owner self pass** — the publisher's own other resources (XEP-0163 §3.4 / PEP §4.2 — owner is among "appropriate subscribers"). Same +notify filter and dedup.

A \`HashSet<FullJid>\` of already-delivered resources dedupes between all three passes so a contact who is BOTH an explicit pubsub subscriber AND a roster from/both peer (with +notify) gets exactly one event.

For non-PEP nodes (Spaces, MUC service components) the new passes are harmless no-ops: \`get_presence_subscribers(service_domain)\` returns empty.

Mid-resolution resources (presence with \`<c/>\` arrived but disco#info round-trip not yet complete) carry no ver mapping and are skipped here. Replaying the last item to such resources is \`send_last_published_item\` territory — tracked for a follow-up PR.

## Conformance

- XEP-0163 §3 — presence-driven fan-out, no explicit \`<subscribe/>\` required
- XEP-0163 §3.4 / PEP §4.2 — owner's own resources receive
- XEP-0163 §4.3 — event \`from\` is the publisher's bare JID
- XEP-0115 §6 — uses the per-resource caps mapping populated in PR 1
- XEP-0191 — blocking is honored in both directions
- Per-resource semantics — resources without \`+notify\` skipped

## Tests

\`tests/xep0163_pep_ws.rs\`:

- \`pep_publish_fans_to_roster_contacts_with_matching_caps_notify\` — happy path, no explicit subscribe.
- \`pep_publish_skips_roster_contact_without_caps_notify_filter\` — +notify filter is necessary.
- \`pep_publish_targets_only_resources_advertising_notify_filter\` — per-resource semantics.
- \`pep_publish_delivers_exactly_once_when_subscriber_also_in_roster\` — dedup contract under overlap.
- \`pep_publish_fans_to_owner_other_resources_with_caps_notify\` — §3.4 self-fan-out.

10 PEP tests pass; PR 1's 5 caps tests pass; \`xep0060_pubsub_ws\` regression-clean.

## Status

- [x] Tests
- [x] Implementation
- [x] Adversarial review (4 issues found and fixed in fixup commit)
- [x] cargo clippy -D warnings clean
- [x] cargo fmt clean
- [ ] CI green