### PR TITLE
feat(chat): vcard4_notify feature + DM peer iterate-and-pull fix

### DIFF
--- a/chat/src/lib/mentions.ts
+++ b/chat/src/lib/mentions.ts
@@ -173,6 +173,45 @@ export function avatarLookupCandidates({
   return candidates;
 }
 
+/**
+ * RFC 363 PR 6: avatar candidate set spanning channel + DM contexts.
+ *
+ * DM messages MUST NOT be resolved through the channel-only nick→JID
+ * map (`authorJidByNick` / member presence): a DM from
+ * `alice@other.example` whose nick collides with a channel member
+ * `alice@waddle.social` would otherwise rank-1 to the channel JID
+ * and the real DM peer would never be queued for `fetchUserAvatar`.
+ *
+ * The resolution: invoke `avatarLookupCandidates` once per context
+ * (channel context with members + nick map; DM context with empty
+ * members + empty nick map) and concatenate the results. The DM
+ * pass falls through to rank 2 (`message.authorJid`), the
+ * authoritative DM peer JID. Downstream consumers dedupe by JID via
+ * `avatarFetchStateByJid`.
+ */
+export function avatarLookupCandidatesAcrossContexts(params: {
+  channelMembers: readonly MemberSummary[];
+  channelMessages: readonly Pick<TimelineMessage, "author" | "authorJid" | "authorRealJid">[];
+  channelAuthorJidByNick: Readonly<Record<string, string>>;
+  dmMessages: readonly Pick<TimelineMessage, "author" | "authorJid" | "authorRealJid">[];
+  selfDomain: string;
+}): AvatarLookupCandidate[] {
+  return [
+    ...avatarLookupCandidates({
+      members: params.channelMembers,
+      messages: params.channelMessages,
+      authorJidByNick: params.channelAuthorJidByNick,
+      selfDomain: params.selfDomain,
+    }),
+    ...avatarLookupCandidates({
+      members: [],
+      messages: params.dmMessages,
+      authorJidByNick: {},
+      selfDomain: params.selfDomain,
+    }),
+  ];
+}
+
 export function resolveMentionUri(
   mention: string,
   mentionJidsByNick?: Readonly<Record<string, string>>,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -24,7 +24,7 @@ import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MemberSummary } from "@/lib/chat-types";
 import type { ExtensionAnnotationAction, MarkupSpan, MessageReference, TimelineMessage } from "@/lib/chat-ui";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
-import { avatarLookupCandidates, mentionAutocompleteCandidates, mentionMatchesBareJid, mergeMentionMembers } from "@/lib/mentions";
+import { avatarLookupCandidatesAcrossContexts, mentionAutocompleteCandidates, mentionMatchesBareJid, mergeMentionMembers } from "@/lib/mentions";
 import {
   moveReactionSelection,
   preserveReactionSelection,
@@ -499,27 +499,15 @@ export function useChatAppController(giphyApiKey: string) {
   // the channel-message timeline). After #435 (workspace roster
   // bridge) lands, push delivery covers both axes and this fallback
   // can be slimmed back down.
-  //
-  // DM messages are resolved through a SEPARATE call with empty
-  // `members` / `authorJidByNick` so that a DM sender whose nick
-  // collides with a channel member is NOT misresolved through the
-  // channel-only nick→JID map. DM `authorJid` (`fromJid`) is the
-  // authoritative peer JID and falls through to rank 2 with empty
-  // channel context.
-  const avatarCandidates = computed(() => [
-    ...avatarLookupCandidates({
-      members: mergedMentionMembers.value.members,
-      messages: messaging.messages.value,
-      authorJidByNick: authorJidByNick.value,
+  const avatarCandidates = computed(() =>
+    avatarLookupCandidatesAcrossContexts({
+      channelMembers: mergedMentionMembers.value.members,
+      channelMessages: messaging.messages.value,
+      channelAuthorJidByNick: authorJidByNick.value,
+      dmMessages: dmMessaging.messages.value,
       selfDomain: selfDomain.value,
     }),
-    ...avatarLookupCandidates({
-      members: [],
-      messages: dmMessaging.messages.value,
-      authorJidByNick: {},
-      selfDomain: selfDomain.value,
-    }),
-  ]);
+  );
   const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
     const avatars: Record<string, string | null> = {};
 

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -493,14 +493,33 @@ export function useChatAppController(giphyApiKey: string) {
   const notifications = usePushNotifications();
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
-  const avatarCandidates = computed(() =>
-    avatarLookupCandidates({
+  // RFC 363 PR 6: include DM peers in the iterate-and-pull avatar
+  // candidate set. Without this, avatars in DM views never resolve
+  // (the peer never appears in `messaging.messages` because that's
+  // the channel-message timeline). After #435 (workspace roster
+  // bridge) lands, push delivery covers both axes and this fallback
+  // can be slimmed back down.
+  //
+  // DM messages are resolved through a SEPARATE call with empty
+  // `members` / `authorJidByNick` so that a DM sender whose nick
+  // collides with a channel member is NOT misresolved through the
+  // channel-only nick→JID map. DM `authorJid` (`fromJid`) is the
+  // authoritative peer JID and falls through to rank 2 with empty
+  // channel context.
+  const avatarCandidates = computed(() => [
+    ...avatarLookupCandidates({
       members: mergedMentionMembers.value.members,
       messages: messaging.messages.value,
       authorJidByNick: authorJidByNick.value,
       selfDomain: selfDomain.value,
     }),
-  );
+    ...avatarLookupCandidates({
+      members: [],
+      messages: dmMessaging.messages.value,
+      authorJidByNick: {},
+      selfDomain: selfDomain.value,
+    }),
+  ]);
   const avatarUrlByAuthor = computed<Record<string, string | null>>(() => {
     const avatars: Record<string, string | null> = {};
 

--- a/chat/tests/mentions.test.ts
+++ b/chat/tests/mentions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   avatarLookupCandidates,
+  avatarLookupCandidatesAcrossContexts,
   messageMentionsBareJid,
   mentionAutocompleteCandidates,
   mentionAutocompleteNames,
@@ -243,44 +244,54 @@ describe("mention helpers", () => {
     ]);
   });
 
-  // RFC 363 PR 6: regression — passing DM messages through the
-  // channel-only `authorJidByNick` map can resolve a foreign-domain
-  // DM peer to a same-nick channel member's JID. Callers must split
-  // DM resolution into a separate call with empty channel context.
-  test("avatar lookup candidates from empty channel context resolve DM peers via message authorJid", () => {
-    const candidates = avatarLookupCandidates({
-      members: [],
-      messages: [
+  // RFC 363 PR 6: avatar candidate set MUST queue DM peers (not just
+  // channel members) and MUST resolve a DM author via the DM stanza's
+  // own `authorJid`, NOT via any channel-only nick map.
+  test("across-contexts merge resolves DM peer via DM authorJid even when nick collides with a channel member", () => {
+    const candidates = avatarLookupCandidatesAcrossContexts({
+      channelMembers: [
+        { jid: "alice@waddle.social", username: "alice", avatar_url: null, role: "member", joined_at: "" },
+      ],
+      channelMessages: [
+        { author: "alice", authorJid: "chat@muc.waddle.social/alice", authorRealJid: "alice@waddle.social/laptop" },
+      ],
+      channelAuthorJidByNick: { alice: "alice@waddle.social" },
+      dmMessages: [
         { author: "alice", authorJid: "alice@other.example/desktop" },
       ],
-      authorJidByNick: {},
+      selfDomain: "waddle.social",
+    });
+
+    const jids = candidates.map((c) => c.jid);
+    expect(jids).toContain("alice@waddle.social");
+    expect(jids).toContain("alice@other.example");
+  });
+
+  test("across-contexts merge produces empty result for empty inputs", () => {
+    const candidates = avatarLookupCandidatesAcrossContexts({
+      channelMembers: [],
+      channelMessages: [],
+      channelAuthorJidByNick: {},
+      dmMessages: [],
+      selfDomain: "waddle.social",
+    });
+
+    expect(candidates).toEqual([]);
+  });
+
+  test("across-contexts merge queues DM-only peers when no channel context exists", () => {
+    const candidates = avatarLookupCandidatesAcrossContexts({
+      channelMembers: [],
+      channelMessages: [],
+      channelAuthorJidByNick: {},
+      dmMessages: [
+        { author: "bob", authorJid: "bob@other.example/desktop" },
+      ],
       selfDomain: "waddle.social",
     });
 
     expect(candidates).toEqual([
-      { nick: "alice", jid: "alice@other.example", avatar_url: null },
+      { nick: "bob", jid: "bob@other.example", avatar_url: null },
     ]);
-  });
-
-  test("avatar lookup candidates with channel context misresolve DM-shaped messages — split required", () => {
-    // Demonstrates the bug being fixed: passing DM messages into a
-    // channel-context call resolves the DM author through
-    // `mappedJidByNick`, ignoring the DM's own `authorJid`. The
-    // production fix at chat/src/shell/chat-app-controller.ts splits
-    // DM messages into their own call with empty members /
-    // authorJidByNick to avoid this collision.
-    const candidates = avatarLookupCandidates({
-      members: [{ jid: "alice@waddle.social", username: "alice", avatar_url: null, role: "member", joined_at: "" }],
-      messages: [
-        { author: "alice", authorJid: "alice@other.example/desktop" },
-      ],
-      authorJidByNick: { alice: "alice@waddle.social" },
-      selfDomain: "waddle.social",
-    });
-
-    // alice resolves to channel member, NOT to the DM `authorJid`.
-    // This is why splitting calls per-context is necessary.
-    expect(candidates.map((c) => c.jid)).toEqual(["alice@waddle.social"]);
-    expect(candidates.map((c) => c.jid)).not.toContain("alice@other.example");
   });
 });

--- a/chat/tests/mentions.test.ts
+++ b/chat/tests/mentions.test.ts
@@ -242,4 +242,45 @@ describe("mention helpers", () => {
       { nick: "randax", jid: "randax@waddle.social", avatar_url: null },
     ]);
   });
+
+  // RFC 363 PR 6: regression — passing DM messages through the
+  // channel-only `authorJidByNick` map can resolve a foreign-domain
+  // DM peer to a same-nick channel member's JID. Callers must split
+  // DM resolution into a separate call with empty channel context.
+  test("avatar lookup candidates from empty channel context resolve DM peers via message authorJid", () => {
+    const candidates = avatarLookupCandidates({
+      members: [],
+      messages: [
+        { author: "alice", authorJid: "alice@other.example/desktop" },
+      ],
+      authorJidByNick: {},
+      selfDomain: "waddle.social",
+    });
+
+    expect(candidates).toEqual([
+      { nick: "alice", jid: "alice@other.example", avatar_url: null },
+    ]);
+  });
+
+  test("avatar lookup candidates with channel context misresolve DM-shaped messages — split required", () => {
+    // Demonstrates the bug being fixed: passing DM messages into a
+    // channel-context call resolves the DM author through
+    // `mappedJidByNick`, ignoring the DM's own `authorJid`. The
+    // production fix at chat/src/shell/chat-app-controller.ts splits
+    // DM messages into their own call with empty members /
+    // authorJidByNick to avoid this collision.
+    const candidates = avatarLookupCandidates({
+      members: [{ jid: "alice@waddle.social", username: "alice", avatar_url: null, role: "member", joined_at: "" }],
+      messages: [
+        { author: "alice", authorJid: "alice@other.example/desktop" },
+      ],
+      authorJidByNick: { alice: "alice@waddle.social" },
+      selfDomain: "waddle.social",
+    });
+
+    // alice resolves to channel member, NOT to the DM `authorJid`.
+    // This is why splitting calls per-context is necessary.
+    expect(candidates.map((c) => c.jid)).toEqual(["alice@waddle.social"]);
+    expect(candidates.map((c) => c.jid)).not.toContain("alice@other.example");
+  });
 });

--- a/server/crates/waddle-xmpp-core/src/disco/info/features.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/features.rs
@@ -267,6 +267,12 @@ impl Feature {
         Self::new("urn:xmpp:avatar:metadata+notify")
     }
 
+    /// XEP-0292 vCard4 over XMPP — `+notify` filter advertised by
+    /// clients that want to receive vCard4 PEP fan-out per XEP-0163 §3.
+    pub fn vcard4_notify() -> Self {
+        Self::new("urn:xmpp:vcard4+notify")
+    }
+
     pub fn private_storage() -> Self {
         Self::new("jabber:iq:private")
     }

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -76,9 +76,11 @@ fn test_server_features_include_core_features() {
 #[test]
 fn test_vcard4_notify_feature_var_pins_xep0292_namespace() {
     // Pin the `+notify` filter contract so a future rename trips a test
-    // instead of silently breaking XEP-0292 / XEP-0163 §3 fan-out.
+    // instead of silently breaking XEP-0292 / XEP-0163 §3 fan-out. The
+    // var must equal the XEP-0292 PEP node `urn:xmpp:vcard4` plus the
+    // standard `+notify` suffix; that is the string the runtime
+    // fan-out filter constructs per XEP-0163 §3.
     assert_eq!(Feature::vcard4_notify().0, "urn:xmpp:vcard4+notify");
-    assert_eq!(Feature::vcard4_notify(), Feature::vcard4_notify());
     assert_ne!(Feature::vcard4_notify(), Feature::avatar_metadata_notify());
 }
 

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -70,6 +70,16 @@ fn test_server_features_include_core_features() {
     assert!(!features.contains(&Feature::fulltext_mam()));
     assert!(!features.contains(&Feature::pep()));
     assert!(!features.contains(&Feature::avatar_metadata_notify()));
+    assert!(!features.contains(&Feature::vcard4_notify()));
+}
+
+#[test]
+fn test_vcard4_notify_feature_var_pins_xep0292_namespace() {
+    // Pin the `+notify` filter contract so a future rename trips a test
+    // instead of silently breaking XEP-0292 / XEP-0163 §3 fan-out.
+    assert_eq!(Feature::vcard4_notify().0, "urn:xmpp:vcard4+notify");
+    assert_eq!(Feature::vcard4_notify(), Feature::vcard4_notify());
+    assert_ne!(Feature::vcard4_notify(), Feature::avatar_metadata_notify());
 }
 
 #[test]


### PR DESCRIPTION
PR 6 of 6 implementing [RFC 363](https://github.com/waddle-social/waddle/blob/main/docs/rfc/363-avatar-vcard-pep-sync.md). Stacked on top of #442 (PR 5, merged).

This branch was force-replaced after #441 / #442 merged: the original commit was authored against pre-merge versions of PR 1–5 and migration v0002 was missing. Fresh re-author on top of `main`.

## What changed

- **`Feature::vcard4_notify()`** added to `waddle-xmpp-core` (companion to the pre-existing `avatar_metadata_notify`). Advertises `urn:xmpp:vcard4+notify` per XEP-0292 / XEP-0163 §3 so chat clients participating in the §3 fan-out (PR 2) explicitly opt in to vCard4 PEP notifications. Pinned by `test_vcard4_notify_feature_var_pins_xep0292_namespace` and asserted absent from `server_features()` (server is publisher, not subscriber).

- **DM peers in the iterate-and-pull avatar candidate set** at `chat/src/shell/chat-app-controller.ts`. The pre-RFC `avatarLookupCandidates` consumed only `messaging.messages.value` (channel timeline), so DM peers never queued for `client.fetchUserAvatar`. Fixed via a new `avatarLookupCandidatesAcrossContexts` helper that invokes `avatarLookupCandidates` twice — once for channel context, once for DM context with empty `members` / `authorJidByNick` — and concatenates the results. Splitting per-context prevents a cross-context nick collision (DM from `alice@other.example` resolving to a same-nick channel member). Pinned by three new mention tests covering the collision case, empty inputs, and DM-only peers.

## Tests

- 19 chat mention tests (was 16; +3 net for the new helper).
- 9 disco/info Rust unit tests (+1 for `vcard4_notify`).
- All existing tests still pass; knip clean; clippy `-D warnings` clean.

## Adversarial review

Three personas (XEP conformance, chat correctness, test quality) ran on commit `a9a7f2eb`. Test-quality reviewer surfaced two real findings:
- The "demonstrates the bug" test pinned wrong-by-design behavior that would rot. Replaced with positive tests against the new helper.
- Controller-level coverage gap (helper-only tests would still pass if controller reverted to single-call). Resolved by extracting the merge into `avatarLookupCandidatesAcrossContexts` so the contract is now a testable seam, not ad-hoc composition inside a Vue computed.

Both addressed in commit `d967c332`.

## Out of scope (deferred)

- A typed inbound PEP `<message><event>` handler in the chat client that updates `fetchedAvatarUrlByJid` and `displayedName` on receipt. The plumbing — runtime emit hook, typed dispatcher, push-served set — is substantial and follows up after #435 (workspace roster bridge), per the RFC. Until then the iterate-and-pull fallback (now extended with DM peers) covers the user-visible gap.
- Outbound CAPS adverts in the chat WASM bundle. The client today doesn't construct its own `<presence><c/>` element; it inherits the server's advertised features. Wiring `vcard4_notify` through to outbound presence pairs naturally with the inbound handler.

## Status

- [x] Implementation
- [x] Tests (Rust unit + chat unit)
- [x] Adversarial review (3 personas, all findings addressed)
- [ ] CI green