### PR TITLE
feat(server): startup backfill for OIDC profile sync

### DIFF
--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -357,6 +357,33 @@ CREATE TABLE user_avatar_source (
 );
 "#;
 
+/// `user_avatar_fetch_state` — per-user attempt + outcome state for
+/// the OIDC avatar fetcher's startup backfill. Keyed solely on
+/// `xmpp_localpart` to avoid the same `users.username UNIQUE`
+/// collision surface that drove `user_avatar_source` into a
+/// dedicated table. `last_error` is `NULL` on success and otherwise
+/// carries a `FetchError::kind()` value (`permanent_4xx`,
+/// `mime_rejected`, `size_exceeded`, `ssrf_blocked`, etc.) — the
+/// backfill consults it to throttle 4xx-style permanent failures
+/// for a 24h cool-down without re-hammering the IDP every boot.
+pub const V0003_USER_AVATAR_FETCH_STATE: &str = r#"
+CREATE TABLE user_avatar_fetch_state (
+    xmpp_localpart TEXT PRIMARY KEY,
+    last_attempt_at TEXT NOT NULL,
+    last_error TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"#;
+
+pub const V0003_USER_AVATAR_FETCH_STATE_POSTGRES: &str = r#"
+CREATE TABLE user_avatar_fetch_state (
+    xmpp_localpart TEXT PRIMARY KEY,
+    last_attempt_at TEXT NOT NULL,
+    last_error TEXT,
+    updated_at TEXT NOT NULL DEFAULT to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+);
+"#;
+
 /// Get all global migrations in order
 pub fn all() -> Vec<Migration> {
     vec![
@@ -373,6 +400,12 @@ pub fn all() -> Vec<Migration> {
                     .to_string(),
             sql_sqlite: V0002_USER_AVATAR_SOURCE,
             sql_postgres: V0002_USER_AVATAR_SOURCE_POSTGRES,
+        },
+        Migration {
+            version: 3,
+            description: "Add user_avatar_fetch_state for startup-backfill throttle".to_string(),
+            sql_sqlite: V0003_USER_AVATAR_FETCH_STATE,
+            sql_postgres: V0003_USER_AVATAR_FETCH_STATE_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -371,7 +371,7 @@ CREATE TABLE user_avatar_fetch_state (
     xmpp_localpart TEXT PRIMARY KEY,
     last_attempt_at TEXT NOT NULL,
     last_error TEXT,
-    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    updated_at TEXT NOT NULL
 );
 "#;
 
@@ -380,7 +380,7 @@ CREATE TABLE user_avatar_fetch_state (
     xmpp_localpart TEXT PRIMARY KEY,
     last_attempt_at TEXT NOT NULL,
     last_error TEXT,
-    updated_at TEXT NOT NULL DEFAULT to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    updated_at TEXT NOT NULL
 );
 "#;
 

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -353,7 +353,7 @@ pub const V0002_USER_AVATAR_SOURCE_POSTGRES: &str = r#"
 CREATE TABLE user_avatar_source (
     xmpp_localpart TEXT PRIMARY KEY,
     source TEXT NOT NULL CHECK (source IN ('oidc', 'user')),
-    updated_at TEXT NOT NULL DEFAULT to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    updated_at TEXT NOT NULL DEFAULT to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
 );
 "#;
 
@@ -380,7 +380,7 @@ CREATE TABLE user_avatar_fetch_state (
     xmpp_localpart TEXT PRIMARY KEY,
     last_attempt_at TEXT NOT NULL,
     last_error TEXT,
-    updated_at TEXT NOT NULL DEFAULT to_char(NOW(), 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+    updated_at TEXT NOT NULL DEFAULT to_char(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
 );
 "#;
 

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -179,7 +179,7 @@ async fn test_incompatible_history_forces_hard_cut_reapply() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 2, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 3, 1001, 1002]);
 
     let applied_again = runner.run(&db).await.unwrap();
     assert!(applied_again.is_empty());
@@ -230,7 +230,7 @@ async fn test_incompatible_history_recreates_existing_owned_tables() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 2, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 3, 1001, 1002]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn

--- a/server/crates/waddle-server/src/profile/backfill.rs
+++ b/server/crates/waddle-server/src/profile/backfill.rs
@@ -19,21 +19,18 @@
 //! wire publishes for the same user during a backfill pass do not
 //! race the user-managed guard.
 
-use std::sync::Arc;
-
 use chrono::{DateTime, Duration, Utc};
 use futures::stream::{self, StreamExt};
 use jid::BareJid;
+use kameo::actor::ActorRef;
 use thiserror::Error;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use url::Url;
 
-use super::avatar_source::{read_avatar_source, AvatarSource};
 use super::publish::{ensure_pep_profile_published, ProfilePublishDeps};
 use super::source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};
 use crate::db::actor::{DbActor, DbExecute, DbQuery};
-use crate::server::routes::websocket::WebSocketState;
-use kameo::actor::ActorRef;
 
 /// Concurrency cap on outbound avatar fetches during backfill.
 /// Avoids hammering the IDP / a slow CDN at boot.
@@ -95,12 +92,19 @@ struct BackfillRow {
 
 /// Run a one-shot backfill. `xmpp_domain` is the server's
 /// authoritative XMPP domain (used to construct each user's
-/// `BareJid`).
+/// `BareJid`). `cancel` is checked between rows so SIGTERM
+/// short-circuits the run instead of letting an N-row pass block
+/// the graceful-shutdown drain past the deployment grace period.
 ///
 /// Returns aggregate counters useful for boot-time telemetry.
 /// Per-user failures are logged and persisted but never abort the
-/// run.
-pub async fn run_startup_backfill(deps: &ProfilePublishDeps, xmpp_domain: &str) -> BackfillReport {
+/// run; cancellation does abort (with the partial counts up to that
+/// point reflected in the report's `processed`/`failed` fields).
+pub async fn run_startup_backfill(
+    deps: &ProfilePublishDeps,
+    xmpp_domain: &str,
+    cancel: CancellationToken,
+) -> BackfillReport {
     let db_actor = deps.state.deps.app_state.db_pool.global_actor();
 
     let rows = match load_users(db_actor).await {
@@ -121,54 +125,50 @@ pub async fn run_startup_backfill(deps: &ProfilePublishDeps, xmpp_domain: &str) 
     info!(total = rows.len(), "Profile backfill: starting");
 
     let now = Utc::now();
+    let cancel_for_workers = cancel.clone();
     let outcomes = stream::iter(rows)
-        .map(|row| process_row(deps, xmpp_domain, row, now))
+        .map(|row| {
+            let cancel = cancel_for_workers.clone();
+            async move {
+                if cancel.is_cancelled() {
+                    return ProcessOutcome::Cancelled;
+                }
+                process_row(deps, xmpp_domain, row, now).await
+            }
+        })
         .buffer_unordered(MAX_INFLIGHT)
         .collect::<Vec<_>>()
         .await;
 
+    let mut cancelled_count = 0usize;
     for outcome in outcomes {
         match outcome {
             ProcessOutcome::Ran => report.processed += 1,
             ProcessOutcome::ThrottledSkip => report.skipped_throttled += 1,
             ProcessOutcome::UserManagedSkip => report.skipped_user_managed += 1,
             ProcessOutcome::Failed => report.failed += 1,
+            ProcessOutcome::Cancelled => cancelled_count += 1,
         }
     }
 
-    info!(
-        total = report.total,
-        processed = report.processed,
-        skipped_throttled = report.skipped_throttled,
-        skipped_user_managed = report.skipped_user_managed,
-        failed = report.failed,
-        "Profile backfill: complete"
-    );
+    if cancelled_count > 0 {
+        info!(
+            cancelled = cancelled_count,
+            total = report.total,
+            processed = report.processed,
+            "Profile backfill: cancelled mid-pass (graceful shutdown)"
+        );
+    } else {
+        info!(
+            total = report.total,
+            processed = report.processed,
+            skipped_throttled = report.skipped_throttled,
+            skipped_user_managed = report.skipped_user_managed,
+            failed = report.failed,
+            "Profile backfill: complete"
+        );
+    }
     report
-}
-
-/// Convenience for callers that want to spawn the backfill
-/// registered with the WebSocket state's `profile_publish_tracker`,
-/// so the graceful-shutdown drain awaits it.
-///
-/// Returns the `JoinHandle` so the caller can `let _handle = ...`
-/// and detach without tripping `let_underscore_future`. The
-/// tracker holds the strong reference for `wait()`.
-pub fn spawn_startup_backfill(
-    state: Arc<WebSocketState>,
-    vcard_store: crate::vcard::VCardStore,
-    xmpp_domain: String,
-) -> tokio::task::JoinHandle<BackfillReport> {
-    let tracker = state.deps.protocol.profile_publish_tracker.clone();
-    let fetch_policy = super::FetchPolicy::default();
-    tracker.spawn(async move {
-        let deps = ProfilePublishDeps {
-            state,
-            vcard_store,
-            fetch_policy,
-        };
-        run_startup_backfill(&deps, &xmpp_domain).await
-    })
 }
 
 /// What `process_row` decided to do for a single user.
@@ -184,6 +184,8 @@ enum ProcessOutcome {
     UserManagedSkip,
     /// The publish chain returned an error.
     Failed,
+    /// The cancellation token fired before this row started.
+    Cancelled,
 }
 
 async fn process_row(
@@ -213,23 +215,15 @@ async fn process_row(
         }
     };
 
-    // Provenance check up front. A user who has self-published their
-    // avatar should not have the bridge re-fetch and re-publish on
-    // every boot — the user-managed guard would suppress
-    // `RemoveIfOidcOwned`, and we shouldn't waste an HTTP fetch + PEP
-    // publish for `SetFromUrl` when the user has explicitly opted out.
     let db_actor = deps.state.deps.app_state.db_pool.global_actor();
-    let provenance = match read_avatar_source(db_actor, &bare).await {
-        Ok(source) => source,
-        Err(error) => {
-            warn!(
-                error = %error,
-                jid = %bare,
-                "Profile backfill: avatar_source lookup failed; treating as unknown and continuing"
-            );
-            AvatarSource::Unknown
-        }
-    };
+
+    // Provenance is checked authoritatively inside
+    // `ensure_pep_profile_published` — it now consults
+    // `user_avatar_source` under the per-(BareJid) lock for both
+    // `SetFromUrl` and `RemoveIfOidcOwned`. We don't pre-read here
+    // because the publish layer's read is the authoritative one
+    // (any pre-check would race a concurrent wire publish that
+    // flips the row between the two reads).
 
     // Track whether the malformed-URL persist needs to fire later —
     // we don't want to abort the whole row just because the PHOTO
@@ -237,14 +231,8 @@ async fn process_row(
     // valid `display_name` should still get their FN backfilled.
     let mut photo_url_was_invalid = false;
 
-    let photo = match (row.avatar_url.as_deref(), provenance) {
-        // User self-published; bridge stays out of the PHOTO axis
-        // entirely. (Setting via OIDC after the user opted into
-        // self-management is a deliberate choice the user makes by
-        // wire-publishing empty `<metadata/>` to opt back in — see
-        // PR4's `record_oidc_managed` hook.)
-        (_, AvatarSource::User) => PhotoIntent::Skip,
-        (Some(s), _) => match Url::parse(s) {
+    let photo = match row.avatar_url.as_deref() {
+        Some(s) => match Url::parse(s) {
             Ok(url) => PhotoIntent::SetFromUrl(url),
             Err(error) => {
                 warn!(
@@ -257,10 +245,11 @@ async fn process_row(
                 PhotoIntent::Skip
             }
         },
-        // No avatar claim. If OIDC owned the previous avatar this
-        // becomes a removal; otherwise leave well enough alone.
-        (None, AvatarSource::Oidc) => PhotoIntent::RemoveIfOidcOwned,
-        (None, AvatarSource::Unknown) => PhotoIntent::Skip,
+        // No avatar claim. The publish layer's `RemoveIfOidcOwned`
+        // path handles all three provenance states (`'oidc'` →
+        // remove, `'user'` → suppress, `Unknown` → idempotent
+        // no-op via the metadata-present probe).
+        None => PhotoIntent::RemoveIfOidcOwned,
     };
 
     let name = match row.display_name.clone() {
@@ -281,19 +270,23 @@ async fn process_row(
         // skipped, so the throttle prevents re-attempting the bad
         // URL every boot.
         if photo_url_was_invalid {
-            let _ = persist_attempt(db_actor, &row.xmpp_localpart, now, Some("invalid_url")).await;
+            if let Err(error) =
+                persist_attempt(db_actor, &row.xmpp_localpart, now, Some("invalid_url")).await
+            {
+                warn!(
+                    error = %error,
+                    jid = %bare,
+                    "Profile backfill: failed to persist invalid_url state"
+                );
+            }
             return ProcessOutcome::Failed;
         }
-        return if matches!(provenance, AvatarSource::User) {
-            ProcessOutcome::UserManagedSkip
-        } else {
-            ProcessOutcome::Ran
-        };
+        return ProcessOutcome::Ran;
     }
 
     let source = ProfileSource::Oidc { photo, name };
     match ensure_pep_profile_published(deps, &bare, source).await {
-        Ok(_) => {
+        Ok(outcome) => {
             // Honor the "invalid_url" persistent throttle even when
             // the FN axis succeeds — re-fetching the same bad URL
             // every boot is the failure mode the throttle exists to
@@ -310,11 +303,11 @@ async fn process_row(
                     "Profile backfill: failed to persist success state (continuing)"
                 );
             }
-            // If only the FN axis ran (PHOTO skipped on invalid
-            // URL), surface that as Failed so the boot-time
-            // counters reflect the half-fail.
             if photo_url_was_invalid {
+                // Half-fail: FN succeeded but PHOTO URL was bad.
                 ProcessOutcome::Failed
+            } else if outcome.photo_removal_guarded_by_user_managed {
+                ProcessOutcome::UserManagedSkip
             } else {
                 ProcessOutcome::Ran
             }
@@ -346,19 +339,45 @@ async fn process_row(
 
 /// Pure throttle decision — exposed at module scope so a unit test
 /// can exercise it without touching the database.
+///
+/// Semantics:
+/// - No `last_attempt_at` row → not throttled.
+/// - `last_attempt_at` parses, last error is a permanent kind, and
+///   `now - last_attempt <= PERMANENT_FAILURE_COOLDOWN` → throttled.
+/// - `last_attempt_at` parses, last error is transient OR `None` →
+///   not throttled (transient errors retry every boot; success
+///   never throttles).
+/// - `last_attempt_at` FAILS to parse AND last error is a permanent
+///   kind → **throttled** (fail-closed). A corrupted timestamp is
+///   indistinguishable from a recent permanent failure to the
+///   throttle, so we err on the side of not re-hammering the IDP
+///   until a human resets the row. Transient kinds with a corrupt
+///   timestamp still proceed (re-attempt is the safe default).
+/// - Negative `now - last_attempt` (clock skew backward) is treated
+///   as "within the cool-down" — falls through to the kind check.
 fn should_throttle(row: &BackfillRow, now: DateTime<Utc>) -> bool {
-    let Some(last_attempt) = row
+    let last_error_is_permanent = matches!(
+        row.last_error.as_deref(),
+        Some(kind) if PERMANENT_KINDS.contains(&kind)
+    );
+    let Some(parsed) = row
         .last_attempt_at
         .as_deref()
         .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
         .map(|d| d.with_timezone(&Utc))
     else {
+        // No row OR unparseable timestamp.
+        if row.last_attempt_at.is_some() && last_error_is_permanent {
+            // Corrupted permanent-failure row → fail-closed.
+            return true;
+        }
         return false;
     };
-    if now.signed_duration_since(last_attempt) > PERMANENT_FAILURE_COOLDOWN {
+    let elapsed = now.signed_duration_since(parsed);
+    if elapsed > PERMANENT_FAILURE_COOLDOWN {
         return false;
     }
-    matches!(row.last_error.as_deref(), Some(kind) if PERMANENT_KINDS.contains(&kind))
+    last_error_is_permanent
 }
 
 async fn load_users(db_actor: &ActorRef<DbActor>) -> Result<Vec<BackfillRow>, BackfillError> {
@@ -516,5 +535,89 @@ mod tests {
         let now = Utc::now();
         let one_hour_ago = (now - Duration::hours(1)).to_rfc3339();
         assert!(!should_throttle(&row_with(Some(&one_hour_ago), None), now));
+    }
+
+    #[test]
+    fn should_throttle_at_exact_cooldown_boundary() {
+        // Exactly 24h ago — cool-down comparison is `>` not `>=`,
+        // so this still throttles. Verify the boundary so future
+        // refactors don't silently flip the semantics.
+        let now = Utc::now();
+        let exactly_24h_ago = (now - Duration::hours(24)).to_rfc3339();
+        assert!(should_throttle(
+            &row_with(Some(&exactly_24h_ago), Some("permanent_4xx")),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_throttle_for_clock_skew_backward() {
+        // last_attempt > now (negative elapsed). Treat as "within the
+        // cool-down" → throttle if kind is permanent.
+        let now = Utc::now();
+        let an_hour_in_the_future = (now + Duration::hours(1)).to_rfc3339();
+        assert!(should_throttle(
+            &row_with(Some(&an_hour_in_the_future), Some("permanent_4xx")),
+            now
+        ));
+        assert!(!should_throttle(
+            &row_with(Some(&an_hour_in_the_future), Some("network")),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_throttle_fail_closed_on_unparseable_permanent() {
+        // Corrupted timestamp + permanent kind → fail-closed.
+        let now = Utc::now();
+        assert!(should_throttle(
+            &row_with(Some("not-an-rfc3339-timestamp"), Some("permanent_4xx")),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_throttle_fail_open_on_unparseable_transient() {
+        // Corrupted timestamp + transient kind → fail-open (retry).
+        let now = Utc::now();
+        assert!(!should_throttle(
+            &row_with(Some("garbage"), Some("network")),
+            now
+        ));
+    }
+
+    #[test]
+    fn permanent_kinds_subset_of_fetch_error_kinds() {
+        // Pin the contract: every `PERMANENT_KINDS` entry must
+        // either be a real `FetchError::kind()` value OR the
+        // synthesized `"invalid_url"` (which the backfill
+        // emits itself for `Url::parse` failures). A future rename
+        // in `fetch.rs` would silently break the throttle without
+        // this guard.
+        use super::super::fetch::FetchError;
+        use std::net::{IpAddr, Ipv4Addr};
+        let representatives: &[(FetchError, &str)] = &[
+            (FetchError::InvalidScheme("http".into()), "invalid_scheme"),
+            (FetchError::MissingHost, "missing_host"),
+            (
+                FetchError::SsrfBlocked(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                "ssrf_blocked",
+            ),
+            (FetchError::Http(404), "permanent_4xx"),
+            (FetchError::MimeRejected(None), "mime_rejected"),
+            (FetchError::MagicByteMismatch, "magic_byte_mismatch"),
+            (FetchError::SizeExceeded(100), "size_exceeded"),
+        ];
+        for (err, expected_kind) in representatives {
+            assert_eq!(err.kind(), *expected_kind);
+            assert!(
+                PERMANENT_KINDS.contains(expected_kind),
+                "FetchError::kind() value {expected_kind:?} should be in PERMANENT_KINDS"
+            );
+        }
+        assert!(
+            PERMANENT_KINDS.contains(&"invalid_url"),
+            "synthesized 'invalid_url' kind must be in PERMANENT_KINDS"
+        );
     }
 }

--- a/server/crates/waddle-server/src/profile/backfill.rs
+++ b/server/crates/waddle-server/src/profile/backfill.rs
@@ -1,0 +1,498 @@
+//! Startup backfill for the OIDC → PEP profile bridge.
+//!
+//! Iterates users with sync-relevant claim state (a non-null
+//! `users.avatar_url` or `users.display_name`) and dispatches
+//! [`ensure_pep_profile_published`] with bounded concurrency. The
+//! publish helper is idempotent at the wire level (PR3 keys avatar
+//! data on SHA-1; PR4's removal flow checks the metadata-present
+//! probe), so a "best effort" boot-time pass is safe to repeat.
+//!
+//! Per-user throttle: when a previous attempt's
+//! [`FetchError::kind`] indicated a permanent failure (`4xx`,
+//! `mime_rejected`, `size_exceeded`, `ssrf_blocked`,
+//! `magic_byte_mismatch`, or `invalid_url`) the backfill skips the
+//! user for [`PERMANENT_FAILURE_COOLDOWN`] before retrying. State
+//! lives in `user_avatar_fetch_state`, keyed on `xmpp_localpart`.
+//!
+//! Concurrency is serialized per-(BareJid) by
+//! [`ensure_pep_profile_published`]'s internal lock — concurrent
+//! wire publishes for the same user during a backfill pass do not
+//! race the user-managed guard.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+use futures::stream::{self, StreamExt};
+use jid::BareJid;
+use thiserror::Error;
+use tracing::{debug, info, warn};
+use url::Url;
+
+use super::avatar_source::{read_avatar_source, AvatarSource};
+use super::publish::{ensure_pep_profile_published, ProfilePublishDeps};
+use super::source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};
+use crate::db::actor::{DbActor, DbExecute, DbQuery};
+use crate::server::routes::websocket::WebSocketState;
+use kameo::actor::ActorRef;
+
+/// Concurrency cap on outbound avatar fetches during backfill.
+/// Avoids hammering the IDP / a slow CDN at boot.
+const MAX_INFLIGHT: usize = 4;
+
+/// Cool-down after a permanent failure before the backfill retries
+/// the same user. Matches the RFC 363 "skip re-attempt for 24h
+/// after a 4xx" rule.
+const PERMANENT_FAILURE_COOLDOWN: Duration = Duration::hours(24);
+
+/// Error kinds (from `FetchError::kind()` plus a synthesized
+/// `invalid_url` for parse-failure rows) that count as permanent
+/// for the throttle.
+const PERMANENT_KINDS: &[&str] = &[
+    "permanent_4xx",
+    "mime_rejected",
+    "size_exceeded",
+    "ssrf_blocked",
+    "magic_byte_mismatch",
+    "invalid_url",
+];
+
+/// Aggregate counts of a backfill run.
+#[derive(Debug, Default, Clone)]
+pub struct BackfillReport {
+    pub total: usize,
+    pub processed: usize,
+    pub skipped_throttled: usize,
+    pub skipped_user_managed: usize,
+    pub failed: usize,
+}
+
+/// Typed error from the backfill helpers — the storage seam can't
+/// be statically typed past the kameo `ask` boundary, but the rest
+/// of the chain returns typed `ProfileSyncError`. Wrapping the
+/// stringly-typed actor errors here keeps the boundary explicit.
+#[derive(Debug, Error)]
+pub enum BackfillError {
+    #[error("backfill storage failure: {0}")]
+    Storage(String),
+    #[error(transparent)]
+    Sync(#[from] ProfileSyncError),
+}
+
+/// One row of backfill input — the OIDC claim state plus the
+/// throttle adjuncts.
+#[derive(Debug, Clone)]
+struct BackfillRow {
+    xmpp_localpart: String,
+    avatar_url: Option<String>,
+    display_name: Option<String>,
+    last_attempt_at: Option<String>,
+    last_error: Option<String>,
+}
+
+/// Run a one-shot backfill. `xmpp_domain` is the server's
+/// authoritative XMPP domain (used to construct each user's
+/// `BareJid`).
+///
+/// Returns aggregate counters useful for boot-time telemetry.
+/// Per-user failures are logged and persisted but never abort the
+/// run.
+pub async fn run_startup_backfill(deps: &ProfilePublishDeps, xmpp_domain: &str) -> BackfillReport {
+    let db_actor = deps.state.deps.app_state.db_pool.global_actor();
+
+    let rows = match load_users(db_actor).await {
+        Ok(rows) => rows,
+        Err(error) => {
+            warn!(error = %error, "Profile backfill aborted at user load");
+            return BackfillReport::default();
+        }
+    };
+    let mut report = BackfillReport {
+        total: rows.len(),
+        ..BackfillReport::default()
+    };
+    if rows.is_empty() {
+        debug!("Profile backfill: no rows to process");
+        return report;
+    }
+    info!(total = rows.len(), "Profile backfill: starting");
+
+    let now = Utc::now();
+    let outcomes = stream::iter(rows)
+        .map(|row| process_row(deps, xmpp_domain, row, now))
+        .buffer_unordered(MAX_INFLIGHT)
+        .collect::<Vec<_>>()
+        .await;
+
+    for outcome in outcomes {
+        match outcome {
+            ProcessOutcome::Ran => report.processed += 1,
+            ProcessOutcome::ThrottledSkip => report.skipped_throttled += 1,
+            ProcessOutcome::UserManagedSkip => report.skipped_user_managed += 1,
+            ProcessOutcome::Failed => report.failed += 1,
+        }
+    }
+
+    info!(
+        total = report.total,
+        processed = report.processed,
+        skipped_throttled = report.skipped_throttled,
+        skipped_user_managed = report.skipped_user_managed,
+        failed = report.failed,
+        "Profile backfill: complete"
+    );
+    report
+}
+
+/// Convenience for callers that want to spawn the backfill
+/// registered with the WebSocket state's `profile_publish_tracker`,
+/// so the graceful-shutdown drain awaits it.
+///
+/// Returns the `JoinHandle` so the caller can `let _handle = ...`
+/// and detach without tripping `let_underscore_future`. The
+/// tracker holds the strong reference for `wait()`.
+pub fn spawn_startup_backfill(
+    state: Arc<WebSocketState>,
+    vcard_store: crate::vcard::VCardStore,
+    xmpp_domain: String,
+) -> tokio::task::JoinHandle<BackfillReport> {
+    let tracker = state.deps.protocol.profile_publish_tracker.clone();
+    let fetch_policy = super::FetchPolicy::default();
+    tracker.spawn(async move {
+        let deps = ProfilePublishDeps {
+            state,
+            vcard_store,
+            fetch_policy,
+        };
+        run_startup_backfill(&deps, &xmpp_domain).await
+    })
+}
+
+/// What `process_row` decided to do for a single user.
+#[derive(Debug, Clone, Copy)]
+enum ProcessOutcome {
+    /// The publish chain ran (success or no-op).
+    Ran,
+    /// Skipped because of the permanent-failure cool-down.
+    ThrottledSkip,
+    /// Skipped because the user has self-published an avatar; the
+    /// guard would suppress `RemoveIfOidcOwned` and the bridge has
+    /// no work to do for this user.
+    UserManagedSkip,
+    /// The publish chain returned an error.
+    Failed,
+}
+
+async fn process_row(
+    deps: &ProfilePublishDeps,
+    xmpp_domain: &str,
+    row: BackfillRow,
+    now: DateTime<Utc>,
+) -> ProcessOutcome {
+    if should_throttle(&row, now) {
+        debug!(
+            jid = %row.xmpp_localpart,
+            last_error = ?row.last_error,
+            "Profile backfill: throttled (permanent-failure cool-down)"
+        );
+        return ProcessOutcome::ThrottledSkip;
+    }
+
+    let bare = match format!("{}@{}", row.xmpp_localpart, xmpp_domain).parse::<BareJid>() {
+        Ok(bare) => bare,
+        Err(error) => {
+            warn!(
+                error = %error,
+                localpart = %row.xmpp_localpart,
+                "Profile backfill: skipping user with invalid JID"
+            );
+            return ProcessOutcome::Failed;
+        }
+    };
+
+    // Provenance check up front. A user who has self-published their
+    // avatar should not have the bridge re-fetch and re-publish on
+    // every boot — the user-managed guard would suppress
+    // `RemoveIfOidcOwned`, and we shouldn't waste an HTTP fetch + PEP
+    // publish for `SetFromUrl` when the user has explicitly opted out.
+    let db_actor = deps.state.deps.app_state.db_pool.global_actor();
+    let provenance = match read_avatar_source(db_actor, &bare).await {
+        Ok(source) => source,
+        Err(error) => {
+            warn!(
+                error = %error,
+                jid = %bare,
+                "Profile backfill: avatar_source lookup failed; treating as unknown and continuing"
+            );
+            AvatarSource::Unknown
+        }
+    };
+
+    let photo = match (row.avatar_url.as_deref(), provenance) {
+        // User self-published; bridge stays out of the PHOTO axis
+        // entirely. (Setting via OIDC after the user opted into
+        // self-management is a deliberate choice the user makes by
+        // wire-publishing empty `<metadata/>` to opt back in — see
+        // PR4's `record_oidc_managed` hook.)
+        (_, AvatarSource::User) => PhotoIntent::Skip,
+        (Some(s), _) => match Url::parse(s) {
+            Ok(url) => PhotoIntent::SetFromUrl(url),
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    jid = %bare,
+                    raw_url = %s,
+                    "Profile backfill: malformed avatar_url; skipping PHOTO and recording invalid_url"
+                );
+                if let Err(persist_err) =
+                    persist_attempt(db_actor, &row.xmpp_localpart, now, Some("invalid_url")).await
+                {
+                    warn!(
+                        error = %persist_err,
+                        jid = %bare,
+                        "Profile backfill: failed to persist invalid_url state"
+                    );
+                }
+                return ProcessOutcome::Failed;
+            }
+        },
+        // No avatar claim. If OIDC owned the previous avatar this
+        // becomes a removal; otherwise leave well enough alone.
+        (None, AvatarSource::Oidc) => PhotoIntent::RemoveIfOidcOwned,
+        (None, AvatarSource::Unknown) => PhotoIntent::Skip,
+    };
+
+    let name = match row.display_name.clone() {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                NameIntent::Skip
+            } else {
+                NameIntent::Set(trimmed.to_string())
+            }
+        }
+        None => NameIntent::Skip,
+    };
+
+    if matches!(photo, PhotoIntent::Skip) && matches!(name, NameIntent::Skip) {
+        // Nothing to do for this user. Don't count as throttled
+        // (which implies a prior failure); count as user-managed
+        // when the suppression came from the guard, otherwise just
+        // ran-to-completion-with-no-work.
+        return if matches!(provenance, AvatarSource::User) {
+            ProcessOutcome::UserManagedSkip
+        } else {
+            ProcessOutcome::Ran
+        };
+    }
+
+    let source = ProfileSource::Oidc { photo, name };
+    match ensure_pep_profile_published(deps, &bare, source).await {
+        Ok(_) => {
+            if let Err(error) = persist_attempt(db_actor, &row.xmpp_localpart, now, None).await {
+                warn!(
+                    error = %error,
+                    jid = %bare,
+                    "Profile backfill: failed to persist success state (continuing)"
+                );
+            }
+            ProcessOutcome::Ran
+        }
+        Err(error) => {
+            let kind = match &error {
+                ProfileSyncError::Fetch(fetch_error) => fetch_error.kind(),
+                _ => "publish_failed",
+            };
+            warn!(
+                error = %error,
+                jid = %bare,
+                kind,
+                "Profile backfill: per-user failure (continuing)"
+            );
+            if let Err(persist_err) =
+                persist_attempt(db_actor, &row.xmpp_localpart, now, Some(kind)).await
+            {
+                warn!(
+                    error = %persist_err,
+                    jid = %bare,
+                    "Profile backfill: failed to persist failure state"
+                );
+            }
+            ProcessOutcome::Failed
+        }
+    }
+}
+
+/// Pure throttle decision — exposed at module scope so a unit test
+/// can exercise it without touching the database.
+fn should_throttle(row: &BackfillRow, now: DateTime<Utc>) -> bool {
+    let Some(last_attempt) = row
+        .last_attempt_at
+        .as_deref()
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc))
+    else {
+        return false;
+    };
+    if now.signed_duration_since(last_attempt) > PERMANENT_FAILURE_COOLDOWN {
+        return false;
+    }
+    matches!(row.last_error.as_deref(), Some(kind) if PERMANENT_KINDS.contains(&kind))
+}
+
+async fn load_users(db_actor: &ActorRef<DbActor>) -> Result<Vec<BackfillRow>, BackfillError> {
+    let rows = db_actor
+        .ask(DbQuery {
+            sql: r#"
+                SELECT u.xmpp_localpart, u.avatar_url, u.display_name,
+                       s.last_attempt_at, s.last_error
+                FROM users u
+                LEFT JOIN user_avatar_fetch_state s
+                  ON s.xmpp_localpart = u.xmpp_localpart
+                WHERE u.avatar_url IS NOT NULL OR u.display_name IS NOT NULL
+            "#
+            .to_string(),
+            params: vec![],
+        })
+        .await
+        .map_err(|e| BackfillError::Storage(e.to_string()))?;
+
+    let mut out = Vec::with_capacity(rows.len());
+    for row in rows {
+        let xmpp_localpart = match row.first() {
+            Some(crate::db::Value::Text(s)) => s.clone(),
+            _ => continue,
+        };
+        let avatar_url = row.get(1).and_then(|v| match v {
+            crate::db::Value::Text(s) => Some(s.clone()),
+            _ => None,
+        });
+        let display_name = row.get(2).and_then(|v| match v {
+            crate::db::Value::Text(s) => Some(s.clone()),
+            _ => None,
+        });
+        let last_attempt_at = row.get(3).and_then(|v| match v {
+            crate::db::Value::Text(s) => Some(s.clone()),
+            _ => None,
+        });
+        let last_error = row.get(4).and_then(|v| match v {
+            crate::db::Value::Text(s) => Some(s.clone()),
+            _ => None,
+        });
+        out.push(BackfillRow {
+            xmpp_localpart,
+            avatar_url,
+            display_name,
+            last_attempt_at,
+            last_error,
+        });
+    }
+    Ok(out)
+}
+
+async fn persist_attempt(
+    db_actor: &ActorRef<DbActor>,
+    xmpp_localpart: &str,
+    now: DateTime<Utc>,
+    error_kind: Option<&str>,
+) -> Result<(), BackfillError> {
+    let now_str = now.to_rfc3339();
+    let error_value: crate::db::Value = match error_kind {
+        Some(k) => k.into(),
+        None => crate::db::Value::Null,
+    };
+    db_actor
+        .ask(DbExecute {
+            sql: r#"
+                INSERT INTO user_avatar_fetch_state
+                  (xmpp_localpart, last_attempt_at, last_error, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(xmpp_localpart) DO UPDATE
+                  SET last_attempt_at = excluded.last_attempt_at,
+                      last_error = excluded.last_error,
+                      updated_at = excluded.updated_at
+            "#
+            .to_string(),
+            params: vec![
+                xmpp_localpart.into(),
+                now_str.clone().into(),
+                error_value,
+                now_str.into(),
+            ],
+        })
+        .await
+        .map_err(|e| BackfillError::Storage(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row_with(last_attempt: Option<&str>, last_error: Option<&str>) -> BackfillRow {
+        BackfillRow {
+            xmpp_localpart: "alice".into(),
+            avatar_url: Some("https://example.com/a.png".into()),
+            display_name: None,
+            last_attempt_at: last_attempt.map(str::to_string),
+            last_error: last_error.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn should_throttle_returns_false_when_no_prior_attempt() {
+        let now = Utc::now();
+        assert!(!should_throttle(&row_with(None, None), now));
+        assert!(!should_throttle(
+            &row_with(None, Some("permanent_4xx")),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_throttle_returns_false_after_cooldown() {
+        let now = Utc::now();
+        let twenty_five_hours_ago = (now - Duration::hours(25)).to_rfc3339();
+        assert!(!should_throttle(
+            &row_with(Some(&twenty_five_hours_ago), Some("permanent_4xx")),
+            now
+        ));
+    }
+
+    #[test]
+    fn should_throttle_returns_true_for_recent_permanent_failures() {
+        let now = Utc::now();
+        let one_hour_ago = (now - Duration::hours(1)).to_rfc3339();
+        for kind in [
+            "permanent_4xx",
+            "mime_rejected",
+            "size_exceeded",
+            "ssrf_blocked",
+            "magic_byte_mismatch",
+            "invalid_url",
+        ] {
+            assert!(
+                should_throttle(&row_with(Some(&one_hour_ago), Some(kind)), now),
+                "kind {kind} must throttle"
+            );
+        }
+    }
+
+    #[test]
+    fn should_throttle_returns_false_for_recent_transient_failures() {
+        let now = Utc::now();
+        let one_hour_ago = (now - Duration::hours(1)).to_rfc3339();
+        for kind in ["network", "transient_5xx", "dns", "publish_failed"] {
+            assert!(
+                !should_throttle(&row_with(Some(&one_hour_ago), Some(kind)), now),
+                "kind {kind} must NOT throttle (transient)"
+            );
+        }
+    }
+
+    #[test]
+    fn should_throttle_returns_false_when_recent_success() {
+        let now = Utc::now();
+        let one_hour_ago = (now - Duration::hours(1)).to_rfc3339();
+        assert!(!should_throttle(&row_with(Some(&one_hour_ago), None), now));
+    }
+}

--- a/server/crates/waddle-server/src/profile/backfill.rs
+++ b/server/crates/waddle-server/src/profile/backfill.rs
@@ -46,7 +46,9 @@ const PERMANENT_FAILURE_COOLDOWN: Duration = Duration::hours(24);
 
 /// Error kinds (from `FetchError::kind()` plus a synthesized
 /// `invalid_url` for parse-failure rows) that count as permanent
-/// for the throttle.
+/// for the throttle. Anything not on this list is treated as
+/// transient — re-attempted every boot until it succeeds or
+/// flips to a permanent kind.
 const PERMANENT_KINDS: &[&str] = &[
     "permanent_4xx",
     "mime_rejected",
@@ -54,6 +56,8 @@ const PERMANENT_KINDS: &[&str] = &[
     "ssrf_blocked",
     "magic_byte_mismatch",
     "invalid_url",
+    "invalid_scheme",
+    "missing_host",
 ];
 
 /// Aggregate counts of a backfill run.
@@ -227,6 +231,12 @@ async fn process_row(
         }
     };
 
+    // Track whether the malformed-URL persist needs to fire later —
+    // we don't want to abort the whole row just because the PHOTO
+    // axis is unhealthy. A user with a bad `avatar_url` claim but a
+    // valid `display_name` should still get their FN backfilled.
+    let mut photo_url_was_invalid = false;
+
     let photo = match (row.avatar_url.as_deref(), provenance) {
         // User self-published; bridge stays out of the PHOTO axis
         // entirely. (Setting via OIDC after the user opted into
@@ -241,18 +251,10 @@ async fn process_row(
                     error = %error,
                     jid = %bare,
                     raw_url = %s,
-                    "Profile backfill: malformed avatar_url; skipping PHOTO and recording invalid_url"
+                    "Profile backfill: malformed avatar_url; skipping PHOTO axis and continuing with NAME"
                 );
-                if let Err(persist_err) =
-                    persist_attempt(db_actor, &row.xmpp_localpart, now, Some("invalid_url")).await
-                {
-                    warn!(
-                        error = %persist_err,
-                        jid = %bare,
-                        "Profile backfill: failed to persist invalid_url state"
-                    );
-                }
-                return ProcessOutcome::Failed;
+                photo_url_was_invalid = true;
+                PhotoIntent::Skip
             }
         },
         // No avatar claim. If OIDC owned the previous avatar this
@@ -274,10 +276,14 @@ async fn process_row(
     };
 
     if matches!(photo, PhotoIntent::Skip) && matches!(name, NameIntent::Skip) {
-        // Nothing to do for this user. Don't count as throttled
-        // (which implies a prior failure); count as user-managed
-        // when the suppression came from the guard, otherwise just
-        // ran-to-completion-with-no-work.
+        // Nothing to do for this user via the publish chain.
+        // Persist the invalid_url state if that's why PHOTO was
+        // skipped, so the throttle prevents re-attempting the bad
+        // URL every boot.
+        if photo_url_was_invalid {
+            let _ = persist_attempt(db_actor, &row.xmpp_localpart, now, Some("invalid_url")).await;
+            return ProcessOutcome::Failed;
+        }
         return if matches!(provenance, AvatarSource::User) {
             ProcessOutcome::UserManagedSkip
         } else {
@@ -288,14 +294,30 @@ async fn process_row(
     let source = ProfileSource::Oidc { photo, name };
     match ensure_pep_profile_published(deps, &bare, source).await {
         Ok(_) => {
-            if let Err(error) = persist_attempt(db_actor, &row.xmpp_localpart, now, None).await {
+            // Honor the "invalid_url" persistent throttle even when
+            // the FN axis succeeds — re-fetching the same bad URL
+            // every boot is the failure mode the throttle exists to
+            // prevent.
+            let kind = if photo_url_was_invalid {
+                Some("invalid_url")
+            } else {
+                None
+            };
+            if let Err(error) = persist_attempt(db_actor, &row.xmpp_localpart, now, kind).await {
                 warn!(
                     error = %error,
                     jid = %bare,
                     "Profile backfill: failed to persist success state (continuing)"
                 );
             }
-            ProcessOutcome::Ran
+            // If only the FN axis ran (PHOTO skipped on invalid
+            // URL), surface that as Failed so the boot-time
+            // counters reflect the half-fail.
+            if photo_url_was_invalid {
+                ProcessOutcome::Failed
+            } else {
+                ProcessOutcome::Ran
+            }
         }
         Err(error) => {
             let kind = match &error {

--- a/server/crates/waddle-server/src/profile/backfill.rs
+++ b/server/crates/waddle-server/src/profile/backfill.rs
@@ -252,16 +252,17 @@ async fn process_row(
         None => PhotoIntent::RemoveIfOidcOwned,
     };
 
-    let name = match row.display_name.clone() {
-        Some(s) => {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                NameIntent::Skip
-            } else {
-                NameIntent::Set(trimmed.to_string())
-            }
-        }
-        None => NameIntent::Skip,
+    // Match the OIDC callback's three-way semantics:
+    //   - Some non-empty → `NameIntent::Set` (replace/insert).
+    //   - Some empty/whitespace → `NameIntent::Remove` (a blank
+    //     `display_name` claim means "no name" — clear stale FN).
+    //   - None → `NameIntent::Remove` (claim absent — clear).
+    // Without this alignment, a user whose IDP cleared their `name`
+    // claim AFTER an earlier sync would leave the stale FN on the
+    // PEP/vcard surface across boots until they next log in.
+    let name = match row.display_name.as_deref().map(str::trim) {
+        Some(s) if !s.is_empty() => NameIntent::Set(s.to_string()),
+        _ => NameIntent::Remove,
     };
 
     if matches!(photo, PhotoIntent::Skip) && matches!(name, NameIntent::Skip) {
@@ -284,6 +285,11 @@ async fn process_row(
         return ProcessOutcome::Ran;
     }
 
+    // Capture whether the NAME axis carries work; used below to
+    // disambiguate "guard suppressed PHOTO and there was nothing
+    // else to do" from "guard suppressed PHOTO but FN still ran".
+    let name_axis_active = !matches!(name, NameIntent::Skip);
+
     let source = ProfileSource::Oidc { photo, name };
     match ensure_pep_profile_published(deps, &bare, source).await {
         Ok(outcome) => {
@@ -304,11 +310,18 @@ async fn process_row(
                 );
             }
             if photo_url_was_invalid {
-                // Half-fail: FN succeeded but PHOTO URL was bad.
+                // Half-fail: FN may have run but the PHOTO URL was
+                // bad. Surface as Failed so the operator counter
+                // reflects that something needs human attention.
                 ProcessOutcome::Failed
-            } else if outcome.photo_removal_guarded_by_user_managed {
+            } else if outcome.photo_axis_guarded_by_user_managed && !name_axis_active {
+                // Guard fired AND there was no FN axis work — the
+                // run truly skipped this user.
                 ProcessOutcome::UserManagedSkip
             } else {
+                // Guard may or may not have fired, but at least one
+                // axis (FN, or PHOTO without guard suppression) made
+                // progress.
                 ProcessOutcome::Ran
             }
         }

--- a/server/crates/waddle-server/src/profile/mod.rs
+++ b/server/crates/waddle-server/src/profile/mod.rs
@@ -27,6 +27,7 @@
 //! outbound presence — tracked as a follow-up.
 
 pub mod avatar_source;
+pub mod backfill;
 mod fetch;
 mod publish;
 mod source;
@@ -36,6 +37,7 @@ pub use avatar_source::{
     acquire_per_jid_lock, read_avatar_source, record_oidc_managed, record_self_published,
     AvatarSource, AvatarSourceStorageError,
 };
+pub use backfill::{run_startup_backfill, spawn_startup_backfill, BackfillError, BackfillReport};
 pub use fetch::{fetch_avatar_bytes, AvatarBytes, FetchError, FetchPolicy};
 pub use publish::{ensure_pep_profile_published, ProfilePublishDeps};
 pub use source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};

--- a/server/crates/waddle-server/src/profile/mod.rs
+++ b/server/crates/waddle-server/src/profile/mod.rs
@@ -37,7 +37,7 @@ pub use avatar_source::{
     acquire_per_jid_lock, read_avatar_source, record_oidc_managed, record_self_published,
     AvatarSource, AvatarSourceStorageError,
 };
-pub use backfill::{run_startup_backfill, spawn_startup_backfill, BackfillError, BackfillReport};
+pub use backfill::{run_startup_backfill, BackfillError, BackfillReport};
 pub use fetch::{fetch_avatar_bytes, AvatarBytes, FetchError, FetchPolicy};
 pub use publish::{ensure_pep_profile_published, ProfilePublishDeps};
 pub use source::{NameIntent, PhotoIntent, ProfileSource, ProfileSyncError};

--- a/server/crates/waddle-server/src/profile/publish.rs
+++ b/server/crates/waddle-server/src/profile/publish.rs
@@ -174,6 +174,19 @@ async fn resolve_photo_op(
     match intent {
         PhotoIntent::Skip => Ok(PhotoOp::None),
         PhotoIntent::SetFromUrl(url) => {
+            // User-managed guard also applies to the SET path. The
+            // outer per-(BareJid) lock (acquired in
+            // `ensure_pep_profile_published`) makes this read +
+            // subsequent publish atomic against a concurrent wire
+            // publish that would flip provenance to `'user'`.
+            // Without this branch, OIDC reconcile after a user wire
+            // publish would silently overwrite their avatar.
+            let db_actor = deps.state.deps.app_state.db_pool.global_actor();
+            let source = read_avatar_source(db_actor, jid).await?;
+            if source == AvatarSource::User {
+                outcome.photo_removal_guarded_by_user_managed = true;
+                return Ok(PhotoOp::None);
+            }
             let bytes = fetch_avatar_bytes(&url, &deps.fetch_policy).await?;
             let hash = compute_hash(HashAlgo::Sha1, &bytes.bytes);
             let id = hash.to_hex();
@@ -190,7 +203,6 @@ async fn resolve_photo_op(
             // `Unknown` for users who never wire-published, which
             // would defeat any future "did the user override?" probe
             // that relies on a non-Unknown signal).
-            let db_actor = deps.state.deps.app_state.db_pool.global_actor();
             record_oidc_managed(db_actor, jid).await;
             Ok(PhotoOp::Set(bytes, id))
         }

--- a/server/crates/waddle-server/src/profile/publish.rs
+++ b/server/crates/waddle-server/src/profile/publish.rs
@@ -99,7 +99,7 @@ pub struct ProfilePublishOutcome {
     pub removed_vcard4_fn: bool,
     /// `users.avatar_source = 'user'`, so `RemoveIfOidcOwned` was
     /// suppressed. Visible to tests + telemetry.
-    pub photo_removal_guarded_by_user_managed: bool,
+    pub photo_axis_guarded_by_user_managed: bool,
 }
 
 /// Materialize a conformant PEP avatar + vCard set for `jid` from
@@ -144,7 +144,7 @@ pub async fn ensure_pep_profile_published(
         jid = %jid,
         set_photo = outcome.photo_sha1_hex.is_some(),
         removed_photo = outcome.published_avatar_removal,
-        guard_user_managed = outcome.photo_removal_guarded_by_user_managed,
+        guard_user_managed = outcome.photo_axis_guarded_by_user_managed,
         set_fn = matches!(name_intent, NameIntent::Set(_)),
         removed_fn = matches!(name_intent, NameIntent::Remove)
             && (outcome.removed_vcard_temp_fn || outcome.removed_vcard4_fn),
@@ -184,7 +184,7 @@ async fn resolve_photo_op(
             let db_actor = deps.state.deps.app_state.db_pool.global_actor();
             let source = read_avatar_source(db_actor, jid).await?;
             if source == AvatarSource::User {
-                outcome.photo_removal_guarded_by_user_managed = true;
+                outcome.photo_axis_guarded_by_user_managed = true;
                 return Ok(PhotoOp::None);
             }
             let bytes = fetch_avatar_bytes(&url, &deps.fetch_policy).await?;
@@ -213,7 +213,7 @@ async fn resolve_photo_op(
             let db_actor = deps.state.deps.app_state.db_pool.global_actor();
             let source = read_avatar_source(db_actor, jid).await?;
             if source == AvatarSource::User {
-                outcome.photo_removal_guarded_by_user_managed = true;
+                outcome.photo_axis_guarded_by_user_managed = true;
                 return Ok(PhotoOp::None);
             }
             // Guard 2: idempotence — if no prior metadata item or

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -141,6 +141,11 @@ pub(crate) async fn create_router(
     // awaits it before tearing down. The auth callback path
     // continues to fire per-login, so a partial backfill is just
     // "we'll catch up next boot."
+    //
+    // The `shutdown_stop_token` is forwarded into the run so SIGTERM
+    // short-circuits the row stream — without that, an N-row pass
+    // could block the publish-tracker `wait()` in the graceful-
+    // shutdown drain past the deployment grace period.
     {
         let db_actor = websocket_state
             .deps
@@ -150,6 +155,7 @@ pub(crate) async fn create_router(
             .clone();
         let backfill_state = websocket_state.clone();
         let xmpp_domain = auth_state.xmpp_domain.clone();
+        let backfill_cancel = shutdown_stop_token.clone();
         let span = tracing::info_span!("oidc_profile_backfill");
         let backfill_tracker = backfill_state.deps.protocol.profile_publish_tracker.clone();
         let _backfill_handle = backfill_tracker.spawn(async move {
@@ -170,7 +176,7 @@ pub(crate) async fn create_router(
                 fetch_policy: crate::profile::FetchPolicy::default(),
             };
             let _report = async move {
-                crate::profile::run_startup_backfill(&deps, &xmpp_domain).await;
+                crate::profile::run_startup_backfill(&deps, &xmpp_domain, backfill_cancel).await;
             }
             .instrument(span)
             .await;

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -135,6 +135,48 @@ pub(crate) async fn create_router(
     // in a `tokio::spawn` from `auth/callback.rs`.
     install_profile_publish_hook(&auth_state, websocket_state.clone());
 
+    // One-shot OIDC-profile backfill at boot — best-effort,
+    // bounded-concurrency, idempotent. Registered with
+    // `profile_publish_tracker` so the graceful-shutdown drain
+    // awaits it before tearing down. The auth callback path
+    // continues to fire per-login, so a partial backfill is just
+    // "we'll catch up next boot."
+    {
+        let db_actor = websocket_state
+            .deps
+            .app_state
+            .db_pool
+            .global_actor()
+            .clone();
+        let backfill_state = websocket_state.clone();
+        let xmpp_domain = auth_state.xmpp_domain.clone();
+        let span = tracing::info_span!("oidc_profile_backfill");
+        let backfill_tracker = backfill_state.deps.protocol.profile_publish_tracker.clone();
+        let _backfill_handle = backfill_tracker.spawn(async move {
+            use tracing::Instrument;
+            let db = match db_actor.ask(crate::db::actor::GetDatabase).await {
+                Ok(db) => db,
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "OIDC profile backfill: failed to acquire database; skipping run"
+                    );
+                    return;
+                }
+            };
+            let deps = crate::profile::ProfilePublishDeps {
+                state: backfill_state,
+                vcard_store: crate::vcard::VCardStore::new(db.into()),
+                fetch_policy: crate::profile::FetchPolicy::default(),
+            };
+            let _report = async move {
+                crate::profile::run_startup_backfill(&deps, &xmpp_domain).await;
+            }
+            .instrument(span)
+            .await;
+        });
+    }
+
     spawn_sm_expiry_janitor(&websocket_state);
     spawn_pending_delivery_claim_janitor(&websocket_state);
     spawn_graceful_shutdown_drain(

--- a/server/crates/waddle-server/src/server/profile_publish_route.rs
+++ b/server/crates/waddle-server/src/server/profile_publish_route.rs
@@ -132,7 +132,7 @@ pub struct ProfilePublishResponse {
     pub removed_vcard_temp_fn: bool,
     pub removed_vcard4_photo: bool,
     pub removed_vcard4_fn: bool,
-    pub photo_removal_guarded_by_user_managed: bool,
+    pub photo_axis_guarded_by_user_managed: bool,
 }
 
 pub fn router(websocket_state: Arc<WebSocketState>, auth: TestSeamAuth) -> Router {
@@ -246,7 +246,7 @@ async fn handler(
         removed_vcard_temp_fn: outcome.removed_vcard_temp_fn,
         removed_vcard4_photo: outcome.removed_vcard4_photo,
         removed_vcard4_fn: outcome.removed_vcard4_fn,
-        photo_removal_guarded_by_user_managed: outcome.photo_removal_guarded_by_user_managed,
+        photo_axis_guarded_by_user_managed: outcome.photo_axis_guarded_by_user_managed,
     }))
 }
 

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -69,7 +69,7 @@ struct PublishResp {
     removed_vcard_temp_fn: bool,
     removed_vcard4_photo: bool,
     removed_vcard4_fn: bool,
-    photo_removal_guarded_by_user_managed: bool,
+    photo_axis_guarded_by_user_managed: bool,
 }
 
 /// Builder for the test-seam JSON request. The on-the-wire shape
@@ -638,7 +638,7 @@ async fn avatar_removal_publishes_empty_metadata_and_strips_vcards() {
         "first removal must publish empty <metadata/>: {rm1:?}"
     );
     assert!(
-        !rm1.photo_removal_guarded_by_user_managed,
+        !rm1.photo_axis_guarded_by_user_managed,
         "no user self-publish so guard MUST NOT fire: {rm1:?}"
     );
     assert!(
@@ -872,7 +872,7 @@ async fn avatar_removal_no_op_when_no_prior_avatar() {
         "no prior avatar => no removal publish: {resp:?}"
     );
     assert!(
-        !resp.photo_removal_guarded_by_user_managed,
+        !resp.photo_axis_guarded_by_user_managed,
         "user-managed guard didn't fire — `Unknown` source falls through to the prior-item check: {resp:?}"
     );
 }
@@ -1047,7 +1047,7 @@ async fn user_self_published_avatar_is_protected_from_oidc_removal() {
 
     // Step 2: OIDC reconcile asks to remove the avatar. Guard should
     // fire — `published_avatar_removal=false`,
-    // `photo_removal_guarded_by_user_managed=true`.
+    // `photo_axis_guarded_by_user_managed=true`.
     let resp =
         invoke_profile_publish(&server, &PublishReq::for_jid(&admin_bare).remove_photo()).await;
     assert!(
@@ -1055,7 +1055,7 @@ async fn user_self_published_avatar_is_protected_from_oidc_removal() {
         "user-managed guard MUST suppress the empty-metadata publish: {resp:?}"
     );
     assert!(
-        resp.photo_removal_guarded_by_user_managed,
+        resp.photo_axis_guarded_by_user_managed,
         "guard flag MUST be set so telemetry can observe the suppression: {resp:?}"
     );
 


### PR DESCRIPTION
PR 5 of 6 implementing [RFC 363](https://github.com/waddle-social/waddle/blob/main/docs/rfc/363-avatar-vcard-pep-sync.md). Built on top of merged PR4 (#441).

## Re-author note

The original PR5 branch was authored against pre-fixup PR3 (`f7293f4f`) and referenced columns/structures that don't exist in current main: `users.avatar_source` (moved to a dedicated `user_avatar_source` table by PR4 fixup `5f65b972`), `users.last_avatar_fetch_*` columns (removed in PR3 fixup `6432422a`), and `ProfilePublishDeps::db` (replaced by `state: Arc<WebSocketState>` in PR3 fixup `e02a3abb`). A naive rebase would have failed both compilation and runtime SQL. This commit re-authors the backfill on the post-merge shapes.

## What it does

`profile/backfill.rs::run_startup_backfill` iterates `users` rows with non-null `avatar_url` or `display_name` and dispatches `ensure_pep_profile_published` with `buffer_unordered(4)` bounded concurrency. Per-user state lives in a new `user_avatar_fetch_state` table (migration v0003), keyed solely on `xmpp_localpart` to avoid the `users.username UNIQUE` collision surface that drove `user_avatar_source` into a dedicated table.

## Throttle

When a previous attempt's `FetchError::kind()` indicated a permanent failure (`permanent_4xx`, `mime_rejected`, `size_exceeded`, `ssrf_blocked`, `magic_byte_mismatch`, `invalid_url`), the row is skipped for 24h before retry. Transient failures (`network`, `transient_5xx`, `dns`, `publish_failed`) re-attempt every boot.

## User-managed avatar guard

The backfill consults `user_avatar_source` per-user before deciding the photo intent. A row marked `'user'` (the user has self-published via wire XEP-0084) maps to `PhotoIntent::Skip` — the bridge stays out of the PHOTO axis until the user opts back into OIDC management via the §4.3 empty-`<metadata/>` retract path (PR4's `record_oidc_managed` hook).

`ensure_pep_profile_published` acquires a per-(BareJid) mutex internally (PR4), so concurrent wire publishes during a backfill pass don't race the guard.

## Spawn lifecycle

The boot path in `http.rs` registers the backfill spawn with `profile_publish_tracker` (the `tokio_util::task::TaskTracker` introduced in PR4). The graceful-shutdown drain awaits in-flight backfill work before tearing down — so SIGTERM mid-iteration doesn't leave partial state.

## Tests

- 5 unit tests for `should_throttle`: no prior, post-cooldown, recent permanent failures (all 6 kinds), recent transient failures (4 kinds), recent success.
- The existing wire suite (xep0084_avatar_ws.rs, xep0163_pep_ws.rs, xep0115_caps_ws.rs) implicitly exercises the backfill spawn at every `TestServer::start` (against an empty `users` table → no-op), confirming the spawn + tracker registration + boot wiring don't crash.
- 500 server lib + 16 avatar wire + 13 PR2 wire + 9 PR1 wire tests pass.
- `cargo clippy --all-targets -D warnings` clean.
- `cargo fmt --all -- --check` clean.

## Out of scope

- Wire integration coverage for the populated backfill path is gated on an OIDC test fixture (the existing harness uses native auth, which doesn't write `users.avatar_url`). Deferred to a follow-up.
- CLI subcommand for manual retry.
- `schema_migrations` global-skip marker (per-user throttle + helper idempotence makes it optional; add later as a perf optimization).