### PR TITLE
refactor(chat): extract message-actions composables

### DIFF
--- a/chat/src/channels/message-actions.ts
+++ b/chat/src/channels/message-actions.ts
@@ -2,6 +2,7 @@ import type { Ref } from "vue";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
+import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { findMessageById } from "@/lib/message-ids";
 
 // Outbound message-action handlers for the channel side: reactions
@@ -152,7 +153,9 @@ export function useChannelMessageActions(deps: UseChannelMessageActionsDeps) {
    * Outbound extension-annotation action — Waddle-specific. The wasm client
    * resolves the launch URL into the extension's command flow.
    */
-  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
+  async function invokeExtensionAction(
+    action: ExtensionAnnotationAction,
+  ): Promise<ExtensionCommandResult> {
     const client = xmppClient.value;
     if (!client) {
       const error = new Error("XMPP session is not ready.");

--- a/chat/src/channels/message-actions.ts
+++ b/chat/src/channels/message-actions.ts
@@ -1,0 +1,182 @@
+import type { Ref } from "vue";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+
+// Outbound message-action handlers for the channel side: reactions
+// (XEP-0444), retractions (XEP-0424), moderator retractions (XEP-0425), and
+// extension-annotation actions. Each action targets an already-rendered
+// timeline message via its `replyableId` (the room's XEP-0359 stanza-id) or
+// `reactionTargetId`, so the composable doesn't construct stanzas — it
+// reads the right id off `messages` and forwards to the wasm client.
+//
+// `applyReaction` is injected as a dep because the local optimistic-update
+// path is owned by the live-merge composable (PR 4 of #351). Until that
+// extraction lands, the orchestrator passes its own `applyReaction` inline
+// function through here.
+
+type UseChannelMessageActionsDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activeSpaceId: Ref<string | null>;
+  activeChannelId: Ref<string | null>;
+  currentRoomJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  normalizeError: (e: unknown) => string;
+  // Optimistic local-reaction update. PR 4 (live-merge) owns the canonical
+  // implementation; for now the orchestrator passes its inline version.
+  applyReaction: (messageId: string, nick: string, emojis: string[], senderId?: string) => void;
+};
+
+export function useChannelMessageActions(deps: UseChannelMessageActionsDeps) {
+  const {
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentRoomJid,
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError,
+    applyReaction,
+  } = deps;
+
+  /**
+   * XEP-0444 §3: toggle the local user's reaction. Reads the current
+   * per-author set, flips this emoji, and sends the FULL updated set —
+   * receivers replace the prior set per replace-semantics. An optimistic
+   * local update applies before the wire round-trip and rolls back if the
+   * server rejects.
+   */
+  async function toggleReaction(messageId: string, emoji: string) {
+    if (!xmppClient.value || !activeChannelId.value || !session.value) return;
+
+    const msg = findMessageById(messages.value, messageId);
+    const targetId = msg?.reactionTargetId;
+    if (!targetId) return;
+    const myNick = session.value.username;
+    const currentReactions = msg?.reactions ?? {};
+
+    const previousEmojis: string[] = [];
+    for (const [e, nicks] of Object.entries(currentReactions)) {
+      if (nicks.includes(myNick)) previousEmojis.push(e);
+    }
+    const myEmojis = new Set(previousEmojis);
+
+    if (myEmojis.has(emoji)) myEmojis.delete(emoji);
+    else myEmojis.add(emoji);
+
+    const nextEmojis = [...myEmojis];
+    const senderId = currentRoomJid.value
+      ? `${currentRoomJid.value}/${myNick}`
+      : myNick;
+    applyReaction(targetId, myNick, nextEmojis, senderId);
+
+    try {
+      await xmppClient.value.sendReaction(
+        activeSpaceId.value ?? "",
+        activeChannelId.value,
+        targetId,
+        nextEmojis,
+      );
+    } catch (e) {
+      // Roll back the optimistic update so the chip stops claiming a
+      // reaction the server never accepted (no echo will arrive to
+      // reconcile it).
+      applyReaction(targetId, myNick, previousEmojis, senderId);
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  /**
+   * XEP-0424: retract the message identified by its room-assigned stanza-id
+   * (`replyableId`). Refuses to send when the id is missing — origin-id
+   * isn't trustworthy enough to retract by per XEP-0359 §5.
+   */
+  async function retractMessage(messageId: string) {
+    if (!xmppClient.value || !activeChannelId.value) return;
+    const target = findMessageById(messages.value, messageId);
+    const targetId = target?.replyableId;
+
+    clearActionError();
+    if (!targetId) {
+      actionError.value =
+        "This message can't be retracted (no room stanza-id). Try reloading the channel.";
+      return;
+    }
+
+    try {
+      await xmppClient.value.sendRetraction(
+        activeSpaceId.value ?? "",
+        activeChannelId.value,
+        targetId,
+      );
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  /**
+   * XEP-0425: moderator retract (MUC only). Same id-trust requirement as
+   * `retractMessage` — uses the room stanza-id, not origin-id.
+   */
+  async function moderateMessage(messageId: string, reason?: string) {
+    if (!xmppClient.value || !activeChannelId.value) return;
+    const target = findMessageById(messages.value, messageId);
+    const targetId = target?.replyableId;
+
+    clearActionError();
+    if (!targetId) {
+      actionError.value =
+        "This message can't be moderated (no room stanza-id). Try reloading the channel.";
+      return;
+    }
+
+    try {
+      await xmppClient.value.sendModeration(
+        activeSpaceId.value ?? "",
+        activeChannelId.value,
+        targetId,
+        reason,
+      );
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  /**
+   * Outbound extension-annotation action — Waddle-specific. The wasm client
+   * resolves the launch URL into the extension's command flow.
+   */
+  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
+    const client = xmppClient.value;
+    if (!client) {
+      const error = new Error("XMPP session is not ready.");
+      actionError.value = normalizeError(error);
+      throw error;
+    }
+    if (!action.launch) {
+      const error = new Error("This extension action is missing launch metadata.");
+      actionError.value = normalizeError(error);
+      throw error;
+    }
+    clearActionError();
+    try {
+      return await client.invokeExtensionLaunch(action.launch);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+      throw e;
+    }
+  }
+
+  return {
+    toggleReaction,
+    retractMessage,
+    moderateMessage,
+    invokeExtensionAction,
+  };
+}

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -19,7 +19,6 @@ import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
   type DeliveryStatus,
-  type ExtensionAnnotationAction,
   type MarkupSpan,
   type MessageReference,
   type TimelineMessage,
@@ -59,6 +58,7 @@ import {
 } from "@/channels/message-timeline-state";
 import { useChannelMamPaging } from "@/channels/mam-paging";
 import { useMucSend } from "@/channels/muc-send";
+import { useChannelMessageActions } from "@/channels/message-actions";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -668,6 +668,27 @@ export function useChannelMessages(
     onMessageDeliveryFailure,
   } = send;
 
+  const actions = useChannelMessageActions({
+    session,
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    currentRoomJid,
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError,
+    // applyReaction is still orchestrator-owned in PR 3; PR 4 (live-merge)
+    // moves it into useChannelLiveMerge and the dep wiring updates there.
+    applyReaction,
+  });
+  const {
+    toggleReaction,
+    retractMessage,
+    moderateMessage,
+    invokeExtensionAction,
+  } = actions;
+
   const paging = useChannelMamPaging({
     session,
     xmppClient,
@@ -721,115 +742,6 @@ export function useChannelMessages(
     messages.value = [];
     clearTypingState();
     await loadMessages(activeSpaceId.value ?? "", channelId);
-  }
-
-  async function toggleReaction(messageId: string, emoji: string) {
-    if (!xmppClient.value || !activeChannelId.value || !session.value)
-      return;
-
-    const msg = findMessageById(messages.value, messageId);
-    const targetId = msg?.reactionTargetId;
-    if (!targetId) return;
-    const myNick = session.value.username;
-    const currentReactions = msg?.reactions ?? {};
-
-    const previousEmojis: string[] = [];
-    for (const [e, nicks] of Object.entries(currentReactions)) {
-      if (nicks.includes(myNick)) previousEmojis.push(e);
-    }
-    const myEmojis = new Set(previousEmojis);
-
-    if (myEmojis.has(emoji)) myEmojis.delete(emoji);
-    else myEmojis.add(emoji);
-
-    const nextEmojis = [...myEmojis];
-    const senderId = currentRoomJid.value
-      ? `${currentRoomJid.value}/${myNick}`
-      : myNick;
-    applyReaction(targetId, myNick, nextEmojis, senderId);
-
-    try {
-      await xmppClient.value.sendReaction(
-        activeSpaceId.value ?? "",
-        activeChannelId.value,
-        targetId,
-        nextEmojis,
-      );
-    } catch (e) {
-      // Roll back the optimistic update so the chip stops claiming a
-      // reaction the server never accepted (no echo will arrive to
-      // reconcile it).
-      applyReaction(targetId, myNick, previousEmojis, senderId);
-      actionError.value = normalizeError(e);
-    }
-  }
-
-  async function retractMessage(messageId: string) {
-    if (!xmppClient.value || !activeChannelId.value) return;
-    const target = findMessageById(messages.value, messageId);
-    const targetId = target?.replyableId;
-
-    clearActionError();
-    if (!targetId) {
-      actionError.value =
-        "This message can't be retracted (no room stanza-id). Try reloading the channel.";
-      return;
-    }
-
-    try {
-      await xmppClient.value.sendRetraction(
-        activeSpaceId.value ?? "",
-        activeChannelId.value,
-        targetId,
-      );
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    }
-  }
-
-  async function moderateMessage(messageId: string, reason?: string) {
-    if (!xmppClient.value || !activeChannelId.value) return;
-    const target = findMessageById(messages.value, messageId);
-    const targetId = target?.replyableId;
-
-    clearActionError();
-    if (!targetId) {
-      actionError.value =
-        "This message can't be moderated (no room stanza-id). Try reloading the channel.";
-      return;
-    }
-
-    try {
-      await xmppClient.value.sendModeration(
-        activeSpaceId.value ?? "",
-        activeChannelId.value,
-        targetId,
-        reason,
-      );
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    }
-  }
-
-  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
-    const client = xmppClient.value;
-    if (!client) {
-      const error = new Error("XMPP session is not ready.");
-      actionError.value = normalizeError(error);
-      throw error;
-    }
-    if (!action.launch) {
-      const error = new Error("This extension action is missing launch metadata.");
-      actionError.value = normalizeError(error);
-      throw error;
-    }
-    clearActionError();
-    try {
-      return await client.invokeExtensionLaunch(action.launch);
-    } catch (e) {
-      actionError.value = normalizeError(e);
-      throw e;
-    }
   }
 
   function disconnect() {

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -1,0 +1,109 @@
+import type { Ref } from "vue";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+
+// Outbound message-action handlers for the DM side: reactions (XEP-0444),
+// retractions (XEP-0424), and extension-annotation actions. Mirrors the
+// channel-side composable minus moderator retract (XEP-0425 is MUC-only).
+//
+// `applyReaction` is injected — the local optimistic-update path lives in
+// the orchestrator today and moves into useDmLiveMerge in PR 4 of #351.
+
+type UseDmMessageActionsDeps = {
+  session: Ref<WaddleSession | null>;
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activePeerJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+  actionError: Ref<string>;
+  clearActionError: () => void;
+  normalizeError: (e: unknown) => string;
+  applyReaction: (messageId: string, nick: string, emojis: string[]) => void;
+};
+
+export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
+  const {
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError,
+    applyReaction,
+  } = deps;
+
+  /**
+   * XEP-0444 replace semantics for 1:1 chat. The sender device never
+   * receives an XEP-0280 carbon of its own send, so the optimistic local
+   * update is the only signal the author's reaction landed until a MAM
+   * reload — rollback on send failure is essential.
+   */
+  async function toggleReaction(messageId: string, emoji: string) {
+    if (!xmppClient.value || !activePeerJid.value || !session.value) return;
+    const msg = findMessageById(messages.value, messageId);
+    const targetId = msg?.replyableId ?? msg?.id ?? messageId;
+    const myNick = session.value.username;
+    const currentReactions = msg?.reactions ?? {};
+    const previousEmojis: string[] = [];
+    for (const [e, nicks] of Object.entries(currentReactions)) {
+      if (nicks.includes(myNick)) previousEmojis.push(e);
+    }
+    const myEmojis = new Set(previousEmojis);
+    if (myEmojis.has(emoji)) myEmojis.delete(emoji);
+    else myEmojis.add(emoji);
+
+    const nextEmojis = [...myEmojis];
+    applyReaction(targetId, myNick, nextEmojis);
+
+    try {
+      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis);
+    } catch (e) {
+      applyReaction(targetId, myNick, previousEmojis);
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  /**
+   * XEP-0424 retraction for 1:1. No room stanza-id requirement — the
+   * client-assigned message id is sufficient for DMs.
+   */
+  async function retractMessage(messageId: string) {
+    if (!xmppClient.value || !activePeerJid.value) return;
+    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    clearActionError();
+    try {
+      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+    }
+  }
+
+  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
+    const client = xmppClient.value;
+    if (!client) {
+      const error = new Error("XMPP session is not ready.");
+      actionError.value = normalizeError(error);
+      throw error;
+    }
+    if (!action.launch) {
+      const error = new Error("This extension action is missing launch metadata.");
+      actionError.value = normalizeError(error);
+      throw error;
+    }
+    clearActionError();
+    try {
+      return await client.invokeExtensionLaunch(action.launch);
+    } catch (e) {
+      actionError.value = normalizeError(e);
+      throw e;
+    }
+  }
+
+  return {
+    toggleReaction,
+    retractMessage,
+    invokeExtensionAction,
+  };
+}

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -2,6 +2,7 @@ import type { Ref } from "vue";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
+import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { findMessageById } from "@/lib/message-ids";
 
 // Outbound message-action handlers for the DM side: reactions (XEP-0444),
@@ -80,7 +81,9 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     }
   }
 
-  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
+  async function invokeExtensionAction(
+    action: ExtensionAnnotationAction,
+  ): Promise<ExtensionCommandResult> {
     const client = xmppClient.value;
     if (!client) {
       const error = new Error("XMPP session is not ready.");

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -67,12 +67,17 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
   }
 
   /**
-   * XEP-0424 retraction for 1:1. No room stanza-id requirement — the
-   * client-assigned message id is sufficient for DMs.
+   * XEP-0424 retraction for 1:1. Prefer `replyableId` (origin-id per
+   * XEP-0461 §3.2 in `dmMessageFromArchived`) over `TimelineMessage.id`
+   * — the latter can fall back to the MAM archive id when origin-id and
+   * the message's own `@id` are absent, and a MAM id is not a valid
+   * XEP-0424 retraction target. The trailing `?? messageId` keeps the
+   * caller's id usable when the message isn't in our timeline yet.
    */
   async function retractMessage(messageId: string) {
     if (!xmppClient.value || !activePeerJid.value) return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    const target = findMessageById(messages.value, messageId);
+    const targetId = target?.replyableId ?? target?.id ?? messageId;
     clearActionError();
     try {
       await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId);

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -1,7 +1,6 @@
 import { computed, nextTick, ref, watch, type Ref } from "vue";
 import {
   type DeliveryStatus,
-  type ExtensionAnnotationAction,
   type TimelineMessage,
 } from "@/lib/chat-ui";
 import type {
@@ -37,6 +36,7 @@ import {
 } from "@/dms/message-timeline-state";
 import { useDmMamPaging } from "@/dms/mam-paging";
 import { useChatSend } from "@/dms/chat-send";
+import { useDmMessageActions } from "@/dms/message-actions";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -278,6 +278,24 @@ export function useDirectMessages(
     onMessageDeliveryFailure,
   } = send;
 
+  const actions = useDmMessageActions({
+    session,
+    xmppClient,
+    activePeerJid,
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError,
+    // applyReaction is still orchestrator-owned in PR 3; PR 4 (live-merge)
+    // moves it into useDmLiveMerge and the dep wiring updates there.
+    applyReaction,
+  });
+  const {
+    toggleReaction,
+    retractMessage,
+    invokeExtensionAction,
+  } = actions;
+
   const paging = useDmMamPaging({
     session,
     xmppClient,
@@ -389,67 +407,6 @@ export function useDirectMessages(
     })();
   }
 
-  async function toggleReaction(messageId: string, emoji: string) {
-    if (!xmppClient.value || !activePeerJid.value || !session.value) return;
-    const msg = findMessageById(messages.value, messageId);
-    const targetId = msg?.replyableId ?? msg?.id ?? messageId;
-    const myNick = session.value.username;
-    const currentReactions = msg?.reactions ?? {};
-    const previousEmojis: string[] = [];
-    for (const [e, nicks] of Object.entries(currentReactions)) {
-      if (nicks.includes(myNick)) previousEmojis.push(e);
-    }
-    const myEmojis = new Set(previousEmojis);
-    if (myEmojis.has(emoji)) myEmojis.delete(emoji);
-    else myEmojis.add(emoji);
-
-    const nextEmojis = [...myEmojis];
-    // Optimistic local update: the sender device never receives an XEP-0280
-    // carbon of its own send, so without this the reaction stays invisible
-    // to its author until the next MAM reload.
-    applyReaction(targetId, myNick, nextEmojis);
-
-    try {
-      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis);
-    } catch (e) {
-      // Roll back the optimistic update — no echo or carbon will arrive
-      // to reconcile a failed send.
-      applyReaction(targetId, myNick, previousEmojis);
-      actionError.value = normalizeError(e);
-    }
-  }
-
-  async function retractMessage(messageId: string) {
-    if (!xmppClient.value || !activePeerJid.value) return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
-    clearActionError();
-    try {
-      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId);
-    } catch (e) {
-      actionError.value = normalizeError(e);
-    }
-  }
-
-  async function invokeExtensionAction(action: ExtensionAnnotationAction) {
-    const client = xmppClient.value;
-    if (!client) {
-      const error = new Error("XMPP session is not ready.");
-      actionError.value = normalizeError(error);
-      throw error;
-    }
-    if (!action.launch) {
-      const error = new Error("This extension action is missing launch metadata.");
-      actionError.value = normalizeError(error);
-      throw error;
-    }
-    clearActionError();
-    try {
-      return await client.invokeExtensionLaunch(action.launch);
-    } catch (e) {
-      actionError.value = normalizeError(e);
-      throw e;
-    }
-  }
 
   function markDisplayed(messageId: string) {
     if (!xmppClient.value || !activePeerJid.value) return;

--- a/chat/tests/channel-message-actions.test.ts
+++ b/chat/tests/channel-message-actions.test.ts
@@ -7,7 +7,7 @@ import { ref } from "vue";
 import { useChannelMessageActions } from "../src/channels/message-actions";
 import type { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
-import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { ExtensionAnnotationAction, TimelineMessage } from "../src/lib/chat-ui";
 
 const session: WaddleSession = {
   username: "alice",
@@ -187,12 +187,13 @@ describe("invokeExtensionAction", () => {
     const client = makeClient({ invokeExtensionLaunch } as Partial<BrowserXmppClient>);
     const h = harness({ client });
 
-    const result = await h.actions.invokeExtensionAction({
+    const action: ExtensionAnnotationAction = {
       annotationId: "a1",
       extensionId: "ext",
       label: "Do it",
       launch: { kind: "launch", url: "https://example.com/x" },
-    } as any);
+    };
+    const result = await h.actions.invokeExtensionAction(action);
 
     expect(invokeExtensionLaunch).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ ok: true, value: "abc" });
@@ -202,13 +203,20 @@ describe("invokeExtensionAction", () => {
   test("throws and sets actionError when no client is available", async () => {
     const h = harness();
     h.xmppClient.value = null;
-    await expect(h.actions.invokeExtensionAction({} as any)).rejects.toThrow("XMPP session is not ready");
+    const action: ExtensionAnnotationAction = {
+      annotationId: "a1",
+      extensionId: "ext",
+      label: "Do it",
+      launch: { kind: "launch", url: "https://example.com/x" },
+    };
+    await expect(h.actions.invokeExtensionAction(action)).rejects.toThrow("XMPP session is not ready");
     expect(h.actionError.value).toContain("XMPP session is not ready");
   });
 
   test("throws and sets actionError when launch metadata is missing", async () => {
     const h = harness();
-    await expect(h.actions.invokeExtensionAction({ annotationId: "a1", extensionId: "ext", label: "Do it" } as any))
+    const action = { annotationId: "a1", extensionId: "ext", label: "Do it" } as ExtensionAnnotationAction;
+    await expect(h.actions.invokeExtensionAction(action))
       .rejects.toThrow("missing launch metadata");
     expect(h.actionError.value).toContain("missing launch metadata");
   });

--- a/chat/tests/channel-message-actions.test.ts
+++ b/chat/tests/channel-message-actions.test.ts
@@ -1,0 +1,215 @@
+// Direct unit tests for useChannelMessageActions covering XEP-0444 reaction
+// replace semantics, XEP-0424 retraction id-trust requirement, XEP-0425
+// moderator retract, and the extension-annotation action surface.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelMessageActions } from "../src/channels/message-actions";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+function makeClient(overrides: Partial<BrowserXmppClient> = {}): BrowserXmppClient {
+  return {
+    sendReaction: mock(async () => undefined),
+    sendRetraction: mock(async () => undefined),
+    sendModeration: mock(async () => undefined),
+    invokeExtensionLaunch: mock(async () => ({ ok: true })),
+    ...overrides,
+  } as unknown as BrowserXmppClient;
+}
+
+function harness(opts: { client?: BrowserXmppClient } = {}) {
+  const xmppClient = ref<BrowserXmppClient | null>(opts.client ?? makeClient());
+  const messages = ref<TimelineMessage[]>([]);
+  const actionError = ref("");
+  const clearActionError = mock(() => { actionError.value = ""; });
+  const applyReaction = mock(() => {});
+
+  const actions = useChannelMessageActions({
+    session: ref(session),
+    xmppClient,
+    activeSpaceId: ref("space"),
+    activeChannelId: ref("general"),
+    currentRoomJid: ref("general@muc.example.com"),
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError: (e) => String(e),
+    applyReaction,
+  });
+
+  return { xmppClient, messages, actionError, actions, applyReaction };
+}
+
+describe("toggleReaction (XEP-0444)", () => {
+  test("adds an emoji to the local user's reaction set with replace semantics", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "msg-1", reactionTargetId: "stanza-1", reactions: {}, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("msg-1", "👍");
+
+    // Optimistic local update fired
+    expect(h.applyReaction).toHaveBeenCalledTimes(1);
+    const applyCall = (h.applyReaction as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(applyCall[0]).toBe("stanza-1");
+    expect(applyCall[1]).toBe("alice");
+    expect(applyCall[2]).toEqual(["👍"]);
+
+    // sendReaction received the full updated set per XEP-0444 replace semantics
+    const sendReaction = h.xmppClient.value!.sendReaction as unknown as ReturnType<typeof mock>;
+    expect(sendReaction).toHaveBeenCalledTimes(1);
+    const sendArgs = sendReaction.mock.calls[0]!;
+    expect(sendArgs[2]).toBe("stanza-1");
+    expect(sendArgs[3]).toEqual(["👍"]);
+  });
+
+  test("removes an emoji when the local user has already reacted with it", async () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "msg-1",
+        reactionTargetId: "stanza-1",
+        reactions: { "👍": ["alice"], "❤️": ["alice"] },
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("msg-1", "👍");
+
+    // The full updated set for alice no longer includes 👍
+    const sendReaction = h.xmppClient.value!.sendReaction as unknown as ReturnType<typeof mock>;
+    const sentEmojis = sendReaction.mock.calls[0]![3] as string[];
+    expect(sentEmojis).toEqual(["❤️"]);
+  });
+
+  test("rolls back the optimistic update if the send fails", async () => {
+    const client = makeClient({
+      sendReaction: mock(async () => { throw new Error("server angry"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      { id: "msg-1", reactionTargetId: "stanza-1", reactions: {}, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+
+    await h.actions.toggleReaction("msg-1", "👍");
+
+    // Optimistic + rollback = 2 applyReaction calls
+    expect(h.applyReaction).toHaveBeenCalledTimes(2);
+    const rollback = (h.applyReaction as unknown as ReturnType<typeof mock>).mock.calls[1]!;
+    expect(rollback[2]).toEqual([]); // back to no reactions
+    expect(h.actionError.value).toContain("server angry");
+  });
+
+  test("no-op without reactionTargetId (message can't be reacted to)", async () => {
+    const h = harness();
+    h.messages.value = [
+      // No reactionTargetId — message wasn't reflected by the room with a stanza-id.
+      { id: "msg-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("msg-1", "👍");
+    expect((h.xmppClient.value!.sendReaction as unknown as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect(h.applyReaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("retractMessage (XEP-0424)", () => {
+  test("sends with replyableId (room stanza-id)", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "msg-1", replyableId: "stanza-by-room", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("msg-1");
+    const sendRetraction = h.xmppClient.value!.sendRetraction as unknown as ReturnType<typeof mock>;
+    expect(sendRetraction).toHaveBeenCalledTimes(1);
+    expect(sendRetraction.mock.calls[0]![2]).toBe("stanza-by-room");
+  });
+
+  test("refuses without replyableId — origin-id is too weak to retract by (XEP-0359 §5)", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "msg-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("msg-1");
+    const sendRetraction = h.xmppClient.value!.sendRetraction as unknown as ReturnType<typeof mock>;
+    expect(sendRetraction).not.toHaveBeenCalled();
+    expect(h.actionError.value).toContain("no room stanza-id");
+  });
+
+  test("send-throws surfaces normalized error", async () => {
+    const client = makeClient({
+      sendRetraction: mock(async () => { throw new Error("forbidden"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      { id: "msg-1", replyableId: "stanza-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("msg-1");
+    expect(h.actionError.value).toContain("forbidden");
+  });
+});
+
+describe("moderateMessage (XEP-0425, MUC-only)", () => {
+  test("sends with replyableId and optional reason", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "msg-1", replyableId: "stanza-by-room", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.moderateMessage("msg-1", "spam");
+    const sendModeration = h.xmppClient.value!.sendModeration as unknown as ReturnType<typeof mock>;
+    expect(sendModeration).toHaveBeenCalledTimes(1);
+    const args = sendModeration.mock.calls[0]!;
+    expect(args[2]).toBe("stanza-by-room");
+    expect(args[3]).toBe("spam");
+  });
+
+  test("refuses without replyableId", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "msg-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.moderateMessage("msg-1");
+    expect((h.xmppClient.value!.sendModeration as unknown as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+    expect(h.actionError.value).toContain("no room stanza-id");
+  });
+});
+
+describe("invokeExtensionAction", () => {
+  test("forwards launch metadata to the wasm client and returns the result", async () => {
+    const invokeExtensionLaunch = mock(async () => ({ ok: true, value: "abc" }));
+    const client = makeClient({ invokeExtensionLaunch } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+
+    const result = await h.actions.invokeExtensionAction({
+      annotationId: "a1",
+      extensionId: "ext",
+      label: "Do it",
+      launch: { kind: "launch", url: "https://example.com/x" },
+    } as any);
+
+    expect(invokeExtensionLaunch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, value: "abc" });
+    expect(h.actionError.value).toBe("");
+  });
+
+  test("throws and sets actionError when no client is available", async () => {
+    const h = harness();
+    h.xmppClient.value = null;
+    await expect(h.actions.invokeExtensionAction({} as any)).rejects.toThrow("XMPP session is not ready");
+    expect(h.actionError.value).toContain("XMPP session is not ready");
+  });
+
+  test("throws and sets actionError when launch metadata is missing", async () => {
+    const h = harness();
+    await expect(h.actions.invokeExtensionAction({ annotationId: "a1", extensionId: "ext", label: "Do it" } as any))
+      .rejects.toThrow("missing launch metadata");
+    expect(h.actionError.value).toContain("missing launch metadata");
+  });
+});

--- a/chat/tests/dm-message-actions.test.ts
+++ b/chat/tests/dm-message-actions.test.ts
@@ -1,0 +1,133 @@
+// Direct unit tests for useDmMessageActions: XEP-0444 reactions, XEP-0424
+// retractions, and extension-annotation actions on 1:1 chat.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useDmMessageActions } from "../src/dms/message-actions";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+function makeClient(overrides: Partial<BrowserXmppClient> = {}): BrowserXmppClient {
+  return {
+    sendDmReaction: mock(async () => undefined),
+    sendDmRetraction: mock(async () => undefined),
+    invokeExtensionLaunch: mock(async () => ({ ok: true })),
+    ...overrides,
+  } as unknown as BrowserXmppClient;
+}
+
+function harness(opts: { client?: BrowserXmppClient } = {}) {
+  const xmppClient = ref<BrowserXmppClient | null>(opts.client ?? makeClient());
+  const messages = ref<TimelineMessage[]>([]);
+  const actionError = ref("");
+  const clearActionError = mock(() => { actionError.value = ""; });
+  const applyReaction = mock(() => {});
+
+  const actions = useDmMessageActions({
+    session: ref(session),
+    xmppClient,
+    activePeerJid: ref("bob@example.com"),
+    messages,
+    actionError,
+    clearActionError,
+    normalizeError: (e) => String(e),
+    applyReaction,
+  });
+
+  return { xmppClient, messages, actionError, actions, applyReaction };
+}
+
+describe("toggleReaction (XEP-0444)", () => {
+  test("adds an emoji and sends the full updated set", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "dm-1", reactions: {}, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("dm-1", "🎉");
+
+    expect(h.applyReaction).toHaveBeenCalledTimes(1);
+    const sendDmReaction = h.xmppClient.value!.sendDmReaction as unknown as ReturnType<typeof mock>;
+    expect(sendDmReaction).toHaveBeenCalledTimes(1);
+    expect(sendDmReaction.mock.calls[0]![2]).toEqual(["🎉"]);
+  });
+
+  test("rolls back optimistic update on send failure (no XEP-0280 carbon for own send)", async () => {
+    const client = makeClient({
+      sendDmReaction: mock(async () => { throw new Error("network"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      { id: "dm-1", reactions: {}, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+
+    await h.actions.toggleReaction("dm-1", "🎉");
+
+    expect(h.applyReaction).toHaveBeenCalledTimes(2);
+    const rollback = (h.applyReaction as unknown as ReturnType<typeof mock>).mock.calls[1]!;
+    expect(rollback[2]).toEqual([]);
+    expect(h.actionError.value).toContain("network");
+  });
+});
+
+describe("retractMessage (XEP-0424)", () => {
+  test("falls back to message id when replyableId is absent (DMs don't require room stanza-id)", async () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "dm-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("dm-1");
+    const sendDmRetraction = h.xmppClient.value!.sendDmRetraction as unknown as ReturnType<typeof mock>;
+    expect(sendDmRetraction).toHaveBeenCalledTimes(1);
+    expect(sendDmRetraction.mock.calls[0]![1]).toBe("dm-1");
+  });
+
+  test("send-throws surfaces normalized error", async () => {
+    const client = makeClient({
+      sendDmRetraction: mock(async () => { throw new Error("forbidden"); }),
+    } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+    h.messages.value = [
+      { id: "dm-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("dm-1");
+    expect(h.actionError.value).toContain("forbidden");
+  });
+});
+
+describe("invokeExtensionAction", () => {
+  test("forwards launch metadata to the wasm client", async () => {
+    const invokeExtensionLaunch = mock(async () => ({ ok: true }));
+    const client = makeClient({ invokeExtensionLaunch } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+
+    const result = await h.actions.invokeExtensionAction({
+      annotationId: "a1",
+      extensionId: "ext",
+      label: "Do it",
+      launch: { kind: "launch", url: "https://example.com/x" },
+    } as any);
+
+    expect(invokeExtensionLaunch).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true });
+  });
+
+  test("throws when no client", async () => {
+    const h = harness();
+    h.xmppClient.value = null;
+    await expect(h.actions.invokeExtensionAction({} as any)).rejects.toThrow("XMPP session is not ready");
+  });
+
+  test("throws when launch metadata is missing", async () => {
+    const h = harness();
+    await expect(h.actions.invokeExtensionAction({ annotationId: "a1", extensionId: "ext", label: "Do it" } as any))
+      .rejects.toThrow("missing launch metadata");
+  });
+});

--- a/chat/tests/dm-message-actions.test.ts
+++ b/chat/tests/dm-message-actions.test.ts
@@ -6,7 +6,7 @@ import { ref } from "vue";
 import { useDmMessageActions } from "../src/dms/message-actions";
 import type { BrowserXmppClient } from "../src/lib/xmpp-client";
 import type { WaddleSession } from "../src/lib/server-auth";
-import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { ExtensionAnnotationAction, TimelineMessage } from "../src/lib/chat-ui";
 
 const session: WaddleSession = {
   username: "alice",
@@ -77,6 +77,28 @@ describe("toggleReaction (XEP-0444)", () => {
   });
 });
 
+describe("toggleReaction target-id precedence", () => {
+  test("prefers replyableId over id when both are present", async () => {
+    // If a DM carries a server-stable XEP-0359 stanza-id (currently rare,
+    // but possible if the server starts attaching one), the reaction MUST
+    // target the stable id, not the client-assigned message id. Lock the
+    // precedence in to catch any regression in `msg.replyableId ?? msg.id`.
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "client-id",
+        replyableId: "server-stable-id",
+        reactions: {},
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    await h.actions.toggleReaction("client-id", "👀");
+    const sendDmReaction = h.xmppClient.value!.sendDmReaction as unknown as ReturnType<typeof mock>;
+    expect(sendDmReaction).toHaveBeenCalledTimes(1);
+    expect(sendDmReaction.mock.calls[0]![1]).toBe("server-stable-id");
+  });
+});
+
 describe("retractMessage (XEP-0424)", () => {
   test("falls back to message id when replyableId is absent (DMs don't require room stanza-id)", async () => {
     const h = harness();
@@ -108,12 +130,13 @@ describe("invokeExtensionAction", () => {
     const client = makeClient({ invokeExtensionLaunch } as Partial<BrowserXmppClient>);
     const h = harness({ client });
 
-    const result = await h.actions.invokeExtensionAction({
+    const action: ExtensionAnnotationAction = {
       annotationId: "a1",
       extensionId: "ext",
       label: "Do it",
       launch: { kind: "launch", url: "https://example.com/x" },
-    } as any);
+    };
+    const result = await h.actions.invokeExtensionAction(action);
 
     expect(invokeExtensionLaunch).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ ok: true });
@@ -122,12 +145,19 @@ describe("invokeExtensionAction", () => {
   test("throws when no client", async () => {
     const h = harness();
     h.xmppClient.value = null;
-    await expect(h.actions.invokeExtensionAction({} as any)).rejects.toThrow("XMPP session is not ready");
+    const action: ExtensionAnnotationAction = {
+      annotationId: "a1",
+      extensionId: "ext",
+      label: "Do it",
+      launch: { kind: "launch", url: "https://example.com/x" },
+    };
+    await expect(h.actions.invokeExtensionAction(action)).rejects.toThrow("XMPP session is not ready");
   });
 
   test("throws when launch metadata is missing", async () => {
     const h = harness();
-    await expect(h.actions.invokeExtensionAction({ annotationId: "a1", extensionId: "ext", label: "Do it" } as any))
+    const action = { annotationId: "a1", extensionId: "ext", label: "Do it" } as ExtensionAnnotationAction;
+    await expect(h.actions.invokeExtensionAction(action))
       .rejects.toThrow("missing launch metadata");
   });
 });

--- a/chat/tests/dm-message-actions.test.ts
+++ b/chat/tests/dm-message-actions.test.ts
@@ -79,10 +79,12 @@ describe("toggleReaction (XEP-0444)", () => {
 
 describe("toggleReaction target-id precedence", () => {
   test("prefers replyableId over id when both are present", async () => {
-    // If a DM carries a server-stable XEP-0359 stanza-id (currently rare,
-    // but possible if the server starts attaching one), the reaction MUST
-    // target the stable id, not the client-assigned message id. Lock the
-    // precedence in to catch any regression in `msg.replyableId ?? msg.id`.
+    // DM `replyableId` is the XEP-0461 §3.2 reply-target id —
+    // `dmMessageFromArchived` sets it to `origin_id ?? message.id`, which
+    // is wire-stable across MAM round-trips. `TimelineMessage.id` can fall
+    // back to a MAM archive id when origin-id and message.id are absent;
+    // that's not a valid reaction target. Lock the
+    // `msg.replyableId ?? msg.id` precedence in.
     const h = harness();
     h.messages.value = [
       {
@@ -100,6 +102,24 @@ describe("toggleReaction target-id precedence", () => {
 });
 
 describe("retractMessage (XEP-0424)", () => {
+  test("prefers replyableId over id (wire-stable origin-id beats potential MAM-id fallback)", async () => {
+    // `dmMessageFromArchived` sets `replyableId = origin_id ?? message.id`
+    // — that's the wire-stable retract target. `TimelineMessage.id` can
+    // fall back to a MAM archive id, which is NOT a valid XEP-0424 target.
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "mam-archive-id",
+        replyableId: "wire-origin-id",
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    await h.actions.retractMessage("mam-archive-id");
+    const sendDmRetraction = h.xmppClient.value!.sendDmRetraction as unknown as ReturnType<typeof mock>;
+    expect(sendDmRetraction).toHaveBeenCalledTimes(1);
+    expect(sendDmRetraction.mock.calls[0]![1]).toBe("wire-origin-id");
+  });
+
   test("falls back to message id when replyableId is absent (DMs don't require room stanza-id)", async () => {
     const h = harness();
     h.messages.value = [


### PR DESCRIPTION
## Summary

PR 3 of 7. Extract outbound message-action handlers (reactions, retractions, moderation, extension annotations) out of `channels/messages.ts` and `dms/messages.ts` into focused composables. Each action is a distinct XEP, so the new files read as "this implements XEP-0xxx" rather than a generic action bucket.

Refs: #351 — see the full implementation plan there.

## What lands

- **`chat/src/channels/message-actions.ts`** (new) — `useChannelMessageActions` owning:
  - **`toggleReaction`** (XEP-0444) — add/remove reaction with replace semantics; reads the current set, toggles the emoji for the local user, sends the full updated set.
  - **`retractMessage`** (XEP-0424) — requires `replyableId` (room stanza-id), gates by author.
  - **`moderateMessage`** (XEP-0425) — MUC-only moderator retract.
  - **`invokeExtensionAction`** — outbound extension command on an annotated message.
- **`chat/src/dms/message-actions.ts`** (new) — `useDmMessageActions` mirroring the channel side minus `moderateMessage`.
- **`chat/tests/channel-message-actions.test.ts`** + **`chat/tests/dm-message-actions.test.ts`** — direct unit tests per PR Compliance #2.
- **`chat/src/channels/messages.ts`** + **`chat/src/dms/messages.ts`** — orchestrators wire the new composables; ~200 LOC removed from each.

## XEP conformance (caveats from #351 plan)

1. **XEP-0444 replace semantics** — `toggleReaction` reads the current per-author reaction set, toggles the local user's emoji, sends the *full* updated set. Empty set removes all of the user's reactions on that message. Tested directly.
2. **XEP-0424 sender match** — retraction sender comparison stays in `channels/message-timeline-state.ts::isSameMucRetractionSender` (uses real-JID or full-JID for non-anon MUC; uses `replyableId` derived from the room's XEP-0359 stanza-id, never origin-id). PR preserves this — no change to the helper.
3. **Reactions on retracted messages** — the inbound `mergeLiveMessage` path was already audited; reactions to a `<retracted/>` tombstone are no-ops in `applyReaction`. PR doesn't touch this path; it only extracts the *outbound* action surface.

## Test strategy

- Composables: direct unit tests with mocked `BrowserXmppClient` (same pattern as PR 2's `muc-send.test.ts` / `chat-send.test.ts`).
- Targeted integration tests pass: `reaction-mode`, `tombstone-replay`, `reply-preview-population`.
- Gates: `bun test`, `bun run lint`, `bunx astro check`.

## Acceptance criteria

- [ ] `channels/messages.ts` and `dms/messages.ts` no longer define `toggleReaction` / `retractMessage` / `moderateMessage` / `invokeExtensionAction` inline.
- [ ] Composables expose the same public methods on `useChannelMessages` / `useDirectMessages` return shapes (call-site stability).
- [ ] Direct unit tests for each composable green.
- [ ] Existing integration tests pass unchanged.
- [ ] `bun test`, `bun run lint`, `astro check` clean.

## Plan checkpoint

Sequential off `main`. PR 2 (#465) merged. After this lands, PR 4 (`refactor(chat): extract live-merge composables`) branches off the new `main`.
