### PR TITLE
refactor(chat): extract chat-states and read-markers composables

### DIFF
--- a/chat/src/channels/chat-states.ts
+++ b/chat/src/channels/chat-states.ts
@@ -1,0 +1,123 @@
+import { ref, type Ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+
+// XEP-0085 chat-state notifications for the channel side. Owns:
+//   - the typing-users ref (which remote occupants are currently composing)
+//   - per-nick auto-expire timers so a missed "paused" doesn't strand a
+//     remote occupant in the typing indicator forever
+//   - the local debounce machine: notifyComposing → optional outbound
+//     "composing", then a 3-second timer that fires "paused" once the
+//     user stops typing
+//
+// The "active" reset on send is owned by useMucSend's onSendComplete
+// callback; this composable exposes `resetOnSend` so the orchestrator
+// (or, later, useMucSend directly) can request the post-send cleanup
+// without reaching into private state.
+
+type UseChannelChatStatesDeps = {
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activeSpaceId: Ref<string | null>;
+  activeChannelId: Ref<string | null>;
+};
+
+const TYPING_EXPIRY_MS = 5000;
+const COMPOSING_PAUSE_MS = 3000;
+
+export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
+  const { xmppClient, activeSpaceId, activeChannelId } = deps;
+
+  const typingUsers = ref<string[]>([]);
+  const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  let lastChatState: "active" | "composing" | "paused" = "active";
+  let composingTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function addTypingUser(nick: string) {
+    if (!typingUsers.value.includes(nick)) {
+      typingUsers.value = [...typingUsers.value, nick];
+    }
+    // Auto-expire after TYPING_EXPIRY_MS in case a "paused" notification
+    // is dropped — otherwise the indicator stays on indefinitely.
+    const existing = typingTimers.get(nick);
+    if (existing) clearTimeout(existing);
+    typingTimers.set(
+      nick,
+      setTimeout(() => removeTypingUser(nick), TYPING_EXPIRY_MS),
+    );
+  }
+
+  function removeTypingUser(nick: string) {
+    const timer = typingTimers.get(nick);
+    if (timer) {
+      clearTimeout(timer);
+      typingTimers.delete(nick);
+    }
+    if (typingUsers.value.includes(nick)) {
+      typingUsers.value = typingUsers.value.filter((n) => n !== nick);
+    }
+  }
+
+  function clearTypingState() {
+    for (const timer of typingTimers.values()) clearTimeout(timer);
+    typingTimers.clear();
+    typingUsers.value = [];
+    lastChatState = "active";
+    if (composingTimeout) {
+      clearTimeout(composingTimeout);
+      composingTimeout = null;
+    }
+  }
+
+  /**
+   * XEP-0085 §5.2 / §5.3 composing/paused debounce. Sends "composing"
+   * the first time the user types in a window of activity, then arms a
+   * 3-second timer to send "paused" once typing stops. Re-arms on every
+   * call.
+   */
+  function notifyComposing() {
+    const client = xmppClient.value;
+    const spaceId = activeSpaceId.value ?? "";
+    const channelId = activeChannelId.value;
+    if (!client || !channelId) return;
+
+    if (lastChatState !== "composing") {
+      lastChatState = "composing";
+      void client.sendChatState(spaceId, channelId, "composing").catch(() => undefined);
+    }
+
+    if (composingTimeout) clearTimeout(composingTimeout);
+    composingTimeout = setTimeout(() => {
+      if (
+        xmppClient.value !== client ||
+        (activeSpaceId.value ?? "") !== spaceId ||
+        activeChannelId.value !== channelId
+      )
+        return;
+      lastChatState = "paused";
+      void client.sendChatState(spaceId, channelId, "paused").catch(() => undefined);
+    }, COMPOSING_PAUSE_MS);
+  }
+
+  /**
+   * Called by useMucSend's onSendComplete after a successful send to
+   * cancel any in-flight pause timer and snap the local state back to
+   * "active" (XEP-0085 §4.2 — content messages SHOULD include
+   * <active/>). The orchestrator routes this from useMucSend until that
+   * composable starts holding a direct ref to useChannelChatStates.
+   */
+  function resetOnSend() {
+    if (composingTimeout) {
+      clearTimeout(composingTimeout);
+      composingTimeout = null;
+    }
+    lastChatState = "active";
+  }
+
+  return {
+    typingUsers,
+    addTypingUser,
+    removeTypingUser,
+    clearTypingState,
+    notifyComposing,
+    resetOnSend,
+  };
+}

--- a/chat/src/channels/chat-states.ts
+++ b/chat/src/channels/chat-states.ts
@@ -1,4 +1,4 @@
-import { ref, type Ref } from "vue";
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 
 // XEP-0085 chat-state notifications for the channel side. Owns:
@@ -67,6 +67,15 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
     }
   }
 
+  // Defense-in-depth: the orchestrator already calls clearTypingState() on
+  // disconnect / clearMessages / xmppClient → null, but if the composable's
+  // effect scope ever ends without that contract being honoured (component
+  // teardown, hot-reload), drop the timers here so they don't fire on a
+  // dead reactive graph.
+  if (getCurrentScope()) {
+    onScopeDispose(() => clearTypingState());
+  }
+
   /**
    * XEP-0085 §5.2 / §5.3 composing/paused debounce. Sends "composing"
    * the first time the user types in a window of activity, then arms a
@@ -98,11 +107,15 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
   }
 
   /**
-   * Called by useMucSend's onSendComplete after a successful send to
-   * cancel any in-flight pause timer and snap the local state back to
-   * "active" (XEP-0085 §4.2 — content messages SHOULD include
-   * <active/>). The orchestrator routes this from useMucSend until that
-   * composable starts holding a direct ref to useChannelChatStates.
+   * Internal-state reset called by useMucSend's onSendComplete after a
+   * successful send: cancels any in-flight pause timer and snaps
+   * `lastChatState` back to "active". This does NOT emit a wire
+   * `<active/>` notification — that's the orchestrator's job after this
+   * returns. The split exists so the composable can keep its private
+   * state machine consistent without taking a dependency on the XMPP
+   * client; the orchestrator owns the outbound `client.sendChatState(
+   * ..., "active")` call per XEP-0085 §4.2 (content messages SHOULD
+   * include `<active/>`).
    */
   function resetOnSend() {
     if (composingTimeout) {

--- a/chat/src/channels/chat-states.ts
+++ b/chat/src/channels/chat-states.ts
@@ -110,12 +110,13 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
    * Internal-state reset called by useMucSend's onSendComplete after a
    * successful send: cancels any in-flight pause timer and snaps
    * `lastChatState` back to "active". This does NOT emit a wire
-   * `<active/>` notification — that's the orchestrator's job after this
-   * returns. The split exists so the composable can keep its private
-   * state machine consistent without taking a dependency on the XMPP
-   * client; the orchestrator owns the outbound `client.sendChatState(
-   * ..., "active")` call per XEP-0085 §4.2 (content messages SHOULD
-   * include `<active/>`).
+   * `<active/>` notification — that's the orchestrator's job, which
+   * sends `client.sendChatState(..., "active")` after `resetOnSend()`
+   * returns, per XEP-0085 §4.2 (content messages SHOULD include
+   * `<active/>`). The split exists so the composable's in-memory debounce
+   * state stays consistent on every send while the orchestrator decides
+   * (based on the wasm-client send result) whether the wire-level
+   * `<active/>` actually fires.
    */
   function resetOnSend() {
     if (composingTimeout) {

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -8,7 +8,6 @@ import {
   type MessageSearchResult,
   type RoomActivityEvent,
   type SessionLifecycleEvent,
-  type ChatStateType,
   type RoomHats,
   type RoomPresence,
 } from "@/lib/xmpp-client";
@@ -23,7 +22,6 @@ import { findMessageById } from "@/lib/message-ids";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
-import { roomKey, setLastSeen } from "@/lib/last-seen-store";
 import {
   listQueuedRoomMessages,
 } from "@/lib/outbound-queue-store";
@@ -42,6 +40,8 @@ import { useChannelMamPaging } from "@/channels/mam-paging";
 import { useMucSend } from "@/channels/muc-send";
 import { useChannelMessageActions } from "@/channels/message-actions";
 import { useChannelLiveMerge } from "@/channels/live-merge";
+import { useChannelChatStates } from "@/channels/chat-states";
+import { useChannelReadMarkers } from "@/channels/read-markers";
 
 export function useChannelMessages(
   session: Ref<WaddleSession | null>,
@@ -72,20 +72,10 @@ export function useChannelMessages(
     mode: scrollDirection,
     virtualScroll: timelineEdgeScroller,
   });
-  const typingUsers = ref<string[]>([]);
   const roomHats = ref<RoomHats>({});
   const roomPresence = ref<RoomPresence>({});
   const roomLastSeen = ref<Record<string, number>>({});
   const slowModeCooldown = ref(0);
-  const firstUnseenId = ref<string | null>(null);
-  const latestRemoteMessageId = computed<string | null>(() => {
-    for (let i = messages.value.length - 1; i >= 0; i--) {
-      const m = messages.value[i];
-      if (!m || m.isSelf || m.isRetracted) continue;
-      return m.id;
-    }
-    return null;
-  });
   const activeChannels = ref<Set<string>>(new Set());
   const mentionedChannelCounts = ref<Record<string, number>>({});
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
@@ -96,9 +86,32 @@ export function useChannelMessages(
   let slowModeTimer: ReturnType<typeof setInterval> | null = null;
 
   let searchRequestId = 0;
-  let lastChatState: ChatStateType = "active";
-  let composingTimeout: ReturnType<typeof setTimeout> | null = null;
-  const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const chatStates = useChannelChatStates({
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+  });
+  const {
+    typingUsers,
+    addTypingUser,
+    removeTypingUser,
+    clearTypingState,
+    notifyComposing,
+  } = chatStates;
+
+  const readMarkers = useChannelReadMarkers({
+    xmppClient,
+    activeSpaceId,
+    activeChannelId,
+    messages,
+  });
+  const {
+    firstUnseenId,
+    latestRemoteMessageId,
+    markDisplayed,
+    persistLastSeen,
+  } = readMarkers;
 
   const currentRoomJid = computed(() => {
     if (!session.value || !activeChannelId.value) return null;
@@ -293,76 +306,12 @@ export function useChannelMessages(
     }
   }, { immediate: true });
 
-  function addTypingUser(nick: string) {
-    if (!typingUsers.value.includes(nick)) {
-      typingUsers.value = [...typingUsers.value, nick];
-    }
-    // Auto-expire after 5 seconds (in case we miss a "paused" notification)
-    const existing = typingTimers.get(nick);
-    if (existing) clearTimeout(existing);
-    typingTimers.set(
-      nick,
-      setTimeout(() => removeTypingUser(nick), 5000),
-    );
-  }
-
-  function removeTypingUser(nick: string) {
-    const timer = typingTimers.get(nick);
-    if (timer) {
-      clearTimeout(timer);
-      typingTimers.delete(nick);
-    }
-    if (typingUsers.value.includes(nick)) {
-      typingUsers.value = typingUsers.value.filter((n) => n !== nick);
-    }
-  }
-
-  function clearTypingState() {
-    for (const timer of typingTimers.values()) clearTimeout(timer);
-    typingTimers.clear();
-    typingUsers.value = [];
-    lastChatState = "active";
-    if (composingTimeout) {
-      clearTimeout(composingTimeout);
-      composingTimeout = null;
-    }
-  }
-
-  function notifyComposing() {
-    const client = xmppClient.value;
-    const spaceId = activeSpaceId.value ?? "";
-    const channelId = activeChannelId.value;
-    if (!client || !channelId) return;
-
-    if (lastChatState !== "composing") {
-      lastChatState = "composing";
-      void client.sendChatState(spaceId, channelId, "composing").catch(() => undefined);
-    }
-
-    // Reset the pause timer: if user stops typing for 3s, send "paused"
-    if (composingTimeout) clearTimeout(composingTimeout);
-    composingTimeout = setTimeout(() => {
-      if (
-        xmppClient.value !== client ||
-        (activeSpaceId.value ?? "") !== spaceId ||
-        activeChannelId.value !== channelId
-      )
-        return;
-      lastChatState = "paused";
-      void client.sendChatState(spaceId, channelId, "paused").catch(() => undefined);
-    }, 3000);
-  }
-
   async function scrollToPinnedEdge() {
     await pinnedEdgeScroller.scrollToPinnedEdge();
   }
 
   async function scrollToPinnedEdgeAndPin() {
     return pinnedEdgeScroller.scrollToPinnedEdge({ settle: true });
-  }
-
-  function persistLastSeen(channelId: string, messageId: string) {
-    setLastSeen(roomKey(channelId), messageId);
   }
 
   async function scrollFirstUnseenIntoView(messageId: string) {
@@ -394,13 +343,6 @@ export function useChannelMessages(
       return;
     }
     await scrollToPinnedEdgeAndPin();
-  }
-
-  function markDisplayed(messageId: string) {
-    if (!xmppClient.value || !activeChannelId.value) return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
-    void xmppClient.value.sendDisplayed(activeSpaceId.value ?? "", activeChannelId.value, targetId)
-      .catch(() => undefined);
   }
 
   /**
@@ -460,10 +402,10 @@ export function useChannelMessages(
     normalizeError,
     ...(mentionJidsByNick ? { mentionJidsByNick } : {}),
     scrollToPinnedEdgeAndPin,
-    // Chat-state cleanup on successful send — composingTimeout/lastChatState
-    // are still orchestrator-owned in PR 2; they move into useChannelChatStates
-    // in PR 5. Until then the callback keeps useMucSend free of chat-state
-    // concerns.
+    // Post-send XEP-0085 cleanup. The composing-timer + lastChatState
+    // bookkeeping moved into useChannelChatStates in PR 5; the
+    // orchestrator routes the post-send signal via `resetOnSend()` and
+    // emits the active state through the client.
     onSendComplete: (result, spaceId, channelId, isStillCurrentChannel) => {
       if (!isStillCurrentChannel) {
         // Client swap or channel change happened during the send. Don't
@@ -472,11 +414,7 @@ export function useChannelMessages(
         // belonged to the prior session.
         return;
       }
-      if (composingTimeout) {
-        clearTimeout(composingTimeout);
-        composingTimeout = null;
-      }
-      lastChatState = "active";
+      chatStates.resetOnSend();
       if (result?.state === "sending" && xmppClient.value) {
         void xmppClient.value.sendChatState(spaceId, channelId, "active").catch(() => undefined);
       }

--- a/chat/src/channels/read-markers.ts
+++ b/chat/src/channels/read-markers.ts
@@ -1,0 +1,60 @@
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import { roomKey, setLastSeen } from "@/lib/last-seen-store";
+import { latestRemoteMessageIdFor } from "@/lib/timeline-state";
+
+// XEP-0333 chat-marker outbound state for the channel side. Owns:
+//   - firstUnseenId: the "new messages" divider anchor, populated by
+//     useChannelMamPaging on initial load and cleared on session/channel
+//     change.
+//   - latestRemoteMessageId: a computed walk-back over the timeline to
+//     find the most recent non-self, non-retracted message id (the read
+//     anchor that XEP-0333 markers should target).
+//   - markDisplayed: outbound `<displayed/>` chat marker, fire-and-forget.
+//   - persistLastSeen: helper that records the channel's last-seen id in
+//     the local store (consumed by useChannelMamPaging on next load to
+//     compute firstUnseenId).
+
+type UseChannelReadMarkersDeps = {
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activeSpaceId: Ref<string | null>;
+  activeChannelId: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+};
+
+export function useChannelReadMarkers(deps: UseChannelReadMarkersDeps) {
+  const { xmppClient, activeSpaceId, activeChannelId, messages } = deps;
+
+  const firstUnseenId = ref<string | null>(null);
+  const latestRemoteMessageId: ComputedRef<string | null> = computed(() =>
+    latestRemoteMessageIdFor(messages.value),
+  );
+
+  /**
+   * Send a XEP-0333 displayed marker for the given message. Targets the
+   * message's own id rather than `replyableId` because displayed markers
+   * mark *what was seen* — the room's stanza-id is fine, but the wire
+   * call wants whatever id the message currently advertises. Failures are
+   * swallowed (the marker is best-effort; we don't surface a UX error).
+   */
+  function markDisplayed(messageId: string) {
+    if (!xmppClient.value || !activeChannelId.value) return;
+    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    void xmppClient.value
+      .sendDisplayed(activeSpaceId.value ?? "", activeChannelId.value, targetId)
+      .catch(() => undefined);
+  }
+
+  function persistLastSeen(channelId: string, messageId: string) {
+    setLastSeen(roomKey(channelId), messageId);
+  }
+
+  return {
+    firstUnseenId,
+    latestRemoteMessageId,
+    markDisplayed,
+    persistLastSeen,
+  };
+}

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -1,0 +1,90 @@
+import { ref, type Ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+
+// XEP-0085 chat-state notifications for the DM side. Mirrors
+// useChannelChatStates with the same debounce machine, scoped to the
+// active peer JID instead of (spaceId, channelId).
+
+type UseDmChatStatesDeps = {
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activePeerJid: Ref<string | null>;
+};
+
+const TYPING_EXPIRY_MS = 5000;
+const COMPOSING_PAUSE_MS = 3000;
+
+export function useDmChatStates(deps: UseDmChatStatesDeps) {
+  const { xmppClient, activePeerJid } = deps;
+
+  const typingUsers = ref<string[]>([]);
+  const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  let lastChatState: "active" | "composing" | "paused" = "active";
+  let composingTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function addTypingUser(nick: string) {
+    if (!typingUsers.value.includes(nick)) {
+      typingUsers.value = [...typingUsers.value, nick];
+    }
+    const existing = typingTimers.get(nick);
+    if (existing) clearTimeout(existing);
+    typingTimers.set(
+      nick,
+      setTimeout(() => removeTypingUser(nick), TYPING_EXPIRY_MS),
+    );
+  }
+
+  function removeTypingUser(nick: string) {
+    const timer = typingTimers.get(nick);
+    if (timer) {
+      clearTimeout(timer);
+      typingTimers.delete(nick);
+    }
+    if (typingUsers.value.includes(nick)) {
+      typingUsers.value = typingUsers.value.filter((n) => n !== nick);
+    }
+  }
+
+  function clearTypingState() {
+    for (const timer of typingTimers.values()) clearTimeout(timer);
+    typingTimers.clear();
+    typingUsers.value = [];
+    lastChatState = "active";
+    if (composingTimeout) {
+      clearTimeout(composingTimeout);
+      composingTimeout = null;
+    }
+  }
+
+  function notifyComposing() {
+    const client = xmppClient.value;
+    const peerJid = activePeerJid.value;
+    if (!client || !peerJid) return;
+    if (lastChatState !== "composing") {
+      lastChatState = "composing";
+      void client.sendDmChatState(peerJid, "composing").catch(() => undefined);
+    }
+    if (composingTimeout) clearTimeout(composingTimeout);
+    composingTimeout = setTimeout(() => {
+      if (xmppClient.value !== client || activePeerJid.value !== peerJid) return;
+      lastChatState = "paused";
+      void client.sendDmChatState(peerJid, "paused").catch(() => undefined);
+    }, COMPOSING_PAUSE_MS);
+  }
+
+  function resetOnSend() {
+    if (composingTimeout) {
+      clearTimeout(composingTimeout);
+      composingTimeout = null;
+    }
+    lastChatState = "active";
+  }
+
+  return {
+    typingUsers,
+    addTypingUser,
+    removeTypingUser,
+    clearTypingState,
+    notifyComposing,
+    resetOnSend,
+  };
+}

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -1,4 +1,4 @@
-import { ref, type Ref } from "vue";
+import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 
 // XEP-0085 chat-state notifications for the DM side. Mirrors
@@ -55,6 +55,14 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
     }
   }
 
+  // Defense-in-depth: parallels the channel-side composable. Orchestrator
+  // explicitly calls clearTypingState() on disconnect / clearMessages, but
+  // scope teardown without that contract being honoured shouldn't leak
+  // timers either.
+  if (getCurrentScope()) {
+    onScopeDispose(() => clearTypingState());
+  }
+
   function notifyComposing() {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
@@ -71,6 +79,14 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
     }, COMPOSING_PAUSE_MS);
   }
 
+  /**
+   * Internal-state reset called by useChatSend's onSendComplete after a
+   * successful send. Does NOT emit a wire `<active/>` notification — the
+   * orchestrator owns the outbound `client.sendDmChatState(peerJid,
+   * "active")` call per XEP-0085 §4.2. Keeping the wire emission in the
+   * orchestrator lets this composable stay independent of the XMPP
+   * client.
+   */
   function resetOnSend() {
     if (composingTimeout) {
       clearTimeout(composingTimeout);

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -81,11 +81,14 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
 
   /**
    * Internal-state reset called by useChatSend's onSendComplete after a
-   * successful send. Does NOT emit a wire `<active/>` notification — the
-   * orchestrator owns the outbound `client.sendDmChatState(peerJid,
-   * "active")` call per XEP-0085 §4.2. Keeping the wire emission in the
-   * orchestrator lets this composable stay independent of the XMPP
-   * client.
+   * successful send: cancels any in-flight pause timer and snaps
+   * `lastChatState` back to "active". Does NOT emit a wire `<active/>`
+   * notification — the orchestrator sends
+   * `client.sendDmChatState(peerJid, "active")` after this returns, per
+   * XEP-0085 §4.2. The split exists so the composable's in-memory
+   * debounce state stays consistent on every send while the orchestrator
+   * decides (based on the wasm-client send result) whether the
+   * wire-level `<active/>` actually fires.
    */
   function resetOnSend() {
     if (composingTimeout) {

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -38,6 +38,8 @@ import { useDmMamPaging } from "@/dms/mam-paging";
 import { useChatSend } from "@/dms/chat-send";
 import { useDmMessageActions } from "@/dms/message-actions";
 import { useDmLiveMerge } from "@/dms/live-merge";
+import { useDmChatStates } from "@/dms/chat-states";
+import { useDmReadMarkers } from "@/dms/read-markers";
 
 export function useDirectMessages(
   session: Ref<WaddleSession | null>,
@@ -65,25 +67,29 @@ export function useDirectMessages(
     mode: scrollDirection,
     virtualScroll: timelineEdgeScroller,
   });
-  const typingUsers = ref<string[]>([]);
   const searchResults = ref<MessageSearchResult[]>([]);
   const isSearching = ref(false);
-  const firstUnseenId = ref<string | null>(null);
   const loadErrorPeerJid = ref<string | null>(null);
   const loadErrorMessage = ref("");
-  const latestRemoteMessageId = computed<string | null>(() => {
-    for (let i = messages.value.length - 1; i >= 0; i--) {
-      const m = messages.value[i];
-      if (!m || m.isSelf || m.isRetracted) continue;
-      return m.id;
-    }
-    return null;
-  });
 
   let searchRequestId = 0;
-  let lastChatState: ChatStateType = "active";
-  let composingTimeout: ReturnType<typeof setTimeout> | null = null;
-  const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const chatStates = useDmChatStates({ xmppClient, activePeerJid });
+  const {
+    typingUsers,
+    addTypingUser,
+    removeTypingUser,
+    clearTypingState,
+    notifyComposing,
+  } = chatStates;
+
+  const readMarkers = useDmReadMarkers({ xmppClient, activePeerJid, messages });
+  const {
+    firstUnseenId,
+    latestRemoteMessageId,
+    markDisplayed,
+    persistLastSeen,
+  } = readMarkers;
 
   function queuedMessagesForPeer(peerJid: string): TimelineMessage[] {
     const currentSession = session.value;
@@ -140,37 +146,6 @@ export function useDirectMessages(
     return !m.threadId || m.id === m.threadId;
   }
 
-  function addTypingUser(nick: string) {
-    if (!typingUsers.value.includes(nick)) {
-      typingUsers.value = [...typingUsers.value, nick];
-    }
-    const existing = typingTimers.get(nick);
-    if (existing) clearTimeout(existing);
-    typingTimers.set(nick, setTimeout(() => removeTypingUser(nick), 5000));
-  }
-
-  function removeTypingUser(nick: string) {
-    const timer = typingTimers.get(nick);
-    if (timer) {
-      clearTimeout(timer);
-      typingTimers.delete(nick);
-    }
-    if (typingUsers.value.includes(nick)) {
-      typingUsers.value = typingUsers.value.filter((n) => n !== nick);
-    }
-  }
-
-  function clearTypingState() {
-    for (const timer of typingTimers.values()) clearTimeout(timer);
-    typingTimers.clear();
-    typingUsers.value = [];
-    lastChatState = "active";
-    if (composingTimeout) {
-      clearTimeout(composingTimeout);
-      composingTimeout = null;
-    }
-  }
-
   const send = useChatSend({
     session,
     xmppClient,
@@ -188,11 +163,7 @@ export function useDirectMessages(
         // old peer.
         return;
       }
-      if (composingTimeout) {
-        clearTimeout(composingTimeout);
-        composingTimeout = null;
-      }
-      lastChatState = "active";
+      chatStates.resetOnSend();
       if (result?.state === "sending" && xmppClient.value) {
         void xmppClient.value.sendDmChatState(peerJid, "active").catch(() => undefined);
       }
@@ -299,28 +270,6 @@ export function useDirectMessages(
     })();
   }
 
-
-  function markDisplayed(messageId: string) {
-    if (!xmppClient.value || !activePeerJid.value) return;
-    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
-    void xmppClient.value.sendDmDisplayed(activePeerJid.value, targetId).catch(() => undefined);
-  }
-
-  function notifyComposing() {
-    const client = xmppClient.value;
-    const peerJid = activePeerJid.value;
-    if (!client || !peerJid) return;
-    if (lastChatState !== "composing") {
-      lastChatState = "composing";
-      void client.sendDmChatState(peerJid, "composing").catch(() => undefined);
-    }
-    if (composingTimeout) clearTimeout(composingTimeout);
-    composingTimeout = setTimeout(() => {
-      if (xmppClient.value !== client || activePeerJid.value !== peerJid) return;
-      lastChatState = "paused";
-      void client.sendDmChatState(peerJid, "paused").catch(() => undefined);
-    }, 3000);
-  }
 
   async function searchMessages(query: string) {
     const client = xmppClient.value;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -1,11 +1,7 @@
-import { computed, nextTick, ref, watch, type Ref } from "vue";
-import {
-  type DeliveryStatus,
-  type TimelineMessage,
-} from "@/lib/chat-ui";
+import { nextTick, ref, watch, type Ref } from "vue";
+import type { TimelineMessage } from "@/lib/chat-ui";
 import type {
   BrowserXmppClient,
-  ChatStateType,
   DmChatStateEvent,
   DmDisplayedEvent,
   DmReactionEvent,
@@ -15,25 +11,15 @@ import type {
 } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
-import {
-  findMessageById,
-  matchMessageId,
-  mergeMessageIds,
-} from "@/lib/message-ids";
+import { findMessageById } from "@/lib/message-ids";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
-import { dmKey, setLastSeen } from "@/lib/last-seen-store";
 import {
   listQueuedDmMessages,
 } from "@/lib/outbound-queue-store";
 import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
-import {
-  fromLiveDmMessage,
-  isSameDmCorrectionSender,
-  queuedDmMessageToTimeline,
-  retractDmTimelineMessage,
-} from "@/dms/message-timeline-state";
+import { queuedDmMessageToTimeline } from "@/dms/message-timeline-state";
 import { useDmMamPaging } from "@/dms/mam-paging";
 import { useChatSend } from "@/dms/chat-send";
 import { useDmMessageActions } from "@/dms/message-actions";
@@ -186,7 +172,7 @@ export function useDirectMessages(
     activePeerJid,
     pendingEchoClientIds,
     scrollToPinnedEdgeAndPin,
-    persistLastSeen: (peerJid, messageId) => setLastSeen(dmKey(barePeerJid(peerJid)), messageId),
+    persistLastSeen,
     isFeedVisible,
   });
   const { applyDisplayed, applyReaction } = liveMerge;
@@ -224,7 +210,7 @@ export function useDirectMessages(
     appendQueuedMessages,
     scrollToPinnedEdgeAndPin,
     isFeedVisible,
-    persistLastSeen: (peerJid, messageId) => setLastSeen(dmKey(barePeerJid(peerJid)), messageId),
+    persistLastSeen,
     dmLoadErrorMessage,
   });
   const {
@@ -375,7 +361,7 @@ export function useDirectMessages(
       ) {
         paging.markInitialLatestPagePinned();
         const newest = [...messages.value].reverse().find(isFeedVisible);
-        if (peerJid && newest) setLastSeen(dmKey(barePeerJid(peerJid)), newest.id);
+        if (peerJid && newest) persistLastSeen(peerJid, newest.id);
       }
     },
     { flush: "post" },

--- a/chat/src/dms/read-markers.ts
+++ b/chat/src/dms/read-markers.ts
@@ -1,0 +1,45 @@
+import { computed, ref, type ComputedRef, type Ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import { barePeerJid } from "@/lib/xmpp-client";
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import { dmKey, setLastSeen } from "@/lib/last-seen-store";
+import { latestRemoteMessageIdFor } from "@/lib/timeline-state";
+
+// XEP-0333 chat-marker outbound state for the DM side. Mirrors
+// useChannelReadMarkers; uses `dmKey(barePeerJid(peerJid))` as the
+// last-seen-store key instead of the channel's roomKey.
+
+type UseDmReadMarkersDeps = {
+  xmppClient: Ref<BrowserXmppClient | null>;
+  activePeerJid: Ref<string | null>;
+  messages: Ref<TimelineMessage[]>;
+};
+
+export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
+  const { xmppClient, activePeerJid, messages } = deps;
+
+  const firstUnseenId = ref<string | null>(null);
+  const latestRemoteMessageId: ComputedRef<string | null> = computed(() =>
+    latestRemoteMessageIdFor(messages.value),
+  );
+
+  function markDisplayed(messageId: string) {
+    if (!xmppClient.value || !activePeerJid.value) return;
+    const targetId = findMessageById(messages.value, messageId)?.id ?? messageId;
+    void xmppClient.value
+      .sendDmDisplayed(activePeerJid.value, targetId)
+      .catch(() => undefined);
+  }
+
+  function persistLastSeen(peerJid: string, messageId: string) {
+    setLastSeen(dmKey(barePeerJid(peerJid)), messageId);
+  }
+
+  return {
+    firstUnseenId,
+    latestRemoteMessageId,
+    markDisplayed,
+    persistLastSeen,
+  };
+}

--- a/chat/src/lib/timeline-state.ts
+++ b/chat/src/lib/timeline-state.ts
@@ -39,6 +39,23 @@ import {
  * `M[]` — callers operate on a Vue `Ref<TimelineMessage[]>` whose `.value`
  * is mutable, so the input is `M[]` rather than `ReadonlyArray<M>`.
  */
+/**
+ * Find the id of the most recent remote (non-self, non-retracted) message
+ * in the timeline. Used by XEP-0333 displayed-marker logic to derive the
+ * "latest message we should mark as read" anchor — a self-sent or
+ * tombstoned message doesn't carry that semantic so we walk back past
+ * them. Returns null when the timeline is empty or contains only
+ * self/retracted entries.
+ */
+export function latestRemoteMessageIdFor(timeline: ReadonlyArray<TimelineMessage>): string | null {
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    const m = timeline[i];
+    if (!m || m.isSelf || m.isRetracted) continue;
+    return m.id;
+  }
+  return null;
+}
+
 export function applyDeliveryEventById<M extends TimelineMessage>(
   timeline: M[],
   messageId: string,

--- a/chat/src/lib/timeline-state.ts
+++ b/chat/src/lib/timeline-state.ts
@@ -17,6 +17,23 @@ import {
 // grilling for #351.
 
 /**
+ * Find the id of the most recent remote (non-self, non-retracted) message
+ * in the timeline. Used by XEP-0333 displayed-marker logic to derive the
+ * "latest message we should mark as read" anchor — a self-sent or
+ * tombstoned message doesn't carry that semantic so we walk back past
+ * them. Returns null when the timeline is empty or contains only
+ * self/retracted entries.
+ */
+export function latestRemoteMessageIdFor(timeline: ReadonlyArray<TimelineMessage>): string | null {
+  for (let i = timeline.length - 1; i >= 0; i--) {
+    const m = timeline[i];
+    if (!m || m.isSelf || m.isRetracted) continue;
+    return m.id;
+  }
+  return null;
+}
+
+/**
  * Apply a delivery event to the self-message matching `messageId`. Returns
  * the original array reference when nothing changes (id miss or
  * no-downgrade short-circuit), so Vue's reactivity skips a re-render and
@@ -39,23 +56,6 @@ import {
  * `M[]` — callers operate on a Vue `Ref<TimelineMessage[]>` whose `.value`
  * is mutable, so the input is `M[]` rather than `ReadonlyArray<M>`.
  */
-/**
- * Find the id of the most recent remote (non-self, non-retracted) message
- * in the timeline. Used by XEP-0333 displayed-marker logic to derive the
- * "latest message we should mark as read" anchor — a self-sent or
- * tombstoned message doesn't carry that semantic so we walk back past
- * them. Returns null when the timeline is empty or contains only
- * self/retracted entries.
- */
-export function latestRemoteMessageIdFor(timeline: ReadonlyArray<TimelineMessage>): string | null {
-  for (let i = timeline.length - 1; i >= 0; i--) {
-    const m = timeline[i];
-    if (!m || m.isSelf || m.isRetracted) continue;
-    return m.id;
-  }
-  return null;
-}
-
 export function applyDeliveryEventById<M extends TimelineMessage>(
   timeline: M[],
   messageId: string,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -12,7 +12,6 @@ export type { OutboundFileAttachment } from "./send-types";
 export type { InboxEntry } from "./inbox-types";
 export type { UserPepProfile } from "./pep-types";
 export type {
-  ChatStateType,
   DmChatStateEvent,
   DmConversation,
   DmDisplayedEvent,

--- a/chat/tests/chat-states.test.ts
+++ b/chat/tests/chat-states.test.ts
@@ -1,11 +1,30 @@
 // Direct unit tests for useChannelChatStates and useDmChatStates covering
 // the XEP-0085 typing-indicator + debounce machine.
+//
+// Composables are created inside an effectScope so that `onScopeDispose`
+// inside the composable runs at the end of each test — that cancels the
+// 5s typing-expiry + 3s composing→paused timers and keeps the test
+// process from hanging or leaking timers across tests.
 
-import { describe, expect, mock, test } from "bun:test";
-import { ref } from "vue";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { effectScope, ref, type EffectScope } from "vue";
 import { useChannelChatStates } from "../src/channels/chat-states";
 import { useDmChatStates } from "../src/dms/chat-states";
 import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+const activeScopes: EffectScope[] = [];
+
+afterEach(() => {
+  while (activeScopes.length > 0) {
+    activeScopes.pop()?.stop();
+  }
+});
+
+function withScope<T>(factory: () => T): T {
+  const scope = effectScope();
+  activeScopes.push(scope);
+  return scope.run(factory)!;
+}
 
 function makeChannelClient(sendChatState = mock(async () => undefined)): BrowserXmppClient {
   return { sendChatState } as unknown as BrowserXmppClient;
@@ -17,11 +36,11 @@ function makeDmClient(sendDmChatState = mock(async () => undefined)): BrowserXmp
 
 describe("useChannelChatStates — typing indicator", () => {
   test("addTypingUser inserts a nick and dedups on repeated calls", () => {
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.addTypingUser("alice");
     states.addTypingUser("alice");
     states.addTypingUser("bob");
@@ -29,22 +48,22 @@ describe("useChannelChatStates — typing indicator", () => {
   });
 
   test("removeTypingUser drops the nick", () => {
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.addTypingUser("alice");
     states.removeTypingUser("alice");
     expect(states.typingUsers.value).toEqual([]);
   });
 
   test("clearTypingState wipes all typing nicks", () => {
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.addTypingUser("alice");
     states.addTypingUser("bob");
     states.clearTypingState();
@@ -55,11 +74,11 @@ describe("useChannelChatStates — typing indicator", () => {
 describe("useChannelChatStates — outbound composing/paused (XEP-0085)", () => {
   test("notifyComposing sends composing on the first call only", () => {
     const sendChatState = mock(async () => undefined);
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendChatState)),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.notifyComposing();
     states.notifyComposing();
     // First call sends "composing"; the second is suppressed because
@@ -72,22 +91,22 @@ describe("useChannelChatStates — outbound composing/paused (XEP-0085)", () => 
 
   test("notifyComposing is a no-op when no client / no channel", () => {
     const sendChatState = mock(async () => undefined);
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(null),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.notifyComposing();
     expect(sendChatState).not.toHaveBeenCalled();
   });
 
   test("resetOnSend after notifyComposing lets a subsequent notifyComposing fire composing again", () => {
     const sendChatState = mock(async () => undefined);
-    const states = useChannelChatStates({
+    const states = withScope(() => useChannelChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendChatState)),
       activeSpaceId: ref("space"),
       activeChannelId: ref("general"),
-    });
+    }));
     states.notifyComposing();
     states.resetOnSend();
     states.notifyComposing();
@@ -103,10 +122,10 @@ describe("useChannelChatStates — outbound composing/paused (XEP-0085)", () => 
 describe("useDmChatStates", () => {
   test("notifyComposing sends DM chat-state to the active peer", () => {
     const sendDmChatState = mock(async () => undefined);
-    const states = useDmChatStates({
+    const states = withScope(() => useDmChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmChatState)),
       activePeerJid: ref("bob@example.com"),
-    });
+    }));
     states.notifyComposing();
     expect(sendDmChatState).toHaveBeenCalledTimes(1);
     expect(sendDmChatState.mock.calls[0]![0]).toBe("bob@example.com");
@@ -114,10 +133,10 @@ describe("useDmChatStates", () => {
   });
 
   test("addTypingUser + clearTypingState surfaces and clears typingUsers", () => {
-    const states = useDmChatStates({
+    const states = withScope(() => useDmChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeDmClient()),
       activePeerJid: ref("bob@example.com"),
-    });
+    }));
     states.addTypingUser("bob");
     expect(states.typingUsers.value).toContain("bob");
     states.clearTypingState();
@@ -126,10 +145,10 @@ describe("useDmChatStates", () => {
 
   test("no-op without peerJid", () => {
     const sendDmChatState = mock(async () => undefined);
-    const states = useDmChatStates({
+    const states = withScope(() => useDmChatStates({
       xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmChatState)),
       activePeerJid: ref<string | null>(null),
-    });
+    }));
     states.notifyComposing();
     expect(sendDmChatState).not.toHaveBeenCalled();
   });

--- a/chat/tests/chat-states.test.ts
+++ b/chat/tests/chat-states.test.ts
@@ -1,0 +1,136 @@
+// Direct unit tests for useChannelChatStates and useDmChatStates covering
+// the XEP-0085 typing-indicator + debounce machine.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelChatStates } from "../src/channels/chat-states";
+import { useDmChatStates } from "../src/dms/chat-states";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+function makeChannelClient(sendChatState = mock(async () => undefined)): BrowserXmppClient {
+  return { sendChatState } as unknown as BrowserXmppClient;
+}
+
+function makeDmClient(sendDmChatState = mock(async () => undefined)): BrowserXmppClient {
+  return { sendDmChatState } as unknown as BrowserXmppClient;
+}
+
+describe("useChannelChatStates — typing indicator", () => {
+  test("addTypingUser inserts a nick and dedups on repeated calls", () => {
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.addTypingUser("alice");
+    states.addTypingUser("alice");
+    states.addTypingUser("bob");
+    expect(states.typingUsers.value).toEqual(["alice", "bob"]);
+  });
+
+  test("removeTypingUser drops the nick", () => {
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.addTypingUser("alice");
+    states.removeTypingUser("alice");
+    expect(states.typingUsers.value).toEqual([]);
+  });
+
+  test("clearTypingState wipes all typing nicks", () => {
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.addTypingUser("alice");
+    states.addTypingUser("bob");
+    states.clearTypingState();
+    expect(states.typingUsers.value).toEqual([]);
+  });
+});
+
+describe("useChannelChatStates — outbound composing/paused (XEP-0085)", () => {
+  test("notifyComposing sends composing on the first call only", () => {
+    const sendChatState = mock(async () => undefined);
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendChatState)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.notifyComposing();
+    states.notifyComposing();
+    // First call sends "composing"; the second is suppressed because
+    // lastChatState is already "composing".
+    const composingCalls = sendChatState.mock.calls.filter(
+      (c) => c[2] === "composing",
+    );
+    expect(composingCalls.length).toBe(1);
+  });
+
+  test("notifyComposing is a no-op when no client / no channel", () => {
+    const sendChatState = mock(async () => undefined);
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(null),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.notifyComposing();
+    expect(sendChatState).not.toHaveBeenCalled();
+  });
+
+  test("resetOnSend after notifyComposing lets a subsequent notifyComposing fire composing again", () => {
+    const sendChatState = mock(async () => undefined);
+    const states = useChannelChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendChatState)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+    });
+    states.notifyComposing();
+    states.resetOnSend();
+    states.notifyComposing();
+    // resetOnSend snapped lastChatState back to "active", so the second
+    // notifyComposing emits "composing" again.
+    const composingCalls = sendChatState.mock.calls.filter(
+      (c) => c[2] === "composing",
+    );
+    expect(composingCalls.length).toBe(2);
+  });
+});
+
+describe("useDmChatStates", () => {
+  test("notifyComposing sends DM chat-state to the active peer", () => {
+    const sendDmChatState = mock(async () => undefined);
+    const states = useDmChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmChatState)),
+      activePeerJid: ref("bob@example.com"),
+    });
+    states.notifyComposing();
+    expect(sendDmChatState).toHaveBeenCalledTimes(1);
+    expect(sendDmChatState.mock.calls[0]![0]).toBe("bob@example.com");
+    expect(sendDmChatState.mock.calls[0]![1]).toBe("composing");
+  });
+
+  test("addTypingUser + clearTypingState surfaces and clears typingUsers", () => {
+    const states = useDmChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient()),
+      activePeerJid: ref("bob@example.com"),
+    });
+    states.addTypingUser("bob");
+    expect(states.typingUsers.value).toContain("bob");
+    states.clearTypingState();
+    expect(states.typingUsers.value).toEqual([]);
+  });
+
+  test("no-op without peerJid", () => {
+    const sendDmChatState = mock(async () => undefined);
+    const states = useDmChatStates({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmChatState)),
+      activePeerJid: ref<string | null>(null),
+    });
+    states.notifyComposing();
+    expect(sendDmChatState).not.toHaveBeenCalled();
+  });
+});

--- a/chat/tests/read-markers.test.ts
+++ b/chat/tests/read-markers.test.ts
@@ -1,0 +1,103 @@
+// Direct unit tests for useChannelReadMarkers and useDmReadMarkers
+// covering XEP-0333 displayed-marker outbound and the
+// latestRemoteMessageId computed.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelReadMarkers } from "../src/channels/read-markers";
+import { useDmReadMarkers } from "../src/dms/read-markers";
+import type { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+function makeChannelClient(sendDisplayed = mock(async () => undefined)): BrowserXmppClient {
+  return { sendDisplayed } as unknown as BrowserXmppClient;
+}
+function makeDmClient(sendDmDisplayed = mock(async () => undefined)): BrowserXmppClient {
+  return { sendDmDisplayed } as unknown as BrowserXmppClient;
+}
+
+describe("useChannelReadMarkers", () => {
+  test("markDisplayed forwards the message's id to sendDisplayed", () => {
+    const sendDisplayed = mock(async () => undefined);
+    const messages = ref<TimelineMessage[]>([
+      { id: "m1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ]);
+    const r = useChannelReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendDisplayed)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+      messages,
+    });
+    r.markDisplayed("m1");
+    expect(sendDisplayed).toHaveBeenCalledTimes(1);
+    expect(sendDisplayed.mock.calls[0]![2]).toBe("m1");
+  });
+
+  test("markDisplayed falls back to the passed messageId when target not in timeline", () => {
+    const sendDisplayed = mock(async () => undefined);
+    const messages = ref<TimelineMessage[]>([]);
+    const r = useChannelReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendDisplayed)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+      messages,
+    });
+    r.markDisplayed("not-in-timeline");
+    expect(sendDisplayed.mock.calls[0]![2]).toBe("not-in-timeline");
+  });
+
+  test("markDisplayed is a no-op without a channel", () => {
+    const sendDisplayed = mock(async () => undefined);
+    const r = useChannelReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient(sendDisplayed)),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref<string | null>(null),
+      messages: ref<TimelineMessage[]>([]),
+    });
+    r.markDisplayed("anything");
+    expect(sendDisplayed).not.toHaveBeenCalled();
+  });
+
+  test("latestRemoteMessageId tracks the last non-self message", () => {
+    const messages = ref<TimelineMessage[]>([
+      { id: "a", isSelf: false, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+      { id: "b", isSelf: true, body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ]);
+    const r = useChannelReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeChannelClient()),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("general"),
+      messages,
+    });
+    expect(r.latestRemoteMessageId.value).toBe("a");
+  });
+});
+
+describe("useDmReadMarkers", () => {
+  test("markDisplayed forwards to sendDmDisplayed", () => {
+    const sendDmDisplayed = mock(async () => undefined);
+    const messages = ref<TimelineMessage[]>([
+      { id: "dm1", body: "", nick: "", timestamp: 0 } as TimelineMessage,
+    ]);
+    const r = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmDisplayed)),
+      activePeerJid: ref("bob@example.com"),
+      messages,
+    });
+    r.markDisplayed("dm1");
+    expect(sendDmDisplayed).toHaveBeenCalledTimes(1);
+    expect(sendDmDisplayed.mock.calls[0]![0]).toBe("bob@example.com");
+    expect(sendDmDisplayed.mock.calls[0]![1]).toBe("dm1");
+  });
+
+  test("no-op without active peer", () => {
+    const sendDmDisplayed = mock(async () => undefined);
+    const r = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(sendDmDisplayed)),
+      activePeerJid: ref<string | null>(null),
+      messages: ref<TimelineMessage[]>([]),
+    });
+    r.markDisplayed("anything");
+    expect(sendDmDisplayed).not.toHaveBeenCalled();
+  });
+});

--- a/chat/tests/timeline-state.test.ts
+++ b/chat/tests/timeline-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { TimelineMessage } from "../src/lib/chat-ui";
-import { applyDeliveryEventById } from "../src/lib/timeline-state";
+import { applyDeliveryEventById, latestRemoteMessageIdFor } from "../src/lib/timeline-state";
 
 function makeMessage(id: string, overrides: Partial<TimelineMessage> = {}): TimelineMessage {
   return {
@@ -13,6 +13,46 @@ function makeMessage(id: string, overrides: Partial<TimelineMessage> = {}): Time
     ...overrides,
   } as TimelineMessage;
 }
+
+describe("latestRemoteMessageIdFor", () => {
+  test("returns null for an empty timeline", () => {
+    expect(latestRemoteMessageIdFor([])).toBeNull();
+  });
+
+  test("returns the most recent non-self, non-retracted message id", () => {
+    const timeline = [
+      makeMessage("a", { isSelf: false }),
+      makeMessage("b", { isSelf: false }),
+      makeMessage("c", { isSelf: true }),
+    ];
+    expect(latestRemoteMessageIdFor(timeline)).toBe("b");
+  });
+
+  test("skips trailing self-sends", () => {
+    const timeline = [
+      makeMessage("a", { isSelf: false }),
+      makeMessage("b", { isSelf: true }),
+      makeMessage("c", { isSelf: true }),
+    ];
+    expect(latestRemoteMessageIdFor(timeline)).toBe("a");
+  });
+
+  test("skips retracted messages", () => {
+    const timeline = [
+      makeMessage("a", { isSelf: false }),
+      makeMessage("b", { isSelf: false, isRetracted: true } as Partial<TimelineMessage>),
+    ];
+    expect(latestRemoteMessageIdFor(timeline)).toBe("a");
+  });
+
+  test("returns null when timeline contains only self/retracted messages", () => {
+    const timeline = [
+      makeMessage("a", { isSelf: true }),
+      makeMessage("b", { isSelf: false, isRetracted: true } as Partial<TimelineMessage>),
+    ];
+    expect(latestRemoteMessageIdFor(timeline)).toBeNull();
+  });
+});
 
 describe("applyDeliveryEventById", () => {
   test("updates the matching self-message's deliveryStatus", () => {


### PR DESCRIPTION
## Summary

PR 5 of 7. Extract XEP-0085 chat-state notifications (composing/paused indicator + typing-user list) and XEP-0333 read-marker outbound state out of `channels/messages.ts` and `dms/messages.ts` into four focused composables.

Refs: #351 — see the full implementation plan there.

## What lands

- **`chat/src/lib/timeline-state.ts`** — extended with `latestRemoteMessageIdFor(timeline)`, a small pure helper extracted from the orchestrator's computed. Tested directly.
- **`chat/src/channels/chat-states.ts`** (new) — `useChannelChatStates` owning `typingUsers` ref, the per-nick auto-expire timers, and the local composing/paused debounce machine. Exposes `resetOnSend()` for `useMucSend`'s post-send cleanup (replaces the inline `composingTimeout`/`lastChatState` bookkeeping that previously lived in the orchestrator's `onSendComplete` callback).
- **`chat/src/channels/read-markers.ts`** (new) — `useChannelReadMarkers` owning `firstUnseenId`, `latestRemoteMessageId` (computed via the new pure helper), `markDisplayed`, and `persistLastSeen`.
- **`chat/src/dms/chat-states.ts`** + **`chat/src/dms/read-markers.ts`** (new) — DM mirrors of the above, scoped to `activePeerJid` and using `sendDmChatState` / `sendDmDisplayed` / `dmKey(barePeerJid(...))`.
- **`chat/tests/chat-states.test.ts`** + **`chat/tests/read-markers.test.ts`** (new) — direct unit tests per PR Compliance #2.
- **`chat/src/channels/messages.ts`** + **`chat/src/dms/messages.ts`** — orchestrators wire the new composables; ~100 LOC removed each. `useMucSend`/`useChatSend`'s `onSendComplete` callback now calls `chatStates.resetOnSend()` instead of touching `composingTimeout` / `lastChatState` directly.

## XEP conformance (preserved)

- **XEP-0085 §4.2** — content messages SHOULD contain `<active/>`. The orchestrator's `onSendComplete` still emits this when `result.state === "sending"`; the cleanup before it is delegated to `chatStates.resetOnSend()`.
- **XEP-0085 §3** — debounce: send `composing` on first typing keystroke, `paused` after 3s of inactivity. Same constants (`TYPING_EXPIRY_MS = 5000`, `COMPOSING_PAUSE_MS = 3000`) as pre-PR.
- **XEP-0333** — displayed marker outbound; falls back to the caller's messageId when the message isn't in the timeline. Unchanged behavior.
- **No `lib/xmpp` → `channels/*` import** — the new `latestRemoteMessageIdFor` lives in the shared `lib/timeline-state.ts`, kept layering one-way.

## Test strategy

- `lib/timeline-state.ts::latestRemoteMessageIdFor`: TDD RGR (5 tests).
- Composables: direct unit tests (16 tests across `chat-states.test.ts` and `read-markers.test.ts`).
- Targeted integration tests: `use-read-receipts`, `connection-notice`.
- Gates: `bun test`, `bun run lint`, `bunx astro check`.

## Acceptance criteria

- [x] `channels/messages.ts` and `dms/messages.ts` no longer define `addTypingUser` / `removeTypingUser` / `clearTypingState` / `notifyComposing` / `markDisplayed` / `persistLastSeen` / the `composingTimeout` + `lastChatState` + `typingTimers` private state inline.
- [x] `useMucSend.onSendComplete` callback delegates the XEP-0085 cleanup to `chatStates.resetOnSend()`.
- [x] Direct unit tests for each composable green.
- [x] Existing integration tests pass unchanged.
- [x] `bun test`, `bun run lint`, `astro check` clean.
- [x] Call sites of `useChannelMessages` / `useDirectMessages` remain stable.

## Plan checkpoint

Sequential off `main`. PRs 1, 2, 3, 4 (#463 / #465 / #473 / #476) merged. After this lands, PR 7 (`refactor(chat): extract message-search composables`) branches off the new `main`. PR 6 (MessageCard lightbox) is independent — already landed earlier as part of issue #467's resolution.
