### PR TITLE
refactor(chat): extract live-merge composables with typed classifier

### DIFF
--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -1,0 +1,269 @@
+import type { Ref } from "vue";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { LiveRoomMessage } from "@/lib/xmpp-client";
+import {
+  type DeliveryStatus,
+  type TimelineMessage,
+} from "@/lib/chat-ui";
+import { findMessageById, matchMessageId, mergeMessageIds } from "@/lib/message-ids";
+import { applyForumContext, isFeedTimelineMessage, mapLiveRoomMessageToTimeline } from "@/channels/timeline";
+import {
+  isMucServiceModeration,
+  isSameMucCorrectionSender,
+  isSameMucRetractionSender,
+  isValidMucModerationTarget,
+  isValidMucRetractionTarget,
+  reactionSendersForUpdate,
+  reactionsFromSenders,
+  removeSenderReactions,
+  retractChannelTimelineMessage,
+} from "@/channels/message-timeline-state";
+import { classifyRoomMessage } from "@/lib/xmpp/classify-room-message";
+
+// Inbound merge composable for the channel side: applies incoming
+// retractions (XEP-0424 / 0425), corrections (XEP-0308), reactions
+// (XEP-0444), displayed markers (XEP-0333), and plain messages to the
+// timeline. Self-echo reconciliation lives here too — it reads the
+// `pendingEchoClientIds` Set from `useMucSend` so the body-match
+// fallback only targets sends still awaiting their server-assigned id.
+//
+// The omnibus `setMessageHandler` from `BrowserXmppClient` is filtered
+// and routed by `handleRoomMessage`, which delegates per-kind work to
+// the per-XEP `apply*` helpers via the pure `classifyRoomMessage` pass.
+// Once `BrowserXmppClient` exposes typed inbound events (follow-up from
+// #351's plan), the classifier becomes redundant.
+
+type UseChannelLiveMergeDeps = {
+  session: Ref<WaddleSession | null>;
+  messages: Ref<TimelineMessage[]>;
+  activeChannelId: Ref<string | null>;
+  pendingEchoClientIds: Set<string>;
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  persistLastSeen: (channelId: string, messageId: string) => void;
+};
+
+const isFeedVisible = isFeedTimelineMessage;
+
+export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
+  const {
+    session,
+    messages,
+    activeChannelId,
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+  } = deps;
+
+  /**
+   * XEP-0333: record the displayed marker (`<displayed/>` chat marker) for
+   * a remote read of one of our messages. Cumulative — all earlier messages
+   * are implicitly displayed for that reader too, but the helper only
+   * mutates the exact target since the timeline carries `readBy` per
+   * message.
+   */
+  function applyDisplayed(messageId: string, nick: string) {
+    messages.value = messages.value.map((m): TimelineMessage => {
+      if (!matchMessageId(m, messageId)) return m;
+      const existing = m.readBy ? [...m.readBy] : [];
+      if (!existing.includes(nick)) existing.push(nick);
+      return { ...m, readBy: existing };
+    });
+  }
+
+  /**
+   * XEP-0444 replace semantics: this author's full reaction set on the
+   * target message becomes `emojis`. The previous per-author set is wiped
+   * via `removeSenderReactions` so unticking an emoji actually removes it.
+   */
+  function applyReaction(messageId: string, nick: string, emojis: string[], senderId: string = nick) {
+    messages.value = messages.value.map((m): TimelineMessage => {
+      if (m.reactionTargetId !== messageId) return m;
+      const reactionSenders = reactionSendersForUpdate(m, nick, senderId);
+      removeSenderReactions(reactionSenders, nick, senderId);
+      for (const emoji of emojis) {
+        if (!reactionSenders[emoji]) reactionSenders[emoji] = {};
+        reactionSenders[emoji][senderId] = nick;
+      }
+      const reactions = reactionsFromSenders(reactionSenders);
+      const updated = { ...m };
+      if (Object.keys(reactionSenders).length > 0) {
+        updated.reactionSenders = reactionSenders;
+        updated.reactions = reactions;
+      } else {
+        delete updated.reactionSenders;
+        delete updated.reactions;
+      }
+      return updated;
+    });
+  }
+
+  /**
+   * XEP-0424 retraction with XEP-0425 moderation support. Sender gating
+   * happens here via `isSameMucRetractionSender` / `isMucServiceModeration`
+   * so a spoofed retraction from a different occupant can't tombstone
+   * someone else's message.
+   */
+  function applyRetraction(msg: LiveRoomMessage) {
+    messages.value = messages.value.map((m) => {
+      if (!msg.retractsId || !matchMessageId(m, msg.retractsId)) return m;
+      if (msg.moderationTargetId) {
+        if (!isMucServiceModeration(msg)) return m;
+        if (!isValidMucModerationTarget(m, msg.moderationTargetId)) return m;
+      } else if (
+        !isValidMucRetractionTarget(m, msg.retractsId)
+        || !isSameMucRetractionSender(m, mucCorrectionSenderFor(msg))
+      ) {
+        return m;
+      }
+      return retractChannelTimelineMessage(m, msg.retractionId);
+    });
+  }
+
+  /**
+   * XEP-0308 last-message correction. Sender match enforced via
+   * `isSameMucCorrectionSender` (real-JID for non-anon MUC, occupant-id
+   * elsewhere). Markup / references / extension annotations are replaced
+   * wholesale to mirror the wire shape — null/empty drops the field.
+   */
+  function applyCorrection(
+    replacesId: string,
+    newBody: string,
+    correctionSender: { authorJid: string; authorRealJid?: string },
+    markup?: LiveRoomMessage["markup"],
+    references?: LiveRoomMessage["references"],
+    extensionAnnotations?: LiveRoomMessage["extensionAnnotations"],
+    extensionBodyFallback?: boolean,
+  ) {
+    const idx = messages.value.findIndex((m) =>
+      matchMessageId(m, replacesId) && isSameMucCorrectionSender(m, correctionSender)
+    );
+    if (idx === -1) return;
+    messages.value = messages.value.map((m) => {
+      if (!matchMessageId(m, replacesId) || !isSameMucCorrectionSender(m, correctionSender)) return m;
+      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
+      if (markup && markup.length > 0) updated.markup = markup;
+      else delete updated.markup;
+      if (references && references.length > 0) updated.references = references;
+      else delete updated.references;
+      if (extensionAnnotations && extensionAnnotations.length > 0) {
+        updated.extensionAnnotations = extensionAnnotations;
+        if (extensionBodyFallback) updated.extensionBodyFallback = true;
+        else delete updated.extensionBodyFallback;
+      } else {
+        delete updated.extensionAnnotations;
+        delete updated.extensionBodyFallback;
+      }
+      return updated;
+    });
+  }
+
+  /**
+   * Merges a regular incoming message (no retract, no correction). If the
+   * message reconciles a still-pending self-echo we promote the existing
+   * optimistic entry to "delivered" via the `pendingEchoClientIds` body
+   * match. Otherwise we append.
+   */
+  function mergeLiveMessage(rawMessage: TimelineMessage) {
+    const msg = rawMessage.isRetracted
+      ? retractChannelTimelineMessage(rawMessage, rawMessage.retractionId)
+      : rawMessage;
+    const existingById = [msg.id, ...(msg.wireIds ?? [])]
+      .map((id) => findMessageById(messages.value, id))
+      .find((message): message is TimelineMessage => !!message);
+    const pendingSelfEcho = messages.value.find(
+      (m) => pendingEchoClientIds.has(m.id) && m.isSelf && msg.isSelf && m.body === msg.body,
+    );
+    const preservedSelfEcho = [...messages.value].reverse().find(
+      (m) =>
+        m.isSelf
+        && msg.isSelf
+        && m.body === msg.body
+        && !!m.deliveryStatus
+        && m.deliveryStatus !== "delivered",
+    );
+    const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
+    if (existing) {
+      const wasPending = existing.id !== msg.id;
+      messages.value = messages.value.map((m) => {
+        if (m.id !== existing.id) return m;
+        const updated: TimelineMessage = {
+          ...m,
+          ...msg,
+          ...mergeMessageIds(m, msg.id, msg.wireIds),
+        };
+        if (m.isSelf && msg.isSelf) {
+          // A self-echo from the room is authoritative; it supersedes any
+          // prior "sending" / "failed" optimistic state.
+          updated.deliveryStatus = "delivered" as DeliveryStatus;
+        }
+        return updated;
+      });
+      messages.value = applyForumContext(messages.value);
+      if (wasPending) pendingEchoClientIds.delete(existing.id);
+      return;
+    }
+    const channelId = activeChannelId.value;
+    messages.value = applyForumContext([...messages.value, msg]);
+    void scrollToPinnedEdgeAndPin();
+    if (channelId && isFeedVisible(msg)) {
+      persistLastSeen(channelId, msg.id);
+    }
+  }
+
+  /**
+   * Routes an inbound `LiveRoomMessage` through the typed classifier and
+   * dispatches to the per-XEP `apply*` helpers. Returns the classifier's
+   * tagged output so callers (the orchestrator's notification logic) can
+   * inspect the kind without re-classifying.
+   */
+  function handleRoomMessage(msg: LiveRoomMessage) {
+    const classified = classifyRoomMessage(msg);
+    switch (classified.kind) {
+      case "retraction":
+        applyRetraction(msg);
+        break;
+      case "correction":
+        applyCorrection(
+          classified.replacesId,
+          classified.body,
+          classified.sender,
+          classified.markup,
+          classified.references,
+          classified.extensionAnnotations,
+          classified.extensionBodyFallback,
+        );
+        break;
+      case "live":
+        if (session.value) {
+          mergeLiveMessage(
+            mapLiveRoomMessageToTimeline(session.value, msg, (id) => findMessageById(messages.value, id)),
+          );
+        }
+        break;
+      case "ignore":
+        break;
+    }
+    return classified;
+  }
+
+  return {
+    applyDisplayed,
+    applyReaction,
+    applyRetraction,
+    applyCorrection,
+    mergeLiveMessage,
+    handleRoomMessage,
+  };
+}
+
+// Local helper to avoid a cross-file circular: mucCorrectionSender lives in
+// message-timeline-state and is also used by the classifier. We keep a
+// thin local function here so applyRetraction doesn't reach into the
+// classifier's typed output for the sender — it's still building it from
+// the raw stanza.
+function mucCorrectionSenderFor(msg: LiveRoomMessage): { authorJid: string; authorRealJid?: string } {
+  return {
+    authorJid: `${msg.roomJid}/${msg.nick}`,
+    ...(msg.authorRealJid ? { authorRealJid: msg.authorRealJid } : {}),
+  };
+}

--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -13,6 +13,7 @@ import {
   isSameMucRetractionSender,
   isValidMucModerationTarget,
   isValidMucRetractionTarget,
+  mucCorrectionSender,
   reactionSendersForUpdate,
   reactionsFromSenders,
   removeSenderReactions,
@@ -59,64 +60,74 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
    * a remote read of one of our messages. Cumulative — all earlier messages
    * are implicitly displayed for that reader too, but the helper only
    * mutates the exact target since the timeline carries `readBy` per
-   * message.
+   * message. Short-circuits on id-miss to avoid allocating on every
+   * inbound XEP-0333 marker.
    */
   function applyDisplayed(messageId: string, nick: string) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing = m.readBy ? [...m.readBy] : [];
-      if (!existing.includes(nick)) existing.push(nick);
-      return { ...m, readBy: existing };
-    });
+    const index = messages.value.findIndex((m) => matchMessageId(m, messageId));
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const existing = current.readBy ? [...current.readBy] : [];
+    if (existing.includes(nick)) return;
+    existing.push(nick);
+    const next = messages.value.slice();
+    next[index] = { ...current, readBy: existing };
+    messages.value = next;
   }
 
   /**
    * XEP-0444 replace semantics: this author's full reaction set on the
    * target message becomes `emojis`. The previous per-author set is wiped
    * via `removeSenderReactions` so unticking an emoji actually removes it.
+   * Short-circuits on target miss.
    */
   function applyReaction(messageId: string, nick: string, emojis: string[], senderId: string = nick) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (m.reactionTargetId !== messageId) return m;
-      const reactionSenders = reactionSendersForUpdate(m, nick, senderId);
-      removeSenderReactions(reactionSenders, nick, senderId);
-      for (const emoji of emojis) {
-        if (!reactionSenders[emoji]) reactionSenders[emoji] = {};
-        reactionSenders[emoji][senderId] = nick;
-      }
-      const reactions = reactionsFromSenders(reactionSenders);
-      const updated = { ...m };
-      if (Object.keys(reactionSenders).length > 0) {
-        updated.reactionSenders = reactionSenders;
-        updated.reactions = reactions;
-      } else {
-        delete updated.reactionSenders;
-        delete updated.reactions;
-      }
-      return updated;
-    });
+    const index = messages.value.findIndex((m) => m.reactionTargetId === messageId);
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const reactionSenders = reactionSendersForUpdate(current, nick, senderId);
+    removeSenderReactions(reactionSenders, nick, senderId);
+    for (const emoji of emojis) {
+      if (!reactionSenders[emoji]) reactionSenders[emoji] = {};
+      reactionSenders[emoji][senderId] = nick;
+    }
+    const reactions = reactionsFromSenders(reactionSenders);
+    const updated: TimelineMessage = { ...current };
+    if (Object.keys(reactionSenders).length > 0) {
+      updated.reactionSenders = reactionSenders;
+      updated.reactions = reactions;
+    } else {
+      delete updated.reactionSenders;
+      delete updated.reactions;
+    }
+    const next = messages.value.slice();
+    next[index] = updated;
+    messages.value = next;
   }
 
   /**
    * XEP-0424 retraction with XEP-0425 moderation support. Sender gating
    * happens here via `isSameMucRetractionSender` / `isMucServiceModeration`
    * so a spoofed retraction from a different occupant can't tombstone
-   * someone else's message.
+   * someone else's message. Short-circuits on target miss / sender mismatch.
    */
   function applyRetraction(msg: LiveRoomMessage) {
-    messages.value = messages.value.map((m) => {
-      if (!msg.retractsId || !matchMessageId(m, msg.retractsId)) return m;
-      if (msg.moderationTargetId) {
-        if (!isMucServiceModeration(msg)) return m;
-        if (!isValidMucModerationTarget(m, msg.moderationTargetId)) return m;
-      } else if (
-        !isValidMucRetractionTarget(m, msg.retractsId)
-        || !isSameMucRetractionSender(m, mucCorrectionSenderFor(msg))
-      ) {
-        return m;
-      }
-      return retractChannelTimelineMessage(m, msg.retractionId);
-    });
+    if (!msg.retractsId) return;
+    const index = messages.value.findIndex((m) => matchMessageId(m, msg.retractsId!));
+    if (index < 0) return;
+    const target = messages.value[index]!;
+    if (msg.moderationTargetId) {
+      if (!isMucServiceModeration(msg)) return;
+      if (!isValidMucModerationTarget(target, msg.moderationTargetId)) return;
+    } else if (
+      !isValidMucRetractionTarget(target, msg.retractsId)
+      || !isSameMucRetractionSender(target, mucCorrectionSender(msg))
+    ) {
+      return;
+    }
+    const next = messages.value.slice();
+    next[index] = retractChannelTimelineMessage(target, msg.retractionId);
+    messages.value = next;
   }
 
   /**
@@ -124,6 +135,7 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
    * `isSameMucCorrectionSender` (real-JID for non-anon MUC, occupant-id
    * elsewhere). Markup / references / extension annotations are replaced
    * wholesale to mirror the wire shape — null/empty drops the field.
+   * Short-circuits on target miss / sender mismatch.
    */
   function applyCorrection(
     replacesId: string,
@@ -134,27 +146,27 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
     extensionAnnotations?: LiveRoomMessage["extensionAnnotations"],
     extensionBodyFallback?: boolean,
   ) {
-    const idx = messages.value.findIndex((m) =>
+    const index = messages.value.findIndex((m) =>
       matchMessageId(m, replacesId) && isSameMucCorrectionSender(m, correctionSender)
     );
-    if (idx === -1) return;
-    messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId) || !isSameMucCorrectionSender(m, correctionSender)) return m;
-      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
-      if (markup && markup.length > 0) updated.markup = markup;
-      else delete updated.markup;
-      if (references && references.length > 0) updated.references = references;
-      else delete updated.references;
-      if (extensionAnnotations && extensionAnnotations.length > 0) {
-        updated.extensionAnnotations = extensionAnnotations;
-        if (extensionBodyFallback) updated.extensionBodyFallback = true;
-        else delete updated.extensionBodyFallback;
-      } else {
-        delete updated.extensionAnnotations;
-        delete updated.extensionBodyFallback;
-      }
-      return updated;
-    });
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const updated: TimelineMessage = { ...current, body: newBody.trim(), isEdited: true };
+    if (markup && markup.length > 0) updated.markup = markup;
+    else delete updated.markup;
+    if (references && references.length > 0) updated.references = references;
+    else delete updated.references;
+    if (extensionAnnotations && extensionAnnotations.length > 0) {
+      updated.extensionAnnotations = extensionAnnotations;
+      if (extensionBodyFallback) updated.extensionBodyFallback = true;
+      else delete updated.extensionBodyFallback;
+    } else {
+      delete updated.extensionAnnotations;
+      delete updated.extensionBodyFallback;
+    }
+    const next = messages.value.slice();
+    next[index] = updated;
+    messages.value = next;
   }
 
   /**
@@ -256,14 +268,3 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
   };
 }
 
-// Local helper to avoid a cross-file circular: mucCorrectionSender lives in
-// message-timeline-state and is also used by the classifier. We keep a
-// thin local function here so applyRetraction doesn't reach into the
-// classifier's typed output for the sender — it's still building it from
-// the raw stanza.
-function mucCorrectionSenderFor(msg: LiveRoomMessage): { authorJid: string; authorRealJid?: string } {
-  return {
-    authorJid: `${msg.roomJid}/${msg.nick}`,
-    ...(msg.authorRealJid ? { authorRealJid: msg.authorRealJid } : {}),
-  };
-}

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -5,7 +5,6 @@ import type { WaddleSession } from "@/lib/server-auth";
 import {
   BrowserXmppClient,
   barePeerJid,
-  type LiveRoomMessage,
   type MessageSearchResult,
   type RoomActivityEvent,
   type SessionLifecycleEvent,
@@ -18,16 +17,9 @@ import { applyPinEvent } from "@/stores/pinned-messages";
 import { hydrateSinglePinnedBody } from "@/services/pinned-message-bodies";
 import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
 import {
-  type DeliveryStatus,
-  type MarkupSpan,
-  type MessageReference,
   type TimelineMessage,
 } from "@/lib/chat-ui";
-import {
-  findMessageById,
-  matchMessageId,
-  mergeMessageIds,
-} from "@/lib/message-ids";
+import { findMessageById } from "@/lib/message-ids";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
@@ -44,21 +36,12 @@ import {
   mapLiveRoomMessageToTimeline,
 } from "@/channels/timeline";
 import {
-  isMucServiceModeration,
-  isSameMucRetractionSender,
-  isValidMucModerationTarget,
-  isValidMucRetractionTarget,
-  isSameMucCorrectionSender,
-  mucCorrectionSender,
   queuedRoomMessageToTimeline,
-  reactionSendersForUpdate,
-  reactionsFromSenders,
-  retractChannelTimelineMessage,
-  removeSenderReactions,
 } from "@/channels/message-timeline-state";
 import { useChannelMamPaging } from "@/channels/mam-paging";
 import { useMucSend } from "@/channels/muc-send";
 import { useChannelMessageActions } from "@/channels/message-actions";
+import { useChannelLiveMerge } from "@/channels/live-merge";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -150,6 +133,10 @@ export function useChannelMessages(
   watch(xmppClient, (client) => {
     if (client) {
       client.setMessageHandler((msg) => {
+        // Out-of-room body-bearing message: record cross-room activity
+        // (channel-list unread badge, etc.) and do not route to the
+        // in-room live-merge path. Retractions / corrections targeting
+        // other rooms are silently ignored.
         if (
           (!activeTimelineRoomJid.value || msg.roomJid !== activeTimelineRoomJid.value) &&
           msg.type === "message" &&
@@ -175,31 +162,15 @@ export function useChannelMessages(
         // When a user sends a real message, clear their typing state
         removeTypingUser(msg.nick);
 
-        // XEP-0424: Handle message retractions
-        if (msg.retractsId) {
-          applyRetraction(msg);
-          return;
-        }
+        // Typed dispatch via the live-merge composable. The classifier
+        // inside handleRoomMessage routes to applyRetraction /
+        // applyCorrection / mergeLiveMessage based on the stanza shape.
+        const classified = liveMerge.handleRoomMessage(msg);
 
-        // XEP-0308: Handle message corrections
-        if (msg.replacesId) {
-          applyCorrection(
-            msg.replacesId,
-            msg.body,
-            mucCorrectionSender(msg),
-            msg.markup,
-            msg.references,
-            msg.extensionAnnotations,
-            msg.extensionBodyFallback,
-          );
-          return;
-        }
-
-        mergeLiveMessage(
-          mapLiveRoomMessageToTimeline(session.value!, msg, (id) => findMessageById(messages.value, id)),
-        );
-
-        // Trigger notification for mentions when tab is unfocused
+        // Mention-driven notification routing stays in the orchestrator —
+        // it depends on cross-room session state and the tab-visibility
+        // signal, both of which are out of scope for live-merge.
+        if (classified.kind !== "live") return;
         const isTabHidden = typeof document !== "undefined"
           && (!document.hasFocus() || document.visibilityState === "hidden");
         if (msg.nick !== session.value?.username && isTabHidden) {
@@ -425,157 +396,11 @@ export function useChannelMessages(
     await scrollToPinnedEdgeAndPin();
   }
 
-  function applyDisplayed(messageId: string, nick: string) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing = m.readBy ? [...m.readBy] : [];
-      if (!existing.includes(nick)) {
-        existing.push(nick);
-      }
-      return { ...m, readBy: existing };
-    });
-  }
-
   function markDisplayed(messageId: string) {
     if (!xmppClient.value || !activeChannelId.value) return;
     const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
     void xmppClient.value.sendDisplayed(activeSpaceId.value ?? "", activeChannelId.value, targetId)
       .catch(() => undefined);
-  }
-
-  function applyReaction(messageId: string, nick: string, emojis: string[], senderId = nick) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (m.reactionTargetId !== messageId) return m;
-      const reactionSenders = reactionSendersForUpdate(m, nick, senderId);
-      removeSenderReactions(reactionSenders, nick, senderId);
-      for (const emoji of emojis) {
-        if (!reactionSenders[emoji]) reactionSenders[emoji] = {};
-        reactionSenders[emoji][senderId] = nick;
-      }
-      const reactions = reactionsFromSenders(reactionSenders);
-      const updated = { ...m };
-      if (Object.keys(reactionSenders).length > 0) {
-        updated.reactionSenders = reactionSenders;
-        updated.reactions = reactions;
-      } else {
-        delete updated.reactionSenders;
-        delete updated.reactions;
-      }
-      return updated;
-    });
-  }
-
-  function applyRetraction(msg: LiveRoomMessage) {
-    messages.value = messages.value.map((m) => {
-      if (!msg.retractsId || !matchMessageId(m, msg.retractsId)) return m;
-      if (msg.moderationTargetId) {
-        if (!isMucServiceModeration(msg)) return m;
-        if (!isValidMucModerationTarget(m, msg.moderationTargetId)) return m;
-      } else if (
-        !isValidMucRetractionTarget(m, msg.retractsId)
-        || !isSameMucRetractionSender(m, mucCorrectionSender(msg))
-      ) {
-        return m;
-      }
-      return retractChannelTimelineMessage(m, msg.retractionId);
-    });
-  }
-
-  function applyCorrection(
-    replacesId: string,
-    newBody: string,
-    correctionSender: { authorJid: string; authorRealJid?: string },
-    markup?: MarkupSpan[],
-    references?: MessageReference[],
-    extensionAnnotations?: LiveRoomMessage["extensionAnnotations"],
-    extensionBodyFallback?: boolean,
-  ) {
-    const idx = messages.value.findIndex((m) =>
-      matchMessageId(m, replacesId) && isSameMucCorrectionSender(m, correctionSender)
-    );
-    if (idx === -1) return;
-    messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId) || !isSameMucCorrectionSender(m, correctionSender)) return m;
-      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
-      if (markup && markup.length > 0) {
-        updated.markup = markup;
-      } else {
-        delete updated.markup;
-      }
-      if (references && references.length > 0) {
-        updated.references = references;
-      } else {
-        delete updated.references;
-      }
-      if (extensionAnnotations && extensionAnnotations.length > 0) {
-        updated.extensionAnnotations = extensionAnnotations;
-        if (extensionBodyFallback) updated.extensionBodyFallback = true;
-        else delete updated.extensionBodyFallback;
-      } else {
-        delete updated.extensionAnnotations;
-        delete updated.extensionBodyFallback;
-      }
-      return updated;
-    });
-  }
-
-  function mergeLiveMessage(rawMessage: TimelineMessage) {
-    const msg = rawMessage.isRetracted
-      ? retractChannelTimelineMessage(rawMessage, rawMessage.retractionId)
-      : rawMessage;
-    // Check if this is a self-echo reconciling an optimistically-inserted
-    // message. Match by ID first; otherwise, for our own sends, fall back
-    // to body matching — but only against messages still awaiting echo
-    // reconciliation (tracked via pendingEchoClientIds). Without that
-    // constraint, sending the same text twice would let the second echo
-    // re-target the already-reconciled first message.
-    const existingById = [msg.id, ...(msg.wireIds ?? [])]
-      .map((id) => findMessageById(messages.value, id))
-      .find((message): message is TimelineMessage => !!message);
-    const pendingSelfEcho = messages.value.find(
-      (m) => pendingEchoClientIds.has(m.id) && m.isSelf && msg.isSelf && m.body === msg.body,
-    );
-    const preservedSelfEcho = [...messages.value].reverse().find(
-      (m) =>
-        m.isSelf
-        && msg.isSelf
-        && m.body === msg.body
-        && !!m.deliveryStatus
-        && m.deliveryStatus !== "delivered",
-    );
-    const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
-    if (existing) {
-      const wasPending = existing.id !== msg.id;
-      // Reconcile the ID to the server-assigned one and merge authoritative
-      // server-side enrichment while preserving local-only UI state.
-      messages.value = messages.value.map((m) => {
-        if (m.id !== existing.id) return m;
-        const updated: TimelineMessage = {
-          ...m,
-          ...msg,
-          ...mergeMessageIds(m, msg.id, msg.wireIds),
-        };
-        if (m.isSelf && msg.isSelf) {
-          // A self-echo is authoritative evidence that the server accepted
-          // the stanza, so it supersedes any prior "sending" or "failed"
-          // optimistic state.
-          updated.deliveryStatus = "delivered" as DeliveryStatus;
-        }
-        return updated;
-      });
-      messages.value = applyForumContext(messages.value);
-      if (wasPending) pendingEchoClientIds.delete(existing.id);
-      return;
-    }
-    const channelId = activeChannelId.value;
-    messages.value = applyForumContext([...messages.value, msg]);
-    // mergeLiveMessage always snaps to the active edge, so last-seen should advance
-    // in lockstep regardless of the user's prior scroll position — if we're
-    // scrolling them to the message, by definition they can see it.
-    void scrollToPinnedEdgeAndPin();
-    if (channelId && isFeedVisible(msg)) {
-      persistLastSeen(channelId, msg.id);
-    }
   }
 
   /**
@@ -668,6 +493,16 @@ export function useChannelMessages(
     onMessageDeliveryFailure,
   } = send;
 
+  const liveMerge = useChannelLiveMerge({
+    session,
+    messages,
+    activeChannelId,
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+  });
+  const { applyDisplayed, applyReaction } = liveMerge;
+
   const actions = useChannelMessageActions({
     session,
     xmppClient,
@@ -678,8 +513,6 @@ export function useChannelMessages(
     actionError,
     clearActionError,
     normalizeError,
-    // applyReaction is still orchestrator-owned in PR 3; PR 4 (live-merge)
-    // moves it into useChannelLiveMerge and the dep wiring updates there.
     applyReaction,
   });
   const {

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -1,0 +1,203 @@
+import type { Ref } from "vue";
+import type { WaddleSession } from "@/lib/server-auth";
+import type { LiveDmMessage } from "@/lib/xmpp-client";
+import {
+  type DeliveryStatus,
+  type TimelineMessage,
+} from "@/lib/chat-ui";
+import { findMessageById, matchMessageId, mergeMessageIds } from "@/lib/message-ids";
+import {
+  fromLiveDmMessage,
+  isSameDmCorrectionSender,
+  retractDmTimelineMessage,
+} from "@/dms/message-timeline-state";
+
+// Inbound merge composable for DMs: applies incoming retractions
+// (XEP-0424), corrections (XEP-0308), reactions (XEP-0444), and displayed
+// markers (XEP-0333) to the 1:1 timeline. Self-echo reconciliation uses
+// `pendingEchoClientIds` from `useChatSend` so the body-match fallback
+// only targets sends still awaiting their wire-stable id.
+//
+// DM-side already has typed event handlers from `BrowserXmppClient`
+// (`onIncomingMessage`, `onChatState`, `onDisplayed`, `onReaction`), so no
+// classifier is required — `handleIncomingMessage` just branches on
+// `msg.retractsId` / `msg.replacesId` directly per the existing wire
+// dispatch.
+
+type UseDmLiveMergeDeps = {
+  session: Ref<WaddleSession | null>;
+  messages: Ref<TimelineMessage[]>;
+  activePeerJid: Ref<string | null>;
+  pendingEchoClientIds: Set<string>;
+  scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  persistLastSeen: (peerJid: string, messageId: string) => void;
+  isFeedVisible: (m: TimelineMessage) => boolean;
+};
+
+export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
+  const {
+    session,
+    messages,
+    activePeerJid,
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+    isFeedVisible,
+  } = deps;
+
+  /** XEP-0333 displayed marker: append the reader's nick to `readBy`. */
+  function applyDisplayed(messageId: string, nick: string) {
+    messages.value = messages.value.map((m): TimelineMessage => {
+      if (!matchMessageId(m, messageId)) return m;
+      const existing = m.readBy ? [...m.readBy] : [];
+      if (!existing.includes(nick)) existing.push(nick);
+      return { ...m, readBy: existing };
+    });
+  }
+
+  /**
+   * XEP-0444 replace semantics for DMs. No real-JID sender attribution —
+   * the DM stanza already arrives keyed on the conversation partner, so
+   * the reaction-set per nick is sufficient. (Carbon-forwarded self
+   * reactions are attributed via the orchestrator-side `peerNameFromJid`
+   * mapping in onReaction.)
+   */
+  function applyReaction(messageId: string, nick: string, emojis: string[]) {
+    messages.value = messages.value.map((m): TimelineMessage => {
+      if (!matchMessageId(m, messageId)) return m;
+      const existing: Record<string, string[]> = m.reactions ? { ...m.reactions } : {};
+      for (const key of Object.keys(existing)) {
+        existing[key] = (existing[key] ?? []).filter((n) => n !== nick);
+        if (existing[key].length === 0) delete existing[key];
+      }
+      for (const emoji of emojis) {
+        if (!existing[emoji]) existing[emoji] = [];
+        existing[emoji].push(nick);
+      }
+      const updated = { ...m };
+      if (Object.keys(existing).length > 0) updated.reactions = existing;
+      else delete updated.reactions;
+      return updated;
+    });
+  }
+
+  /** XEP-0424 retraction. Sender match via `isSameDmCorrectionSender`. */
+  function applyRetraction(msg: LiveDmMessage) {
+    messages.value = messages.value.map((m) =>
+      msg.retractsId && matchMessageId(m, msg.retractsId) && isSameDmCorrectionSender(m, msg.fromJid)
+        ? retractDmTimelineMessage(m, msg.retractionId)
+        : m
+    );
+  }
+
+  /** XEP-0308 last-message correction. Same sender match as retraction. */
+  function applyCorrection(
+    replacesId: string,
+    newBody: string,
+    correctionFromJid: string,
+    markup?: LiveDmMessage["markup"],
+    references?: LiveDmMessage["references"],
+    extensionAnnotations?: LiveDmMessage["extensionAnnotations"],
+    extensionBodyFallback?: boolean,
+  ) {
+    messages.value = messages.value.map((m) => {
+      if (!matchMessageId(m, replacesId) || !isSameDmCorrectionSender(m, correctionFromJid)) return m;
+      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
+      if (markup && markup.length > 0) updated.markup = markup;
+      else delete updated.markup;
+      if (references && references.length > 0) updated.references = references;
+      else delete updated.references;
+      if (extensionAnnotations && extensionAnnotations.length > 0) {
+        updated.extensionAnnotations = extensionAnnotations;
+        if (extensionBodyFallback) updated.extensionBodyFallback = true;
+        else delete updated.extensionBodyFallback;
+      } else {
+        delete updated.extensionAnnotations;
+        delete updated.extensionBodyFallback;
+      }
+      return updated;
+    });
+  }
+
+  /** Plain inbound message — reconciles self-echo if pending, else appends. */
+  function mergeLiveMessage(rawMessage: TimelineMessage) {
+    const msg = rawMessage.isRetracted
+      ? retractDmTimelineMessage(rawMessage, rawMessage.retractionId)
+      : rawMessage;
+    const existingById = [msg.id, ...(msg.wireIds ?? [])]
+      .map((id) => findMessageById(messages.value, id))
+      .find((message): message is TimelineMessage => !!message);
+    const pendingSelfEcho = messages.value.find(
+      (m) => pendingEchoClientIds.has(m.id) && m.isSelf && msg.isSelf && m.body === msg.body,
+    );
+    const preservedSelfEcho = [...messages.value].reverse().find(
+      (m) =>
+        m.isSelf
+        && msg.isSelf
+        && m.body === msg.body
+        && !!m.deliveryStatus
+        && m.deliveryStatus !== "delivered",
+    );
+    const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
+    if (existing) {
+      const wasPending = existing.id !== msg.id;
+      messages.value = messages.value.map((m) => {
+        if (m.id !== existing.id) return m;
+        const updated: TimelineMessage = {
+          ...m,
+          ...msg,
+          ...mergeMessageIds(m, msg.id, msg.wireIds),
+        };
+        if (m.isSelf && msg.isSelf) {
+          updated.deliveryStatus = "delivered" as DeliveryStatus;
+        }
+        return updated;
+      });
+      if (wasPending) pendingEchoClientIds.delete(existing.id);
+      return;
+    }
+    const peerJid = activePeerJid.value;
+    messages.value = [...messages.value, msg];
+    void scrollToPinnedEdgeAndPin();
+    if (peerJid && isFeedVisible(msg)) {
+      persistLastSeen(peerJid, msg.id);
+    }
+  }
+
+  /**
+   * Routes an inbound `LiveDmMessage` to the right `apply*` helper based
+   * on the stanza's retract/correct/plain shape. Pre-filtered by the
+   * orchestrator (active-peer check, typing-state clear).
+   */
+  function handleIncomingMessage(msg: LiveDmMessage) {
+    if (msg.retractsId) {
+      applyRetraction(msg);
+      return;
+    }
+    if (msg.replacesId) {
+      applyCorrection(
+        msg.replacesId,
+        msg.body,
+        msg.fromJid,
+        msg.markup,
+        msg.references,
+        msg.extensionAnnotations,
+        msg.extensionBodyFallback,
+      );
+      return;
+    }
+    if (!session.value) return;
+    mergeLiveMessage(
+      fromLiveDmMessage(session.value, msg, (id) => findMessageById(messages.value, id)),
+    );
+  }
+
+  return {
+    applyDisplayed,
+    applyReaction,
+    applyRetraction,
+    applyCorrection,
+    mergeLiveMessage,
+    handleIncomingMessage,
+  };
+}

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -45,14 +45,20 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
     isFeedVisible,
   } = deps;
 
-  /** XEP-0333 displayed marker: append the reader's nick to `readBy`. */
+  /**
+   * XEP-0333 displayed marker: append the reader's nick to `readBy`.
+   * Short-circuits on target miss / already-marked.
+   */
   function applyDisplayed(messageId: string, nick: string) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing = m.readBy ? [...m.readBy] : [];
-      if (!existing.includes(nick)) existing.push(nick);
-      return { ...m, readBy: existing };
-    });
+    const index = messages.value.findIndex((m) => matchMessageId(m, messageId));
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const existing = current.readBy ? [...current.readBy] : [];
+    if (existing.includes(nick)) return;
+    existing.push(nick);
+    const next = messages.value.slice();
+    next[index] = { ...current, readBy: existing };
+    messages.value = next;
   }
 
   /**
@@ -60,37 +66,48 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
    * the DM stanza already arrives keyed on the conversation partner, so
    * the reaction-set per nick is sufficient. (Carbon-forwarded self
    * reactions are attributed via the orchestrator-side `peerNameFromJid`
-   * mapping in onReaction.)
+   * mapping in onReaction.) Short-circuits on target miss.
    */
   function applyReaction(messageId: string, nick: string, emojis: string[]) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing: Record<string, string[]> = m.reactions ? { ...m.reactions } : {};
-      for (const key of Object.keys(existing)) {
-        existing[key] = (existing[key] ?? []).filter((n) => n !== nick);
-        if (existing[key].length === 0) delete existing[key];
-      }
-      for (const emoji of emojis) {
-        if (!existing[emoji]) existing[emoji] = [];
-        existing[emoji].push(nick);
-      }
-      const updated = { ...m };
-      if (Object.keys(existing).length > 0) updated.reactions = existing;
-      else delete updated.reactions;
-      return updated;
-    });
+    const index = messages.value.findIndex((m) => matchMessageId(m, messageId));
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const existing: Record<string, string[]> = current.reactions ? { ...current.reactions } : {};
+    for (const key of Object.keys(existing)) {
+      existing[key] = (existing[key] ?? []).filter((n) => n !== nick);
+      if (existing[key].length === 0) delete existing[key];
+    }
+    for (const emoji of emojis) {
+      if (!existing[emoji]) existing[emoji] = [];
+      existing[emoji].push(nick);
+    }
+    const updated: TimelineMessage = { ...current };
+    if (Object.keys(existing).length > 0) updated.reactions = existing;
+    else delete updated.reactions;
+    const next = messages.value.slice();
+    next[index] = updated;
+    messages.value = next;
   }
 
-  /** XEP-0424 retraction. Sender match via `isSameDmCorrectionSender`. */
+  /**
+   * XEP-0424 retraction. Sender match via `isSameDmCorrectionSender`
+   * — short-circuits on target miss / sender mismatch.
+   */
   function applyRetraction(msg: LiveDmMessage) {
-    messages.value = messages.value.map((m) =>
-      msg.retractsId && matchMessageId(m, msg.retractsId) && isSameDmCorrectionSender(m, msg.fromJid)
-        ? retractDmTimelineMessage(m, msg.retractionId)
-        : m
+    if (!msg.retractsId) return;
+    const index = messages.value.findIndex(
+      (m) => matchMessageId(m, msg.retractsId!) && isSameDmCorrectionSender(m, msg.fromJid),
     );
+    if (index < 0) return;
+    const next = messages.value.slice();
+    next[index] = retractDmTimelineMessage(messages.value[index]!, msg.retractionId);
+    messages.value = next;
   }
 
-  /** XEP-0308 last-message correction. Same sender match as retraction. */
+  /**
+   * XEP-0308 last-message correction. Same sender match as retraction.
+   * Short-circuits on target miss / sender mismatch.
+   */
   function applyCorrection(
     replacesId: string,
     newBody: string,
@@ -100,23 +117,27 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
     extensionAnnotations?: LiveDmMessage["extensionAnnotations"],
     extensionBodyFallback?: boolean,
   ) {
-    messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId) || !isSameDmCorrectionSender(m, correctionFromJid)) return m;
-      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
-      if (markup && markup.length > 0) updated.markup = markup;
-      else delete updated.markup;
-      if (references && references.length > 0) updated.references = references;
-      else delete updated.references;
-      if (extensionAnnotations && extensionAnnotations.length > 0) {
-        updated.extensionAnnotations = extensionAnnotations;
-        if (extensionBodyFallback) updated.extensionBodyFallback = true;
-        else delete updated.extensionBodyFallback;
-      } else {
-        delete updated.extensionAnnotations;
-        delete updated.extensionBodyFallback;
-      }
-      return updated;
-    });
+    const index = messages.value.findIndex(
+      (m) => matchMessageId(m, replacesId) && isSameDmCorrectionSender(m, correctionFromJid),
+    );
+    if (index < 0) return;
+    const current = messages.value[index]!;
+    const updated: TimelineMessage = { ...current, body: newBody.trim(), isEdited: true };
+    if (markup && markup.length > 0) updated.markup = markup;
+    else delete updated.markup;
+    if (references && references.length > 0) updated.references = references;
+    else delete updated.references;
+    if (extensionAnnotations && extensionAnnotations.length > 0) {
+      updated.extensionAnnotations = extensionAnnotations;
+      if (extensionBodyFallback) updated.extensionBodyFallback = true;
+      else delete updated.extensionBodyFallback;
+    } else {
+      delete updated.extensionAnnotations;
+      delete updated.extensionBodyFallback;
+    }
+    const next = messages.value.slice();
+    next[index] = updated;
+    messages.value = next;
   }
 
   /** Plain inbound message — reconciles self-echo if pending, else appends. */

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -37,6 +37,7 @@ import {
 import { useDmMamPaging } from "@/dms/mam-paging";
 import { useChatSend } from "@/dms/chat-send";
 import { useDmMessageActions } from "@/dms/message-actions";
+import { useDmLiveMerge } from "@/dms/live-merge";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -170,76 +171,6 @@ export function useDirectMessages(
     }
   }
 
-  function applyDisplayed(messageId: string, nick: string) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing = m.readBy ? [...m.readBy] : [];
-      if (!existing.includes(nick)) existing.push(nick);
-      return { ...m, readBy: existing };
-    });
-  }
-
-  function applyReaction(messageId: string, nick: string, emojis: string[]) {
-    messages.value = messages.value.map((m): TimelineMessage => {
-      if (!matchMessageId(m, messageId)) return m;
-      const existing: Record<string, string[]> = m.reactions ? { ...m.reactions } : {};
-      for (const key of Object.keys(existing)) {
-        existing[key] = (existing[key] ?? []).filter((n) => n !== nick);
-        if (existing[key].length === 0) delete existing[key];
-      }
-      for (const emoji of emojis) {
-        if (!existing[emoji]) existing[emoji] = [];
-        existing[emoji].push(nick);
-      }
-      const updated = { ...m };
-      if (Object.keys(existing).length > 0) updated.reactions = existing;
-      else delete updated.reactions;
-      return updated;
-    });
-  }
-
-  function applyRetraction(msg: LiveDmMessage) {
-    messages.value = messages.value.map((m) =>
-      msg.retractsId && matchMessageId(m, msg.retractsId) && isSameDmCorrectionSender(m, msg.fromJid)
-        ? retractDmTimelineMessage(m, msg.retractionId)
-        : m
-    );
-  }
-
-  function applyCorrection(
-    replacesId: string,
-    newBody: string,
-    correctionFromJid: string,
-    markup?: LiveDmMessage["markup"],
-    references?: LiveDmMessage["references"],
-    extensionAnnotations?: LiveDmMessage["extensionAnnotations"],
-    extensionBodyFallback?: boolean,
-  ) {
-    messages.value = messages.value.map((m) => {
-      if (!matchMessageId(m, replacesId) || !isSameDmCorrectionSender(m, correctionFromJid)) return m;
-      const updated: TimelineMessage = { ...m, body: newBody.trim(), isEdited: true };
-      if (markup && markup.length > 0) {
-        updated.markup = markup;
-      } else {
-        delete updated.markup;
-      }
-      if (references && references.length > 0) {
-        updated.references = references;
-      } else {
-        delete updated.references;
-      }
-      if (extensionAnnotations && extensionAnnotations.length > 0) {
-        updated.extensionAnnotations = extensionAnnotations;
-        if (extensionBodyFallback) updated.extensionBodyFallback = true;
-        else delete updated.extensionBodyFallback;
-      } else {
-        delete updated.extensionAnnotations;
-        delete updated.extensionBodyFallback;
-      }
-      return updated;
-    });
-  }
-
   const send = useChatSend({
     session,
     xmppClient,
@@ -278,6 +209,17 @@ export function useDirectMessages(
     onMessageDeliveryFailure,
   } = send;
 
+  const liveMerge = useDmLiveMerge({
+    session,
+    messages,
+    activePeerJid,
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen: (peerJid, messageId) => setLastSeen(dmKey(barePeerJid(peerJid)), messageId),
+    isFeedVisible,
+  });
+  const { applyDisplayed, applyReaction } = liveMerge;
+
   const actions = useDmMessageActions({
     session,
     xmppClient,
@@ -286,8 +228,6 @@ export function useDirectMessages(
     actionError,
     clearActionError,
     normalizeError,
-    // applyReaction is still orchestrator-owned in PR 3; PR 4 (live-merge)
-    // moves it into useDmLiveMerge and the dep wiring updates there.
     applyReaction,
   });
   const {
@@ -333,54 +273,6 @@ export function useDirectMessages(
     searchResults.value = [];
     isSearching.value = false;
     await paging.loadMessages(peerJid, unreadAtLoad);
-  }
-
-  function mergeLiveMessage(rawMessage: TimelineMessage) {
-    const msg = rawMessage.isRetracted
-      ? retractDmTimelineMessage(rawMessage, rawMessage.retractionId)
-      : rawMessage;
-    // Self-echo reconciliation: match by id first; otherwise body-match only
-    // against messages still awaiting reconciliation so duplicates don't
-    // retarget already-reconciled entries. Echo = authoritative → delivered.
-    const existingById = [msg.id, ...(msg.wireIds ?? [])]
-      .map((id) => findMessageById(messages.value, id))
-      .find((message): message is TimelineMessage => !!message);
-    const pendingSelfEcho = messages.value.find(
-      (m) => pendingEchoClientIds.has(m.id) && m.isSelf && msg.isSelf && m.body === msg.body,
-    );
-    const preservedSelfEcho = [...messages.value].reverse().find(
-      (m) =>
-        m.isSelf
-        && msg.isSelf
-        && m.body === msg.body
-        && !!m.deliveryStatus
-        && m.deliveryStatus !== "delivered",
-    );
-    const existing = existingById ?? pendingSelfEcho ?? preservedSelfEcho;
-    if (existing) {
-      const wasPending = existing.id !== msg.id;
-      messages.value = messages.value.map((m) => {
-        if (m.id !== existing.id) return m;
-        const updated: TimelineMessage = {
-          ...m,
-          ...msg,
-          ...mergeMessageIds(m, msg.id, msg.wireIds),
-        };
-        if (m.isSelf && msg.isSelf) {
-          updated.deliveryStatus = "delivered" as DeliveryStatus;
-        }
-        return updated;
-      });
-      if (wasPending) pendingEchoClientIds.delete(existing.id);
-      return;
-    }
-    const peerJid = activePeerJid.value;
-    messages.value = [...messages.value, msg];
-    // Always snaps to the active edge, so last-seen advances in lockstep.
-    void scrollToPinnedEdgeAndPin();
-    if (peerJid && isFeedVisible(msg)) {
-      setLastSeen(dmKey(barePeerJid(peerJid)), msg.id);
-    }
   }
 
   /** On a fresh session (SM resume failed), re-fetch MAM to close any gap
@@ -490,25 +382,7 @@ export function useDirectMessages(
   function onIncomingMessage(msg: LiveDmMessage) {
     if (!session.value || !activePeerJid.value || msg.peerJid !== activePeerJid.value) return;
     removeTypingUser(msg.nick);
-    if (msg.retractsId) {
-      applyRetraction(msg);
-      return;
-    }
-    if (msg.replacesId) {
-      applyCorrection(
-        msg.replacesId,
-        msg.body,
-        msg.fromJid,
-        msg.markup,
-        msg.references,
-        msg.extensionAnnotations,
-        msg.extensionBodyFallback,
-      );
-      return;
-    }
-    mergeLiveMessage(
-      fromLiveDmMessage(session.value, msg, (id) => findMessageById(messages.value, id)),
-    );
+    liveMerge.handleIncomingMessage(msg);
   }
 
   function onChatState(event: DmChatStateEvent) {

--- a/chat/src/lib/xmpp/classify-room-message.ts
+++ b/chat/src/lib/xmpp/classify-room-message.ts
@@ -1,6 +1,5 @@
 import type { LiveRoomMessage } from "@/lib/xmpp-client";
 import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
-import { mucCorrectionSender } from "@/channels/message-timeline-state";
 
 // Typed-dispatch classifier for the channel-side omnibus inbound message
 // handler. The wasm client currently exposes a single `setMessageHandler`
@@ -8,6 +7,11 @@ import { mucCorrectionSender } from "@/channels/message-timeline-state";
 // XEP-0308 correction, XEP-0424 retraction, XEP-0425 moderator retract);
 // the pre-refactor code branched on `msg.replacesId` / `msg.retractsId`
 // inside the handler body.
+//
+// Reaction (XEP-0444) and displayed (XEP-0333) events arrive on their own
+// typed handlers (`setReactionHandler` / `setDisplayedHandler`) — they
+// never flow through `setMessageHandler` and so are deliberately excluded
+// from this classifier's union.
 //
 // This classifier lifts the branch into a pure helper so `useLiveMerge`
 // can switch on a tagged union instead of sniffing stanza properties. The
@@ -19,6 +23,21 @@ import { mucCorrectionSender } from "@/channels/message-timeline-state";
 // migrating `BrowserXmppClient` itself to emit typed events
 // (`onRoomRetraction`, `onRoomReaction`, etc.) so the classifier becomes
 // redundant and the channel side ends up as typed as the DM side already is.
+
+// Inline trivial helper — pre-refactor this lived in
+// channels/message-timeline-state, but importing UI-layer modules from
+// lib/xmpp violates the dependency direction. The computation is four
+// lines of pure stanza shaping; lifting it here keeps the protocol layer
+// independent of channels/*.
+function mucCorrectionSender(msg: Pick<LiveRoomMessage, "roomJid" | "nick" | "authorRealJid">): {
+  authorJid: string;
+  authorRealJid?: string;
+} {
+  return {
+    authorJid: `${msg.roomJid}/${msg.nick}`,
+    ...(msg.authorRealJid ? { authorRealJid: msg.authorRealJid } : {}),
+  };
+}
 
 type ClassifiedRoomMessage =
   | {

--- a/chat/src/lib/xmpp/classify-room-message.ts
+++ b/chat/src/lib/xmpp/classify-room-message.ts
@@ -1,0 +1,81 @@
+import type { LiveRoomMessage } from "@/lib/xmpp-client";
+import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
+import { mucCorrectionSender } from "@/channels/message-timeline-state";
+
+// Typed-dispatch classifier for the channel-side omnibus inbound message
+// handler. The wasm client currently exposes a single `setMessageHandler`
+// callback that delivers every kind of room-bound stanza (regular message,
+// XEP-0308 correction, XEP-0424 retraction, XEP-0425 moderator retract);
+// the pre-refactor code branched on `msg.replacesId` / `msg.retractsId`
+// inside the handler body.
+//
+// This classifier lifts the branch into a pure helper so `useLiveMerge`
+// can switch on a tagged union instead of sniffing stanza properties. The
+// classifier inspects ONLY the stanza shape — active-room filtering,
+// notification routing, and chat-state typing all stay in the orchestrator
+// because they depend on context the classifier doesn't see.
+//
+// A follow-up issue (filed from #351's plan) tracks the deeper fix:
+// migrating `BrowserXmppClient` itself to emit typed events
+// (`onRoomRetraction`, `onRoomReaction`, etc.) so the classifier becomes
+// redundant and the channel side ends up as typed as the DM side already is.
+
+type ClassifiedRoomMessage =
+  | {
+      kind: "retraction";
+      retractsId: string;
+      retractionId?: string;
+      moderationTargetId?: string;
+      sender: { authorJid: string; authorRealJid?: string };
+      raw: LiveRoomMessage;
+    }
+  | {
+      kind: "correction";
+      replacesId: string;
+      body: string;
+      sender: { authorJid: string; authorRealJid?: string };
+      markup?: MarkupSpan[];
+      references?: MessageReference[];
+      extensionAnnotations?: LiveRoomMessage["extensionAnnotations"];
+      extensionBodyFallback?: boolean;
+    }
+  | { kind: "live"; raw: LiveRoomMessage }
+  | { kind: "ignore" };
+
+export function classifyRoomMessage(msg: LiveRoomMessage): ClassifiedRoomMessage {
+  if (msg.type !== "message") return { kind: "ignore" };
+
+  // Retraction wins over correction when both are set: deleting a message
+  // takes precedence over editing it. The pre-refactor handler had this
+  // ordering implicitly via two sequential `if (msg.retractsId)` /
+  // `if (msg.replacesId)` blocks; the classifier makes it explicit.
+  if (msg.retractsId) {
+    const out: ClassifiedRoomMessage = {
+      kind: "retraction",
+      retractsId: msg.retractsId,
+      sender: mucCorrectionSender(msg),
+      raw: msg,
+    };
+    if (msg.retractionId) out.retractionId = msg.retractionId;
+    if (msg.moderationTargetId) out.moderationTargetId = msg.moderationTargetId;
+    return out;
+  }
+
+  if (msg.replacesId) {
+    const out: ClassifiedRoomMessage = {
+      kind: "correction",
+      replacesId: msg.replacesId,
+      body: msg.body,
+      sender: mucCorrectionSender(msg),
+    };
+    if (msg.markup && msg.markup.length > 0) out.markup = msg.markup;
+    if (msg.references && msg.references.length > 0) out.references = msg.references;
+    if (msg.extensionAnnotations && msg.extensionAnnotations.length > 0) {
+      out.extensionAnnotations = msg.extensionAnnotations;
+    }
+    if (msg.extensionBodyFallback) out.extensionBodyFallback = true;
+    return out;
+  }
+
+  return { kind: "live", raw: msg };
+}

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -1,0 +1,231 @@
+// Direct unit tests for useChannelLiveMerge covering the per-XEP apply*
+// helpers and the typed-dispatch path through handleRoomMessage.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelLiveMerge } from "../src/channels/live-merge";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+function harness() {
+  const messages = ref<TimelineMessage[]>([]);
+  const pendingEchoClientIds = new Set<string>();
+  const scrollToPinnedEdgeAndPin = mock(async () => true);
+  const persistLastSeen = mock(() => {});
+
+  const liveMerge = useChannelLiveMerge({
+    session: ref(session),
+    messages,
+    activeChannelId: ref("general"),
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+  });
+
+  return { messages, pendingEchoClientIds, liveMerge, persistLastSeen };
+}
+
+function makeLive(overrides: Partial<LiveRoomMessage> = {}): LiveRoomMessage {
+  return {
+    type: "message",
+    roomJid: "room@muc.example.com",
+    fromJid: "room@muc.example.com/bob",
+    nick: "bob",
+    body: "hi",
+    timestamp: Date.now(),
+    isSelf: false,
+    ...overrides,
+  } as unknown as LiveRoomMessage;
+}
+
+describe("applyDisplayed (XEP-0333)", () => {
+  test("appends the reader's nick to readBy", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "hi", nick: "alice", timestamp: 0, isSelf: true } as TimelineMessage,
+    ];
+    h.liveMerge.applyDisplayed("m1", "bob");
+    expect(h.messages.value[0]?.readBy).toEqual(["bob"]);
+  });
+
+  test("dedups when the same reader is already in readBy", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "", nick: "", timestamp: 0, readBy: ["bob"] } as TimelineMessage,
+    ];
+    h.liveMerge.applyDisplayed("m1", "bob");
+    expect(h.messages.value[0]?.readBy).toEqual(["bob"]);
+  });
+});
+
+describe("applyReaction (XEP-0444 replace semantics)", () => {
+  test("adds a new emoji from a new sender", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", reactionTargetId: "stanza-1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], "room@muc.example.com/bob");
+    expect(h.messages.value[0]?.reactions).toEqual({ "👍": ["bob"] });
+  });
+
+  test("replace semantics: empty emojis set drops all of that sender's reactions", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        reactionTargetId: "stanza-1",
+        reactions: { "👍": ["bob"], "❤️": ["bob"] },
+        reactionSenders: { "👍": { "room@muc.example.com/bob": "bob" }, "❤️": { "room@muc.example.com/bob": "bob" } },
+        body: "", nick: "", timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyReaction("stanza-1", "bob", [], "room@muc.example.com/bob");
+    expect(h.messages.value[0]?.reactions).toBeUndefined();
+  });
+
+  test("non-matching reactionTargetId is ignored", () => {
+    const h = harness();
+    const original: TimelineMessage = {
+      id: "m1",
+      reactionTargetId: "stanza-1",
+      body: "", nick: "", timestamp: 0,
+    } as TimelineMessage;
+    h.messages.value = [original];
+    h.liveMerge.applyReaction("different-stanza", "bob", ["👍"], "x");
+    expect(h.messages.value[0]?.reactions).toBeUndefined();
+  });
+});
+
+describe("handleRoomMessage typed dispatch", () => {
+  test("retraction routes to applyRetraction (with sender match) and reports kind", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "hi",
+        nick: "bob",
+        authorJid: "room@muc.example.com/bob",
+        replyableId: "m1",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    const out = h.liveMerge.handleRoomMessage(makeLive({
+      retractsId: "m1",
+      retractionId: "r1",
+    }));
+    expect(out.kind).toBe("retraction");
+    expect(h.messages.value[0]?.isRetracted).toBe(true);
+  });
+
+  test("correction routes to applyCorrection (with sender match) and reports kind", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "old",
+        nick: "bob",
+        authorJid: "room@muc.example.com/bob",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    const out = h.liveMerge.handleRoomMessage(makeLive({
+      replacesId: "m1",
+      body: "edited",
+    }));
+    expect(out.kind).toBe("correction");
+    expect(h.messages.value[0]?.body).toBe("edited");
+    expect(h.messages.value[0]?.isEdited).toBe(true);
+  });
+
+  test("plain message routes to mergeLiveMessage (append)", () => {
+    const h = harness();
+    const before = h.messages.value.length;
+    const out = h.liveMerge.handleRoomMessage(makeLive({ body: "hi" }));
+    expect(out.kind).toBe("live");
+    expect(h.messages.value.length).toBe(before + 1);
+  });
+
+  test("ignore: non-message stanza doesn't touch the timeline", () => {
+    const h = harness();
+    const before = h.messages.value.length;
+    const out = h.liveMerge.handleRoomMessage({ type: "presence" } as unknown as LiveRoomMessage);
+    expect(out.kind).toBe("ignore");
+    expect(h.messages.value.length).toBe(before);
+  });
+});
+
+describe("mergeLiveMessage self-echo reconciliation", () => {
+  test("reconciles by id when the server-assigned id matches a wireId of an optimistic insert", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "client-id",
+        wireIds: ["server-id"],
+        body: "my msg",
+        nick: "alice",
+        isSelf: true,
+        deliveryStatus: "sending",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "server-id",
+      body: "my msg",
+      nick: "alice",
+      isSelf: true,
+      timestamp: 0,
+    } as TimelineMessage);
+    expect(h.messages.value.length).toBe(1);
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+  });
+
+  test("reconciles by body fallback when id misses but pendingEchoClientIds tracks the optimistic id", () => {
+    const h = harness();
+    h.pendingEchoClientIds.add("client-id");
+    h.messages.value = [
+      {
+        id: "client-id",
+        body: "duplicate-body",
+        nick: "alice",
+        isSelf: true,
+        deliveryStatus: "sending",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "different-server-id",
+      body: "duplicate-body",
+      nick: "alice",
+      isSelf: true,
+      timestamp: 0,
+    } as TimelineMessage);
+    expect(h.messages.value.length).toBe(1);
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+    // Body-match fallback consumed the pending entry so a second same-body
+    // send can't accidentally retarget it.
+    expect(h.pendingEchoClientIds.has("client-id")).toBe(false);
+  });
+
+  test("non-self echo appends without reconciling", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "earlier", nick: "alice", timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "m2",
+      body: "from bob",
+      nick: "bob",
+      isSelf: false,
+      timestamp: 0,
+    } as TimelineMessage);
+    expect(h.messages.value.length).toBe(2);
+  });
+});

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -162,6 +162,92 @@ describe("handleRoomMessage typed dispatch", () => {
   });
 });
 
+describe("applyRetraction sender-match gate (XEP-0424)", () => {
+  test("retracts when sender matches the target's authorJid", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "alice's message",
+        nick: "alice",
+        authorJid: "room@muc.example.com/alice",
+        replyableId: "m1",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "m1",
+      retractionId: "r1",
+      fromJid: "room@muc.example.com/alice",
+      nick: "alice",
+    }));
+    expect(h.messages.value[0]?.isRetracted).toBe(true);
+  });
+
+  test("refuses to retract when sender doesn't match target's authorJid (spoof attempt)", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "alice's message",
+        nick: "alice",
+        authorJid: "room@muc.example.com/alice",
+        replyableId: "m1",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "m1",
+      retractionId: "r1",
+      fromJid: "room@muc.example.com/mallory",
+      nick: "mallory",
+    }));
+    expect(h.messages.value[0]?.isRetracted).toBeFalsy();
+  });
+});
+
+describe("applyCorrection sender-match gate (XEP-0308)", () => {
+  test("corrects when sender matches the target's authorJid", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "old text",
+        nick: "alice",
+        authorJid: "room@muc.example.com/alice",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyCorrection(
+      "m1",
+      "new text",
+      { authorJid: "room@muc.example.com/alice" },
+    );
+    expect(h.messages.value[0]?.body).toBe("new text");
+    expect(h.messages.value[0]?.isEdited).toBe(true);
+  });
+
+  test("refuses to correct when sender doesn't match (spoof attempt)", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "old text",
+        nick: "alice",
+        authorJid: "room@muc.example.com/alice",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyCorrection(
+      "m1",
+      "hijacked!",
+      { authorJid: "room@muc.example.com/mallory" },
+    );
+    expect(h.messages.value[0]?.body).toBe("old text");
+    expect(h.messages.value[0]?.isEdited).toBeFalsy();
+  });
+});
+
 describe("mergeLiveMessage self-echo reconciliation", () => {
   test("reconciles by id when the server-assigned id matches a wireId of an optimistic insert", () => {
     const h = harness();

--- a/chat/tests/classify-room-message.test.ts
+++ b/chat/tests/classify-room-message.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { classifyRoomMessage } from "../src/lib/xmpp/classify-room-message";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+
+// Pure-helper tests for the typed-dispatch classifier that replaces the
+// inline "switch on msg.replacesId / msg.retractsId" sniffing inside the
+// channel-side message handler. The classifier inspects ONLY the inbound
+// stanza shape — the orchestrator handles cross-room filtering and
+// notification routing separately.
+
+function makeLive(overrides: Partial<LiveRoomMessage> = {}): LiveRoomMessage {
+  return {
+    type: "message",
+    roomJid: "room@muc.example.com",
+    fromJid: "room@muc.example.com/bob",
+    nick: "bob",
+    body: "hello",
+    timestamp: Date.now(),
+    isSelf: false,
+    ...overrides,
+  } as unknown as LiveRoomMessage;
+}
+
+describe("classifyRoomMessage", () => {
+  test("non-message stanza → ignore", () => {
+    const result = classifyRoomMessage(makeLive({ type: "subject" as LiveRoomMessage["type"] }));
+    expect(result.kind).toBe("ignore");
+  });
+
+  test("retraction wins over body", () => {
+    const result = classifyRoomMessage(makeLive({
+      retractsId: "target-1",
+      retractionId: "retract-1",
+      body: "",
+    }));
+    expect(result.kind).toBe("retraction");
+    if (result.kind === "retraction") {
+      expect(result.retractsId).toBe("target-1");
+      expect(result.retractionId).toBe("retract-1");
+    }
+  });
+
+  test("retraction with moderationTargetId surfaces it", () => {
+    const result = classifyRoomMessage(makeLive({
+      retractsId: "target-1",
+      moderationTargetId: "target-1",
+      authorRealJid: "mod@example.com/full",
+    }));
+    expect(result.kind).toBe("retraction");
+    if (result.kind === "retraction") {
+      expect(result.moderationTargetId).toBe("target-1");
+    }
+  });
+
+  test("correction wins over plain body when replacesId is set", () => {
+    const result = classifyRoomMessage(makeLive({
+      replacesId: "orig-1",
+      body: "edited",
+    }));
+    expect(result.kind).toBe("correction");
+    if (result.kind === "correction") {
+      expect(result.replacesId).toBe("orig-1");
+      expect(result.body).toBe("edited");
+    }
+  });
+
+  test("correction carries markup / references / extensionAnnotations through", () => {
+    const result = classifyRoomMessage(makeLive({
+      replacesId: "orig-1",
+      body: "edited",
+      markup: [{ kind: "bold", start: 0, end: 2 } as never],
+      references: [{ kind: "mention", uri: "xmpp:bob@example.com" } as never],
+      extensionAnnotations: [{ annotationId: "a1" } as never],
+      extensionBodyFallback: true,
+    } as Partial<LiveRoomMessage>));
+    expect(result.kind).toBe("correction");
+    if (result.kind === "correction") {
+      expect(result.markup?.length).toBe(1);
+      expect(result.references?.length).toBe(1);
+      expect(result.extensionAnnotations?.length).toBe(1);
+      expect(result.extensionBodyFallback).toBe(true);
+    }
+  });
+
+  test("retraction wins when both retractsId and replacesId are present", () => {
+    // Defensive: a malformed stanza setting both should retract; deleting
+    // wins over editing.
+    const result = classifyRoomMessage(makeLive({
+      retractsId: "target-1",
+      replacesId: "orig-1",
+    }));
+    expect(result.kind).toBe("retraction");
+  });
+
+  test("plain message (no retract, no correction) → live", () => {
+    const result = classifyRoomMessage(makeLive({ body: "hello" }));
+    expect(result.kind).toBe("live");
+    if (result.kind === "live") {
+      expect(result.raw.body).toBe("hello");
+    }
+  });
+
+  test("empty body + no retract/correction → live (consumer decides what to do with empty body)", () => {
+    // The pre-extraction code already passed empty-body messages through
+    // to mergeLiveMessage; the classifier keeps that contract.
+    const result = classifyRoomMessage(makeLive({ body: "" }));
+    expect(result.kind).toBe("live");
+  });
+});

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -128,6 +128,46 @@ describe("handleIncomingMessage typed dispatch", () => {
   });
 });
 
+describe("applyRetraction sender-match gate (XEP-0424)", () => {
+  test("refuses to retract when sender doesn't match target's authorJid", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "from bob",
+        nick: "bob",
+        authorJid: "bob@example.com",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "m1",
+      retractionId: "r1",
+      fromJid: "mallory@example.com",
+      nick: "mallory",
+    }));
+    expect(h.messages.value[0]?.isRetracted).toBeFalsy();
+  });
+});
+
+describe("applyCorrection sender-match gate (XEP-0308)", () => {
+  test("refuses to correct when fromJid doesn't match target", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "from bob",
+        nick: "bob",
+        authorJid: "bob@example.com",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.applyCorrection("m1", "hijacked!", "mallory@example.com");
+    expect(h.messages.value[0]?.body).toBe("from bob");
+    expect(h.messages.value[0]?.isEdited).toBeFalsy();
+  });
+});
+
 describe("mergeLiveMessage self-echo reconciliation", () => {
   test("body-match fallback only targets messages tracked in pendingEchoClientIds", () => {
     const h = harness();

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -1,0 +1,181 @@
+// Direct unit tests for useDmLiveMerge: per-XEP apply* helpers, the
+// handleIncomingMessage dispatcher, and self-echo reconciliation for 1:1.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useDmLiveMerge } from "../src/dms/live-merge";
+import type { LiveDmMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+function harness() {
+  const messages = ref<TimelineMessage[]>([]);
+  const pendingEchoClientIds = new Set<string>();
+  const scrollToPinnedEdgeAndPin = mock(async () => true);
+  const persistLastSeen = mock(() => {});
+  const isFeedVisible = (m: TimelineMessage) => !m.threadId || m.id === m.threadId;
+
+  const liveMerge = useDmLiveMerge({
+    session: ref(session),
+    messages,
+    activePeerJid: ref("bob@example.com"),
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin,
+    persistLastSeen,
+    isFeedVisible,
+  });
+
+  return { messages, pendingEchoClientIds, liveMerge };
+}
+
+function makeLive(overrides: Partial<LiveDmMessage> = {}): LiveDmMessage {
+  return {
+    type: "message",
+    peerJid: "bob@example.com",
+    fromJid: "bob@example.com",
+    nick: "bob",
+    body: "hi",
+    timestamp: Date.now(),
+    isSelf: false,
+    ...overrides,
+  } as unknown as LiveDmMessage;
+}
+
+describe("applyDisplayed (XEP-0333)", () => {
+  test("appends reader nick once and dedups", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.applyDisplayed("m1", "bob");
+    h.liveMerge.applyDisplayed("m1", "bob");
+    expect(h.messages.value[0]?.readBy).toEqual(["bob"]);
+  });
+});
+
+describe("applyReaction (XEP-0444 replace semantics)", () => {
+  test("adds an emoji", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"]);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("empty emoji list removes the sender's reactions", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", reactions: { "🎉": ["bob"] }, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.applyReaction("m1", "bob", []);
+    expect(h.messages.value[0]?.reactions).toBeUndefined();
+  });
+});
+
+describe("handleIncomingMessage typed dispatch", () => {
+  test("retraction routes to applyRetraction (with DM sender match)", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "to retract",
+        nick: "bob",
+        authorJid: "bob@example.com",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.handleIncomingMessage(makeLive({
+      retractsId: "m1",
+      retractionId: "r1",
+      fromJid: "bob@example.com",
+    }));
+    expect(h.messages.value[0]?.isRetracted).toBe(true);
+  });
+
+  test("correction routes to applyCorrection", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "old",
+        nick: "bob",
+        authorJid: "bob@example.com",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.handleIncomingMessage(makeLive({
+      replacesId: "m1",
+      body: "edited",
+      fromJid: "bob@example.com",
+    }));
+    expect(h.messages.value[0]?.body).toBe("edited");
+    expect(h.messages.value[0]?.isEdited).toBe(true);
+  });
+
+  test("plain message routes to mergeLiveMessage and appends", () => {
+    const h = harness();
+    const before = h.messages.value.length;
+    h.liveMerge.handleIncomingMessage(makeLive({ body: "hi" }));
+    expect(h.messages.value.length).toBe(before + 1);
+  });
+});
+
+describe("mergeLiveMessage self-echo reconciliation", () => {
+  test("body-match fallback only targets messages tracked in pendingEchoClientIds", () => {
+    const h = harness();
+    h.pendingEchoClientIds.add("client-1");
+    h.messages.value = [
+      // Tracked pending — should match
+      {
+        id: "client-1",
+        body: "same-body",
+        isSelf: true,
+        deliveryStatus: "sending",
+        nick: "alice",
+        timestamp: 0,
+      } as TimelineMessage,
+      // Not pending — must NOT be retargeted by a same-body echo
+      {
+        id: "older-self-already-delivered",
+        body: "same-body",
+        isSelf: true,
+        deliveryStatus: "delivered",
+        nick: "alice",
+        timestamp: 0,
+      } as TimelineMessage,
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "server-id",
+      body: "same-body",
+      nick: "alice",
+      isSelf: true,
+      timestamp: 0,
+    } as TimelineMessage);
+    // Pending one became delivered; older delivered one is untouched.
+    expect(h.messages.value.find((m) => m.body === "same-body" && m.deliveryStatus === "delivered")).toBeTruthy();
+    expect(h.pendingEchoClientIds.has("client-1")).toBe(false);
+  });
+
+  test("non-self incoming appends without reconciling", () => {
+    const h = harness();
+    h.messages.value = [
+      { id: "m1", body: "earlier", nick: "alice", isSelf: true, timestamp: 0 } as TimelineMessage,
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "m2",
+      body: "from bob",
+      nick: "bob",
+      isSelf: false,
+      timestamp: 0,
+    } as TimelineMessage);
+    expect(h.messages.value.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

PR 4 of 7. Extract inbound live-merge — `mergeLiveMessage`, `applyReaction`, `applyRetraction`, `applyCorrection`, `applyDisplayed` — out of `channels/messages.ts` and `dms/messages.ts` into focused composables. Channel side gets a typed-dispatch classifier so the `useLiveMerge` body no longer sniffs `msg.replacesId` / `msg.retractsId` directly.

Refs: #351 — see the full implementation plan there.

## What lands

- **`chat/src/lib/xmpp/classify-room-message.ts`** (new, pure) — maps a `LiveRoomMessage` into typed event variants: `{ kind: "retraction" | "correction" | "live" | "ignore"; ... }`. Pure, RGR'd.
- **`chat/src/channels/live-merge.ts`** (new) — `useChannelLiveMerge` owning `mergeLiveMessage`, `applyReaction`, `applyRetraction`, `applyCorrection`, `applyDisplayed`. Consumes `pendingEchoClientIds` from `useMucSend` as a dep (the MUC self-echo body-match fallback).
- **`chat/src/dms/live-merge.ts`** (new) — `useDmLiveMerge` mirroring the channel side. DM already has typed event handlers from `BrowserXmppClient` (`onIncomingMessage`, `onChatState`, `onDisplayed`, `onReaction`) — no classifier needed.
- **`chat/tests/classify-room-message.test.ts`** + composable test files — direct unit tests per PR Compliance #2.
- **`chat/src/channels/messages.ts`** + **`chat/src/dms/messages.ts`** — orchestrators wire the new composables; ~200 LOC removed from each.

## Classifier scope (corrected from earlier description)

The classifier covers the **omnibus `setMessageHandler` callback** only: `retraction` / `correction` / `live` / `ignore`. Reactions (XEP-0444) and displayed markers (XEP-0333) arrive on **separate typed handlers** in `BrowserXmppClient` — `setReactionHandler` and `setDisplayedHandler` — and never flow through `setMessageHandler`. Including them in the classifier would create dead variants that never fire.

The earlier draft of this description listed `reaction` / `displayed` in the classifier union; that was wrong about the wire-shape dispatch. The follow-up issue tracking the deeper migration (`BrowserXmppClient` exposes typed events directly) is #477.

## Follow-up filed

The classifier-inside-`useLiveMerge` approach is intermediate: the channel side still receives one omnibus `LiveRoomMessage` from `BrowserXmppClient.setMessageHandler` and classifies internally. The full XMPP-native fix migrates `BrowserXmppClient` itself to expose typed inbound events (`onRoomRetraction`, `onRoomCorrection`, etc.), eliminating the classifier. Filed as **#477**.

## Test strategy

- `lib/xmpp/classify-room-message.ts`: TDD RGR for each event variant + the "ignore" cases (8 tests).
- `channels/live-merge.ts`: direct unit tests covering self-echo reconciliation (with `pendingEchoClientIds`), retract/correct/reaction/displayed paths, sender-spoofing rejection (XEP-0424 / XEP-0308 gates) (14 tests).
- `dms/live-merge.ts`: same axes minus channel-specific variants (10 tests).
- Targeted integration tests pass: `tombstone-replay`, `reaction-mode`, `inbound-references`, `reconnect-catchup`, `xmpp-telemetry`.
- Gates: `bun test`, `bun run lint`, `bunx astro check`.

## Acceptance criteria

- [x] `channels/messages.ts` and `dms/messages.ts` no longer define `mergeLiveMessage` / `applyReaction` / `applyRetraction` / `applyCorrection` / `applyDisplayed` inline.
- [x] `useMucSend.pendingEchoClientIds` flows into `useChannelLiveMerge` as a dep — no orchestrator-owned Set duplication.
- [x] Classifier covers every `LiveRoomMessage` shape arriving via `setMessageHandler`; reactions/displayed deliberately excluded (they have their own typed handlers).
- [x] Existing integration tests pass unchanged.
- [x] Call sites of `useChannelMessages` / `useDirectMessages` remain stable.
- [x] `bun test`, `bun run lint`, `astro check` clean.
- [x] No `lib/xmpp` → `channels/*` import (layering kept one-way).

## Plan checkpoint

Sequential off `main`. PRs 1, 2, 3 (#463 / #465 / #473) merged. After this lands, PR 5 (`refactor(chat): extract chat-states and read-markers composables`) branches off the new `main`.

Follow-up: **#477** (`BrowserXmppClient` typed inbound events for the channel side — eliminates the classifier).
