### PR TITLE
fix(chat): drop extension-route spaces from sidebar and unify multi-line code blocks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
         "@tanstack/vue-query": "^5.100.6",
         "@tanstack/vue-virtual": "^3.13.24",
         "@tiptap/core": "^3.22.4",
+        "@tiptap/extension-code-block": "^3.22.4",
         "@tiptap/extension-link": "^3.22.4",
         "@tiptap/extension-placeholder": "^3.22.4",
         "@tiptap/pm": "^3.22.4",

--- a/chat/package.json
+++ b/chat/package.json
@@ -31,6 +31,7 @@
     "@tanstack/vue-query": "^5.100.6",
     "@tanstack/vue-virtual": "^3.13.24",
     "@tiptap/core": "^3.22.4",
+    "@tiptap/extension-code-block": "^3.22.4",
     "@tiptap/extension-link": "^3.22.4",
     "@tiptap/extension-placeholder": "^3.22.4",
     "@tiptap/pm": "^3.22.4",

--- a/chat/src/lib/editor/chat-code-block.ts
+++ b/chat/src/lib/editor/chat-code-block.ts
@@ -1,0 +1,94 @@
+import type { JSONContent } from "@tiptap/core";
+import { CodeBlock } from "@tiptap/extension-code-block";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import type { EditorState } from "@tiptap/pm/state";
+
+export const ChatCodeBlock = CodeBlock.extend({
+  addCommands() {
+    const parent = this.parent?.();
+
+    return {
+      ...parent,
+      toggleCodeBlock:
+        (attributes) =>
+        ({ editor, state, commands }) => {
+          const { empty } = state.selection;
+
+          if (empty || editor.isActive(this.name, attributes)) {
+            return commands.toggleNode(this.name, "paragraph", attributes);
+          }
+
+          const selection = selectedTopLevelTextblockSelection(state);
+          if (!selection) {
+            return commands.toggleNode(this.name, "paragraph", attributes);
+          }
+
+          return commands.insertContentAt({ from: selection.from, to: selection.to }, {
+            type: this.name,
+            attrs: { language: attributes?.language ?? null },
+            ...codeBlockContent(selection.text),
+          });
+        },
+    };
+  },
+});
+
+type SelectedTextblock = {
+  from: number;
+  to: number;
+  text: string;
+};
+
+function selectedTopLevelTextblockSelection(state: EditorState): { from: number; to: number; text: string } | null {
+  const { from, to } = state.selection;
+  const blocks: SelectedTextblock[] = [];
+  let unsupportedSelection = false;
+
+  state.doc.nodesBetween(from, to, (node, pos, parent) => {
+    if (unsupportedSelection) return false;
+    if (parent !== state.doc) {
+      if (node.isTextblock) unsupportedSelection = true;
+      return true;
+    }
+    if (!node.isTextblock) {
+      unsupportedSelection = true;
+      return false;
+    }
+    if (!coversWholeTextblock({ from, to }, node, pos)) {
+      unsupportedSelection = true;
+      return false;
+    }
+    blocks.push({
+      from: pos,
+      to: pos + node.nodeSize,
+      text: textblockText(node),
+    });
+    return false;
+  });
+
+  if (unsupportedSelection || blocks.length === 0) return null;
+  if (blocks.length === 1 && !blocks[0].text.includes("\n")) return null;
+  return {
+    from: blocks[0].from,
+    to: blocks[blocks.length - 1].to,
+    text: blocks.map((block) => block.text).join("\n"),
+  };
+}
+
+function coversWholeTextblock(
+  selection: { from: number; to: number },
+  node: ProseMirrorNode,
+  pos: number,
+): boolean {
+  const contentFrom = pos + 1;
+  const contentTo = contentFrom + node.content.size;
+  return selection.from <= contentFrom && selection.to >= contentTo;
+}
+
+function textblockText(node: ProseMirrorNode): string {
+  return node.textBetween(0, node.content.size, "\n", "\n");
+}
+
+function codeBlockContent(text: string): Pick<JSONContent, "content"> {
+  return text ? { content: [{ type: "text", text }] } : {};
+}

--- a/chat/src/lib/editor/chat-editor-extensions.ts
+++ b/chat/src/lib/editor/chat-editor-extensions.ts
@@ -1,6 +1,7 @@
 import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import type { Extensions, JSONContent } from "@tiptap/core";
+import { ChatCodeBlock } from "@/lib/editor/chat-code-block";
 import { ChatLink } from "@/lib/editor/chat-link";
 import { ChatKeymap } from "@/lib/editor/chat-keymap";
 
@@ -19,14 +20,15 @@ export function createChatEditorExtensions(options: ChatEditorExtensionsOptions 
 
   extensions.push(
     StarterKit.configure({
-      codeBlock: {
-        exitOnTripleEnter: false,
-      },
+      codeBlock: false,
       heading: false,
       horizontalRule: false,
       link: false,
       trailingNode: false,
       underline: false,
+    }),
+    ChatCodeBlock.configure({
+      exitOnTripleEnter: false,
     }),
     ChatLink.configure({
       openOnClick: false,

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -75,6 +75,10 @@ function channelTypeFromInfo(info: DiscoInfoData): DiscoveredChannel["channelTyp
   return normalizeChannelType(info.features.includes(NS_FORUMS_0) || forumField ? "forum" : "text");
 }
 
+function hasDiscoFeature(info: DiscoInfoData | null | undefined, feature: string): boolean {
+  return info?.features.some((candidate) => candidate === feature) ?? false;
+}
+
 function roomParentSpaceId(info: DiscoInfoData): string | null {
   return parseSpaceNodeIri(info.fields.get("parent") ?? null)
     ?? parseSpaceNodeIri(info.fields.get("muc#roominfo_pubsub") ?? null);
@@ -149,16 +153,21 @@ async function discoverComponentServices(xmpp: HybridClient, domain: string, jid
   try {
     const items = await sendDiscoItems(xmpp, domain);
     const candidates = items.map((item) => item.jid).filter((value): value is string => !!value);
-    let muc = fallback.muc;
-    let spaces = fallback.spaces;
-    await Promise.all(candidates.map(async (serviceJid) => {
+    const serviceInfo = await Promise.all(candidates.map(async (serviceJid) => {
       try {
-        const info = await sendDiscoInfo(xmpp, serviceJid);
-        if (!info) return;
-        if (info.features.includes(NS_MUC) || info.identities.some((identity) => identity.category === "conference")) muc = serviceJid;
-        if (info.features.includes(NS_SPACES_0) || info.identities.some((identity) => identity.category === "pubsub")) spaces = serviceJid;
-      } catch {}
+        return { serviceJid, info: await sendDiscoInfo(xmpp, serviceJid) };
+      } catch {
+        return { serviceJid, info: null };
+      }
     }));
+    const muc = serviceInfo.find(({ info }) =>
+      hasDiscoFeature(info, NS_MUC)
+      || info?.identities.some((identity) => identity.category === "conference")
+    )?.serviceJid ?? fallback.muc;
+    // A generic pubsub identity is not enough: the extensions component is
+    // also pubsub. Keep the conventional Spaces fallback unless a component
+    // explicitly advertises the XEP-0503 namespace.
+    const spaces = serviceInfo.find(({ info }) => hasDiscoFeature(info, NS_SPACES_0))?.serviceJid ?? fallback.spaces;
     return { muc, spaces };
   } catch {
     return fallback;
@@ -224,28 +233,27 @@ export async function discoverTopology(xmpp: HybridClient, jid: string): Promise
   const spaces: DiscoveredSpace[] = [];
   let serverRole: DiscoveryRole = null;
 
-  try {
-    const serverInfo = await sendDiscoInfo(xmpp, domain);
-    if (serverInfo) serverRole = parseDiscoveryRole(serverInfo.fields.get("waddle#server_affiliation") ?? null);
-  } catch {}
+  const serverInfoResult = await sendDiscoInfo(xmpp, domain).catch(() => null);
+  if (serverInfoResult) {
+    serverRole = parseDiscoveryRole(serverInfoResult.fields.get("waddle#server_affiliation") ?? null);
+  }
 
   try {
     const spaceItems = await sendDiscoItems(xmpp, services.spaces);
-    for (const [index, item] of spaceItems.entries()) {
-      const spaceId = item.node ?? barePeerJid(item.jid ?? "").split("@")[0] ?? `space-${index}`;
+    for (const item of spaceItems) {
+      if (!item.node) continue;
+      const spaceId = item.node;
       let role = serverRole;
-      if (item.node) {
-        try {
-          const info = await sendDiscoInfo(xmpp, services.spaces, item.node);
-          if (info) role = parseDiscoveryRole(info.fields.get("pubsub#affiliation") ?? null) ?? serverRole;
-        } catch {}
-        try {
-          const bookmarks = await sendPubsubItems(xmpp, services.spaces, item.node);
-          for (const bookmark of bookmarks) {
-            if (bookmark.jid) bookmarkedSpaceIds.set(barePeerJid(bookmark.jid), spaceId);
-          }
-        } catch {}
-      }
+      try {
+        const info = await sendDiscoInfo(xmpp, services.spaces, item.node);
+        if (info) role = parseDiscoveryRole(info.fields.get("pubsub#affiliation") ?? null) ?? serverRole;
+      } catch {}
+      try {
+        const bookmarks = await sendPubsubItems(xmpp, services.spaces, item.node);
+        for (const bookmark of bookmarks) {
+          if (bookmark.jid) bookmarkedSpaceIds.set(barePeerJid(bookmark.jid), spaceId);
+        }
+      } catch {}
       spaces.push({ id: spaceId, name: item.name ?? spaceId, role });
     }
   } catch {}

--- a/chat/tests/discovery-pin-permission.test.ts
+++ b/chat/tests/discovery-pin-permission.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   applyDiscoInfoToChannel,
+  discoverTopology,
   pinPermissionFromDiscoFields,
   type DiscoInfoData,
 } from "../src/lib/xmpp/discovery";
@@ -93,3 +94,229 @@ describe("applyDiscoInfoToChannel pinPermission (#422)", () => {
     expect(hydrated.pinPermission).toBeUndefined();
   });
 });
+
+describe("discoverTopology spaces service discovery", () => {
+  test("uses the conventional Spaces service instead of the generic extension pubsub service", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(topologyClient(), "alice@example.test");
+
+      expect(topology.services.spaces).toBe("spaces.example.test");
+      expect(topology.spaces.map((space) => space.id)).toEqual(["space-polls", "space-engineering"]);
+      expect(topology.spaces.map((space) => space.name)).toEqual(["Polls", "Engineering"]);
+    });
+  });
+
+  test("falls back to the conventional Spaces service when root discovery returns no services", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(topologyClient({ emptyRootItems: true }), "alice@example.test");
+
+      expect(topology.services.spaces).toBe("spaces.example.test");
+      expect(topology.spaces.map((space) => space.id)).toEqual(["space-polls", "space-engineering"]);
+    });
+  });
+
+  test("falls back to the conventional Spaces service when only the extension pubsub service is advertised", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(topologyClient({ omitSpacesServiceItem: true }), "alice@example.test");
+
+      expect(topology.services.spaces).toBe("spaces.example.test");
+      expect(topology.spaces.map((space) => space.id)).toEqual(["space-polls", "space-engineering"]);
+    });
+  });
+
+  test("does not render root service disco items as empty Spaces groups", async () => {
+    await withFakeDomParser(async () => {
+      const topology = await discoverTopology(topologyClient({ rootAdvertisesSpacesService: true }), "alice@example.test");
+
+      expect(topology.services.spaces).toBe("example.test");
+      expect(topology.spaces).toEqual([]);
+    });
+  });
+});
+
+type TopologyClientOptions = {
+  emptyRootItems?: boolean;
+  omitSpacesServiceItem?: boolean;
+  rootAdvertisesSpacesService?: boolean;
+};
+
+function topologyClient(options: TopologyClientOptions = {}) {
+  return {
+    async send_raw_iq(xml: string): Promise<string> {
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#items"')) {
+        if (xml.includes('to="example.test"')) {
+          if (options.emptyRootItems) return discoItemsXml([]);
+          const rootItems = [
+            { jid: "extensions.example.test", name: "Extensions" },
+            ...(options.omitSpacesServiceItem ? [] : [{ jid: "spaces.example.test", name: "Spaces" }]),
+            { jid: "muc.example.test", name: "Chatrooms" },
+            ...(options.rootAdvertisesSpacesService ? [{ jid: "example.test", name: "Waddle" }] : []),
+          ];
+          return discoItemsXml(rootItems);
+        }
+        if (xml.includes('to="extensions.example.test"')) {
+          return discoItemsXml([
+            { jid: "extensions.example.test", name: "Polls", node: "urn:waddle:extension:1:route:decision-polls:polls" },
+            { jid: "extensions.example.test", name: "Saved Links", node: "urn:waddle:extension:1:route:link-board:saved-links" },
+          ]);
+        }
+        if (xml.includes('to="spaces.example.test"')) {
+          return discoItemsXml([
+            { name: "Polls", node: "space-polls" },
+            { name: "Engineering", node: "space-engineering" },
+          ]);
+        }
+        return discoItemsXml([]);
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/disco#info"')) {
+        if (xml.includes('to="muc.example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "conference", type: "text", name: "Chatrooms" }],
+            features: ["http://jabber.org/protocol/muc"],
+          });
+        }
+        if (xml.includes('to="spaces.example.test"') && !xml.includes(' node=')) {
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service", name: "Spaces" }],
+            features: [
+              "http://jabber.org/protocol/pubsub",
+              "http://jabber.org/protocol/pubsub#create-nodes",
+              "http://jabber.org/protocol/pubsub#meta-data",
+              "http://jabber.org/protocol/pubsub#retrieve-items",
+            ],
+          });
+        }
+        if (xml.includes('to="extensions.example.test"')) {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return discoInfoXml({
+            identities: [{ category: "pubsub", type: "service", name: "Waddle Extensions" }],
+            features: ["http://jabber.org/protocol/pubsub", "urn:waddle:extension:1"],
+          });
+        }
+        if (xml.includes('to="example.test"')) {
+          return discoInfoXml({
+            identities: [{ category: "server", type: "im", name: "Waddle" }],
+            features: options.rootAdvertisesSpacesService ? ["urn:xmpp:spaces:0"] : [],
+          });
+        }
+        return discoInfoXml();
+      }
+      if (xml.includes('xmlns="http://jabber.org/protocol/pubsub"')) {
+        return pubsubItemsXml([]);
+      }
+      throw new Error(`Unexpected IQ: ${xml}`);
+    },
+  };
+}
+
+function discoItemsXml(items: Array<{ name?: string; node?: string; jid?: string }>): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#items">${items.map((item) =>
+    `<item${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}${item.node ? ` node="${item.node}"` : ""}/>`
+  ).join("")}</query></iq>`;
+}
+
+function discoInfoXml(info: { features?: string[]; identities?: Array<{ category: string; type: string; name?: string }> } = {}): string {
+  return `<iq type="result"><query xmlns="http://jabber.org/protocol/disco#info">${
+    (info.identities ?? []).map((identity) =>
+      `<identity category="${identity.category}" type="${identity.type}"${identity.name ? ` name="${identity.name}"` : ""}/>`
+    ).join("")
+  }${
+    (info.features ?? []).map((feature) => `<feature var="${feature}"/>`).join("")
+  }</query></iq>`;
+}
+
+function pubsubItemsXml(items: Array<{ id?: string; jid?: string; name?: string }>): string {
+  return `<iq type="result"><pubsub xmlns="http://jabber.org/protocol/pubsub"><items>${items.map((item) =>
+    `<item${item.id ? ` id="${item.id}"` : ""}>${item.jid || item.name ? `<conference${item.jid ? ` jid="${item.jid}"` : ""}${item.name ? ` name="${item.name}"` : ""}/>` : ""}</item>`
+  ).join("")}</items></pubsub></iq>`;
+}
+
+async function withFakeDomParser(run: () => Promise<void>): Promise<void> {
+  const original = globalThis.DOMParser;
+  globalThis.DOMParser = FakeDOMParser as typeof DOMParser;
+  try {
+    await run();
+  } finally {
+    globalThis.DOMParser = original;
+  }
+}
+
+class FakeDOMParser {
+  parseFromString(xml: string): Document {
+    return parseTestXml(xml) as unknown as Document;
+  }
+}
+
+class FakeXmlElement {
+  readonly children: FakeXmlElement[] = [];
+  text = "";
+  parentNode: FakeXmlElement | null = null;
+
+  constructor(
+    readonly localName: string,
+    readonly namespaceURI: string | null,
+    private readonly attrs: Record<string, string>,
+  ) {}
+
+  get textContent(): string {
+    return `${this.text}${this.children.map((child) => child.textContent ?? "").join("")}`;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+
+  querySelector(localName: string): FakeXmlElement | null {
+    return this.getElementsByTagName(localName)[0] ?? null;
+  }
+
+  getElementsByTagNameNS(namespace: string, localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.namespaceURI === namespace && node.localName === localName);
+  }
+
+  getElementsByTagName(localName: string): FakeXmlElement[] {
+    return this.descendants().filter((node) => node.localName === localName);
+  }
+
+  private descendants(): FakeXmlElement[] {
+    return this.children.flatMap((child) => [child, ...child.descendants()]);
+  }
+}
+
+function parseTestXml(xml: string): FakeXmlElement {
+  const root = new FakeXmlElement("#document", null, {});
+  const stack: FakeXmlElement[] = [root];
+  const tokenPattern = /<[^>]+>|[^<]+/g;
+  for (const token of xml.match(tokenPattern) ?? []) {
+    if (token.startsWith("</")) {
+      stack.pop();
+      continue;
+    }
+    if (token.startsWith("<")) {
+      const selfClosing = token.endsWith("/>");
+      const body = token.slice(1, selfClosing ? -2 : -1).trim();
+      const [qualifiedName = ""] = body.split(/\s+/, 1);
+      const attrs = attributesFromTag(body);
+      const parent = stack[stack.length - 1];
+      const node = new FakeXmlElement(
+        qualifiedName.includes(":") ? qualifiedName.split(":").pop()! : qualifiedName,
+        attrs.xmlns ?? parent.namespaceURI,
+        attrs,
+      );
+      node.parentNode = parent;
+      parent.children.push(node);
+      if (!selfClosing) stack.push(node);
+      continue;
+    }
+    stack[stack.length - 1].text += token;
+  }
+  return root;
+}
+
+function attributesFromTag(tagBody: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const match of tagBody.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}

--- a/chat/tests/editor-message-input.test.ts
+++ b/chat/tests/editor-message-input.test.ts
@@ -440,6 +440,140 @@ describe("message input editor", () => {
     }
   });
 
+  test("formats selected pasted multi-line code as one code block", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "one" }] },
+        { type: "paragraph", content: [{ type: "text", text: "two" }] },
+      ],
+    });
+
+    try {
+      editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size });
+
+      editor.chain().focus().toggleCodeBlock().run();
+      expect(editor.getJSON()).toEqual({
+        type: "doc",
+        content: [
+          {
+            type: "codeBlock",
+            attrs: { language: null },
+            content: [{ type: "text", text: "one\ntwo" }],
+          },
+        ],
+      });
+      expect(tiptapToRichMessage(editor.getJSON())).toEqual({
+        body: "one\ntwo",
+        markup: [{ type: "bcode", start: 0, end: 7 }],
+        references: [],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("preserves selected hard breaks when formatting as a code block", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "one" },
+            { type: "hardBreak" },
+            { type: "text", text: "two" },
+          ],
+        },
+      ],
+    });
+
+    try {
+      editor.commands.setTextSelection({ from: 1, to: editor.state.doc.content.size });
+
+      editor.chain().focus().toggleCodeBlock().run();
+      expect(editor.getJSON()).toEqual({
+        type: "doc",
+        content: [
+          {
+            type: "codeBlock",
+            attrs: { language: null },
+            content: [{ type: "text", text: "one\ntwo" }],
+          },
+        ],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("delegates nested selections to Tiptap's normal code block command", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [
+        {
+          type: "bulletList",
+          content: [
+            { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "one" }] }] },
+            { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "two" }] }] },
+          ],
+        },
+      ],
+    });
+
+    try {
+      let firstItemParagraphStart: number | null = null;
+      editor.state.doc.descendants((node, pos, parent) => {
+        if (node.type.name === "paragraph" && parent?.type.name === "listItem" && firstItemParagraphStart === null) {
+          firstItemParagraphStart = pos;
+          return false;
+        }
+        return true;
+      });
+      expect(firstItemParagraphStart).not.toBeNull();
+      editor.commands.setTextSelection({
+        from: firstItemParagraphStart! + 1,
+        to: firstItemParagraphStart! + 4,
+      });
+
+      editor.commands.toggleCodeBlock();
+      expect(editor.getText()).toContain("two");
+    } finally {
+      editor.destroy();
+    }
+  });
+
+  test("keeps normal code block toggling for a cursor inside one block", () => {
+    const editor = createEditor({
+      type: "doc",
+      content: [{ type: "paragraph", content: [{ type: "text", text: "code" }] }],
+    });
+
+    try {
+      expect(editor.commands.toggleCodeBlock()).toBe(true);
+      expect(editor.getJSON()).toEqual({
+        type: "doc",
+        content: [
+          {
+            type: "codeBlock",
+            attrs: { language: null },
+            content: [{ type: "text", text: "code" }],
+          },
+        ],
+      });
+
+      expect(editor.commands.toggleCodeBlock()).toBe(true);
+      expect(editor.getJSON()).toEqual({
+        type: "doc",
+        content: [
+          { type: "paragraph", content: [{ type: "text", text: "code" }] },
+        ],
+      });
+    } finally {
+      editor.destroy();
+    }
+  });
+
   test("serializes TipTap marks and links as XEP body, markup, and references", () => {
     const serialized = tiptapToRichMessage({
       type: "doc",


### PR DESCRIPTION
## Summary

This cleans up PR #461 so the fixes live at the right abstraction boundary.

1. Multi-line selected code is handled in the TipTap editor extension layer, not in the Vue toolbar.
2. The sidebar no longer confuses service discovery entries or extension routes for actual Spaces.

## Changes

### Code block formatting

- Adds `ChatCodeBlock`, a small TipTap `CodeBlock` extension override.
- Keeps the toolbar on the standard `chain().focus().toggleCodeBlock().run()` command path.
- For top-level multi-block selections, replaces the selected textblocks with one `codeBlock` containing newline-joined text.
- Preserves Shift+Enter hard breaks as `\n`.
- Delegates nested selections and ordinary cursor toggles back to TipTap's normal `toggleNode` behavior.
- Keeps XEP-0394 output as one `bcode` span for the selected multi-line body.

### Spaces sidebar discovery

- Removes label/node based suppression of extension routes from the sidebar path.
- Fixes the root cause: `discoverComponentServices` no longer treats any generic `pubsub` identity as the Spaces service.
- Uses the conventional `spaces.<domain>` fallback unless a component explicitly advertises the XEP-0503 namespace.
- Requires sidebar space entries to have an actual PubSub node, so root service disco items such as Chatrooms, Extensions, HTTP File Upload, and Spaces cannot render as empty Spaces groups.

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun test chat/tests/discovery-pin-permission.test.ts chat/tests/editor-message-input.test.ts chat/tests/autolinkify-bare-urls.test.ts`
- [x] `bun x knip` from `chat/`
- [x] `bun x tsc --noEmit --project tsconfig.json --ignoreDeprecations 6.0` from `chat/`
- [x] `bun test chat/tests` ran 520 tests: 519 pass, 1 pre-existing stale build-output failure in `chat/tests/startup-loading.test.ts`
- [x] Adversarial review pass found and fixed nested-selection and hard-break issues in the TipTap extension
- [x] Adversarial review pass found and fixed the too-broad extension-route sidebar filtering approach
- [x] Added regression coverage for root service disco items being shown as empty Spaces groups

## Local verification blockers

- `bun run lint` from `chat/` currently stops in `bun run wasm:build` because `wasm-pack` is not installed in this environment.
- `bun run astro check` initially hit sandbox port binding for `0.0.0.0:9229`; with sandbox escalation it then failed because `server/wasm-pkg/waddle-xmpp-client-wasm` is missing `waddle_xmpp_client_wasm_bg.wasm` and `waddle_xmpp_client_wasm_bg.js`.
- The remaining `startup-loading.test.ts` failure reads stale `chat/dist` output. The source fallback exists in `chat/src/layouts/AppLayout.astro`; local rebuild is blocked by the missing WASM artifacts above.

## TODO

- [ ] CI must pass full generated WASM/build/lint/test checks.
- [ ] Live verify sidebar discovery no longer shows service disco items or extension-route items as Spaces groups.
- [ ] Live verify selecting pasted multi-line code and pressing the toolbar Code Block button renders as one code block.