### PR TITLE
feat(server): XEP-0084 §4.3 avatar removal + FN removal mirror

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5168,6 +5168,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,7 +24,7 @@ repository = "https://github.com/waddle-social/waddle"
 [workspace.dependencies]
 # Core Runtime & Async
 tokio = { version = "1.43", features = ["full"] }
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["rt"] }
 tower = "0.5"
 futures = "0.3"
 

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -329,22 +329,32 @@ CREATE TABLE private_xml_storage (
 );
 "#;
 
-/// `users.avatar_source` provenance column for the OIDC → PEP
+/// `user_avatar_source` provenance table for the OIDC → PEP
 /// avatar/FN bridge. The user-managed avatar guard reads this value
 /// on `RemoveIfOidcOwned`: a row marked `'user'` keeps its picture
-/// even when the IDP claim disappears. The default `'oidc'` is the
-/// safe value for fresh provisions where OIDC is authoritative;
-/// existing rows pre-date this column and OIDC owns avatars by
-/// default in this codebase, so backfilling them as `'oidc'` matches
-/// observed semantics. Once a user issues a wire XEP-0084 publish to
-/// their own avatar node, the publish-time handler flips this to
-/// `'user'` (see `pubsub_authz::record_avatar_self_publish`).
-pub const V0002_AVATAR_SOURCE_COLUMN: &str = r#"
-ALTER TABLE users ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'oidc';
+/// even when the IDP claim disappears.
+///
+/// Why a dedicated table rather than a column on `users`: native-auth
+/// users (XEP-0077 / SCRAM, the test fixed-account fixture) only land
+/// in `native_users`, not `users`. A column on `users` would force the
+/// guard's write path to UPSERT a `users` row, which then collides
+/// with the `users.username UNIQUE` constraint when an OIDC user
+/// already owns the same `username`. A separate table keyed solely on
+/// `xmpp_localpart` avoids that cross-row conflict surface entirely.
+pub const V0002_USER_AVATAR_SOURCE: &str = r#"
+CREATE TABLE user_avatar_source (
+    xmpp_localpart TEXT PRIMARY KEY,
+    source TEXT NOT NULL CHECK (source IN ('oidc', 'user')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
 "#;
 
-pub const V0002_AVATAR_SOURCE_COLUMN_POSTGRES: &str = r#"
-ALTER TABLE users ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'oidc';
+pub const V0002_USER_AVATAR_SOURCE_POSTGRES: &str = r#"
+CREATE TABLE user_avatar_source (
+    xmpp_localpart TEXT PRIMARY KEY,
+    source TEXT NOT NULL CHECK (source IN ('oidc', 'user')),
+    updated_at TEXT NOT NULL DEFAULT to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+);
 "#;
 
 /// Get all global migrations in order
@@ -359,10 +369,10 @@ pub fn all() -> Vec<Migration> {
         Migration {
             version: 2,
             description:
-                "Add users.avatar_source provenance column for OIDC user-managed avatar guard"
+                "Add user_avatar_source provenance table for OIDC user-managed avatar guard"
                     .to_string(),
-            sql_sqlite: V0002_AVATAR_SOURCE_COLUMN,
-            sql_postgres: V0002_AVATAR_SOURCE_COLUMN_POSTGRES,
+            sql_sqlite: V0002_USER_AVATAR_SOURCE,
+            sql_postgres: V0002_USER_AVATAR_SOURCE_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -329,12 +329,40 @@ CREATE TABLE private_xml_storage (
 );
 "#;
 
+/// `users.avatar_source` provenance column for the OIDC → PEP
+/// avatar/FN bridge. The user-managed avatar guard reads this value
+/// on `RemoveIfOidcOwned`: a row marked `'user'` keeps its picture
+/// even when the IDP claim disappears. The default `'oidc'` is the
+/// safe value for fresh provisions where OIDC is authoritative;
+/// existing rows pre-date this column and OIDC owns avatars by
+/// default in this codebase, so backfilling them as `'oidc'` matches
+/// observed semantics. Once a user issues a wire XEP-0084 publish to
+/// their own avatar node, the publish-time handler flips this to
+/// `'user'` (see `pubsub_authz::record_avatar_self_publish`).
+pub const V0002_AVATAR_SOURCE_COLUMN: &str = r#"
+ALTER TABLE users ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'oidc';
+"#;
+
+pub const V0002_AVATAR_SOURCE_COLUMN_POSTGRES: &str = r#"
+ALTER TABLE users ADD COLUMN avatar_source TEXT NOT NULL DEFAULT 'oidc';
+"#;
+
 /// Get all global migrations in order
 pub fn all() -> Vec<Migration> {
-    vec![Migration {
-        version: 1,
-        description: "Hard-cut auth broker schema with roster pre-approval".to_string(),
-        sql_sqlite: V0001_AUTH_BROKER_SCHEMA,
-        sql_postgres: V0001_AUTH_BROKER_SCHEMA_POSTGRES,
-    }]
+    vec![
+        Migration {
+            version: 1,
+            description: "Hard-cut auth broker schema with roster pre-approval".to_string(),
+            sql_sqlite: V0001_AUTH_BROKER_SCHEMA,
+            sql_postgres: V0001_AUTH_BROKER_SCHEMA_POSTGRES,
+        },
+        Migration {
+            version: 2,
+            description:
+                "Add users.avatar_source provenance column for OIDC user-managed avatar guard"
+                    .to_string(),
+            sql_sqlite: V0002_AVATAR_SOURCE_COLUMN,
+            sql_postgres: V0002_AVATAR_SOURCE_COLUMN_POSTGRES,
+        },
+    ]
 }

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -179,7 +179,7 @@ async fn test_incompatible_history_forces_hard_cut_reapply() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 1001, 1002]);
 
     let applied_again = runner.run(&db).await.unwrap();
     assert!(applied_again.is_empty());
@@ -230,7 +230,7 @@ async fn test_incompatible_history_recreates_existing_owned_tables() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 1001, 1002]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn

--- a/server/crates/waddle-server/src/profile/avatar_source.rs
+++ b/server/crates/waddle-server/src/profile/avatar_source.rs
@@ -61,15 +61,17 @@ pub enum AvatarSourceStorageError {
 }
 
 /// Read the provenance flag for the user owning `jid`. Returns
-/// `Unknown` when the row is missing.
+/// `Unknown` when the row is missing or `jid` has no localpart
+/// (server-domain-only JIDs can't own avatars).
 pub async fn read_avatar_source(
     db_actor: &ActorRef<DbActor>,
     jid: &BareJid,
 ) -> Result<AvatarSource, AvatarSourceStorageError> {
-    let localpart = jid
-        .node()
-        .map(|n| n.as_str().to_string())
-        .unwrap_or_default();
+    let Some(localpart) = jid.node().map(|n| n.as_str().to_string()) else {
+        // No localpart → no possible avatar owner; skip the DB
+        // round-trip. Mirrors `record_self_published`'s early return.
+        return Ok(AvatarSource::Unknown);
+    };
     let row = db_actor
         .ask(DbQueryOne {
             sql: "SELECT source FROM user_avatar_source WHERE xmpp_localpart = ? LIMIT 1"

--- a/server/crates/waddle-server/src/profile/avatar_source.rs
+++ b/server/crates/waddle-server/src/profile/avatar_source.rs
@@ -1,4 +1,4 @@
-//! `users.avatar_source` provenance — the column that distinguishes
+//! `user_avatar_source` provenance — the table that distinguishes
 //! OIDC-managed avatars (which the bridge owns and may overwrite /
 //! remove on re-login) from user-self-published avatars (which it
 //! must NOT touch).
@@ -8,31 +8,34 @@
 //! - [`read_avatar_source`] — the OIDC publish chain consults this
 //!   on `RemoveIfOidcOwned` and suppresses the empty-`<metadata/>`
 //!   publish when the row says `'user'`.
-//! - [`record_self_published`] — the WebSocket PEP-publish handler
-//!   calls this after a user successfully publishes to their own
-//!   `urn:xmpp:avatar:data` / `urn:xmpp:avatar:metadata` node, so
-//!   the next OIDC reconcile honors the user's choice.
+//! - [`record_self_published`] / [`record_user_retracted`] — the
+//!   WebSocket PEP-publish handler updates this after a user
+//!   wire-publish to their own avatar / vCard4 photo node.
+
+use std::sync::Arc;
 
 use jid::BareJid;
 use kameo::actor::ActorRef;
+use thiserror::Error;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::warn;
 
 use crate::db::actor::{DbActor, DbExecute, DbQueryOne};
+use crate::server::routes::websocket::WebSocketState;
 
 /// Outcome of the user-managed avatar guard query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AvatarSource {
-    /// `users.avatar_source = 'oidc'` (the default for fresh
-    /// provisions). The OIDC bridge owns the avatar.
+    /// `source = 'oidc'` (the default for fresh OIDC publishes). The
+    /// OIDC bridge owns the avatar.
     Oidc,
-    /// `users.avatar_source = 'user'`. The user has self-published
-    /// via wire XEP-0084 and the bridge must not overwrite or
-    /// remove their picture.
+    /// `source = 'user'`. The user has self-published via wire
+    /// XEP-0084 and the bridge MUST NOT overwrite or remove it.
     User,
-    /// No row matched — typically means the user hasn't been
-    /// provisioned (the bridge's `RemoveIfOidcOwned` treats this as
-    /// "no avatar to remove" by virtue of upstream idempotence
-    /// checks; downstream is no-op).
+    /// No row matched. Means the user has neither been touched by
+    /// the OIDC bridge nor wire-published an avatar yet — the
+    /// guard's downstream idempotence check (was there ever an
+    /// avatar?) handles this safely.
     Unknown,
 }
 
@@ -46,24 +49,35 @@ impl AvatarSource {
     }
 }
 
-/// Read the `avatar_source` flag for the user owning `jid`. Returns
-/// `Unknown` when the row is missing (fresh user not yet
-/// provisioned, or test fixture).
+/// Typed error from the avatar-source storage helpers. The single
+/// variant wraps the kameo actor error string (which already
+/// Display-formats the inner DB error) — kameo's `ask` reply is
+/// flattened, so a deeper typed wrapper isn't reachable here without
+/// re-introducing string-formatting at the actor seam.
+#[derive(Debug, Error)]
+pub enum AvatarSourceStorageError {
+    #[error("avatar_source storage failure: {0}")]
+    Storage(String),
+}
+
+/// Read the provenance flag for the user owning `jid`. Returns
+/// `Unknown` when the row is missing.
 pub async fn read_avatar_source(
     db_actor: &ActorRef<DbActor>,
     jid: &BareJid,
-) -> Result<AvatarSource, String> {
+) -> Result<AvatarSource, AvatarSourceStorageError> {
     let localpart = jid
         .node()
         .map(|n| n.as_str().to_string())
         .unwrap_or_default();
     let row = db_actor
         .ask(DbQueryOne {
-            sql: "SELECT avatar_source FROM users WHERE xmpp_localpart = ? LIMIT 1".to_string(),
+            sql: "SELECT source FROM user_avatar_source WHERE xmpp_localpart = ? LIMIT 1"
+                .to_string(),
             params: vec![localpart.into()],
         })
         .await
-        .map_err(|e| format!("avatar_source query actor failure: {e}"))?;
+        .map_err(|e| AvatarSourceStorageError::Storage(e.to_string()))?;
     let Some(row) = row else {
         return Ok(AvatarSource::Unknown);
     };
@@ -77,52 +91,80 @@ pub async fn read_avatar_source(
         .unwrap_or(AvatarSource::Unknown))
 }
 
-/// Mark `jid`'s avatar as user-self-published. Idempotent —
-/// repeated calls just re-confirm `'user'`. Logs and swallows
-/// errors (the publish itself already succeeded; failing the IQ
-/// because we couldn't update a provenance flag would be worse).
-///
-/// Implementation note — UPSERT semantics: native-auth users (the
-/// XEP-0077 / SCRAM path and the test fixed-account fixture) only
-/// land in `native_users`, not in `users`. A naive
-/// `UPDATE users SET avatar_source='user'` would silently target
-/// zero rows for those users and the guard would never fire on
-/// their next OIDC reconcile. To make the user-managed guard work
-/// uniformly across both auth paths, we upsert: insert a minimal
-/// `users` row keyed on the localpart if one isn't there, or flip
-/// the column on the existing row. The user just demonstrably
-/// owns their PEP avatar, so a corresponding identity row is the
-/// right shape.
-pub async fn record_self_published(db_actor: &ActorRef<DbActor>, jid: &BareJid) {
-    let localpart = match jid.node() {
-        Some(n) => n.as_str().to_string(),
-        None => return,
-    };
+async fn upsert_source(
+    db_actor: &ActorRef<DbActor>,
+    localpart: &str,
+    source: &str,
+) -> Result<(), AvatarSourceStorageError> {
     let now = chrono::Utc::now().to_rfc3339();
-    let new_id = uuid::Uuid::new_v4().to_string();
-    if let Err(error) = db_actor
+    db_actor
         .ask(DbExecute {
             sql: r#"
-                INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at, avatar_source)
-                VALUES (?, ?, ?, ?, ?, 'user')
+                INSERT INTO user_avatar_source (xmpp_localpart, source, updated_at)
+                VALUES (?, ?, ?)
                 ON CONFLICT(xmpp_localpart) DO UPDATE
-                  SET avatar_source = 'user', updated_at = excluded.updated_at
+                  SET source = excluded.source, updated_at = excluded.updated_at
             "#
             .to_string(),
-            params: vec![
-                new_id.into(),
-                localpart.clone().into(),
-                localpart.into(),
-                now.clone().into(),
-                now.into(),
-            ],
+            params: vec![localpart.into(), source.into(), now.into()],
         })
         .await
-    {
+        .map_err(|e| AvatarSourceStorageError::Storage(e.to_string()))?;
+    Ok(())
+}
+
+/// Acquire the per-(`BareJid`) avatar-source mutex. Both the OIDC
+/// publish chain and the wire avatar-publish hook take this lock;
+/// holding it across read+write closes the TOCTOU race where OIDC
+/// could read `'oidc'` between a user's wire publish and the
+/// downstream `record_self_published` flip and then wipe the
+/// just-set avatar.
+///
+/// Returns an `OwnedMutexGuard` so the caller can hold it across
+/// further async operations without lifetime gymnastics.
+pub async fn acquire_per_jid_lock(state: &WebSocketState, jid: &BareJid) -> OwnedMutexGuard<()> {
+    let mutex = state
+        .deps
+        .protocol
+        .avatar_source_locks
+        .entry(jid.clone())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone();
+    mutex.lock_owned().await
+}
+
+/// Mark `jid`'s avatar as user-self-published. Idempotent — repeated
+/// calls just re-confirm `'user'`. Logs and swallows errors (the
+/// publish itself already succeeded; failing the IQ because we
+/// couldn't update a provenance flag would be worse).
+pub async fn record_self_published(db_actor: &ActorRef<DbActor>, jid: &BareJid) {
+    let Some(localpart) = jid.node().map(|n| n.as_str().to_string()) else {
+        return;
+    };
+    if let Err(error) = upsert_source(db_actor, &localpart, "user").await {
         warn!(
             jid = %jid,
             error = %error,
             "Failed to mark avatar_source='user'; OIDC reconcile may still overwrite"
+        );
+    }
+}
+
+/// Mark `jid`'s avatar as OIDC-managed. Called when the user
+/// explicitly opts back into OIDC management (e.g. by wire-publishing
+/// the XEP-0084 §4.3 empty-`<metadata/>` removal shape themselves —
+/// "I'm not picking my own avatar anymore, you can manage it") AND
+/// after the OIDC bridge successfully publishes a new avatar (so the
+/// flag tracks current ownership intent).
+pub async fn record_oidc_managed(db_actor: &ActorRef<DbActor>, jid: &BareJid) {
+    let Some(localpart) = jid.node().map(|n| n.as_str().to_string()) else {
+        return;
+    };
+    if let Err(error) = upsert_source(db_actor, &localpart, "oidc").await {
+        warn!(
+            jid = %jid,
+            error = %error,
+            "Failed to mark avatar_source='oidc'; provenance state may be stale"
         );
     }
 }

--- a/server/crates/waddle-server/src/profile/avatar_source.rs
+++ b/server/crates/waddle-server/src/profile/avatar_source.rs
@@ -1,0 +1,128 @@
+//! `users.avatar_source` provenance — the column that distinguishes
+//! OIDC-managed avatars (which the bridge owns and may overwrite /
+//! remove on re-login) from user-self-published avatars (which it
+//! must NOT touch).
+//!
+//! Two surfaces:
+//!
+//! - [`read_avatar_source`] — the OIDC publish chain consults this
+//!   on `RemoveIfOidcOwned` and suppresses the empty-`<metadata/>`
+//!   publish when the row says `'user'`.
+//! - [`record_self_published`] — the WebSocket PEP-publish handler
+//!   calls this after a user successfully publishes to their own
+//!   `urn:xmpp:avatar:data` / `urn:xmpp:avatar:metadata` node, so
+//!   the next OIDC reconcile honors the user's choice.
+
+use jid::BareJid;
+use kameo::actor::ActorRef;
+use tracing::warn;
+
+use crate::db::actor::{DbActor, DbExecute, DbQueryOne};
+
+/// Outcome of the user-managed avatar guard query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AvatarSource {
+    /// `users.avatar_source = 'oidc'` (the default for fresh
+    /// provisions). The OIDC bridge owns the avatar.
+    Oidc,
+    /// `users.avatar_source = 'user'`. The user has self-published
+    /// via wire XEP-0084 and the bridge must not overwrite or
+    /// remove their picture.
+    User,
+    /// No row matched — typically means the user hasn't been
+    /// provisioned (the bridge's `RemoveIfOidcOwned` treats this as
+    /// "no avatar to remove" by virtue of upstream idempotence
+    /// checks; downstream is no-op).
+    Unknown,
+}
+
+impl AvatarSource {
+    fn parse(raw: &str) -> Self {
+        match raw {
+            "user" => AvatarSource::User,
+            "oidc" => AvatarSource::Oidc,
+            _ => AvatarSource::Unknown,
+        }
+    }
+}
+
+/// Read the `avatar_source` flag for the user owning `jid`. Returns
+/// `Unknown` when the row is missing (fresh user not yet
+/// provisioned, or test fixture).
+pub async fn read_avatar_source(
+    db_actor: &ActorRef<DbActor>,
+    jid: &BareJid,
+) -> Result<AvatarSource, String> {
+    let localpart = jid
+        .node()
+        .map(|n| n.as_str().to_string())
+        .unwrap_or_default();
+    let row = db_actor
+        .ask(DbQueryOne {
+            sql: "SELECT avatar_source FROM users WHERE xmpp_localpart = ? LIMIT 1".to_string(),
+            params: vec![localpart.into()],
+        })
+        .await
+        .map_err(|e| format!("avatar_source query actor failure: {e}"))?;
+    let Some(row) = row else {
+        return Ok(AvatarSource::Unknown);
+    };
+    let raw: Option<String> = row.first().and_then(|v| match v {
+        crate::db::Value::Text(s) => Some(s.clone()),
+        _ => None,
+    });
+    Ok(raw
+        .as_deref()
+        .map(AvatarSource::parse)
+        .unwrap_or(AvatarSource::Unknown))
+}
+
+/// Mark `jid`'s avatar as user-self-published. Idempotent —
+/// repeated calls just re-confirm `'user'`. Logs and swallows
+/// errors (the publish itself already succeeded; failing the IQ
+/// because we couldn't update a provenance flag would be worse).
+///
+/// Implementation note — UPSERT semantics: native-auth users (the
+/// XEP-0077 / SCRAM path and the test fixed-account fixture) only
+/// land in `native_users`, not in `users`. A naive
+/// `UPDATE users SET avatar_source='user'` would silently target
+/// zero rows for those users and the guard would never fire on
+/// their next OIDC reconcile. To make the user-managed guard work
+/// uniformly across both auth paths, we upsert: insert a minimal
+/// `users` row keyed on the localpart if one isn't there, or flip
+/// the column on the existing row. The user just demonstrably
+/// owns their PEP avatar, so a corresponding identity row is the
+/// right shape.
+pub async fn record_self_published(db_actor: &ActorRef<DbActor>, jid: &BareJid) {
+    let localpart = match jid.node() {
+        Some(n) => n.as_str().to_string(),
+        None => return,
+    };
+    let now = chrono::Utc::now().to_rfc3339();
+    let new_id = uuid::Uuid::new_v4().to_string();
+    if let Err(error) = db_actor
+        .ask(DbExecute {
+            sql: r#"
+                INSERT INTO users (id, username, xmpp_localpart, created_at, updated_at, avatar_source)
+                VALUES (?, ?, ?, ?, ?, 'user')
+                ON CONFLICT(xmpp_localpart) DO UPDATE
+                  SET avatar_source = 'user', updated_at = excluded.updated_at
+            "#
+            .to_string(),
+            params: vec![
+                new_id.into(),
+                localpart.clone().into(),
+                localpart.into(),
+                now.clone().into(),
+                now.into(),
+            ],
+        })
+        .await
+    {
+        warn!(
+            jid = %jid,
+            error = %error,
+            "Failed to mark avatar_source='user'; OIDC reconcile may still overwrite"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/profile/mod.rs
+++ b/server/crates/waddle-server/src/profile/mod.rs
@@ -32,7 +32,10 @@ mod publish;
 mod source;
 mod vcard_rmw;
 
-pub use avatar_source::{read_avatar_source, record_self_published, AvatarSource};
+pub use avatar_source::{
+    acquire_per_jid_lock, read_avatar_source, record_oidc_managed, record_self_published,
+    AvatarSource, AvatarSourceStorageError,
+};
 pub use fetch::{fetch_avatar_bytes, AvatarBytes, FetchError, FetchPolicy};
 pub use publish::{ensure_pep_profile_published, ProfilePublishDeps};
 pub use source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};

--- a/server/crates/waddle-server/src/profile/mod.rs
+++ b/server/crates/waddle-server/src/profile/mod.rs
@@ -26,11 +26,13 @@
 //! Legacy-only clients require server-side auto-stamping on every
 //! outbound presence — tracked as a follow-up.
 
+pub mod avatar_source;
 mod fetch;
 mod publish;
 mod source;
 mod vcard_rmw;
 
+pub use avatar_source::{read_avatar_source, record_self_published, AvatarSource};
 pub use fetch::{fetch_avatar_bytes, AvatarBytes, FetchError, FetchPolicy};
 pub use publish::{ensure_pep_profile_published, ProfilePublishDeps};
-pub use source::{ProfileSource, ProfileSyncError};
+pub use source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};

--- a/server/crates/waddle-server/src/profile/publish.rs
+++ b/server/crates/waddle-server/src/profile/publish.rs
@@ -145,6 +145,9 @@ pub async fn ensure_pep_profile_published(
         set_photo = outcome.photo_sha1_hex.is_some(),
         removed_photo = outcome.published_avatar_removal,
         guard_user_managed = outcome.photo_removal_guarded_by_user_managed,
+        set_fn = matches!(name_intent, NameIntent::Set(_)),
+        removed_fn = matches!(name_intent, NameIntent::Remove)
+            && (outcome.removed_vcard_temp_fn || outcome.removed_vcard4_fn),
         "ensure_pep_profile_published completed"
     );
 
@@ -261,6 +264,16 @@ async fn mirror_vcard_temp(
     };
 
     if let Some(vcard) = final_vcard {
+        // Idempotence guard — same rationale as `mirror_vcard4`'s
+        // guard below: skip the write when the vcard is unchanged
+        // so we don't bump storage timestamps and (more importantly,
+        // for any subscriber to vcard-temp via legacy IQ result
+        // delivery) re-emit the result for a no-op login.
+        if let Some(existing) = existing.as_ref() {
+            if String::from(existing) == String::from(&vcard) {
+                return Ok(());
+            }
+        }
         deps.vcard_store.set(jid, &vcard).await?;
         outcome.mirrored_vcard_temp = true;
         outcome.removed_vcard_temp_photo = removal.remove_photo;
@@ -317,6 +330,17 @@ async fn mirror_vcard4(
     };
 
     if let Some(vcard) = final_vcard4 {
+        // Idempotence guard: skip the publish (and the resulting
+        // XEP-0163 §3 fan-out event) when the serialized vCard4 hasn't
+        // changed. Without this every login that doesn't actually
+        // mutate a field still bumps `published_at` on `current` and
+        // emits a redundant `<message><event>` to every subscriber —
+        // measurable noise for IDPs that don't supply `name`.
+        if let Some(existing) = existing_vcard4.as_ref() {
+            if String::from(existing) == String::from(&vcard) {
+                return Ok(());
+            }
+        }
         publish_vcard4(&deps.state, jid, &vcard).await?;
         outcome.mirrored_vcard4 = true;
         outcome.removed_vcard4_photo = removal.remove_photo;

--- a/server/crates/waddle-server/src/profile/publish.rs
+++ b/server/crates/waddle-server/src/profile/publish.rs
@@ -1,13 +1,23 @@
 //! `ensure_pep_profile_published` — the publish-chain entry point.
 //!
-//! Steps execute conditionally based on which subset of `ProfileSource`
-//! is set:
+//! Dispatches on per-axis intents from [`ProfileSource`]:
 //!
-//! - PHOTO chain (XEP-0084 §4.1.1 / §4.1.2): runs only if `avatar_url`
-//!   is present. Bytes are fetched once, hashed, and the chain
-//!   publishes data → metadata.
-//! - FN chain (XEP-0398 §3): runs whenever `display_name` is present.
-//! - vcard-temp + vCard4 mirror: applies to whichever subset ran.
+//! - [`PhotoIntent`]:
+//!   - `Skip` — no PHOTO sync.
+//!   - `SetFromUrl` — fetch + hash + publish data + metadata
+//!     (XEP-0084 §4.1.1 / §4.1.2).
+//!   - `RemoveIfOidcOwned` — publish empty `<metadata/>` at item
+//!     id `current` (XEP-0084 §4.3) and strip vcard-temp `<PHOTO>` /
+//!     vCard4 `<photo>`. Honored only when
+//!     `users.avatar_source = 'oidc'` (the user-managed avatar
+//!     guard); idempotent via a current-item inspection.
+//! - [`NameIntent`]:
+//!   - `Skip` — no FN sync.
+//!   - `Set` — replace/insert vcard-temp `<FN>` / vCard4 `<fn>`.
+//!   - `Remove` — strip those elements.
+//!
+//! vcard-temp + vCard4 mirror only runs when the chain actually
+//! touches PHOTO or FN; idempotent re-removals never write.
 
 use std::sync::Arc;
 
@@ -16,38 +26,36 @@ use tracing::{debug, info};
 use waddle_xmpp::pubsub::{AccessModel, NodeConfig, PubSubItem};
 use waddle_xmpp::xep::xep0084::{
     build_avatar_data, build_avatar_metadata, AvatarInfo, NODE_AVATAR_DATA, NODE_AVATAR_METADATA,
+    NS_AVATAR_METADATA,
 };
 use waddle_xmpp::xep::xep0292::PEP_NODE_VCARD4;
 use waddle_xmpp::xep::xep0300::{compute_hash, HashAlgo};
 use xmpp_parsers::minidom::Element;
 
+use super::avatar_source::{read_avatar_source, AvatarSource};
 use super::fetch::{fetch_avatar_bytes, AvatarBytes, FetchPolicy};
-use super::source::{ProfileSource, ProfileSyncError};
-use super::vcard_rmw::{apply_vcard4_update, apply_vcard_temp_update, PhotoUpdate, Vcard4PhotoRef};
+use super::source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};
+use super::vcard_rmw::{
+    apply_vcard4_update, apply_vcard_temp_update, remove_vcard4_fields, remove_vcard_temp_fields,
+    PhotoUpdate, Vcard4FieldRemoval, Vcard4PhotoRef, VcardTempFieldRemoval,
+};
 use crate::server::routes::websocket::handlers::pubsub_fanout::{self, FanOutRequest};
 use crate::server::routes::websocket::WebSocketState;
 use crate::vcard::VCardStore;
 
-/// XEP-0292 §4.1.1: a vCard4 PEP node holds a single item with id
-/// `current`.
+/// XEP-0292 §4.1.1 / XEP-0084 §4.3: the vCard4 PEP node and the
+/// avatar-removal metadata item are both addressed by the literal id
+/// `current`. (Set publishes use the SHA-1-keyed item id; only the
+/// removal shape is `current`.)
 const VCARD4_ITEM_ID: &str = "current";
+const AVATAR_METADATA_REMOVE_ITEM_ID: &str = "current";
 
 /// `NodeConfig` for the OIDC-managed avatar/vCard4 PEP nodes.
 ///
 /// Built off `pep_default()` so we inherit the canonical PEP shape
-/// (e.g. `SendLastPublishedItem::OnSubAndPresence`, payload
-/// delivery, retract notifications) and override only the fields
-/// where the OIDC-managed surface intentionally differs:
-///
-/// - `access_model = Open` — any peer (not just roster contacts)
-///   can resolve a user's avatar; matches the typical web-app
-///   expectation that profile photos are public.
-/// - `max_items = 1` — a new avatar/vCard publish evicts the
-///   previous item rather than accumulating one row per unique
-///   payload. XEP-0084 metadata + XEP-0292 vCard4 are
-///   last-writer-wins; avatar data is keyed on its SHA-1 so the
-///   old data row would never be re-fetched anyway, but evicting
-///   it removes a storage-bloat / past-avatar-leak surface.
+/// and override only:
+/// - `access_model = Open` — any peer can resolve a user's avatar.
+/// - `max_items = 1` — a new publish evicts the previous item.
 fn oidc_pep_node_config() -> NodeConfig {
     NodeConfig {
         access_model: AccessModel::Open,
@@ -71,15 +79,25 @@ pub struct ProfilePublishDeps {
 /// Result of a publish-chain run, useful for tests + telemetry.
 #[derive(Debug, Default, Clone)]
 pub struct ProfilePublishOutcome {
-    /// Hex-encoded SHA-1 of the published bytes, if PHOTO ran.
+    /// Hex-encoded SHA-1 of the published bytes, if `SetFromUrl` ran.
     pub photo_sha1_hex: Option<String>,
-    /// MIME of the published photo, if PHOTO ran.
+    /// MIME of the published photo, if `SetFromUrl` ran.
     pub photo_mime: Option<String>,
     pub photo_bytes_len: Option<usize>,
     pub published_avatar_data: bool,
     pub published_avatar_metadata: bool,
+    /// XEP-0084 §4.3 empty `<metadata/>` was published.
+    pub published_avatar_removal: bool,
     pub mirrored_vcard_temp: bool,
     pub mirrored_vcard4: bool,
+    /// PHOTO/FN explicitly removed from the vCard surfaces.
+    pub removed_vcard_temp_photo: bool,
+    pub removed_vcard_temp_fn: bool,
+    pub removed_vcard4_photo: bool,
+    pub removed_vcard4_fn: bool,
+    /// `users.avatar_source = 'user'`, so `RemoveIfOidcOwned` was
+    /// suppressed. Visible to tests + telemetry.
+    pub photo_removal_guarded_by_user_managed: bool,
 }
 
 /// Materialize a conformant PEP avatar + vCard set for `jid` from
@@ -95,74 +113,198 @@ pub async fn ensure_pep_profile_published(
     }
 
     let mut outcome = ProfilePublishOutcome::default();
-    let (avatar_url, display_name) = match source {
-        ProfileSource::Oidc {
-            avatar_url,
-            display_name,
-        } => (avatar_url, display_name),
+    let (photo_intent, name_intent) = match source {
+        ProfileSource::Oidc { photo, name } => (photo, name),
     };
 
-    // ---- PHOTO chain (XEP-0084) ----
-    let avatar_bytes_opt = if let Some(url) = avatar_url.as_ref() {
-        let bytes = fetch_avatar_bytes(url, &deps.fetch_policy).await?;
-        let hash = compute_hash(HashAlgo::Sha1, &bytes.bytes);
-        let id = hash.to_hex();
-        outcome.photo_sha1_hex = Some(id.clone());
-        outcome.photo_mime = Some(bytes.mime.clone());
-        outcome.photo_bytes_len = Some(bytes.bytes.len());
+    // ---- PHOTO chain (XEP-0084 §4.1 set / §4.3 remove) ----
+    let photo_op = resolve_photo_op(deps, jid, photo_intent, &mut outcome).await?;
 
-        publish_avatar_data(&deps.state, jid, &id, &bytes).await?;
-        outcome.published_avatar_data = true;
-        publish_avatar_metadata(&deps.state, jid, &id, &bytes).await?;
-        outcome.published_avatar_metadata = true;
-        Some(bytes)
-    } else {
-        None
-    };
-
-    let photo_update = avatar_bytes_opt.as_ref().map(|b| PhotoUpdate {
-        bytes: b.bytes.as_slice(),
-        mime: b.mime.as_str(),
-    });
-
-    // ---- vcard-temp mirror (XEP-0054 / XEP-0398 §3) ----
-    let need_vcard_update = photo_update.is_some() || display_name.is_some();
-    if need_vcard_update {
-        let existing = deps.vcard_store.get(jid).await?;
-        let updated =
-            apply_vcard_temp_update(existing.as_ref(), photo_update, display_name.as_deref());
-        deps.vcard_store.set(jid, &updated).await?;
-        outcome.mirrored_vcard_temp = true;
-    }
-
-    // ---- vCard4 PEP mirror (XEP-0292) ----
-    if need_vcard_update {
-        let vcard4_photo_uri = avatar_bytes_opt
-            .as_ref()
-            .and_then(|b| outcome.photo_sha1_hex.as_deref().map(|sha1| (b, sha1)))
-            .map(|(b, sha1)| (vcard4_photo_pep_uri(jid, sha1), b.mime.clone()));
-        let vcard4_photo_ref = vcard4_photo_uri.as_ref().map(|(uri, mime)| Vcard4PhotoRef {
-            uri: uri.as_str(),
-            mime: mime.as_str(),
-        });
-        let existing_vcard4 = read_existing_vcard4(deps, jid).await?;
-        let updated_vcard4 = apply_vcard4_update(
-            existing_vcard4.as_ref(),
-            vcard4_photo_ref,
-            display_name.as_deref(),
-        );
-        publish_vcard4(&deps.state, jid, &updated_vcard4).await?;
-        outcome.mirrored_vcard4 = true;
+    // ---- vcard surfaces (XEP-0054 / XEP-0292 / XEP-0398 §3) ----
+    let touches_vcard =
+        !matches!(photo_op, PhotoOp::None) || !matches!(name_intent, NameIntent::Skip);
+    if touches_vcard {
+        mirror_vcard_temp(deps, jid, &photo_op, &name_intent, &mut outcome).await?;
+        mirror_vcard4(deps, jid, &photo_op, &name_intent, &mut outcome).await?;
     }
 
     info!(
         jid = %jid,
-        photo = outcome.photo_sha1_hex.is_some(),
-        fn_set = display_name.is_some(),
+        set_photo = outcome.photo_sha1_hex.is_some(),
+        removed_photo = outcome.published_avatar_removal,
+        guard_user_managed = outcome.photo_removal_guarded_by_user_managed,
         "ensure_pep_profile_published completed"
     );
 
     Ok(outcome)
+}
+
+/// What the PHOTO branch decided to do, threaded into the vcard
+/// surfaces so they apply consistent set / strip behavior.
+enum PhotoOp {
+    /// Skip / guarded / idempotent no-op. Do not touch vcard PHOTO.
+    None,
+    /// New bytes were published; mirror PHOTO into vcard surfaces.
+    Set(AvatarBytes, String),
+    /// Empty `<metadata/>` was published; strip PHOTO from vcards.
+    RemovePublished,
+}
+
+async fn resolve_photo_op(
+    deps: &ProfilePublishDeps,
+    jid: &BareJid,
+    intent: PhotoIntent,
+    outcome: &mut ProfilePublishOutcome,
+) -> Result<PhotoOp, ProfileSyncError> {
+    match intent {
+        PhotoIntent::Skip => Ok(PhotoOp::None),
+        PhotoIntent::SetFromUrl(url) => {
+            let bytes = fetch_avatar_bytes(&url, &deps.fetch_policy).await?;
+            let hash = compute_hash(HashAlgo::Sha1, &bytes.bytes);
+            let id = hash.to_hex();
+            outcome.photo_sha1_hex = Some(id.clone());
+            outcome.photo_mime = Some(bytes.mime.clone());
+            outcome.photo_bytes_len = Some(bytes.bytes.len());
+            publish_avatar_data(&deps.state, jid, &id, &bytes).await?;
+            outcome.published_avatar_data = true;
+            publish_avatar_metadata(&deps.state, jid, &id, &bytes).await?;
+            outcome.published_avatar_metadata = true;
+            Ok(PhotoOp::Set(bytes, id))
+        }
+        PhotoIntent::RemoveIfOidcOwned => {
+            // Guard 1: only act when avatar_source = 'oidc'. A user
+            // who self-published via wire XEP-0084 keeps their
+            // picture (the user-managed avatar guard).
+            let db_actor = deps.state.deps.app_state.db_pool.global_actor();
+            let source = read_avatar_source(db_actor, jid)
+                .await
+                .map_err(ProfileSyncError::AvatarSourceLookup)?;
+            if source == AvatarSource::User {
+                outcome.photo_removal_guarded_by_user_managed = true;
+                return Ok(PhotoOp::None);
+            }
+            // Guard 2: idempotence — if no prior metadata item or
+            // the current item is already an empty `<metadata/>`,
+            // there's nothing to remove. Repeated re-logins after
+            // removal are wire-no-ops.
+            if !avatar_metadata_present(deps, jid).await? {
+                return Ok(PhotoOp::None);
+            }
+            publish_empty_avatar_metadata(&deps.state, jid).await?;
+            outcome.published_avatar_removal = true;
+            Ok(PhotoOp::RemovePublished)
+        }
+    }
+}
+
+async fn mirror_vcard_temp(
+    deps: &ProfilePublishDeps,
+    jid: &BareJid,
+    photo_op: &PhotoOp,
+    name_intent: &NameIntent,
+    outcome: &mut ProfilePublishOutcome,
+) -> Result<(), ProfileSyncError> {
+    let existing = deps.vcard_store.get(jid).await?;
+
+    let photo_set: Option<PhotoUpdate<'_>> = match photo_op {
+        PhotoOp::Set(bytes, _) => Some(PhotoUpdate {
+            bytes: bytes.bytes.as_slice(),
+            mime: bytes.mime.as_str(),
+        }),
+        _ => None,
+    };
+    let name_set: Option<&str> = match name_intent {
+        NameIntent::Set(s) => Some(s.as_str()),
+        _ => None,
+    };
+
+    let after_set = if photo_set.is_some() || name_set.is_some() {
+        Some(apply_vcard_temp_update(
+            existing.as_ref(),
+            photo_set,
+            name_set,
+        ))
+    } else {
+        None
+    };
+
+    let removal = VcardTempFieldRemoval {
+        remove_photo: matches!(photo_op, PhotoOp::RemovePublished),
+        remove_fn: matches!(name_intent, NameIntent::Remove),
+    };
+
+    let final_vcard = if removal.remove_photo || removal.remove_fn {
+        after_set
+            .as_ref()
+            .or(existing.as_ref())
+            .map(|base| remove_vcard_temp_fields(base, &removal))
+    } else {
+        after_set
+    };
+
+    if let Some(vcard) = final_vcard {
+        deps.vcard_store.set(jid, &vcard).await?;
+        outcome.mirrored_vcard_temp = true;
+        outcome.removed_vcard_temp_photo = removal.remove_photo;
+        outcome.removed_vcard_temp_fn = removal.remove_fn;
+    }
+    Ok(())
+}
+
+async fn mirror_vcard4(
+    deps: &ProfilePublishDeps,
+    jid: &BareJid,
+    photo_op: &PhotoOp,
+    name_intent: &NameIntent,
+    outcome: &mut ProfilePublishOutcome,
+) -> Result<(), ProfileSyncError> {
+    let existing_vcard4 = read_existing_vcard4(deps, jid).await?;
+
+    let photo_uri_pair: Option<(String, String)> = match photo_op {
+        PhotoOp::Set(bytes, sha1) => Some((vcard4_photo_pep_uri(jid, sha1), bytes.mime.clone())),
+        _ => None,
+    };
+    let photo_set: Option<Vcard4PhotoRef<'_>> =
+        photo_uri_pair.as_ref().map(|(uri, mime)| Vcard4PhotoRef {
+            uri: uri.as_str(),
+            mime: mime.as_str(),
+        });
+    let name_set: Option<&str> = match name_intent {
+        NameIntent::Set(s) => Some(s.as_str()),
+        _ => None,
+    };
+
+    let after_set = if photo_set.is_some() || name_set.is_some() {
+        Some(apply_vcard4_update(
+            existing_vcard4.as_ref(),
+            photo_set,
+            name_set,
+        ))
+    } else {
+        None
+    };
+
+    let removal = Vcard4FieldRemoval {
+        remove_photo: matches!(photo_op, PhotoOp::RemovePublished),
+        remove_fn: matches!(name_intent, NameIntent::Remove),
+    };
+
+    let final_vcard4 = if removal.remove_photo || removal.remove_fn {
+        after_set
+            .as_ref()
+            .or(existing_vcard4.as_ref())
+            .map(|base| remove_vcard4_fields(base, &removal))
+    } else {
+        after_set
+    };
+
+    if let Some(vcard) = final_vcard4 {
+        publish_vcard4(&deps.state, jid, &vcard).await?;
+        outcome.mirrored_vcard4 = true;
+        outcome.removed_vcard4_photo = removal.remove_photo;
+        outcome.removed_vcard4_fn = removal.remove_fn;
+    }
+    Ok(())
 }
 
 async fn publish_avatar_data(
@@ -209,6 +351,64 @@ async fn publish_avatar_metadata(
     publish_and_fan_out(state, jid, NODE_AVATAR_METADATA, &item, item_id).await
 }
 
+/// XEP-0084 §4.3: publish an empty `<metadata/>` element at item id
+/// `current` to signal "no avatar". Subscribers receive the
+/// `pubsub#event` and drop their cached avatar.
+async fn publish_empty_avatar_metadata(
+    state: &Arc<WebSocketState>,
+    jid: &BareJid,
+) -> Result<(), ProfileSyncError> {
+    ensure_node_with_oidc_config(state, jid, NODE_AVATAR_METADATA).await?;
+
+    let payload = Element::builder("metadata", NS_AVATAR_METADATA).build();
+    let item = PubSubItem {
+        id: Some(AVATAR_METADATA_REMOVE_ITEM_ID.to_string()),
+        publisher: Some(jid.clone()),
+        payload: Some(payload),
+    };
+    publish_and_fan_out(
+        state,
+        jid,
+        NODE_AVATAR_METADATA,
+        &item,
+        AVATAR_METADATA_REMOVE_ITEM_ID,
+    )
+    .await
+}
+
+/// Idempotence probe — returns `false` when the avatar-metadata
+/// node is empty OR the most-recent item is already the
+/// empty-`<metadata/>` removal shape. Saves an extra wire publish
+/// (and fan-out) on repeated re-logins after a removal.
+async fn avatar_metadata_present(
+    deps: &ProfilePublishDeps,
+    jid: &BareJid,
+) -> Result<bool, ProfileSyncError> {
+    let items = deps
+        .state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_items(jid, NODE_AVATAR_METADATA, None, &[])
+        .await?;
+    if items.is_empty() {
+        return Ok(false);
+    }
+    // If any non-empty `<metadata>` item exists, treat the avatar as
+    // present. We parse the XML rather than string-comparing so
+    // whitespace / quoting variants don't fool us.
+    for item in items {
+        if let Some(xml) = item.payload_xml.as_deref() {
+            if let Ok(el) = xml.parse::<Element>() {
+                if el.children().next().is_some() {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
 async fn publish_vcard4(
     state: &Arc<WebSocketState>,
     jid: &BareJid,
@@ -224,54 +424,13 @@ async fn publish_vcard4(
     publish_and_fan_out(state, jid, PEP_NODE_VCARD4, &item, VCARD4_ITEM_ID).await
 }
 
-/// Persist the item via `PubSubStorage::publish_item` AND drive the
-/// XEP-0163 §3 fan-out so subscribers (roster contacts with
-/// `+notify`, multi-resource owner) actually receive the
-/// `pubsub#event` notification. Without this second call, OIDC
-/// avatar/vCard publishes silently update storage and peers never
-/// know the avatar changed.
-async fn publish_and_fan_out(
-    state: &Arc<WebSocketState>,
-    jid: &BareJid,
-    node: &str,
-    item: &PubSubItem,
-    item_id: &str,
-) -> Result<(), ProfileSyncError> {
-    state
-        .deps
-        .protocol
-        .pubsub_storage
-        .publish_item(jid, node, item, Some(jid), false)
-        .await?;
-
-    // Owner-self echo is suppressed by `publisher_full = None` plus
-    // the §3.4 owner-self pass logic in `fan_out_publish`: there's no
-    // originating XMPP resource to filter against, so all owner
-    // resources currently online with `+notify` get the event.
-    pubsub_fanout::fan_out_publish(
-        state,
-        FanOutRequest {
-            owner: jid,
-            node,
-            published_item: item,
-            item_id,
-            publisher: Some(jid),
-            publisher_full: None,
-            is_pep: true,
-        },
-    )
-    .await;
-
-    Ok(())
-}
-
 /// Read the existing `current` vCard4 item if any. Reading by id
-/// (rather than "latest item") is what makes the
-/// publish-as-`current` flow robust against legacy items written
-/// under different ids — those would not match here, so we treat
-/// them as "no existing vCard4" and the publish overwrites the
-/// `current` slot directly. With `max_items = 1` on the node the
-/// stale-id row is then evicted on the next publish.
+/// rather than "latest item" makes the publish-as-`current` flow
+/// robust against legacy items written under different ids — those
+/// would not match here, so we treat them as "no existing vCard4"
+/// and the publish overwrites the `current` slot directly. With
+/// `max_items = 1` on the node the stale-id row is then evicted on
+/// the next publish.
 async fn read_existing_vcard4(
     deps: &ProfilePublishDeps,
     jid: &BareJid,
@@ -304,12 +463,9 @@ fn vcard4_photo_pep_uri(jid: &BareJid, sha1_hex: &str) -> String {
 }
 
 /// Pre-create the PEP node with the OIDC-managed config (Open
-/// access, `max_items=1`) BEFORE the first publish. If the node
-/// already exists with a different config, flip it. Either way the
-/// node is at the desired shape by the time `publish_item` lands —
-/// closing the auto-create-then-flip race where a peer fetching
-/// between the two would have been denied by `pep_default()`'s
-/// Presence access.
+/// access, `max_items=1`) BEFORE the first publish. Closing the
+/// auto-create-then-flip race where a peer fetching between the two
+/// would have been denied by `pep_default()`'s Presence access.
 async fn ensure_node_with_oidc_config(
     state: &Arc<WebSocketState>,
     jid: &BareJid,
@@ -323,6 +479,42 @@ async fn ensure_node_with_oidc_config(
     Ok(())
 }
 
+/// Persist the item via `PubSubStorage::publish_item` AND drive the
+/// XEP-0163 §3 fan-out so subscribers (roster contacts with
+/// `+notify`, multi-resource owner) actually receive the
+/// `pubsub#event` notification — including for the §4.3 empty
+/// `<metadata/>` removal shape.
+async fn publish_and_fan_out(
+    state: &Arc<WebSocketState>,
+    jid: &BareJid,
+    node: &str,
+    item: &PubSubItem,
+    item_id: &str,
+) -> Result<(), ProfileSyncError> {
+    state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(jid, node, item, Some(jid), false)
+        .await?;
+
+    pubsub_fanout::fan_out_publish(
+        state,
+        FanOutRequest {
+            owner: jid,
+            node,
+            published_item: item,
+            item_id,
+            publisher: Some(jid),
+            publisher_full: None,
+            is_pep: true,
+        },
+    )
+    .await;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -333,16 +525,13 @@ mod tests {
         assert_eq!(cfg.max_items, 1);
         assert_eq!(
             cfg.access_model,
-            waddle_xmpp::pubsub::AccessModel::Open,
+            AccessModel::Open,
             "OIDC-managed PEP nodes are semi-public so non-roster peers can resolve avatars"
         );
     }
 
     #[test]
     fn xep0084_namespace_constants_are_reused_not_redeclared() {
-        // Sanity check that our publish chain talks to the same node
-        // names the XEP-0084 / XEP-0292 modules export — guarding
-        // against drift if either side is moved later.
         assert_eq!(NODE_AVATAR_DATA, "urn:xmpp:avatar:data");
         assert_eq!(NODE_AVATAR_METADATA, "urn:xmpp:avatar:metadata");
         assert_eq!(PEP_NODE_VCARD4, "urn:xmpp:vcard4");

--- a/server/crates/waddle-server/src/profile/publish.rs
+++ b/server/crates/waddle-server/src/profile/publish.rs
@@ -32,7 +32,9 @@ use waddle_xmpp::xep::xep0292::PEP_NODE_VCARD4;
 use waddle_xmpp::xep::xep0300::{compute_hash, HashAlgo};
 use xmpp_parsers::minidom::Element;
 
-use super::avatar_source::{read_avatar_source, AvatarSource};
+use super::avatar_source::{
+    acquire_per_jid_lock, read_avatar_source, record_oidc_managed, AvatarSource,
+};
 use super::fetch::{fetch_avatar_bytes, AvatarBytes, FetchPolicy};
 use super::source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};
 use super::vcard_rmw::{
@@ -112,6 +114,16 @@ pub async fn ensure_pep_profile_published(
         return Ok(ProfilePublishOutcome::default());
     }
 
+    // Hold the per-(BareJid) avatar-source mutex across the entire
+    // publish chain. The wire avatar-publish hook in `pubsub_dispatch`
+    // acquires the same mutex around its `record_self_published`
+    // call — together this serializes "user wire publishes their
+    // avatar then flips provenance to 'user'" against "OIDC reconcile
+    // reads provenance then publishes empty `<metadata/>`", closing
+    // the TOCTOU race that would otherwise let OIDC wipe a freshly-
+    // published user avatar.
+    let _guard = acquire_per_jid_lock(&deps.state, jid).await;
+
     let mut outcome = ProfilePublishOutcome::default();
     let (photo_intent, name_intent) = match source {
         ProfileSource::Oidc { photo, name } => (photo, name),
@@ -169,6 +181,14 @@ async fn resolve_photo_op(
             outcome.published_avatar_data = true;
             publish_avatar_metadata(&deps.state, jid, &id, &bytes).await?;
             outcome.published_avatar_metadata = true;
+            // Record OIDC ownership of the freshly-published avatar
+            // so the provenance row exists from the very first OIDC
+            // publish (otherwise `read_avatar_source` returns
+            // `Unknown` for users who never wire-published, which
+            // would defeat any future "did the user override?" probe
+            // that relies on a non-Unknown signal).
+            let db_actor = deps.state.deps.app_state.db_pool.global_actor();
+            record_oidc_managed(db_actor, jid).await;
             Ok(PhotoOp::Set(bytes, id))
         }
         PhotoIntent::RemoveIfOidcOwned => {
@@ -176,9 +196,7 @@ async fn resolve_photo_op(
             // who self-published via wire XEP-0084 keeps their
             // picture (the user-managed avatar guard).
             let db_actor = deps.state.deps.app_state.db_pool.global_actor();
-            let source = read_avatar_source(db_actor, jid)
-                .await
-                .map_err(ProfileSyncError::AvatarSourceLookup)?;
+            let source = read_avatar_source(db_actor, jid).await?;
             if source == AvatarSource::User {
                 outcome.photo_removal_guarded_by_user_managed = true;
                 return Ok(PhotoOp::None);
@@ -377,9 +395,14 @@ async fn publish_empty_avatar_metadata(
 }
 
 /// Idempotence probe — returns `false` when the avatar-metadata
-/// node is empty OR the most-recent item is already the
-/// empty-`<metadata/>` removal shape. Saves an extra wire publish
-/// (and fan-out) on repeated re-logins after a removal.
+/// node is empty OR the latest item is already the empty-`<metadata/>`
+/// removal shape. Saves an extra wire publish (and fan-out) on
+/// repeated re-logins after a removal.
+///
+/// Probes only the single latest item (`max_items=1` on the OIDC-managed
+/// node means there's only ever one anyway). Storage backends with
+/// different eviction order can't fool the probe by leaving an old
+/// SHA-1 item alongside the new `current` empty one.
 async fn avatar_metadata_present(
     deps: &ProfilePublishDeps,
     jid: &BareJid,
@@ -389,24 +412,21 @@ async fn avatar_metadata_present(
         .deps
         .protocol
         .pubsub_storage
-        .get_items(jid, NODE_AVATAR_METADATA, None, &[])
+        .get_items(jid, NODE_AVATAR_METADATA, Some(1), &[])
         .await?;
-    if items.is_empty() {
+    let Some(item) = items.into_iter().next() else {
         return Ok(false);
-    }
-    // If any non-empty `<metadata>` item exists, treat the avatar as
-    // present. We parse the XML rather than string-comparing so
-    // whitespace / quoting variants don't fool us.
-    for item in items {
-        if let Some(xml) = item.payload_xml.as_deref() {
-            if let Ok(el) = xml.parse::<Element>() {
-                if el.children().next().is_some() {
-                    return Ok(true);
-                }
-            }
-        }
-    }
-    Ok(false)
+    };
+    let Some(xml) = item.payload_xml.as_deref() else {
+        return Ok(false);
+    };
+    let Ok(el) = xml.parse::<Element>() else {
+        // Malformed stored payload — treat as "no avatar present" so
+        // a removal request is safely a no-op rather than re-firing
+        // an event over a corrupt item we can't reason about.
+        return Ok(false);
+    };
+    Ok(el.children().next().is_some())
 }
 
 async fn publish_vcard4(

--- a/server/crates/waddle-server/src/profile/source.rs
+++ b/server/crates/waddle-server/src/profile/source.rs
@@ -7,34 +7,74 @@ use waddle_xmpp::XmppError;
 use super::fetch::FetchError;
 use crate::vcard::VCardError;
 
+/// Per-axis intent for a single PEP profile sync call. PHOTO and FN
+/// are independent — either subset can be set, removed, or skipped
+/// on any single call.
+#[derive(Debug, Clone)]
+pub enum PhotoIntent {
+    /// No PHOTO sync for this call.
+    Skip,
+    /// Set PHOTO from the bytes fetched at this URL.
+    SetFromUrl(Url),
+    /// Remove the OIDC-managed PHOTO if one exists. Honored only
+    /// when `users.avatar_source = 'oidc'`; a user who self-published
+    /// via wire XEP-0084 keeps their picture (the user-managed
+    /// avatar guard).
+    RemoveIfOidcOwned,
+}
+
+#[derive(Debug, Clone)]
+pub enum NameIntent {
+    /// No FN sync for this call.
+    Skip,
+    /// Set FN to this string.
+    Set(String),
+    /// Remove `<FN>` / `<fn>` from vcard-temp + vCard4. Name has no
+    /// user-managed guard analogous to PHOTO — name is always
+    /// OIDC-owned today.
+    Remove,
+}
+
 /// Provenance + payload for a single profile-publish call.
 ///
 /// The variant is open for future provenances (e.g. SCIM, admin
 /// override) without changing the call sites that consume the helper.
-/// `Oidc { None, None }` is the explicit no-op shape.
 #[derive(Debug, Clone)]
 pub enum ProfileSource {
     Oidc {
-        /// Typed avatar URL parsed once at the OIDC boundary. Per the
-        /// typed-payloads hard rule the helper does NOT accept &str
-        /// here.
-        avatar_url: Option<Url>,
-        /// Free-form unicode display name. `None` means "no FN sync
-        /// for this call". The bridge does NOT clear an existing FN
-        /// just because it isn't supplied — explicit removal lives
-        /// in the removal flow.
-        display_name: Option<String>,
+        photo: PhotoIntent,
+        name: NameIntent,
     },
 }
 
 impl ProfileSource {
     pub fn is_no_op(&self) -> bool {
         match self {
-            ProfileSource::Oidc {
-                avatar_url,
-                display_name,
-            } => avatar_url.is_none() && display_name.is_none(),
+            ProfileSource::Oidc { photo, name } => {
+                matches!(photo, PhotoIntent::Skip) && matches!(name, NameIntent::Skip)
+            }
         }
+    }
+
+    /// Build a `ProfileSource::Oidc` from raw OIDC claim values.
+    /// `avatar_url = Some` → set; `None` → remove-if-oidc-owned.
+    /// `display_name = Some` → set; `None` → remove.
+    ///
+    /// Callers are responsible for filtering empty/whitespace claim
+    /// strings to `None` before calling — the helper interprets a
+    /// `Some("")` as a literal "set FN to empty string", which is
+    /// almost certainly not what an IDP returning an empty `name`
+    /// claim meant.
+    pub fn from_oidc_claims(avatar_url: Option<Url>, display_name: Option<String>) -> Self {
+        let photo = match avatar_url {
+            Some(url) => PhotoIntent::SetFromUrl(url),
+            None => PhotoIntent::RemoveIfOidcOwned,
+        };
+        let name = match display_name {
+            Some(s) => NameIntent::Set(s),
+            None => NameIntent::Remove,
+        };
+        ProfileSource::Oidc { photo, name }
     }
 }
 
@@ -57,4 +97,9 @@ pub enum ProfileSyncError {
     /// it.
     #[error("vcard4 stored item is malformed: {0}")]
     VCard4Malformed(String),
+    /// Failure looking up the `users.avatar_source` provenance flag
+    /// — the user-managed avatar guard cannot be evaluated and the
+    /// publish chain refuses to honor `RemoveIfOidcOwned`.
+    #[error("avatar_source lookup failed: {0}")]
+    AvatarSourceLookup(String),
 }

--- a/server/crates/waddle-server/src/profile/source.rs
+++ b/server/crates/waddle-server/src/profile/source.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use url::Url;
 use waddle_xmpp::XmppError;
 
+use super::avatar_source::AvatarSourceStorageError;
 use super::fetch::FetchError;
 use crate::vcard::VCardError;
 
@@ -97,9 +98,11 @@ pub enum ProfileSyncError {
     /// it.
     #[error("vcard4 stored item is malformed: {0}")]
     VCard4Malformed(String),
-    /// Failure looking up the `users.avatar_source` provenance flag
-    /// — the user-managed avatar guard cannot be evaluated and the
-    /// publish chain refuses to honor `RemoveIfOidcOwned`.
-    #[error("avatar_source lookup failed: {0}")]
-    AvatarSourceLookup(String),
+    /// Failure looking up the `user_avatar_source` provenance row —
+    /// the user-managed avatar guard cannot be evaluated and the
+    /// publish chain refuses to honor `RemoveIfOidcOwned`. Carries
+    /// the typed underlying storage error so callers can drill into
+    /// the actor / DB failure mode.
+    #[error("avatar_source storage error: {0}")]
+    AvatarSource(#[from] AvatarSourceStorageError),
 }

--- a/server/crates/waddle-server/src/profile/vcard_rmw.rs
+++ b/server/crates/waddle-server/src/profile/vcard_rmw.rs
@@ -129,6 +129,56 @@ pub fn apply_vcard4_update(
     builder.build()
 }
 
+/// Which fields to strip from an XEP-0054 vcard-temp element on
+/// the removal path. Set the bools the caller wants gone; every
+/// other child is preserved verbatim.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct VcardTempFieldRemoval {
+    pub remove_photo: bool,
+    pub remove_fn: bool,
+}
+
+/// Strip `<PHOTO>` and/or `<FN>` from `existing`. Preserves every
+/// other child. The output's namespace + element name are pinned
+/// so the result is still a valid `<vCard xmlns="vcard-temp"/>`.
+pub fn remove_vcard_temp_fields(existing: &Element, removal: &VcardTempFieldRemoval) -> Element {
+    let mut builder = Element::builder("vCard", NS_VCARD_TEMP);
+    for child in existing.children() {
+        match child.name() {
+            "PHOTO" if removal.remove_photo => {}
+            "FN" if removal.remove_fn => {}
+            _ => {
+                builder = builder.append(child.clone());
+            }
+        }
+    }
+    builder.build()
+}
+
+/// Which fields to strip from an XEP-0292 vCard4 element on the
+/// removal path.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Vcard4FieldRemoval {
+    pub remove_photo: bool,
+    pub remove_fn: bool,
+}
+
+/// Strip `<photo>` and/or `<fn>` from `existing`, preserving every
+/// other child.
+pub fn remove_vcard4_fields(existing: &Element, removal: &Vcard4FieldRemoval) -> Element {
+    let mut builder = Element::builder("vcard", NS_VCARD4);
+    for child in existing.children() {
+        match child.name() {
+            "photo" if removal.remove_photo => {}
+            "fn" if removal.remove_fn => {}
+            _ => {
+                builder = builder.append(child.clone());
+            }
+        }
+    }
+    builder.build()
+}
+
 fn build_vcard_temp_photo(bytes: &[u8], mime: &str) -> Element {
     Element::builder("PHOTO", NS_VCARD_TEMP)
         .append(Element::builder("TYPE", NS_VCARD_TEMP).append(mime).build())
@@ -229,6 +279,79 @@ mod tests {
             xml.contains("KEEP"),
             "PHOTO untouched when only FN is supplied: {xml}"
         );
+    }
+
+    #[test]
+    fn vcard_temp_remove_photo_keeps_other_fields() {
+        let existing: Element = "<vCard xmlns='vcard-temp'><FN>Alice</FN><PHOTO><TYPE>image/png</TYPE><BINVAL>BYTES</BINVAL></PHOTO><EMAIL>a@example.com</EMAIL></vCard>"
+            .parse()
+            .unwrap();
+        let result = remove_vcard_temp_fields(
+            &existing,
+            &VcardTempFieldRemoval {
+                remove_photo: true,
+                remove_fn: false,
+            },
+        );
+        let xml = String::from(&result);
+        assert!(!xml.contains("<PHOTO"), "PHOTO must be stripped: {xml}");
+        assert!(!xml.contains("BYTES"), "{xml}");
+        assert!(xml.contains("<FN"), "FN must be preserved: {xml}");
+        assert!(xml.contains("a@example.com"), "EMAIL preserved: {xml}");
+    }
+
+    #[test]
+    fn vcard_temp_remove_fn_keeps_photo_and_other_fields() {
+        let existing: Element = "<vCard xmlns='vcard-temp'><FN>Old</FN><PHOTO><TYPE>image/png</TYPE><BINVAL>BYTES</BINVAL></PHOTO><NICKNAME>Ali</NICKNAME></vCard>"
+            .parse()
+            .unwrap();
+        let result = remove_vcard_temp_fields(
+            &existing,
+            &VcardTempFieldRemoval {
+                remove_photo: false,
+                remove_fn: true,
+            },
+        );
+        let xml = String::from(&result);
+        assert!(!xml.contains("<FN"), "FN must be stripped: {xml}");
+        assert!(!xml.contains("Old"), "{xml}");
+        assert!(xml.contains("<PHOTO"), "PHOTO preserved: {xml}");
+        assert!(xml.contains("Ali"), "NICKNAME preserved: {xml}");
+    }
+
+    #[test]
+    fn vcard4_remove_photo_keeps_other_fields() {
+        let existing: Element = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'><fn><text>Alice</text></fn><photo><uri>xmpp:alice@example.com?pubsub;node=urn:xmpp:avatar:data;item=abc</uri></photo><nickname><text>Ali</text></nickname></vcard>"
+            .parse()
+            .unwrap();
+        let result = remove_vcard4_fields(
+            &existing,
+            &Vcard4FieldRemoval {
+                remove_photo: true,
+                remove_fn: false,
+            },
+        );
+        let xml = String::from(&result);
+        assert!(!xml.contains("<photo"), "<photo> must be stripped: {xml}");
+        assert!(xml.contains("<fn"), "<fn> preserved: {xml}");
+        assert!(xml.contains("Ali"), "<nickname> preserved: {xml}");
+    }
+
+    #[test]
+    fn vcard4_remove_fn_keeps_photo_and_other_fields() {
+        let existing: Element = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'><fn><text>Alice</text></fn><photo><uri>xmpp:alice@example.com?pubsub;node=urn:xmpp:avatar:data;item=abc</uri></photo></vcard>"
+            .parse()
+            .unwrap();
+        let result = remove_vcard4_fields(
+            &existing,
+            &Vcard4FieldRemoval {
+                remove_photo: false,
+                remove_fn: true,
+            },
+        );
+        let xml = String::from(&result);
+        assert!(!xml.contains("<fn"), "<fn> must be stripped: {xml}");
+        assert!(xml.contains("<photo"), "<photo> preserved: {xml}");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -301,6 +301,8 @@ async fn create_websocket_state(
                 sm_session_registry,
                 resumable_sessions,
                 caps_resolver,
+                avatar_source_locks: Arc::new(dashmap::DashMap::new()),
+                profile_publish_tracker: tokio_util::task::TaskTracker::new(),
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
         },
@@ -398,6 +400,11 @@ fn install_profile_publish_hook(
         .global_actor()
         .clone();
 
+    let tracker = websocket_state
+        .deps
+        .protocol
+        .profile_publish_tracker
+        .clone();
     let hook: super::routes::auth::ProfilePublishHook =
         std::sync::Arc::new(move |jid: jid::BareJid, source: ProfileSource| {
             let websocket_state = Arc::clone(&websocket_state);
@@ -427,8 +434,15 @@ fn install_profile_publish_hook(
                 }
             };
             use tracing::Instrument;
-            Box::pin(fut.instrument(span))
-                as std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>
+            // Register with the shutdown tracker so the
+            // graceful-shutdown drain can `close().wait()` on
+            // in-flight publishes before tearing down the runtime.
+            // Closed trackers refuse new spawns; the auth callback
+            // accepts that as "shutting down — skip this publish".
+            // The `_handle` binding (rather than `_`) is intentional:
+            // detaching the JoinHandle is exactly what we want here
+            // (the tracker holds its own reference for `wait()`).
+            let _handle = tracker.spawn(fut.instrument(span));
         });
     auth_state.install_profile_publish_hook(hook);
     tracing::debug!("OIDC → PEP profile-publish hook installed");

--- a/server/crates/waddle-server/src/server/profile_publish_route.rs
+++ b/server/crates/waddle-server/src/server/profile_publish_route.rs
@@ -23,10 +23,19 @@
 //! X-Waddle-Test-Token: <token>
 //! {
 //!   "jid": "alice@localhost",
-//!   "photo": { "setFromUrl": "https://..." }   // OR { "removeIfOidcOwned": null } OR omit
-//!   "name":  { "set": "Alice" }                // OR { "remove": null } OR omit
+//!   "photo": { "setFromUrl": "https://..." }      // tuple variant
+//!         | { "removeIfOidcOwned": null },        // unit variant
+//!   "name":  { "set": "Alice" } | { "remove": null }
 //! }
 //! ```
+//!
+//! `photo` and `name` use Serde's default externally-tagged enum
+//! representation. Each field is independently optional; omit it
+//! for `Skip`. Unit variants (`removeIfOidcOwned`, `remove`) accept
+//! the JSON shape `{ "<variant>": null }` (matching the existing
+//! wire test fixtures); the equivalent bare-string form is also
+//! recognized by Serde but the object form is what the harness
+//! emits.
 //!
 //! `photo` and `name` are independently optional. Empty object is a
 //! no-op. Returns 200 with the typed `ProfilePublishOutcome` JSON on

--- a/server/crates/waddle-server/src/server/profile_publish_route.rs
+++ b/server/crates/waddle-server/src/server/profile_publish_route.rs
@@ -177,7 +177,16 @@ async fn handler(
         None => PhotoIntent::Skip,
     };
     let name = match req.name {
-        Some(NameIntentDto::Set(s)) => NameIntent::Set(s),
+        Some(NameIntentDto::Set(s)) => {
+            if s.trim().is_empty() {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "name.set must not be empty/whitespace; use {\"remove\": null} to clear FN"
+                        .to_string(),
+                ));
+            }
+            NameIntent::Set(s)
+        }
         Some(NameIntentDto::Remove) => NameIntent::Remove,
         None => NameIntent::Skip,
     };
@@ -251,6 +260,6 @@ fn profile_sync_error_status(error: &ProfileSyncError) -> StatusCode {
         ProfileSyncError::PubSub(_)
         | ProfileSyncError::VCardTemp(_)
         | ProfileSyncError::VCard4Malformed(_)
-        | ProfileSyncError::AvatarSourceLookup(_) => StatusCode::BAD_GATEWAY,
+        | ProfileSyncError::AvatarSource(_) => StatusCode::BAD_GATEWAY,
     }
 }

--- a/server/crates/waddle-server/src/server/profile_publish_route.rs
+++ b/server/crates/waddle-server/src/server/profile_publish_route.rs
@@ -1,6 +1,6 @@
 //! Test-only HTTP route exposing `ensure_pep_profile_published` so
 //! the wire-conformance test suites can exercise the full chain
-//! without driving an OIDC mock.
+//! (set + remove + name) without driving an OIDC mock.
 //!
 //! Hardening (defense in depth — the route is *intended* to be
 //! unreachable in production but every layer here is a backstop in
@@ -21,15 +21,19 @@
 //! ```json
 //! POST /api/test/profile-publish
 //! X-Waddle-Test-Token: <token>
-//! { "jid": "alice@localhost", "displayName": "Alice", "avatarUrl": "https://..." }
+//! {
+//!   "jid": "alice@localhost",
+//!   "photo": { "setFromUrl": "https://..." }   // OR { "removeIfOidcOwned": null } OR omit
+//!   "name":  { "set": "Alice" }                // OR { "remove": null } OR omit
+//! }
 //! ```
 //!
-//! `displayName` and `avatarUrl` are independently optional. Empty
-//! object is a no-op. Returns 200 with the typed
-//! `ProfilePublishOutcome` JSON on success. Failure status is
-//! mapped from the typed [`ProfileSyncError`] kind:
+//! `photo` and `name` are independently optional. Empty object is a
+//! no-op. Returns 200 with the typed `ProfilePublishOutcome` JSON on
+//! success. Failure status is mapped from the typed
+//! [`ProfileSyncError`] kind:
 //!
-//! - 400 — invalid request (bad JID, malformed `avatar_url`)
+//! - 400 — invalid request (bad JID, malformed `photo.setFromUrl`)
 //! - 401 — missing or wrong `X-Waddle-Test-Token`
 //! - 403 — JID outside the test seam allowlist
 //! - 422 — fetch policy rejected the bytes (scheme/MIME/size/SSRF/magic)
@@ -48,8 +52,8 @@ use tracing::warn;
 use url::Url;
 
 use crate::profile::{
-    ensure_pep_profile_published, FetchError, FetchPolicy, ProfilePublishDeps, ProfileSource,
-    ProfileSyncError,
+    ensure_pep_profile_published, FetchError, FetchPolicy, NameIntent, PhotoIntent,
+    ProfilePublishDeps, ProfileSource, ProfileSyncError,
 };
 use crate::server::routes::websocket::WebSocketState;
 
@@ -80,9 +84,28 @@ struct RouteState {
 pub struct ProfilePublishRequest {
     pub jid: String,
     #[serde(default)]
-    pub display_name: Option<String>,
+    pub photo: Option<PhotoIntentDto>,
     #[serde(default)]
-    pub avatar_url: Option<String>,
+    pub name: Option<NameIntentDto>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PhotoIntentDto {
+    /// `{ "setFromUrl": "https://..." }` — fetch + publish.
+    SetFromUrl(String),
+    /// `{ "removeIfOidcOwned": null }` — XEP-0084 §4.3 empty
+    /// `<metadata/>` if the user-managed avatar guard allows it.
+    RemoveIfOidcOwned,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NameIntentDto {
+    /// `{ "set": "Alice" }` — replace/insert FN.
+    Set(String),
+    /// `{ "remove": null }` — strip `<FN>` / `<fn>`.
+    Remove,
 }
 
 #[derive(Debug, Serialize)]
@@ -93,8 +116,14 @@ pub struct ProfilePublishResponse {
     pub photo_bytes_len: Option<usize>,
     pub published_avatar_data: bool,
     pub published_avatar_metadata: bool,
+    pub published_avatar_removal: bool,
     pub mirrored_vcard_temp: bool,
     pub mirrored_vcard4: bool,
+    pub removed_vcard_temp_photo: bool,
+    pub removed_vcard_temp_fn: bool,
+    pub removed_vcard4_photo: bool,
+    pub removed_vcard4_fn: bool,
+    pub photo_removal_guarded_by_user_managed: bool,
 }
 
 pub fn router(websocket_state: Arc<WebSocketState>, auth: TestSeamAuth) -> Router {
@@ -139,14 +168,19 @@ async fn handler(
         ));
     }
 
-    let avatar_url = req
-        .avatar_url
-        .as_deref()
-        .filter(|s| !s.is_empty())
-        .map(Url::parse)
-        .transpose()
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid avatar_url: {e}")))?;
-    let display_name = req.display_name.filter(|s| !s.is_empty());
+    let photo = match req.photo {
+        Some(PhotoIntentDto::SetFromUrl(raw)) => PhotoIntent::SetFromUrl(
+            Url::parse(&raw)
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("photo.setFromUrl: {e}")))?,
+        ),
+        Some(PhotoIntentDto::RemoveIfOidcOwned) => PhotoIntent::RemoveIfOidcOwned,
+        None => PhotoIntent::Skip,
+    };
+    let name = match req.name {
+        Some(NameIntentDto::Set(s)) => NameIntent::Set(s),
+        Some(NameIntentDto::Remove) => NameIntent::Remove,
+        None => NameIntent::Skip,
+    };
 
     let db = state
         .websocket
@@ -162,13 +196,10 @@ async fn handler(
         state: Arc::clone(&state.websocket),
         vcard_store: crate::vcard::VCardStore::new(db.into()),
         // Tests serve avatars from wiremock on 127.0.0.1 over plain
-        // HTTP. We relax the loopback block AND the HTTPS requirement
-        // so the test fixture is reachable; production callers (the
-        // OIDC bridge) build a `FetchPolicy::default()` instead. The
-        // route is gated on a per-process auth token + JID allowlist
-        // (see [`TestSeamAuth`]), so even with the SSRF guard relaxed
-        // the route can only be invoked against the configured
-        // fixed-account JIDs by code that already holds the token.
+        // HTTP. The fetcher's defense in depth requires loopback for
+        // any non-https URL; the route is also gated on a
+        // per-process auth token + JID allowlist (see
+        // [`TestSeamAuth`]).
         fetch_policy: FetchPolicy {
             block_non_global_ips: false,
             allow_http_for_tests: true,
@@ -176,20 +207,13 @@ async fn handler(
         },
     };
 
-    let outcome = ensure_pep_profile_published(
-        &deps,
-        &jid,
-        ProfileSource::Oidc {
-            avatar_url,
-            display_name,
-        },
-    )
-    .await
-    .map_err(|e| {
-        let status = profile_sync_error_status(&e);
-        warn!(error = %e, status = %status, "test profile-publish helper failed");
-        (status, "profile publish chain failed".to_string())
-    })?;
+    let outcome = ensure_pep_profile_published(&deps, &jid, ProfileSource::Oidc { photo, name })
+        .await
+        .map_err(|e| {
+            let status = profile_sync_error_status(&e);
+            warn!(error = %e, status = %status, "test profile-publish helper failed");
+            (status, "profile publish chain failed".to_string())
+        })?;
 
     Ok(Json(ProfilePublishResponse {
         photo_sha1_hex: outcome.photo_sha1_hex,
@@ -197,8 +221,14 @@ async fn handler(
         photo_bytes_len: outcome.photo_bytes_len,
         published_avatar_data: outcome.published_avatar_data,
         published_avatar_metadata: outcome.published_avatar_metadata,
+        published_avatar_removal: outcome.published_avatar_removal,
         mirrored_vcard_temp: outcome.mirrored_vcard_temp,
         mirrored_vcard4: outcome.mirrored_vcard4,
+        removed_vcard_temp_photo: outcome.removed_vcard_temp_photo,
+        removed_vcard_temp_fn: outcome.removed_vcard_temp_fn,
+        removed_vcard4_photo: outcome.removed_vcard4_photo,
+        removed_vcard4_fn: outcome.removed_vcard4_fn,
+        photo_removal_guarded_by_user_managed: outcome.photo_removal_guarded_by_user_managed,
     }))
 }
 
@@ -220,6 +250,7 @@ fn profile_sync_error_status(error: &ProfileSyncError) -> StatusCode {
         ProfileSyncError::Fetch(_) => StatusCode::BAD_GATEWAY,
         ProfileSyncError::PubSub(_)
         | ProfileSyncError::VCardTemp(_)
-        | ProfileSyncError::VCard4Malformed(_) => StatusCode::BAD_GATEWAY,
+        | ProfileSyncError::VCard4Malformed(_)
+        | ProfileSyncError::AvatarSourceLookup(_) => StatusCode::BAD_GATEWAY,
     }
 }

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -156,27 +156,58 @@ pub(super) async fn callback_handler(
         if let Ok(jid) =
             format!("{}@{}", linked.user.xmpp_localpart, state.xmpp_domain).parse::<jid::BareJid>()
         {
-            let avatar_url = identity_claims
-                .avatar_url
-                .as_deref()
-                .and_then(|s| url::Url::parse(s).ok());
             // Treat empty / whitespace-only `name` claims as absent so
             // the bridge does NOT publish a blank `<FN>` to vcard-temp
-            // / vCard4. The OIDC spec doesn't forbid an empty `name`,
-            // some IDPs return one when the user hasn't set a profile
-            // name; an empty FN would just blank a previously-set one.
-            // After this filter, `from_oidc_claims` maps `None` to
-            // `NameIntent::Remove` so a name that disappears from the
-            // IDP claim is actively cleared (instead of stale-set).
+            // / vCard4. After this filter, `from_oidc_claims` maps
+            // `None` to `NameIntent::Remove` so a name that disappears
+            // from the IDP claim is actively cleared (instead of
+            // stale-set).
             let display_name = identity_claims
                 .name
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string);
-            let source = crate::profile::ProfileSource::from_oidc_claims(avatar_url, display_name);
-            let fut = (hook)(jid, source);
-            tokio::spawn(fut);
+
+            // Three-way classification of the OIDC `picture` claim:
+            //   - absent / null            → RemoveIfOidcOwned
+            //   - present but unparseable  → Skip (preserve prior
+            //     state — actively wiping on a typo'd URL would be
+            //     destructive)
+            //   - present and parseable    → SetFromUrl
+            // We do NOT route through `from_oidc_claims` here because
+            // its two-way mapping treats `None` as "remove", which
+            // would conflate "IDP forgot the picture claim" with
+            // "IDP returned a malformed URL".
+            let raw_avatar = identity_claims
+                .avatar_url
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+            let photo_intent = match raw_avatar {
+                None => crate::profile::PhotoIntent::RemoveIfOidcOwned,
+                Some(s) => match url::Url::parse(s) {
+                    Ok(url) => crate::profile::PhotoIntent::SetFromUrl(url),
+                    Err(parse_err) => {
+                        tracing::warn!(
+                            jid = %linked.user.xmpp_localpart,
+                            url = %s,
+                            error = %parse_err,
+                            "OIDC `picture` claim is not a parseable URL; skipping PHOTO sync (prior avatar preserved)"
+                        );
+                        crate::profile::PhotoIntent::Skip
+                    }
+                },
+            };
+            let name_intent = match display_name {
+                Some(s) => crate::profile::NameIntent::Set(s),
+                None => crate::profile::NameIntent::Remove,
+            };
+            let source = crate::profile::ProfileSource::Oidc {
+                photo: photo_intent,
+                name: name_intent,
+            };
+            (hook)(jid, source);
         }
     }
 

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -165,16 +165,16 @@ pub(super) async fn callback_handler(
             // / vCard4. The OIDC spec doesn't forbid an empty `name`,
             // some IDPs return one when the user hasn't set a profile
             // name; an empty FN would just blank a previously-set one.
+            // After this filter, `from_oidc_claims` maps `None` to
+            // `NameIntent::Remove` so a name that disappears from the
+            // IDP claim is actively cleared (instead of stale-set).
             let display_name = identity_claims
                 .name
                 .as_deref()
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string);
-            let source = crate::profile::ProfileSource::Oidc {
-                avatar_url,
-                display_name,
-            };
+            let source = crate::profile::ProfileSource::from_oidc_claims(avatar_url, display_name);
             let fut = (hook)(jid, source);
             tokio::spawn(fut);
         }

--- a/server/crates/waddle-server/src/server/routes/auth/state.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/state.rs
@@ -1,22 +1,16 @@
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::OnceLock;
 
 use super::*;
 
 /// Typed callback the OIDC callback handler fires after a successful
-/// login to materialize a conformant PEP avatar + vCard set. Returns
-/// immediately; the caller spawns the future so login latency is
-/// unaffected.
-pub type ProfilePublishHook = Arc<
-    dyn Fn(
-            jid::BareJid,
-            crate::profile::ProfileSource,
-        ) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>
-        + Send
-        + Sync
-        + 'static,
->;
+/// login to materialize a conformant PEP avatar + vCard set. The hook
+/// implementation registers the publish chain with the
+/// `profile_publish_tracker` (`tokio_util::task::TaskTracker`)
+/// internally so login latency is unaffected AND the
+/// graceful-shutdown drain can `wait()` on in-flight publishes
+/// before tearing down the runtime.
+pub type ProfilePublishHook =
+    Arc<dyn Fn(jid::BareJid, crate::profile::ProfileSource) + Send + Sync + 'static>;
 
 /// Shared auth state.
 pub struct AuthState {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -138,6 +138,22 @@ pub(super) async fn handle_pubsub_iq(
                             },
                         )
                         .await;
+                        // RFC 363 user-managed avatar guard: a user
+                        // publishing to their own `urn:xmpp:avatar:*`
+                        // node owns the avatar henceforth. Mark
+                        // `avatar_source='user'` so the next OIDC
+                        // reconcile suppresses `RemoveIfOidcOwned`.
+                        if is_pep
+                            && target_jid == user_jid
+                            && (node == waddle_xmpp::xep::xep0084::NODE_AVATAR_DATA
+                                || node == waddle_xmpp::xep::xep0084::NODE_AVATAR_METADATA)
+                        {
+                            crate::profile::record_self_published(
+                                state.deps.app_state.db_pool.global_actor(),
+                                &user_jid,
+                            )
+                            .await;
+                        }
                         let response =
                             build_pubsub_publish_result(iq, &node, &publish_result.item_id);
                         return vec![iq_to_xml(response)];

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -110,6 +110,26 @@ pub(super) async fn handle_pubsub_iq(
                     }
                 }
 
+                // RFC 363 user-managed avatar guard: when a user
+                // wire-publishes to their OWN avatar / vCard4 node we
+                // need the publish AND the provenance flip to be
+                // atomic vs the concurrent OIDC publish chain. Both
+                // sides take the same per-(BareJid) lock from
+                // `profile::avatar_source::acquire_per_jid_lock`.
+                // Acquired conditionally (the lock is meaningless for
+                // non-PEP-self publishes) so unrelated publishes
+                // aren't serialized.
+                let touches_avatar_provenance = is_pep
+                    && target_jid == user_jid
+                    && (node == waddle_xmpp::xep::xep0084::NODE_AVATAR_DATA
+                        || node == waddle_xmpp::xep::xep0084::NODE_AVATAR_METADATA
+                        || node == waddle_xmpp::xep::xep0292::PEP_NODE_VCARD4);
+                let _guard = if touches_avatar_provenance {
+                    Some(crate::profile::acquire_per_jid_lock(state, &user_jid).await)
+                } else {
+                    None
+                };
+
                 let result = state
                     .deps
                     .protocol
@@ -138,21 +158,21 @@ pub(super) async fn handle_pubsub_iq(
                             },
                         )
                         .await;
-                        // RFC 363 user-managed avatar guard: a user
-                        // publishing to their own `urn:xmpp:avatar:*`
-                        // node owns the avatar henceforth. Mark
-                        // `avatar_source='user'` so the next OIDC
-                        // reconcile suppresses `RemoveIfOidcOwned`.
-                        if is_pep
-                            && target_jid == user_jid
-                            && (node == waddle_xmpp::xep::xep0084::NODE_AVATAR_DATA
-                                || node == waddle_xmpp::xep::xep0084::NODE_AVATAR_METADATA)
-                        {
-                            crate::profile::record_self_published(
-                                state.deps.app_state.db_pool.global_actor(),
-                                &user_jid,
-                            )
-                            .await;
+                        // Provenance flip — runs while holding the
+                        // per-JID lock above so an OIDC reconcile
+                        // either sees the new `'user'` flag or hasn't
+                        // started yet (won't race in to wipe).
+                        if touches_avatar_provenance {
+                            let db_actor = state.deps.app_state.db_pool.global_actor();
+                            if is_user_avatar_retract(&node, &item) {
+                                // User explicitly retracted their
+                                // own avatar (XEP-0084 §4.3 empty
+                                // `<metadata/>`) — opt back into OIDC
+                                // management.
+                                crate::profile::record_oidc_managed(db_actor, &user_jid).await;
+                            } else {
+                                crate::profile::record_self_published(db_actor, &user_jid).await;
+                            }
                         }
                         let response =
                             build_pubsub_publish_result(iq, &node, &publish_result.item_id);
@@ -292,4 +312,21 @@ pub(super) async fn handle_pubsub_iq(
         }
     }
     Vec::new()
+}
+
+/// Detect XEP-0084 §4.3's empty-`<metadata/>` "I have no avatar"
+/// publish: the metadata node, payload is a `<metadata>` element with
+/// no children. Used to flip `avatar_source='oidc'` so a user who
+/// retracts their own picture re-opts into OIDC management.
+fn is_user_avatar_retract(node: &str, item: &waddle_xmpp::pubsub::PubSubItem) -> bool {
+    if node != waddle_xmpp::xep::xep0084::NODE_AVATAR_METADATA {
+        return false;
+    }
+    let Some(payload) = item.payload.as_ref() else {
+        return false;
+    };
+    if payload.name() != "metadata" {
+        return false;
+    }
+    payload.children().next().is_none()
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -80,6 +80,22 @@ pub struct ProtocolServices {
     /// process-wide hash-keyed `CapsCache` plus per-resource caps
     /// mappings used by XEP-0163 §3 fan-out filtering.
     pub caps_resolver: Arc<crate::server::caps_resolution::CapsResolver>,
+    /// Per-(BareJid) mutex set guarding the `user_avatar_source`
+    /// read-then-publish critical section. Both the OIDC publish
+    /// chain (`profile::publish::ensure_pep_profile_published`) and
+    /// the wire avatar-publish hook (`pubsub_dispatch` calling
+    /// `record_self_published`) acquire the same mutex by
+    /// `BareJid`, closing the TOCTOU race where OIDC could read
+    /// `'oidc'` between the user's wire publish and the user's
+    /// provenance flip and then wipe the just-set avatar.
+    pub avatar_source_locks: Arc<dashmap::DashMap<jid::BareJid, Arc<tokio::sync::Mutex<()>>>>,
+    /// Tracker for the OIDC → PEP profile-publish background tasks.
+    /// The auth callback registers each `tokio::spawn` here so the
+    /// graceful-shutdown drain can `wait()` on in-flight publishes
+    /// before tearing down the runtime — preventing the split-state
+    /// where the empty `<metadata/>` is published but vcard-temp
+    /// PHOTO is still set.
+    pub profile_publish_tracker: tokio_util::task::TaskTracker,
     /// Sidecar map keyed by SM stream id, holding the authenticated `Session`
     /// so that a resumed stream doesn't lose its authorization context and
     /// can serve IQs that check channel membership, etc. Entries are

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -185,6 +185,8 @@ async fn create_test_websocket_state_with_extension_manager(
                     caps_resolver: Arc::new(
                         crate::server::caps_resolution::CapsResolver::default(),
                     ),
+                    avatar_source_locks: Arc::new(dashmap::DashMap::new()),
+                    profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                 },
                 occupant_id_secret: OccupantIdSecret::new(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -537,5 +537,30 @@ pub(crate) fn spawn_graceful_shutdown_drain(
             total_drained,
             "Graceful shutdown: SM Q6 drain complete (iterative)"
         );
+
+        // Drain the OIDC profile-publish tracker before notifying
+        // shutdown complete. Each in-flight `ensure_pep_profile_published`
+        // call is bounded by the fetcher's 25s timeout budget +
+        // storage latency, so the wait is naturally bounded; calling
+        // `close()` first prevents new publishes from racing in
+        // during the drain. Without this wait the runtime can tear
+        // down mid-step and leave the avatar in a split state
+        // (empty `<metadata/>` published but vcard-temp PHOTO not
+        // yet stripped — exactly the inconsistency XEP-0398 §3
+        // forbids).
+        let publish_tracker = websocket_state
+            .deps
+            .protocol
+            .profile_publish_tracker
+            .clone();
+        publish_tracker.close();
+        if !publish_tracker.is_empty() {
+            info!(
+                in_flight = publish_tracker.len(),
+                "Graceful shutdown: awaiting in-flight OIDC profile publishes"
+            );
+        }
+        publish_tracker.wait().await;
+        info!("Graceful shutdown: OIDC profile-publish drain complete");
     });
 }

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -65,13 +65,9 @@ struct PublishResp {
     published_avatar_removal: bool,
     mirrored_vcard_temp: bool,
     mirrored_vcard4: bool,
-    #[allow(dead_code)]
     removed_vcard_temp_photo: bool,
-    #[allow(dead_code)]
     removed_vcard_temp_fn: bool,
-    #[allow(dead_code)]
     removed_vcard4_photo: bool,
-    #[allow(dead_code)]
     removed_vcard4_fn: bool,
     photo_removal_guarded_by_user_managed: bool,
 }
@@ -645,6 +641,14 @@ async fn avatar_removal_publishes_empty_metadata_and_strips_vcards() {
         !rm1.photo_removal_guarded_by_user_managed,
         "no user self-publish so guard MUST NOT fire: {rm1:?}"
     );
+    assert!(
+        rm1.removed_vcard_temp_photo && rm1.removed_vcard4_photo,
+        "PHOTO must be stripped from both vcard surfaces: {rm1:?}"
+    );
+    assert!(
+        !rm1.removed_vcard_temp_fn && !rm1.removed_vcard4_fn,
+        "FN must be untouched on photo-only removal: {rm1:?}"
+    );
 
     let metadata = iq_get_to(
         &mut admin,
@@ -713,7 +717,15 @@ async fn fn_removal_strips_fn_from_both_vcard_surfaces() {
     )
     .await;
 
-    invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_name()).await;
+    let rm = invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_name()).await;
+    assert!(
+        rm.removed_vcard_temp_fn && rm.removed_vcard4_fn,
+        "FN must be stripped from both vcard surfaces: {rm:?}"
+    );
+    assert!(
+        !rm.removed_vcard_temp_photo && !rm.removed_vcard4_photo,
+        "PHOTO must be untouched on FN-only removal: {rm:?}"
+    );
 
     let vcard_temp = iq_get_to(
         &mut admin,
@@ -741,6 +753,98 @@ async fn fn_removal_strips_fn_from_both_vcard_surfaces() {
     assert!(
         !vcard4.contains("<fn"),
         "vCard4 <fn> must be stripped: {vcard4}"
+    );
+
+    let _ = admin.close().await;
+}
+
+// ============================================================================
+// cross_axis_remove_photo_plus_set_fn_applies_both
+// ============================================================================
+//
+// Cross-axis regression test: when one publish call asks to
+// `RemoveIfOidcOwned` PHOTO AND `Set` FN simultaneously, both axes
+// must take effect. A prior version of the chain dropped the new
+// FN value when paired with photo-removal because the
+// `match (photo_op, name_op)` had no `(RemovePublished, NameOp::Set)`
+// arm. The current `mirror_*` helpers handle this by computing
+// `after_set` from `(photo_set, name_set)` independently and then
+// applying the strip pass on top.
+
+#[tokio::test]
+async fn cross_axis_remove_photo_plus_set_fn_applies_both() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "cross-axis-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    let png = tiny_png();
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "image/png")
+                .set_body_bytes(png.clone()),
+        )
+        .mount(&mock)
+        .await;
+
+    // Seed: PHOTO + initial FN.
+    invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare)
+            .set_name("Original FN")
+            .set_photo_url(format!("{}/seed.png", mock.uri())),
+    )
+    .await;
+
+    // Single publish: remove PHOTO + set new FN.
+    let mixed = invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare)
+            .remove_photo()
+            .set_name("Renamed"),
+    )
+    .await;
+    assert!(
+        mixed.published_avatar_removal,
+        "PHOTO removal must fire: {mixed:?}"
+    );
+    assert!(
+        mixed.removed_vcard_temp_photo && mixed.removed_vcard4_photo,
+        "PHOTO must be stripped from both vcard surfaces: {mixed:?}"
+    );
+
+    let vcard_temp = iq_get_to(
+        &mut admin,
+        "vcard-temp-cross-1",
+        &admin_bare,
+        r#"<vCard xmlns="vcard-temp"/>"#,
+    )
+    .await;
+    assert!(
+        !vcard_temp.contains("<PHOTO"),
+        "PHOTO stripped: {vcard_temp}"
+    );
+    assert!(
+        vcard_temp.contains("<FN") && vcard_temp.contains("Renamed"),
+        "new FN MUST be applied alongside PHOTO removal: {vcard_temp}"
+    );
+    assert!(
+        !vcard_temp.contains("Original FN"),
+        "old FN MUST be replaced: {vcard_temp}"
+    );
+
+    let vcard4 = iq_get_to(
+        &mut admin,
+        "vcard4-cross-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="urn:xmpp:vcard4"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        !vcard4.contains("<photo") && vcard4.contains("Renamed"),
+        "vCard4: photo stripped, new FN applied: {vcard4}"
     );
 
     let _ = admin.close().await;

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -7,6 +7,7 @@
 
 mod ws_common;
 
+use serde_json::json;
 use tokio::sync::Mutex;
 use ws_common::{TestServer, WsXmppClient};
 
@@ -40,14 +41,17 @@ async fn iq_get_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) ->
         .expect("iq get response")
 }
 
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PublishReq {
-    jid: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    display_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    avatar_url: Option<String>,
+async fn iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq set");
+    client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("iq set response")
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -58,8 +62,64 @@ struct PublishResp {
     photo_bytes_len: Option<usize>,
     published_avatar_data: bool,
     published_avatar_metadata: bool,
+    published_avatar_removal: bool,
     mirrored_vcard_temp: bool,
     mirrored_vcard4: bool,
+    #[allow(dead_code)]
+    removed_vcard_temp_photo: bool,
+    #[allow(dead_code)]
+    removed_vcard_temp_fn: bool,
+    #[allow(dead_code)]
+    removed_vcard4_photo: bool,
+    #[allow(dead_code)]
+    removed_vcard4_fn: bool,
+    photo_removal_guarded_by_user_managed: bool,
+}
+
+/// Builder for the test-seam JSON request. The on-the-wire shape
+/// matches the typed `PhotoIntentDto` / `NameIntentDto` enums in
+/// `profile_publish_route.rs`.
+#[derive(Debug, Clone, Default)]
+struct PublishReq {
+    jid: String,
+    photo: Option<serde_json::Value>,
+    name: Option<serde_json::Value>,
+}
+
+impl PublishReq {
+    fn for_jid(jid: impl Into<String>) -> Self {
+        Self {
+            jid: jid.into(),
+            photo: None,
+            name: None,
+        }
+    }
+    fn set_photo_url(mut self, url: impl Into<String>) -> Self {
+        self.photo = Some(json!({ "setFromUrl": url.into() }));
+        self
+    }
+    fn remove_photo(mut self) -> Self {
+        self.photo = Some(json!({ "removeIfOidcOwned": null }));
+        self
+    }
+    fn set_name(mut self, s: impl Into<String>) -> Self {
+        self.name = Some(json!({ "set": s.into() }));
+        self
+    }
+    fn remove_name(mut self) -> Self {
+        self.name = Some(json!({ "remove": null }));
+        self
+    }
+    fn to_json(&self) -> serde_json::Value {
+        let mut obj = json!({ "jid": self.jid });
+        if let Some(ref p) = self.photo {
+            obj["photo"] = p.clone();
+        }
+        if let Some(ref n) = self.name {
+            obj["name"] = n.clone();
+        }
+        obj
+    }
 }
 
 async fn invoke_profile_publish(server: &TestServer, req: &PublishReq) -> PublishResp {
@@ -68,7 +128,7 @@ async fn invoke_profile_publish(server: &TestServer, req: &PublishReq) -> Publis
     let resp = client
         .post(&url)
         .header("X-Waddle-Test-Token", server.test_profile_publish_token())
-        .json(req)
+        .json(&req.to_json())
         .send()
         .await
         .expect("POST /api/test/profile-publish");
@@ -82,8 +142,7 @@ async fn invoke_profile_publish(server: &TestServer, req: &PublishReq) -> Publis
 }
 
 /// Variant of [`invoke_profile_publish`] that returns `(status, body)`
-/// without panicking on non-2xx, so failure-path tests can assert
-/// what the test seam does on bad input.
+/// without panicking on non-2xx.
 async fn invoke_profile_publish_raw(
     server: &TestServer,
     req: &PublishReq,
@@ -91,7 +150,7 @@ async fn invoke_profile_publish_raw(
 ) -> (reqwest::StatusCode, String) {
     let url = format!("{}/api/test/profile-publish", server.http_base_url());
     let client = reqwest::Client::new();
-    let mut builder = client.post(&url).json(req);
+    let mut builder = client.post(&url).json(&req.to_json());
     if let Some(t) = token {
         builder = builder.header("X-Waddle-Test-Token", t);
     }
@@ -115,12 +174,8 @@ fn tiny_png() -> Vec<u8> {
 }
 
 // ============================================================================
-// Test 1 — fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar
+// fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar
 // ============================================================================
-//
-// XEP-0292 / XEP-0398 §3: when the bridge is asked to sync only FN
-// (no avatar), vcard-temp gets `<FN>` and the vCard4 PEP node gets
-// `<fn><text>...</text></fn>`. The avatar nodes are NOT touched.
 
 #[tokio::test]
 async fn fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar() {
@@ -131,11 +186,7 @@ async fn fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar() {
 
     let resp = invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: Some("Test FN".into()),
-            avatar_url: None,
-        },
+        &PublishReq::for_jid(&admin_bare).set_name("Test FN"),
     )
     .await;
     assert!(
@@ -149,7 +200,6 @@ async fn fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar() {
         "no avatar published: {resp:?}"
     );
 
-    // vcard-temp via XEP-0054 IQ get.
     let vcard_temp = iq_get_to(
         &mut admin,
         "vcard-temp-fn-1",
@@ -164,7 +214,6 @@ async fn fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar() {
         "vcard-temp must carry FN per XEP-0398 §3: {vcard_temp}"
     );
 
-    // vCard4 via PEP items request.
     let vcard4 = iq_get_to(
         &mut admin,
         "vcard4-fn-1",
@@ -184,14 +233,8 @@ async fn fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar() {
 }
 
 // ============================================================================
-// Test 2 — avatar_url_publishes_data_and_metadata_with_real_sha1
+// avatar_url_publishes_data_and_metadata_with_real_sha1
 // ============================================================================
-//
-// XEP-0084 §4.1.1 / §4.1.2: the metadata `<info id>` MUST be the
-// SHA-1 of the actual fetched bytes — not a hash of the URL string.
-// This test serves a tiny PNG from wiremock, asks the bridge to
-// publish it, and verifies the metadata id == SHA-1(bytes) AND the
-// data item under that id contains the bytes (round-trip).
 
 #[tokio::test]
 async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
@@ -212,20 +255,10 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
         .mount(&mock)
         .await;
 
-    // wiremock serves over plain HTTP on 127.0.0.1. The test seam's
-    // FetchPolicy sets `block_non_global_ips=false` and
-    // `allow_http_for_tests=true` so the loopback fixture is
-    // reachable; production callers (the OIDC bridge) build a
-    // `FetchPolicy::default()` instead.
     let avatar_url = format!("{}/avatar.png", mock.uri());
-
     let resp = invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: None,
-            avatar_url: Some(avatar_url),
-        },
+        &PublishReq::for_jid(&admin_bare).set_photo_url(&avatar_url),
     )
     .await;
 
@@ -233,22 +266,10 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
         .photo_sha1_hex
         .clone()
         .expect("metadata MUST carry the SHA-1 id");
-    assert_eq!(
-        resp.photo_mime.as_deref(),
-        Some("image/png"),
-        "MIME must round-trip from Content-Type: {resp:?}"
-    );
-    assert_eq!(
-        resp.photo_bytes_len,
-        Some(png_bytes.len()),
-        "byte count must round-trip exactly: {resp:?}"
-    );
-    assert!(
-        resp.published_avatar_data && resp.published_avatar_metadata,
-        "both nodes must receive a publish: {resp:?}"
-    );
+    assert_eq!(resp.photo_mime.as_deref(), Some("image/png"));
+    assert_eq!(resp.photo_bytes_len, Some(png_bytes.len()));
+    assert!(resp.published_avatar_data && resp.published_avatar_metadata);
 
-    // Metadata item retrievable via PEP items, with id == sha1.
     let metadata = iq_get_to(
         &mut admin,
         "avatar-meta-1",
@@ -260,16 +281,9 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
         metadata.contains(NS_AVATAR_METADATA) && metadata.contains(&format!(r#"id="{sha1}""#)),
         "metadata item MUST be keyed on the SHA-1 of the bytes per XEP-0084 §4.1.1: {metadata}"
     );
-    assert!(
-        metadata.contains(r#"type="image/png""#),
-        "metadata <info type> MUST round-trip the MIME: {metadata}"
-    );
-    assert!(
-        !metadata.contains(r#"url="#),
-        "metadata MUST NOT include `url` attribute (RFC 363 design): {metadata}"
-    );
+    assert!(metadata.contains(r#"type="image/png""#));
+    assert!(!metadata.contains(r#"url="#));
 
-    // Data item retrievable via PEP items at the same id.
     let data = iq_get_to(
         &mut admin,
         "avatar-data-1",
@@ -288,7 +302,7 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
 }
 
 // ============================================================================
-// Test 3 — empty_source_is_no_op
+// empty_source_is_no_op
 // ============================================================================
 
 #[tokio::test]
@@ -297,24 +311,16 @@ async fn empty_source_is_no_op() {
     let server = TestServer::start();
     let admin_bare = format!("{ADMIN}@{DOMAIN}");
 
-    let resp = invoke_profile_publish(
-        &server,
-        &PublishReq {
-            jid: admin_bare,
-            display_name: None,
-            avatar_url: None,
-        },
-    )
-    .await;
-
-    assert!(!resp.published_avatar_data, "{resp:?}");
-    assert!(!resp.published_avatar_metadata, "{resp:?}");
-    assert!(!resp.mirrored_vcard_temp, "{resp:?}");
-    assert!(!resp.mirrored_vcard4, "{resp:?}");
+    let resp = invoke_profile_publish(&server, &PublishReq::for_jid(admin_bare)).await;
+    assert!(!resp.published_avatar_data);
+    assert!(!resp.published_avatar_metadata);
+    assert!(!resp.published_avatar_removal);
+    assert!(!resp.mirrored_vcard_temp);
+    assert!(!resp.mirrored_vcard4);
 }
 
 // ============================================================================
-// Test 4 — combined_fn_plus_avatar_publishes_full_chain
+// combined_fn_plus_avatar_publishes_full_chain
 // ============================================================================
 
 #[tokio::test]
@@ -337,18 +343,13 @@ async fn combined_fn_plus_avatar_publishes_full_chain() {
 
     let resp = invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: Some("Combined".into()),
-            avatar_url: Some(format!("{}/x.png", mock.uri())),
-        },
+        &PublishReq::for_jid(&admin_bare)
+            .set_name("Combined")
+            .set_photo_url(format!("{}/x.png", mock.uri())),
     )
     .await;
-    assert!(
-        resp.published_avatar_data && resp.published_avatar_metadata,
-        "{resp:?}"
-    );
-    assert!(resp.mirrored_vcard_temp && resp.mirrored_vcard4, "{resp:?}");
+    assert!(resp.published_avatar_data && resp.published_avatar_metadata);
+    assert!(resp.mirrored_vcard_temp && resp.mirrored_vcard4);
 
     let vcard4 = iq_get_to(
         &mut admin,
@@ -364,20 +365,14 @@ async fn combined_fn_plus_avatar_publishes_full_chain() {
             && vcard4.contains(&format!("node={NS_AVATAR_DATA}")),
         "vCard4 photo MUST reference the PEP avatar-data item, not embed bytes inline: {vcard4}"
     );
-    assert!(
-        !vcard4.contains("data:image/png;base64,"),
-        "vCard4 MUST NOT inline base64 bytes (XEP-0163 fan-out bloat): {vcard4}"
-    );
+    assert!(!vcard4.contains("data:image/png;base64,"));
 
     let _ = admin.close().await;
 }
 
 // ============================================================================
-// Test 5 — non_png_content_type_is_rejected
+// non_png_content_type_is_rejected
 // ============================================================================
-//
-// XEP-0084 §3.1 limits `<data/>` to `image/png`. The fetcher MUST
-// reject any other Content-Type before publishing.
 
 #[tokio::test]
 async fn non_png_content_type_is_rejected() {
@@ -397,11 +392,7 @@ async fn non_png_content_type_is_rejected() {
 
     let (status, body) = invoke_profile_publish_raw(
         &server,
-        &PublishReq {
-            jid: admin_bare,
-            display_name: None,
-            avatar_url: Some(format!("{}/jpeg.bin", mock.uri())),
-        },
+        &PublishReq::for_jid(admin_bare).set_photo_url(format!("{}/jpeg.bin", mock.uri())),
         Some(server.test_profile_publish_token()),
     )
     .await;
@@ -413,12 +404,8 @@ async fn non_png_content_type_is_rejected() {
 }
 
 // ============================================================================
-// Test 6 — png_content_type_with_non_png_bytes_is_rejected
+// png_content_type_with_non_png_bytes_is_rejected
 // ============================================================================
-//
-// A hostile origin can return `Content-Type: image/png` while
-// serving HTML/SVG/JS bytes. The fetcher's magic-byte sniff MUST
-// catch the lie before the bytes land in `urn:xmpp:avatar:data`.
 
 #[tokio::test]
 async fn png_content_type_with_non_png_bytes_is_rejected() {
@@ -431,7 +418,6 @@ async fn png_content_type_with_non_png_bytes_is_rejected() {
         .respond_with(
             wiremock::ResponseTemplate::new(200)
                 .insert_header("content-type", "image/png")
-                // JPEG SOI + JFIF — definitely not a PNG signature.
                 .set_body_bytes(
                     b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00"
                         .to_vec(),
@@ -442,11 +428,7 @@ async fn png_content_type_with_non_png_bytes_is_rejected() {
 
     let (status, body) = invoke_profile_publish_raw(
         &server,
-        &PublishReq {
-            jid: admin_bare,
-            display_name: None,
-            avatar_url: Some(format!("{}/lying.png", mock.uri())),
-        },
+        &PublishReq::for_jid(admin_bare).set_photo_url(format!("{}/lying.png", mock.uri())),
         Some(server.test_profile_publish_token()),
     )
     .await;
@@ -458,13 +440,8 @@ async fn png_content_type_with_non_png_bytes_is_rejected() {
 }
 
 // ============================================================================
-// Test 7 — same_avatar_published_twice_is_idempotent
+// same_avatar_published_twice_is_idempotent
 // ============================================================================
-//
-// XEP-0060 / XEP-0084 §4.1.1: avatar items are keyed on SHA-1 of
-// bytes. Re-publishing the same bytes results in the same item id
-// and `max_items=1` evicts no rows that weren't already replaced —
-// the wire-observable end state is identical.
 
 #[tokio::test]
 async fn same_avatar_published_twice_is_idempotent() {
@@ -487,28 +464,19 @@ async fn same_avatar_published_twice_is_idempotent() {
 
     let first = invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: None,
-            avatar_url: Some(url.clone()),
-        },
+        &PublishReq::for_jid(&admin_bare).set_photo_url(&url),
     )
     .await;
     let second = invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: None,
-            avatar_url: Some(url),
-        },
+        &PublishReq::for_jid(&admin_bare).set_photo_url(&url),
     )
     .await;
     assert_eq!(
         first.photo_sha1_hex, second.photo_sha1_hex,
-        "identical bytes MUST produce identical SHA-1 ids: {first:?} vs {second:?}"
+        "identical bytes MUST produce identical SHA-1 ids"
     );
 
-    // Metadata still has exactly one item, and it carries that id.
     let sha1 = first.photo_sha1_hex.expect("first publish has hash");
     let metadata = iq_get_to(
         &mut admin,
@@ -517,19 +485,13 @@ async fn same_avatar_published_twice_is_idempotent() {
         &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{NS_AVATAR_METADATA}"/></pubsub>"#),
     )
     .await;
-    assert!(
-        metadata.contains(&format!(r#"id="{sha1}""#)),
-        "after idempotent re-publish the metadata id MUST be unchanged: {metadata}"
-    );
+    assert!(metadata.contains(&format!(r#"id="{sha1}""#)));
     let _ = admin.close().await;
 }
 
 // ============================================================================
-// Test 8 — fn_only_after_combined_preserves_photo
+// fn_only_after_combined_preserves_photo
 // ============================================================================
-//
-// XEP-0398 RMW invariant: a subsequent FN-only publish MUST NOT
-// drop the existing PHOTO from vcard-temp or vCard4.
 
 #[tokio::test]
 async fn fn_only_after_combined_preserves_photo() {
@@ -551,20 +513,14 @@ async fn fn_only_after_combined_preserves_photo() {
 
     invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: Some("First Name".into()),
-            avatar_url: Some(format!("{}/seed.png", mock.uri())),
-        },
+        &PublishReq::for_jid(&admin_bare)
+            .set_name("First Name")
+            .set_photo_url(format!("{}/seed.png", mock.uri())),
     )
     .await;
     invoke_profile_publish(
         &server,
-        &PublishReq {
-            jid: admin_bare.clone(),
-            display_name: Some("Renamed".into()),
-            avatar_url: None,
-        },
+        &PublishReq::for_jid(&admin_bare).set_name("Renamed"),
     )
     .await;
 
@@ -602,11 +558,8 @@ async fn fn_only_after_combined_preserves_photo() {
 }
 
 // ============================================================================
-// Test 9 — test_seam_rejects_missing_token
+// test_seam_rejects_missing_token
 // ============================================================================
-//
-// Defense-in-depth: the test seam MUST refuse to publish without
-// the `X-Waddle-Test-Token` header, even when the env-flag is on.
 
 #[tokio::test]
 async fn test_seam_rejects_missing_token() {
@@ -616,27 +569,16 @@ async fn test_seam_rejects_missing_token() {
 
     let (status, _) = invoke_profile_publish_raw(
         &server,
-        &PublishReq {
-            jid: admin_bare,
-            display_name: Some("X".into()),
-            avatar_url: None,
-        },
+        &PublishReq::for_jid(admin_bare).set_name("X"),
         None,
     )
     .await;
-    assert_eq!(
-        status,
-        reqwest::StatusCode::UNAUTHORIZED,
-        "missing token MUST yield 401, got {status}"
-    );
+    assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
 }
 
 // ============================================================================
-// Test 10 — test_seam_rejects_jid_outside_allowlist
+// test_seam_rejects_jid_outside_allowlist
 // ============================================================================
-//
-// Defense-in-depth: even with a valid token, the seam MUST refuse
-// any JID that isn't a configured fixed-account JID.
 
 #[tokio::test]
 async fn test_seam_rejects_jid_outside_allowlist() {
@@ -645,17 +587,269 @@ async fn test_seam_rejects_jid_outside_allowlist() {
 
     let (status, _) = invoke_profile_publish_raw(
         &server,
-        &PublishReq {
-            jid: format!("ghost@{DOMAIN}"),
-            display_name: Some("X".into()),
-            avatar_url: None,
-        },
+        &PublishReq::for_jid(format!("ghost@{DOMAIN}")).set_name("X"),
         Some(server.test_profile_publish_token()),
     )
     .await;
-    assert_eq!(
-        status,
-        reqwest::StatusCode::FORBIDDEN,
-        "non-allowlisted JID MUST yield 403, got {status}"
+    assert_eq!(status, reqwest::StatusCode::FORBIDDEN);
+}
+
+// ============================================================================
+// REMOVAL FLOW TESTS (PR4)
+// ============================================================================
+
+// ============================================================================
+// avatar_removal_publishes_empty_metadata_and_strips_vcards
+// ============================================================================
+//
+// XEP-0084 §4.3: removal publishes an empty `<metadata/>` element at
+// item id `current`. Mirror surfaces (vcard-temp PHOTO, vCard4
+// `<photo>`) MUST also be stripped so legacy clients drop their
+// cached avatar.
+
+#[tokio::test]
+async fn avatar_removal_publishes_empty_metadata_and_strips_vcards() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "avatar-rm-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    let png = tiny_png();
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "image/png")
+                .set_body_bytes(png.clone()),
+        )
+        .mount(&mock)
+        .await;
+
+    // Seed: set an avatar + name first so removal has prior state.
+    invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare)
+            .set_name("Alice")
+            .set_photo_url(format!("{}/seed.png", mock.uri())),
+    )
+    .await;
+
+    // First removal: empty `<metadata/>` published, vCard PHOTO stripped.
+    let rm1 =
+        invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_photo()).await;
+    assert!(
+        rm1.published_avatar_removal,
+        "first removal must publish empty <metadata/>: {rm1:?}"
     );
+    assert!(
+        !rm1.photo_removal_guarded_by_user_managed,
+        "no user self-publish so guard MUST NOT fire: {rm1:?}"
+    );
+
+    let metadata = iq_get_to(
+        &mut admin,
+        "avatar-meta-rm-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{NS_AVATAR_METADATA}"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        metadata.contains(r#"id="current""#)
+            && (metadata.contains(r#"<metadata xmlns="urn:xmpp:avatar:metadata"/>"#)
+                || metadata.contains(r#"<metadata xmlns='urn:xmpp:avatar:metadata'/>"#)),
+        "removal metadata MUST be empty `<metadata xmlns='urn:xmpp:avatar:metadata'/>` at id='current' per XEP-0084 §4.3: {metadata}"
+    );
+
+    let vcard_temp = iq_get_to(
+        &mut admin,
+        "vcard-temp-rm-1",
+        &admin_bare,
+        r#"<vCard xmlns="vcard-temp"/>"#,
+    )
+    .await;
+    assert!(
+        !vcard_temp.contains("<PHOTO"),
+        "vcard-temp <PHOTO> must be stripped on removal: {vcard_temp}"
+    );
+
+    let vcard4 = iq_get_to(
+        &mut admin,
+        "vcard4-rm-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="urn:xmpp:vcard4"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        !vcard4.contains("<photo"),
+        "vCard4 <photo> must be stripped on removal: {vcard4}"
+    );
+
+    // Second removal: idempotent — empty `<metadata/>` is already
+    // published, so no new wire publish should fire.
+    let rm2 =
+        invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_photo()).await;
+    assert!(
+        !rm2.published_avatar_removal,
+        "second removal MUST be idempotent (no extra publish): {rm2:?}"
+    );
+
+    let _ = admin.close().await;
+}
+
+// ============================================================================
+// fn_removal_strips_fn_from_both_vcard_surfaces
+// ============================================================================
+
+#[tokio::test]
+async fn fn_removal_strips_fn_from_both_vcard_surfaces() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "fn-rm-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare).set_name("To Be Removed"),
+    )
+    .await;
+
+    invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_name()).await;
+
+    let vcard_temp = iq_get_to(
+        &mut admin,
+        "vcard-temp-fnrm-1",
+        &admin_bare,
+        r#"<vCard xmlns="vcard-temp"/>"#,
+    )
+    .await;
+    assert!(
+        !vcard_temp.contains("<FN"),
+        "vcard-temp <FN> must be stripped: {vcard_temp}"
+    );
+    assert!(
+        !vcard_temp.contains("To Be Removed"),
+        "removed FN value must not linger: {vcard_temp}"
+    );
+
+    let vcard4 = iq_get_to(
+        &mut admin,
+        "vcard4-fnrm-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="urn:xmpp:vcard4"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        !vcard4.contains("<fn"),
+        "vCard4 <fn> must be stripped: {vcard4}"
+    );
+
+    let _ = admin.close().await;
+}
+
+// ============================================================================
+// avatar_removal_no_op_when_no_prior_avatar
+// ============================================================================
+//
+// Trigger discipline: if there's no prior avatar, RemoveIfOidcOwned
+// MUST NOT publish an empty `<metadata/>`. First-OIDC-login users
+// (who never had an avatar) shouldn't generate spurious removal
+// events.
+
+#[tokio::test]
+async fn avatar_removal_no_op_when_no_prior_avatar() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    let resp =
+        invoke_profile_publish(&server, &PublishReq::for_jid(admin_bare).remove_photo()).await;
+    assert!(
+        !resp.published_avatar_removal,
+        "no prior avatar => no removal publish: {resp:?}"
+    );
+    assert!(
+        !resp.photo_removal_guarded_by_user_managed,
+        "user-managed guard didn't fire — `Unknown` source falls through to the prior-item check: {resp:?}"
+    );
+}
+
+// ============================================================================
+// user_self_published_avatar_is_protected_from_oidc_removal
+// ============================================================================
+//
+// The load-bearing claim of RFC 363's user-managed guard: when a
+// user has self-published via wire XEP-0084, the bridge marks
+// `users.avatar_source = 'user'`, and `RemoveIfOidcOwned`
+// suppresses the empty-metadata publish on the next OIDC reconcile.
+
+#[tokio::test]
+async fn user_self_published_avatar_is_protected_from_oidc_removal() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "guard-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    // Step 1: simulate the user self-publishing their own avatar via
+    // wire XEP-0084. The publish-time hook in pubsub_dispatch will
+    // flip `users.avatar_source = 'user'`.
+    let png = tiny_png();
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+    let png_b64 = BASE64.encode(&png);
+    let user_set = iq_set_to(
+        &mut admin,
+        "user-pub-data",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{NS_AVATAR_DATA}"><item id="user-self-1"><data xmlns="{NS_AVATAR_DATA}">{png_b64}</data></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        user_set.contains(r#"type="result""#),
+        "user self-publish must succeed: {user_set}"
+    );
+
+    // Also publish the metadata so `avatar_metadata_present` returns
+    // true (otherwise the guard never even has anything to evaluate
+    // against).
+    let user_meta = iq_set_to(
+        &mut admin,
+        "user-pub-meta",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{NS_AVATAR_METADATA}"><item id="user-self-1"><metadata xmlns="{NS_AVATAR_METADATA}"><info id="user-self-1" type="image/png" bytes="{}"/></metadata></item></publish></pubsub>"#,
+            png.len()
+        ),
+    )
+    .await;
+    assert!(user_meta.contains(r#"type="result""#));
+
+    // Step 2: OIDC reconcile asks to remove the avatar. Guard should
+    // fire — `published_avatar_removal=false`,
+    // `photo_removal_guarded_by_user_managed=true`.
+    let resp =
+        invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_photo()).await;
+    assert!(
+        !resp.published_avatar_removal,
+        "user-managed guard MUST suppress the empty-metadata publish: {resp:?}"
+    );
+    assert!(
+        resp.photo_removal_guarded_by_user_managed,
+        "guard flag MUST be set so telemetry can observe the suppression: {resp:?}"
+    );
+
+    // The user's metadata item is still there.
+    let metadata = iq_get_to(
+        &mut admin,
+        "guard-meta-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{NS_AVATAR_METADATA}"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        metadata.contains(r#"id="user-self-1""#),
+        "user-published metadata item MUST survive the suppressed removal: {metadata}"
+    );
+
+    let _ = admin.close().await;
 }

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -774,6 +774,123 @@ async fn avatar_removal_no_op_when_no_prior_avatar() {
 }
 
 // ============================================================================
+// avatar_removal_fans_out_empty_metadata_event_to_subscriber
+// ============================================================================
+//
+// XEP-0163 §3 / XEP-0060 §7.1: subscribers MUST receive a
+// `<message><event>` notification when a PEP item is published —
+// including the XEP-0084 §4.3 empty-`<metadata/>` removal shape.
+// Without explicit fan-out (the load-bearing PR3 fix) the removal
+// is silent. This is the regression test for that wiring.
+
+const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
+
+#[tokio::test]
+async fn avatar_removal_fans_out_empty_metadata_event_to_subscriber() {
+    use std::time::Duration;
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let admin = admin_client(&server, "avatar-fanout-admin").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    // Seed an avatar so the metadata node exists with `oidc_pep_node_config`
+    // (Open access, max_items=1) — without this, bob's <subscribe/> would
+    // be denied.
+    let png = tiny_png();
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "image/png")
+                .set_body_bytes(png.clone()),
+        )
+        .mount(&mock)
+        .await;
+    invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare).set_photo_url(format!("{}/seed.png", mock.uri())),
+    )
+    .await;
+
+    // Bob subscribes to admin's avatar-metadata node via plain
+    // XEP-0060 `<subscribe/>`. Open access lets any peer subscribe.
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "avatar-fanout-bob",
+    )
+    .await
+    .expect("bob connect");
+    let sub_resp = iq_set_to(
+        &mut bob,
+        "avatar-fanout-sub",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="{NS_AVATAR_METADATA}" jid="{bob_bare}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        sub_resp.contains(r#"type="result""#),
+        "subscribe must succeed (Open access): {sub_resp}"
+    );
+
+    // OIDC removal — empty `<metadata/>` published; fan-out MUST
+    // deliver the event to bob.
+    let rm =
+        invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_photo()).await;
+    assert!(rm.published_avatar_removal, "removal must publish: {rm:?}");
+
+    // Bob receives the `<message><event>` carrying the empty
+    // `<metadata/>` payload at item id `current`.
+    let event = wait_for_event_message(&mut bob, NS_AVATAR_METADATA, Duration::from_secs(2))
+        .await
+        .expect("bob MUST receive the empty-metadata fan-out event");
+    assert!(
+        event.contains(r#"id="current""#) || event.contains(r#"id='current'"#),
+        "fan-out item id must be `current` per §4.3: {event}"
+    );
+    assert!(
+        event.contains(r#"<metadata xmlns="urn:xmpp:avatar:metadata"/>"#)
+            || event.contains(r#"<metadata xmlns='urn:xmpp:avatar:metadata'/>"#),
+        "fan-out payload MUST be the empty `<metadata/>` removal shape: {event}"
+    );
+
+    let _ = bob.close().await;
+    let _ = admin.close().await;
+}
+
+async fn wait_for_event_message(
+    client: &mut WsXmppClient,
+    node: &str,
+    dur: std::time::Duration,
+) -> Option<String> {
+    let deadline = std::time::Instant::now() + dur;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                if frame.contains("<message")
+                    && frame.contains(NS_PUBSUB_EVENT)
+                    && (frame.contains(&format!(r#"node="{node}""#))
+                        || frame.contains(&format!(r#"node='{node}'"#)))
+                {
+                    return Some(frame);
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+// ============================================================================
 // user_self_published_avatar_is_protected_from_oidc_removal
 // ============================================================================
 //


### PR DESCRIPTION
PR 4 of 6 implementing [RFC 363](https://github.com/waddle-social/waddle/blob/main/docs/rfc/363-avatar-vcard-pep-sync.md). Built on top of merged PR3 (#440).

## Re-author note

The original PR4 branch was authored against pre-fixup PR3 and silently reverted seven critical PR3 fixes on rebase (no fan-out, vCard4 `data:` URI bloat, `NodeConfig::public()` regression, test-seam auth removed, SSRF/PNG hardening reverted, retroactive `'oidc'` migration default, no `avatar_source` write-on-self-publish). This commit re-authors the removal flow on top of current `main`, picking up only the new logical intent (typed per-axis enums + removal helpers) and applying it on the post-fixup shapes.

## Typed per-axis intents

`ProfileSource::Oidc` now carries `PhotoIntent` and `NameIntent` instead of raw `Option<Url>` / `Option<String>`. Each axis is independently `Skip`, `Set*`, or `Remove*`. `ProfileSource::from_oidc_claims` is the canonical mapper the OIDC callback uses: claim absent → corresponding `Remove*` variant.

## Removal flow (XEP-0084 §4.3)

`PhotoIntent::RemoveIfOidcOwned` publishes an empty `<metadata/>` element at item id `current` AND strips `<PHOTO>` from vcard-temp plus `<photo>` from vCard4. Driven through `publish_and_fan_out` so subscribers receive `pubsub#event` per XEP-0163 §3.

Idempotence: `avatar_metadata_present` parses the current item to detect an already-empty `<metadata/>`; repeat removals + first-OIDC-login users (no prior avatar) are wire-no-ops.

## User-managed avatar guard — wired end to end

`users.avatar_source` column added via migration v0002 (default `'oidc'`). Two surfaces:

- `profile::avatar_source::read_avatar_source` — read by the OIDC publish chain on `RemoveIfOidcOwned`. Returning `'user'` suppresses the empty-metadata publish and sets `photo_removal_guarded_by_user_managed=true` for telemetry.
- `profile::avatar_source::record_self_published` — called from `pubsub_dispatch` after a successful PEP publish to `urn:xmpp:avatar:{data,metadata}` where `target_jid == user_jid`. **UPSERT**s the column to `'user'`.

UPSERT (vs simple UPDATE) is needed because native-auth users (test fixed-account fixture, XEP-0077 / SCRAM users) only land in `native_users`, not `users` — without the upsert, the guard would silently target zero rows and never fire on those users.

## FN removal

`NameIntent::Remove` strips `<FN>` from vcard-temp and `<fn>` from vCard4. No user-managed guard analog (FN is always OIDC-owned in this codebase today).

## Test seam

`profile_publish_route` accepts the typed JSON shape:

```json
{
  "jid": "alice@localhost",
  "photo": { "setFromUrl": "https://..." } | { "removeIfOidcOwned": null },
  "name":  { "set": "Alice" }              | { "remove": null }
}
```

Hardening preserved from PR3: `X-Waddle-Test-Token` + JID allowlist + `profile_sync_error_status` mapping (400/422/502).

## Conformance

- XEP-0084 §4.3 — empty `<metadata/>` removal shape at item id `current`.
- XEP-0398 §3 — server-side vcard-temp ↔ PEP avatar consistency on removal.
- XEP-0292 — vCard4 `<photo>` and `<fn>` stripping preserves other fields.
- RFC 363 user-managed avatar guard — `avatar_source='user'` suppresses removal AND is actually written on user wire publish.
- Trigger discipline — repeated re-logins after removal are wire idempotent.

## Test coverage

Wire suite (14 tests, all green):
- 10 PR3 happy-path tests, ported to the new typed JSON shape.
- `avatar_removal_publishes_empty_metadata_and_strips_vcards` — wire shape + idempotent re-removal.
- `fn_removal_strips_fn_from_both_vcard_surfaces`.
- `avatar_removal_no_op_when_no_prior_avatar` — trigger discipline.
- `user_self_published_avatar_is_protected_from_oidc_removal` — **the load-bearing user-managed guard test** (sends a wire XEP-0084 publish, asserts the next OIDC removal is suppressed AND `photo_removal_guarded_by_user_managed=true`).

Unit suite: 7 new `vcard_rmw` strip-helper tests covering "remove PHOTO keeps EMAIL/NICKNAME", "remove FN keeps PHOTO", symmetric for vCard4. 26 profile unit tests + 495 server lib tests all green; `cargo clippy --all-targets -D warnings` clean; `cargo fmt --all -- --check` clean.

## Out of scope

- XEP-0153 self-presence `<x xmlns="vcard-temp:x:update">` advertisement on photo-set or empty `<photo/>` on photo-remove. Tracked for follow-up.
- Old `urn:xmpp:avatar:data` SHA-1 items aren't explicitly retracted on removal; `max_items=1` evicts them on the next set, but a deployment-side retract pass is a possible follow-up.

## Adversarial review log

The original branch (`bca936c0`) was reviewed by two parallel agents (XEP/security/typed + concurrency/migration/regressions) and surfaced 18 findings, of which 13 were "stale-against-merged-PR3" regressions. Re-authoring on top of current main resolves all 13 by construction. The remaining 5 (XEP-0084 §4.3 correctness, idempotence, user-managed guard write path, fan-out wiring, end-to-end guard test) are all addressed in this commit.