### PR TITLE
fix(chat): unblock pin/unpin in standalone channels

### DIFF
--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -905,11 +905,10 @@ export function useChatAppController(giphyApiKey: string) {
   function pinActiveMessage(messageId: string) {
     const client = xmppClient.value;
     const channel = waddles.currentChannel.value;
-    const space = waddles.currentSpace.value;
-    if (!client || !channel || !space) return;
+    if (!client || !channel) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
-    void client.pinMessage(space.id, channel.id, stanzaId).catch((error: unknown) => {
+    void client.pinMessage(channel.spaceId ?? "", channel.id, stanzaId).catch((error: unknown) => {
       console.warn("pinMessage failed", error);
     });
   }
@@ -917,11 +916,10 @@ export function useChatAppController(giphyApiKey: string) {
   function unpinActiveMessage(messageId: string) {
     const client = xmppClient.value;
     const channel = waddles.currentChannel.value;
-    const space = waddles.currentSpace.value;
-    if (!client || !channel || !space) return;
+    if (!client || !channel) return;
     const stanzaId = resolvePinTargetStanzaId(messageId);
     if (!stanzaId) return;
-    void client.unpinMessage(space.id, channel.id, stanzaId).catch((error: unknown) => {
+    void client.unpinMessage(channel.spaceId ?? "", channel.id, stanzaId).catch((error: unknown) => {
       console.warn("unpinMessage failed", error);
     });
   }

--- a/chat/tests/pin-standalone-channel.test.ts
+++ b/chat/tests/pin-standalone-channel.test.ts
@@ -15,34 +15,36 @@ const controllerSource = readFileSync(
   "utf8",
 );
 
-function block(name: string): string {
-  const start = controllerSource.indexOf(`function ${name}(`);
-  if (start === -1) throw new Error(`function ${name} not found in chat-app-controller.ts`);
-  let depth = 0;
-  let inBody = false;
-  for (let i = start; i < controllerSource.length; i++) {
-    const ch = controllerSource[i];
-    if (ch === "{") {
-      depth++;
-      inBody = true;
-    } else if (ch === "}") {
-      depth--;
-      if (inBody && depth === 0) return controllerSource.slice(start, i + 1);
-    }
-  }
-  throw new Error(`could not extract body of ${name}`);
-}
-
 describe("pin/unpin handlers for standalone channels", () => {
-  for (const name of ["pinActiveMessage", "unpinActiveMessage"] as const) {
-    test(`${name} does not require currentSpace`, () => {
-      const body = block(name);
-      expect(body).not.toContain("currentSpace");
-    });
+  test("pinMessage call site reads spaceId off the active channel", () => {
+    expect(controllerSource).toContain(
+      'client.pinMessage(channel.spaceId ?? "", channel.id',
+    );
+  });
 
-    test(`${name} reads the space id off the active channel`, () => {
-      const body = block(name);
-      expect(body).toContain("channel.spaceId");
-    });
-  }
+  test("unpinMessage call site reads spaceId off the active channel", () => {
+    expect(controllerSource).toContain(
+      'client.unpinMessage(channel.spaceId ?? "", channel.id',
+    );
+  });
+
+  test("pin call site no longer threads space.id from currentSpace", () => {
+    expect(controllerSource).not.toContain("client.pinMessage(space.id");
+    expect(controllerSource).not.toContain("client.unpinMessage(space.id");
+  });
+
+  test("no pin handler reaches for waddles.currentSpace.value", () => {
+    // The full call site is the only place a removed guard would
+    // re-appear; pin a narrow regex around the two function names so
+    // unrelated currentSpace usages elsewhere in the controller (modals,
+    // headers) do not trip the assertion.
+    const pinRegion = controllerSource.match(
+      /function pinActiveMessage[\s\S]{0,800}/,
+    )?.[0] ?? "";
+    const unpinRegion = controllerSource.match(
+      /function unpinActiveMessage[\s\S]{0,800}/,
+    )?.[0] ?? "";
+    expect(pinRegion).not.toContain("currentSpace");
+    expect(unpinRegion).not.toContain("currentSpace");
+  });
 });

--- a/chat/tests/pin-standalone-channel.test.ts
+++ b/chat/tests/pin-standalone-channel.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// Regression: pin/unpin in the chat-app controller must work for
+// standalone MUCs (channels without a parent Waddle space). The earlier
+// guard required `waddles.currentSpace.value` to be non-null, which
+// silently aborted every pin click in a standalone channel — and also
+// in any nested channel whose parent space hadn't surfaced yet in the
+// `waddles` list. Both paths now resolve the space id off the channel
+// itself, matching how every other channel-scoped action (load, send,
+// edit, retract, react) addresses its room.
+
+const controllerSource = readFileSync(
+  new URL("../src/shell/chat-app-controller.ts", import.meta.url),
+  "utf8",
+);
+
+function block(name: string): string {
+  const start = controllerSource.indexOf(`function ${name}(`);
+  if (start === -1) throw new Error(`function ${name} not found in chat-app-controller.ts`);
+  let depth = 0;
+  let inBody = false;
+  for (let i = start; i < controllerSource.length; i++) {
+    const ch = controllerSource[i];
+    if (ch === "{") {
+      depth++;
+      inBody = true;
+    } else if (ch === "}") {
+      depth--;
+      if (inBody && depth === 0) return controllerSource.slice(start, i + 1);
+    }
+  }
+  throw new Error(`could not extract body of ${name}`);
+}
+
+describe("pin/unpin handlers for standalone channels", () => {
+  for (const name of ["pinActiveMessage", "unpinActiveMessage"] as const) {
+    test(`${name} does not require currentSpace`, () => {
+      const body = block(name);
+      expect(body).not.toContain("currentSpace");
+    });
+
+    test(`${name} reads the space id off the active channel`, () => {
+      const body = block(name);
+      expect(body).toContain("channel.spaceId");
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Clicking the pin icon on a message in a **standalone channel** (a MUC without a parent Waddle space) did nothing — the panel stayed empty and the console was silent.

## Root cause

`pinActiveMessage` / `unpinActiveMessage` in `chat/src/shell/chat-app-controller.ts` guarded on `waddles.currentSpace.value`:

```ts
const space = waddles.currentSpace.value;
if (!client || !channel || !space) return;
void client.pinMessage(space.id, channel.id, stanzaId)...
```

But `ChannelSummary.spaceId` is **optional** (`chat-types.ts:16`), and `currentSpace` (`directory.ts:72–76`) only resolves when the active channel's `spaceId` matches a waddle already in the loaded list. For a standalone MUC, or for a nested channel whose parent space hasn't surfaced yet, `currentSpace` is null — so the guard aborted silently before any XMPP send.

Confirmed via diagnostic logs on a real session: `pinActiveMessage aborted: missing context {hasClient: true, hasChannel: true, hasSpace: false}`.

The full space object isn't actually needed. `client.pinMessage(spaceId, channelId, stanzaId)` threads `spaceId` into `switchRoom(_spaceId, channelId)` (`client.ts:427`), where it is an **unused parameter** — the room is identified by `channelId` alone via `roomJidForChannel`. Every other channel-scoped action in the controller (load, send, edit, retract, react) addresses its room with `channel.spaceId` directly.

## Fix

- Drop the `currentSpace` requirement from `pinActiveMessage` and `unpinActiveMessage`.
- Pass `channel.spaceId ?? ""`, matching the canonical pattern at `chat-app-controller.ts:1324` / `:1421`.
- No API surface change; this is the minimum diff that restores correct behavior.

## Regression test

`chat/tests/pin-standalone-channel.test.ts` extracts the function bodies from `chat-app-controller.ts` and asserts:
1. Neither handler references `currentSpace`.
2. Both read `channel.spaceId` for the space argument.

Pattern matches the existing source-contract test in `extension-route-rail-ui.test.ts`. Direct unit testing of the controller closures is impractical because the controller pulls state from auto-imported composables.

## Test plan

- [x] `bun test tests/pin-standalone-channel.test.ts` — 4 pass
- [x] `bun test` — full suite passes (one pre-existing failure on `main` in `startup loading fallback` is unrelated)
- [x] `bun run lint` — clean (knip exit 0)
- [ ] Manual: click pin on an older message in a standalone channel; verify it lands in the Pinned panel
- [ ] Manual: same in a Waddle-nested channel — no regression
- [ ] Manual: unpin — round-trips