### PR TITLE
refactor(chat): extract send-flow into muc-send / chat-send composables

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -62,6 +62,7 @@ import {
   removeSenderReactions,
 } from "@/channels/message-timeline-state";
 import { useChannelMamPaging } from "@/channels/mam-paging";
+import { useMucSend } from "@/channels/muc-send";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -85,7 +86,6 @@ export function useChannelMessages(
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
   const forumPostTitle = ref("");
-  const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
   const pinnedEdgeScroller = createPinnedEdgeScroller({
@@ -98,7 +98,6 @@ export function useChannelMessages(
   const roomPresence = ref<RoomPresence>({});
   const roomLastSeen = ref<Record<string, number>>({});
   const slowModeCooldown = ref(0);
-  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const firstUnseenId = ref<string | null>(null);
   const latestRemoteMessageId = computed<string | null>(() => {
     for (let i = messages.value.length - 1; i >= 0; i--) {
@@ -121,12 +120,6 @@ export function useChannelMessages(
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  // Client-assigned stanza ids still awaiting MUC-echo reconciliation. A self
-  // echo with a server-rewritten id falls back to body matching, but only
-  // against messages in this set — otherwise sending the same text twice
-  // would cause the second echo to rewrite the first (already reconciled)
-  // message's id.
-  const pendingEchoClientIds = new Set<string>();
 
   const currentRoomJid = computed(() => {
     if (!session.value || !activeChannelId.value) return null;
@@ -586,42 +579,6 @@ export function useChannelMessages(
   }
 
   /**
-   * XEP-0198: server acked our outbound stanza. The id here is the
-   * client-assigned stanza ID. Promote the matching optimistic entry to
-   * "delivered" even if the MUC self-echo hasn't arrived yet (the echo
-   * will later reconcile the ID through mergeLiveMessage).
-   */
-  function onMessageAck(messageId: string) {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: "delivered" as DeliveryStatus }
-        : m,
-    );
-  }
-
-  function onMessageQueueStatus(messageId: string, status: "queued" | "sending") {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: status as DeliveryStatus }
-        : m,
-    );
-  }
-
-  /**
-   * XEP-0198: the XMPP client gave up on the stanza (resume failed or no
-   * resumable transport). Mark the message as failed so the UI can
-   * surface a retry affordance. Kept in place so the user can see what
-   * did not go through.
-   */
-  function onMessageDeliveryFailure(messageId: string) {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: "failed" as DeliveryStatus }
-        : m,
-    );
-  }
-
-  /**
    * On a fresh XMPP session (resume failed or first connect after a drop),
    * refetch MAM to close any message gap for the current channel. Local
    * optimistic sends (sending/failed) are preserved across the reload so
@@ -662,6 +619,49 @@ export function useChannelMessages(
   // threadId that isn't their own id) are hidden, so the last-seen anchor
   // and the "New messages" divider must be computed against this predicate.
   const isFeedVisible = isFeedTimelineMessage;
+
+  const send = useMucSend({
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentChannel,
+    currentRoomJid,
+    messages,
+    draft,
+    forumPostTitle,
+    actionError,
+    clearActionError,
+    normalizeError,
+    ...(mentionJidsByNick ? { mentionJidsByNick } : {}),
+    scrollToPinnedEdgeAndPin,
+    // Chat-state cleanup on successful send — composingTimeout/lastChatState
+    // are still orchestrator-owned in PR 2; they move into useChannelChatStates
+    // in PR 5. Until then the callback keeps useMucSend free of chat-state
+    // concerns.
+    onSendComplete: (result, spaceId, channelId, isStillCurrentChannel) => {
+      if (isStillCurrentChannel) {
+        if (composingTimeout) {
+          clearTimeout(composingTimeout);
+          composingTimeout = null;
+        }
+        lastChatState = "active";
+      }
+      if (result?.state === "sending" && xmppClient.value) {
+        void xmppClient.value.sendChatState(spaceId, channelId, "active").catch(() => undefined);
+      }
+    },
+  });
+  const {
+    isSending,
+    uploadProgress,
+    pendingEchoClientIds,
+    sendMessage,
+    editMessage,
+    onMessageAck,
+    onMessageQueueStatus,
+    onMessageDeliveryFailure,
+  } = send;
 
   const paging = useChannelMamPaging({
     session,
@@ -716,184 +716,6 @@ export function useChannelMessages(
     messages.value = [];
     clearTypingState();
     await loadMessages(activeSpaceId.value ?? "", channelId);
-  }
-
-  async function sendMessage(
-    body?: string,
-    markup?: MarkupSpan[],
-    references?: MessageReference[],
-    files?: Array<File | Blob>,
-    replyTo?: { id: string; author: string; body?: string },
-    forumTitleOrThreadOverride?: string | { threadId: string; parentThreadId?: string },
-  ) {
-    const bodyText = body ?? draft.value;
-    // markup !== undefined means this came from the rich editor (composer send)
-    // undefined means it came from a programmatic send (GIF, etc.)
-    const fromComposer = markup !== undefined;
-    const threadOverride = typeof forumTitleOrThreadOverride === "string"
-      ? undefined
-      : forumTitleOrThreadOverride;
-    const forumTitle = typeof forumTitleOrThreadOverride === "string"
-      ? forumTitleOrThreadOverride
-      : undefined;
-    const client = xmppClient.value;
-    const spaceId = activeSpaceId.value ?? "";
-    const channelId = activeChannelId.value;
-    const hasFiles = !!files && files.length > 0;
-    const isForumPost = channelIsForum.value && !replyTo;
-    const resolvedForumTitle = (forumTitle ?? forumPostTitle.value).trim();
-    const hasThreadMetadataIntent = !!threadOverride?.threadId.trim();
-    const hasForumMetadataIntent = (isForumPost && !!resolvedForumTitle) || (channelIsForum.value && !!replyTo);
-    if (!client || !channelId) return;
-    if (!bodyText.trim() && !hasFiles && !hasThreadMetadataIntent && !hasForumMetadataIntent) return;
-    if (isForumPost && !resolvedForumTitle) {
-      actionError.value = "Add a title before posting to this forum.";
-      return;
-    }
-
-    if (hasFiles) {
-      for (const f of files!) {
-        if (f.size > MAX_FILE_UPLOAD_BYTES) {
-          actionError.value = `File too large (${(f.size / 1024 / 1024).toFixed(1)} MB). Maximum upload size is 10 MB.`;
-          return;
-        }
-      }
-    }
-
-    isSending.value = true;
-    clearActionError();
-
-    try {
-      let attachments: OutboundFileAttachment[] | undefined;
-      if (hasFiles) {
-        const filenames = files!.map((f) => (f instanceof File ? f.name : `attachment-${Date.now()}.bin`));
-        uploadProgress.value = { uploading: true, progress: 0, filename: filenames[0] };
-        attachments = await client.uploadAttachments(files!, (overall, idx) => {
-          uploadProgress.value = {
-            uploading: true,
-            progress: overall.total > 0 ? overall.loaded / overall.total : 0,
-            filename: filenames[idx] ?? "",
-          };
-        });
-      }
-
-      const parent = replyTo ? findMessageById(messages.value, replyTo.id) : undefined;
-      // XEP-0461 §3.2: groupchat replies MUST quote the room-assigned
-      // XEP-0359 stanza-id. Without one, "messages without one cannot be
-      // replied to"; refuse the send rather than leak a non-conformant id.
-      if (replyTo && parent && !parent.replyableId) {
-        actionError.value =
-          "This message can't be replied to (no room stanza-id). Try reloading the channel.";
-        isSending.value = false;
-        return;
-      }
-      const wireReplyTo = replyTo && parent && parent.replyableId
-        ? {
-            id: parent.replyableId,
-            author: parent.authorOccupantJid ?? parent.authorJid ?? replyTo.author,
-            ...(replyTo.body ? { body: replyTo.body } : {}),
-          }
-        : undefined;
-      // Thread membership is explicit via threadOverride, except forum replies,
-      // which derive their thread from the replied-to topic/message.
-      const threadId = threadOverride?.threadId
-        ?? (channelIsForum.value && parent ? (parent.threadId ?? parent.id) : undefined);
-      const parentThreadId = threadOverride?.parentThreadId;
-      const threadCreate = isForumPost ? { title: resolvedForumTitle } : undefined;
-      const threadReply = channelIsForum.value && replyTo && threadId
-        ? { threadId }
-        : undefined;
-      const result = await client.sendGroupMessage(spaceId, channelId, bodyText, {
-        markup,
-        references,
-        files: attachments,
-        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
-        ...(threadId ? { threadId } : {}),
-        ...(parentThreadId ? { parentThreadId } : {}),
-        ...(threadCreate ? { threadCreate } : {}),
-        ...(threadReply ? { threadReply } : {}),
-        ...(mentionJidsByNick ? { mentionJidsByNick: mentionJidsByNick.value } : {}),
-      });
-      const msgId = result?.id ?? null;
-      const isStillCurrentChannel =
-        xmppClient.value === client &&
-        (activeSpaceId.value ?? "") === spaceId &&
-        activeChannelId.value === channelId;
-
-      if (msgId && session.value && isStillCurrentChannel) {
-        // Optimistic insert: show message immediately with "sending" status
-        const optimistic: TimelineMessage = {
-          id: msgId,
-          correctionTargetId: msgId,
-          author: session.value.username,
-          authorJid: `${currentRoomJid.value}/${session.value.username}`,
-          body: bodyText || (attachments?.[0]?.url ?? ""),
-          createdAt: new Date().toISOString(),
-          isSelf: true,
-          deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
-          ...(markup && markup.length > 0 ? { markup } : {}),
-          ...(references && references.length > 0 ? { references } : {}),
-        };
-        if (replyTo && parent && parent.replyableId) {
-          // Mirror the wire reply id on the optimistic insert so the local
-          // chip and the eventual MAM round-trip resolve to the same id.
-          optimistic.replyTo = {
-            id: parent.replyableId,
-            author: replyTo.author,
-            ...(replyTo.body ? { preview: replyTo.body } : {}),
-          };
-        }
-        if (threadId) optimistic.threadId = threadId;
-        if (parentThreadId) optimistic.parentThreadId = parentThreadId;
-        if (threadCreate) {
-          optimistic.threadId = msgId;
-          optimistic.forumPostKind = "topic";
-          optimistic.forumTitle = threadCreate.title;
-          optimistic.forumThreadTitle = threadCreate.title;
-        } else if (threadReply) {
-          optimistic.forumPostKind = "reply";
-          const threadTitle = parent?.forumTitle ?? parent?.forumThreadTitle;
-          if (threadTitle) optimistic.forumThreadTitle = threadTitle;
-        }
-        if (attachments && attachments.length > 0) {
-          optimistic.sharedFiles = attachments.map((a) => ({
-            url: a.url,
-            name: a.name,
-            mediaType: a.mediaType,
-            size: a.size,
-            ...(a.width ? { width: a.width } : {}),
-            ...(a.height ? { height: a.height } : {}),
-            disposition: inferredFileDisposition(a.mediaType, a.name ?? a.url),
-            ...(a.encrypted ? { encrypted: a.encrypted } : {}),
-          }));
-        }
-        pendingEchoClientIds.add(msgId);
-        messages.value = applyForumContext([...messages.value, optimistic]);
-        void scrollToPinnedEdgeAndPin();
-      }
-
-      // Clear draft on successful send (triggers ChatEditor clear via watcher)
-      if (fromComposer && isStillCurrentChannel) {
-        draft.value = "";
-        if (threadCreate) forumPostTitle.value = "";
-      }
-      // Send "active" state after sending a message (stops composing indicator)
-      if (isStillCurrentChannel) {
-        if (composingTimeout) {
-          clearTimeout(composingTimeout);
-          composingTimeout = null;
-        }
-        lastChatState = "active";
-      }
-      if (result?.state === "sending") {
-        void client.sendChatState(spaceId, channelId, "active").catch(() => undefined);
-      }
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    } finally {
-      isSending.value = false;
-      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
-    }
   }
 
   async function toggleReaction(messageId: string, emoji: string) {
@@ -1002,28 +824,6 @@ export function useChannelMessages(
     } catch (e) {
       actionError.value = normalizeError(e);
       throw e;
-    }
-  }
-
-  async function editMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {
-    if (!xmppClient.value || !activeChannelId.value || !newBody.trim())
-      return;
-    const message = findMessageById(messages.value, messageId);
-    const targetId = message?.correctionTargetId ?? messageId;
-
-    clearActionError();
-
-    try {
-      await xmppClient.value.sendCorrection(
-        activeSpaceId.value ?? "",
-        activeChannelId.value,
-        newBody,
-        targetId,
-        markup,
-        references,
-      );
-    } catch (e) {
-      actionError.value = normalizeError(e);
     }
   }
 

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -640,13 +640,18 @@ export function useChannelMessages(
     // in PR 5. Until then the callback keeps useMucSend free of chat-state
     // concerns.
     onSendComplete: (result, spaceId, channelId, isStillCurrentChannel) => {
-      if (isStillCurrentChannel) {
-        if (composingTimeout) {
-          clearTimeout(composingTimeout);
-          composingTimeout = null;
-        }
-        lastChatState = "active";
+      if (!isStillCurrentChannel) {
+        // Client swap or channel change happened during the send. Don't
+        // emit XEP-0085 "active" through the new session targeting the
+        // old room — and skip the composing-timer cleanup since it
+        // belonged to the prior session.
+        return;
       }
+      if (composingTimeout) {
+        clearTimeout(composingTimeout);
+        composingTimeout = null;
+      }
+      lastChatState = "active";
       if (result?.state === "sending" && xmppClient.value) {
         void xmppClient.value.sendChatState(spaceId, channelId, "active").catch(() => undefined);
       }

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -1,7 +1,6 @@
 import { ref, computed, nextTick, watch, type Ref } from "vue";
 import { useStore } from "@nanostores/vue";
 import type { ChannelSummary } from "@/lib/chat-types";
-import { isForumChannel } from "@/lib/channel-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
   BrowserXmppClient,
@@ -19,15 +18,12 @@ import { applyPinEvent } from "@/stores/pinned-messages";
 import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
-  inferredFileDisposition,
   type DeliveryStatus,
   type ExtensionAnnotationAction,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
 } from "@/lib/chat-ui";
-import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
-import type { OutboundFileAttachment } from "@/lib/xmpp";
 import {
   findMessageById,
   matchMessageId,
@@ -128,7 +124,6 @@ export function useChannelMessages(
   const activeTimelineRoomJid = computed(() =>
     isChannelTimelineActive.value ? currentRoomJid.value : null
   );
-  const channelIsForum = computed(() => isForumChannel(currentChannel.value));
 
   function roomJidForChannel(channelId: string): string | null {
     const currentSession = session.value;

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -1,0 +1,294 @@
+import { ref, type Ref } from "vue";
+import type { ChannelSummary } from "@/lib/chat-types";
+import { isForumChannel } from "@/lib/channel-types";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
+import type { OutboundFileAttachment } from "@/lib/xmpp";
+import {
+  inferredFileDisposition,
+  type DeliveryStatus,
+  type MarkupSpan,
+  type MessageReference,
+  type TimelineMessage,
+} from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import { applyForumContext } from "@/channels/timeline";
+import { applyDeliveryEventById } from "@/lib/timeline-state";
+
+type UseMucSendDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activeSpaceId: Ref<string | null>;
+  activeChannelId: Ref<string | null>;
+  currentChannel: Ref<ChannelSummary | null>;
+  currentRoomJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+  draft: Ref<string>;
+  forumPostTitle: Ref<string>;
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  normalizeError: (e: unknown) => string;
+  mentionJidsByNick?: Ref<Record<string, string>>;
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  // Side-effect hook the orchestrator runs after a successful send — used
+  // to clear chat-state debounce timers and mark XEP-0085 state as "active"
+  // again. Keeps PR 2 free of chat-states ownership (extracted in PR 5).
+  onSendComplete: (
+    result: { state?: string } | null,
+    spaceId: string,
+    channelId: string,
+    isStillCurrentChannel: boolean,
+  ) => void;
+};
+
+export function useMucSend(deps: UseMucSendDeps) {
+  const {
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentChannel,
+    currentRoomJid,
+    messages,
+    draft,
+    forumPostTitle,
+    actionError,
+    clearActionError,
+    normalizeError,
+    mentionJidsByNick,
+    scrollToPinnedEdgeAndPin,
+    onSendComplete,
+  } = deps;
+
+  const isSending = ref(false);
+  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
+
+  // Client-assigned stanza ids still awaiting MUC-echo reconciliation (XEP-0045
+  // §8.5 + XEP-0359 stable-id reflection). The live-merge composable (PR 4)
+  // reads this set to body-match an unrecognised self-echo against pending
+  // sends, so two identical bodies in flight don't retarget each other.
+  const pendingEchoClientIds = new Set<string>();
+
+  async function sendMessage(
+    body?: string,
+    markup?: MarkupSpan[],
+    references?: MessageReference[],
+    files?: Array<File | Blob>,
+    replyTo?: { id: string; author: string; body?: string },
+    forumTitleOrThreadOverride?: string | { threadId: string; parentThreadId?: string },
+  ) {
+    const bodyText = body ?? draft.value;
+    // markup !== undefined means this came from the rich editor (composer send)
+    // undefined means it came from a programmatic send (GIF, etc.)
+    const fromComposer = markup !== undefined;
+    const threadOverride = typeof forumTitleOrThreadOverride === "string"
+      ? undefined
+      : forumTitleOrThreadOverride;
+    const forumTitle = typeof forumTitleOrThreadOverride === "string"
+      ? forumTitleOrThreadOverride
+      : undefined;
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value ?? "";
+    const channelId = activeChannelId.value;
+    const channelIsForum = isForumChannel(currentChannel.value);
+    const hasFiles = !!files && files.length > 0;
+    const isForumPost = channelIsForum && !replyTo;
+    const resolvedForumTitle = (forumTitle ?? forumPostTitle.value).trim();
+    const hasThreadMetadataIntent = !!threadOverride?.threadId.trim();
+    const hasForumMetadataIntent = (isForumPost && !!resolvedForumTitle) || (channelIsForum && !!replyTo);
+    if (!client || !channelId) return;
+    if (!bodyText.trim() && !hasFiles && !hasThreadMetadataIntent && !hasForumMetadataIntent) return;
+    if (isForumPost && !resolvedForumTitle) {
+      actionError.value = "Add a title before posting to this forum.";
+      return;
+    }
+
+    if (hasFiles) {
+      for (const f of files!) {
+        if (f.size > MAX_FILE_UPLOAD_BYTES) {
+          actionError.value = `File too large (${(f.size / 1024 / 1024).toFixed(1)} MB). Maximum upload size is 10 MB.`;
+          return;
+        }
+      }
+    }
+
+    isSending.value = true;
+    clearActionError();
+
+    try {
+      let attachments: OutboundFileAttachment[] | undefined;
+      if (hasFiles) {
+        const filenames = files!.map((f) => (f instanceof File ? f.name : `attachment-${Date.now()}.bin`));
+        uploadProgress.value = { uploading: true, progress: 0, filename: filenames[0] };
+        attachments = await client.uploadAttachments(files!, (overall, idx) => {
+          uploadProgress.value = {
+            uploading: true,
+            progress: overall.total > 0 ? overall.loaded / overall.total : 0,
+            filename: filenames[idx] ?? "",
+          };
+        });
+      }
+
+      const parent = replyTo ? findMessageById(messages.value, replyTo.id) : undefined;
+      // XEP-0461 §3.2: groupchat replies MUST quote the room-assigned
+      // XEP-0359 stanza-id. Without one, "messages without one cannot be
+      // replied to"; refuse the send rather than leak a non-conformant id.
+      if (replyTo && parent && !parent.replyableId) {
+        actionError.value =
+          "This message can't be replied to (no room stanza-id). Try reloading the channel.";
+        isSending.value = false;
+        return;
+      }
+      const wireReplyTo = replyTo && parent && parent.replyableId
+        ? {
+            id: parent.replyableId,
+            author: parent.authorOccupantJid ?? parent.authorJid ?? replyTo.author,
+            ...(replyTo.body ? { body: replyTo.body } : {}),
+          }
+        : undefined;
+      // Thread membership is explicit via threadOverride, except forum replies,
+      // which derive their thread from the replied-to topic/message.
+      const threadId = threadOverride?.threadId
+        ?? (channelIsForum && parent ? (parent.threadId ?? parent.id) : undefined);
+      const parentThreadId = threadOverride?.parentThreadId;
+      const threadCreate = isForumPost ? { title: resolvedForumTitle } : undefined;
+      const threadReply = channelIsForum && replyTo && threadId
+        ? { threadId }
+        : undefined;
+      const result = await client.sendGroupMessage(spaceId, channelId, bodyText, {
+        markup,
+        references,
+        files: attachments,
+        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
+        ...(threadId ? { threadId } : {}),
+        ...(parentThreadId ? { parentThreadId } : {}),
+        ...(threadCreate ? { threadCreate } : {}),
+        ...(threadReply ? { threadReply } : {}),
+        ...(mentionJidsByNick ? { mentionJidsByNick: mentionJidsByNick.value } : {}),
+      });
+      const msgId = result?.id ?? null;
+      const isStillCurrentChannel =
+        xmppClient.value === client &&
+        (activeSpaceId.value ?? "") === spaceId &&
+        activeChannelId.value === channelId;
+
+      if (msgId && session.value && isStillCurrentChannel) {
+        // Optimistic insert: show message immediately with "sending" status
+        const optimistic: TimelineMessage = {
+          id: msgId,
+          correctionTargetId: msgId,
+          author: session.value.username,
+          authorJid: `${currentRoomJid.value}/${session.value.username}`,
+          body: bodyText || (attachments?.[0]?.url ?? ""),
+          createdAt: new Date().toISOString(),
+          isSelf: true,
+          deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
+          ...(markup && markup.length > 0 ? { markup } : {}),
+          ...(references && references.length > 0 ? { references } : {}),
+        };
+        if (replyTo && parent && parent.replyableId) {
+          // Mirror the wire reply id on the optimistic insert so the local
+          // chip and the eventual MAM round-trip resolve to the same id.
+          optimistic.replyTo = {
+            id: parent.replyableId,
+            author: replyTo.author,
+            ...(replyTo.body ? { preview: replyTo.body } : {}),
+          };
+        }
+        if (threadId) optimistic.threadId = threadId;
+        if (parentThreadId) optimistic.parentThreadId = parentThreadId;
+        if (threadCreate) {
+          optimistic.threadId = msgId;
+          optimistic.forumPostKind = "topic";
+          optimistic.forumTitle = threadCreate.title;
+          optimistic.forumThreadTitle = threadCreate.title;
+        } else if (threadReply) {
+          optimistic.forumPostKind = "reply";
+          const threadTitle = parent?.forumTitle ?? parent?.forumThreadTitle;
+          if (threadTitle) optimistic.forumThreadTitle = threadTitle;
+        }
+        if (attachments && attachments.length > 0) {
+          optimistic.sharedFiles = attachments.map((a) => ({
+            url: a.url,
+            name: a.name,
+            mediaType: a.mediaType,
+            size: a.size,
+            ...(a.width ? { width: a.width } : {}),
+            ...(a.height ? { height: a.height } : {}),
+            disposition: inferredFileDisposition(a.mediaType, a.name ?? a.url),
+            ...(a.encrypted ? { encrypted: a.encrypted } : {}),
+          }));
+        }
+        pendingEchoClientIds.add(msgId);
+        messages.value = applyForumContext([...messages.value, optimistic]);
+        void scrollToPinnedEdgeAndPin();
+      }
+
+      // Clear draft on successful send (triggers ChatEditor clear via watcher)
+      if (fromComposer && isStillCurrentChannel) {
+        draft.value = "";
+        if (threadCreate) forumPostTitle.value = "";
+      }
+      onSendComplete(result ?? null, spaceId, channelId, isStillCurrentChannel);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    } finally {
+      isSending.value = false;
+      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
+    }
+  }
+
+  async function editMessage(
+    messageId: string,
+    newBody: string,
+    markup?: MarkupSpan[],
+    references?: MessageReference[],
+  ) {
+    if (!xmppClient.value || !activeChannelId.value || !newBody.trim()) return;
+    const message = findMessageById(messages.value, messageId);
+    const targetId = message?.correctionTargetId ?? messageId;
+
+    clearActionError();
+
+    try {
+      await xmppClient.value.sendCorrection(
+        activeSpaceId.value ?? "",
+        activeChannelId.value,
+        newBody,
+        targetId,
+        markup,
+        references,
+      );
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  // XEP-0184 receipt / XEP-0198 SM ack from the wasm client. Idempotent —
+  // see lib/xmpp/delivery-lifecycle.ts for the no-downgrade invariant.
+  function onMessageAck(messageId: string) {
+    messages.value = applyDeliveryEventById(messages.value, messageId, "delivered");
+  }
+
+  function onMessageQueueStatus(messageId: string, status: "queued" | "sending") {
+    messages.value = applyDeliveryEventById(messages.value, messageId, status);
+  }
+
+  // XEP-0198: the XMPP client gave up on the stanza (resume failed or no
+  // resumable transport).
+  function onMessageDeliveryFailure(messageId: string) {
+    messages.value = applyDeliveryEventById(messages.value, messageId, "failed");
+  }
+
+  return {
+    isSending,
+    uploadProgress,
+    pendingEchoClientIds,
+    sendMessage,
+    editMessage,
+    onMessageAck,
+    onMessageQueueStatus,
+    onMessageDeliveryFailure,
+  };
+}

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -230,7 +230,14 @@ export function useMucSend(deps: UseMucSendDeps) {
         draft.value = "";
         if (threadCreate) forumPostTitle.value = "";
       }
-      onSendComplete(result ?? null, spaceId, channelId, isStillCurrentChannel);
+      // Isolate the post-send side-effect callback so a misbehaving
+      // orchestrator (chat-state cleanup, XEP-0085 "active" send) can't be
+      // mistaken for a send failure and surface as actionError.
+      try {
+        onSendComplete(result ?? null, spaceId, channelId, isStillCurrentChannel);
+      } catch (callbackError) {
+        console.warn("useMucSend onSendComplete callback threw", callbackError);
+      }
     } catch (e) {
       actionError.value = normalizeError(e);
     } finally {

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -16,6 +16,11 @@ import { findMessageById } from "@/lib/message-ids";
 import { applyForumContext } from "@/channels/timeline";
 import { applyDeliveryEventById } from "@/lib/timeline-state";
 
+// Derived from the wasm client's return shape — `OutboundSendResult | null`
+// today, but tracked through the actual method so the union stays in sync
+// without re-declaring the literal `state` values.
+type MucSendResult = Awaited<ReturnType<BrowserXmppClient["sendGroupMessage"]>>;
+
 type UseMucSendDeps = {
   session: Ref<WaddleSession | null>;
   xmppClient: Ref<BrowserXmppClient | null>;
@@ -35,7 +40,7 @@ type UseMucSendDeps = {
   // to clear chat-state debounce timers and mark XEP-0085 state as "active"
   // again. Keeps PR 2 free of chat-states ownership (extracted in PR 5).
   onSendComplete: (
-    result: { state?: string } | null,
+    result: MucSendResult,
     spaceId: string,
     channelId: string,
     isStillCurrentChannel: boolean,

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -1,0 +1,204 @@
+import { ref, type Ref } from "vue";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
+import type { OutboundFileAttachment } from "@/lib/xmpp";
+import {
+  inferredFileDisposition,
+  type DeliveryStatus,
+  type MarkupSpan,
+  type MessageReference,
+  type TimelineMessage,
+} from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import { applyDeliveryEventById } from "@/lib/timeline-state";
+
+type UseChatSendDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activePeerJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+  draft: Ref<string>;
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  normalizeError: (e: unknown) => string;
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  // Mirror of useMucSend's contract: the orchestrator handles XEP-0085 chat
+  // state cleanup until that axis lands its own composable in PR 5.
+  onSendComplete: (
+    result: { state?: string } | null,
+    peerJid: string,
+    isStillActive: boolean,
+  ) => void;
+};
+
+export function useChatSend(deps: UseChatSendDeps) {
+  const {
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    draft,
+    actionError,
+    clearActionError,
+    normalizeError,
+    scrollToPinnedEdgeAndPin,
+    onSendComplete,
+  } = deps;
+
+  const isSending = ref(false);
+  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
+
+  // Client-assigned stanza ids still awaiting reconciliation. DMs don't have
+  // MUC self-echo, but a recently-queued message replayed from
+  // outbound-queue-store needs the same body-match fallback when the carbon
+  // arrives back from the server. Live-merge (PR 4) consumes this set.
+  const pendingEchoClientIds = new Set<string>();
+
+  async function sendMessage(
+    explicitBody?: string,
+    markup?: MarkupSpan[],
+    references?: MessageReference[],
+    files?: Array<File | Blob>,
+    replyTo?: { id: string; author: string; body?: string },
+  ) {
+    const bodyText = explicitBody ?? draft.value;
+    const fromComposer = markup !== undefined;
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    const hasFiles = !!files && files.length > 0;
+    if (!client || !peerJid || !session.value) return;
+    if (!bodyText.trim() && !hasFiles) return;
+
+    if (hasFiles) {
+      for (const f of files!) {
+        if (f.size > MAX_FILE_UPLOAD_BYTES) {
+          actionError.value = `File too large (${(f.size / 1024 / 1024).toFixed(1)} MB). Maximum upload size is 10 MB.`;
+          return;
+        }
+      }
+    }
+
+    isSending.value = true;
+    clearActionError();
+    try {
+      let attachments: OutboundFileAttachment[] | undefined;
+      if (hasFiles) {
+        const filenames = files!.map((f) => (f instanceof File ? f.name : `attachment-${Date.now()}.bin`));
+        uploadProgress.value = { uploading: true, progress: 0, filename: filenames[0] };
+        attachments = await client.uploadAttachments(files!, (overall, idx) => {
+          uploadProgress.value = {
+            uploading: true,
+            progress: overall.total > 0 ? overall.loaded / overall.total : 0,
+            filename: filenames[idx] ?? "",
+          };
+        });
+      }
+
+      const parent = replyTo ? findMessageById(messages.value, replyTo.id) : undefined;
+      const wireReplyTo = replyTo && parent
+        ? {
+            id: parent.id,
+            author: parent.authorJid ?? replyTo.author,
+            ...(replyTo.body ? { body: replyTo.body } : {}),
+          }
+        : undefined;
+      const threadId = parent ? (parent.threadId ?? parent.id) : undefined;
+      const result = await client.sendDirectMessage(peerJid, bodyText, {
+        markup,
+        references,
+        files: attachments,
+        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
+        ...(threadId ? { threadId } : {}),
+      });
+      const msgId = result?.id ?? null;
+      const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
+      if (isStillActive) {
+        if (msgId) {
+          pendingEchoClientIds.add(msgId);
+          const optimistic: TimelineMessage = {
+            id: msgId,
+            correctionTargetId: msgId,
+            author: session.value.username,
+            authorJid: session.value.jid,
+            body: bodyText || (attachments?.[0]?.url ?? ""),
+            createdAt: new Date().toISOString(),
+            isSelf: true,
+            deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
+            ...(markup && markup.length > 0 ? { markup } : {}),
+            ...(references && references.length > 0 ? { references } : {}),
+          };
+          if (replyTo && parent) {
+            optimistic.replyTo = {
+              id: parent.id,
+              author: replyTo.author,
+              ...(replyTo.body ? { preview: replyTo.body } : {}),
+            };
+          }
+          if (threadId) optimistic.threadId = threadId;
+          if (attachments && attachments.length > 0) {
+            optimistic.sharedFiles = attachments.map((a) => ({
+              url: a.url,
+              name: a.name,
+              mediaType: a.mediaType,
+              size: a.size,
+              ...(a.width ? { width: a.width } : {}),
+              ...(a.height ? { height: a.height } : {}),
+              disposition: inferredFileDisposition(a.mediaType, a.name ?? a.url),
+              ...(a.encrypted ? { encrypted: a.encrypted } : {}),
+            }));
+          }
+          messages.value = [...messages.value, optimistic];
+          void scrollToPinnedEdgeAndPin();
+        }
+        if (fromComposer) draft.value = "";
+      }
+      onSendComplete(result ?? null, peerJid, isStillActive);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    } finally {
+      isSending.value = false;
+      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
+    }
+  }
+
+  async function editMessage(
+    messageId: string,
+    newBody: string,
+    markup?: MarkupSpan[],
+    references?: MessageReference[],
+  ) {
+    if (!xmppClient.value || !activePeerJid.value || !newBody.trim()) return;
+    const message = findMessageById(messages.value, messageId);
+    const targetId = message?.correctionTargetId ?? messageId;
+    clearActionError();
+    try {
+      await xmppClient.value.sendDmCorrection(activePeerJid.value, newBody, targetId, markup, references);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  function onMessageAck(messageId: string) {
+    messages.value = applyDeliveryEventById(messages.value, messageId, "delivered");
+  }
+
+  function onMessageQueueStatus(messageId: string, status: "queued" | "sending") {
+    messages.value = applyDeliveryEventById(messages.value, messageId, status);
+  }
+
+  function onMessageDeliveryFailure(messageId: string) {
+    messages.value = applyDeliveryEventById(messages.value, messageId, "failed");
+  }
+
+  return {
+    isSending,
+    uploadProgress,
+    pendingEchoClientIds,
+    sendMessage,
+    editMessage,
+    onMessageAck,
+    onMessageQueueStatus,
+    onMessageDeliveryFailure,
+  };
+}

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -153,7 +153,14 @@ export function useChatSend(deps: UseChatSendDeps) {
         }
         if (fromComposer) draft.value = "";
       }
-      onSendComplete(result ?? null, peerJid, isStillActive);
+      // Isolate the post-send side-effect callback so a misbehaving
+      // orchestrator (chat-state cleanup, XEP-0085 "active" send) can't be
+      // mistaken for a send failure and surface as actionError.
+      try {
+        onSendComplete(result ?? null, peerJid, isStillActive);
+      } catch (callbackError) {
+        console.warn("useChatSend onSendComplete callback threw", callbackError);
+      }
     } catch (e) {
       actionError.value = normalizeError(e);
     } finally {

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -13,6 +13,9 @@ import {
 import { findMessageById } from "@/lib/message-ids";
 import { applyDeliveryEventById } from "@/lib/timeline-state";
 
+// Derived from the wasm client's return shape; see useMucSend for rationale.
+type ChatSendResult = Awaited<ReturnType<BrowserXmppClient["sendDirectMessage"]>>;
+
 type UseChatSendDeps = {
   session: Ref<WaddleSession | null>;
   xmppClient: Ref<BrowserXmppClient | null>;
@@ -26,7 +29,7 @@ type UseChatSendDeps = {
   // Mirror of useMucSend's contract: the orchestrator handles XEP-0085 chat
   // state cleanup until that axis lands its own composable in PR 5.
   onSendComplete: (
-    result: { state?: string } | null,
+    result: ChatSendResult,
     peerJid: string,
     isStillActive: boolean,
   ) => void;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -252,13 +252,17 @@ export function useDirectMessages(
     normalizeError,
     scrollToPinnedEdgeAndPin,
     onSendComplete: (result, peerJid, isStillActive) => {
-      if (isStillActive) {
-        if (composingTimeout) {
-          clearTimeout(composingTimeout);
-          composingTimeout = null;
-        }
-        lastChatState = "active";
+      if (!isStillActive) {
+        // Client swap or peer change happened during the send. Don't
+        // emit XEP-0085 "active" through the new session targeting the
+        // old peer.
+        return;
       }
+      if (composingTimeout) {
+        clearTimeout(composingTimeout);
+        composingTimeout = null;
+      }
+      lastChatState = "active";
       if (result?.state === "sending" && xmppClient.value) {
         void xmppClient.value.sendDmChatState(peerJid, "active").catch(() => undefined);
       }

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -41,6 +41,7 @@ import {
   retractDmTimelineMessage,
 } from "@/dms/message-timeline-state";
 import { useDmMamPaging } from "@/dms/mam-paging";
+import { useChatSend } from "@/dms/chat-send";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -61,7 +62,6 @@ export function useDirectMessages(
   };
   const messages = ref<TimelineMessage[]>([]);
   const draft = ref("");
-  const isSending = ref(false);
   const timelineEl: Ref<HTMLDivElement | null> = ref(null);
   const timelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
   const pinnedEdgeScroller = createPinnedEdgeScroller({
@@ -72,7 +72,6 @@ export function useDirectMessages(
   const typingUsers = ref<string[]>([]);
   const searchResults = ref<MessageSearchResult[]>([]);
   const isSearching = ref(false);
-  const uploadProgress = ref({ uploading: false, progress: 0, filename: "" });
   const firstUnseenId = ref<string | null>(null);
   const loadErrorPeerJid = ref<string | null>(null);
   const loadErrorMessage = ref("");
@@ -89,10 +88,6 @@ export function useDirectMessages(
   let lastChatState: ChatStateType = "active";
   let composingTimeout: ReturnType<typeof setTimeout> | null = null;
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  // Client-assigned stanza ids still awaiting server-echo reconciliation.
-  // Only these participate in the body-based fallback match so repeated
-  // identical text doesn't mis-target already-reconciled messages.
-  const pendingEchoClientIds = new Set<string>();
 
   function queuedMessagesForPeer(peerJid: string): TimelineMessage[] {
     const currentSession = session.value;
@@ -246,6 +241,40 @@ export function useDirectMessages(
     });
   }
 
+  const send = useChatSend({
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    draft,
+    actionError,
+    clearActionError,
+    normalizeError,
+    scrollToPinnedEdgeAndPin,
+    onSendComplete: (result, peerJid, isStillActive) => {
+      if (isStillActive) {
+        if (composingTimeout) {
+          clearTimeout(composingTimeout);
+          composingTimeout = null;
+        }
+        lastChatState = "active";
+      }
+      if (result?.state === "sending" && xmppClient.value) {
+        void xmppClient.value.sendDmChatState(peerJid, "active").catch(() => undefined);
+      }
+    },
+  });
+  const {
+    isSending,
+    uploadProgress,
+    pendingEchoClientIds,
+    sendMessage,
+    editMessage,
+    onMessageAck,
+    onMessageQueueStatus,
+    onMessageDeliveryFailure,
+  } = send;
+
   const paging = useDmMamPaging({
     session,
     xmppClient,
@@ -333,33 +362,6 @@ export function useDirectMessages(
     }
   }
 
-  /** XEP-0198: SM ack promotes the matching self-sent message to delivered. */
-  function onMessageAck(messageId: string) {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: "delivered" as DeliveryStatus }
-        : m,
-    );
-  }
-
-  function onMessageQueueStatus(messageId: string, status: "queued" | "sending") {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: status as DeliveryStatus }
-        : m,
-    );
-  }
-
-  /** XEP-0198: the XMPP client gave up on the stanza — surface as failed so the
-   *  user can retry. */
-  function onMessageDeliveryFailure(messageId: string) {
-    messages.value = messages.value.map((m) =>
-      m.id === messageId && m.isSelf && m.deliveryStatus !== "delivered"
-        ? { ...m, deliveryStatus: "failed" as DeliveryStatus }
-        : m,
-    );
-  }
-
   /** On a fresh session (SM resume failed), re-fetch MAM to close any gap
    *  for the currently-open conversation. Local optimistic sends are
    *  preserved across the reload so the user keeps retry affordances. */
@@ -382,120 +384,6 @@ export function useDirectMessages(
       const toAppend = preserved.filter((m) => !findMessageById(messages.value, m.id));
       if (toAppend.length > 0) messages.value = [...messages.value, ...toAppend];
     })();
-  }
-
-  async function sendMessage(
-    explicitBody?: string,
-    markup?: MarkupSpan[],
-    references?: MessageReference[],
-    files?: Array<File | Blob>,
-    replyTo?: { id: string; author: string; body?: string },
-  ) {
-    const bodyText = explicitBody ?? draft.value;
-    const fromComposer = markup !== undefined;
-    const client = xmppClient.value;
-    const peerJid = activePeerJid.value;
-    const hasFiles = !!files && files.length > 0;
-    if (!client || !peerJid || !session.value) return;
-    if (!bodyText.trim() && !hasFiles) return;
-
-    if (hasFiles) {
-      for (const f of files!) {
-        if (f.size > MAX_FILE_UPLOAD_BYTES) {
-          actionError.value = `File too large (${(f.size / 1024 / 1024).toFixed(1)} MB). Maximum upload size is 10 MB.`;
-          return;
-        }
-      }
-    }
-
-    isSending.value = true;
-    clearActionError();
-    try {
-      let attachments: OutboundFileAttachment[] | undefined;
-      if (hasFiles) {
-        const filenames = files!.map((f) => (f instanceof File ? f.name : `attachment-${Date.now()}.bin`));
-        uploadProgress.value = { uploading: true, progress: 0, filename: filenames[0] };
-        attachments = await client.uploadAttachments(files!, (overall, idx) => {
-          uploadProgress.value = {
-            uploading: true,
-            progress: overall.total > 0 ? overall.loaded / overall.total : 0,
-            filename: filenames[idx] ?? "",
-          };
-        });
-      }
-
-      const parent = replyTo ? findMessageById(messages.value, replyTo.id) : undefined;
-      const wireReplyTo = replyTo && parent
-        ? {
-            id: parent.id,
-            author: parent.authorJid ?? replyTo.author,
-            ...(replyTo.body ? { body: replyTo.body } : {}),
-          }
-        : undefined;
-      const threadId = parent ? (parent.threadId ?? parent.id) : undefined;
-      const result = await client.sendDirectMessage(peerJid, bodyText, {
-        markup,
-        references,
-        files: attachments,
-        ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
-        ...(threadId ? { threadId } : {}),
-      });
-      const msgId = result?.id ?? null;
-      const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
-      if (isStillActive) {
-        if (msgId) {
-          pendingEchoClientIds.add(msgId);
-          const optimistic: TimelineMessage = {
-            id: msgId,
-            correctionTargetId: msgId,
-            author: session.value.username,
-            authorJid: session.value.jid,
-            body: bodyText || (attachments?.[0]?.url ?? ""),
-            createdAt: new Date().toISOString(),
-            isSelf: true,
-            deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
-            ...(markup && markup.length > 0 ? { markup } : {}),
-            ...(references && references.length > 0 ? { references } : {}),
-          };
-          if (replyTo && parent) {
-            optimistic.replyTo = {
-              id: parent.id,
-              author: replyTo.author,
-              ...(replyTo.body ? { preview: replyTo.body } : {}),
-            };
-          }
-          if (threadId) optimistic.threadId = threadId;
-          if (attachments && attachments.length > 0) {
-            optimistic.sharedFiles = attachments.map((a) => ({
-              url: a.url,
-              name: a.name,
-              mediaType: a.mediaType,
-              size: a.size,
-              ...(a.width ? { width: a.width } : {}),
-              ...(a.height ? { height: a.height } : {}),
-              disposition: inferredFileDisposition(a.mediaType, a.name ?? a.url),
-              ...(a.encrypted ? { encrypted: a.encrypted } : {}),
-            }));
-          }
-          messages.value = [...messages.value, optimistic];
-          void scrollToPinnedEdgeAndPin();
-        }
-        if (fromComposer) draft.value = "";
-        if (composingTimeout) {
-          clearTimeout(composingTimeout);
-          composingTimeout = null;
-        }
-        lastChatState = "active";
-      }
-      if (result?.state === "sending") {
-        void client.sendDmChatState(peerJid, "active").catch(() => undefined);
-      }
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    } finally {
-      isSending.value = false;
-      uploadProgress.value = { uploading: false, progress: 0, filename: "" };
-    }
   }
 
   async function toggleReaction(messageId: string, emoji: string) {
@@ -557,18 +445,6 @@ export function useDirectMessages(
     } catch (e) {
       actionError.value = normalizeError(e);
       throw e;
-    }
-  }
-
-  async function editMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {
-    if (!xmppClient.value || !activePeerJid.value || !newBody.trim()) return;
-    const message = findMessageById(messages.value, messageId);
-    const targetId = message?.correctionTargetId ?? messageId;
-    clearActionError();
-    try {
-      await xmppClient.value.sendDmCorrection(activePeerJid.value, newBody, targetId, markup, references);
-    } catch (e) {
-      actionError.value = normalizeError(e);
     }
   }
 

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -1,10 +1,7 @@
 import { computed, nextTick, ref, watch, type Ref } from "vue";
 import {
-  inferredFileDisposition,
   type DeliveryStatus,
   type ExtensionAnnotationAction,
-  type MarkupSpan,
-  type MessageReference,
   type TimelineMessage,
 } from "@/lib/chat-ui";
 import type {
@@ -19,8 +16,6 @@ import type {
 } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
-import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
-import type { OutboundFileAttachment } from "@/lib/xmpp";
 import {
   findMessageById,
   matchMessageId,

--- a/chat/src/lib/timeline-state.ts
+++ b/chat/src/lib/timeline-state.ts
@@ -1,4 +1,5 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
+import { matchMessageId } from "@/lib/message-ids";
 import {
   applyDeliveryEvent,
   type DeliveryEvent,
@@ -21,6 +22,13 @@ import {
  * no-downgrade short-circuit), so Vue's reactivity skips a re-render and
  * downstream watchers don't fire.
  *
+ * Matches the id via `matchMessageId` (primary id OR a XEP-0359-reconciled
+ * id in `wireIds`). XEP-0198 SM acks and the wasm queue/failure callbacks
+ * fire with the client-assigned id, but by the time they arrive the
+ * message's primary id may already have been swapped to the room/server
+ * stanza-id while the original client id moved into `wireIds`. Strict
+ * equality on `m.id` would miss those messages.
+ *
  * Optimised for the XEP-0184 / XEP-0198 fan-out hot path: ack, queue, and
  * failure events arrive on every outbound stanza id and fan out to both
  * the room and DM timelines. The previous implementation always allocated
@@ -36,7 +44,7 @@ export function applyDeliveryEventById<M extends TimelineMessage>(
   messageId: string,
   event: DeliveryEvent,
 ): M[] {
-  const index = timeline.findIndex((m) => m.id === messageId && m.isSelf);
+  const index = timeline.findIndex((m) => m.isSelf && matchMessageId(m, messageId));
   if (index < 0) return timeline;
   const current = timeline[index]!;
   const nextStatus = applyDeliveryEvent(current.deliveryStatus, event);

--- a/chat/src/lib/timeline-state.ts
+++ b/chat/src/lib/timeline-state.ts
@@ -16,27 +16,32 @@ import {
 // grilling for #351.
 
 /**
- * Apply a delivery event to the message matching `messageId`, but only when
- * the message is a self-send. Non-self messages are untouched because the
- * delivery lifecycle tracks the local outbound stanza, not received ones.
+ * Apply a delivery event to the self-message matching `messageId`. Returns
+ * the original array reference when nothing changes (id miss or
+ * no-downgrade short-circuit), so Vue's reactivity skips a re-render and
+ * downstream watchers don't fire.
  *
- * The helper preserves reference identity when the result would be
- * structurally identical to the input — both at the array level (id miss
- * or terminal-no-op) and at the element level (no-downgrade short-circuits
- * to the existing object). Vue's reactivity skips re-renders in that case.
+ * Optimised for the XEP-0184 / XEP-0198 fan-out hot path: ack, queue, and
+ * failure events arrive on every outbound stanza id and fan out to both
+ * the room and DM timelines. The previous implementation always allocated
+ * via `Array.map`; this version locates the target via `findIndex` and
+ * only allocates when the transition is real.
+ *
+ * Generic `M extends TimelineMessage` accepts mutable `M[]` and returns
+ * `M[]` — callers operate on a Vue `Ref<TimelineMessage[]>` whose `.value`
+ * is mutable, so the input is `M[]` rather than `ReadonlyArray<M>`.
  */
 export function applyDeliveryEventById<M extends TimelineMessage>(
-  timeline: ReadonlyArray<M>,
+  timeline: M[],
   messageId: string,
   event: DeliveryEvent,
 ): M[] {
-  let changed = false;
-  const next = timeline.map((m): M => {
-    if (m.id !== messageId || !m.isSelf) return m;
-    const nextStatus = applyDeliveryEvent(m.deliveryStatus, event);
-    if (nextStatus === m.deliveryStatus) return m;
-    changed = true;
-    return { ...m, deliveryStatus: nextStatus };
-  });
-  return changed ? next : (timeline as M[]);
+  const index = timeline.findIndex((m) => m.id === messageId && m.isSelf);
+  if (index < 0) return timeline;
+  const current = timeline[index]!;
+  const nextStatus = applyDeliveryEvent(current.deliveryStatus, event);
+  if (nextStatus === current.deliveryStatus) return timeline;
+  const next = timeline.slice();
+  next[index] = { ...current, deliveryStatus: nextStatus };
+  return next;
 }

--- a/chat/src/lib/timeline-state.ts
+++ b/chat/src/lib/timeline-state.ts
@@ -1,0 +1,42 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+import {
+  applyDeliveryEvent,
+  type DeliveryEvent,
+} from "@/lib/xmpp/delivery-lifecycle";
+
+// Shared UI-mutation helpers used by both the channel-side useMucSend and
+// the DM-side useChatSend composables. Operates on TimelineMessage arrays
+// without depending on Vue, MUC vs 1:1 semantics, or the XMPP client — so
+// each helper is testable in isolation and reusable across both surfaces.
+//
+// Helpers that are MUC-specific (e.g. sender comparison via real-JID + nick)
+// belong in channels/message-timeline-state.ts; helpers that are DM-specific
+// in dms/message-timeline-state.ts; this file is the home for the
+// genuinely-cross-side operations identified during the PR 1/PR 2 design
+// grilling for #351.
+
+/**
+ * Apply a delivery event to the message matching `messageId`, but only when
+ * the message is a self-send. Non-self messages are untouched because the
+ * delivery lifecycle tracks the local outbound stanza, not received ones.
+ *
+ * The helper preserves reference identity when the result would be
+ * structurally identical to the input — both at the array level (id miss
+ * or terminal-no-op) and at the element level (no-downgrade short-circuits
+ * to the existing object). Vue's reactivity skips re-renders in that case.
+ */
+export function applyDeliveryEventById<M extends TimelineMessage>(
+  timeline: ReadonlyArray<M>,
+  messageId: string,
+  event: DeliveryEvent,
+): M[] {
+  let changed = false;
+  const next = timeline.map((m): M => {
+    if (m.id !== messageId || !m.isSelf) return m;
+    const nextStatus = applyDeliveryEvent(m.deliveryStatus, event);
+    if (nextStatus === m.deliveryStatus) return m;
+    changed = true;
+    return { ...m, deliveryStatus: nextStatus };
+  });
+  return changed ? next : (timeline as M[]);
+}

--- a/chat/src/lib/xmpp/delivery-lifecycle.ts
+++ b/chat/src/lib/xmpp/delivery-lifecycle.ts
@@ -9,6 +9,12 @@ import type { DeliveryStatus } from "@/lib/chat-ui";
 //                 or self-echo from MUC reflection)
 // - "failed"    — transport gave up (resume failed / no resumable session)
 //
+// "delivered" means *delivered to the server / reflected by the room*, not
+// "read". Read state lives separately on `TimelineMessage.readBy` and is
+// driven by XEP-0333 chat markers. These are distinct lifecycles by design:
+// a message can be "delivered" but never read, and the displayed marker can
+// only move forward independently of any later XEP-0184/0198 signal.
+//
 // Invariants:
 // - "delivered" is terminal — duplicate or stale events MUST NOT downgrade
 //   a confirmed delivery. This guards against XEP-0198's documented

--- a/chat/src/lib/xmpp/delivery-lifecycle.ts
+++ b/chat/src/lib/xmpp/delivery-lifecycle.ts
@@ -1,0 +1,32 @@
+import type { DeliveryStatus } from "@/lib/chat-ui";
+
+// Pure DeliveryStatus state machine for the outbound send lifecycle.
+//
+// Inputs collapse the various transport signals into a single event type:
+// - "queued"    — stanza enqueued (XEP-0198 ackable outbound, or local queue)
+// - "sending"   — transport picked up the stanza
+// - "delivered" — confirmed delivered (XEP-0184 receipt, XEP-0198 SM ack,
+//                 or self-echo from MUC reflection)
+// - "failed"    — transport gave up (resume failed / no resumable session)
+//
+// Invariants:
+// - "delivered" is terminal — duplicate or stale events MUST NOT downgrade
+//   a confirmed delivery. This guards against XEP-0198's documented
+//   retransmit-on-resume behavior, late XEP-0184 receipts, and out-of-order
+//   self-echo + failure signals.
+// - Every other transition is idempotent: applying the same event twice
+//   yields the same result the second time.
+// - "failed" is NOT terminal: a delayed XEP-0184 receipt or XEP-0198 ack
+//   may upgrade a previously-failed message to "delivered", because the
+//   transport's failure callback can race a confirmation that's already
+//   in flight from the server.
+
+export type DeliveryEvent = "queued" | "sending" | "delivered" | "failed";
+
+export function applyDeliveryEvent(
+  current: DeliveryStatus | undefined,
+  event: DeliveryEvent,
+): DeliveryStatus {
+  if (current === "delivered") return "delivered";
+  return event;
+}

--- a/chat/tests/chat-send.test.ts
+++ b/chat/tests/chat-send.test.ts
@@ -1,0 +1,188 @@
+// Direct unit tests for useChatSend (PR Compliance #2 — non-trivial extracted
+// behavior gets direct tests at the composable level). No Vue component
+// mounting; the composable takes plain refs and callbacks.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChatSend } from "../src/dms/chat-send";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+function makeClient(overrides: Partial<BrowserXmppClient> = {}): BrowserXmppClient {
+  return {
+    sendDirectMessage: mock(async () => ({ id: "dm-sid-1", state: "sending" })),
+    sendDmChatState: mock(async () => undefined),
+    sendDmCorrection: mock(async () => undefined),
+    uploadAttachments: mock(async () => []),
+    ...overrides,
+  } as unknown as BrowserXmppClient;
+}
+
+function harness(opts: {
+  client?: BrowserXmppClient;
+  peerJid?: string | null;
+  draft?: string;
+} = {}) {
+  const xmppClient = ref<BrowserXmppClient | null>(opts.client ?? makeClient());
+  const activePeerJid = ref<string | null>(opts.peerJid === undefined ? "bob@example.com" : opts.peerJid);
+  const draft = ref(opts.draft ?? "");
+  const messages = ref<TimelineMessage[]>([]);
+  const actionError = ref("");
+  const clearActionError = mock(() => { actionError.value = ""; });
+  const scrollToPinnedEdgeAndPin = mock(async () => true);
+  const onSendComplete = mock(() => {});
+
+  const send = useChatSend({
+    session: ref(session),
+    xmppClient,
+    activePeerJid,
+    messages,
+    draft,
+    actionError,
+    clearActionError,
+    normalizeError: (e) => String(e),
+    scrollToPinnedEdgeAndPin,
+    onSendComplete,
+  });
+
+  return { xmppClient, activePeerJid, draft, messages, actionError, send, onSendComplete };
+}
+
+describe("useChatSend.sendMessage — happy path", () => {
+  test("optimistic-inserts self message, registers pending echo, clears draft, fires onSendComplete", async () => {
+    const h = harness({ draft: "hi bob" });
+
+    await h.send.sendMessage(undefined, []);
+
+    expect(h.messages.value.length).toBe(1);
+    expect(h.messages.value[0]?.isSelf).toBe(true);
+    expect(h.messages.value[0]?.id).toBe("dm-sid-1");
+    expect(h.messages.value[0]?.body).toBe("hi bob");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("sending");
+
+    expect(h.send.pendingEchoClientIds.has("dm-sid-1")).toBe(true);
+    expect(h.draft.value).toBe("");
+    expect(h.send.isSending.value).toBe(false);
+    expect(h.onSendComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useChatSend.sendMessage — guards", () => {
+  test("empty body + no files: silent no-op", async () => {
+    const h = harness({ draft: "   " });
+    await h.send.sendMessage();
+    expect(h.messages.value.length).toBe(0);
+    expect((h.xmppClient.value!.sendDirectMessage as unknown as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("no peerJid: silent no-op", async () => {
+    const h = harness({ peerJid: null, draft: "hello" });
+    await h.send.sendMessage(undefined, []);
+    expect(h.messages.value.length).toBe(0);
+    expect(h.actionError.value).toBe("");
+  });
+
+  test("file too large: actionError set, no send", async () => {
+    const h = harness();
+    const big = { size: 999_999_999 } as File;
+    await h.send.sendMessage("hi", [], undefined, [big]);
+    expect(h.actionError.value).toContain("File too large");
+    expect(h.messages.value.length).toBe(0);
+  });
+});
+
+describe("useChatSend.sendMessage — failure paths", () => {
+  test("send throws: actionError = normalized, isSending reset", async () => {
+    const client = makeClient({
+      sendDirectMessage: mock(async () => { throw new Error("offline"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "hello" });
+
+    await h.send.sendMessage(undefined, []);
+
+    expect(h.actionError.value).toContain("offline");
+    expect(h.send.isSending.value).toBe(false);
+    expect(h.messages.value.length).toBe(0);
+  });
+
+  test("isStillActive false after peer swap mid-send: no optimistic insert", async () => {
+    let resolveSend: (v: { id: string; state: "queued" | "sending" }) => void = () => {};
+    const client = makeClient({
+      sendDirectMessage: mock(() => new Promise<{ id: string; state: "queued" | "sending" }>((resolve) => {
+        resolveSend = resolve;
+      })),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "hello" });
+
+    const sendPromise = h.send.sendMessage(undefined, []);
+    // Simulate peer change mid-send
+    h.activePeerJid.value = "carol@example.com";
+    resolveSend({ id: "dm-late", state: "sending" });
+    await sendPromise;
+
+    expect(h.messages.value.length).toBe(0);
+    expect(h.send.isSending.value).toBe(false);
+  });
+});
+
+describe("useChatSend.editMessage", () => {
+  test("delegates to client.sendDmCorrection with the message's correctionTargetId", async () => {
+    const sendDmCorrection = mock(async () => undefined);
+    const client = makeClient({ sendDmCorrection } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      {
+        id: "dm-msg-1",
+        correctionTargetId: "original-server-id",
+        body: "old text",
+        nick: "alice",
+        timestamp: 0,
+        isSelf: true,
+      } as TimelineMessage,
+    ];
+
+    await h.send.editMessage("dm-msg-1", "new text");
+
+    expect(sendDmCorrection).toHaveBeenCalledTimes(1);
+    const call = (sendDmCorrection as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[2]).toBe("original-server-id");
+  });
+
+  test("empty body: no send", async () => {
+    const sendDmCorrection = mock(async () => undefined);
+    const client = makeClient({ sendDmCorrection } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    await h.send.editMessage("any-id", "   ");
+    expect(sendDmCorrection).not.toHaveBeenCalled();
+  });
+});
+
+describe("useChatSend delivery lifecycle handlers", () => {
+  test("onMessageAck promotes a sending self-message to delivered", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", isSelf: true, deliveryStatus: "sending", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.send.onMessageAck("m1");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+  });
+
+  test("onMessageQueueStatus + onMessageDeliveryFailure each apply via the pure helper", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", isSelf: true, deliveryStatus: "queued", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.send.onMessageQueueStatus("m1", "sending");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("sending");
+    h.send.onMessageDeliveryFailure("m1");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("failed");
+  });
+});

--- a/chat/tests/delivery-lifecycle.test.ts
+++ b/chat/tests/delivery-lifecycle.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { applyDeliveryEvent } from "../src/lib/xmpp/delivery-lifecycle";
+
+// XEP-0184 received and XEP-0198 stream-management acks both feed the
+// delivery lifecycle. The pure helper enforces the "delivered is terminal,
+// never downgrade" invariant and keeps every transition idempotent — a
+// duplicate ack/queue-status/failure event after a confirmed delivery is a
+// no-op, never a regression.
+
+describe("applyDeliveryEvent — forward transitions", () => {
+  test("undefined → queued (initial outbound)", () => {
+    expect(applyDeliveryEvent(undefined, "queued")).toBe("queued");
+  });
+
+  test("queued → sending (transport picks up the stanza)", () => {
+    expect(applyDeliveryEvent("queued", "sending")).toBe("sending");
+  });
+
+  test("sending → delivered (XEP-0184 receipt / XEP-0198 ack / self-echo)", () => {
+    expect(applyDeliveryEvent("sending", "delivered")).toBe("delivered");
+  });
+
+  test("sending → failed (transport gave up)", () => {
+    expect(applyDeliveryEvent("sending", "failed")).toBe("failed");
+  });
+
+  test("queued → failed (queue rejection)", () => {
+    expect(applyDeliveryEvent("queued", "failed")).toBe("failed");
+  });
+
+  test("failed → sending (retry kicks in)", () => {
+    expect(applyDeliveryEvent("failed", "sending")).toBe("sending");
+  });
+
+  test("failed → delivered (delayed ack arrives after failure timeout)", () => {
+    // A late XEP-0184 receipt or XEP-0198 ack proves the stanza got through
+    // even though we'd given up on it.
+    expect(applyDeliveryEvent("failed", "delivered")).toBe("delivered");
+  });
+});
+
+describe("applyDeliveryEvent — terminal 'delivered' (no downgrade)", () => {
+  test("delivered + queued → delivered (duplicate XEP-0198 retransmit)", () => {
+    expect(applyDeliveryEvent("delivered", "queued")).toBe("delivered");
+  });
+
+  test("delivered + sending → delivered (late retry signal)", () => {
+    expect(applyDeliveryEvent("delivered", "sending")).toBe("delivered");
+  });
+
+  test("delivered + failed → delivered (stale failure signal after confirm)", () => {
+    expect(applyDeliveryEvent("delivered", "failed")).toBe("delivered");
+  });
+
+  test("delivered + delivered → delivered (idempotent ack)", () => {
+    expect(applyDeliveryEvent("delivered", "delivered")).toBe("delivered");
+  });
+});
+
+describe("applyDeliveryEvent — undefined current state", () => {
+  test("undefined + sending → sending (non-canonical but accepted)", () => {
+    expect(applyDeliveryEvent(undefined, "sending")).toBe("sending");
+  });
+
+  test("undefined + delivered → delivered", () => {
+    expect(applyDeliveryEvent(undefined, "delivered")).toBe("delivered");
+  });
+
+  test("undefined + failed → failed", () => {
+    expect(applyDeliveryEvent(undefined, "failed")).toBe("failed");
+  });
+});

--- a/chat/tests/muc-send.test.ts
+++ b/chat/tests/muc-send.test.ts
@@ -1,0 +1,264 @@
+// Direct unit tests for useMucSend (PR Compliance #2 — non-trivial extracted
+// behavior gets direct tests at the composable level, not only via integration).
+// No Vue component mounting; the composable accepts plain refs and callbacks
+// so we drive it from regular bun tests.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useMucSend } from "../src/channels/muc-send";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { ChannelSummary } from "../src/lib/chat-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+const channel: ChannelSummary = { id: "general", name: "General" };
+
+function makeClient(overrides: Partial<BrowserXmppClient> = {}): BrowserXmppClient {
+  return {
+    sendGroupMessage: mock(async () => ({ id: "sid-1", state: "sending" })),
+    sendChatState: mock(async () => undefined),
+    sendCorrection: mock(async () => undefined),
+    uploadAttachments: mock(async () => []),
+    ...overrides,
+  } as unknown as BrowserXmppClient;
+}
+
+function harness(opts: {
+  client?: BrowserXmppClient;
+  channelId?: string | null;
+  draft?: string;
+  currentChannel?: ChannelSummary;
+} = {}) {
+  const xmppClient = ref<BrowserXmppClient | null>(opts.client ?? makeClient());
+  const activeChannelId = ref<string | null>(opts.channelId === undefined ? "general" : opts.channelId);
+  const draft = ref(opts.draft ?? "");
+  const messages = ref<TimelineMessage[]>([]);
+  const actionError = ref("");
+  const clearActionError = mock(() => { actionError.value = ""; });
+  const scrollToPinnedEdgeAndPin = mock(async () => true);
+  const onSendComplete = mock(() => {});
+
+  const send = useMucSend({
+    session: ref(session),
+    xmppClient,
+    activeSpaceId: ref("space"),
+    activeChannelId,
+    currentChannel: ref(opts.currentChannel ?? channel),
+    currentRoomJid: ref("general@muc.example.com"),
+    messages,
+    draft,
+    forumPostTitle: ref(""),
+    actionError,
+    clearActionError,
+    normalizeError: (e) => String(e),
+    scrollToPinnedEdgeAndPin,
+    onSendComplete,
+  });
+
+  return { xmppClient, activeChannelId, draft, messages, actionError, send, onSendComplete, scrollToPinnedEdgeAndPin };
+}
+
+describe("useMucSend.sendMessage — happy path", () => {
+  test("optimistic-inserts a self message, registers pending echo, clears draft, fires onSendComplete", async () => {
+    const h = harness({ draft: "hello world" });
+
+    await h.send.sendMessage(undefined, []);
+
+    // Optimistic insert lands with isSelf and "sending" delivery
+    expect(h.messages.value.length).toBe(1);
+    expect(h.messages.value[0]?.isSelf).toBe(true);
+    expect(h.messages.value[0]?.id).toBe("sid-1");
+    expect(h.messages.value[0]?.body).toBe("hello world");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("sending");
+
+    // Pending echo set tracks the client-assigned id for self-echo reconciliation
+    expect(h.send.pendingEchoClientIds.has("sid-1")).toBe(true);
+
+    // Draft cleared (composer send: markup was passed as [])
+    expect(h.draft.value).toBe("");
+
+    // isSending false after finally, onSendComplete invoked once
+    expect(h.send.isSending.value).toBe(false);
+    expect(h.onSendComplete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("useMucSend.sendMessage — guards", () => {
+  test("empty body + no files + no metadata: silent no-op (no send, no insert)", async () => {
+    const h = harness({ draft: "   " });
+    await h.send.sendMessage();
+    expect(h.messages.value.length).toBe(0);
+    expect(h.send.isSending.value).toBe(false);
+    expect((h.xmppClient.value!.sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("no client: silent no-op", async () => {
+    const h = harness({ client: undefined });
+    h.xmppClient.value = null;
+    await h.send.sendMessage("hello", []);
+    expect(h.messages.value.length).toBe(0);
+    expect(h.actionError.value).toBe("");
+  });
+
+  test("file too large: actionError set, no send", async () => {
+    const h = harness();
+    // Construct an oversized "file" (Blob with .size > MAX_FILE_UPLOAD_BYTES)
+    const big = { size: 999_999_999 } as File;
+    await h.send.sendMessage("hi", [], undefined, [big]);
+    expect(h.actionError.value).toContain("File too large");
+    expect(h.messages.value.length).toBe(0);
+    expect((h.xmppClient.value!.sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+
+  test("forum post without title: actionError set, no send", async () => {
+    const h = harness({
+      draft: "body",
+      currentChannel: { id: "general", name: "General", channel_type: "forum" } as ChannelSummary,
+    });
+    await h.send.sendMessage(undefined, []);
+    expect(h.actionError.value).toBe("Add a title before posting to this forum.");
+    expect(h.messages.value.length).toBe(0);
+  });
+});
+
+describe("useMucSend.sendMessage — reply guard (XEP-0461 §3.2)", () => {
+  test("replyTo to an unreplyable target: actionError set, isSending reset, no optimistic insert", async () => {
+    const h = harness({ draft: "reply text" });
+    // Seed the timeline with a parent that lacks replyableId (no XEP-0359
+    // stanza-id from the room) — sending should be refused per XEP-0461 §3.2.
+    h.messages.value = [
+      {
+        id: "parent-1",
+        body: "older message",
+        nick: "bob",
+        timestamp: 0,
+        isSelf: false,
+        // intentionally NO replyableId
+      } as TimelineMessage,
+    ];
+
+    await h.send.sendMessage(undefined, [], undefined, undefined, {
+      id: "parent-1",
+      author: "bob",
+    });
+
+    expect(h.actionError.value).toContain("no room stanza-id");
+    expect(h.send.isSending.value).toBe(false);
+    // The original parent is still there; no new optimistic message.
+    expect(h.messages.value.length).toBe(1);
+  });
+});
+
+describe("useMucSend.sendMessage — failure paths", () => {
+  test("send throws: actionError = normalized, isSending reset, no optimistic insert", async () => {
+    const client = makeClient({
+      sendGroupMessage: mock(async () => { throw new Error("server angry"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "hello" });
+
+    await h.send.sendMessage(undefined, []);
+
+    expect(h.actionError.value).toContain("server angry");
+    expect(h.send.isSending.value).toBe(false);
+    expect(h.messages.value.length).toBe(0);
+  });
+
+  test("isStillCurrentChannel false after await (channel swap): no optimistic insert", async () => {
+    let resolveSend: (v: { id: string; state: "queued" | "sending" }) => void = () => {};
+    const client = makeClient({
+      sendGroupMessage: mock(() => new Promise<{ id: string; state: "queued" | "sending" }>((resolve) => {
+        resolveSend = resolve;
+      })),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client, draft: "hello" });
+
+    const sendPromise = h.send.sendMessage(undefined, []);
+    // Simulate channel swap mid-send
+    h.activeChannelId.value = "different-channel";
+    resolveSend({ id: "sid-late", state: "sending" });
+    await sendPromise;
+
+    // No optimistic insert because the channel changed before the await resolved
+    expect(h.messages.value.length).toBe(0);
+    expect(h.send.isSending.value).toBe(false);
+  });
+});
+
+describe("useMucSend.editMessage", () => {
+  test("delegates to client.sendCorrection with the message's correctionTargetId", async () => {
+    const sendCorrection = mock(async () => undefined);
+    const client = makeClient({ sendCorrection } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      {
+        id: "msg-1",
+        correctionTargetId: "original-server-id",
+        body: "old text",
+        nick: "alice",
+        timestamp: 0,
+        isSelf: true,
+      } as TimelineMessage,
+    ];
+
+    await h.send.editMessage("msg-1", "new text");
+
+    expect(sendCorrection).toHaveBeenCalledTimes(1);
+    const call = (sendCorrection as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    // Target id is correctionTargetId, not the message id
+    expect(call[3]).toBe("original-server-id");
+  });
+
+  test("empty body: no send, no error", async () => {
+    const sendCorrection = mock(async () => undefined);
+    const client = makeClient({ sendCorrection } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    await h.send.editMessage("any-id", "   ");
+    expect(sendCorrection).not.toHaveBeenCalled();
+    expect(h.actionError.value).toBe("");
+  });
+});
+
+describe("useMucSend delivery lifecycle handlers", () => {
+  test("onMessageAck promotes a sending self-message to delivered", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", isSelf: true, deliveryStatus: "sending", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.send.onMessageAck("m1");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+  });
+
+  test("onMessageQueueStatus + onMessageDeliveryFailure each apply via the pure helper", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", isSelf: true, deliveryStatus: "queued", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+
+    h.send.onMessageQueueStatus("m1", "sending");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("sending");
+
+    h.send.onMessageDeliveryFailure("m1");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("failed");
+  });
+
+  test("onMessageAck after delivered stays delivered (idempotent terminal)", () => {
+    // Reference-identity preservation is verified at the pure-helper level in
+    // tests/timeline-state.test.ts; here we just check the observable
+    // outcome (status unchanged) since the Vue reactive proxy on the ref's
+    // value array breaks raw === identity comparisons.
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", isSelf: true, deliveryStatus: "delivered", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.send.onMessageAck("m1");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+    expect(h.messages.value.length).toBe(1);
+  });
+});

--- a/chat/tests/timeline-state.test.ts
+++ b/chat/tests/timeline-state.test.ts
@@ -49,6 +49,21 @@ describe("applyDeliveryEventById", () => {
     expect(applyDeliveryEventById([], "any", "delivered")).toEqual([]);
   });
 
+  test("matches via wireIds when the primary id was reconciled by XEP-0359", () => {
+    // After a self-echo, the message's primary id swaps to the
+    // server-assigned stanza-id while the original client id moves into
+    // wireIds. A subsequent XEP-0198 SM ack referencing the original client
+    // id must still find the message.
+    const timeline = [
+      makeMessage("server-stanza-id", {
+        deliveryStatus: "sending",
+        wireIds: ["original-client-id"],
+      } as Partial<TimelineMessage>),
+    ];
+    const next = applyDeliveryEventById(timeline, "original-client-id", "delivered");
+    expect(next.find((m) => m.id === "server-stanza-id")?.deliveryStatus).toBe("delivered");
+  });
+
   test("preserves all other fields on the updated message", () => {
     const original = makeMessage("a", { deliveryStatus: "sending", body: "hello", nick: "bob" });
     const next = applyDeliveryEventById([original], "a", "delivered");

--- a/chat/tests/timeline-state.test.ts
+++ b/chat/tests/timeline-state.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import { applyDeliveryEventById } from "../src/lib/timeline-state";
+
+function makeMessage(id: string, overrides: Partial<TimelineMessage> = {}): TimelineMessage {
+  return {
+    id,
+    body: "msg",
+    nick: "alice",
+    timestamp: 0,
+    isSelf: true,
+    deliveryStatus: "queued",
+    ...overrides,
+  } as TimelineMessage;
+}
+
+describe("applyDeliveryEventById", () => {
+  test("updates the matching self-message's deliveryStatus", () => {
+    const timeline = [makeMessage("a"), makeMessage("b", { deliveryStatus: "sending" })];
+    const next = applyDeliveryEventById(timeline, "b", "delivered");
+    expect(next.find((m) => m.id === "b")?.deliveryStatus).toBe("delivered");
+  });
+
+  test("leaves non-matching messages untouched", () => {
+    const timeline = [makeMessage("a"), makeMessage("b", { deliveryStatus: "sending" })];
+    const next = applyDeliveryEventById(timeline, "b", "delivered");
+    expect(next.find((m) => m.id === "a")).toBe(timeline[0]!);
+  });
+
+  test("never mutates messages that aren't self", () => {
+    const timeline = [makeMessage("a", { isSelf: false, deliveryStatus: "sending" })];
+    const next = applyDeliveryEventById(timeline, "a", "delivered");
+    expect(next[0]?.deliveryStatus).toBe("sending");
+  });
+
+  test("returns the same array reference when nothing changed (id miss)", () => {
+    const timeline = [makeMessage("a"), makeMessage("b")];
+    expect(applyDeliveryEventById(timeline, "missing", "delivered")).toBe(timeline);
+  });
+
+  test("returns the same array reference when the transition is a no-op (terminal)", () => {
+    const timeline = [makeMessage("a", { deliveryStatus: "delivered" })];
+    // delivered → failed is a no-op (no-downgrade rule from applyDeliveryEvent).
+    // Helper should preserve reference identity to let Vue skip a re-render.
+    expect(applyDeliveryEventById(timeline, "a", "failed")).toBe(timeline);
+  });
+
+  test("empty timeline returns empty", () => {
+    expect(applyDeliveryEventById([], "any", "delivered")).toEqual([]);
+  });
+
+  test("preserves all other fields on the updated message", () => {
+    const original = makeMessage("a", { deliveryStatus: "sending", body: "hello", nick: "bob" });
+    const next = applyDeliveryEventById([original], "a", "delivered");
+    const updated = next.find((m) => m.id === "a")!;
+    expect(updated.deliveryStatus).toBe("delivered");
+    expect(updated.body).toBe("hello");
+    expect(updated.nick).toBe("bob");
+    // updated must be a new object reference (Vue reactivity needs the swap)
+    expect(updated).not.toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 7. Extract send-flow + delivery lifecycle out of `channels/messages.ts` (MUC, XEP-0045 §8.5 + XEP-0359 self-echo reconciliation) and `dms/messages.ts` (1:1 chat + XEP-0184 receipts + XEP-0198 stream-management acks) into focused composables, backed by Vue-free pure helpers.

Refs: #351 — see the full implementation plan there.

## What lands

- **`chat/src/lib/xmpp/delivery-lifecycle.ts`** (new, pure) — `DeliveryStatus` state machine (queued → sending → delivered plus failed branches). All transitions are idempotent — a duplicate ack must be a no-op, never a downgrade. "delivered" tracks XEP-0184/XEP-0198 only; XEP-0333 read state stays on `readBy` as a separate lifecycle (documented inline).
- **`chat/src/lib/timeline-state.ts`** (new, shared) — UI-mutation pure helpers genuinely shared between channel and DM sides. Created lazily here per the PR 1/PR 2 design plan.
- **`chat/tests/delivery-lifecycle.test.ts`** + **`chat/tests/timeline-state.test.ts`** — TDD red-green-refactor for the pure helpers (23 tests).
- **`chat/src/channels/muc-send.ts`** (new) — `useMucSend` owning `sendMessage`, `editMessage`, `onMessageAck`, `onMessageQueueStatus`, `onMessageDeliveryFailure`, `isSending`, `uploadProgress`, `pendingEchoClientIds`.
- **`chat/src/dms/chat-send.ts`** (new) — `useChatSend` for 1:1; no MUC echo, but ack/queue/failure lifecycle is shared via the pure helper.
- **`chat/src/channels/messages.ts`** + **`chat/src/dms/messages.ts`** — orchestrators wire the new composables; send-flow code removed (~225 LOC channel + ~165 LOC DM).

## XEP conformance (caveats from #351 plan)

1. **Idempotent delivery-lifecycle transitions** — pure helper enforces "delivered is terminal, never downgrade." A duplicate XEP-0198 ack or XEP-0184 received on an already-delivered message is a no-op.
2. **XEP-0184 received ≠ XEP-0333 displayed** — explicitly separated. `DeliveryStatus` has no "displayed" state; read state lives on `readBy`.
3. **Receive-path dedup by `(stanza-id id, by)` tuple, not origin-id (XEP-0359 §4)** — enforced on the channel side at `wasm-message-codecs.ts:179` (`byScoped` match against the room JID). **The DM side does NOT currently verify `by` against `selfBareJid`** — pre-existing in `main`, not introduced by this PR. Filed as **#466** (`fix(chat): verify XEP-0359 stanza-id 'by' attribute for 1:1 messages`).

## Test strategy

- Pure helpers: TDD RGR (`tests/delivery-lifecycle.test.ts`, `tests/timeline-state.test.ts`).
- Composables: ride on existing integration tests (`sm-delivery`, `client-send-readiness`, `editor-message-input`, `slash-flow`, `reaction-mode`, `tombstone-replay`).
- Gates: `bun test`, `bun run lint`, plus `bunx astro check` (added to local routine after the PR 1 CI regression).

## Acceptance criteria

- [x] `channels/messages.ts` and `dms/messages.ts` send-flow code lifted; orchestrators are wiring surfaces.
- [x] Pure helpers tested directly (RGR).
- [x] Existing integration tests pass unchanged.
- [x] Stanza-id `by` verified before MUC self-echo reconciliation (XEP-0359 caveat) — channels yes via `wasm-message-codecs.ts`; DM-side gap filed as #466.
- [x] Delivery-lifecycle transitions idempotent (XEP-0198 / XEP-0184 dedup).
- [x] `bun test`, `bun run lint`, `astro check` all clean.
- [x] Call sites of `useChannelMessages` / `useDirectMessages` remain stable.

## Adversarial review

Three reviewers — XMPP protocol pedant, refactor regression, concurrency.

- **Refactor regression**: CLEAN, no behavior changes detected.
- **Concurrency**: 1 MINOR (onSendComplete swallowed errors) — fixed by wrapping the callback in its own try/catch in `728c916e`. Two flagged majors verified false positives (`pendingEchoClientIds` *is* cleared on channel switch via `paging.loadMessages`; isStillCurrentChannel re-check is sufficient for current code paths).
- **XMPP pedant**: 1 MAJOR (DM `by`-verification gap) — pre-existing on `main`, filed as **#466**. 1 MAJOR (delivered/displayed conflation risk) — addressed by adding clarifying documentation to `delivery-lifecycle.ts` in `728c916e`. Other findings (correction-chain semantics, optimistic `correctionTargetId` mutation) are pre-existing behavior unchanged by this PR.

## Plan checkpoint

Sequential off `main`. PR 1 (#463) merged. After this lands, PR 3 (`refactor(chat): extract message-actions composables`) branches off the new `main`.

Follow-up: **#466** (DM XEP-0359 `by` verification).
