### PR TITLE
fix(server): widen pending_delivery.original_receipt_at to BIGINT on Postgres

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -49,7 +49,8 @@ pub fn sweep_recipient_locks(
 /// CREATE TABLE pending_delivery (
 ///     row_id TEXT PRIMARY KEY,            -- UUID v7 — sortable for FIFO
 ///     recipient_jid TEXT NOT NULL,
-///     original_receipt_at INTEGER NOT NULL, -- ms since unix epoch
+///     original_receipt_at BIGINT NOT NULL, -- ms since unix epoch (i64;
+///                                          -- SQLite collapses to INTEGER)
 ///     payload_kind TEXT NOT NULL,         -- 'archived' | 'transient'
 ///     archive_stanza_by TEXT,             -- bare jid stamping `<stanza-id/>`
 ///     archive_stanza_id TEXT,             -- XEP-0359 id (Archived rows)

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -38,18 +38,51 @@ pub(super) async fn initialize(
         .await?;
     // Online migration for existing Postgres tables that were created
     // with the pre-fix `INTEGER` (i32) shape. Widening to BIGINT is
-    // lossless and idempotent — Postgres rewrites the column type, but
-    // every value that actually made it in fits in i32 anyway (writes
-    // past i32::MAX rejected at the wire). SQLite columns are
-    // dynamic-width, so the type doesn't need rewriting there.
+    // lossless — every value that actually made it in fits in i32
+    // anyway (writes past i32::MAX rejected at the wire). SQLite
+    // columns are dynamic-width, so the type doesn't need rewriting
+    // there.
+    //
+    // Gate the ALTER on the current column type so subsequent restarts
+    // (and racing replicas in a rolling deploy) do not re-issue an
+    // `ALTER COLUMN ... TYPE BIGINT` that still takes ACCESS EXCLUSIVE
+    // even when the column is already BIGINT.
     if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
-        storage
-            .execute(
-                "ALTER TABLE pending_delivery \
-                 ALTER COLUMN original_receipt_at TYPE BIGINT",
+        let mut rows = storage
+            .query(
+                "SELECT data_type \
+                 FROM information_schema.columns \
+                 WHERE table_name = 'pending_delivery' \
+                   AND column_name = 'original_receipt_at'",
                 (),
             )
             .await?;
+        let current_type: Option<String> = match rows
+            .next()
+            .await
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?
+        {
+            Some(row) => row
+                .get(0)
+                .map_err(|error| PendingStorageError::Other(error.to_string()))?,
+            None => None,
+        };
+        // `information_schema.columns.data_type` reports `integer` for
+        // int4 and `bigint` for int8 — case is lowercase per the SQL
+        // standard. Compare lowercase to be defensive against any
+        // future Postgres surface changes.
+        let needs_widen = current_type
+            .as_deref()
+            .is_some_and(|t| !t.eq_ignore_ascii_case("bigint"));
+        if needs_widen {
+            storage
+                .execute(
+                    "ALTER TABLE pending_delivery \
+                     ALTER COLUMN original_receipt_at TYPE BIGINT",
+                    (),
+                )
+                .await?;
+        }
     }
     // Idempotent column-add migration for the locked Q7b
     // outbound_sequence column. Tables created by an older

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -3,13 +3,27 @@ use super::*;
 pub(super) async fn initialize(
     storage: &DatabasePendingDeliveryStorage,
 ) -> Result<(), PendingStorageError> {
+    // `original_receipt_at` stores `timestamp_millis()` (i64 ms since
+    // unix epoch). Postgres `INTEGER` is i32 (max ~2.1B), which
+    // overflows on every insert from 2001-09-09 onward — every prod
+    // write since the column was introduced in #339 has failed with
+    // `numeric_value_out_of_range`, taking reactions and other
+    // pending-delivery writes down with it. Sibling
+    // `sm_persistence/schema.rs` already uses this driver-aware
+    // selector for the same reason. SQLite `INTEGER` is dynamic-width,
+    // so the same DDL stays correct there.
+    let bigint = match storage.db.driver() {
+        DatabaseDriver::Postgres => "BIGINT",
+        DatabaseDriver::Sqlite => "INTEGER",
+    };
     storage
         .execute(
-            r#"
+            &format!(
+                r#"
         CREATE TABLE IF NOT EXISTS pending_delivery (
             row_id TEXT PRIMARY KEY,
             recipient_jid TEXT NOT NULL,
-            original_receipt_at INTEGER NOT NULL,
+            original_receipt_at {bigint} NOT NULL,
             payload_kind TEXT NOT NULL,
             archive_stanza_by TEXT,
             archive_stanza_id TEXT,
@@ -17,10 +31,26 @@ pub(super) async fn initialize(
             flushed_in_session TEXT,
             outbound_sequence INTEGER
         )
-        "#,
+        "#
+            ),
             (),
         )
         .await?;
+    // Online migration for existing Postgres tables that were created
+    // with the pre-fix `INTEGER` (i32) shape. Widening to BIGINT is
+    // lossless and idempotent — Postgres rewrites the column type, but
+    // every value that actually made it in fits in i32 anyway (writes
+    // past i32::MAX rejected at the wire). SQLite columns are
+    // dynamic-width, so the type doesn't need rewriting there.
+    if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
+        storage
+            .execute(
+                "ALTER TABLE pending_delivery \
+                 ALTER COLUMN original_receipt_at TYPE BIGINT",
+                (),
+            )
+            .await?;
+    }
     // Idempotent column-add migration for the locked Q7b
     // outbound_sequence column. Tables created by an older
     // version of waddle-server (before PR #358) were missing this

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -7,8 +7,8 @@ pub(super) async fn initialize(
     // unix epoch). Postgres `INTEGER` is i32 (max ~2.1B), which
     // overflows on every insert from 2001-09-09 onward — every prod
     // write since the column was introduced in #339 has failed with
-    // `numeric_value_out_of_range`, taking reactions and other
-    // pending-delivery writes down with it. Sibling
+    // `numeric_value_out_of_range`, breaking XEP-0160 offline DM
+    // delivery on SM session resume / detach promotion. Sibling
     // `sm_persistence/schema.rs` already uses this driver-aware
     // selector for the same reason. SQLite `INTEGER` is dynamic-width,
     // so the same DDL stays correct there.
@@ -48,11 +48,20 @@ pub(super) async fn initialize(
     // `ALTER COLUMN ... TYPE BIGINT` that still takes ACCESS EXCLUSIVE
     // even when the column is already BIGINT.
     if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
+        // Constrain by `table_schema = current_schema()` so the probe
+        // looks at the same table the unqualified `ALTER TABLE
+        // pending_delivery` below would hit (which resolves via
+        // `search_path`). Without this, in databases that contain
+        // `pending_delivery` in multiple schemas, the probe could read
+        // a sibling table's type and incorrectly skip the widening
+        // (leaving the overflow bug in place) or trigger an ALTER
+        // against a table whose type was already correct.
         let mut rows = storage
             .query(
                 "SELECT data_type \
                  FROM information_schema.columns \
-                 WHERE table_name = 'pending_delivery' \
+                 WHERE table_schema = current_schema() \
+                   AND table_name = 'pending_delivery' \
                    AND column_name = 'original_receipt_at'",
                 (),
             )

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1311,8 +1311,9 @@ async fn xep0160_pending_delivery_survives_server_restart() {
 /// Regression: `original_receipt_at` stores `timestamp_millis()` (i64
 /// ms-since-epoch). On Postgres, the column MUST be `BIGINT` — using
 /// `INTEGER` (i32, max ~2.1B) overflowed on every write past
-/// 2001-09-09, taking reactions and other pending-delivery writes down
-/// with it (production logs spammed `numeric_value_out_of_range`).
+/// 2001-09-09, breaking XEP-0160 offline DM delivery on SM session
+/// resume / detach promotion (production logs spammed
+/// `numeric_value_out_of_range`).
 ///
 /// CI runs only against SQLite (where `INTEGER` is dynamic-width), so
 /// the bug slipped past the existing SQLite-backed coverage. This test
@@ -1349,8 +1350,9 @@ async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
     let recipient_local = format!("alice-{}", uuid::Uuid::new_v4());
     let recipient = bare(&format!("{recipient_local}@example.com"));
 
+    let row_id = PendingRowId::fresh();
     let row = PendingRow {
-        id: PendingRowId::fresh(),
+        id: row_id.clone(),
         recipient: recipient.clone(),
         original_receipt_at: receipt,
         payload: PendingPayload::Archived(StanzaId::new(
@@ -1370,9 +1372,12 @@ async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].original_receipt_at, receipt);
 
-    // Clean up so repeated runs are idempotent.
-    storage
-        .delete_older_than(receipt + chrono::Duration::seconds(1))
-        .await
-        .expect("cleanup");
+    // Clean up by the exact row id we just inserted so repeated runs
+    // are idempotent without touching unrelated rows. `delete_older_than`
+    // is a global cutoff across all recipients — using it for test
+    // cleanup against a `WADDLE_TEST_POSTGRES_URL` pointed at a shared
+    // dev/CI database could wipe production-shaped test fixtures from
+    // other suites.
+    let deleted = storage.delete_row(&row_id).await.expect("cleanup");
+    assert_eq!(deleted, 1, "test row must be deleted by id");
 }

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1307,3 +1307,72 @@ async fn xep0160_pending_delivery_survives_server_restart() {
     };
     assert_eq!(body, Some("across-restart"));
 }
+
+/// Regression: `original_receipt_at` stores `timestamp_millis()` (i64
+/// ms-since-epoch). On Postgres, the column MUST be `BIGINT` — using
+/// `INTEGER` (i32, max ~2.1B) overflowed on every write past
+/// 2001-09-09, taking reactions and other pending-delivery writes down
+/// with it (production logs spammed `numeric_value_out_of_range`).
+///
+/// CI runs only against SQLite (where `INTEGER` is dynamic-width), so
+/// the bug slipped past the existing SQLite-backed coverage. This test
+/// opts in to a real Postgres via `WADDLE_TEST_POSTGRES_URL` and proves
+/// the round-trip with a 2026-era millisecond value that does not fit
+/// in i32.
+#[tokio::test]
+async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping: WADDLE_TEST_POSTGRES_URL not set \
+             (postgres-backed regression for pending_delivery BIGINT)"
+        );
+        return;
+    };
+
+    let storage = DatabasePendingDeliveryStorage::open(Some(&database_url), QuotaPolicy::Unlimited)
+        .await
+        .expect("open postgres storage");
+
+    // 2026-era ms timestamp — comfortably past i32::MAX (~2.147B). A
+    // pre-fix `INTEGER` column would reject this with
+    // `22003 numeric_value_out_of_range`.
+    let receipt_ms: i64 = 1_778_000_000_000;
+    assert!(
+        receipt_ms > i64::from(i32::MAX),
+        "test value must exceed i32::MAX to exercise the regression"
+    );
+    let receipt = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(receipt_ms)
+        .expect("valid timestamp");
+
+    // Unique recipient per run so concurrent test runs against the
+    // same Postgres do not collide on the archived-id unique index.
+    let recipient_local = format!("alice-{}", uuid::Uuid::new_v4());
+    let recipient = bare(&format!("{recipient_local}@example.com"));
+
+    let row = PendingRow {
+        id: PendingRowId::fresh(),
+        recipient: recipient.clone(),
+        original_receipt_at: receipt,
+        payload: PendingPayload::Archived(StanzaId::new(
+            uuid::Uuid::new_v4().to_string(),
+            jid::Jid::from(recipient.clone()),
+        )),
+        flushed_in_session: None,
+        outbound_sequence: None,
+    };
+    assert_eq!(
+        storage.insert(row).await.expect("insert"),
+        InsertOutcome::Inserted,
+        "BIGINT column must accept i64 ms past i32::MAX"
+    );
+
+    let rows = storage.list(&recipient).await.expect("list");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].original_receipt_at, receipt);
+
+    // Clean up so repeated runs are idempotent.
+    storage
+        .delete_older_than(receipt + chrono::Duration::seconds(1))
+        .await
+        .expect("cleanup");
+}


### PR DESCRIPTION
## Summary

`pending_delivery.original_receipt_at` is declared `INTEGER NOT NULL` but writers bind `timestamp_millis()` (i64 ms). On Postgres, `INTEGER` is i32 (max ~2.1B); ms-since-epoch in 2026 is ~1.78T, so every insert has been rejected with `numeric_value_out_of_range` since #339 landed on 2026-05-05. SQLite tolerates it because its `INTEGER` is dynamic-width — which is why CI (SQLite-only) didn't catch it.

This PR widens the column to `BIGINT` on Postgres, mirroring the driver-aware pattern that `sm_persistence/schema.rs:29-32` already uses, plus an online ALTER with an `information_schema` gate so the ALTER is a true no-op on subsequent restarts (no `ACCESS EXCLUSIVE` lock acquired against live traffic).

## Production impact

**Confirmed broken by this bug**

XEP-0160 offline DM delivery on SM session resume / detach promotion. Server logs continuously emit:

```
WARN Q6 promotion: pending_delivery insert failed; integer out of range
     target: waddle_server::sm_promotion::pending
```

— once per unacked stanza per promotion attempt. Every SM-managed session that detaches today loses its undelivered messages because they can't be promoted to durable `pending_delivery`.

**Originally suspected but NOT actually caused by this bug**

I started this PR investigating "MUC reactions vanish after refresh" and assumed the temporal correlation (reactions stopped landing in MAM on 2026-05-05, same day #339 landed) + the log spam pointed at the same root cause. An adversarial review demolished that claim:

- ``MucArchiveHandler`` (``server/crates/waddle-xmpp/src/protocol/room/archive.rs:43-67``) emits ``OutboundEvent::ArchiveGroupchat``.
- The interpreter handles it via ``archive_groupchat_message`` (``server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs:3-41``) → ``mam_storage.store_message(...)``.
- ``grep -rn 'pending_delivery' server/crates/waddle-xmpp/src/protocol/room/`` returns **zero hits**.
- Regular MUC messages and reactions take the *same* MAM archive path through ``MucArchiveHandler``. Regular messages keep landing in MAM; reactions don't. A ``pending_delivery`` failure cannot selectively skip the reaction branch.

So this PR fixes a real, important, separate bug — but the reaction-persistence regression has a different root cause that still needs investigation. Filed as a follow-up.

## Migration safety

``ALTER TABLE pending_delivery ALTER COLUMN original_receipt_at TYPE BIGINT`` is gated on ``information_schema.columns.data_type != 'bigint'`` so:

- First server start after deploy: the gate fires, the ALTER widens the column. Verified against the production cluster's Postgres (current ``data_type`` is ``integer``).
- Every subsequent start: the gate skips the ALTER. No ``ACCESS EXCLUSIVE`` lock acquired, no serialization with live traffic.
- Rolling deploy across N replicas: only the first to win the race performs the rewrite; the rest no-op.
- Idempotence: verified against the production cluster's Postgres with a rolled-back transaction (``BEGIN; ALTER; ALTER; ROLLBACK;``).

Widening is lossless: every accepted row was already ≤ i32::MAX (the bug rejected larger values at the wire).

## Sibling bugs filed as follow-up

#456:

- ``inbox_entries.last_updated INTEGER`` — currently stores seconds (``Utc::now().timestamp()``) so it doesn't overflow today, but it's a Y2038 bug and a foot-gun for anyone who later refactors to ``timestamp_millis()``.
- ``sm_unacked.original_receipt_at_ms`` — fresh tables use the driver-aware ``BIGINT`` selector, but there's no online ALTER for production tables that may have been created before that selector landed.

Both should get the same gated-ALTER pattern.

## Test plan

- [x] ``cargo test -p waddle-server --lib pending_delivery`` — 25/25 passing (one new env-gated test skips without ``WADDLE_TEST_POSTGRES_URL``).
- [x] ``cargo test -p waddle-server --lib`` — 524/524 passing.
- [x] ``cargo fmt --package waddle-server`` clean.
- [x] ``cargo clippy -p waddle-server --tests -- -D warnings`` clean.
- [x] Production ``ALTER`` dry-run (rolled back): column flips from ``integer`` → ``bigint`` cleanly; second ALTER no-ops.
- [ ] Post-deploy smoke: watch waddle-server logs, confirm the ``integer out of range`` warnings stop. Trigger an SM-managed session detach with an undelivered DM, confirm the row lands in ``pending_delivery`` and replays on reconnect.
- [ ] **Open: separate investigation into the reaction-persistence regression.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)