### PR TITLE
fix(server): accept empty provider webhook strings

### DIFF
--- a/server/crates/waddle-extensions/src/types/primitives.rs
+++ b/server/crates/waddle-extensions/src/types/primitives.rs
@@ -14,7 +14,6 @@ typed_non_empty_string!(ProviderDeliveryId, "provider delivery id");
 typed_non_empty_string!(ProviderEventType, "provider event type");
 typed_non_empty_string!(ProviderFieldName, "provider field name");
 typed_non_empty_string!(ProviderFieldNumber, "provider field number");
-typed_non_empty_string!(ProviderFieldText, "provider field text");
 typed_non_empty_string!(ProviderId, "provider id");
 typed_non_empty_string!(PubSubItemId, "pubsub item id");
 typed_non_empty_string!(PubSubNode, "pubsub node");
@@ -26,6 +25,35 @@ typed_non_empty_string!(UiActionId, "ui action id");
 typed_non_empty_string!(UiViewId, "ui view id");
 typed_non_empty_string!(Url, "url");
 typed_non_empty_string!(WaddleId, "waddle id");
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ProviderFieldText(String);
+
+impl ProviderFieldText {
+    pub fn new(value: impl Into<String>) -> Result<Self, FrameworkTypeError> {
+        Ok(Self(value.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for ProviderFieldText {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for ProviderFieldText {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RoomJid(String);

--- a/server/crates/waddle-extensions/src/types/tests.rs
+++ b/server/crates/waddle-extensions/src/types/tests.rs
@@ -62,6 +62,14 @@ fn pubsub_node_declaration_does_not_grant_prefix_or_sibling_nodes() {
 }
 
 #[test]
+fn provider_field_text_preserves_empty_strings() {
+    let text = ProviderFieldText::new("").expect("empty provider text is valid");
+
+    assert_eq!(text.as_str(), "");
+    assert_eq!(text.into_string(), "");
+}
+
+#[test]
 fn pubsub_publish_accepts_framework_extension_item_without_manifest_payload_rule() {
     let manifest = ExtensionManifest {
         id: PluginId::new("test-extension").expect("plugin id"),

--- a/server/crates/waddle-server/src/server/routes/extension_webhooks.rs
+++ b/server/crates/waddle-server/src/server/routes/extension_webhooks.rs
@@ -631,7 +631,7 @@ mod tests {
         let payload = br#"{
             "action": "completed",
             "subject": {"id": 100, "name": "example"},
-            "event": {"status": "failure", "attempt": 2}
+            "event": {"status": "failure", "attempt": 2, "description": ""}
         }"#;
 
         let parsed = parse_provider_payload(payload).expect("payload");
@@ -660,6 +660,10 @@ mod tests {
         assert!(fields.iter().any(|(path, value)| {
             path == "event.status"
                 && matches!(value, ProviderFieldValue::Text(text) if text.as_str() == "failure")
+        }));
+        assert!(fields.iter().any(|(path, value)| {
+            path == "event.description"
+                && matches!(value, ProviderFieldValue::Text(text) if text.as_str().is_empty())
         }));
     }
 


### PR DESCRIPTION
## Plan

- Allow provider webhook string payload values to preserve empty strings instead of rejecting the whole delivery.
- Add a regression test that flattens a GitHub-like JSON payload containing an empty string.
- Run focused Rust tests for extension types and provider webhook payload parsing.
- After merge, monitor CI and the waddle production rollout again.