### PR TITLE
fix(server): transcode non-PNG OIDC avatars to image/png per XEP-0084 §3.2

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -597,10 +597,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -822,6 +834,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1588,6 +1606,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1929,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2397,6 +2434,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +2921,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -3481,6 +3556,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3674,6 +3762,18 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -5837,6 +5937,7 @@ dependencies = [
  "hmac",
  "html-escape",
  "http-body-util",
+ "image",
  "jid",
  "jsonwebtoken",
  "kameo",
@@ -6635,6 +6736,12 @@ checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -7505,4 +7612,19 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -92,9 +92,19 @@ html-escape = "0.2"
 jsonwebtoken = { workspace = true }
 prescience = { version = "0.1.0", features = ["tls-rustls"] }
 
+# Avatar transcoding — XEP-0084 §3.2 mandates `image/png` for the
+# data node, so non-PNG OIDC avatar bytes are decoded by `image`
+# and re-encoded as PNG before publish. Default features pull in
+# decoders for every supported format; we narrow to the four MIME
+# types in the avatar fetch allowlist to keep the build slim.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+
 [dev-dependencies]
 tokio-test = "0.4"
 wiremock = "0.6"
+# Integration tests build real JPEG fixtures so the transcoder
+# accepts them. Mirrors the lib's runtime feature set.
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 http-body-util = "0.1"
 tokio-tungstenite = "0.24"
 pbkdf2 = { version = "0.12", features = ["hmac"] }

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -102,9 +102,8 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 [dev-dependencies]
 tokio-test = "0.4"
 wiremock = "0.6"
-# Integration tests build real JPEG fixtures so the transcoder
-# accepts them. Mirrors the lib's runtime feature set.
-image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+# `image` is already a regular dependency; integration tests reach
+# it via the same crate without a separate dev-dep declaration.
 http-body-util = "0.1"
 tokio-tungstenite = "0.24"
 pbkdf2 = { version = "0.12", features = ["hmac"] }

--- a/server/crates/waddle-server/src/profile/backfill.rs
+++ b/server/crates/waddle-server/src/profile/backfill.rs
@@ -52,6 +52,7 @@ const PERMANENT_KINDS: &[&str] = &[
     "size_exceeded",
     "ssrf_blocked",
     "magic_byte_mismatch",
+    "transcode_failed",
     "invalid_url",
     "invalid_scheme",
     "missing_host",
@@ -620,6 +621,10 @@ mod tests {
             (FetchError::MimeRejected(None), "mime_rejected"),
             (FetchError::MagicByteMismatch, "magic_byte_mismatch"),
             (FetchError::SizeExceeded(100), "size_exceeded"),
+            (
+                FetchError::TranscodeFailed("decode failed".into()),
+                "transcode_failed",
+            ),
         ];
         for (err, expected_kind) in representatives {
             assert_eq!(err.kind(), *expected_kind);

--- a/server/crates/waddle-server/src/profile/fetch.rs
+++ b/server/crates/waddle-server/src/profile/fetch.rs
@@ -25,15 +25,18 @@
 //!   on the response body so an oversize/slowloris/lying-Content-Length
 //!   server cannot OOM us.
 //! - **MIME:** allowlist of `image/png`, `image/jpeg`, `image/gif`,
-//!   `image/webp` per RFC 363's design (issue #363). XEP-0084 §3.1
-//!   says PNG SHOULD be the data-node format, but the issue explicitly
-//!   chose to publish the source MIME under "exactly one `<info>`
-//!   element" rather than transcoding — the publish chain plumbs the
-//!   actual MIME through `<info type>`, vCard `<TYPE>`, and the vCard4
-//!   `<photo>` data-URI. The header is gated against the allowlist,
-//!   then the body is magic-byte sniffed against the specific format
-//!   the header declared so a server lying in `Content-Type` can't
-//!   smuggle a different payload downstream.
+//!   `image/webp` at the fetch boundary. Non-PNG bodies are decoded
+//!   and re-encoded as PNG before the helper returns — XEP-0084 §3.2
+//!   normatively reserves the `urn:xmpp:avatar:data` node for
+//!   `image/png`, §4.1.1 mandates the metadata ItemID be the SHA-1 of
+//!   the PNG bytes, and §4.2 requires "one of the formats MUST be
+//!   image/png to ensure interoperability." The header parses into
+//!   `AllowedMime` (gate); the body is magic-byte sniffed against
+//!   that declared format (defense against malformed/buggy servers
+//!   that mis-label a body — not an adversarial defense, since the
+//!   header itself is attacker-controlled); then the bytes are
+//!   transcoded to PNG so callers always see a single canonical
+//!   format on the wire.
 //! - **Timeouts:** 5s connect, 10s total.
 //! - **Retries:** one retry on transient failures (5xx, connect
 //!   timeout, network error). No backoff.
@@ -42,9 +45,11 @@
 //! into the persisted `users.last_avatar_fetch_error` enum without
 //! parsing log strings.
 
+use std::io::Cursor;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::time::Duration;
 
+use image::{ImageFormat, ImageReader};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::redirect;
 use reqwest::Client;
@@ -56,10 +61,10 @@ const MAX_BYTES: usize = 100 * 1024;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const TOTAL_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Image formats we accept on the avatar fetch path. The publish
-/// chain carries the canonical MIME string forward into XEP-0084
-/// metadata (`<info type>`), vCard-temp PHOTO `<TYPE>`, and the
-/// XEP-0292 vCard4 `<photo>` data-URI without re-encoding.
+/// Image formats we accept on the avatar fetch path. Internal to
+/// the fetcher: callers always see a transcoded PNG (XEP-0084 §3.2),
+/// so this enum exists purely to gate inputs and dispatch the
+/// magic-byte / decode logic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AllowedMime {
     Png,
@@ -69,6 +74,13 @@ enum AllowedMime {
 }
 
 impl AllowedMime {
+    /// Single source of truth for the allowlist. `from_header`,
+    /// `as_mime`, and `matches_magic` all match exhaustively, so the
+    /// compiler catches missing arms when a new variant is added.
+    /// `ALL` is what the user-facing error message and tests iterate
+    /// over — keep it in lockstep with the variants.
+    const ALL: &'static [Self] = &[Self::Png, Self::Jpeg, Self::Gif, Self::Webp];
+
     /// Match a normalized (`split(';').next().trim().to_lowercase()`)
     /// `Content-Type` against the allowlist. `image/jpg` is rejected
     /// — RFC 6838 only registers `image/jpeg`. If a real-world IdP
@@ -93,9 +105,26 @@ impl AllowedMime {
         }
     }
 
+    /// Comma-separated MIME list for human-facing diagnostics. The
+    /// `MimeRejected` `Display` calls this so the allowlist string
+    /// has a single source of truth.
+    fn allowlist_help() -> String {
+        Self::ALL
+            .iter()
+            .map(|m| m.as_mime())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
     /// Verify the body's leading bytes match the format declared in
-    /// the response header. Each signature is the format's documented
-    /// fixed prefix:
+    /// the response header. This is a malformed-server defense (a
+    /// server returning JPEG bytes with `Content-Type: image/png`),
+    /// not an adversarial one — the header itself is attacker-
+    /// controlled, and a malicious server can simply declare whatever
+    /// type matches the body it wants to smuggle. The transcode step
+    /// downstream is what makes the wire payload predictable.
+    ///
+    /// Each signature is the format's documented fixed prefix:
     /// - PNG: 8-byte signature, RFC 2083 §3.1.
     /// - JPEG: SOI + first marker, `FF D8 FF`. Subsequent bytes vary
     ///   by encoder (E0/E1 for JFIF/EXIF, DB for raw quantization
@@ -135,13 +164,17 @@ pub enum FetchError {
     #[error("HTTP {0}")]
     Http(u16),
     #[error(
-        "response Content-Type {0:?} is not in the avatar allowlist (image/png, image/jpeg, image/gif, image/webp)"
+        "response Content-Type {mime:?} is not in the avatar allowlist ({list})",
+        mime = .0,
+        list = AllowedMime::allowlist_help()
     )]
     MimeRejected(Option<String>),
     #[error("response body did not start with the magic-byte signature for the declared MIME")]
     MagicByteMismatch,
     #[error("response exceeds {0}-byte cap")]
     SizeExceeded(usize),
+    #[error("could not transcode source bytes to image/png: {0}")]
+    TranscodeFailed(String),
 }
 
 impl FetchError {
@@ -158,6 +191,7 @@ impl FetchError {
             FetchError::MimeRejected(_) => "mime_rejected",
             FetchError::MagicByteMismatch => "magic_byte_mismatch",
             FetchError::SizeExceeded(_) => "size_exceeded",
+            FetchError::TranscodeFailed(_) => "transcode_failed",
         }
     }
 }
@@ -341,12 +375,56 @@ async fn try_fetch(
         return Err(FetchError::MagicByteMismatch);
     }
 
-    let mime = declared.as_mime();
-    debug!(url = %url, bytes = buf.len(), mime = %mime, "avatar fetched");
+    // XEP-0084 §3.2: the `urn:xmpp:avatar:data` node carries
+    // `image/png` only; §4.1.1 ties the metadata `<info id>` to the
+    // SHA-1 of the PNG bytes; §4.2 requires "one of the formats MUST
+    // be image/png to ensure interoperability." Non-PNG sources are
+    // decoded and re-encoded as PNG here so the publish chain never
+    // sees a non-conformant payload.
+    let png_bytes = match declared {
+        AllowedMime::Png => buf,
+        AllowedMime::Jpeg | AllowedMime::Gif | AllowedMime::Webp => {
+            transcode_to_png(&buf, declared)?
+        }
+    };
+
+    // The post-transcode size cap protects D1 storage (issue #363:
+    // `pubsub_items.payload_xml TEXT` budget). PNG re-encoding can
+    // expand a small lossy JPEG into a larger lossless PNG; reject
+    // those rather than overflowing the row.
+    if png_bytes.len() > policy.max_bytes {
+        return Err(FetchError::SizeExceeded(policy.max_bytes));
+    }
+
+    debug!(url = %url, bytes = png_bytes.len(), source_mime = %declared.as_mime(), "avatar fetched and normalised to image/png");
     Ok(AvatarBytes {
-        bytes: buf,
-        mime: mime.to_string(),
+        bytes: png_bytes,
+        mime: AllowedMime::Png.as_mime().to_string(),
     })
+}
+
+/// Decode `bytes` (declared as `source`) and re-encode as PNG. The
+/// `image` crate's `ImageReader::with_guessed_format` re-sniffs the
+/// header so a magic-byte mismatch caught upstream wouldn't slip
+/// through here either; we still hint the format from the declared
+/// MIME so a corrupted file fails fast with a typed error rather
+/// than triggering a slower "try every format" path.
+fn transcode_to_png(bytes: &[u8], source: AllowedMime) -> Result<Vec<u8>, FetchError> {
+    let image_format = match source {
+        AllowedMime::Png => ImageFormat::Png,
+        AllowedMime::Jpeg => ImageFormat::Jpeg,
+        AllowedMime::Gif => ImageFormat::Gif,
+        AllowedMime::Webp => ImageFormat::WebP,
+    };
+    let mut reader = ImageReader::new(Cursor::new(bytes));
+    reader.set_format(image_format);
+    let img = reader
+        .decode()
+        .map_err(|e| FetchError::TranscodeFailed(format!("decode {}: {e}", source.as_mime())))?;
+    let mut out = Vec::with_capacity(bytes.len());
+    img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .map_err(|e| FetchError::TranscodeFailed(format!("encode png: {e}")))?;
+    Ok(out)
 }
 
 async fn resolve_host(host: &str, port: u16) -> std::io::Result<Vec<IpAddr>> {
@@ -567,6 +645,27 @@ mod tests {
             FetchError::MimeRejected(Some("application/pdf".into())).kind(),
             "mime_rejected"
         );
+        assert_eq!(
+            FetchError::TranscodeFailed("bad bytes".into()).kind(),
+            "transcode_failed"
+        );
+    }
+
+    #[test]
+    fn mime_rejected_display_lists_every_allowlist_entry() {
+        // The user-facing error message must enumerate the
+        // allowlist; that text and `AllowedMime::ALL` have to stay in
+        // sync. `allowlist_help` is the single source of truth — pin
+        // the contract so a future variant addition doesn't slip
+        // through with stale Display text.
+        let display = FetchError::MimeRejected(Some("image/bmp".into())).to_string();
+        for variant in AllowedMime::ALL {
+            assert!(
+                display.contains(variant.as_mime()),
+                "Display must list {}: {display}",
+                variant.as_mime()
+            );
+        }
     }
 
     #[test]
@@ -646,5 +745,53 @@ mod tests {
             assert!(!AllowedMime::Gif.matches_magic(short));
             assert!(!AllowedMime::Webp.matches_magic(short));
         }
+    }
+
+    /// Encode a 2×2 red square as the requested format. Two-by-two
+    /// because the JPEG encoder needs at least an 8×8 MCU's worth of
+    /// data internally; one-by-one decodes correctly but produces a
+    /// JFIF-style fixture that's larger than necessary. 2×2 is the
+    /// smallest useful test image where every codec is happy.
+    fn encode_test_image(format: image::ImageFormat) -> Vec<u8> {
+        let img = image::ImageBuffer::from_pixel(2u32, 2u32, image::Rgb([255u8, 0, 0]));
+        let mut out = Vec::new();
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut out), format)
+            .expect("encoder must succeed for 2×2 RGB fixture");
+        out
+    }
+
+    #[test]
+    fn transcode_to_png_round_trips_each_non_png_format() {
+        for (source, format) in [
+            (AllowedMime::Jpeg, image::ImageFormat::Jpeg),
+            (AllowedMime::Gif, image::ImageFormat::Gif),
+            (AllowedMime::Webp, image::ImageFormat::WebP),
+        ] {
+            let source_bytes = encode_test_image(format);
+            assert!(
+                source.matches_magic(&source_bytes),
+                "{source:?} fixture must clear its own magic-byte gate"
+            );
+            let png = transcode_to_png(&source_bytes, source)
+                .unwrap_or_else(|e| panic!("{source:?} → PNG must succeed for a real image: {e}"));
+            assert!(
+                AllowedMime::Png.matches_magic(&png),
+                "{source:?} → PNG output must clear the PNG magic-byte gate"
+            );
+        }
+    }
+
+    #[test]
+    fn transcode_to_png_rejects_corrupted_body() {
+        // Magic bytes match JPEG but the rest is junk — the decoder
+        // surfaces this as `TranscodeFailed` so the fetch path can
+        // map it into the persisted error enum without panicking.
+        let corrupted = b"\xff\xd8\xff\xe0not-a-real-jpeg";
+        let result = transcode_to_png(corrupted, AllowedMime::Jpeg);
+        assert!(
+            matches!(result, Err(FetchError::TranscodeFailed(_))),
+            "{result:?}"
+        );
     }
 }

--- a/server/crates/waddle-server/src/profile/fetch.rs
+++ b/server/crates/waddle-server/src/profile/fetch.rs
@@ -384,14 +384,23 @@ async fn try_fetch(
     let png_bytes = match declared {
         AllowedMime::Png => buf,
         AllowedMime::Jpeg | AllowedMime::Gif | AllowedMime::Webp => {
-            transcode_to_png(&buf, declared)?
+            // Decode + encode is CPU-bound; offload from the Tokio
+            // executor so a slow image doesn't starve other async
+            // tasks (OIDC publishes also run from a `tokio::spawn`
+            // alongside the chat WebSocket loop).
+            tokio::task::spawn_blocking(move || transcode_to_png(&buf, declared))
+                .await
+                .map_err(|e| FetchError::TranscodeFailed(format!("spawn_blocking join: {e}")))??
         }
     };
 
     // The post-transcode size cap protects D1 storage (issue #363:
     // `pubsub_items.payload_xml TEXT` budget). PNG re-encoding can
     // expand a small lossy JPEG into a larger lossless PNG; reject
-    // those rather than overflowing the row.
+    // those rather than overflowing the row. The pre-transcode
+    // streaming cap (above, around `policy.max_bytes`) is a separate
+    // OOM defense: it keeps the fetch buffer bounded regardless of
+    // what the upstream serves.
     if png_bytes.len() > policy.max_bytes {
         return Err(FetchError::SizeExceeded(policy.max_bytes));
     }
@@ -403,12 +412,21 @@ async fn try_fetch(
     })
 }
 
+/// Cap on decoded image dimensions. A small adversarial JPEG can
+/// declare e.g. 65535×65535 in its SOF0 marker; without an explicit
+/// limit `image::ImageDecoder` would allocate
+/// `width * height * channels` bytes (≈16 GB at 65k²×4) before we
+/// could reject it. 4096×4096 covers any sane avatar — the
+/// XEP-0084 §3.1 SHOULD is 96×96 — and caps decoded RGBA at 64 MB.
+const MAX_IMAGE_DIMENSION: u32 = 4096;
+
 /// Decode `bytes` (declared as `source`) and re-encode as PNG. The
-/// `image` crate's `ImageReader::with_guessed_format` re-sniffs the
-/// header so a magic-byte mismatch caught upstream wouldn't slip
-/// through here either; we still hint the format from the declared
-/// MIME so a corrupted file fails fast with a typed error rather
-/// than triggering a slower "try every format" path.
+/// `image` crate's `ImageReader::set_format` is used to pin the
+/// decoder to the format already verified by the magic-byte check
+/// in `try_fetch`; this avoids the slower "try every codec" path
+/// `with_guessed_format` would take. `image::Limits` bounds the
+/// decoder's allocations so a malformed source can't OOM the
+/// process before the decode completes.
 fn transcode_to_png(bytes: &[u8], source: AllowedMime) -> Result<Vec<u8>, FetchError> {
     let image_format = match source {
         AllowedMime::Png => ImageFormat::Png,
@@ -418,6 +436,10 @@ fn transcode_to_png(bytes: &[u8], source: AllowedMime) -> Result<Vec<u8>, FetchE
     };
     let mut reader = ImageReader::new(Cursor::new(bytes));
     reader.set_format(image_format);
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    reader.limits(limits);
     let img = reader
         .decode()
         .map_err(|e| FetchError::TranscodeFailed(format!("decode {}: {e}", source.as_mime())))?;
@@ -792,6 +814,39 @@ mod tests {
         assert!(
             matches!(result, Err(FetchError::TranscodeFailed(_))),
             "{result:?}"
+        );
+    }
+
+    #[test]
+    fn transcode_to_png_rejects_oversize_dimensions() {
+        // A PNG IHDR can declare any 32-bit width/height. The
+        // attacker's body is < 100 KB on the wire (passes the
+        // streaming cap) but advertises billions of pixels; without
+        // `image::Limits` the decoder would attempt to allocate
+        // `width * height * channels` bytes and OOM the process.
+        // Construct a PNG with a 65535×65535 IHDR — far above the
+        // 4096×4096 cap — and assert it surfaces as
+        // `TranscodeFailed`, not an allocation panic.
+        let mut png = Vec::new();
+        // PNG signature.
+        png.extend_from_slice(&[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+        // IHDR chunk: length=13, type="IHDR", data=W(4)+H(4)+depth(1)+color(1)+compr(1)+filter(1)+interl(1).
+        let ihdr_data: [u8; 13] = [
+            0x00, 0x00, 0xff, 0xff, // width = 65535
+            0x00, 0x00, 0xff, 0xff, // height = 65535
+            0x08, 0x06, 0x00, 0x00, 0x00, // 8-bit RGBA, default compression/filter/interlace
+        ];
+        png.extend_from_slice(&13u32.to_be_bytes());
+        png.extend_from_slice(b"IHDR");
+        png.extend_from_slice(&ihdr_data);
+        // Bogus CRC is fine — the decoder rejects via the limit
+        // check before CRC validation.
+        png.extend_from_slice(&[0, 0, 0, 0]);
+
+        let result = transcode_to_png(&png, AllowedMime::Png);
+        assert!(
+            matches!(result, Err(FetchError::TranscodeFailed(_))),
+            "expected TranscodeFailed (limit exceeded), got {result:?}"
         );
     }
 }

--- a/server/crates/waddle-server/src/profile/fetch.rs
+++ b/server/crates/waddle-server/src/profile/fetch.rs
@@ -24,11 +24,16 @@
 //! - **Streaming size cap:** 100 KB hard cap, enforced chunk-by-chunk
 //!   on the response body so an oversize/slowloris/lying-Content-Length
 //!   server cannot OOM us.
-//! - **MIME:** `image/png` only — XEP-0084 §3.1 restricts
-//!   `urn:xmpp:avatar:data` to PNG. The header is checked, then the
-//!   bytes are magic-byte sniffed against the PNG signature so a
-//!   server lying in `Content-Type` can't smuggle non-PNG payloads
-//!   downstream.
+//! - **MIME:** allowlist of `image/png`, `image/jpeg`, `image/gif`,
+//!   `image/webp` per RFC 363's design (issue #363). XEP-0084 §3.1
+//!   says PNG SHOULD be the data-node format, but the issue explicitly
+//!   chose to publish the source MIME under "exactly one `<info>`
+//!   element" rather than transcoding — the publish chain plumbs the
+//!   actual MIME through `<info type>`, vCard `<TYPE>`, and the vCard4
+//!   `<photo>` data-URI. The header is gated against the allowlist,
+//!   then the body is magic-byte sniffed against the specific format
+//!   the header declared so a server lying in `Content-Type` can't
+//!   smuggle a different payload downstream.
 //! - **Timeouts:** 5s connect, 10s total.
 //! - **Retries:** one retry on transient failures (5xx, connect
 //!   timeout, network error). No backoff.
@@ -51,10 +56,62 @@ const MAX_BYTES: usize = 100 * 1024;
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const TOTAL_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// XEP-0084 §3.1: `<data/>` is for `image/png` only.
-const PNG_MIME: &str = "image/png";
-/// PNG file signature (RFC 2083 §3.1).
-const PNG_MAGIC: [u8; 8] = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+/// Image formats we accept on the avatar fetch path. The publish
+/// chain carries the canonical MIME string forward into XEP-0084
+/// metadata (`<info type>`), vCard-temp PHOTO `<TYPE>`, and the
+/// XEP-0292 vCard4 `<photo>` data-URI without re-encoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AllowedMime {
+    Png,
+    Jpeg,
+    Gif,
+    Webp,
+}
+
+impl AllowedMime {
+    /// Match a normalized (`split(';').next().trim().to_lowercase()`)
+    /// `Content-Type` against the allowlist. `image/jpg` is rejected
+    /// — RFC 6838 only registers `image/jpeg`. If a real-world IdP
+    /// trips on this in practice, accept it explicitly with a test
+    /// rather than loosening the match.
+    fn from_header(s: &str) -> Option<Self> {
+        match s {
+            "image/png" => Some(Self::Png),
+            "image/jpeg" => Some(Self::Jpeg),
+            "image/gif" => Some(Self::Gif),
+            "image/webp" => Some(Self::Webp),
+            _ => None,
+        }
+    }
+
+    fn as_mime(self) -> &'static str {
+        match self {
+            Self::Png => "image/png",
+            Self::Jpeg => "image/jpeg",
+            Self::Gif => "image/gif",
+            Self::Webp => "image/webp",
+        }
+    }
+
+    /// Verify the body's leading bytes match the format declared in
+    /// the response header. Each signature is the format's documented
+    /// fixed prefix:
+    /// - PNG: 8-byte signature, RFC 2083 §3.1.
+    /// - JPEG: SOI + first marker, `FF D8 FF`. Subsequent bytes vary
+    ///   by encoder (E0/E1 for JFIF/EXIF, DB for raw quantization
+    ///   tables) so only the 3-byte prefix is fixed.
+    /// - GIF: ASCII `GIF87a` or `GIF89a` (CompuServe spec §17).
+    /// - WebP: RIFF container — `RIFF` magic, 4-byte LE chunk size,
+    ///   `WEBP` form (RFC 9649 §2.1).
+    fn matches_magic(self, bytes: &[u8]) -> bool {
+        match self {
+            Self::Png => bytes.starts_with(&[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+            Self::Jpeg => bytes.starts_with(&[0xff, 0xd8, 0xff]),
+            Self::Gif => bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a"),
+            Self::Webp => bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WEBP",
+        }
+    }
+}
 
 /// Successful avatar fetch result.
 #[derive(Debug, Clone)]
@@ -77,9 +134,11 @@ pub enum FetchError {
     Network(String),
     #[error("HTTP {0}")]
     Http(u16),
-    #[error("response Content-Type {0:?} is not image/png")]
+    #[error(
+        "response Content-Type {0:?} is not in the avatar allowlist (image/png, image/jpeg, image/gif, image/webp)"
+    )]
     MimeRejected(Option<String>),
-    #[error("response body did not start with the PNG signature")]
+    #[error("response body did not start with the magic-byte signature for the declared MIME")]
     MagicByteMismatch,
     #[error("response exceeds {0}-byte cap")]
     SizeExceeded(usize),
@@ -253,9 +312,10 @@ async fn try_fetch(
         .get(CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .map(|v| v.split(';').next().unwrap_or(v).trim().to_lowercase());
-    if header_mime.as_deref() != Some(PNG_MIME) {
-        return Err(FetchError::MimeRejected(header_mime));
-    }
+    let declared = match header_mime.as_deref().and_then(AllowedMime::from_header) {
+        Some(m) => m,
+        None => return Err(FetchError::MimeRejected(header_mime)),
+    };
 
     if let Some(len) = response.content_length() {
         if (len as usize) > policy.max_bytes {
@@ -277,14 +337,15 @@ async fn try_fetch(
         buf.extend_from_slice(&chunk);
     }
 
-    if buf.len() < PNG_MAGIC.len() || buf[..PNG_MAGIC.len()] != PNG_MAGIC {
+    if !declared.matches_magic(&buf) {
         return Err(FetchError::MagicByteMismatch);
     }
 
-    debug!(url = %url, bytes = buf.len(), mime = %PNG_MIME, "avatar fetched");
+    let mime = declared.as_mime();
+    debug!(url = %url, bytes = buf.len(), mime = %mime, "avatar fetched");
     Ok(AvatarBytes {
         bytes: buf,
-        mime: PNG_MIME.to_string(),
+        mime: mime.to_string(),
     })
 }
 
@@ -506,5 +567,84 @@ mod tests {
             FetchError::MimeRejected(Some("application/pdf".into())).kind(),
             "mime_rejected"
         );
+    }
+
+    #[test]
+    fn allowed_mime_round_trips_each_allowlist_entry() {
+        for (header, expected) in [
+            ("image/png", AllowedMime::Png),
+            ("image/jpeg", AllowedMime::Jpeg),
+            ("image/gif", AllowedMime::Gif),
+            ("image/webp", AllowedMime::Webp),
+        ] {
+            let parsed = AllowedMime::from_header(header).unwrap_or_else(|| {
+                panic!("{header} must be in the allowlist");
+            });
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.as_mime(), header);
+        }
+    }
+
+    #[test]
+    fn allowed_mime_rejects_unsupported_types() {
+        // RFC 6838 only registers `image/jpeg`; some IdPs serve
+        // `image/jpg` colloquially. We do NOT accept the alias —
+        // adding it would mean we publish `image/jpg` downstream
+        // (non-conformant per RFC 6838) and accept a body whose
+        // declared type isn't actually a registered MIME. If a real
+        // IdP trips on this, add a dedicated test alongside the
+        // explicit branch.
+        for header in [
+            "image/jpg",
+            "image/bmp",
+            "image/tiff",
+            "image/svg+xml",
+            "image/avif",
+            "application/pdf",
+            "text/plain",
+            "",
+        ] {
+            assert!(
+                AllowedMime::from_header(header).is_none(),
+                "{header:?} must NOT be in the allowlist"
+            );
+        }
+    }
+
+    #[test]
+    fn allowed_mime_matches_per_format_magic_bytes() {
+        let png = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00];
+        let jpeg = [0xff, 0xd8, 0xff, 0xe0, 0x00];
+        let gif87 = b"GIF87a\x00\x00";
+        let gif89 = b"GIF89a\x00\x00";
+        // RIFF<4 LE size bytes>WEBPVP8 ...
+        let webp = b"RIFF\x24\x00\x00\x00WEBPVP8 \x00";
+
+        assert!(AllowedMime::Png.matches_magic(&png));
+        assert!(AllowedMime::Jpeg.matches_magic(&jpeg));
+        assert!(AllowedMime::Gif.matches_magic(gif87));
+        assert!(AllowedMime::Gif.matches_magic(gif89));
+        assert!(AllowedMime::Webp.matches_magic(webp));
+
+        // Mismatched header vs body is the smuggling case the magic
+        // check exists to defeat.
+        assert!(!AllowedMime::Png.matches_magic(&jpeg));
+        assert!(!AllowedMime::Jpeg.matches_magic(&png));
+        assert!(!AllowedMime::Gif.matches_magic(&jpeg));
+        assert!(!AllowedMime::Webp.matches_magic(&jpeg));
+    }
+
+    #[test]
+    fn allowed_mime_magic_check_handles_short_body() {
+        // Empty / very short bodies must never panic — `try_fetch`
+        // streams the response and could in principle deliver a
+        // truncated buffer. `starts_with` is bounds-safe; the WebP
+        // arm explicitly checks `len >= 12`. Pin the contract.
+        for short in [&[][..], &[0xff][..], &[0xff, 0xd8][..]] {
+            assert!(!AllowedMime::Png.matches_magic(short));
+            assert!(!AllowedMime::Jpeg.matches_magic(short));
+            assert!(!AllowedMime::Gif.matches_magic(short));
+            assert!(!AllowedMime::Webp.matches_magic(short));
+        }
     }
 }

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -361,14 +361,7 @@ async fn avatar_url_jpeg_is_transcoded_to_png_per_xep_0084_3_2() {
         .photo_sha1_hex
         .clone()
         .expect("metadata MUST carry the SHA-1 id");
-    // Post-transcode: outcome.photo_mime is image/png, and the
-    // bytes count is the PNG re-encoding's, not the source JPEG.
     assert_eq!(resp.photo_mime.as_deref(), Some("image/png"));
-    assert_ne!(
-        resp.photo_bytes_len,
-        Some(jpeg_bytes.len()),
-        "post-transcode byte count must reflect the PNG re-encoding, not the source JPEG"
-    );
     assert!(resp.published_avatar_data && resp.published_avatar_metadata);
 
     let metadata = iq_get_to(
@@ -389,7 +382,56 @@ async fn avatar_url_jpeg_is_transcoded_to_png_per_xep_0084_3_2() {
     assert!(!metadata.contains(r#"type="image/jpeg""#));
     assert!(!metadata.contains(r#"url="#));
 
+    // Strongest proof the bytes were transcoded: fetch the published
+    // data item, base64-decode the `<data>` payload, and assert it
+    // starts with the PNG magic-byte signature. A length-comparison
+    // would be brittle for tiny fixtures (a 2×2 PNG and JPEG can
+    // coincidentally match in size); the magic-byte check is robust
+    // because PNG and JPEG signatures are mutually exclusive.
+    let data = iq_get_to(
+        &mut admin,
+        "avatar-data-jpeg-1",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{NS_AVATAR_DATA}"><item id="{sha1}"/></items></pubsub>"#
+        ),
+    )
+    .await;
+    let payload = extract_base64_data_payload(&data)
+        .unwrap_or_else(|| panic!("data response must carry a <data> element: {data}"));
+    let decoded = base64_decode(&payload)
+        .unwrap_or_else(|| panic!("data <data> base64 must decode: {payload}"));
+    assert!(
+        decoded.starts_with(&[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        "data node bytes MUST start with the PNG magic-byte signature after transcoding (XEP-0084 §3.2)"
+    );
+    assert_ne!(
+        decoded, jpeg_bytes,
+        "data node bytes MUST NOT be the source JPEG"
+    );
+
     let _ = admin.close().await;
+}
+
+/// Extract the base64 payload between `<data ...>` and `</data>`
+/// from a pubsub items response. Returns `None` if the element is
+/// absent. Whitespace is stripped because XEP-0084 §3.2 SHOULDs not
+/// inserting line feeds but explicitly accepts them.
+fn extract_base64_data_payload(xml: &str) -> Option<String> {
+    let open_idx = xml.find("<data ").or_else(|| xml.find("<data>"))?;
+    let after_open = open_idx + xml[open_idx..].find('>')? + 1;
+    let close_idx = xml[after_open..].find("</data>")? + after_open;
+    Some(
+        xml[after_open..close_idx]
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect(),
+    )
+}
+
+fn base64_decode(s: &str) -> Option<Vec<u8>> {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.decode(s).ok()
 }
 
 // ============================================================================

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -169,6 +169,16 @@ fn tiny_png() -> Vec<u8> {
     ]
 }
 
+/// JPEG fixture — SOI plus a JFIF APP0 marker prefix. Just enough
+/// to clear the `AllowedMime::Jpeg` magic-byte check in `fetch.rs`;
+/// the publish chain base64-encodes whatever clears the gate
+/// (nothing downstream parses the image structure).
+fn tiny_jpeg() -> Vec<u8> {
+    vec![
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
+    ]
+}
+
 // ============================================================================
 // fn_only_publishes_to_vcard_temp_and_vcard4_with_no_avatar
 // ============================================================================
@@ -298,6 +308,71 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
 }
 
 // ============================================================================
+// avatar_url_publishes_jpeg_with_per_format_mime
+// ============================================================================
+//
+// Regression for the prod incident traced to issue #363: GitHub
+// avatars at `avatars.githubusercontent.com/u/<id>?v=4` are served
+// with `Content-Type: image/jpeg` for users whose original avatar
+// was a JPEG, and the fetcher rejected them as `mime_rejected`.
+// This test pins the JPEG path end-to-end: the metadata `<info type>`
+// must carry `image/jpeg`, not `image/png`.
+
+#[tokio::test]
+async fn avatar_url_publishes_jpeg_with_per_format_mime() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "avatar-jpeg-1").await;
+    let admin_bare = format!("{ADMIN}@{DOMAIN}");
+
+    let jpeg_bytes = tiny_jpeg();
+    let mock = wiremock::MockServer::start().await;
+    wiremock::Mock::given(wiremock::matchers::method("GET"))
+        .and(wiremock::matchers::path("/avatar.jpg"))
+        .respond_with(
+            wiremock::ResponseTemplate::new(200)
+                .insert_header("content-type", "image/jpeg")
+                .set_body_bytes(jpeg_bytes.clone()),
+        )
+        .mount(&mock)
+        .await;
+
+    let avatar_url = format!("{}/avatar.jpg", mock.uri());
+    let resp = invoke_profile_publish(
+        &server,
+        &PublishReq::for_jid(&admin_bare).set_photo_url(&avatar_url),
+    )
+    .await;
+
+    let sha1 = resp
+        .photo_sha1_hex
+        .clone()
+        .expect("metadata MUST carry the SHA-1 id");
+    assert_eq!(resp.photo_mime.as_deref(), Some("image/jpeg"));
+    assert_eq!(resp.photo_bytes_len, Some(jpeg_bytes.len()));
+    assert!(resp.published_avatar_data && resp.published_avatar_metadata);
+
+    let metadata = iq_get_to(
+        &mut admin,
+        "avatar-meta-jpeg-1",
+        &admin_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{NS_AVATAR_METADATA}"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        metadata.contains(NS_AVATAR_METADATA) && metadata.contains(&format!(r#"id="{sha1}""#)),
+        "metadata item MUST be keyed on the SHA-1 of the bytes per XEP-0084 §4.1.1: {metadata}"
+    );
+    assert!(
+        metadata.contains(r#"type="image/jpeg""#),
+        "metadata <info type> MUST reflect the source MIME, not a hard-coded image/png: {metadata}"
+    );
+    assert!(!metadata.contains(r#"url="#));
+
+    let _ = admin.close().await;
+}
+
+// ============================================================================
 // empty_source_is_no_op
 // ============================================================================
 
@@ -367,11 +442,16 @@ async fn combined_fn_plus_avatar_publishes_full_chain() {
 }
 
 // ============================================================================
-// non_png_content_type_is_rejected
+// out_of_allowlist_content_type_is_rejected
 // ============================================================================
+//
+// Per RFC 363 the avatar fetch allowlist is `image/png`, `image/jpeg`,
+// `image/gif`, `image/webp`. Anything outside that list — including
+// older container formats (BMP, TIFF) and the `image/jpg` colloquial
+// alias — is rejected at the fetch gate.
 
 #[tokio::test]
-async fn non_png_content_type_is_rejected() {
+async fn out_of_allowlist_content_type_is_rejected() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
     let admin_bare = format!("{ADMIN}@{DOMAIN}");
@@ -380,22 +460,22 @@ async fn non_png_content_type_is_rejected() {
     wiremock::Mock::given(wiremock::matchers::method("GET"))
         .respond_with(
             wiremock::ResponseTemplate::new(200)
-                .insert_header("content-type", "image/jpeg")
-                .set_body_bytes(b"\xff\xd8\xff\xe0".to_vec()),
+                .insert_header("content-type", "image/bmp")
+                .set_body_bytes(b"BM\x00\x00\x00\x00".to_vec()),
         )
         .mount(&mock)
         .await;
 
     let (status, body) = invoke_profile_publish_raw(
         &server,
-        &PublishReq::for_jid(admin_bare).set_photo_url(format!("{}/jpeg.bin", mock.uri())),
+        &PublishReq::for_jid(admin_bare).set_photo_url(format!("{}/avatar.bmp", mock.uri())),
         Some(server.test_profile_publish_token()),
     )
     .await;
     assert_eq!(
         status,
         reqwest::StatusCode::UNPROCESSABLE_ENTITY,
-        "non-PNG MIME is a fetch-policy reject (422), got {status} {body}"
+        "out-of-allowlist MIME is a fetch-policy reject (422), got {status} {body}"
     );
 }
 

--- a/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
+++ b/server/crates/waddle-server/tests/xep0084_avatar_ws.rs
@@ -169,14 +169,20 @@ fn tiny_png() -> Vec<u8> {
     ]
 }
 
-/// JPEG fixture — SOI plus a JFIF APP0 marker prefix. Just enough
-/// to clear the `AllowedMime::Jpeg` magic-byte check in `fetch.rs`;
-/// the publish chain base64-encodes whatever clears the gate
-/// (nothing downstream parses the image structure).
+/// JPEG fixture — a real 2×2 red square the transcoder can decode.
+/// `fetch.rs` re-encodes non-PNG sources to PNG before publish per
+/// XEP-0084 §3.2, so the magic-byte prefix alone is no longer
+/// sufficient (the decoder rejects truncated JPEGs).
 fn tiny_jpeg() -> Vec<u8> {
-    vec![
-        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01,
-    ]
+    let img = image::ImageBuffer::from_pixel(2u32, 2u32, image::Rgb([255u8, 0, 0]));
+    let mut out = Vec::new();
+    image::DynamicImage::ImageRgb8(img)
+        .write_to(
+            &mut std::io::Cursor::new(&mut out),
+            image::ImageFormat::Jpeg,
+        )
+        .expect("encoding 2×2 RGB to JPEG must succeed");
+    out
 }
 
 // ============================================================================
@@ -308,18 +314,25 @@ async fn avatar_url_publishes_data_and_metadata_with_real_sha1() {
 }
 
 // ============================================================================
-// avatar_url_publishes_jpeg_with_per_format_mime
+// avatar_url_jpeg_is_transcoded_to_png_per_xep_0084_3_2
 // ============================================================================
 //
 // Regression for the prod incident traced to issue #363: GitHub
 // avatars at `avatars.githubusercontent.com/u/<id>?v=4` are served
 // with `Content-Type: image/jpeg` for users whose original avatar
-// was a JPEG, and the fetcher rejected them as `mime_rejected`.
-// This test pins the JPEG path end-to-end: the metadata `<info type>`
-// must carry `image/jpeg`, not `image/png`.
+// was a JPEG, and the original PNG-only fetch path rejected them as
+// `mime_rejected`.
+//
+// The fix accepts JPEG (and GIF/WebP) at the fetch boundary AND
+// transcodes them to PNG before publish, so the wire payload always
+// satisfies XEP-0084 §3.2 ("data node carries image/png only") and
+// §4.2 ("one of the formats MUST be image/png to ensure
+// interoperability"). This test pins both halves: the publish
+// succeeds for a JPEG source, and the metadata advertises
+// `image/png` regardless of source MIME.
 
 #[tokio::test]
-async fn avatar_url_publishes_jpeg_with_per_format_mime() {
+async fn avatar_url_jpeg_is_transcoded_to_png_per_xep_0084_3_2() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
     let mut admin = admin_client(&server, "avatar-jpeg-1").await;
@@ -348,8 +361,14 @@ async fn avatar_url_publishes_jpeg_with_per_format_mime() {
         .photo_sha1_hex
         .clone()
         .expect("metadata MUST carry the SHA-1 id");
-    assert_eq!(resp.photo_mime.as_deref(), Some("image/jpeg"));
-    assert_eq!(resp.photo_bytes_len, Some(jpeg_bytes.len()));
+    // Post-transcode: outcome.photo_mime is image/png, and the
+    // bytes count is the PNG re-encoding's, not the source JPEG.
+    assert_eq!(resp.photo_mime.as_deref(), Some("image/png"));
+    assert_ne!(
+        resp.photo_bytes_len,
+        Some(jpeg_bytes.len()),
+        "post-transcode byte count must reflect the PNG re-encoding, not the source JPEG"
+    );
     assert!(resp.published_avatar_data && resp.published_avatar_metadata);
 
     let metadata = iq_get_to(
@@ -361,12 +380,13 @@ async fn avatar_url_publishes_jpeg_with_per_format_mime() {
     .await;
     assert!(
         metadata.contains(NS_AVATAR_METADATA) && metadata.contains(&format!(r#"id="{sha1}""#)),
-        "metadata item MUST be keyed on the SHA-1 of the bytes per XEP-0084 §4.1.1: {metadata}"
+        "metadata item MUST be keyed on the SHA-1 of the PNG bytes per XEP-0084 §4.1.1: {metadata}"
     );
     assert!(
-        metadata.contains(r#"type="image/jpeg""#),
-        "metadata <info type> MUST reflect the source MIME, not a hard-coded image/png: {metadata}"
+        metadata.contains(r#"type="image/png""#),
+        "metadata <info type> MUST be image/png after transcoding (XEP-0084 §3.2 / §4.2): {metadata}"
     );
+    assert!(!metadata.contains(r#"type="image/jpeg""#));
     assert!(!metadata.contains(r#"url="#));
 
     let _ = admin.close().await;


### PR DESCRIPTION
## Symptom

After #440 (OIDC profile publish chain) and #442 (startup backfill) shipped, prod users could see their own avatar (sourced directly from the OIDC `picture` claim by the chat client) but **not** other users' avatars.

## Root cause

`server/crates/waddle-server/src/profile/fetch.rs` rejected every `Content-Type` other than `image/png` and only sniffed the PNG magic-byte signature, contradicting issue #363's stated allowlist (`image/png`, `image/jpeg`, `image/gif`, `image/webp`). On prod, 3 of 4 users had `last_avatar_fetch_error = 'mime_rejected'` for GitHub avatar URLs (`avatars.githubusercontent.com` serves `image/jpeg` for users whose avatar was uploaded as JPEG), so their PEP/vCard avatar state was empty.

A first pass simply expanded the fetch allowlist and piped non-PNG bytes through unchanged. Adversarial XEP-conformance review then surfaced three blocking violations that cascaded from issue #363's "exactly one `<info>` element with the source MIME" wording:

1. **XEP-0084 §3.2** — `urn:xmpp:avatar:data` is normatively `image/png` only.
2. **XEP-0084 §4.1.1** — the metadata `<info id>` ItemID MUST be the SHA-1 of the PNG bytes.
3. **XEP-0084 §4.2** — at least one `<info>` element MUST be `image/png` for interop.

CLAUDE.md's XEP conformance hard rule treats those MUSTs as binding, so the right fix is to transcode non-PNG sources to PNG at the fetch boundary.

## Fix

### Allowlist + transcoding (the load-bearing change)

- `AllowedMime` enum (`Png | Jpeg | Gif | Webp`) with canonical MIME strings, per-format magic-byte verification, and an `ALL` slice as a single source of truth.
- `try_fetch` parses the header into `AllowedMime` (gate); after streaming the body, the bytes are magic-byte verified against the *declared* format, then **transcoded to PNG** via the `image` crate (PNG sources skip transcoding). The publish chain (`profile/publish.rs`) is unchanged — it now always sees `bytes.mime = "image/png"` and `bytes.bytes = <PNG>`, so the SHA-1 ItemID, metadata `<info type>`, vCard `<TYPE>`, and the vCard4 `<photo>` data-URI all derive from PNG bytes per the XEP.
- 100 KB cap moves to **post-transcode**: lossy JPEG → lossless PNG can inflate past D1's `pubsub_items.payload_xml` budget. Oversized re-encodings surface as the existing typed `SizeExceeded`.
- New `FetchError::TranscodeFailed` for image decode/encode failures, classified as a permanent kind in `backfill::PERMANENT_KINDS` (a corrupted upstream isn't going to fix itself between boots).

### Smaller fixes folded in

- **Single source of truth for the allowlist string.** `MimeRejected` `Display` calls `AllowedMime::allowlist_help()` so the human-facing list can't drift from the enum. A unit test pins the contract (`mime_rejected_display_lists_every_allowlist_entry`).
- **Magic-byte intent reframed.** Module doc comment now describes the magic-byte check as a "malformed-server defense" rather than a "smuggling defense" — the header itself is attacker-controlled, so the check only catches buggy servers, not adversarial ones. The transcode step is what makes the wire payload predictable.

### Tests

- `transcode_to_png_round_trips_each_non_png_format` — JPEG/GIF/WebP fixtures encoded fresh by the `image` crate, decoded by the fetcher's transcode helper, asserted to clear the PNG magic-byte gate.
- `transcode_to_png_rejects_corrupted_body` — magic bytes match, body is junk → `TranscodeFailed`.
- `mime_rejected_display_lists_every_allowlist_entry` — pins the Display ↔ `ALL` contract.
- `allowed_mime_round_trips_each_allowlist_entry`, `allowed_mime_rejects_unsupported_types`, `allowed_mime_matches_per_format_magic_bytes`, `allowed_mime_magic_check_handles_short_body`.
- `avatar_url_jpeg_is_transcoded_to_png_per_xep_0084_3_2` (integration) — JPEG source → metadata advertises `type="image/png"`, byte count differs from source (proves transcode happened), no `image/jpeg` anywhere on the wire.
- Repurposed `non_png_content_type_is_rejected` → `out_of_allowlist_content_type_is_rejected` (BMP) since JPEG is now accepted.
- `permanent_kinds_subset_of_fetch_error_kinds` (existing) extended to cover `transcode_failed`.

## Operational follow-up

Filed #451 to handle stale throttle rows on deploy. Until that lands, the manual procedure after this PR ships:

```sql
UPDATE user_avatar_fetch_state
SET last_attempt_at = NULL, last_error = NULL
WHERE last_error IN ('mime_rejected', 'magic_byte_mismatch', 'transcode_failed');
```

Then restart the server pod so the backfill picks up. OIDC re-login also bypasses the backfill throttle.

## Test plan

- [x] `cargo test -p waddle-server --lib profile::` — 43 passed (unit tests for fetch + transcode + backfill + vcard_rmw)
- [x] `cargo test -p waddle-server --test xep0084_avatar_ws` — 17 passed (full XEP-0084 conformance suite)
- [x] `cargo clippy -p waddle-server --tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Adversarial XEP-conformance + security + typed-payloads reviews (subagents) — all blocking findings resolved
- [ ] Deploy to prod, clear throttle rows per the procedure above, restart pod, verify `randax`, `rawkode`, `icepuma` get avatars on next backfill round