### PR TITLE
refactor(chat): extract MAM paging into mam-paging composables

### DIFF
--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -311,7 +311,12 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
           // A fresh loadMessages() resets both to their initial state.
           oldestArchiveId = null;
           hasOlderMessages.value = false;
-        } else if (isCurrentRequest()) {
+        } else if (
+          requestId === messageRequestId &&
+          xmppClient.value === client &&
+          (activeSpaceId.value ?? "") === spaceId &&
+          activeChannelId.value === channelId
+        ) {
           // Non-§4.3.4 failure: surface so the caller (reply jump / pinned
           // jump / search-result open) doesn't see a silent "not found".
           actionError.value = normalizeError(e);

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -261,11 +261,21 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
         // XEP-0313 §4.3.4: the server reports the `<before/>` UID is gone
         // from the archive. The cursor moved past us (e.g. server-side
         // compaction). Drop the stale cursor and re-fetch the tail page —
-        // safer than reporting "no more history" to the user.
+        // safer than reporting "no more history" to the user. The explicit
+        // `isLoadingOlderMessages = false` here is necessary because
+        // `loadMessages` bumps `messageRequestId`, so the `finally` block's
+        // `isCurrentRequest()` guard will be false by the time it runs.
+        // Setting `oldestArchiveId = null` first also blocks any concurrent
+        // `loadOlderMessages` from racing past its `!before` guard while we
+        // await the tail-page refetch.
         if (isCurrentRequest()) {
           oldestArchiveId = null;
           isLoadingOlderMessages.value = false;
-          await loadMessages(spaceId, channelId);
+          try {
+            await loadMessages(spaceId, channelId);
+          } catch (recoveryError) {
+            console.warn("MAM §4.3.4 recovery failed", recoveryError);
+          }
           return;
         }
       }

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -1,0 +1,461 @@
+import { nextTick, ref, type Ref } from "vue";
+import type { ChannelSummary } from "@/lib/chat-types";
+import { isForumChannel } from "@/lib/channel-types";
+import type { WaddleSession } from "@/lib/server-auth";
+import type {
+  BrowserXmppClient,
+  LiveRoomMessage,
+} from "@/lib/xmpp-client";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import {
+  isTopPinnedScrollDirection,
+  type ScrollDirectionMode,
+} from "@/lib/scroll-direction";
+import {
+  buildChannelTimelineFromMamResults,
+  type TimelineBuildOptions,
+} from "@/channels/message-timeline-state";
+import { isFeedTimelineMessage } from "@/channels/timeline";
+import {
+  advanceCursorWithBeforePage,
+  advanceThreadCursor,
+  classifyMamError,
+  cursorFromLatestPage,
+  isMamCursorNotFound,
+  stripQueuedSelfMessages,
+  threadCursorFromLatestPage,
+} from "@/lib/xmpp/mam-paging";
+import { hydratePinnedRoom, pinnedRoomsEpoch } from "@/stores/pinned-messages";
+
+const PAGE_SIZE = 100;
+
+type UseChannelMamPagingDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activeSpaceId: Ref<string | null>;
+  activeChannelId: Ref<string | null>;
+  currentChannel: Ref<ChannelSummary | null>;
+  messages: Ref<TimelineMessage[]>;
+  firstUnseenId: Ref<string | null>;
+  timelineEl: Ref<HTMLDivElement | null>;
+  scrollDirection: Ref<ScrollDirectionMode>;
+  pinnedEdgeScroller: { disconnect: () => void };
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  normalizeError: (e: unknown) => string;
+  pendingEchoClientIds: Set<string>;
+  appendQueuedMessages: (timeline: TimelineMessage[], roomJid: string) => TimelineMessage[];
+  roomJidForChannel: (channelId: string) => string | null;
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  persistLastSeen: (channelId: string, messageId: string) => void;
+};
+
+export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
+  const {
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentChannel,
+    messages,
+    firstUnseenId,
+    timelineEl,
+    scrollDirection,
+    pinnedEdgeScroller,
+    actionError,
+    clearActionError,
+    normalizeError,
+    pendingEchoClientIds,
+    appendQueuedMessages,
+    roomJidForChannel,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+  } = deps;
+
+  const isLoadingMessages = ref(false);
+  const isLoadingOlderMessages = ref(false);
+  const hasOlderMessages = ref(true);
+  const loadingOlderThreadIds = ref<Set<string>>(new Set());
+  const threadHasOlder = ref<Record<string, boolean>>({});
+
+  let messageRequestId = 0;
+  let oldestArchiveId: string | null = null;
+  let initialLatestPagePinned = false;
+  const oldestThreadArchiveIds = new Map<string, string>();
+
+  function buildTimelineFromMamResults(
+    mamResults: LiveRoomMessage[],
+    existing: TimelineMessage[] = [],
+    options: TimelineBuildOptions = {},
+  ): TimelineMessage[] {
+    if (!session.value) return existing;
+    return buildChannelTimelineFromMamResults({
+      session: session.value,
+      channelIsForum: isForumChannel(currentChannel.value),
+      mamResults,
+      existing,
+      options,
+    });
+  }
+
+  const isFeedVisible = isFeedTimelineMessage;
+
+  async function loadMessages(
+    spaceId: string,
+    channelId: string,
+    unreadAtLoad = 0,
+    metadataSeed: TimelineMessage[] = [],
+  ) {
+    if (!session.value) return;
+
+    const requestId = ++messageRequestId;
+    const roomJid = roomJidForChannel(channelId);
+    if (!roomJid) return;
+    initialLatestPagePinned = false;
+    isLoadingMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    hasOlderMessages.value = true;
+    oldestArchiveId = null;
+    loadingOlderThreadIds.value = new Set();
+    threadHasOlder.value = {};
+    oldestThreadArchiveIds.clear();
+    pinnedEdgeScroller.disconnect();
+    // Reset the divider anchor up-front: a previous conversation's id could
+    // coincidentally match a message in the new timeline, and an aborted
+    // request (requestId mismatch) would otherwise leave stale state.
+    firstUnseenId.value = null;
+    clearActionError();
+    pendingEchoClientIds.clear();
+    messages.value = appendQueuedMessages([], roomJid);
+
+    try {
+      // #414: hydrate the pin store for this room. Fire-and-forget — the
+      // panel + badge tolerate an empty store and the live pin-event
+      // handler will mutate it from now on. Capture the epoch at request
+      // time so a late callback after logout drops itself.
+      if (xmppClient.value && "fetchRoomPins" in xmppClient.value) {
+        const epoch = pinnedRoomsEpoch();
+        void xmppClient.value
+          .fetchRoomPins(spaceId, channelId)
+          .then((entries) => {
+            hydratePinnedRoom(roomJid, entries, epoch);
+          })
+          .catch((error: unknown) => {
+            console.warn("fetchRoomPins failed", error);
+            hydratePinnedRoom(roomJid, [], epoch);
+          });
+      } else {
+        hydratePinnedRoom(roomJid, []);
+      }
+
+      // XEP-0313: Load message history via MAM.
+      const page = xmppClient.value && "queryMamPage" in xmppClient.value
+        ? await xmppClient.value.queryMamPage(spaceId, channelId, PAGE_SIZE, { type: "latest" })
+        : null;
+      const mamResults = page
+        ? page.messages
+        : xmppClient.value
+          ? await xmppClient.value.queryMam(spaceId, channelId, PAGE_SIZE)
+          : [];
+
+      if (
+        requestId !== messageRequestId ||
+        (activeSpaceId.value ?? "") !== spaceId ||
+        activeChannelId.value !== channelId
+      ) {
+        return;
+      }
+
+      const cursor = cursorFromLatestPage({
+        page,
+        pageSize: PAGE_SIZE,
+        fallbackMessages: page ? undefined : mamResults,
+      });
+      oldestArchiveId = cursor.oldestArchiveId;
+      hasOlderMessages.value = cursor.hasOlderMessages;
+      const timelineWithQueue = appendQueuedMessages(
+        buildTimelineFromMamResults(mamResults, metadataSeed, {
+          seedExistingOnly: metadataSeed.length > 0,
+        }),
+        roomJid,
+      );
+      messages.value = timelineWithQueue;
+      if (requestId === messageRequestId) {
+        isLoadingMessages.value = false;
+      }
+
+      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
+      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
+        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
+        : null;
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (
+        !pinned ||
+        requestId !== messageRequestId ||
+        (activeSpaceId.value ?? "") !== spaceId ||
+        activeChannelId.value !== channelId
+      ) {
+        return;
+      }
+      initialLatestPagePinned = true;
+      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
+      if (newest) persistLastSeen(channelId, newest.id);
+    } catch (e) {
+      if (requestId === messageRequestId) {
+        const queuedOnly = appendQueuedMessages([], roomJid);
+        messages.value = queuedOnly;
+        actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
+        isLoadingMessages.value = false;
+      }
+    }
+  }
+
+  async function loadOlderMessages() {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value ?? "";
+    const channelId = activeChannelId.value;
+    const before = oldestArchiveId;
+    if (
+      !client ||
+      !channelId ||
+      !before ||
+      !initialLatestPagePinned ||
+      !hasOlderMessages.value ||
+      isLoadingOlderMessages.value
+    ) {
+      return;
+    }
+    if (!("queryMamPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      (activeSpaceId.value ?? "") === spaceId &&
+      activeChannelId.value === channelId;
+
+    const el = timelineEl.value;
+    const previousHeight = el?.scrollHeight ?? 0;
+    const previousTop = el?.scrollTop ?? 0;
+    isLoadingOlderMessages.value = true;
+    try {
+      const page = await client.queryMamPage(spaceId, channelId, PAGE_SIZE, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      const advanced = advanceCursorWithBeforePage({
+        prior: { oldestArchiveId, hasOlderMessages: hasOlderMessages.value },
+        page,
+      });
+      oldestArchiveId = advanced.next.oldestArchiveId;
+      hasOlderMessages.value = advanced.next.hasOlderMessages;
+      const withoutQueued = stripQueuedSelfMessages(messages.value);
+      const roomJid = roomJidForChannel(channelId);
+      if (!roomJid) return;
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), roomJid);
+      await nextTick();
+      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
+        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
+      }
+    } catch (e) {
+      const classified = classifyMamError(e);
+      if (isMamCursorNotFound(classified)) {
+        // XEP-0313 §4.3.4: the server reports the `<before/>` UID is gone
+        // from the archive. The cursor moved past us (e.g. server-side
+        // compaction). Drop the stale cursor and re-fetch the tail page —
+        // safer than reporting "no more history" to the user.
+        if (isCurrentRequest()) {
+          oldestArchiveId = null;
+          isLoadingOlderMessages.value = false;
+          await loadMessages(spaceId, channelId);
+          return;
+        }
+      }
+      if (isCurrentRequest()) actionError.value = normalizeError(e);
+    } finally {
+      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
+    }
+  }
+
+  async function ensureMessageLoaded(messageId: string): Promise<boolean> {
+    if (findMessageById(messages.value, messageId)) return true;
+    const client = xmppClient.value;
+    const channelId = activeChannelId.value;
+    if (!client || !channelId || !session.value || !("queryMamPage" in client)) return false;
+    const roomJid = roomJidForChannel(channelId);
+    if (!roomJid) return false;
+
+    let before = oldestArchiveId;
+    while (before && hasOlderMessages.value && !findMessageById(messages.value, messageId)) {
+      const requestId = messageRequestId;
+      const spaceId = activeSpaceId.value ?? "";
+      const previousBefore = before;
+      let page: Awaited<ReturnType<typeof client.queryMamPage>>;
+      try {
+        page = await client.queryMamPage(spaceId, channelId, PAGE_SIZE, { type: "before", before });
+      } catch (e) {
+        const classified = classifyMamError(e);
+        if (isMamCursorNotFound(classified)) {
+          // §4.3.4 — stale cursor; the message we were chasing is no longer
+          // reachable via the prior cursor. Surface as "not found" so the
+          // caller can decide whether to retry from a fresh tail page.
+          oldestArchiveId = null;
+        }
+        return false;
+      }
+      if (
+        requestId !== messageRequestId ||
+        xmppClient.value !== client ||
+        (activeSpaceId.value ?? "") !== spaceId ||
+        activeChannelId.value !== channelId
+      ) {
+        return false;
+      }
+      const advanced = advanceCursorWithBeforePage({
+        prior: { oldestArchiveId: previousBefore, hasOlderMessages: hasOlderMessages.value },
+        page,
+      });
+      oldestArchiveId = advanced.next.oldestArchiveId;
+      hasOlderMessages.value = advanced.next.hasOlderMessages;
+      const withoutQueued = stripQueuedSelfMessages(messages.value);
+      messages.value = appendQueuedMessages(
+        buildTimelineFromMamResults(page.messages, withoutQueued),
+        roomJid,
+      );
+      if (findMessageById(messages.value, messageId)) return true;
+      if (advanced.stalled || advanced.next.hasOlderMessages === false) break;
+      before = advanced.next.oldestArchiveId;
+    }
+    return !!findMessageById(messages.value, messageId);
+  }
+
+  // Backfill a thread via XEP-0313 MAM filtered by thread id. Returns every
+  // archived reply whose `<thread>` element matches `threadId`. The thread
+  // root does not carry `<thread>` (threads start when someone replies into
+  // one), so MAM-by-thread never includes it — the panel resolves the root
+  // separately from the loaded channel window.
+  async function backfillThread(threadId: string): Promise<void> {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value;
+    const channelId = activeChannelId.value;
+    if (!client || !channelId || !threadId || !session.value) return;
+    const requestId = messageRequestId;
+    let page: { messages: LiveRoomMessage[]; firstArchiveId?: string; complete?: boolean } | null = null;
+    let results: LiveRoomMessage[] = [];
+    try {
+      page = "queryMamThreadPage" in client
+        ? await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, PAGE_SIZE, { type: "latest" })
+        : null;
+      results = page ? page.messages : await client.queryMamByThread(spaceId ?? "", channelId, threadId, PAGE_SIZE);
+    } catch (e) {
+      if (
+        xmppClient.value === client &&
+        (activeSpaceId.value ?? "") === (spaceId ?? "") &&
+        activeChannelId.value === channelId &&
+        requestId === messageRequestId
+      ) {
+        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        actionError.value = normalizeError(e);
+      }
+      return;
+    }
+    if (
+      xmppClient.value !== client ||
+      (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
+      activeChannelId.value !== channelId ||
+      requestId !== messageRequestId
+    ) {
+      return;
+    }
+    const cursor = threadCursorFromLatestPage({
+      page,
+      pageSize: PAGE_SIZE,
+      fallbackMessages: page ? undefined : results,
+    });
+    if (cursor.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, cursor.oldestId);
+    threadHasOlder.value = { ...threadHasOlder.value, [threadId]: cursor.hasOlder };
+    const next = buildTimelineFromMamResults(results, messages.value);
+    if (
+      next.length === messages.value.length &&
+      next.every((message, index) => message === messages.value[index])
+    ) {
+      return;
+    }
+    messages.value = next;
+  }
+
+  async function loadOlderThreadMessages(threadId: string): Promise<void> {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value;
+    const channelId = activeChannelId.value;
+    const before = oldestThreadArchiveIds.get(threadId);
+    if (!client || !channelId || !threadId || !before || loadingOlderThreadIds.value.has(threadId)) return;
+    if (!("queryMamThreadPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      (activeSpaceId.value ?? "") === (spaceId ?? "") &&
+      activeChannelId.value === channelId;
+    loadingOlderThreadIds.value = new Set([...loadingOlderThreadIds.value, threadId]);
+    try {
+      const page = await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, PAGE_SIZE, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      const advanced = advanceThreadCursor({
+        prior: { oldestId: before },
+        page,
+      });
+      if (advanced.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, advanced.oldestId);
+      threadHasOlder.value = { ...threadHasOlder.value, [threadId]: advanced.hasOlder };
+      messages.value = buildTimelineFromMamResults(page.messages, messages.value);
+    } catch (e) {
+      const classified = classifyMamError(e);
+      if (isMamCursorNotFound(classified)) {
+        // §4.3.4 — drop stale thread cursor and let the next backfill restart
+        // from the latest page.
+        oldestThreadArchiveIds.delete(threadId);
+        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+      } else if (isCurrentRequest()) {
+        actionError.value = normalizeError(e);
+      }
+    } finally {
+      const next = new Set(loadingOlderThreadIds.value);
+      next.delete(threadId);
+      loadingOlderThreadIds.value = next;
+    }
+  }
+
+  function reset() {
+    messageRequestId++;
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    isLoadingMessages.value = false;
+    loadingOlderThreadIds.value = new Set();
+    threadHasOlder.value = {};
+    oldestThreadArchiveIds.clear();
+  }
+
+  function currentRequestId(): number {
+    return messageRequestId;
+  }
+
+  function markInitialLatestPagePinned() {
+    initialLatestPagePinned = true;
+  }
+
+  return {
+    isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
+    loadMessages,
+    loadOlderMessages,
+    ensureMessageLoaded,
+    backfillThread,
+    loadOlderThreadMessages,
+    reset,
+    currentRequestId,
+    markInitialLatestPagePinned,
+  };
+}

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -305,9 +305,16 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
         const classified = classifyMamError(e);
         if (isMamCursorNotFound(classified)) {
           // §4.3.4 — stale cursor; the message we were chasing is no longer
-          // reachable via the prior cursor. Surface as "not found" so the
-          // caller can decide whether to retry from a fresh tail page.
+          // reachable via the prior cursor. Drop the cursor AND collapse
+          // hasOlderMessages so the UI's "load older" sentinel stops
+          // offering a paging entry that would early-return on !before.
+          // A fresh loadMessages() resets both to their initial state.
           oldestArchiveId = null;
+          hasOlderMessages.value = false;
+        } else if (isCurrentRequest()) {
+          // Non-§4.3.4 failure: surface so the caller (reply jump / pinned
+          // jump / search-result open) doesn't see a silent "not found".
+          actionError.value = normalizeError(e);
         }
         return false;
       }
@@ -420,16 +427,25 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       const classified = classifyMamError(e);
       if (isMamCursorNotFound(classified)) {
         // §4.3.4 — drop stale thread cursor and let the next backfill restart
-        // from the latest page.
-        oldestThreadArchiveIds.delete(threadId);
-        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        // from the latest page. Guarded by isCurrentRequest() so a late
+        // completion after channel switch can't corrupt the new channel's
+        // thread state (which a fresh reset() has already cleared).
+        if (isCurrentRequest()) {
+          oldestThreadArchiveIds.delete(threadId);
+          threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
+        }
       } else if (isCurrentRequest()) {
         actionError.value = normalizeError(e);
       }
     } finally {
-      const next = new Set(loadingOlderThreadIds.value);
-      next.delete(threadId);
-      loadingOlderThreadIds.value = next;
+      // Guard the cleanup too — a stale completion must not delete a
+      // threadId entry from the new channel's loading set, which would
+      // unstick a spinner that belongs to a different in-flight request.
+      if (isCurrentRequest()) {
+        const next = new Set(loadingOlderThreadIds.value);
+        next.delete(threadId);
+        loadingOlderThreadIds.value = next;
+      }
     }
   }
 

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -15,7 +15,7 @@ import {
   type RoomPresence,
 } from "@/lib/xmpp-client";
 import { $xmppStatus } from "@/stores/xmpp-status";
-import { applyPinEvent, hydratePinnedRoom, pinnedRoomsEpoch } from "@/stores/pinned-messages";
+import { applyPinEvent } from "@/stores/pinned-messages";
 import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
@@ -49,7 +49,6 @@ import {
   mapLiveRoomMessageToTimeline,
 } from "@/channels/timeline";
 import {
-  buildChannelTimelineFromMamResults,
   isMucServiceModeration,
   isSameMucRetractionSender,
   isValidMucModerationTarget,
@@ -61,8 +60,8 @@ import {
   reactionsFromSenders,
   retractChannelTimelineMessage,
   removeSenderReactions,
-  type TimelineBuildOptions,
 } from "@/channels/message-timeline-state";
+import { useChannelMamPaging } from "@/channels/mam-paging";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -86,11 +85,6 @@ export function useChannelMessages(
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
   const forumPostTitle = ref("");
-  const isLoadingMessages = ref(false);
-  const isLoadingOlderMessages = ref(false);
-  const hasOlderMessages = ref(true);
-  const loadingOlderThreadIds = ref<Set<string>>(new Set());
-  const threadHasOlder = ref<Record<string, boolean>>({});
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
@@ -123,10 +117,6 @@ export function useChannelMessages(
   const isSearching = ref(false);
   let slowModeTimer: ReturnType<typeof setInterval> | null = null;
 
-  let messageRequestId = 0;
-  let oldestArchiveId: string | null = null;
-  let initialLatestPagePinned = false;
-  const oldestThreadArchiveIds = new Map<string, string>();
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -673,307 +663,38 @@ export function useChannelMessages(
   // and the "New messages" divider must be computed against this predicate.
   const isFeedVisible = isFeedTimelineMessage;
 
-  function buildTimelineFromMamResults(
-    mamResults: LiveRoomMessage[],
-    existing: TimelineMessage[] = [],
-    options: TimelineBuildOptions = {},
-  ): TimelineMessage[] {
-    if (!session.value) return existing;
-    return buildChannelTimelineFromMamResults({
-      session: session.value,
-      channelIsForum: channelIsForum.value,
-      mamResults,
-      existing,
-      options,
-    });
-  }
-
-  async function loadMessages(
-    spaceId: string,
-    channelId: string,
-    unreadAtLoad = 0,
-    metadataSeed: TimelineMessage[] = [],
-  ) {
-    if (!session.value) return;
-
-    const requestId = ++messageRequestId;
-    const roomJid = roomJidForChannel(channelId);
-    if (!roomJid) return;
-    initialLatestPagePinned = false;
-    isLoadingMessages.value = true;
-    isLoadingOlderMessages.value = false;
-    hasOlderMessages.value = true;
-    searchRequestId++;
-    searchQuery.value = "";
-    searchResults.value = [];
-    isSearching.value = false;
-    oldestArchiveId = null;
-    loadingOlderThreadIds.value = new Set();
-    threadHasOlder.value = {};
-    oldestThreadArchiveIds.clear();
-    pinnedEdgeScroller.disconnect();
-    // Reset the divider anchor up-front: a previous conversation's id could
-    // coincidentally match a message in the new timeline, and an aborted
-    // request (requestId mismatch) would otherwise leave stale state.
-    firstUnseenId.value = null;
-    clearActionError();
-    pendingEchoClientIds.clear();
-    messages.value = appendQueuedMessages([], roomJid);
-
-    try {
-      // #414: hydrate the pin store for this room. Fire-and-forget —
-      // the panel + badge tolerate an empty store, and the live
-      // pin-event handler will mutate it from now on.
-      // - On error (<forbidden/>, network), hydrate with an empty
-      //   list so the panel exits "Loading…".
-      // - When the wasm client lacks `fetchRoomPins` (stub clients in
-      //   tests, older builds), also hydrate with an empty list to
-      //   prevent the panel from spinning forever.
-      // - Capture the epoch at request-issue time and pass it back
-      //   to hydratePinnedRoom; if logout bumps the epoch in between,
-      //   the late callback is dropped instead of leaking prior-session
-      //   data into the new login.
-      if (xmppClient.value && "fetchRoomPins" in xmppClient.value) {
-        const epoch = pinnedRoomsEpoch();
-        void xmppClient.value
-          .fetchRoomPins(spaceId, channelId)
-          .then((entries) => {
-            hydratePinnedRoom(roomJid, entries, epoch);
-          })
-          .catch((error: unknown) => {
-            console.warn("fetchRoomPins failed", error);
-            hydratePinnedRoom(roomJid, [], epoch);
-          });
-      } else {
-        hydratePinnedRoom(roomJid, []);
-      }
-      // XEP-0313: Load message history via MAM (XMPP-native)
-      const page = xmppClient.value && "queryMamPage" in xmppClient.value
-        ? await xmppClient.value.queryMamPage(spaceId, channelId, 100, { type: "latest" })
-        : null;
-      const mamResults = page
-        ? page.messages
-        : xmppClient.value
-          ? await xmppClient.value.queryMam(spaceId, channelId, 100)
-          : [];
-
-      if (
-        requestId !== messageRequestId ||
-        (activeSpaceId.value ?? "") !== spaceId ||
-        activeChannelId.value !== channelId
-      ) {
-        return;
-      }
-
-      oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
-      hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
-      const timelineWithQueue = appendQueuedMessages(
-        buildTimelineFromMamResults(mamResults, metadataSeed, {
-          seedExistingOnly: metadataSeed.length > 0,
-        }),
-        roomJid,
-      );
-      messages.value = timelineWithQueue;
-      if (requestId === messageRequestId) {
-        isLoadingMessages.value = false;
-      }
-
-      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
-      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
-        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
-        : null;
-      const pinned = await scrollToPinnedEdgeAndPin();
-      if (
-        !pinned ||
-        requestId !== messageRequestId ||
-        (activeSpaceId.value ?? "") !== spaceId ||
-        activeChannelId.value !== channelId
-      ) {
-        return;
-      }
-      initialLatestPagePinned = true;
-      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
-      if (newest) persistLastSeen(channelId, newest.id);
-    } catch (e) {
-      if (requestId === messageRequestId) {
-        const queuedOnly = appendQueuedMessages([], roomJid);
-        messages.value = queuedOnly;
-        actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
-        isLoadingMessages.value = false;
-      }
-    }
-  }
-
-  async function loadOlderMessages() {
-    const client = xmppClient.value;
-    const spaceId = activeSpaceId.value ?? "";
-    const channelId = activeChannelId.value;
-    const before = oldestArchiveId;
-    if (
-      !client ||
-      !channelId ||
-      !before ||
-      !initialLatestPagePinned ||
-      !hasOlderMessages.value ||
-      isLoadingOlderMessages.value
-    ) {
-      return;
-    }
-    if (!("queryMamPage" in client)) return;
-    const requestId = messageRequestId;
-    const isCurrentRequest = () =>
-      requestId === messageRequestId &&
-      xmppClient.value === client &&
-      (activeSpaceId.value ?? "") === spaceId &&
-      activeChannelId.value === channelId;
-
-    const el = timelineEl.value;
-    const previousHeight = el?.scrollHeight ?? 0;
-    const previousTop = el?.scrollTop ?? 0;
-    isLoadingOlderMessages.value = true;
-    try {
-      const page = await client.queryMamPage(spaceId, channelId, 100, { type: "before", before });
-      if (!isCurrentRequest()) return;
-      oldestArchiveId = page.firstArchiveId ?? oldestArchiveId;
-      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before;
-      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
-      const roomJid = roomJidForChannel(channelId);
-      if (!roomJid) return;
-      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), roomJid);
-      await nextTick();
-      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
-        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
-      }
-    } catch (e) {
-      if (isCurrentRequest()) actionError.value = normalizeError(e);
-    } finally {
-      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
-    }
-  }
-
-  async function ensureMessageLoaded(messageId: string): Promise<boolean> {
-    if (findMessageById(messages.value, messageId)) return true;
-    const client = xmppClient.value;
-    const channelId = activeChannelId.value;
-    if (!client || !channelId || !session.value || !("queryMamPage" in client)) return false;
-    const roomJid = roomJidForChannel(channelId);
-    if (!roomJid) return false;
-
-    let before = oldestArchiveId;
-    while (before && hasOlderMessages.value && !findMessageById(messages.value, messageId)) {
-      const requestId = messageRequestId;
-      const spaceId = activeSpaceId.value ?? "";
-      const previousBefore = before;
-      const page = await client.queryMamPage(spaceId, channelId, 100, { type: "before", before });
-      if (
-        requestId !== messageRequestId ||
-        xmppClient.value !== client ||
-        (activeSpaceId.value ?? "") !== spaceId ||
-        activeChannelId.value !== channelId
-      ) {
-        return false;
-      }
-      const nextBefore = page.firstArchiveId ?? previousBefore;
-      oldestArchiveId = nextBefore;
-      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== previousBefore;
-      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
-      messages.value = appendQueuedMessages(
-        buildTimelineFromMamResults(page.messages, withoutQueued),
-        roomJid,
-      );
-      if (findMessageById(messages.value, messageId)) return true;
-      if (!page.firstArchiveId || page.firstArchiveId === previousBefore || page.complete) break;
-      before = nextBefore;
-    }
-    return !!findMessageById(messages.value, messageId);
-  }
-
-  /**
-   * Backfill a thread via XEP-0313 MAM filtered by thread id. Returns every
-   * archived reply whose `<thread>` element matches `threadId`. The thread
-   * root does not carry `<thread>` (threads start when someone replies into
-   * one), so MAM-by-thread never includes it — the panel resolves the root
-   * separately from the loaded channel window.
-   */
-  async function backfillThread(threadId: string): Promise<void> {
-    const client = xmppClient.value;
-    const spaceId = activeSpaceId.value;
-    const channelId = activeChannelId.value;
-    if (!client || !channelId || !threadId || !session.value) return;
-    const requestId = messageRequestId;
-    let page: { messages: LiveRoomMessage[]; firstArchiveId?: string; complete?: boolean } | null = null;
-    let results: LiveRoomMessage[] = [];
-    try {
-      page = "queryMamThreadPage" in client
-        ? await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "latest" })
-        : null;
-      results = page ? page.messages : await client.queryMamByThread(spaceId ?? "", channelId, threadId, 100);
-    } catch (e) {
-      if (
-        xmppClient.value === client &&
-        (activeSpaceId.value ?? "") === (spaceId ?? "") &&
-        activeChannelId.value === channelId &&
-        requestId === messageRequestId
-      ) {
-        threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
-        actionError.value = normalizeError(e);
-      }
-      return;
-    }
-    if (
-      xmppClient.value !== client ||
-      (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
-      activeChannelId.value !== channelId ||
-      requestId !== messageRequestId
-    ) {
-      return;
-    }
-    if (page?.firstArchiveId) oldestThreadArchiveIds.set(threadId, page.firstArchiveId);
-    threadHasOlder.value = {
-      ...threadHasOlder.value,
-      [threadId]: page ? !page.complete && !!page.firstArchiveId : results.length >= 100,
-    };
-    const next = buildTimelineFromMamResults(results, messages.value);
-    if (
-      next.length === messages.value.length &&
-      next.every((message, index) => message === messages.value[index])
-    ) {
-      return;
-    }
-    messages.value = next;
-  }
-
-  async function loadOlderThreadMessages(threadId: string): Promise<void> {
-    const client = xmppClient.value;
-    const spaceId = activeSpaceId.value;
-    const channelId = activeChannelId.value;
-    const before = oldestThreadArchiveIds.get(threadId);
-    if (!client || !channelId || !threadId || !before || loadingOlderThreadIds.value.has(threadId)) return;
-    if (!("queryMamThreadPage" in client)) return;
-    const requestId = messageRequestId;
-    const isCurrentRequest = () =>
-      requestId === messageRequestId &&
-      xmppClient.value === client &&
-      (activeSpaceId.value ?? "") === (spaceId ?? "") &&
-      activeChannelId.value === channelId;
-    loadingOlderThreadIds.value = new Set([...loadingOlderThreadIds.value, threadId]);
-    try {
-      const page = await client.queryMamThreadPage(spaceId ?? "", channelId, threadId, 100, { type: "before", before });
-      if (!isCurrentRequest()) return;
-      if (page.firstArchiveId) oldestThreadArchiveIds.set(threadId, page.firstArchiveId);
-      threadHasOlder.value = {
-        ...threadHasOlder.value,
-        [threadId]: !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before,
-      };
-      messages.value = buildTimelineFromMamResults(page.messages, messages.value);
-    } catch (e) {
-      if (isCurrentRequest()) actionError.value = normalizeError(e);
-    } finally {
-      const next = new Set(loadingOlderThreadIds.value);
-      next.delete(threadId);
-      loadingOlderThreadIds.value = next;
-    }
-  }
+  const paging = useChannelMamPaging({
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentChannel,
+    messages,
+    firstUnseenId,
+    timelineEl,
+    scrollDirection,
+    pinnedEdgeScroller,
+    actionError,
+    clearActionError,
+    normalizeError,
+    pendingEchoClientIds,
+    appendQueuedMessages,
+    roomJidForChannel,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+  });
+  const {
+    isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
+    loadingOlderThreadIds,
+    threadHasOlder,
+    loadMessages,
+    loadOlderMessages,
+    ensureMessageLoaded,
+    backfillThread,
+    loadOlderThreadMessages,
+  } = paging;
 
   async function selectChannel(channelId: string) {
     messages.value = [];
@@ -1291,18 +1012,13 @@ export function useChannelMessages(
   }
 
   function disconnect() {
-    messageRequestId++;
+    paging.reset();
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
-    initialLatestPagePinned = false;
-    oldestArchiveId = null;
-    hasOlderMessages.value = true;
-    isLoadingOlderMessages.value = false;
     // $xmppStatus is authoritative and owned by XmppProvider; do not write it here.
     clearTypingState();
     clearLiveActivityState();
-    isLoadingMessages.value = false;
     isSearching.value = false;
     searchQuery.value = "";
     searchResults.value = [];
@@ -1310,16 +1026,11 @@ export function useChannelMessages(
   }
 
   function clearMessages() {
-    messageRequestId++;
+    paging.reset();
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
-    initialLatestPagePinned = false;
-    oldestArchiveId = null;
-    hasOlderMessages.value = true;
-    isLoadingOlderMessages.value = false;
     messages.value = [];
-    isLoadingMessages.value = false;
     searchQuery.value = "";
     searchResults.value = [];
     isSearching.value = false;
@@ -1425,18 +1136,18 @@ export function useChannelMessages(
     async ([el, edgeScroller]) => {
       if (!el || !edgeScroller || isLoadingMessages.value) return;
       if (!messages.value.some(isFeedVisible)) return;
-      const requestId = messageRequestId;
+      const requestId = paging.currentRequestId();
       const spaceId = activeSpaceId.value ?? "";
       const channelId = activeChannelId.value;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
         pinned &&
-        requestId === messageRequestId &&
+        requestId === paging.currentRequestId() &&
         (activeSpaceId.value ?? "") === spaceId &&
         activeChannelId.value === channelId &&
         messages.value.some(isFeedVisible)
       ) {
-        initialLatestPagePinned = true;
+        paging.markInitialLatestPagePinned();
         const newest = [...messages.value].reverse().find(isFeedVisible);
         if (channelId && newest) persistLastSeen(channelId, newest.id);
       }

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -689,12 +689,28 @@ export function useChannelMessages(
     hasOlderMessages,
     loadingOlderThreadIds,
     threadHasOlder,
-    loadMessages,
     loadOlderMessages,
     ensureMessageLoaded,
     backfillThread,
     loadOlderThreadMessages,
   } = paging;
+
+  // Channel-load entry point. The MAM-paging composable owns paging state,
+  // but search state lives here, so we reset it before delegating — keeping
+  // the pre-#188 invariant that switching channels invalidates in-flight
+  // searches and clears stale results.
+  async function loadMessages(
+    spaceId: string,
+    channelId: string,
+    unreadAtLoad = 0,
+    metadataSeed: TimelineMessage[] = [],
+  ) {
+    searchRequestId++;
+    searchQuery.value = "";
+    searchResults.value = [];
+    isSearching.value = false;
+    await paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed);
+  }
 
   async function selectChannel(channelId: string) {
     messages.value = [];

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -225,7 +225,20 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       } catch (e) {
         const classified = classifyMamError(e);
         if (isMamCursorNotFound(classified)) {
+          // §4.3.4 — drop the cursor AND collapse hasOlderMessages so the
+          // UI's "load older" sentinel doesn't keep prompting paging that
+          // would early-return on !before. A fresh loadMessages() resets
+          // both to their initial state.
           oldestArchiveId = null;
+          hasOlderMessages.value = false;
+        } else if (
+          requestId === messageRequestId &&
+          xmppClient.value === client &&
+          activePeerJid.value === peerJid
+        ) {
+          // Non-§4.3.4 failure: surface to the caller instead of silently
+          // returning false.
+          actionError.value = dmLoadErrorMessage(peerJid);
         }
         return false;
       }

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -1,0 +1,275 @@
+import { nextTick, ref, type Ref } from "vue";
+import type { BrowserXmppClient, LiveDmMessage } from "@/lib/xmpp-client";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import {
+  isTopPinnedScrollDirection,
+  type ScrollDirectionMode,
+} from "@/lib/scroll-direction";
+import { buildDmTimelineFromMamResults } from "@/dms/message-timeline-state";
+import {
+  advanceCursorWithBeforePage,
+  classifyMamError,
+  cursorFromLatestPage,
+  isMamCursorNotFound,
+  stripQueuedSelfMessages,
+} from "@/lib/xmpp/mam-paging";
+
+const PAGE_SIZE = 100;
+
+type UseDmMamPagingDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activePeerJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+  firstUnseenId: Ref<string | null>;
+  loadErrorPeerJid: Ref<string | null>;
+  loadErrorMessage: Ref<string>;
+  timelineEl: Ref<HTMLDivElement | null>;
+  scrollDirection: Ref<ScrollDirectionMode>;
+  pinnedEdgeScroller: { disconnect: () => void };
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  pendingEchoClientIds: Set<string>;
+  appendQueuedMessages: (timeline: TimelineMessage[], peerJid: string) => TimelineMessage[];
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  isFeedVisible: (m: TimelineMessage) => boolean;
+  persistLastSeen: (peerJid: string, messageId: string) => void;
+  dmLoadErrorMessage: (peerJid: string, opts?: { queuedOnly?: boolean }) => string;
+};
+
+export function useDmMamPaging(deps: UseDmMamPagingDeps) {
+  const {
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    firstUnseenId,
+    loadErrorPeerJid,
+    loadErrorMessage,
+    timelineEl,
+    scrollDirection,
+    pinnedEdgeScroller,
+    actionError,
+    clearActionError,
+    pendingEchoClientIds,
+    appendQueuedMessages,
+    scrollToPinnedEdgeAndPin,
+    isFeedVisible,
+    persistLastSeen,
+    dmLoadErrorMessage,
+  } = deps;
+
+  const isLoadingMessages = ref(false);
+  const isLoadingOlderMessages = ref(false);
+  const hasOlderMessages = ref(true);
+
+  let messageRequestId = 0;
+  let oldestArchiveId: string | null = null;
+  let initialLatestPagePinned = false;
+
+  function buildTimelineFromMamResults(
+    mamResults: LiveDmMessage[],
+    existing: TimelineMessage[] = [],
+  ): TimelineMessage[] {
+    if (!session.value) return existing;
+    return buildDmTimelineFromMamResults({
+      session: session.value,
+      mamResults,
+      existing,
+    });
+  }
+
+  async function loadMessages(peerJid: string, unreadAtLoad = 0) {
+    if (!session.value) return;
+    const requestId = ++messageRequestId;
+    initialLatestPagePinned = false;
+    isLoadingMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    hasOlderMessages.value = true;
+    oldestArchiveId = null;
+    pinnedEdgeScroller.disconnect();
+    firstUnseenId.value = null;
+    clearActionError();
+    loadErrorPeerJid.value = null;
+    loadErrorMessage.value = "";
+    pendingEchoClientIds.clear();
+    messages.value = appendQueuedMessages([], peerJid);
+
+    try {
+      const page = xmppClient.value && "queryPersonalMamPage" in xmppClient.value
+        ? await xmppClient.value.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "latest" })
+        : null;
+      const mamResults = page
+        ? page.messages
+        : xmppClient.value
+          ? await xmppClient.value.queryPersonalMam(peerJid, PAGE_SIZE)
+          : [];
+      if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      loadErrorPeerJid.value = null;
+      loadErrorMessage.value = "";
+      const cursor = cursorFromLatestPage({
+        page,
+        pageSize: PAGE_SIZE,
+        fallbackMessages: page ? undefined : mamResults,
+      });
+      oldestArchiveId = cursor.oldestArchiveId;
+      hasOlderMessages.value = cursor.hasOlderMessages;
+      const timeline = buildTimelineFromMamResults(mamResults);
+      const timelineWithQueue = appendQueuedMessages(timeline, peerJid);
+      messages.value = timelineWithQueue;
+      if (requestId === messageRequestId) isLoadingMessages.value = false;
+
+      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
+      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
+        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
+        : null;
+      const pinned = await scrollToPinnedEdgeAndPin();
+      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      initialLatestPagePinned = true;
+      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
+      if (newest) persistLastSeen(peerJid, newest.id);
+    } catch {
+      if (requestId === messageRequestId) {
+        console.warn("Could not load DM conversation");
+        const queuedOnly = appendQueuedMessages([], peerJid);
+        messages.value = queuedOnly;
+        loadErrorPeerJid.value = peerJid;
+        loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
+        actionError.value = loadErrorMessage.value;
+        isLoadingMessages.value = false;
+      }
+    }
+  }
+
+  async function loadOlderMessages() {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    const before = oldestArchiveId;
+    if (
+      !client ||
+      !peerJid ||
+      !before ||
+      !initialLatestPagePinned ||
+      !hasOlderMessages.value ||
+      isLoadingOlderMessages.value
+    ) {
+      return;
+    }
+    if (!("queryPersonalMamPage" in client)) return;
+    const requestId = messageRequestId;
+    const isCurrentRequest = () =>
+      requestId === messageRequestId &&
+      xmppClient.value === client &&
+      activePeerJid.value === peerJid;
+    const el = timelineEl.value;
+    const previousHeight = el?.scrollHeight ?? 0;
+    const previousTop = el?.scrollTop ?? 0;
+    isLoadingOlderMessages.value = true;
+    try {
+      const page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before });
+      if (!isCurrentRequest()) return;
+      const advanced = advanceCursorWithBeforePage({
+        prior: { oldestArchiveId, hasOlderMessages: hasOlderMessages.value },
+        page,
+      });
+      oldestArchiveId = advanced.next.oldestArchiveId;
+      hasOlderMessages.value = advanced.next.hasOlderMessages;
+      const withoutQueued = stripQueuedSelfMessages(messages.value);
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), peerJid);
+      await nextTick();
+      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
+        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
+      }
+    } catch (e) {
+      const classified = classifyMamError(e);
+      if (isMamCursorNotFound(classified)) {
+        // XEP-0313 §4.3.4 — stale cursor. Drop and re-fetch the tail page.
+        if (isCurrentRequest()) {
+          oldestArchiveId = null;
+          isLoadingOlderMessages.value = false;
+          await loadMessages(peerJid);
+          return;
+        }
+      }
+      if (isCurrentRequest()) {
+        console.warn("Could not load older DM messages");
+        actionError.value = dmLoadErrorMessage(peerJid);
+      }
+    } finally {
+      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
+    }
+  }
+
+  async function ensureMessageLoaded(messageId: string): Promise<boolean> {
+    if (findMessageById(messages.value, messageId)) return true;
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    if (!client || !peerJid || !("queryPersonalMamPage" in client)) return false;
+
+    let before = oldestArchiveId;
+    while (before && hasOlderMessages.value && !findMessageById(messages.value, messageId)) {
+      const requestId = messageRequestId;
+      const previousBefore = before;
+      let page: Awaited<ReturnType<typeof client.queryPersonalMamPage>>;
+      try {
+        page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before });
+      } catch (e) {
+        const classified = classifyMamError(e);
+        if (isMamCursorNotFound(classified)) {
+          oldestArchiveId = null;
+        }
+        return false;
+      }
+      if (
+        requestId !== messageRequestId ||
+        xmppClient.value !== client ||
+        activePeerJid.value !== peerJid
+      ) {
+        return false;
+      }
+      const advanced = advanceCursorWithBeforePage({
+        prior: { oldestArchiveId: previousBefore, hasOlderMessages: hasOlderMessages.value },
+        page,
+      });
+      oldestArchiveId = advanced.next.oldestArchiveId;
+      hasOlderMessages.value = advanced.next.hasOlderMessages;
+      const withoutQueued = stripQueuedSelfMessages(messages.value);
+      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), peerJid);
+      if (findMessageById(messages.value, messageId)) return true;
+      if (advanced.stalled || advanced.next.hasOlderMessages === false) break;
+      before = advanced.next.oldestArchiveId;
+    }
+    return !!findMessageById(messages.value, messageId);
+  }
+
+  function reset() {
+    messageRequestId++;
+    initialLatestPagePinned = false;
+    oldestArchiveId = null;
+    hasOlderMessages.value = true;
+    isLoadingOlderMessages.value = false;
+    isLoadingMessages.value = false;
+  }
+
+  function currentRequestId(): number {
+    return messageRequestId;
+  }
+
+  function markInitialLatestPagePinned() {
+    initialLatestPagePinned = true;
+  }
+
+  return {
+    isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
+    loadMessages,
+    loadOlderMessages,
+    ensureMessageLoaded,
+    reset,
+    currentRequestId,
+    markInitialLatestPagePinned,
+  };
+}

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -186,10 +186,17 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       const classified = classifyMamError(e);
       if (isMamCursorNotFound(classified)) {
         // XEP-0313 §4.3.4 — stale cursor. Drop and re-fetch the tail page.
+        // Explicit reset before the await is necessary because `loadMessages`
+        // bumps `messageRequestId`; the `finally` block guards on
+        // `isCurrentRequest()` and would otherwise leave the flag stuck true.
         if (isCurrentRequest()) {
           oldestArchiveId = null;
           isLoadingOlderMessages.value = false;
-          await loadMessages(peerJid);
+          try {
+            await loadMessages(peerJid);
+          } catch (recoveryError) {
+            console.warn("MAM §4.3.4 recovery failed", recoveryError);
+          }
           return;
         }
       }

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -270,10 +270,20 @@ export function useDirectMessages(
     isLoadingMessages,
     isLoadingOlderMessages,
     hasOlderMessages,
-    loadMessages,
     loadOlderMessages,
     ensureMessageLoaded,
   } = paging;
+
+  // DM-load entry point. Search state lives in this orchestrator, so we
+  // reset it before delegating to the MAM-paging composable — keeping the
+  // pre-#188 invariant that switching peers invalidates in-flight searches
+  // and clears stale results.
+  async function loadMessages(peerJid: string, unreadAtLoad = 0) {
+    searchRequestId++;
+    searchResults.value = [];
+    isSearching.value = false;
+    await paging.loadMessages(peerJid, unreadAtLoad);
+  }
 
   function mergeLiveMessage(rawMessage: TimelineMessage) {
     const msg = rawMessage.isRetracted

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -35,12 +35,12 @@ import {
 } from "@/lib/outbound-queue-store";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import {
-  buildDmTimelineFromMamResults,
   fromLiveDmMessage,
   isSameDmCorrectionSender,
   queuedDmMessageToTimeline,
   retractDmTimelineMessage,
 } from "@/dms/message-timeline-state";
+import { useDmMamPaging } from "@/dms/mam-paging";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -61,9 +61,6 @@ export function useDirectMessages(
   };
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
-  const isLoadingMessages = ref(false);
-  const isLoadingOlderMessages = ref(false);
-  const hasOlderMessages = ref(true);
   const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
@@ -88,9 +85,6 @@ export function useDirectMessages(
     return null;
   });
 
-  let messageRequestId = 0;
-  let oldestArchiveId: string | null = null;
-  let initialLatestPagePinned = false;
   let searchRequestId = 0;
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -252,17 +246,34 @@ export function useDirectMessages(
     });
   }
 
-  function buildTimelineFromMamResults(
-    mamResults: LiveDmMessage[],
-    existing: TimelineMessage[] = [],
-  ): TimelineMessage[] {
-    if (!session.value) return existing;
-    return buildDmTimelineFromMamResults({
-      session: session.value,
-      mamResults,
-      existing,
-    });
-  }
+  const paging = useDmMamPaging({
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    firstUnseenId,
+    loadErrorPeerJid,
+    loadErrorMessage,
+    timelineEl,
+    scrollDirection,
+    pinnedEdgeScroller,
+    actionError,
+    clearActionError,
+    pendingEchoClientIds,
+    appendQueuedMessages,
+    scrollToPinnedEdgeAndPin,
+    isFeedVisible,
+    persistLastSeen: (peerJid, messageId) => setLastSeen(dmKey(barePeerJid(peerJid)), messageId),
+    dmLoadErrorMessage,
+  });
+  const {
+    isLoadingMessages,
+    isLoadingOlderMessages,
+    hasOlderMessages,
+    loadMessages,
+    loadOlderMessages,
+    ensureMessageLoaded,
+  } = paging;
 
   function mergeLiveMessage(rawMessage: TimelineMessage) {
     const msg = rawMessage.isRetracted
@@ -361,134 +372,6 @@ export function useDirectMessages(
       const toAppend = preserved.filter((m) => !findMessageById(messages.value, m.id));
       if (toAppend.length > 0) messages.value = [...messages.value, ...toAppend];
     })();
-  }
-
-  async function loadMessages(peerJid: string, unreadAtLoad = 0) {
-    if (!session.value) return;
-    const requestId = ++messageRequestId;
-    initialLatestPagePinned = false;
-    isLoadingMessages.value = true;
-    isLoadingOlderMessages.value = false;
-    hasOlderMessages.value = true;
-    searchRequestId++;
-    searchResults.value = [];
-    isSearching.value = false;
-    oldestArchiveId = null;
-    pinnedEdgeScroller.disconnect();
-    firstUnseenId.value = null;
-    clearActionError();
-    loadErrorPeerJid.value = null;
-    loadErrorMessage.value = "";
-    pendingEchoClientIds.clear();
-    messages.value = appendQueuedMessages([], peerJid);
-    try {
-      const page = xmppClient.value && "queryPersonalMamPage" in xmppClient.value
-        ? await xmppClient.value.queryPersonalMamPage(peerJid, 100, { type: "latest" })
-        : null;
-      const mamResults = page
-        ? page.messages
-        : xmppClient.value
-          ? await xmppClient.value.queryPersonalMam(peerJid, 100)
-          : [];
-      if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
-      loadErrorPeerJid.value = null;
-      loadErrorMessage.value = "";
-      oldestArchiveId = page?.firstArchiveId ?? mamResults[0]?.id ?? null;
-      hasOlderMessages.value = page ? !page.complete && !!page.firstArchiveId : mamResults.length >= 100;
-      const timeline = buildTimelineFromMamResults(mamResults);
-      const timelineWithQueue = appendQueuedMessages(timeline, peerJid);
-      messages.value = timelineWithQueue;
-      if (requestId === messageRequestId) isLoadingMessages.value = false;
-
-      const key = dmKey(barePeerJid(peerJid));
-      const feedTimeline = timelineWithQueue.filter(isFeedVisible);
-      firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
-        ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
-        : null;
-      const pinned = await scrollToPinnedEdgeAndPin();
-      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
-      initialLatestPagePinned = true;
-      const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
-      if (newest) setLastSeen(key, newest.id);
-    } catch {
-      if (requestId === messageRequestId) {
-        console.warn("Could not load DM conversation");
-        const queuedOnly = appendQueuedMessages([], peerJid);
-        messages.value = queuedOnly;
-        loadErrorPeerJid.value = peerJid;
-        loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
-        actionError.value = loadErrorMessage.value;
-        isLoadingMessages.value = false;
-      }
-    }
-  }
-
-  async function loadOlderMessages() {
-    const client = xmppClient.value;
-    const peerJid = activePeerJid.value;
-    const before = oldestArchiveId;
-    if (!client || !peerJid || !before || !initialLatestPagePinned || !hasOlderMessages.value || isLoadingOlderMessages.value) {
-      return;
-    }
-    if (!("queryPersonalMamPage" in client)) return;
-    const requestId = messageRequestId;
-    const isCurrentRequest = () =>
-      requestId === messageRequestId &&
-      xmppClient.value === client &&
-      activePeerJid.value === peerJid;
-    const el = timelineEl.value;
-    const previousHeight = el?.scrollHeight ?? 0;
-    const previousTop = el?.scrollTop ?? 0;
-    isLoadingOlderMessages.value = true;
-    try {
-      const page = await client.queryPersonalMamPage(peerJid, 100, { type: "before", before });
-      if (!isCurrentRequest()) return;
-      oldestArchiveId = page.firstArchiveId ?? oldestArchiveId;
-      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== before;
-      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
-      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), peerJid);
-      await nextTick();
-      if (el && !isTopPinnedScrollDirection(scrollDirection.value)) {
-        el.scrollTop = previousTop + (el.scrollHeight - previousHeight);
-      }
-    } catch {
-      if (isCurrentRequest()) {
-        console.warn("Could not load older DM messages");
-        actionError.value = dmLoadErrorMessage(peerJid);
-      }
-    } finally {
-      if (isCurrentRequest()) isLoadingOlderMessages.value = false;
-    }
-  }
-
-  async function ensureMessageLoaded(messageId: string): Promise<boolean> {
-    if (findMessageById(messages.value, messageId)) return true;
-    const client = xmppClient.value;
-    const peerJid = activePeerJid.value;
-    if (!client || !peerJid || !("queryPersonalMamPage" in client)) return false;
-
-    let before = oldestArchiveId;
-    while (before && hasOlderMessages.value && !findMessageById(messages.value, messageId)) {
-      const requestId = messageRequestId;
-      const previousBefore = before;
-      const page = await client.queryPersonalMamPage(peerJid, 100, { type: "before", before });
-      if (
-        requestId !== messageRequestId ||
-        xmppClient.value !== client ||
-        activePeerJid.value !== peerJid
-      ) {
-        return false;
-      }
-      const nextBefore = page.firstArchiveId ?? previousBefore;
-      oldestArchiveId = nextBefore;
-      hasOlderMessages.value = !page.complete && !!page.firstArchiveId && page.firstArchiveId !== previousBefore;
-      const withoutQueued = messages.value.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
-      messages.value = appendQueuedMessages(buildTimelineFromMamResults(page.messages, withoutQueued), peerJid);
-      if (findMessageById(messages.value, messageId)) return true;
-      if (!page.firstArchiveId || page.firstArchiveId === previousBefore || page.complete) break;
-      before = nextBefore;
-    }
-    return !!findMessageById(messages.value, messageId);
   }
 
   async function sendMessage(
@@ -736,16 +619,11 @@ export function useDirectMessages(
   }
 
   function clearMessages() {
-    messageRequestId++;
+    paging.reset();
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
-    initialLatestPagePinned = false;
-    oldestArchiveId = null;
-    hasOlderMessages.value = true;
-    isLoadingOlderMessages.value = false;
     messages.value = [];
-    isLoadingMessages.value = false;
     searchResults.value = [];
     isSearching.value = false;
     firstUnseenId.value = null;
@@ -753,15 +631,10 @@ export function useDirectMessages(
   }
 
   function disconnect() {
-    messageRequestId++;
+    paging.reset();
     searchRequestId++;
     pinnedEdgeScroller.disconnect();
     pendingEchoClientIds.clear();
-    initialLatestPagePinned = false;
-    oldestArchiveId = null;
-    hasOlderMessages.value = true;
-    isLoadingOlderMessages.value = false;
-    isLoadingMessages.value = false;
     isSearching.value = false;
     searchResults.value = [];
     firstUnseenId.value = null;
@@ -821,16 +694,16 @@ export function useDirectMessages(
     async ([el, edgeScroller]) => {
       if (!el || !edgeScroller || isLoadingMessages.value) return;
       if (!messages.value.some(isFeedVisible)) return;
-      const requestId = messageRequestId;
+      const requestId = paging.currentRequestId();
       const peerJid = activePeerJid.value;
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
         pinned &&
-        requestId === messageRequestId &&
+        requestId === paging.currentRequestId() &&
         activePeerJid.value === peerJid &&
         messages.value.some(isFeedVisible)
       ) {
-        initialLatestPagePinned = true;
+        paging.markInitialLatestPagePinned();
         const newest = [...messages.value].reverse().find(isFeedVisible);
         if (peerJid && newest) setLastSeen(dmKey(barePeerJid(peerJid)), newest.id);
       }

--- a/chat/src/lib/xmpp/mam-paging.ts
+++ b/chat/src/lib/xmpp/mam-paging.ts
@@ -1,0 +1,144 @@
+// Pure helpers for XEP-0313 Message Archive Management paging.
+//
+// These are deliberately Vue-free and stanza-free. The composables that wrap
+// `BrowserXmppClient` are responsible for issuing requests and committing the
+// returned cursor/page into their reactive state; this module only encodes the
+// data shaping that's repeated across every MAM consumer (channels +
+// channel-threads + DMs + search). See XEP-0313 §4 "Querying an archive" and
+// §4.3 "Paging through results"; the §4.3.4 item-not-found gotcha is handled
+// via the dedicated error type below.
+
+type CursorState = Readonly<{
+  oldestArchiveId: string | null;
+  hasOlderMessages: boolean;
+}>;
+
+export const INITIAL_CURSOR: CursorState = Object.freeze({
+  oldestArchiveId: null,
+  hasOlderMessages: true,
+});
+
+type RsmPage = {
+  firstArchiveId?: string;
+  complete?: boolean;
+};
+
+type RsmPageWithMessages = RsmPage & {
+  messages: ReadonlyArray<unknown>;
+};
+
+type CursorAdvanceResult = Readonly<{
+  next: CursorState;
+  stalled: boolean;
+}>;
+
+export function cursorFromLatestPage(opts: {
+  page: RsmPageWithMessages | null;
+  pageSize: number;
+  fallbackMessages?: ReadonlyArray<{ id?: string }>;
+}): CursorState {
+  const { page, pageSize, fallbackMessages } = opts;
+  if (page) {
+    const firstArchiveId = page.firstArchiveId ?? null;
+    const hasOlder = !page.complete && firstArchiveId !== null;
+    return { oldestArchiveId: firstArchiveId, hasOlderMessages: hasOlder };
+  }
+  if (!fallbackMessages || fallbackMessages.length === 0) {
+    return { oldestArchiveId: null, hasOlderMessages: false };
+  }
+  const oldest = fallbackMessages[0]?.id ?? null;
+  return {
+    oldestArchiveId: oldest,
+    hasOlderMessages: fallbackMessages.length >= pageSize,
+  };
+}
+
+export function advanceCursorWithBeforePage(opts: {
+  prior: CursorState;
+  page: RsmPage;
+}): CursorAdvanceResult {
+  const { prior, page } = opts;
+  const nextOldest = page.firstArchiveId ?? prior.oldestArchiveId;
+  const stalled =
+    !page.firstArchiveId ||
+    page.firstArchiveId === prior.oldestArchiveId;
+  const hasOlder = !page.complete && !!page.firstArchiveId && !stalled;
+  return {
+    next: { oldestArchiveId: nextOldest, hasOlderMessages: hasOlder },
+    stalled,
+  };
+}
+
+type ThreadCursorEntry = Readonly<{
+  oldestId: string | undefined;
+  hasOlder: boolean;
+}>;
+
+export function threadCursorFromLatestPage(opts: {
+  page: RsmPageWithMessages | null;
+  pageSize: number;
+  fallbackMessages?: ReadonlyArray<unknown>;
+}): ThreadCursorEntry {
+  const { page, pageSize, fallbackMessages } = opts;
+  if (page) {
+    return {
+      oldestId: page.firstArchiveId,
+      hasOlder: !page.complete && !!page.firstArchiveId,
+    };
+  }
+  const count = fallbackMessages?.length ?? 0;
+  return {
+    oldestId: undefined,
+    hasOlder: count >= pageSize,
+  };
+}
+
+export function advanceThreadCursor(opts: {
+  prior: { oldestId?: string };
+  page: RsmPage;
+}): ThreadCursorEntry {
+  const { prior, page } = opts;
+  const stalled =
+    !page.firstArchiveId || page.firstArchiveId === prior.oldestId;
+  return {
+    oldestId: page.firstArchiveId ?? prior.oldestId,
+    hasOlder: !page.complete && !!page.firstArchiveId && !stalled,
+  };
+}
+
+export function stripQueuedSelfMessages<
+  M extends { isSelf?: boolean; deliveryStatus?: string },
+>(timeline: ReadonlyArray<M>): M[] {
+  return timeline.filter((m) => !(m.isSelf && m.deliveryStatus === "queued"));
+}
+
+// XEP-0313 §4.3.4: the server MUST return <item-not-found/> when the UID
+// referenced by <before/>/<after/> doesn't exist in the archive. Treating
+// that as "no more history" is incorrect — the right move is to drop the
+// stale cursor and re-fetch the tail page. Callers detect this via the
+// dedicated error type below, which `classifyMamError` lifts out of the
+// various raw error shapes the XMPP client may surface.
+export class MamCursorNotFoundError extends Error {
+  readonly cursor: string;
+  constructor(cursor: string) {
+    super(`MAM cursor "${cursor}" not found in archive (XEP-0313 §4.3.4)`);
+    this.name = "MamCursorNotFoundError";
+    this.cursor = cursor;
+  }
+}
+
+export function isMamCursorNotFound(value: unknown): value is MamCursorNotFoundError {
+  return value instanceof MamCursorNotFoundError;
+}
+
+export function classifyMamError(error: unknown): MamCursorNotFoundError | unknown {
+  if (!error || typeof error !== "object") return error;
+  const candidate = error as { condition?: unknown; code?: unknown; cursor?: unknown };
+  const condition = typeof candidate.condition === "string" ? candidate.condition : undefined;
+  const code = typeof candidate.code === "string" ? candidate.code : undefined;
+  const cursor = typeof candidate.cursor === "string" ? candidate.cursor : "";
+  if (condition === "item-not-found" || code === "item-not-found") {
+    return new MamCursorNotFoundError(cursor);
+  }
+  return error;
+}

--- a/chat/src/lib/xmpp/mam-paging.ts
+++ b/chat/src/lib/xmpp/mam-paging.ts
@@ -118,6 +118,12 @@ export function stripQueuedSelfMessages<
 // stale cursor and re-fetch the tail page. Callers detect this via the
 // dedicated error type below, which `classifyMamError` lifts out of the
 // various raw error shapes the XMPP client may surface.
+// Sentinel used when the cursor value can't be extracted from the raw error
+// shape (current waddle wasm client surfaces errors as plain strings without
+// the offending UID). Telemetry/log readers should treat this as "unknown
+// cursor, classified by substring match" rather than an empty cursor.
+export const MAM_UNKNOWN_CURSOR = "<unknown>";
+
 export class MamCursorNotFoundError extends Error {
   readonly cursor: string;
   constructor(cursor: string) {
@@ -140,11 +146,11 @@ export function classifyMamError(error: unknown): MamCursorNotFoundError | unkno
   // stanza-error condition name appears literally somewhere in the string.
   if (typeof error === "string") {
     return error.includes("item-not-found")
-      ? new MamCursorNotFoundError("")
+      ? new MamCursorNotFoundError(MAM_UNKNOWN_CURSOR)
       : error;
   }
   if (error instanceof Error && error.message.includes("item-not-found")) {
-    return new MamCursorNotFoundError("");
+    return new MamCursorNotFoundError(MAM_UNKNOWN_CURSOR);
   }
   if (!error || typeof error !== "object") return error;
   const candidate = error as { condition?: unknown; code?: unknown; cursor?: unknown };

--- a/chat/src/lib/xmpp/mam-paging.ts
+++ b/chat/src/lib/xmpp/mam-paging.ts
@@ -132,6 +132,20 @@ export function isMamCursorNotFound(value: unknown): value is MamCursorNotFoundE
 }
 
 export function classifyMamError(error: unknown): MamCursorNotFoundError | unknown {
+  // String-form fallback: the current wasm client surfaces errors as plain
+  // strings via `JsValue::from_str(err.to_string())` (see
+  // server/crates/waddle-xmpp-client-wasm/src/helpers.rs). Until that layer
+  // emits structured errors, the only way to detect a §4.3.4 condition is
+  // a substring match on the message. Acceptable as long as the underlying
+  // stanza-error condition name appears literally somewhere in the string.
+  if (typeof error === "string") {
+    return error.includes("item-not-found")
+      ? new MamCursorNotFoundError("")
+      : error;
+  }
+  if (error instanceof Error && error.message.includes("item-not-found")) {
+    return new MamCursorNotFoundError("");
+  }
   if (!error || typeof error !== "object") return error;
   const candidate = error as { condition?: unknown; code?: unknown; cursor?: unknown };
   const condition = typeof candidate.condition === "string" ? candidate.condition : undefined;

--- a/chat/tests/mam-paging-recovery.test.ts
+++ b/chat/tests/mam-paging-recovery.test.ts
@@ -1,0 +1,258 @@
+// Tests for XEP-0313 §4.3.4 stale-cursor recovery in the MAM paging
+// composables. These exercise the control-flow path that detects an
+// `item-not-found` response on a `{type:"before"}` page request, drops the
+// stale cursor, resets loading flags, and re-fetches the tail page — for
+// both channel and DM sides.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelMamPaging } from "../src/channels/mam-paging";
+import { useDmMamPaging } from "../src/dms/mam-paging";
+import type { BrowserXmppClient, LiveDmMessage, LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { ChannelSummary } from "../src/lib/chat-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+const channel: ChannelSummary = { id: "space_room", name: "Room" };
+
+function makeRoomMessage(id: string, body: string): LiveRoomMessage {
+  return {
+    id,
+    type: "message",
+    roomJid: "space_room@muc.example.com",
+    fromJid: "alice@example.com/desktop",
+    nick: "alice",
+    body,
+    timestamp: Date.now(),
+    isSelf: false,
+  } as unknown as LiveRoomMessage;
+}
+
+function makeDmMessage(id: string, body: string, peerJid: string): LiveDmMessage {
+  return {
+    id,
+    type: "message",
+    peerJid,
+    fromJid: "alice@example.com/desktop",
+    nick: "alice",
+    body,
+    timestamp: Date.now(),
+    isSelf: false,
+  } as unknown as LiveDmMessage;
+}
+
+describe("useChannelMamPaging — XEP-0313 §4.3.4 recovery", () => {
+  test("loadOlderMessages: item-not-found on a before-cursor triggers cursor reset + tail-page refetch", async () => {
+    const tailMessages = [makeRoomMessage("m1", "older"), makeRoomMessage("m2", "newer")];
+
+    const queryMamPage = mock(async (_space: string, _channel: string, _max: number, param: { type: string }) => {
+      if (param.type === "before") {
+        // First before-cursor query returns the §4.3.4 condition.
+        throw new Error("stanza error: item-not-found");
+      }
+      return { messages: tailMessages, firstArchiveId: "arch-1", complete: false };
+    });
+
+    const xmppClient = {
+      queryMamPage,
+      queryMam: mock(async () => tailMessages),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { disconnect: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds: new Set<string>(),
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    // Initial load: tail page populates the cursor.
+    await paging.loadMessages("space", "space_room");
+    expect(paging.hasOlderMessages.value).toBe(true);
+    paging.markInitialLatestPagePinned();
+
+    // Trigger loadOlderMessages — the before-cursor query throws
+    // item-not-found, which should reset the cursor, clear the loading
+    // flag, and re-fetch the tail page silently.
+    await paging.loadOlderMessages();
+
+    // Recovery path is silent — loading flag must be false.
+    expect(paging.isLoadingOlderMessages.value).toBe(false);
+
+    // Both a `before` and a follow-up `latest` query happened.
+    const calledWith = queryMamPage.mock.calls.map((c) => (c[3] as { type: string }).type);
+    expect(calledWith).toContain("before");
+    expect(calledWith.filter((t) => t === "latest").length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("ensureMessageLoaded: item-not-found nulls cursor AND collapses hasOlderMessages", async () => {
+    const tailMessages = [makeRoomMessage("m1", "older")];
+
+    const queryMamPage = mock(async (_space: string, _channel: string, _max: number, param: { type: string }) => {
+      if (param.type === "before") {
+        throw new Error("stanza error: item-not-found");
+      }
+      return { messages: tailMessages, firstArchiveId: "arch-1", complete: false };
+    });
+
+    const xmppClient = {
+      queryMamPage,
+      queryMam: mock(async () => tailMessages),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { disconnect: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds: new Set<string>(),
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    await paging.loadMessages("space", "space_room");
+    expect(paging.hasOlderMessages.value).toBe(true);
+
+    // Chase a message that isn't in the tail page — triggers a before-query
+    // that returns item-not-found.
+    const found = await paging.ensureMessageLoaded("missing-id");
+    expect(found).toBe(false);
+    // Cursor null is observable indirectly via hasOlderMessages collapsing
+    // so the UI's "load older" sentinel doesn't keep prompting paging that
+    // would early-return on !before.
+    expect(paging.hasOlderMessages.value).toBe(false);
+  });
+});
+
+describe("useDmMamPaging — XEP-0313 §4.3.4 recovery", () => {
+  test("loadOlderMessages: item-not-found on a before-cursor triggers cursor reset + tail-page refetch", async () => {
+    const peerJid = "bob@example.com";
+    const tailMessages = [makeDmMessage("dm1", "older", peerJid), makeDmMessage("dm2", "newer", peerJid)];
+
+    const queryPersonalMamPage = mock(async (_peerJid: string, _max: number, param: { type: string }) => {
+      if (param.type === "before") {
+        throw new Error("stanza error: item-not-found");
+      }
+      return { messages: tailMessages, firstArchiveId: "arch-1", complete: false };
+    });
+
+    const xmppClient = {
+      queryPersonalMamPage,
+      queryPersonalMam: mock(async () => tailMessages),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const paging = useDmMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activePeerJid: ref(peerJid),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      loadErrorPeerJid: ref<string | null>(null),
+      loadErrorMessage: ref(""),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { disconnect: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      pendingEchoClientIds: new Set<string>(),
+      appendQueuedMessages: (timeline) => timeline,
+      scrollToPinnedEdgeAndPin: async () => true,
+      isFeedVisible: (m) => !m.threadId || m.id === m.threadId,
+      persistLastSeen: () => {},
+      dmLoadErrorMessage: () => "load error",
+    });
+
+    await paging.loadMessages(peerJid);
+    expect(paging.hasOlderMessages.value).toBe(true);
+    paging.markInitialLatestPagePinned();
+
+    await paging.loadOlderMessages();
+
+    expect(paging.isLoadingOlderMessages.value).toBe(false);
+    const calledWith = queryPersonalMamPage.mock.calls.map((c) => (c[2] as { type: string }).type);
+    expect(calledWith).toContain("before");
+    expect(calledWith.filter((t) => t === "latest").length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("ensureMessageLoaded: item-not-found nulls cursor AND collapses hasOlderMessages", async () => {
+    const peerJid = "bob@example.com";
+    const tailMessages = [makeDmMessage("dm1", "older", peerJid)];
+
+    const queryPersonalMamPage = mock(async (_peerJid: string, _max: number, param: { type: string }) => {
+      if (param.type === "before") {
+        throw new Error("stanza error: item-not-found");
+      }
+      return { messages: tailMessages, firstArchiveId: "arch-1", complete: false };
+    });
+
+    const xmppClient = {
+      queryPersonalMamPage,
+      queryPersonalMam: mock(async () => tailMessages),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const paging = useDmMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activePeerJid: ref(peerJid),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      loadErrorPeerJid: ref<string | null>(null),
+      loadErrorMessage: ref(""),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { disconnect: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      pendingEchoClientIds: new Set<string>(),
+      appendQueuedMessages: (timeline) => timeline,
+      scrollToPinnedEdgeAndPin: async () => true,
+      isFeedVisible: (m) => !m.threadId || m.id === m.threadId,
+      persistLastSeen: () => {},
+      dmLoadErrorMessage: () => "load error",
+    });
+
+    await paging.loadMessages(peerJid);
+    expect(paging.hasOlderMessages.value).toBe(true);
+
+    const found = await paging.ensureMessageLoaded("missing-id");
+    expect(found).toBe(false);
+    expect(paging.hasOlderMessages.value).toBe(false);
+  });
+});

--- a/chat/tests/mam-paging.test.ts
+++ b/chat/tests/mam-paging.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test";
+import {
+  INITIAL_CURSOR,
+  advanceCursorWithBeforePage,
+  advanceThreadCursor,
+  classifyMamError,
+  cursorFromLatestPage,
+  isMamCursorNotFound,
+  MamCursorNotFoundError,
+  stripQueuedSelfMessages,
+  threadCursorFromLatestPage,
+} from "../src/lib/xmpp/mam-paging";
+
+describe("INITIAL_CURSOR", () => {
+  test("is null/true so a first load is permitted", () => {
+    expect(INITIAL_CURSOR).toEqual({ oldestArchiveId: null, hasOlderMessages: true });
+  });
+});
+
+describe("cursorFromLatestPage — RSM-aware client (queryMamPage)", () => {
+  test("uses page.firstArchiveId and inverts page.complete", () => {
+    const result = cursorFromLatestPage({
+      page: { firstArchiveId: "arch-001", complete: false, messages: [{ id: "m1" }] },
+      pageSize: 100,
+    });
+    expect(result).toEqual({ oldestArchiveId: "arch-001", hasOlderMessages: true });
+  });
+
+  test("treats page.complete = true as 'no older messages'", () => {
+    const result = cursorFromLatestPage({
+      page: { firstArchiveId: "arch-001", complete: true, messages: [{ id: "m1" }] },
+      pageSize: 100,
+    });
+    expect(result.hasOlderMessages).toBe(false);
+  });
+
+  test("missing firstArchiveId disables older-paging even when not complete", () => {
+    const result = cursorFromLatestPage({
+      page: { complete: false, messages: [{ id: "m1" }] },
+      pageSize: 100,
+    });
+    expect(result).toEqual({ oldestArchiveId: null, hasOlderMessages: false });
+  });
+});
+
+describe("cursorFromLatestPage — legacy non-RSM client (page is null)", () => {
+  test("falls back to the first message id and uses a full-page heuristic", () => {
+    const messages = Array.from({ length: 100 }, (_, i) => ({ id: `m${i}` }));
+    const result = cursorFromLatestPage({ page: null, pageSize: 100 });
+    // No page → no id available without messages context; the helper accepts
+    // mamResults as a separate argument when the legacy path is used.
+    expect(result).toEqual({ oldestArchiveId: null, hasOlderMessages: false });
+    void messages; // ensure the array is constructed for the next assertion
+  });
+
+  test("legacy path with messages: oldest id derived from messages[0].id; hasOlder = messages.length >= pageSize", () => {
+    const messages = Array.from({ length: 100 }, (_, i) => ({ id: `m${i}` }));
+    const result = cursorFromLatestPage({ page: null, pageSize: 100, fallbackMessages: messages });
+    expect(result.oldestArchiveId).toBe("m0");
+    expect(result.hasOlderMessages).toBe(true);
+  });
+
+  test("legacy path with messages.length < pageSize → hasOlder false", () => {
+    const messages = [{ id: "m0" }, { id: "m1" }, { id: "m2" }];
+    const result = cursorFromLatestPage({ page: null, pageSize: 100, fallbackMessages: messages });
+    expect(result.oldestArchiveId).toBe("m0");
+    expect(result.hasOlderMessages).toBe(false);
+  });
+});
+
+describe("advanceCursorWithBeforePage", () => {
+  test("advances cursor and reports not-stalled when firstArchiveId moves", () => {
+    const result = advanceCursorWithBeforePage({
+      prior: { oldestArchiveId: "arch-005", hasOlderMessages: true },
+      page: { firstArchiveId: "arch-001", complete: false },
+    });
+    expect(result.next.oldestArchiveId).toBe("arch-001");
+    expect(result.next.hasOlderMessages).toBe(true);
+    expect(result.stalled).toBe(false);
+  });
+
+  test("page.complete = true ends paging", () => {
+    const result = advanceCursorWithBeforePage({
+      prior: { oldestArchiveId: "arch-005", hasOlderMessages: true },
+      page: { firstArchiveId: "arch-001", complete: true },
+    });
+    expect(result.next.hasOlderMessages).toBe(false);
+  });
+
+  test("server returns the same firstArchiveId as the prior cursor → stalled, hasOlder=false", () => {
+    const result = advanceCursorWithBeforePage({
+      prior: { oldestArchiveId: "arch-005", hasOlderMessages: true },
+      page: { firstArchiveId: "arch-005", complete: false },
+    });
+    expect(result.stalled).toBe(true);
+    expect(result.next.hasOlderMessages).toBe(false);
+  });
+
+  test("missing firstArchiveId keeps prior cursor and ends paging", () => {
+    const result = advanceCursorWithBeforePage({
+      prior: { oldestArchiveId: "arch-005", hasOlderMessages: true },
+      page: { complete: false },
+    });
+    expect(result.next.oldestArchiveId).toBe("arch-005");
+    expect(result.next.hasOlderMessages).toBe(false);
+    expect(result.stalled).toBe(true);
+  });
+});
+
+describe("threadCursorFromLatestPage", () => {
+  test("RSM-aware: uses firstArchiveId and inverted complete", () => {
+    const result = threadCursorFromLatestPage({
+      page: { firstArchiveId: "arch-t-001", complete: false, messages: [{ id: "tm1" }] },
+      pageSize: 100,
+    });
+    expect(result).toEqual({ oldestId: "arch-t-001", hasOlder: true });
+  });
+
+  test("legacy fallback: full-page heuristic", () => {
+    const result = threadCursorFromLatestPage({
+      page: null,
+      pageSize: 100,
+      fallbackMessages: Array.from({ length: 100 }, (_, i) => ({ id: `tm${i}` })),
+    });
+    expect(result.hasOlder).toBe(true);
+  });
+
+  test("legacy fallback: partial page → no older", () => {
+    const result = threadCursorFromLatestPage({
+      page: null,
+      pageSize: 100,
+      fallbackMessages: [{ id: "tm0" }],
+    });
+    expect(result.hasOlder).toBe(false);
+  });
+
+  test("empty result with no page → cursor undefined, hasOlder false", () => {
+    const result = threadCursorFromLatestPage({ page: null, pageSize: 100 });
+    expect(result).toEqual({ oldestId: undefined, hasOlder: false });
+  });
+});
+
+describe("advanceThreadCursor", () => {
+  test("happy path advances oldestId, keeps hasOlder true", () => {
+    const result = advanceThreadCursor({
+      prior: { oldestId: "t-005" },
+      page: { firstArchiveId: "t-001", complete: false },
+    });
+    expect(result.oldestId).toBe("t-001");
+    expect(result.hasOlder).toBe(true);
+  });
+
+  test("stalled when firstArchiveId equals prior oldestId", () => {
+    const result = advanceThreadCursor({
+      prior: { oldestId: "t-005" },
+      page: { firstArchiveId: "t-005", complete: false },
+    });
+    expect(result.hasOlder).toBe(false);
+  });
+
+  test("page.complete = true ends paging", () => {
+    const result = advanceThreadCursor({
+      prior: { oldestId: "t-005" },
+      page: { firstArchiveId: "t-001", complete: true },
+    });
+    expect(result.hasOlder).toBe(false);
+  });
+});
+
+describe("stripQueuedSelfMessages", () => {
+  test("filters self+queued; keeps everything else", () => {
+    const timeline = [
+      { id: "a", isSelf: true, deliveryStatus: "queued" },
+      { id: "b", isSelf: true, deliveryStatus: "sent" },
+      { id: "c", isSelf: false, deliveryStatus: "queued" },
+      { id: "d", isSelf: false },
+    ];
+    const result = stripQueuedSelfMessages(timeline);
+    expect(result.map((m) => m.id)).toEqual(["b", "c", "d"]);
+  });
+
+  test("empty timeline returns empty", () => {
+    expect(stripQueuedSelfMessages([])).toEqual([]);
+  });
+});
+
+describe("MamCursorNotFoundError + classifyMamError (XEP-0313 §4.3.4)", () => {
+  test("recognises stanza-error with condition='item-not-found'", () => {
+    const raw = { condition: "item-not-found", cursor: "arch-stale" };
+    const classified = classifyMamError(raw);
+    expect(classified).toBeInstanceOf(MamCursorNotFoundError);
+    if (isMamCursorNotFound(classified)) {
+      expect(classified.cursor).toBe("arch-stale");
+    }
+  });
+
+  test("recognises wasm-style error with code='item-not-found'", () => {
+    const raw = { code: "item-not-found", cursor: "arch-also-stale" };
+    const classified = classifyMamError(raw);
+    expect(isMamCursorNotFound(classified)).toBe(true);
+  });
+
+  test("passes through unrelated errors unchanged", () => {
+    const raw = new Error("network down");
+    const classified = classifyMamError(raw);
+    expect(classified).toBe(raw);
+    expect(isMamCursorNotFound(classified)).toBe(false);
+  });
+
+  test("isMamCursorNotFound is false for null/undefined/strings", () => {
+    expect(isMamCursorNotFound(null)).toBe(false);
+    expect(isMamCursorNotFound(undefined)).toBe(false);
+    expect(isMamCursorNotFound("item-not-found")).toBe(false);
+  });
+});

--- a/chat/tests/mam-paging.test.ts
+++ b/chat/tests/mam-paging.test.ts
@@ -170,9 +170,9 @@ describe("advanceThreadCursor", () => {
 describe("stripQueuedSelfMessages", () => {
   test("filters self+queued; keeps everything else", () => {
     const timeline = [
-      { id: "a", isSelf: true, deliveryStatus: "queued" },
-      { id: "b", isSelf: true, deliveryStatus: "sent" },
-      { id: "c", isSelf: false, deliveryStatus: "queued" },
+      { id: "a", isSelf: true, deliveryStatus: "queued" as const },
+      { id: "b", isSelf: true, deliveryStatus: "delivered" as const },
+      { id: "c", isSelf: false, deliveryStatus: "queued" as const },
       { id: "d", isSelf: false },
     ];
     const result = stripQueuedSelfMessages(timeline);
@@ -200,6 +200,20 @@ describe("MamCursorNotFoundError + classifyMamError (XEP-0313 §4.3.4)", () => {
     expect(isMamCursorNotFound(classified)).toBe(true);
   });
 
+  test("recognises plain-string errors carrying 'item-not-found' (current wasm shape)", () => {
+    // The waddle wasm client surfaces stanza errors via JsValue::from_str,
+    // not as structured objects. Match by substring so §4.3.4 recovery
+    // fires even before the wasm layer learns to emit structured errors.
+    const classified = classifyMamError("MAM query failed: item-not-found");
+    expect(isMamCursorNotFound(classified)).toBe(true);
+  });
+
+  test("recognises Error instances whose message contains 'item-not-found'", () => {
+    const raw = new Error("stanza error: item-not-found");
+    const classified = classifyMamError(raw);
+    expect(isMamCursorNotFound(classified)).toBe(true);
+  });
+
   test("passes through unrelated errors unchanged", () => {
     const raw = new Error("network down");
     const classified = classifyMamError(raw);
@@ -207,7 +221,12 @@ describe("MamCursorNotFoundError + classifyMamError (XEP-0313 §4.3.4)", () => {
     expect(isMamCursorNotFound(classified)).toBe(false);
   });
 
-  test("isMamCursorNotFound is false for null/undefined/strings", () => {
+  test("passes through plain strings without the marker unchanged", () => {
+    const raw = "permission denied";
+    expect(classifyMamError(raw)).toBe(raw);
+  });
+
+  test("isMamCursorNotFound is false for null/undefined/non-marker strings", () => {
     expect(isMamCursorNotFound(null)).toBe(false);
     expect(isMamCursorNotFound(undefined)).toBe(false);
     expect(isMamCursorNotFound("item-not-found")).toBe(false);

--- a/chat/tests/mam-paging.test.ts
+++ b/chat/tests/mam-paging.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   INITIAL_CURSOR,
+  MAM_UNKNOWN_CURSOR,
   advanceCursorWithBeforePage,
   advanceThreadCursor,
   classifyMamError,
@@ -206,12 +207,20 @@ describe("MamCursorNotFoundError + classifyMamError (XEP-0313 §4.3.4)", () => {
     // fires even before the wasm layer learns to emit structured errors.
     const classified = classifyMamError("MAM query failed: item-not-found");
     expect(isMamCursorNotFound(classified)).toBe(true);
+    // No cursor extractable from the raw string — sentinel keeps logs
+    // distinguishable from a real empty-cursor case.
+    if (isMamCursorNotFound(classified)) {
+      expect(classified.cursor).toBe(MAM_UNKNOWN_CURSOR);
+    }
   });
 
   test("recognises Error instances whose message contains 'item-not-found'", () => {
     const raw = new Error("stanza error: item-not-found");
     const classified = classifyMamError(raw);
     expect(isMamCursorNotFound(classified)).toBe(true);
+    if (isMamCursorNotFound(classified)) {
+      expect(classified.cursor).toBe(MAM_UNKNOWN_CURSOR);
+    }
   });
 
   test("passes through unrelated errors unchanged", () => {


### PR DESCRIPTION
## Summary

PR 1 of 7. Extract MAM paging (XEP-0313) state and load functions out of `channels/messages.ts` and `dms/messages.ts` into focused composables backed by pure helpers.

Refs: #351 — see the full implementation plan there.

## What lands

- **`chat/src/lib/xmpp/mam-paging.ts`** (new, pure) — RSM cursor advancement, page-bounds math, and page-merge data shaping. Both MUC archive (room-side) and user-archive (`with=` filter) use the same helpers.
- **`chat/tests/mam-paging.test.ts`** (new) — TDD red-green-refactor coverage for the pure helpers.
- **`chat/src/channels/mam-paging.ts`** (new) — `useChannelMamPaging` composable. Owns `isLoadingMessages`, `isLoadingOlderMessages`, `hasOlderMessages`, `loadingOlderThreadIds`, `threadHasOlder`, `oldestArchiveId`, `oldestThreadArchiveIds`. Exposes `loadMessages`, `loadOlderMessages`, `ensureMessageLoaded`, `backfillThread`, `loadOlderThreadMessages`.
- **`chat/src/dms/mam-paging.ts`** (new) — `useDmMamPaging`. Mirrors the channel side minus thread paging.
- **`chat/src/channels/messages.ts`** + **`chat/src/dms/messages.ts`** — orchestrators wire the new composables; MAM paging code removed (~250 LOC per side).

## XEP conformance (verified)

- §4 + §4.3 of XEP-0313: RSM `<set/>` cursor (`<before/>` empty = last page; `<after id=…/>` = next; `<before id=…/>` = previous). Pure helpers encode this directly.
- §4.3.4 gotcha: **stale UID returns `item-not-found`**. Pure helper surfaces this as a distinct error variant; composable handles by resetting cursor and retrying the tail page, instead of treating empty payload as "no more history." This is one of the three caveats elevated to PR-level acceptance criteria in #351's plan.

## Test strategy

- Pure helpers: red-green-refactor TDD with one `.test.ts` file (`chat/tests/mam-paging.test.ts`).
- Composables: ride on existing integration tests (`channel-unread`, `tombstone-replay`, `reconnect-catchup`, `inbound-references`) — no new composable unit tests.
- Gate: `cd chat && bun test && bun run lint` green.

## Acceptance criteria

- [ ] `channels/messages.ts` MAM-paging code lifted; orchestrator becomes a wiring surface for paging.
- [ ] `dms/messages.ts` mirrors.
- [ ] Pure helpers test green (red-green-refactor on `mam-paging.test.ts`).
- [ ] `item-not-found` handled distinctly from empty pages (XEP-0313 §4.3.4).
- [ ] Existing integration tests pass unchanged.
- [ ] `cd chat && bun test && bun run lint` clean (no knip findings).
- [ ] Call sites of `useChannelMessages` / `useDmMessages` remain stable.

## Plan checkpoint

Sequential off `main`. After this merges, PR 2 (send-flow) branches off the new `main`. PR 6 (lightbox) floats — independent.
