### PR TITLE
fix(server): harden xmpp stream resume delivery

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -121,6 +121,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_message_delivery_failed?: (cb: (id: string) => void) => void;
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
   get_resume_state?: () => XmppResumeState | null;
+  get_resume_state_handle?: () => unknown | null;
 };
 
 type XmppResumeState = {
@@ -206,6 +207,7 @@ export class BrowserXmppClient {
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private resumeState: XmppResumeState | null = null;
+  private resumeStateHandle: unknown | null = null;
   private directQueueFlushPromise: Promise<void> | null = null;
   private readonly roomQueueFlushes = new Map<string, Promise<void>>();
   private readonly inflightQueuedIds = new Set<string>();
@@ -338,7 +340,9 @@ export class BrowserXmppClient {
       this.session.session_id,
       this.resource,
     );
-    if (this.resumeState) {
+    if (this.resumeStateHandle && typeof (config as any).with_resume_state_handle === "function") {
+      (config as any).with_resume_state_handle(this.resumeStateHandle);
+    } else if (this.resumeState) {
       (config as any).with_resume_state?.(
         this.resumeState.previd,
         this.resumeState.inboundH,
@@ -390,6 +394,7 @@ export class BrowserXmppClient {
     this.destroying = true;
     this.clearReconnectTimer();
     this.resumeState = null;
+    this.resumeStateHandle = null;
     const xmpp = this.xmpp;
     const roomBefore = this.currentRoom;
     this.stopSelfPing();
@@ -883,7 +888,8 @@ export class BrowserXmppClient {
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
-    if (this.destroying) { this.resumeState = null; this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    if (this.destroying) { this.resumeState = null; this.resumeStateHandle = null; this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    this.resumeStateHandle = xmpp.get_resume_state_handle?.() ?? null;
     this.resumeState = xmpp.get_resume_state?.() ?? null;
     this.emitStatus({ state: "reconnecting", detail: countQueuedMessages(this.queueScope) > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -130,6 +130,10 @@ type XmppResumeState = {
   outboundH: number;
 };
 
+type XmppResumeStateHandle = {
+  free?: () => void;
+} & Record<PropertyKey, unknown>;
+
 interface OutboundSendResult {
   id: string | null;
   state: "queued" | "sending";
@@ -313,6 +317,31 @@ export class BrowserXmppClient {
     }
   }
 
+  private clearResumeState() {
+    this.resumeState = null;
+    this.setResumeStateHandle(null);
+  }
+
+  private setResumeStateHandle(handle: unknown | null) {
+    if (this.resumeStateHandle && this.resumeStateHandle !== handle) {
+      this.disposeResumeStateHandle(this.resumeStateHandle);
+    }
+    this.resumeStateHandle = handle;
+  }
+
+  private disposeResumeStateHandle(handle: unknown) {
+    const owned = handle as XmppResumeStateHandle;
+    const symbolDispose = typeof Symbol === "function" ? (Symbol as any).dispose : undefined;
+    const dispose = symbolDispose ? (owned as any)[symbolDispose] : undefined;
+    try {
+      if (typeof dispose === "function") {
+        dispose.call(owned);
+      } else if (typeof owned.free === "function") {
+        owned.free.call(owned);
+      }
+    } catch {}
+  }
+
   private scheduleReconnect() {
     if (this.destroying || this.reconnectTimer) return;
     const delay = Math.min(2000 * (2 ** this.reconnectAttempt), 60000);
@@ -341,13 +370,16 @@ export class BrowserXmppClient {
       this.resource,
     );
     if (this.resumeStateHandle && typeof (config as any).with_resume_state_handle === "function") {
-      (config as any).with_resume_state_handle(this.resumeStateHandle);
+      const handle = this.resumeStateHandle;
+      (config as any).with_resume_state_handle(handle);
+      this.clearResumeState();
     } else if (this.resumeState) {
       (config as any).with_resume_state?.(
         this.resumeState.previd,
         this.resumeState.inboundH,
         this.resumeState.outboundH,
       );
+      this.resumeState = null;
     }
     const xmpp = new mod.WaddleClient(config) as unknown as XmppClientInstance;
     this.xmpp = xmpp;
@@ -393,8 +425,7 @@ export class BrowserXmppClient {
   async disconnect() {
     this.destroying = true;
     this.clearReconnectTimer();
-    this.resumeState = null;
-    this.resumeStateHandle = null;
+    this.clearResumeState();
     const xmpp = this.xmpp;
     const roomBefore = this.currentRoom;
     this.stopSelfPing();
@@ -888,8 +919,8 @@ export class BrowserXmppClient {
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
-    if (this.destroying) { this.resumeState = null; this.resumeStateHandle = null; this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
-    this.resumeStateHandle = xmpp.get_resume_state_handle?.() ?? null;
+    if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     this.resumeState = xmpp.get_resume_state?.() ?? null;
     this.emitStatus({ state: "reconnecting", detail: countQueuedMessages(this.queueScope) > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -120,6 +120,13 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_message_delivery_acked?: (cb: (id: string) => void) => void;
   set_on_message_delivery_failed?: (cb: (id: string) => void) => void;
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
+  get_resume_state?: () => XmppResumeState | null;
+};
+
+type XmppResumeState = {
+  previd: string;
+  inboundH: number;
+  outboundH: number;
 };
 
 interface OutboundSendResult {
@@ -198,6 +205,7 @@ export class BrowserXmppClient {
   private reconnectStartedAt: number | null = null;
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private resumeState: XmppResumeState | null = null;
   private directQueueFlushPromise: Promise<void> | null = null;
   private readonly roomQueueFlushes = new Map<string, Promise<void>>();
   private readonly inflightQueuedIds = new Set<string>();
@@ -330,6 +338,13 @@ export class BrowserXmppClient {
       this.session.session_id,
       this.resource,
     );
+    if (this.resumeState) {
+      (config as any).with_resume_state?.(
+        this.resumeState.previd,
+        this.resumeState.inboundH,
+        this.resumeState.outboundH,
+      );
+    }
     const xmpp = new mod.WaddleClient(config) as unknown as XmppClientInstance;
     this.xmpp = xmpp;
     this.wireEvents(xmpp);
@@ -374,6 +389,7 @@ export class BrowserXmppClient {
   async disconnect() {
     this.destroying = true;
     this.clearReconnectTimer();
+    this.resumeState = null;
     const xmpp = this.xmpp;
     const roomBefore = this.currentRoom;
     this.stopSelfPing();
@@ -867,7 +883,8 @@ export class BrowserXmppClient {
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
-    if (this.destroying) { this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    if (this.destroying) { this.resumeState = null; this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    this.resumeState = xmpp.get_resume_state?.() ?? null;
     this.emitStatus({ state: "reconnecting", detail: countQueuedMessages(this.queueScope) > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }
     this.scheduleReconnect();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -121,7 +121,7 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_message_delivery_failed?: (cb: (id: string) => void) => void;
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
   get_resume_state?: () => XmppResumeState | null;
-  get_resume_state_handle?: () => unknown | null;
+  get_resume_state_handle?: () => XmppResumeStateHandle | undefined;
 };
 
 type XmppResumeState = {
@@ -130,9 +130,7 @@ type XmppResumeState = {
   outboundH: number;
 };
 
-type XmppResumeStateHandle = {
-  free?: () => void;
-} & Record<PropertyKey, unknown>;
+type XmppResumeStateHandle = import("@waddle/xmpp-client-wasm").WaddleResumeState;
 
 interface OutboundSendResult {
   id: string | null;
@@ -211,7 +209,7 @@ export class BrowserXmppClient {
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private resumeState: XmppResumeState | null = null;
-  private resumeStateHandle: unknown | null = null;
+  private resumeStateHandle: XmppResumeStateHandle | null = null;
   private directQueueFlushPromise: Promise<void> | null = null;
   private readonly roomQueueFlushes = new Map<string, Promise<void>>();
   private readonly inflightQueuedIds = new Set<string>();
@@ -322,23 +320,16 @@ export class BrowserXmppClient {
     this.setResumeStateHandle(null);
   }
 
-  private setResumeStateHandle(handle: unknown | null) {
+  private setResumeStateHandle(handle: XmppResumeStateHandle | null | undefined) {
     if (this.resumeStateHandle && this.resumeStateHandle !== handle) {
       this.disposeResumeStateHandle(this.resumeStateHandle);
     }
-    this.resumeStateHandle = handle;
+    this.resumeStateHandle = handle ?? null;
   }
 
-  private disposeResumeStateHandle(handle: unknown) {
-    const owned = handle as XmppResumeStateHandle;
-    const symbolDispose = typeof Symbol === "function" ? (Symbol as any).dispose : undefined;
-    const dispose = symbolDispose ? (owned as any)[symbolDispose] : undefined;
+  private disposeResumeStateHandle(handle: XmppResumeStateHandle) {
     try {
-      if (typeof dispose === "function") {
-        dispose.call(owned);
-      } else if (typeof owned.free === "function") {
-        owned.free.call(owned);
-      }
+      handle.free();
     } catch {}
   }
 

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0198_stream_management.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0198_stream_management.cue
@@ -1,0 +1,68 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0198-stream-management"
+	xeps: ["XEP-0198"]
+	users: {
+		alice: devices: phone: #Actor & {
+			user:     "alice"
+			device:   "phone"
+			username: "alice"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+
+	steps: [
+		#StreamManagement & {
+			actor:  alicePhone
+			action: "enable"
+			resume: true
+			max:    60
+		},
+		#ExpectFrame & {
+			target:   alicePhone
+			contains: ["urn:xmpp:sm:3"]
+			elements: [#XmlElement & {
+				name:         "enabled"
+				ns:           "urn:xmpp:sm:3"
+				attrs:        resume: "true"
+				attrsPresent: ["id"]
+			}]
+		},
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-sm-counted"
+			body: "stream-management-counted"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "stream-management-counted"
+		},
+		#StreamManagement & {
+			actor:  alicePhone
+			action: "requestAck"
+		},
+		#ExpectFrame & {
+			target:   alicePhone
+			contains: ["urn:xmpp:sm:3"]
+			elements: [#XmlElement & {
+				name: "a"
+				ns:   "urn:xmpp:sm:3"
+				attrs: h: "1"
+			}]
+		},
+	]
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
@@ -16,7 +16,15 @@ impl WaddleClient {
                 on_error: None,
                 on_message_delivery_acked: None,
                 on_message_delivery_failed: None,
+                resume_state: None,
             })),
+        }
+    }
+
+    pub fn get_resume_state(&self) -> JsValue {
+        match self.inner.borrow().resume_state.as_ref() {
+            Some(state) => to_js_value(state).unwrap_or(JsValue::NULL),
+            None => JsValue::NULL,
         }
     }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
@@ -23,9 +23,19 @@ impl WaddleClient {
 
     pub fn get_resume_state(&self) -> JsValue {
         match self.inner.borrow().resume_state.as_ref() {
-            Some(state) => to_js_value(state).unwrap_or(JsValue::NULL),
+            Some(state) => {
+                to_js_value(&JsResumeState::from(state.clone())).unwrap_or(JsValue::NULL)
+            }
             None => JsValue::NULL,
         }
+    }
+
+    pub fn get_resume_state_handle(&self) -> Option<WaddleResumeState> {
+        self.inner
+            .borrow()
+            .resume_state
+            .clone()
+            .map(|inner| WaddleResumeState { inner })
     }
 
     pub fn set_on_message(&mut self, cb: Function) {

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -82,6 +82,7 @@ pub(crate) async fn disconnect_client(
         .await
         .map_err(|_| js_error("client is disconnected"))?;
     inner.borrow_mut().cmd_tx = None;
+    inner.borrow_mut().resume_state = None;
     rx.await
         .map_err(|_| js_error("client is disconnected"))?
         .map_err(|err| js_error(err.to_string()))

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -325,14 +325,6 @@ impl WasmDriverTask {
         Ok(())
     }
 
-    async fn publish_resume_state(&mut self, state: Option<waddle_xmpp_client::SmResumeState>) {
-        let _ = self
-            .event_tx
-            .clone()
-            .send(DriverEvent::ResumeState(state))
-            .await;
-    }
-
     async fn dispatch_client_event(&mut self, event: ClientEvent) -> Option<TransportMessage> {
         match event {
             ClientEvent::Connection(ConnectionEvent::OutboundMessage(message)) => {
@@ -477,7 +469,11 @@ impl WasmDriverTask {
         } else {
             self.runtime.resume_state()
         };
-        self.publish_resume_state(resume_state).await;
+        let _ = self
+            .event_tx
+            .clone()
+            .send(DriverEvent::ResumeState(resume_state))
+            .await;
 
         for command in self.deferred_commands.drain(..) {
             match command {

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -32,6 +32,7 @@ impl WasmDriverTask {
             event_tx,
             pending_iqs: HashMap::new(),
             pending_mam_queries: HashMap::new(),
+            deferred_commands: VecDeque::new(),
         })
     }
 
@@ -119,75 +120,40 @@ impl WasmDriverTask {
     async fn handle_command(&mut self, cmd: Option<WasmCommand>) -> bool {
         match cmd {
             Some(WasmCommand::SendStanza { stanza, responder }) => {
-                let result = self
-                    .send_transport_message(TransportMessage::Element(stanza.clone()))
-                    .await;
-                let keep_running = result.is_ok();
-                if let Err(err) = &result {
-                    if let Some(stanza_id) = message_delivery_stanza_id(&stanza) {
-                        self.emit_message_delivery_failed(stanza_id).await;
-                    }
-                    self.emit_error(err.to_string()).await;
+                if !self.runtime.can_send_app_stanza() {
+                    self.deferred_commands
+                        .push_back(DeferredWasmCommand::SendStanza { stanza, responder });
+                    return true;
                 }
-                let _ = responder.send(result);
-                keep_running
+
+                self.send_stanza_command(stanza, responder).await
             }
             Some(WasmCommand::SendIq { stanza, responder }) => {
-                let id = stanza.attr("id").map(|value| value.to_string());
-                match self
-                    .send_transport_message(TransportMessage::Element(stanza))
-                    .await
-                {
-                    Ok(()) => match id {
-                        Some(id) => {
-                            self.pending_iqs.insert(id, responder);
-                            true
-                        }
-                        None => {
-                            let _ = responder.send(Err(ClientError::Disconnected));
-                            false
-                        }
-                    },
-                    Err(err) => {
-                        self.emit_error(err.to_string()).await;
-                        let _ = responder.send(Err(err));
-                        false
-                    }
+                if !self.runtime.can_send_app_stanza() {
+                    self.deferred_commands
+                        .push_back(DeferredWasmCommand::SendIq { stanza, responder });
+                    return true;
                 }
+
+                self.send_iq_command(stanza, responder).await
             }
             Some(WasmCommand::SendMamQuery {
                 stanza,
                 query_id,
                 responder,
             }) => {
-                let id = stanza.attr("id").map(|value| value.to_string());
-                match self
-                    .send_transport_message(TransportMessage::Element(stanza))
-                    .await
-                {
-                    Ok(()) => match id {
-                        Some(id) => {
-                            self.pending_mam_queries.insert(
-                                id,
-                                PendingMamQuery {
-                                    query_id,
-                                    messages: Vec::new(),
-                                    responder,
-                                },
-                            );
-                            true
-                        }
-                        None => {
-                            let _ = responder.send(Err(ClientError::Disconnected));
-                            false
-                        }
-                    },
-                    Err(err) => {
-                        self.emit_error(err.to_string()).await;
-                        let _ = responder.send(Err(err));
-                        false
-                    }
+                if !self.runtime.can_send_app_stanza() {
+                    self.deferred_commands
+                        .push_back(DeferredWasmCommand::SendMamQuery {
+                            stanza,
+                            query_id,
+                            responder,
+                        });
+                    return true;
                 }
+
+                self.send_mam_query_command(stanza, query_id, responder)
+                    .await
             }
             Some(WasmCommand::Disconnect { responder }) => {
                 let result = self
@@ -199,6 +165,120 @@ impl WasmDriverTask {
             }
             None => false,
         }
+    }
+
+    async fn send_stanza_command(
+        &mut self,
+        stanza: Element,
+        responder: oneshot::Sender<DriverResult<()>>,
+    ) -> bool {
+        let result = self
+            .send_transport_message(TransportMessage::Element(stanza.clone()))
+            .await;
+        let keep_running = result.is_ok();
+        if let Err(err) = &result {
+            if let Some(stanza_id) = message_delivery_stanza_id(&stanza) {
+                self.emit_message_delivery_failed(stanza_id).await;
+            }
+            self.emit_error(err.to_string()).await;
+        }
+        let _ = responder.send(result);
+        keep_running
+    }
+
+    async fn send_iq_command(
+        &mut self,
+        stanza: Element,
+        responder: oneshot::Sender<DriverResult<Element>>,
+    ) -> bool {
+        let id = stanza.attr("id").map(|value| value.to_string());
+        match self
+            .send_transport_message(TransportMessage::Element(stanza))
+            .await
+        {
+            Ok(()) => match id {
+                Some(id) => {
+                    self.pending_iqs.insert(id, responder);
+                    true
+                }
+                None => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                    false
+                }
+            },
+            Err(err) => {
+                self.emit_error(err.to_string()).await;
+                let _ = responder.send(Err(err));
+                false
+            }
+        }
+    }
+
+    async fn send_mam_query_command(
+        &mut self,
+        stanza: Element,
+        query_id: String,
+        responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,
+    ) -> bool {
+        let id = stanza.attr("id").map(|value| value.to_string());
+        match self
+            .send_transport_message(TransportMessage::Element(stanza))
+            .await
+        {
+            Ok(()) => match id {
+                Some(id) => {
+                    self.pending_mam_queries.insert(
+                        id,
+                        PendingMamQuery {
+                            query_id,
+                            messages: Vec::new(),
+                            responder,
+                        },
+                    );
+                    true
+                }
+                None => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                    false
+                }
+            },
+            Err(err) => {
+                self.emit_error(err.to_string()).await;
+                let _ = responder.send(Err(err));
+                false
+            }
+        }
+    }
+
+    async fn flush_deferred_commands(&mut self) -> bool {
+        while self.runtime.can_send_app_stanza() {
+            let Some(command) = self.deferred_commands.pop_front() else {
+                return true;
+            };
+
+            let keep_running = match command {
+                DeferredWasmCommand::SendStanza { stanza, responder } => {
+                    self.send_stanza_command(stanza, responder).await
+                }
+                DeferredWasmCommand::SendIq { stanza, responder } => {
+                    self.send_iq_command(stanza, responder).await
+                }
+                DeferredWasmCommand::SendMamQuery {
+                    stanza,
+                    query_id,
+                    responder,
+                } => {
+                    self.send_mam_query_command(stanza, query_id, responder)
+                        .await
+                }
+            };
+
+            if !keep_running {
+                return false;
+            }
+        }
+
+        true
     }
 
     async fn apply_transport_event(&mut self, event: TransportEvent) -> bool {
@@ -214,6 +294,10 @@ impl WasmDriverTask {
             if !self.handle_client_event(event).await {
                 return false;
             }
+        }
+
+        if !self.flush_deferred_commands().await {
+            return false;
         }
 
         self.publish_resume_state().await;
@@ -388,6 +472,19 @@ impl WasmDriverTask {
     }
 
     async fn finish(&mut self) {
+        for command in self.deferred_commands.drain(..) {
+            match command {
+                DeferredWasmCommand::SendStanza { responder, .. } => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                }
+                DeferredWasmCommand::SendIq { responder, .. } => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                }
+                DeferredWasmCommand::SendMamQuery { responder, .. } => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                }
+            }
+        }
         for (_, responder) in self.pending_iqs.drain() {
             let _ = responder.send(Err(ClientError::Disconnected));
         }

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -122,7 +122,7 @@ impl WasmDriverTask {
             Some(WasmCommand::SendStanza { stanza, responder }) => {
                 if !self.runtime.can_send_app_stanza() {
                     self.deferred_commands
-                        .push_back(DeferredWasmCommand::SendStanza { stanza, responder });
+                        .push_back(DeferredWasmCommand::Stanza { stanza, responder });
                     return true;
                 }
 
@@ -131,7 +131,7 @@ impl WasmDriverTask {
             Some(WasmCommand::SendIq { stanza, responder }) => {
                 if !self.runtime.can_send_app_stanza() {
                     self.deferred_commands
-                        .push_back(DeferredWasmCommand::SendIq { stanza, responder });
+                        .push_back(DeferredWasmCommand::Iq { stanza, responder });
                     return true;
                 }
 
@@ -144,7 +144,7 @@ impl WasmDriverTask {
             }) => {
                 if !self.runtime.can_send_app_stanza() {
                     self.deferred_commands
-                        .push_back(DeferredWasmCommand::SendMamQuery {
+                        .push_back(DeferredWasmCommand::MamQuery {
                             stanza,
                             query_id,
                             responder,
@@ -257,13 +257,13 @@ impl WasmDriverTask {
             };
 
             let keep_running = match command {
-                DeferredWasmCommand::SendStanza { stanza, responder } => {
+                DeferredWasmCommand::Stanza { stanza, responder } => {
                     self.send_stanza_command(stanza, responder).await
                 }
-                DeferredWasmCommand::SendIq { stanza, responder } => {
+                DeferredWasmCommand::Iq { stanza, responder } => {
                     self.send_iq_command(stanza, responder).await
                 }
-                DeferredWasmCommand::SendMamQuery {
+                DeferredWasmCommand::MamQuery {
                     stanza,
                     query_id,
                     responder,
@@ -474,13 +474,13 @@ impl WasmDriverTask {
     async fn finish(&mut self) {
         for command in self.deferred_commands.drain(..) {
             match command {
-                DeferredWasmCommand::SendStanza { responder, .. } => {
+                DeferredWasmCommand::Stanza { responder, .. } => {
                     let _ = responder.send(Err(ClientError::Disconnected));
                 }
-                DeferredWasmCommand::SendIq { responder, .. } => {
+                DeferredWasmCommand::Iq { responder, .. } => {
                     let _ = responder.send(Err(ClientError::Disconnected));
                 }
-                DeferredWasmCommand::SendMamQuery { responder, .. } => {
+                DeferredWasmCommand::MamQuery { responder, .. } => {
                     let _ = responder.send(Err(ClientError::Disconnected));
                 }
             }

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -32,9 +32,6 @@ impl WasmDriverTask {
             event_tx,
             pending_iqs: HashMap::new(),
             pending_mam_queries: HashMap::new(),
-            sm_delivery_tracking_enabled: false,
-            outbound_h: 0,
-            pending_message_deliveries: VecDeque::new(),
         })
     }
 
@@ -219,6 +216,7 @@ impl WasmDriverTask {
             }
         }
 
+        self.publish_resume_state().await;
         true
     }
 
@@ -226,7 +224,6 @@ impl WasmDriverTask {
         if let Some(message) = self.dispatch_client_event(event).await {
             if let Err(err) = self.send_transport_message(message).await {
                 self.emit_error(err.to_string()).await;
-                self.fail_all_pending_message_deliveries().await;
                 return false;
             }
         }
@@ -240,7 +237,16 @@ impl WasmDriverTask {
                 return Err(ClientError::Disconnected);
             }
         }
+        self.publish_resume_state().await;
         Ok(())
+    }
+
+    async fn publish_resume_state(&mut self) {
+        let _ = self
+            .event_tx
+            .clone()
+            .send(DriverEvent::ResumeState(self.runtime.resume_state()))
+            .await;
     }
 
     async fn dispatch_client_event(&mut self, event: ClientEvent) -> Option<TransportMessage> {
@@ -258,7 +264,6 @@ impl WasmDriverTask {
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Enabled { previd },
             )) => {
-                self.sm_delivery_tracking_enabled = true;
                 let _ = self
                     .event_tx
                     .clone()
@@ -273,7 +278,6 @@ impl WasmDriverTask {
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Resumed { h },
             )) => {
-                self.sm_delivery_tracking_enabled = true;
                 let _ = self
                     .event_tx
                     .clone()
@@ -281,7 +285,6 @@ impl WasmDriverTask {
                         ConnectionEvent::StreamManagement(StreamManagementEvent::Resumed { h }),
                     )))
                     .await;
-                self.emit_acked_message_deliveries(h).await;
                 None
             }
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
@@ -294,13 +297,11 @@ impl WasmDriverTask {
                         ConnectionEvent::StreamManagement(StreamManagementEvent::AckReceived { h }),
                     )))
                     .await;
-                self.emit_acked_message_deliveries(h).await;
                 None
             }
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Failed,
             )) => {
-                self.sm_delivery_tracking_enabled = false;
                 let _ = self
                     .event_tx
                     .clone()
@@ -308,7 +309,6 @@ impl WasmDriverTask {
                         ConnectionEvent::StreamManagement(StreamManagementEvent::Failed),
                     )))
                     .await;
-                self.fail_all_pending_message_deliveries().await;
                 None
             }
             ClientEvent::IqResult { id, element } => {
@@ -361,10 +361,6 @@ impl WasmDriverTask {
             .send(&frame)
             .map_err(|_| ClientError::TransportClosed)?;
 
-        if let TransportMessage::Element(element) = &message {
-            self.record_outbound_element(element);
-        }
-
         if matches!(message, TransportMessage::Close(_)) {
             let _ = self.ws.close();
         }
@@ -373,59 +369,6 @@ impl WasmDriverTask {
 
         Ok(())
     }
-
-    fn record_outbound_element(&mut self, element: &Element) {
-        if is_stream_management_enable(element) {
-            self.sm_delivery_tracking_enabled = true;
-            self.outbound_h = 0;
-            self.pending_message_deliveries.clear();
-            return;
-        }
-
-        if !self.sm_delivery_tracking_enabled {
-            return;
-        }
-
-        if !matches!(element.name(), "iq" | "message" | "presence") {
-            return;
-        }
-
-        self.outbound_h = self.outbound_h.wrapping_add(1);
-        if let Some(stanza_id) = message_delivery_stanza_id(element) {
-            self.pending_message_deliveries
-                .push_back(TrackedMessageDelivery {
-                    stanza_id,
-                    h: self.outbound_h,
-                });
-        }
-    }
-
-    async fn emit_acked_message_deliveries(&mut self, h: u32) {
-        while self
-            .pending_message_deliveries
-            .front()
-            .is_some_and(|pending| pending.h <= h)
-        {
-            if let Some(pending) = self.pending_message_deliveries.pop_front() {
-                let _ = self
-                    .event_tx
-                    .clone()
-                    .send(client_driver_event(ClientEvent::MessageDelivery(
-                        MessageDeliveryEvent::Acked {
-                            stanza_id: pending.stanza_id,
-                        },
-                    )))
-                    .await;
-            }
-        }
-    }
-
-    async fn fail_all_pending_message_deliveries(&mut self) {
-        while let Some(pending) = self.pending_message_deliveries.pop_front() {
-            self.emit_message_delivery_failed(pending.stanza_id).await;
-        }
-    }
-
     async fn emit_message_delivery_failed(&mut self, stanza_id: StanzaId) {
         let _ = self
             .event_tx
@@ -445,8 +388,6 @@ impl WasmDriverTask {
     }
 
     async fn finish(&mut self) {
-        self.fail_all_pending_message_deliveries().await;
-
         for (_, responder) in self.pending_iqs.drain() {
             let _ = responder.send(Err(ClientError::Disconnected));
         }

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -33,6 +33,7 @@ impl WasmDriverTask {
             pending_iqs: HashMap::new(),
             pending_mam_queries: HashMap::new(),
             deferred_commands: VecDeque::new(),
+            explicit_disconnect: false,
         })
     }
 
@@ -156,6 +157,7 @@ impl WasmDriverTask {
                     .await
             }
             Some(WasmCommand::Disconnect { responder }) => {
+                self.explicit_disconnect = true;
                 let result = self
                     .send_transport_message(TransportMessage::Close(StreamClose))
                     .await;
@@ -300,7 +302,6 @@ impl WasmDriverTask {
             return false;
         }
 
-        self.publish_resume_state().await;
         true
     }
 
@@ -321,15 +322,14 @@ impl WasmDriverTask {
                 return Err(ClientError::Disconnected);
             }
         }
-        self.publish_resume_state().await;
         Ok(())
     }
 
-    async fn publish_resume_state(&mut self) {
+    async fn publish_resume_state(&mut self, state: Option<waddle_xmpp_client::SmResumeState>) {
         let _ = self
             .event_tx
             .clone()
-            .send(DriverEvent::ResumeState(self.runtime.resume_state()))
+            .send(DriverEvent::ResumeState(state))
             .await;
     }
 
@@ -472,6 +472,13 @@ impl WasmDriverTask {
     }
 
     async fn finish(&mut self) {
+        let resume_state = if self.explicit_disconnect {
+            None
+        } else {
+            self.runtime.resume_state()
+        };
+        self.publish_resume_state(resume_state).await;
+
         for command in self.deferred_commands.drain(..) {
             match command {
                 DeferredWasmCommand::Stanza { responder, .. } => {

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -7,6 +7,9 @@ pub(crate) async fn event_dispatch_loop(
     while let Some(event) = event_rx.next().await {
         match event {
             DriverEvent::Client(client_event) => dispatch_client_event(&inner, *client_event),
+            DriverEvent::ResumeState(state) => {
+                inner.borrow_mut().resume_state = state.map(JsResumeState::from);
+            }
             DriverEvent::Error(description) => emit_error_callback(&inner, &description),
             DriverEvent::Disconnected => {
                 inner.borrow_mut().cmd_tx = None;

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -8,7 +8,7 @@ pub(crate) async fn event_dispatch_loop(
         match event {
             DriverEvent::Client(client_event) => dispatch_client_event(&inner, *client_event),
             DriverEvent::ResumeState(state) => {
-                inner.borrow_mut().resume_state = state.map(JsResumeState::from);
+                inner.borrow_mut().resume_state = state;
             }
             DriverEvent::Error(description) => emit_error_callback(&inner, &description),
             DriverEvent::Disconnected => {

--- a/server/crates/waddle-xmpp-client-wasm/src/helpers.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/helpers.rs
@@ -21,8 +21,10 @@ pub(crate) fn build_client_config(config: &StoredConfig) -> Result<ClientConfig,
         ClientResource::new(config.resource.clone()).map_err(|err| js_error(err.to_string()))?;
     let auth = OAuthBearerConfig::new(jid, resource, AccessToken::new(config.access_token.clone()))
         .map_err(|err| js_error(err.to_string()))?;
-    ClientConfig::new(ConnectionConfig::new(domain), transport, auth)
-        .map_err(|err| js_error(err.to_string()))
+    let mut client_config = ClientConfig::new(ConnectionConfig::new(domain), transport, auth)
+        .map_err(|err| js_error(err.to_string()))?;
+    client_config.session.stream_management.resume_state = config.resume_state.clone();
+    Ok(client_config)
 }
 
 pub(crate) fn parse_raw_iq(xml: &str) -> Result<Element, JsValue> {
@@ -88,10 +90,6 @@ pub(crate) fn message_delivery_stanza_id(element: &Element) -> Option<StanzaId> 
     }
 
     element.attr("id").and_then(|id| StanzaId::new(id).ok())
-}
-
-pub(crate) fn is_stream_management_enable(element: &Element) -> bool {
-    element.name() == "enable" && element.ns() == waddle_xmpp_client::stream_management::NS_SM
 }
 
 pub(crate) fn to_js_value<T: Serialize + ?Sized>(value: &T) -> Result<JsValue, JsValue> {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use futures::channel::{mpsc, oneshot};

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use futures::channel::{mpsc, oneshot};

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -3,6 +3,11 @@ use super::*;
 pub(crate) type DriverResult<T> = Result<T, ClientError>;
 
 #[wasm_bindgen]
+pub struct WaddleResumeState {
+    pub(crate) inner: waddle_xmpp_client::SmResumeState,
+}
+
+#[wasm_bindgen]
 pub struct WaddleConfig {
     pub(crate) server_url: String,
     pub(crate) jid: String,
@@ -40,6 +45,10 @@ impl WaddleConfig {
                 .map_err(|err| js_error(err.to_string()))?,
         );
         Ok(())
+    }
+
+    pub fn with_resume_state_handle(&mut self, state: &WaddleResumeState) {
+        self.resume_state = Some(state.inner.clone());
     }
 }
 
@@ -98,7 +107,7 @@ pub(crate) struct WaddleClientInner {
     pub(crate) on_error: Option<Function>,
     pub(crate) on_message_delivery_acked: Option<Function>,
     pub(crate) on_message_delivery_failed: Option<Function>,
-    pub(crate) resume_state: Option<JsResumeState>,
+    pub(crate) resume_state: Option<waddle_xmpp_client::SmResumeState>,
 }
 
 pub(crate) enum WasmCommand {

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -120,6 +120,22 @@ pub(crate) enum WasmCommand {
     },
 }
 
+pub(crate) enum DeferredWasmCommand {
+    SendStanza {
+        stanza: Element,
+        responder: oneshot::Sender<DriverResult<()>>,
+    },
+    SendIq {
+        stanza: Element,
+        responder: oneshot::Sender<DriverResult<Element>>,
+    },
+    SendMamQuery {
+        stanza: Element,
+        query_id: String,
+        responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,
+    },
+}
+
 pub(crate) enum DriverEvent {
     Client(Box<ClientEvent>),
     ResumeState(Option<waddle_xmpp_client::SmResumeState>),
@@ -144,4 +160,5 @@ pub(crate) struct WasmDriverTask {
     pub(crate) event_tx: mpsc::Sender<DriverEvent>,
     pub(crate) pending_iqs: HashMap<String, oneshot::Sender<DriverResult<Element>>>,
     pub(crate) pending_mam_queries: HashMap<String, PendingMamQuery>,
+    pub(crate) deferred_commands: VecDeque<DeferredWasmCommand>,
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -130,15 +130,15 @@ pub(crate) enum WasmCommand {
 }
 
 pub(crate) enum DeferredWasmCommand {
-    SendStanza {
+    Stanza {
         stanza: Element,
         responder: oneshot::Sender<DriverResult<()>>,
     },
-    SendIq {
+    Iq {
         stanza: Element,
         responder: oneshot::Sender<DriverResult<Element>>,
     },
-    SendMamQuery {
+    MamQuery {
         stanza: Element,
         query_id: String,
         responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -8,6 +8,7 @@ pub struct WaddleConfig {
     pub(crate) jid: String,
     pub(crate) access_token: String,
     pub(crate) resource: String,
+    pub(crate) resume_state: Option<waddle_xmpp_client::SmResumeState>,
 }
 
 #[wasm_bindgen]
@@ -24,7 +25,21 @@ impl WaddleConfig {
             jid,
             access_token,
             resource,
+            resume_state: None,
         }
+    }
+
+    pub fn with_resume_state(
+        &mut self,
+        previd: String,
+        inbound_h: u32,
+        outbound_h: u32,
+    ) -> Result<(), JsValue> {
+        self.resume_state = Some(
+            waddle_xmpp_client::SmResumeState::new(previd, inbound_h, outbound_h)
+                .map_err(|err| js_error(err.to_string()))?,
+        );
+        Ok(())
     }
 }
 
@@ -34,6 +49,7 @@ pub(crate) struct StoredConfig {
     pub(crate) jid: String,
     pub(crate) access_token: String,
     pub(crate) resource: String,
+    pub(crate) resume_state: Option<waddle_xmpp_client::SmResumeState>,
 }
 
 impl From<&WaddleConfig> for StoredConfig {
@@ -43,6 +59,25 @@ impl From<&WaddleConfig> for StoredConfig {
             jid: value.jid.clone(),
             access_token: value.access_token.clone(),
             resource: value.resource.clone(),
+            resume_state: value.resume_state.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct JsResumeState {
+    pub(crate) previd: String,
+    pub(crate) inbound_h: u32,
+    pub(crate) outbound_h: u32,
+}
+
+impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
+    fn from(value: waddle_xmpp_client::SmResumeState) -> Self {
+        Self {
+            previd: value.previd().to_string(),
+            inbound_h: value.inbound_h(),
+            outbound_h: value.outbound_h(),
         }
     }
 }
@@ -63,6 +98,7 @@ pub(crate) struct WaddleClientInner {
     pub(crate) on_error: Option<Function>,
     pub(crate) on_message_delivery_acked: Option<Function>,
     pub(crate) on_message_delivery_failed: Option<Function>,
+    pub(crate) resume_state: Option<JsResumeState>,
 }
 
 pub(crate) enum WasmCommand {
@@ -86,6 +122,7 @@ pub(crate) enum WasmCommand {
 
 pub(crate) enum DriverEvent {
     Client(Box<ClientEvent>),
+    ResumeState(Option<waddle_xmpp_client::SmResumeState>),
     Error(String),
     Disconnected,
 }
@@ -100,12 +137,6 @@ pub(crate) struct PendingMamQuery {
     pub(crate) responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct TrackedMessageDelivery {
-    pub(crate) stanza_id: StanzaId,
-    pub(crate) h: u32,
-}
-
 pub(crate) struct WasmDriverTask {
     pub(crate) runtime: XmppRuntime,
     pub(crate) ws: WasmWebSocket,
@@ -113,7 +144,4 @@ pub(crate) struct WasmDriverTask {
     pub(crate) event_tx: mpsc::Sender<DriverEvent>,
     pub(crate) pending_iqs: HashMap<String, oneshot::Sender<DriverResult<Element>>>,
     pub(crate) pending_mam_queries: HashMap<String, PendingMamQuery>,
-    pub(crate) sm_delivery_tracking_enabled: bool,
-    pub(crate) outbound_h: u32,
-    pub(crate) pending_message_deliveries: VecDeque<TrackedMessageDelivery>,
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -170,4 +170,5 @@ pub(crate) struct WasmDriverTask {
     pub(crate) pending_iqs: HashMap<String, oneshot::Sender<DriverResult<Element>>>,
     pub(crate) pending_mam_queries: HashMap<String, PendingMamQuery>,
     pub(crate) deferred_commands: VecDeque<DeferredWasmCommand>,
+    pub(crate) explicit_disconnect: bool,
 }

--- a/server/crates/waddle-xmpp-client/src/client.rs
+++ b/server/crates/waddle-xmpp-client/src/client.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use minidom::Element;
@@ -181,9 +181,6 @@ where
             events: evt_tx,
             state,
             pending_iqs: HashMap::new(),
-            sm_delivery_tracking_enabled: false,
-            outbound_h: 0,
-            pending_message_deliveries: VecDeque::new(),
         };
 
         tokio::spawn(task.run());
@@ -200,15 +197,6 @@ struct DriverTask {
     events: broadcast::Sender<ClientEvent>,
     state: Arc<RwLock<SessionSnapshot>>,
     pending_iqs: HashMap<String, oneshot::Sender<ClientResult<Element>>>,
-    sm_delivery_tracking_enabled: bool,
-    outbound_h: u32,
-    pending_message_deliveries: VecDeque<TrackedMessageDelivery>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TrackedMessageDelivery {
-    stanza_id: StanzaId,
-    h: u32,
 }
 
 impl DriverTask {
@@ -302,15 +290,10 @@ impl DriverTask {
         for evt in client_events {
             if let Some(msg) = self.dispatch_client_event(evt) {
                 if self.send_transport_message(msg).await.is_err() {
-                    self.fail_all_pending_message_deliveries();
                     *self.state.write().unwrap() = self.runtime.snapshot().clone();
                     return false;
                 }
             }
-        }
-
-        if is_terminal {
-            self.fail_all_pending_message_deliveries();
         }
 
         *self.state.write().unwrap() = self.runtime.snapshot().clone();
@@ -337,7 +320,6 @@ impl DriverTask {
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Enabled { previd },
             )) => {
-                self.sm_delivery_tracking_enabled = true;
                 let _ =
                     self.events
                         .send(ClientEvent::Connection(ConnectionEvent::StreamManagement(
@@ -348,13 +330,11 @@ impl DriverTask {
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Resumed { h },
             )) => {
-                self.sm_delivery_tracking_enabled = true;
                 let _ =
                     self.events
                         .send(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                             StreamManagementEvent::Resumed { h },
                         )));
-                self.emit_acked_message_deliveries(h);
                 None
             }
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
@@ -365,19 +345,16 @@ impl DriverTask {
                         .send(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                             StreamManagementEvent::AckReceived { h },
                         )));
-                self.emit_acked_message_deliveries(h);
                 None
             }
             ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Failed,
             )) => {
-                self.sm_delivery_tracking_enabled = false;
                 let _ =
                     self.events
                         .send(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                             StreamManagementEvent::Failed,
                         )));
-                self.fail_all_pending_message_deliveries();
                 None
             }
             ClientEvent::IqResult { id, element } => {
@@ -406,62 +383,9 @@ impl DriverTask {
                 self.transport
                     .send(TransportMessage::Element(element.clone()))
                     .await?;
-                self.record_outbound_element(&element);
                 Ok(())
             }
             other => self.transport.send(other).await,
-        }
-    }
-
-    fn record_outbound_element(&mut self, element: &Element) {
-        if is_stream_management_enable(element) {
-            self.sm_delivery_tracking_enabled = true;
-            self.outbound_h = 0;
-            self.pending_message_deliveries.clear();
-            return;
-        }
-
-        if !self.sm_delivery_tracking_enabled {
-            return;
-        }
-
-        if !matches!(element.name(), "iq" | "message" | "presence") {
-            return;
-        }
-
-        self.outbound_h = self.outbound_h.wrapping_add(1);
-        if let Some(stanza_id) = message_delivery_stanza_id(element) {
-            self.pending_message_deliveries
-                .push_back(TrackedMessageDelivery {
-                    stanza_id,
-                    h: self.outbound_h,
-                });
-        }
-    }
-
-    fn emit_acked_message_deliveries(&mut self, h: u32) {
-        loop {
-            let should_ack = self
-                .pending_message_deliveries
-                .front()
-                .is_some_and(|pending| pending.h <= h);
-            if !should_ack {
-                break;
-            }
-
-            if let Some(pending) = self.pending_message_deliveries.pop_front() {
-                let _ =
-                    self.events
-                        .send(ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked {
-                            stanza_id: pending.stanza_id,
-                        }));
-            }
-        }
-    }
-
-    fn fail_all_pending_message_deliveries(&mut self) {
-        while let Some(pending) = self.pending_message_deliveries.pop_front() {
-            self.emit_message_delivery_failed(pending.stanza_id);
         }
     }
 
@@ -480,10 +404,6 @@ fn message_delivery_stanza_id(element: &Element) -> Option<StanzaId> {
     }
 
     element.attr("id").and_then(|id| StanzaId::new(id).ok())
-}
-
-fn is_stream_management_enable(element: &Element) -> bool {
-    element.name() == "enable" && element.ns() == crate::stream_management::NS_SM
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp-client/src/client.rs
+++ b/server/crates/waddle-xmpp-client/src/client.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, RwLock};
 
 use minidom::Element;
@@ -181,6 +181,7 @@ where
             events: evt_tx,
             state,
             pending_iqs: HashMap::new(),
+            deferred_commands: VecDeque::new(),
         };
 
         tokio::spawn(task.run());
@@ -197,6 +198,15 @@ struct DriverTask {
     events: broadcast::Sender<ClientEvent>,
     state: Arc<RwLock<SessionSnapshot>>,
     pending_iqs: HashMap<String, oneshot::Sender<ClientResult<Element>>>,
+    deferred_commands: VecDeque<DeferredXmppCommand>,
+}
+
+enum DeferredXmppCommand {
+    SendStanza(Element),
+    SendIq {
+        stanza: Element,
+        responder: oneshot::Sender<ClientResult<Element>>,
+    },
 }
 
 impl DriverTask {
@@ -233,43 +243,100 @@ impl DriverTask {
                 }
                 cmd = self.commands.recv() => {
                     match cmd {
-                        Some(XmppCommand::SendStanza(el)) => {
-                            let maybe_message_id = message_delivery_stanza_id(&el);
-                            match self.send_transport_message(TransportMessage::Element(el)).await {
-                                Ok(()) => {}
-                                Err(_) => {
-                                    if let Some(stanza_id) = maybe_message_id {
-                                        self.emit_message_delivery_failed(stanza_id);
-                                    }
-                                }
+                        Some(command) => {
+                            if !self.handle_command(command).await {
+                                return;
                             }
-                        }
-                        Some(XmppCommand::SendIq { stanza, responder }) => {
-                            let id = stanza.attr("id").map(|s| s.to_string());
-                            match self.send_transport_message(TransportMessage::Element(stanza)).await {
-                                Err(_) => {
-                                    let _ = responder.send(Err(ClientError::Disconnected));
-                                }
-                                Ok(()) => match id {
-                                    Some(id) => {
-                                        self.pending_iqs.insert(id, responder);
-                                    }
-                                    None => {
-                                        let _ = responder.send(Err(ClientError::Disconnected));
-                                    }
-                                },
-                            }
-                        }
-                        Some(XmppCommand::Disconnect) => {
-                            let _ = self.transport.close().await;
-                            // Drain close events so state reaches Disconnected before we exit.
-                            for event in self.transport.drain_events() {
-                                self.apply_transport_event(event).await;
-                            }
-                            return;
                         }
                         None => return,
                     }
+                }
+            }
+        }
+    }
+
+    async fn handle_command(&mut self, command: XmppCommand) -> bool {
+        match command {
+            XmppCommand::SendStanza(stanza) => {
+                if !self.runtime.can_send_app_stanza() {
+                    self.deferred_commands
+                        .push_back(DeferredXmppCommand::SendStanza(stanza));
+                    return true;
+                }
+
+                self.send_stanza_command(stanza).await;
+                true
+            }
+            XmppCommand::SendIq { stanza, responder } => {
+                if !self.runtime.can_send_app_stanza() {
+                    self.deferred_commands
+                        .push_back(DeferredXmppCommand::SendIq { stanza, responder });
+                    return true;
+                }
+
+                self.send_iq_command(stanza, responder).await;
+                true
+            }
+            XmppCommand::Disconnect => {
+                let _ = self.transport.close().await;
+                // Drain close events so state reaches Disconnected before we exit.
+                for event in self.transport.drain_events() {
+                    self.apply_transport_event(event).await;
+                }
+                false
+            }
+        }
+    }
+
+    async fn send_stanza_command(&mut self, stanza: Element) {
+        let maybe_message_id = message_delivery_stanza_id(&stanza);
+        if self
+            .send_transport_message(TransportMessage::Element(stanza))
+            .await
+            .is_err()
+        {
+            if let Some(stanza_id) = maybe_message_id {
+                self.emit_message_delivery_failed(stanza_id);
+            }
+        }
+    }
+
+    async fn send_iq_command(
+        &mut self,
+        stanza: Element,
+        responder: oneshot::Sender<ClientResult<Element>>,
+    ) {
+        let id = stanza.attr("id").map(|s| s.to_string());
+        match self
+            .send_transport_message(TransportMessage::Element(stanza))
+            .await
+        {
+            Err(_) => {
+                let _ = responder.send(Err(ClientError::Disconnected));
+            }
+            Ok(()) => match id {
+                Some(id) => {
+                    self.pending_iqs.insert(id, responder);
+                }
+                None => {
+                    let _ = responder.send(Err(ClientError::Disconnected));
+                }
+            },
+        }
+    }
+
+    async fn flush_deferred_commands(&mut self) {
+        while self.runtime.can_send_app_stanza() {
+            let Some(command) = self.deferred_commands.pop_front() else {
+                return;
+            };
+
+            match command {
+                DeferredXmppCommand::SendStanza(stanza) => {
+                    self.send_stanza_command(stanza).await;
+                }
+                DeferredXmppCommand::SendIq { stanza, responder } => {
+                    self.send_iq_command(stanza, responder).await;
                 }
             }
         }
@@ -295,6 +362,8 @@ impl DriverTask {
                 }
             }
         }
+
+        self.flush_deferred_commands().await;
 
         *self.state.write().unwrap() = self.runtime.snapshot().clone();
         !is_terminal

--- a/server/crates/waddle-xmpp-client/src/client/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/client/tests.rs
@@ -300,6 +300,49 @@ async fn driver_keeps_deferred_stanzas_behind_fresh_fallback_sm_enable() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn driver_flushes_deferred_stanzas_when_fresh_sm_enable_fails() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _rx) = make_driver_task_with_config(
+        config_with_resume_state(),
+        MockTransport::new(vec![], vec![], shared.clone()),
+    );
+
+    drive_task_to_resume_attempt(&mut task).await;
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("queued-1")))
+        .await;
+
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        failed_sm(0),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        bind_result("bind-1"),
+    )))
+    .await;
+
+    assert!(
+        !shared
+            .sent_messages()
+            .iter()
+            .any(|message| transport_message_id(message) == Some("queued-1")),
+        "app stanza should stay deferred until SM either enables or fails"
+    );
+
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        Element::builder("failed", NS_SM).build(),
+    )))
+    .await;
+
+    let sent = shared.sent_messages();
+    assert!(
+        sent.iter()
+            .any(|message| transport_message_id(message) == Some("queued-1")),
+        "queued app stanza should flush after fresh SM enable fails"
+    );
+}
+
 // ── full bootstrap integration tests ─────────────────────────────────────
 
 #[tokio::test(flavor = "current_thread")]

--- a/server/crates/waddle-xmpp-client/src/client/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/client/tests.rs
@@ -16,6 +16,7 @@ use crate::config::{AccessToken, ClientResource, OAuthBearerConfig, WebSocketCon
 use crate::error::ClientError;
 use crate::event::{ClientEvent, LifecycleEvent, MessageDeliveryEvent};
 use crate::state::{SessionBinding, SessionPhase, SessionSnapshot};
+use crate::stream_management::{SmResumeState, NS_SM};
 use crate::transport::{StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState};
 use crate::ConnectionConfig;
 
@@ -33,9 +34,27 @@ fn config() -> ClientConfig {
     .unwrap()
 }
 
+fn config_with_resume_state() -> ClientConfig {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("prev-stream", 0, 0).unwrap());
+    config
+}
+
 // ── helper constructors ───────────────────────────────────────────────────
 
 fn make_driver_task(
+    transport: MockTransport,
+) -> (
+    DriverTask,
+    mpsc::Sender<XmppCommand>,
+    broadcast::Receiver<ClientEvent>,
+) {
+    make_driver_task_with_config(config(), transport)
+}
+
+fn make_driver_task_with_config(
+    config: ClientConfig,
     transport: MockTransport,
 ) -> (
     DriverTask,
@@ -46,12 +65,13 @@ fn make_driver_task(
     let (evt_tx, evt_rx) = broadcast::channel::<ClientEvent>(256);
     let state = Arc::new(RwLock::new(SessionSnapshot::new()));
     let task = DriverTask {
-        runtime: XmppRuntime::new(config()).unwrap(),
+        runtime: XmppRuntime::new(config).unwrap(),
         transport: Box::new(transport),
         commands: cmd_rx,
         events: evt_tx,
         state,
         pending_iqs: HashMap::new(),
+        deferred_commands: VecDeque::new(),
     };
     (task, cmd_tx, evt_rx)
 }
@@ -202,6 +222,82 @@ async fn driver_forwards_core_message_delivery_ack() {
         }
     }
     assert!(got_ack, "expected forwarded delivery ack event");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn driver_defers_app_stanzas_until_sm_resume_completes() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _rx) = make_driver_task_with_config(
+        config_with_resume_state(),
+        MockTransport::new(vec![], vec![], shared.clone()),
+    );
+
+    drive_task_to_resume_attempt(&mut task).await;
+    let sent_before_command = shared.sent_messages().len();
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("queued-1")))
+        .await;
+
+    assert_eq!(
+        shared.sent_messages().len(),
+        sent_before_command,
+        "app stanza must stay behind the resume barrier"
+    );
+
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        resumed("prev-stream", 0),
+    )))
+    .await;
+
+    let sent = shared.sent_messages();
+    assert!(
+        sent.iter()
+            .any(|message| transport_message_id(message) == Some("queued-1")),
+        "queued app stanza should flush after resumed"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn driver_keeps_deferred_stanzas_behind_fresh_fallback_sm_enable() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _rx) = make_driver_task_with_config(
+        config_with_resume_state(),
+        MockTransport::new(vec![], vec![], shared.clone()),
+    );
+
+    drive_task_to_resume_attempt(&mut task).await;
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("queued-1")))
+        .await;
+
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        failed_sm(0),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        bind_result("bind-1"),
+    )))
+    .await;
+
+    assert!(
+        !shared
+            .sent_messages()
+            .iter()
+            .any(|message| transport_message_id(message) == Some("queued-1")),
+        "fresh fallback must not flush app stanzas before SM is enabled"
+    );
+
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        enabled_sm("new-stream"),
+    )))
+    .await;
+
+    let sent = shared.sent_messages();
+    assert!(
+        sent.iter()
+            .any(|message| transport_message_id(message) == Some("queued-1")),
+        "queued app stanza should flush after fresh SM enable"
+    );
 }
 
 // ── full bootstrap integration tests ─────────────────────────────────────
@@ -520,6 +616,13 @@ fn post_auth_features() -> Element {
         .build()
 }
 
+fn post_auth_features_with_sm() -> Element {
+    Element::builder("features", NS_STREAMS)
+        .append(Element::builder("bind", NS_BIND).build())
+        .append(Element::builder("sm", NS_SM).attr("resume", "true").build())
+        .build()
+}
+
 fn bind_result(stanza_id: &str) -> Element {
     Element::builder("iq", crate::NS_CLIENT)
         .attr("id", stanza_id)
@@ -534,4 +637,72 @@ fn bind_result(stanza_id: &str) -> Element {
                 .build(),
         )
         .build()
+}
+
+fn message_stanza(stanza_id: &str) -> Element {
+    Element::builder("message", crate::NS_CLIENT)
+        .attr("id", stanza_id)
+        .attr("type", "chat")
+        .append(
+            Element::builder("body", crate::NS_CLIENT)
+                .append("queued")
+                .build(),
+        )
+        .build()
+}
+
+fn resumed(previd: &str, h: u32) -> Element {
+    Element::builder("resumed", NS_SM)
+        .attr("previd", previd)
+        .attr("h", h.to_string())
+        .build()
+}
+
+fn failed_sm(h: u32) -> Element {
+    Element::builder("failed", NS_SM)
+        .attr("h", h.to_string())
+        .build()
+}
+
+fn enabled_sm(previd: &str) -> Element {
+    Element::builder("enabled", NS_SM)
+        .attr("resume", "true")
+        .attr("id", previd)
+        .build()
+}
+
+fn transport_message_id(message: &TransportMessage) -> Option<&str> {
+    match message {
+        TransportMessage::Element(element) => element.attr("id"),
+        _ => None,
+    }
+}
+
+async fn drive_task_to_resume_attempt(task: &mut DriverTask) {
+    task.runtime
+        .queue_request(ClientRequest::Connect)
+        .expect("connect request should queue");
+    task.apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+        .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        pre_auth_features(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        Element::builder("success", NS_SASL).build(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        post_auth_features_with_sm(),
+    )))
+    .await;
+    assert_eq!(task.runtime.snapshot().phase, SessionPhase::Resuming);
 }

--- a/server/crates/waddle-xmpp-client/src/client/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/client/tests.rs
@@ -14,7 +14,7 @@ use crate::bootstrap::{NS_BIND, NS_SASL, NS_STREAMS};
 use crate::command::XmppCommand;
 use crate::config::{AccessToken, ClientResource, OAuthBearerConfig, WebSocketConfig};
 use crate::error::ClientError;
-use crate::event::{ClientEvent, LifecycleEvent, MessageDeliveryEvent, StreamManagementEvent};
+use crate::event::{ClientEvent, LifecycleEvent, MessageDeliveryEvent};
 use crate::state::{SessionBinding, SessionPhase, SessionSnapshot};
 use crate::transport::{StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState};
 use crate::ConnectionConfig;
@@ -52,9 +52,6 @@ fn make_driver_task(
         events: evt_tx,
         state,
         pending_iqs: HashMap::new(),
-        sm_delivery_tracking_enabled: false,
-        outbound_h: 0,
-        pending_message_deliveries: VecDeque::new(),
     };
     (task, cmd_tx, evt_rx)
 }
@@ -182,140 +179,29 @@ async fn send_iq_resolves_via_mock_driver() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn stream_management_ack_emits_message_delivery_ack() {
+async fn driver_forwards_core_message_delivery_ack() {
     let (mut task, _cmd_tx, mut rx) = make_driver_task(MockTransport::new(
         vec![],
         vec![],
         MockTransportShared::default(),
     ));
 
-    let message = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "out-1")
-        .attr("type", "chat")
-        .build();
-    task.sm_delivery_tracking_enabled = true;
-    task.record_outbound_element(&message);
-
-    task.dispatch_client_event(ClientEvent::Connection(ConnectionEvent::StreamManagement(
-        StreamManagementEvent::AckReceived { h: 1 },
-    )));
+    task.dispatch_client_event(ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked {
+        stanza_id: StanzaId::new("core-tracked").unwrap(),
+    }));
 
     let mut got_ack = false;
-    for _ in 0..2 {
-        match rx.try_recv() {
-            Ok(ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id }))
-                if stanza_id.as_str() == "out-1" =>
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
+                if stanza_id.as_str() == "core-tracked" =>
             {
                 got_ack = true
             }
-            Ok(_) => {}
-            Err(_) => break,
+            _ => {}
         }
     }
-    assert!(got_ack, "expected delivery ack event for out-1");
-    assert!(task.pending_message_deliveries.is_empty());
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn stream_management_tracking_starts_when_enable_is_sent() {
-    let (mut task, _cmd_tx, mut rx) = make_driver_task(MockTransport::new(
-        vec![],
-        vec![],
-        MockTransportShared::default(),
-    ));
-
-    let enable = crate::stream_management::SmState::build_enable(true);
-    task.record_outbound_element(&enable);
-    assert!(task.sm_delivery_tracking_enabled);
-    assert_eq!(task.outbound_h, 0);
-
-    let message = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "out-before-enabled")
-        .attr("type", "chat")
-        .build();
-    task.record_outbound_element(&message);
-
-    task.dispatch_client_event(ClientEvent::Connection(ConnectionEvent::StreamManagement(
-        StreamManagementEvent::AckReceived { h: 1 },
-    )));
-
-    let mut got_ack = false;
-    for _ in 0..2 {
-        match rx.try_recv() {
-            Ok(ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id }))
-                if stanza_id.as_str() == "out-before-enabled" =>
-            {
-                got_ack = true
-            }
-            Ok(_) => {}
-            Err(_) => break,
-        }
-    }
-    assert!(got_ack, "message sent after <enable/> must be tracked");
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn stream_management_resume_does_not_reset_outbound_counter() {
-    let (mut task, _cmd_tx, _rx) = make_driver_task(MockTransport::new(
-        vec![],
-        vec![],
-        MockTransportShared::default(),
-    ));
-
-    task.sm_delivery_tracking_enabled = true;
-    task.outbound_h = 2;
-
-    task.dispatch_client_event(ClientEvent::Connection(ConnectionEvent::StreamManagement(
-        StreamManagementEvent::Resumed { h: 1 },
-    )));
-
-    let message = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "after-resume")
-        .attr("type", "chat")
-        .build();
-    task.record_outbound_element(&message);
-
-    assert_eq!(task.outbound_h, 3);
-    assert!(matches!(
-        task.pending_message_deliveries.back(),
-        Some(TrackedMessageDelivery { stanza_id, h: 3 })
-            if stanza_id.as_str() == "after-resume"
-    ));
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn stream_management_failure_emits_message_delivery_failed() {
-    let (mut task, _cmd_tx, mut rx) = make_driver_task(MockTransport::new(
-        vec![],
-        vec![],
-        MockTransportShared::default(),
-    ));
-
-    let message = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "out-2")
-        .attr("type", "groupchat")
-        .build();
-    task.sm_delivery_tracking_enabled = true;
-    task.record_outbound_element(&message);
-
-    task.dispatch_client_event(ClientEvent::Connection(ConnectionEvent::StreamManagement(
-        StreamManagementEvent::Failed,
-    )));
-
-    let mut got_failed = false;
-    for _ in 0..2 {
-        match rx.try_recv() {
-            Ok(ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id }))
-                if stanza_id.as_str() == "out-2" =>
-            {
-                got_failed = true
-            }
-            Ok(_) => {}
-            Err(_) => break,
-        }
-    }
-    assert!(got_failed, "expected delivery failure event for out-2");
-    assert!(task.pending_message_deliveries.is_empty());
+    assert!(got_ack, "expected forwarded delivery ack event");
 }
 
 // ── full bootstrap integration tests ─────────────────────────────────────

--- a/server/crates/waddle-xmpp-client/src/config.rs
+++ b/server/crates/waddle-xmpp-client/src/config.rs
@@ -6,6 +6,7 @@ use url::Url;
 use waddle_xmpp_core::ConnectionConfig;
 
 use crate::error::{ClientError, ClientResult};
+use crate::stream_management::SmResumeState;
 
 /// Immutable client bootstrap configuration.
 #[derive(Debug, Clone, PartialEq)]
@@ -187,10 +188,12 @@ pub struct SessionConfig {
 }
 
 /// Stream management feature flags reserved for future parity slices.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StreamManagementConfig {
     pub enable_stream_management: bool,
     pub allow_resume: bool,
+    pub resume_max: Option<u32>,
+    pub resume_state: Option<SmResumeState>,
 }
 
 impl Default for StreamManagementConfig {
@@ -198,6 +201,8 @@ impl Default for StreamManagementConfig {
         Self {
             enable_stream_management: true,
             allow_resume: true,
+            resume_max: Some(300),
+            resume_state: None,
         }
     }
 }

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -89,6 +89,7 @@ pub use request::{
 };
 pub use runtime::{RuntimeStatus, XmppRuntime};
 pub use state::{ClientState, SessionBinding, SessionPhase, SessionSnapshot, StreamId};
+pub use stream_management::SmResumeState;
 pub use transport::{
     decode_message, encode_message, StreamClose, StreamOpen, TransportCapabilities, TransportEvent,
     TransportKind, TransportMessage, TransportState,

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -16,23 +16,35 @@ pub fn build_chat_state_message(
     message_type: &str,
 ) -> ClientResult<Element> {
     let state = validate_chat_state(state)?;
-    Ok(Element::builder("message", NS_CLIENT)
+    let stanza_id = Uuid::new_v4().to_string();
+    let mut builder = Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
-        .append(Element::builder(state, NS_CHAT_STATES).build())
-        .build())
+        .append(Element::builder(state, NS_CHAT_STATES).build());
+    if should_stamp_origin_id(message_type) {
+        builder = builder
+            .attr("id", stanza_id.as_str())
+            .append(build_origin_id(&stanza_id));
+    }
+    Ok(builder.build())
 }
 
 pub fn build_displayed_message(to: &str, message_id: &str, message_type: &str) -> Element {
-    Element::builder("message", NS_CLIENT)
+    let stanza_id = Uuid::new_v4().to_string();
+    let mut builder = Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
         .append(
             Element::builder("displayed", NS_CHAT_MARKERS)
                 .attr("id", message_id)
                 .build(),
-        )
-        .build()
+        );
+    if should_stamp_origin_id(message_type) {
+        builder = builder
+            .attr("id", stanza_id.as_str())
+            .append(build_origin_id(&stanza_id));
+    }
+    builder.build()
 }
 
 pub fn build_reaction_message(
@@ -41,6 +53,7 @@ pub fn build_reaction_message(
     target_id: &str,
     emojis: &[String],
 ) -> Element {
+    let stanza_id = Uuid::new_v4().to_string();
     let mut reactions = Element::builder("reactions", NS_REACTIONS)
         .attr("id", target_id)
         .build();
@@ -55,7 +68,8 @@ pub fn build_reaction_message(
     Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
-        .attr("id", Uuid::new_v4().to_string())
+        .attr("id", stanza_id.as_str())
+        .append(build_origin_id(&stanza_id))
         .append(reactions)
         .append(Element::builder("store", NS_HINTS).build())
         .build()
@@ -65,10 +79,12 @@ pub fn build_reaction_message(
 /// `to` is the room bare JID; `target_stanza_id` is the XEP-0359
 /// stanza-id (`by=room`) of the message being pinned.
 pub fn build_pinned_message(to: &str, target_stanza_id: &str) -> Element {
+    let stanza_id = Uuid::new_v4().to_string();
     Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", "groupchat")
-        .attr("id", Uuid::new_v4().to_string())
+        .attr("id", stanza_id.as_str())
+        .append(build_origin_id(&stanza_id))
         .append(
             Element::builder("pinned", NS_WADDLE_PIN_V0)
                 .attr("target", target_stanza_id)
@@ -79,10 +95,12 @@ pub fn build_pinned_message(to: &str, target_stanza_id: &str) -> Element {
 
 /// Build a `<message><unpinned target='…'/></message>` request for #414.
 pub fn build_unpinned_message(to: &str, target_stanza_id: &str) -> Element {
+    let stanza_id = Uuid::new_v4().to_string();
     Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", "groupchat")
-        .attr("id", Uuid::new_v4().to_string())
+        .attr("id", stanza_id.as_str())
+        .append(build_origin_id(&stanza_id))
         .append(
             Element::builder("unpinned", NS_WADDLE_PIN_V0)
                 .attr("target", target_stanza_id)
@@ -92,10 +110,12 @@ pub fn build_unpinned_message(to: &str, target_stanza_id: &str) -> Element {
 }
 
 pub fn build_retraction_message(to: &str, message_type: &str, retracts_id: &str) -> Element {
+    let stanza_id = Uuid::new_v4().to_string();
     Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
-        .attr("id", Uuid::new_v4().to_string())
+        .attr("id", stanza_id.as_str())
+        .append(build_origin_id(&stanza_id))
         .append(
             Element::builder("retract", NS_MESSAGE_RETRACT)
                 .attr("id", retracts_id)
@@ -169,6 +189,10 @@ pub fn build_outbound_message(
         .attr("type", message_type)
         .attr("id", stanza_id.as_str())
         .append(Element::builder("body", NS_CLIENT).append(body).build());
+
+    if matches!(message_type, "chat" | "groupchat") {
+        builder = builder.append(build_origin_id(stanza_id.as_str()));
+    }
 
     if let Some(subject) = options.subject.as_deref() {
         builder = builder.append(
@@ -289,6 +313,16 @@ pub fn build_outbound_message(
         }
     }
     Ok((stanza_id, builder.build()))
+}
+
+fn should_stamp_origin_id(message_type: &str) -> bool {
+    matches!(message_type, "chat" | "groupchat")
+}
+
+fn build_origin_id(stanza_id: &str) -> Element {
+    Element::builder("origin-id", NS_ORIGIN_ID)
+        .attr("id", stanza_id)
+        .build()
 }
 
 pub fn build_file_sharing_element(file: &SharedFile) -> Element {

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -7,6 +7,14 @@ fn el(xml: &str) -> Element {
     xml.parse().expect("invalid XML")
 }
 
+fn assert_origin_id_matches_message_id(stanza: &Element) {
+    let stanza_id = stanza.attr("id").expect("message id");
+    let origin_id = stanza
+        .get_child("origin-id", NS_ORIGIN_ID)
+        .expect("origin-id");
+    assert_eq!(origin_id.attr("id"), Some(stanza_id));
+}
+
 #[test]
 fn parse_message_with_body() {
     let e = el("<message xmlns='jabber:client' \
@@ -1021,6 +1029,27 @@ fn build_outbound_message_uses_caller_stanza_id() {
 }
 
 #[test]
+fn build_outbound_chat_messages_stamp_origin_id_matching_stanza_id() {
+    for message_type in ["chat", "groupchat"] {
+        let stanza_id = StanzaId::new(format!("{message_type}-client-id")).unwrap();
+        let options = SendMessageOptions {
+            stanza_id: Some(stanza_id.clone()),
+            ..Default::default()
+        };
+
+        let (_, stanza) =
+            build_outbound_message("room@muc.example", message_type, "hello", &options).unwrap();
+        let origin_id = stanza
+            .get_child("origin-id", NS_ORIGIN_ID)
+            .expect("origin-id");
+
+        assert_eq!(origin_id.attr("id"), Some(stanza_id.as_str()));
+        assert_eq!(origin_id.children().count(), 0);
+        assert!(origin_id.text().is_empty());
+    }
+}
+
+#[test]
 fn build_outbound_message_with_markup_spans_and_references() {
     let options = SendMessageOptions {
         markup_spans: vec![
@@ -1211,6 +1240,7 @@ fn build_chat_state_message_validates_state() {
         .expect("valid chat state");
     assert_eq!(stanza.attr("to"), Some("alice@example.com"));
     assert_eq!(stanza.attr("type"), Some("chat"));
+    assert_origin_id_matches_message_id(&stanza);
     assert!(stanza.get_child("composing", NS_CHAT_STATES).is_some());
     assert!(build_chat_state_message("alice@example.com", "typing", "chat").is_err());
 }
@@ -1219,6 +1249,7 @@ fn build_chat_state_message_validates_state() {
 fn build_displayed_message_has_expected_shape() {
     let stanza = build_displayed_message("room@muc.example", "msg-1", "groupchat");
     assert_eq!(stanza.attr("to"), Some("room@muc.example"));
+    assert_origin_id_matches_message_id(&stanza);
     assert!(stanza.get_child("displayed", NS_CHAT_MARKERS).is_some());
     assert_eq!(
         stanza
@@ -1265,6 +1296,7 @@ fn build_correction_message_with_markup_spans() {
 fn build_reaction_message_has_expected_shape() {
     let emojis = vec!["👍".to_string(), "❤️".to_string()];
     let stanza = build_reaction_message("room@muc.example", "groupchat", "msg-1", &emojis);
+    assert_origin_id_matches_message_id(&stanza);
     let reactions = stanza
         .get_child("reactions", NS_REACTIONS)
         .expect("reactions child");
@@ -1281,6 +1313,7 @@ fn build_reaction_message_has_expected_shape() {
 #[test]
 fn build_retraction_message_has_expected_shape() {
     let stanza = build_retraction_message("room@muc.example", "groupchat", "msg-1");
+    assert_origin_id_matches_message_id(&stanza);
     assert_eq!(
         stanza
             .get_child("retract", NS_MESSAGE_RETRACT)
@@ -1294,6 +1327,17 @@ fn build_retraction_message_has_expected_shape() {
         Some("This person attempted to retract a previous message.".to_string())
     );
     assert!(stanza.get_child("store", NS_HINTS).is_some());
+}
+
+#[test]
+fn build_pin_messages_stamp_origin_id_matching_message_id() {
+    let pinned = build_pinned_message("room@muc.example", "room-stanza-1");
+    assert_origin_id_matches_message_id(&pinned);
+    assert!(pinned.get_child("pinned", NS_WADDLE_PIN_V0).is_some());
+
+    let unpinned = build_unpinned_message("room@muc.example", "room-stanza-1");
+    assert_origin_id_matches_message_id(&unpinned);
+    assert!(unpinned.get_child("unpinned", NS_WADDLE_PIN_V0).is_some());
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -9,7 +9,7 @@ use crate::error::{ClientError, ClientResult};
 use crate::event::{ClientEvent, ConnectionEvent, LifecycleEvent};
 use crate::request::{ClientRequest, PendingRequest, RequestTracker, StanzaId};
 use crate::state::{SessionBinding, SessionPhase, SessionSnapshot};
-use crate::stream_management::SmState;
+use crate::stream_management::{SmResumeState, SmState};
 use crate::transport::{StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState};
 use crate::AuthenticationConfig;
 use minidom::Element;
@@ -37,6 +37,8 @@ pub struct XmppRuntime {
     sm_state: SmState,
     sm_advertised: bool,
     pending_fallback_retries: VecDeque<Element>,
+    fallback_resume_state: Option<SmResumeState>,
+    fallback_retry_writes_in_flight: VecDeque<Element>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -71,6 +73,8 @@ impl XmppRuntime {
             sm_state,
             sm_advertised: false,
             pending_fallback_retries: VecDeque::new(),
+            fallback_resume_state: None,
+            fallback_retry_writes_in_flight: VecDeque::new(),
         })
     }
 
@@ -82,7 +86,14 @@ impl XmppRuntime {
         &self.snapshot
     }
 
-    pub fn resume_state(&self) -> Option<crate::stream_management::SmResumeState> {
+    pub fn resume_state(&self) -> Option<SmResumeState> {
+        if self.fallback_resume_state.is_some()
+            && (!self.pending_fallback_retries.is_empty()
+                || !self.fallback_retry_writes_in_flight.is_empty())
+        {
+            return self.fallback_resume_state.clone();
+        }
+
         self.sm_state.resume_state()
     }
 
@@ -232,6 +243,7 @@ impl XmppRuntime {
         {
             self.sm_state.record_sent_stanza(element);
         }
+        self.mark_fallback_retry_sent(element);
     }
 
     fn handle_stream_open(
@@ -485,9 +497,26 @@ impl XmppRuntime {
 
     pub(super) fn flush_pending_fallback_retries(&mut self, events: &mut Vec<ClientEvent>) {
         while let Some(element) = self.pending_fallback_retries.pop_front() {
+            self.fallback_retry_writes_in_flight
+                .push_back(element.clone());
             events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
                 TransportMessage::Element(element),
             )));
+        }
+    }
+
+    fn mark_fallback_retry_sent(&mut self, element: &Element) {
+        if self
+            .fallback_retry_writes_in_flight
+            .front()
+            .is_some_and(|retry| retry == element)
+        {
+            self.fallback_retry_writes_in_flight.pop_front();
+            if self.pending_fallback_retries.is_empty()
+                && self.fallback_retry_writes_in_flight.is_empty()
+            {
+                self.fallback_resume_state = None;
+            }
         }
     }
 

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -44,19 +44,28 @@ enum BootstrapState {
     AwaitingFeatures { authenticated: bool },
     AwaitingAuthenticationOutcome,
     AwaitingBindResult { stanza_id: StanzaId },
+    AwaitingResume,
     Ready,
 }
 
 impl XmppRuntime {
     pub fn new(config: ClientConfig) -> ClientResult<Self> {
         config.validate()?;
+        let sm_state = config
+            .session
+            .stream_management
+            .resume_state
+            .as_ref()
+            .map(SmState::from_resume_state)
+            .unwrap_or_else(SmState::new);
+
         Ok(Self {
             config,
             snapshot: SessionSnapshot::new(),
             requests: RequestTracker::default(),
             bootstrap: BootstrapState::Idle,
             next_bootstrap_stanza: 0,
-            sm_state: SmState::new(),
+            sm_state,
             sm_advertised: false,
         })
     }
@@ -67,6 +76,17 @@ impl XmppRuntime {
 
     pub fn snapshot(&self) -> &SessionSnapshot {
         &self.snapshot
+    }
+
+    pub fn resume_state(&self) -> Option<crate::stream_management::SmResumeState> {
+        self.sm_state.previd.as_ref().and_then(|previd| {
+            crate::stream_management::SmResumeState::new(
+                previd.clone(),
+                self.sm_state.inbound_count,
+                self.sm_state.outbound_count,
+            )
+            .ok()
+        })
     }
 
     pub fn pending_requests(&self) -> Vec<PendingRequest> {
@@ -200,7 +220,7 @@ impl XmppRuntime {
 
         if self.sm_state.outbound_enabled && matches!(element.name(), "iq" | "message" | "presence")
         {
-            self.sm_state.record_sent(1);
+            self.sm_state.record_sent_stanza(element);
         }
     }
 
@@ -294,34 +314,57 @@ impl XmppRuntime {
             BootstrapState::AwaitingFeatures {
                 authenticated: true,
             } => {
+                if features.stream_management {
+                    self.sm_advertised = true;
+                }
+
+                let sm_cfg = &self.config.session.stream_management;
+                if sm_cfg.enable_stream_management
+                    && sm_cfg.allow_resume
+                    && features.stream_management
+                    && self.sm_state.previd.is_some()
+                {
+                    let resume = SmState::build_resume(
+                        self.sm_state.previd.as_deref().unwrap_or_default(),
+                        self.sm_state.inbound_count,
+                    );
+                    self.bootstrap = BootstrapState::AwaitingResume;
+                    self.set_phase(SessionPhase::Resuming)?;
+                    events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                        TransportMessage::Element(resume),
+                    )));
+                    return Ok(());
+                }
+
                 if !features.bind {
                     return Err(ClientError::MissingStreamFeature {
                         feature: RequiredStreamFeature::ResourceBinding,
                     });
                 }
 
-                if features.stream_management {
-                    self.sm_advertised = true;
-                }
-
-                let request = ResourceBindingRequest::new(
-                    self.next_bootstrap_stanza_id()?,
-                    self.oauth_config().resource.clone(),
-                );
-                self.bootstrap = BootstrapState::AwaitingBindResult {
-                    stanza_id: request.stanza_id.clone(),
-                };
-                self.set_phase(SessionPhase::Binding)?;
-                events.push(ClientEvent::Connection(
-                    ConnectionEvent::ResourceBindingRequested(request.clone()),
-                ));
-                events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
-                    request.to_transport_message(),
-                )));
+                self.request_resource_binding(events)?;
             }
             _ => {}
         }
 
+        Ok(())
+    }
+
+    fn request_resource_binding(&mut self, events: &mut Vec<ClientEvent>) -> ClientResult<()> {
+        let request = ResourceBindingRequest::new(
+            self.next_bootstrap_stanza_id()?,
+            self.oauth_config().resource.clone(),
+        );
+        self.bootstrap = BootstrapState::AwaitingBindResult {
+            stanza_id: request.stanza_id.clone(),
+        };
+        self.set_phase(SessionPhase::Binding)?;
+        events.push(ClientEvent::Connection(
+            ConnectionEvent::ResourceBindingRequested(request.clone()),
+        ));
+        events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            request.to_transport_message(),
+        )));
         Ok(())
     }
 
@@ -421,7 +464,7 @@ impl XmppRuntime {
 
         let sm_cfg = &self.config.session.stream_management;
         if sm_cfg.enable_stream_management && self.sm_advertised {
-            let enable = SmState::build_enable(sm_cfg.allow_resume);
+            let enable = SmState::build_enable_with_max(sm_cfg.allow_resume, sm_cfg.resume_max);
             events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
                 TransportMessage::Element(enable),
             )));
@@ -465,7 +508,9 @@ impl XmppRuntime {
                 | (SessionPhase::OpeningStream, SessionPhase::Authenticating)
                 | (SessionPhase::Authenticating, SessionPhase::OpeningStream)
                 | (SessionPhase::OpeningStream, SessionPhase::Binding)
+                | (SessionPhase::OpeningStream, SessionPhase::Resuming)
                 | (SessionPhase::Authenticating, SessionPhase::Binding)
+                | (SessionPhase::Resuming, SessionPhase::Binding)
                 | (SessionPhase::Binding, SessionPhase::Established)
                 | (SessionPhase::Established, SessionPhase::Resuming)
                 | (SessionPhase::Resuming, SessionPhase::Established)

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -100,6 +100,19 @@ impl XmppRuntime {
         }
     }
 
+    pub fn can_send_app_stanza(&self) -> bool {
+        if !matches!(self.snapshot.phase, SessionPhase::Established) {
+            return false;
+        }
+
+        let sm_cfg = &self.config.session.stream_management;
+        if sm_cfg.enable_stream_management && self.sm_advertised {
+            return self.sm_state.enabled;
+        }
+
+        true
+    }
+
     pub fn queue_request(&mut self, request: ClientRequest) -> ClientResult<Vec<ClientEvent>> {
         let previous = self.snapshot.clone();
         let pending = self.requests.register(request)?;

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -60,7 +60,7 @@ impl XmppRuntime {
             .resume_state
             .as_ref()
             .map(SmState::from_resume_state)
-            .unwrap_or_else(SmState::new);
+            .unwrap_or_default();
 
         Ok(Self {
             config,

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use crate::bootstrap::{
     AuthMechanism, AuthenticationRequest, BootstrapElement, RequiredStreamFeature,
     ResourceBindingRequest,
@@ -34,6 +36,7 @@ pub struct XmppRuntime {
     next_bootstrap_stanza: u64,
     sm_state: SmState,
     sm_advertised: bool,
+    pending_fallback_retries: VecDeque<Element>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -67,6 +70,7 @@ impl XmppRuntime {
             next_bootstrap_stanza: 0,
             sm_state,
             sm_advertised: false,
+            pending_fallback_retries: VecDeque::new(),
         })
     }
 
@@ -477,6 +481,14 @@ impl XmppRuntime {
         }
 
         Ok(())
+    }
+
+    pub(super) fn flush_pending_fallback_retries(&mut self, events: &mut Vec<ClientEvent>) {
+        while let Some(element) = self.pending_fallback_retries.pop_front() {
+            events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )));
+        }
     }
 
     fn oauth_config(&self) -> &crate::OAuthBearerConfig {

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -79,14 +79,7 @@ impl XmppRuntime {
     }
 
     pub fn resume_state(&self) -> Option<crate::stream_management::SmResumeState> {
-        self.sm_state.previd.as_ref().and_then(|previd| {
-            crate::stream_management::SmResumeState::new(
-                previd.clone(),
-                self.sm_state.inbound_count,
-                self.sm_state.outbound_count,
-            )
-            .ok()
-        })
+        self.sm_state.resume_state()
     }
 
     pub fn pending_requests(&self) -> Vec<PendingRequest> {

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -1,10 +1,12 @@
 use crate::bootstrap::NS_STREAMS;
-use crate::error::ClientResult;
-use crate::event::{ClientEvent, ConnectionEvent, StreamManagementEvent};
+
+use crate::error::{ClientError, ClientResult};
+use crate::event::{ClientEvent, ConnectionEvent, MessageDeliveryEvent, StreamManagementEvent};
+use crate::state::{SessionBinding, StreamId};
 use crate::transport::{StreamClose, TransportMessage};
 use minidom::Element;
 
-use super::XmppRuntime;
+use super::{BootstrapState, XmppRuntime};
 
 const NS_STREAM_ERRORS: &str = "urn:ietf:params:xml:ns:xmpp-streams";
 
@@ -28,10 +30,13 @@ impl XmppRuntime {
                 self.handle_sm_handled_count_too_high(h, events);
                 return Ok(());
             }
-            self.sm_state.process_ack(h);
+            let acked = self.sm_state.process_ack(h);
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::AckReceived { h },
             )));
+            events.extend(acked.into_iter().map(|stanza_id| {
+                ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
+            }));
         } else if element.name() == "enabled" {
             let previd = crate::stream_management::SmState::parse_enabled(element);
             self.sm_state.previd = previd.clone();
@@ -45,17 +50,38 @@ impl XmppRuntime {
                 self.handle_sm_handled_count_too_high(h, events);
                 return Ok(());
             }
-            self.sm_state.process_ack(h);
+            let acked = self.sm_state.process_ack(h);
             self.sm_state.previd = element.attr("previd").map(|s| s.to_string());
             self.sm_state.enabled = true;
+            self.sm_state.outbound_enabled = true;
+            if matches!(self.bootstrap, BootstrapState::AwaitingResume) {
+                self.snapshot.binding = Some(self.resumed_session_binding()?);
+                self.bootstrap = BootstrapState::Ready;
+                self.set_phase(crate::state::SessionPhase::Established)?;
+            }
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Resumed { h },
             )));
+            events.extend(acked.into_iter().map(|stanza_id| {
+                ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
+            }));
+            for replay in self.sm_state.mark_unhandled_for_replay() {
+                events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                    TransportMessage::Element(replay),
+                )));
+            }
         } else if element.name() == "failed" {
+            let resume_failed = matches!(self.bootstrap, BootstrapState::AwaitingResume);
+            if resume_failed {
+                self.sm_state.previd = None;
+            }
             self.sm_state.stop();
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Failed,
             )));
+            if resume_failed {
+                self.request_resource_binding(events)?;
+            }
         }
 
         Ok(())
@@ -81,5 +107,18 @@ impl XmppRuntime {
         events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
             TransportMessage::Close(StreamClose),
         )));
+    }
+
+    fn resumed_session_binding(&self) -> ClientResult<SessionBinding> {
+        let auth = self.oauth_config();
+        let jid = auth
+            .account
+            .with_resource_str(auth.resource.as_str())
+            .map_err(|_| ClientError::InvalidBindResponse)?;
+        Ok(SessionBinding {
+            jid,
+            stream_id: self.sm_state.previd.as_ref().map(StreamId::new),
+            resumable: self.sm_state.previd.is_some(),
+        })
     }
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -96,6 +96,7 @@ impl XmppRuntime {
             }
             if resume_failed {
                 let failed = self.sm_state.unhandled_message_stanza_ids();
+                // Keep the queue resumable until fallback retries are written to the new stream.
                 self.fallback_resume_state = self.sm_state.resume_state();
                 self.pending_fallback_retries
                     .extend(self.sm_state.unhandled_stanzas_for_fallback_retry());

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -95,9 +95,14 @@ impl XmppRuntime {
                 }));
             }
             if resume_failed {
+                let failed = self.sm_state.unhandled_message_stanza_ids();
+                self.fallback_resume_state = self.sm_state.resume_state();
                 self.pending_fallback_retries
                     .extend(self.sm_state.unhandled_stanzas_for_fallback_retry());
                 self.sm_state.previd = None;
+                events.extend(failed.into_iter().map(|stanza_id| {
+                    ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+                }));
             }
             self.sm_state.stop();
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -44,6 +44,7 @@ impl XmppRuntime {
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Enabled { previd },
             )));
+            self.flush_pending_fallback_retries(events);
         } else if element.name() == "resumed" {
             let h = element.attr("h").and_then(|v| v.parse().ok()).unwrap_or(0);
             if h > self.sm_state.outbound_count {
@@ -72,7 +73,19 @@ impl XmppRuntime {
             }
         } else if element.name() == "failed" {
             let resume_failed = matches!(self.bootstrap, BootstrapState::AwaitingResume);
+            if let Some(h) = element.attr("h").and_then(|value| value.parse().ok()) {
+                if h > self.sm_state.outbound_count {
+                    self.handle_sm_handled_count_too_high(h, events);
+                    return Ok(());
+                }
+                let acked = self.sm_state.process_ack(h);
+                events.extend(acked.into_iter().map(|stanza_id| {
+                    ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
+                }));
+            }
             if resume_failed {
+                self.pending_fallback_retries
+                    .extend(self.sm_state.unhandled_stanzas());
                 self.sm_state.previd = None;
             }
             self.sm_state.stop();

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -26,7 +26,7 @@ impl XmppRuntime {
                 StreamManagementEvent::AckRequested,
             )));
         } else if let Some(h) = crate::stream_management::SmState::parse_ack_h(element) {
-            if h > self.sm_state.outbound_count {
+            if self.sm_state.handled_count_too_high(h) {
                 self.handle_sm_handled_count_too_high(h, events);
                 return Ok(());
             }
@@ -46,20 +46,31 @@ impl XmppRuntime {
             )));
             self.flush_pending_fallback_retries(events);
         } else if element.name() == "resumed" {
-            let h = element.attr("h").and_then(|v| v.parse().ok()).unwrap_or(0);
-            if h > self.sm_state.outbound_count {
+            let Some(h) = element.attr("h").and_then(|v| v.parse().ok()) else {
+                self.handle_sm_protocol_violation(events);
+                return Ok(());
+            };
+            let Some(previd) = element.attr("previd") else {
+                self.handle_sm_protocol_violation(events);
+                return Ok(());
+            };
+            if !matches!(self.bootstrap, BootstrapState::AwaitingResume)
+                || self.sm_state.previd.as_deref() != Some(previd)
+            {
+                self.handle_sm_protocol_violation(events);
+                return Ok(());
+            }
+            if self.sm_state.handled_count_too_high(h) {
                 self.handle_sm_handled_count_too_high(h, events);
                 return Ok(());
             }
             let acked = self.sm_state.process_ack(h);
-            self.sm_state.previd = element.attr("previd").map(|s| s.to_string());
+            self.sm_state.previd = Some(previd.to_string());
             self.sm_state.enabled = true;
             self.sm_state.outbound_enabled = true;
-            if matches!(self.bootstrap, BootstrapState::AwaitingResume) {
-                self.snapshot.binding = Some(self.resumed_session_binding()?);
-                self.bootstrap = BootstrapState::Ready;
-                self.set_phase(crate::state::SessionPhase::Established)?;
-            }
+            self.snapshot.binding = Some(self.resumed_session_binding()?);
+            self.bootstrap = BootstrapState::Ready;
+            self.set_phase(crate::state::SessionPhase::Established)?;
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Resumed { h },
             )));
@@ -74,7 +85,7 @@ impl XmppRuntime {
         } else if element.name() == "failed" {
             let resume_failed = matches!(self.bootstrap, BootstrapState::AwaitingResume);
             if let Some(h) = element.attr("h").and_then(|value| value.parse().ok()) {
-                if h > self.sm_state.outbound_count {
+                if self.sm_state.handled_count_too_high(h) {
                     self.handle_sm_handled_count_too_high(h, events);
                     return Ok(());
                 }
@@ -85,7 +96,7 @@ impl XmppRuntime {
             }
             if resume_failed {
                 self.pending_fallback_retries
-                    .extend(self.sm_state.unhandled_stanzas());
+                    .extend(self.sm_state.unhandled_stanzas_for_fallback_retry());
                 self.sm_state.previd = None;
             }
             self.sm_state.stop();
@@ -94,6 +105,9 @@ impl XmppRuntime {
             )));
             if resume_failed {
                 self.request_resource_binding(events)?;
+            } else {
+                self.sm_advertised = false;
+                self.flush_pending_fallback_retries(events);
             }
         }
 
@@ -109,6 +123,22 @@ impl XmppRuntime {
                     .attr("send-count", self.sm_state.outbound_count.to_string())
                     .build(),
             )
+            .build();
+        self.sm_state.stop();
+        events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(error),
+        )));
+        events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed,
+        )));
+        events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Close(StreamClose),
+        )));
+    }
+
+    fn handle_sm_protocol_violation(&mut self, events: &mut Vec<ClientEvent>) {
+        let error = Element::builder("error", NS_STREAMS)
+            .append(Element::builder("bad-request", NS_STREAM_ERRORS).build())
             .build();
         self.sm_state.stop();
         events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -323,7 +323,7 @@ fn runtime_falls_back_to_resource_binding_when_sm_resume_fails() {
     let events = runtime
         .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
             Element::builder("failed", crate::stream_management::NS_SM)
-                .attr("h", "11")
+                .attr("h", "12")
                 .build(),
         )))
         .unwrap();
@@ -571,6 +571,11 @@ fn runtime_retries_only_unhandled_stanzas_after_failed_resume_fresh_enable() {
         ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Acked { stanza_id })
             if stanza_id.as_str() == "handled-before-fail"
     )));
+    assert!(failed_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "retry-after-fail"
+    )));
 
     let bind_id = failed_events
         .iter()
@@ -630,6 +635,65 @@ fn runtime_retries_only_unhandled_stanzas_after_failed_resume_fresh_enable() {
         .get_child("delay", "urn:xmpp:delay")
         .expect("fallback replay should include XEP-0203 delay");
     assert!(delay.attr("stamp").is_some());
+}
+
+#[test]
+fn runtime_preserves_failed_resume_snapshot_until_fallback_retry_is_sent() {
+    let resume_state = resume_state_with_sent_messages(["retry-after-drop"]);
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr("h", "0")
+                .build(),
+        )))
+        .unwrap();
+    let bind_id = failed_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("fresh bind request");
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+    let enable = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "enable" => Some(element.clone()),
+            _ => None,
+        })
+        .expect("fresh SM enable");
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            enable,
+        )))
+        .unwrap();
+
+    assert_resume_state_replays_id(
+        runtime
+            .resume_state()
+            .expect("fallback snapshot should survive fresh enable attempt"),
+        "retry-after-drop",
+    );
 }
 
 #[test]
@@ -963,4 +1027,32 @@ fn resume_state_with_sent_messages<const N: usize>(ids: [&str; N]) -> SmResumeSt
             .unwrap();
     }
     runtime.resume_state().expect("resume state")
+}
+
+fn assert_resume_state_replays_id(resume_state: SmResumeState, expected_id: &str) {
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "old-sm-id")
+                .attr("h", "0")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.attr("id") == Some(expected_id)
+    )));
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -379,6 +379,62 @@ fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
 }
 
 #[test]
+fn runtime_resume_state_carries_unhandled_stanzas_into_next_runtime() {
+    let mut first_runtime = XmppRuntime::new(config()).unwrap();
+    first_runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    first_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr("resume", "true")
+                .attr("id", "old-sm-id")
+                .build(),
+        )))
+        .unwrap();
+    first_runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            Element::builder("message", crate::NS_CLIENT)
+                .attr("id", "carried-unhandled")
+                .attr("type", "chat")
+                .build(),
+        )))
+        .unwrap();
+
+    let resume_state = first_runtime
+        .resume_state()
+        .expect("resume state with unhandled queue");
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut next_runtime = XmppRuntime::new(config).unwrap();
+
+    drive_to_authenticated_stream(&mut next_runtime);
+    next_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let resumed_events = next_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "old-sm-id")
+                .attr("h", "0")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(resumed_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.attr("id") == Some("carried-unhandled")
+    )));
+}
+
+#[test]
 fn runtime_emits_message_delivery_ack_from_core_sm_queue() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     runtime

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -435,6 +435,87 @@ fn runtime_resume_state_carries_unhandled_stanzas_into_next_runtime() {
 }
 
 #[test]
+fn runtime_retries_only_unhandled_stanzas_after_failed_resume_fresh_enable() {
+    let resume_state = resume_state_with_sent_messages(["handled-before-fail", "retry-after-fail"]);
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr("h", "1")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(failed_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Acked { stanza_id })
+            if stanza_id.as_str() == "handled-before-fail"
+    )));
+
+    let bind_id = failed_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("fresh bind request");
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+
+    let enable = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "enable" => Some(element.clone()),
+            _ => None,
+        })
+        .expect("fresh SM enable");
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            enable,
+        )))
+        .unwrap();
+
+    let enabled_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr("resume", "true")
+                .attr("id", "fresh-sm-id")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(!enabled_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.attr("id") == Some("handled-before-fail")
+    )));
+    assert!(enabled_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.attr("id") == Some("retry-after-fail")
+    )));
+}
+
+#[test]
 fn runtime_emits_message_delivery_ack_from_core_sm_queue() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     runtime
@@ -658,4 +739,32 @@ fn bind_result(stanza_id: &StanzaId) -> Element {
                 .build(),
         )
         .build()
+}
+
+fn resume_state_with_sent_messages<const N: usize>(ids: [&str; N]) -> SmResumeState {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr("resume", "true")
+                .attr("id", "old-sm-id")
+                .build(),
+        )))
+        .unwrap();
+    for id in ids {
+        runtime
+            .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr("id", id)
+                    .attr("type", "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+    runtime.resume_state().expect("resume state")
 }

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -229,6 +229,85 @@ fn runtime_establishes_session_from_successful_sm_resume_without_binding() {
 }
 
 #[test]
+fn runtime_rejects_resumed_without_required_h() {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "old-sm-id")
+                .build(),
+        )))
+        .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Resuming);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(TransportMessage::Close(_)))
+    )));
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::SessionReady(_))
+            | ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_))
+    )));
+}
+
+#[test]
+fn runtime_rejects_resumed_with_mismatched_previd() {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "different-sm-id")
+                .attr("h", "12")
+                .build(),
+        )))
+        .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Resuming);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "error"
+            && element
+                .get_child("bad-request", "urn:ietf:params:xml:ns:xmpp-streams")
+                .is_some()
+    )));
+}
+
+#[test]
 fn runtime_falls_back_to_resource_binding_when_sm_resume_fails() {
     let mut config = config();
     config.session.stream_management.resume_state =
@@ -310,30 +389,57 @@ fn runtime_requests_default_resume_window_when_enabling_stream_management() {
 }
 
 #[test]
-fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
+fn runtime_releases_send_barrier_when_fresh_sm_enable_fails() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let bind_id = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .unwrap();
     runtime
-        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
-            SmState::build_enable(true),
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
         )))
         .unwrap();
 
-    let handled = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "handled")
-        .attr("type", "chat")
-        .build();
-    let unhandled = Element::builder("message", crate::NS_CLIENT)
-        .attr("id", "unhandled")
-        .attr("type", "chat")
-        .build();
-    runtime
-        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
-            handled,
+    assert!(!runtime.can_send_app_stanza());
+
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM).build(),
         )))
         .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Established);
+    assert!(runtime.can_send_app_stanza());
+    assert!(failed_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+}
+
+#[test]
+fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
+    let resume_state = resume_state_with_sent_messages(["handled", "unhandled"]);
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
     runtime
-        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
-            unhandled.clone(),
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
         )))
         .unwrap();
 
@@ -351,11 +457,15 @@ fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
         ClientEvent::Connection(ConnectionEvent::OutboundMessage(
             TransportMessage::Element(element)
         )) if element.attr("id") == Some("unhandled")
+            && element.get_child("delay", "urn:xmpp:delay").is_none()
     )));
 
     runtime
         .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
-            unhandled,
+            Element::builder("message", crate::NS_CLIENT)
+                .attr("id", "unhandled")
+                .attr("type", "chat")
+                .build(),
         )))
         .unwrap();
 
@@ -507,12 +617,98 @@ fn runtime_retries_only_unhandled_stanzas_after_failed_resume_fresh_enable() {
             TransportMessage::Element(element)
         )) if element.attr("id") == Some("handled-before-fail")
     )));
-    assert!(enabled_events.iter().any(|event| matches!(
+    let retry = enabled_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.attr("id") == Some("retry-after-fail") => Some(element),
+            _ => None,
+        })
+        .expect("retry-after-fail replay");
+    let delay = retry
+        .get_child("delay", "urn:xmpp:delay")
+        .expect("fallback replay should include XEP-0203 delay");
+    assert!(delay.attr("stamp").is_some());
+}
+
+#[test]
+fn runtime_retries_unhandled_stanzas_when_fresh_sm_enable_fails() {
+    let resume_state = resume_state_with_sent_messages(["handled-before-fail", "retry-after-fail"]);
+    let mut config = config();
+    config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(config).unwrap();
+
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr("h", "1")
+                .build(),
+        )))
+        .unwrap();
+    let bind_id = failed_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("fresh bind request");
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+
+    let enable = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "enable" => Some(element.clone()),
+            _ => None,
+        })
+        .expect("fresh SM enable");
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            enable,
+        )))
+        .unwrap();
+
+    let failed_enable_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM).build(),
+        )))
+        .unwrap();
+
+    assert!(runtime.can_send_app_stanza());
+    assert!(!failed_enable_events.iter().any(|event| matches!(
         event,
         ClientEvent::Connection(ConnectionEvent::OutboundMessage(
             TransportMessage::Element(element)
-        )) if element.attr("id") == Some("retry-after-fail")
+        )) if element.attr("id") == Some("handled-before-fail")
     )));
+    let retry = failed_enable_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.attr("id") == Some("retry-after-fail") => Some(element),
+            _ => None,
+        })
+        .expect("retry-after-fail replay after fresh enable failure");
+    let delay = retry
+        .get_child("delay", "urn:xmpp:delay")
+        .expect("fresh enable failure replay should include XEP-0203 delay");
+    assert!(delay.attr("stamp").is_some());
 }
 
 #[test]

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -7,7 +7,7 @@ use url::Url;
 use super::*;
 use crate::bootstrap::{NS_BIND, NS_SASL, NS_STREAMS};
 use crate::config::{AccessToken, ClientResource, OAuthBearerConfig, WebSocketConfig};
-use crate::{ConnectionConfig, StreamManagementEvent};
+use crate::{ConnectionConfig, SmResumeState, StreamId, StreamManagementEvent};
 
 fn config() -> ClientConfig {
     ClientConfig::new(
@@ -138,6 +138,275 @@ fn runtime_bootstraps_auth_bind_and_ready_state() {
         event,
         ClientEvent::Lifecycle(LifecycleEvent::SessionReady(binding))
             if binding.jid == FullJid::from_str("alice@example.com/macbook").unwrap()
+    )));
+}
+
+#[test]
+fn runtime_requests_sm_resume_before_resource_binding_when_resume_state_exists() {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Resuming);
+
+    let outbound_elements: Vec<&Element> = events
+        .iter()
+        .filter_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) => Some(element),
+            _ => None,
+        })
+        .collect();
+
+    let resume = outbound_elements
+        .iter()
+        .find(|element| {
+            element.name() == "resume" && element.ns() == crate::stream_management::NS_SM
+        })
+        .expect("resume element before bind");
+    assert_eq!(resume.attr("previd"), Some("old-sm-id"));
+    assert_eq!(resume.attr("h"), Some("7"));
+
+    assert!(
+        !outbound_elements.iter().any(|element| {
+            element.name() == "iq" && element.get_child("bind", NS_BIND).is_some()
+        }),
+        "resume must be attempted before resource binding"
+    );
+}
+
+#[test]
+fn runtime_establishes_session_from_successful_sm_resume_without_binding() {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "old-sm-id")
+                .attr("h", "12")
+                .build(),
+        )))
+        .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Established);
+    assert_eq!(
+        runtime.snapshot().binding,
+        Some(SessionBinding {
+            jid: FullJid::from_str("alice@example.com/macbook").unwrap(),
+            stream_id: Some(StreamId::new("old-sm-id")),
+            resumable: true,
+        })
+    );
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Resumed { h: 12 }
+        ))
+    )));
+    assert!(!events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(_))
+            | ClientEvent::Connection(ConnectionEvent::ResourceBound(_))
+    )));
+}
+
+#[test]
+fn runtime_falls_back_to_resource_binding_when_sm_resume_fails() {
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr("h", "11")
+                .build(),
+        )))
+        .unwrap();
+
+    assert_eq!(runtime.snapshot().phase, SessionPhase::Binding);
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::Failed
+        ))
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(_))
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "iq" && element.get_child("bind", NS_BIND).is_some()
+    )));
+}
+
+#[test]
+fn runtime_requests_default_resume_window_when_enabling_stream_management() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let bind_id = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .unwrap();
+
+    let ready_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+
+    let enable = ready_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "enable" && element.ns() == crate::stream_management::NS_SM => {
+                Some(element)
+            }
+            _ => None,
+        })
+        .expect("stream management enable");
+
+    assert_eq!(enable.attr("resume"), Some("true"));
+    assert_eq!(enable.attr("max"), Some("300"));
+}
+
+#[test]
+fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+
+    let handled = Element::builder("message", crate::NS_CLIENT)
+        .attr("id", "handled")
+        .attr("type", "chat")
+        .build();
+    let unhandled = Element::builder("message", crate::NS_CLIENT)
+        .attr("id", "unhandled")
+        .attr("type", "chat")
+        .build();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            handled,
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            unhandled.clone(),
+        )))
+        .unwrap();
+
+    let resume_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr("previd", "old-sm-id")
+                .attr("h", "1")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(resume_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.attr("id") == Some("unhandled")
+    )));
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            unhandled,
+        )))
+        .unwrap();
+
+    let too_high_ack_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("a", crate::stream_management::NS_SM)
+                .attr("h", "3")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(too_high_ack_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "error"
+            && element
+                .get_child("handled-count-too-high", crate::stream_management::NS_SM)
+                .is_some()
+    )));
+}
+
+#[test]
+fn runtime_emits_message_delivery_ack_from_core_sm_queue() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            Element::builder("message", crate::NS_CLIENT)
+                .attr("id", "core-tracked")
+                .attr("type", "chat")
+                .build(),
+        )))
+        .unwrap();
+
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("a", crate::stream_management::NS_SM)
+                .attr("h", "1")
+                .build(),
+        )))
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Acked { stanza_id })
+            if stanza_id.as_str() == "core-tracked"
     )));
 }
 
@@ -283,6 +552,40 @@ fn post_auth_features() -> Element {
     Element::builder("features", NS_STREAMS)
         .append(Element::builder("bind", NS_BIND).build())
         .build()
+}
+
+fn post_auth_features_with_sm() -> Element {
+    Element::builder("features", NS_STREAMS)
+        .append(Element::builder("bind", NS_BIND).build())
+        .append(Element::builder("sm", crate::stream_management::NS_SM).build())
+        .build()
+}
+
+fn drive_to_authenticated_stream(runtime: &mut XmppRuntime) {
+    runtime.queue_request(ClientRequest::Connect).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+            StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            pre_auth_features(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("success", NS_SASL).build(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+            StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+        )))
+        .unwrap();
 }
 
 fn bind_result(stanza_id: &StanzaId) -> Element {

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -1,17 +1,61 @@
+use std::collections::VecDeque;
+
 use minidom::Element;
+
+use crate::error::{ClientError, ClientResult};
+use crate::request::StanzaId;
 
 pub const NS_SM: &str = "urn:xmpp:sm:3";
 
+/// In-memory XEP-0198 resume snapshot carried across a reconnect attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmResumeState {
+    previd: String,
+    inbound_h: u32,
+    outbound_h: u32,
+}
+
+impl SmResumeState {
+    pub fn new(previd: impl Into<String>, inbound_h: u32, outbound_h: u32) -> ClientResult<Self> {
+        let previd = previd.into();
+        if previd.trim().is_empty() {
+            return Err(ClientError::EmptyStanzaId);
+        }
+
+        Ok(Self {
+            previd,
+            inbound_h,
+            outbound_h,
+        })
+    }
+
+    pub fn previd(&self) -> &str {
+        &self.previd
+    }
+
+    pub fn inbound_h(&self) -> u32 {
+        self.inbound_h
+    }
+
+    pub fn outbound_h(&self) -> u32 {
+        self.outbound_h
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QueuedOutboundStanza {
+    h: u32,
+    element: Element,
+    message_stanza_id: Option<StanzaId>,
+}
+
 /// XEP-0198 client-side stream management state.
 ///
-/// **SM semantics:** Acking tracks transport-level delivery only — the server
-/// acknowledging `h` means it has *received* those stanzas at the transport
-/// boundary.  Application-level stanzas (`<message/>`, `<iq/>`, `<presence/>`)
-/// are **not** queued for resend on session resume.  Resumption restores the
-/// stream so the server can retransmit anything it buffered; the client does not
-/// replay its own unacked stanzas.  This keeps the implementation simple and
-/// avoids double-delivery problems that would otherwise require app-level
-/// deduplication.
+/// **SM semantics:** Acking tracks transport-level responsibility. When the
+/// peer reports `h`, every outbound stanza at or below that sequence number has
+/// been handled by the peer. A resumable session must retain enough typed
+/// outbound state to replay stanzas above the reported `h` without inventing new
+/// message identity.
 #[derive(Debug, Clone, Default)]
 pub struct SmState {
     /// Stanzas sent since the session started (wrapping u32).
@@ -30,6 +74,8 @@ pub struct SmState {
     pub outbound_enabled: bool,
     /// Whether SM is currently enabled for this session.
     pub enabled: bool,
+    outbound_queue: VecDeque<QueuedOutboundStanza>,
+    replay_in_flight: VecDeque<Element>,
 }
 
 impl SmState {
@@ -37,9 +83,32 @@ impl SmState {
         Self::default()
     }
 
+    pub fn from_resume_state(resume_state: &SmResumeState) -> Self {
+        Self {
+            outbound_count: resume_state.outbound_h(),
+            inbound_count: resume_state.inbound_h(),
+            previd: Some(resume_state.previd().to_string()),
+            ..Self::default()
+        }
+    }
+
     /// Increment the outbound stanza counter by `count`.
     pub fn record_sent(&mut self, count: u32) {
         self.outbound_count = self.outbound_count.wrapping_add(count);
+    }
+
+    /// Record a newly sent outbound stanza unless it is a queued replay.
+    pub fn record_sent_stanza(&mut self, element: &Element) {
+        if self.suppress_replay_sent_record(element) {
+            return;
+        }
+
+        self.record_sent(1);
+        self.outbound_queue.push_back(QueuedOutboundStanza {
+            h: self.outbound_count,
+            message_stanza_id: message_delivery_stanza_id(element),
+            element: element.clone(),
+        });
     }
 
     /// Start a fresh outbound SM sequence after sending `<enable/>`.
@@ -47,6 +116,8 @@ impl SmState {
         self.outbound_count = 0;
         self.server_h = 0;
         self.outbound_enabled = true;
+        self.outbound_queue.clear();
+        self.replay_in_flight.clear();
     }
 
     /// Stop all SM counters after `<failed/>` or stream termination.
@@ -61,17 +132,69 @@ impl SmState {
     }
 
     /// Update `server_h` from an `<a h='...'/>` ack.
-    pub fn process_ack(&mut self, h: u32) {
+    pub fn process_ack(&mut self, h: u32) -> Vec<StanzaId> {
         self.server_h = h;
+        let mut acked = Vec::new();
+        while self
+            .outbound_queue
+            .front()
+            .is_some_and(|queued| queued.h <= h)
+        {
+            if let Some(queued) = self.outbound_queue.pop_front() {
+                if let Some(stanza_id) = queued.message_stanza_id {
+                    acked.push(stanza_id);
+                }
+            }
+        }
+        acked
+    }
+
+    /// Mark currently unhandled outbound stanzas for replay and return them.
+    pub fn mark_unhandled_for_replay(&mut self) -> Vec<Element> {
+        let replay: Vec<Element> = self
+            .outbound_queue
+            .iter()
+            .map(|queued| queued.element.clone())
+            .collect();
+        self.replay_in_flight.extend(replay.iter().cloned());
+        replay
+    }
+
+    fn suppress_replay_sent_record(&mut self, element: &Element) -> bool {
+        if self
+            .replay_in_flight
+            .front()
+            .is_some_and(|queued| queued == element)
+        {
+            self.replay_in_flight.pop_front();
+            return true;
+        }
+        false
     }
 
     /// Build `<enable xmlns='urn:xmpp:sm:3' resume='true'/>`.
     pub fn build_enable(resume: bool) -> Element {
+        Self::build_enable_with_max(resume, None)
+    }
+
+    /// Build `<enable/>` with an optional XEP-0198 resumption window request.
+    pub fn build_enable_with_max(resume: bool, max: Option<u32>) -> Element {
         let mut b = Element::builder("enable", NS_SM);
         if resume {
             b = b.attr("resume", "true");
         }
+        if let Some(max) = max {
+            b = b.attr("max", max.to_string());
+        }
         b.build()
+    }
+
+    /// Build `<resume xmlns='urn:xmpp:sm:3' previd='ID' h='N'/>`.
+    pub fn build_resume(previd: &str, h: u32) -> Element {
+        Element::builder("resume", NS_SM)
+            .attr("previd", previd)
+            .attr("h", h.to_string())
+            .build()
     }
 
     /// Build `<r xmlns='urn:xmpp:sm:3'/>` to request an ack.
@@ -89,6 +212,9 @@ impl SmState {
     /// Extract the resumption `id` from an `<enabled/>` element, if present.
     pub fn parse_enabled(element: &Element) -> Option<String> {
         if element.name() == "enabled" && element.ns() == NS_SM {
+            if !matches!(element.attr("resume"), Some("true") | Some("1")) {
+                return None;
+            }
             element.attr("id").map(|s| s.to_string())
         } else {
             None
@@ -108,6 +234,14 @@ impl SmState {
     pub fn is_request_ack(element: &Element) -> bool {
         element.name() == "r" && element.ns() == NS_SM
     }
+}
+
+fn message_delivery_stanza_id(element: &Element) -> Option<StanzaId> {
+    if element.name() != "message" {
+        return None;
+    }
+
+    element.attr("id").and_then(|id| StanzaId::new(id).ok())
 }
 
 #[cfg(test)]
@@ -162,6 +296,20 @@ mod tests {
             .attr("resume", "true")
             .build();
         assert_eq!(SmState::parse_enabled(&el), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn parse_enabled_requires_resumable_response() {
+        let el = Element::builder("enabled", NS_SM)
+            .attr("id", "abc123")
+            .build();
+        assert_eq!(SmState::parse_enabled(&el), None);
+
+        let el = Element::builder("enabled", NS_SM)
+            .attr("id", "abc123")
+            .attr("resume", "false")
+            .build();
+        assert_eq!(SmState::parse_enabled(&el), None);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -186,6 +186,13 @@ impl SmState {
         replay
     }
 
+    pub fn unhandled_stanzas(&self) -> Vec<Element> {
+        self.outbound_queue
+            .iter()
+            .map(|queued| queued.element.clone())
+            .collect()
+    }
+
     fn suppress_replay_sent_record(&mut self, element: &Element) -> bool {
         if self
             .replay_in_flight

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -7,12 +7,20 @@ use crate::request::StanzaId;
 
 pub const NS_SM: &str = "urn:xmpp:sm:3";
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct QueuedOutboundStanza {
+    h: u32,
+    element: Element,
+    message_stanza_id: Option<StanzaId>,
+}
+
 /// In-memory XEP-0198 resume snapshot carried across a reconnect attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SmResumeState {
     previd: String,
     inbound_h: u32,
     outbound_h: u32,
+    outbound_queue: VecDeque<QueuedOutboundStanza>,
 }
 
 impl SmResumeState {
@@ -26,7 +34,19 @@ impl SmResumeState {
             previd,
             inbound_h,
             outbound_h,
+            outbound_queue: VecDeque::new(),
         })
+    }
+
+    fn from_outbound_queue(
+        previd: impl Into<String>,
+        inbound_h: u32,
+        outbound_h: u32,
+        outbound_queue: VecDeque<QueuedOutboundStanza>,
+    ) -> ClientResult<Self> {
+        let mut state = Self::new(previd, inbound_h, outbound_h)?;
+        state.outbound_queue = outbound_queue;
+        Ok(state)
     }
 
     pub fn previd(&self) -> &str {
@@ -40,13 +60,6 @@ impl SmResumeState {
     pub fn outbound_h(&self) -> u32 {
         self.outbound_h
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct QueuedOutboundStanza {
-    h: u32,
-    element: Element,
-    message_stanza_id: Option<StanzaId>,
 }
 
 /// XEP-0198 client-side stream management state.
@@ -88,8 +101,21 @@ impl SmState {
             outbound_count: resume_state.outbound_h(),
             inbound_count: resume_state.inbound_h(),
             previd: Some(resume_state.previd().to_string()),
+            outbound_queue: resume_state.outbound_queue.clone(),
             ..Self::default()
         }
+    }
+
+    pub fn resume_state(&self) -> Option<SmResumeState> {
+        self.previd.as_ref().and_then(|previd| {
+            SmResumeState::from_outbound_queue(
+                previd.clone(),
+                self.inbound_count,
+                self.outbound_count,
+                self.outbound_queue.clone(),
+            )
+            .ok()
+        })
     }
 
     /// Increment the outbound stanza counter by `count`.

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -1,17 +1,19 @@
 use std::collections::VecDeque;
 
+use chrono::{DateTime, SecondsFormat, Utc};
 use minidom::Element;
 
 use crate::error::{ClientError, ClientResult};
 use crate::request::StanzaId;
 
 pub const NS_SM: &str = "urn:xmpp:sm:3";
+const NS_DELAY: &str = "urn:xmpp:delay";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct QueuedOutboundStanza {
-    h: u32,
     element: Element,
     message_stanza_id: Option<StanzaId>,
+    sent_at: DateTime<Utc>,
 }
 
 /// In-memory XEP-0198 resume snapshot carried across a reconnect attempt.
@@ -131,9 +133,9 @@ impl SmState {
 
         self.record_sent(1);
         self.outbound_queue.push_back(QueuedOutboundStanza {
-            h: self.outbound_count,
             message_stanza_id: message_delivery_stanza_id(element),
             element: element.clone(),
+            sent_at: existing_delay_stamp(element).unwrap_or_else(Utc::now),
         });
     }
 
@@ -159,13 +161,13 @@ impl SmState {
 
     /// Update `server_h` from an `<a h='...'/>` ack.
     pub fn process_ack(&mut self, h: u32) -> Vec<StanzaId> {
+        let handled_since_last_ack = h.wrapping_sub(self.server_h);
         self.server_h = h;
         let mut acked = Vec::new();
-        while self
-            .outbound_queue
-            .front()
-            .is_some_and(|queued| queued.h <= h)
-        {
+        let to_drop = usize::try_from(handled_since_last_ack)
+            .unwrap_or(usize::MAX)
+            .min(self.outbound_queue.len());
+        for _ in 0..to_drop {
             if let Some(queued) = self.outbound_queue.pop_front() {
                 if let Some(stanza_id) = queued.message_stanza_id {
                     acked.push(stanza_id);
@@ -173,6 +175,10 @@ impl SmState {
             }
         }
         acked
+    }
+
+    pub fn handled_count_too_high(&self, h: u32) -> bool {
+        h.wrapping_sub(self.server_h) > self.outbound_count.wrapping_sub(self.server_h)
     }
 
     /// Mark currently unhandled outbound stanzas for replay and return them.
@@ -186,10 +192,10 @@ impl SmState {
         replay
     }
 
-    pub fn unhandled_stanzas(&self) -> Vec<Element> {
+    pub fn unhandled_stanzas_for_fallback_retry(&self) -> Vec<Element> {
         self.outbound_queue
             .iter()
-            .map(|queued| queued.element.clone())
+            .map(QueuedOutboundStanza::element_for_fallback_retry)
             .collect()
     }
 
@@ -267,6 +273,34 @@ impl SmState {
     pub fn is_request_ack(element: &Element) -> bool {
         element.name() == "r" && element.ns() == NS_SM
     }
+}
+
+impl QueuedOutboundStanza {
+    fn element_for_fallback_retry(&self) -> Element {
+        if self.element.name() != "message" {
+            return self.element.clone();
+        }
+        if self.element.get_child("delay", NS_DELAY).is_some() {
+            return self.element.clone();
+        }
+
+        let stamp = self.sent_at.to_rfc3339_opts(SecondsFormat::Millis, true);
+        let mut element = self.element.clone();
+        element.append_child(
+            Element::builder("delay", NS_DELAY)
+                .attr("stamp", stamp)
+                .build(),
+        );
+        element
+    }
+}
+
+fn existing_delay_stamp(element: &Element) -> Option<DateTime<Utc>> {
+    element
+        .get_child("delay", NS_DELAY)?
+        .attr("stamp")
+        .and_then(|stamp| DateTime::parse_from_rfc3339(stamp).ok())
+        .map(|stamp| stamp.with_timezone(&Utc))
 }
 
 fn message_delivery_stanza_id(element: &Element) -> Option<StanzaId> {
@@ -432,5 +466,64 @@ mod tests {
         assert_eq!(state.server_h, 10);
         state.process_ack(15);
         assert_eq!(state.server_h, 15);
+    }
+
+    #[test]
+    fn process_ack_trims_queue_across_u32_wrap() {
+        let mut state = SmState::new();
+        state.outbound_enabled = true;
+        state.server_h = u32::MAX - 1;
+        state.outbound_count = u32::MAX - 1;
+
+        state.record_sent_stanza(
+            &Element::builder("message", "jabber:client")
+                .attr("id", "last-before-wrap")
+                .build(),
+        );
+        state.record_sent_stanza(
+            &Element::builder("message", "jabber:client")
+                .attr("id", "first-after-wrap")
+                .build(),
+        );
+
+        assert!(!state.handled_count_too_high(0));
+        let acked = state.process_ack(0);
+
+        assert_eq!(
+            acked
+                .iter()
+                .map(|stanza_id| stanza_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["last-before-wrap", "first-after-wrap"]
+        );
+        assert!(state.outbound_queue.is_empty());
+    }
+
+    #[test]
+    fn fallback_retry_preserves_existing_delay_stamp() {
+        let mut state = SmState::new();
+        state.outbound_enabled = true;
+        let message = Element::builder("message", "jabber:client")
+            .attr("id", "already-delayed")
+            .append(
+                Element::builder("delay", NS_DELAY)
+                    .attr("stamp", "2024-01-15T10:00:00Z")
+                    .build(),
+            )
+            .build();
+
+        state.record_sent_stanza(&message);
+        let retry = state
+            .unhandled_stanzas_for_fallback_retry()
+            .into_iter()
+            .next()
+            .expect("fallback retry");
+        let delays = retry
+            .children()
+            .filter(|child| child.name() == "delay" && child.ns() == NS_DELAY)
+            .collect::<Vec<_>>();
+
+        assert_eq!(delays.len(), 1);
+        assert_eq!(delays[0].attr("stamp"), Some("2024-01-15T10:00:00Z"));
     }
 }

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -100,6 +100,7 @@ impl SmState {
 
     pub fn from_resume_state(resume_state: &SmResumeState) -> Self {
         let queue_len = u32::try_from(resume_state.outbound_queue.len()).unwrap_or(u32::MAX);
+        // The queue contains only stanzas not yet handled by the server.
         Self {
             outbound_count: resume_state.outbound_h(),
             inbound_count: resume_state.inbound_h(),

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -99,9 +99,11 @@ impl SmState {
     }
 
     pub fn from_resume_state(resume_state: &SmResumeState) -> Self {
+        let queue_len = u32::try_from(resume_state.outbound_queue.len()).unwrap_or(u32::MAX);
         Self {
             outbound_count: resume_state.outbound_h(),
             inbound_count: resume_state.inbound_h(),
+            server_h: resume_state.outbound_h().wrapping_sub(queue_len),
             previd: Some(resume_state.previd().to_string()),
             outbound_queue: resume_state.outbound_queue.clone(),
             ..Self::default()
@@ -196,6 +198,13 @@ impl SmState {
         self.outbound_queue
             .iter()
             .map(QueuedOutboundStanza::element_for_fallback_retry)
+            .collect()
+    }
+
+    pub fn unhandled_message_stanza_ids(&self) -> Vec<StanzaId> {
+        self.outbound_queue
+            .iter()
+            .filter_map(|queued| queued.message_stanza_id.clone())
             .collect()
     }
 
@@ -497,6 +506,46 @@ mod tests {
             vec!["last-before-wrap", "first-after-wrap"]
         );
         assert!(state.outbound_queue.is_empty());
+    }
+
+    #[test]
+    fn from_resume_state_restores_prior_server_ack_position() {
+        let mut state = SmState::new();
+        state.start_outbound();
+        state.previd = Some("previous-stream".to_string());
+        for id in 1..=10 {
+            state.record_sent_stanza(
+                &Element::builder("message", "jabber:client")
+                    .attr("id", format!("msg-{id}"))
+                    .build(),
+            );
+        }
+
+        let acked = state.process_ack(8);
+        assert_eq!(acked.len(), 8);
+
+        let resume_state = state.resume_state().expect("resume state");
+        let mut restored = SmState::from_resume_state(&resume_state);
+
+        assert_eq!(restored.server_h, 8);
+        assert!(!restored.handled_count_too_high(9));
+        let acked_after_resume = restored.process_ack(9);
+        assert_eq!(
+            acked_after_resume
+                .iter()
+                .map(|stanza_id| stanza_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["msg-9"]
+        );
+        assert_eq!(
+            restored
+                .outbound_queue
+                .iter()
+                .filter_map(|queued| queued.message_stanza_id.as_ref())
+                .map(|stanza_id| stanza_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["msg-10"]
+        );
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -36,6 +36,7 @@ export class WaddleClient {
      */
     fetch_room_pins(room_jid: string): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
+    get_resume_state(): any;
     get_server_version(): Promise<any>;
     join_room(room_jid: string, nick: string): Promise<any>;
     join_room_without_history(room_jid: string, nick: string): Promise<any>;
@@ -94,6 +95,7 @@ export class WaddleConfig {
     free(): void;
     [Symbol.dispose](): void;
     constructor(server_url: string, jid: string, access_token: string, resource: string);
+    with_resume_state(previd: string, inbound_h: number, outbound_h: number): void;
 }
 
 export default function init(): Promise<void>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -37,6 +37,7 @@ export class WaddleClient {
     fetch_room_pins(room_jid: string): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
     get_resume_state(): any;
+    get_resume_state_handle(): WaddleResumeState | undefined;
     get_server_version(): Promise<any>;
     join_room(room_jid: string, nick: string): Promise<any>;
     join_room_without_history(room_jid: string, nick: string): Promise<any>;
@@ -96,6 +97,13 @@ export class WaddleConfig {
     [Symbol.dispose](): void;
     constructor(server_url: string, jid: string, access_token: string, resource: string);
     with_resume_state(previd: string, inbound_h: number, outbound_h: number): void;
+    with_resume_state_handle(state: WaddleResumeState): void;
+}
+
+export class WaddleResumeState {
+    private constructor();
+    free(): void;
+    [Symbol.dispose](): void;
 }
 
 export default function init(): Promise<void>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3y6j1n";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp404b12";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp2l4pjr";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp2l4pjr";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp2l4pjr";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3s5fxc";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp2l4pjr";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3s5fxc";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3trjxk";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3s5fxc";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3w5re5";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3y6j1n";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3y6j1n";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3u335b";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3up2il";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3up2il";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3w5re5";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3up2il";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3w5re5";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3trjxk";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp3u335b";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3trjxk";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp3u335b";


### PR DESCRIPTION
## Status

Ready for review. This PR fixes #459 with the agreed in-memory-only, XMPP-native/XEP-compliant delivery recovery path and addresses the PR review comments.

## Scope

- In-memory only for this issue: no persisted client replay queue and no out-of-band recovery API.
- XEP-0198 stream management remains the delivery boundary for reconnect/resume.
- XEP-0203 delay metadata is added only when unhandled message stanzas are retried after a failed resume and fresh-session fallback.
- All replay payloads stay typed Rust XML values until the transport write boundary.

## Completed

- Resume-before-bind sends XEP-0198 `<resume/>` before resource binding when an in-memory resume snapshot exists.
- Successful `<resumed/>` validates `previd`, processes `h` as an ack, and replays only unhandled stanzas before new app sends.
- Failed `<failed/>` trims handled stanzas, reports still-unhandled message deliveries as failed, preserves fallback replay state across reconnect drops, and retries only unhandled stanzas on fresh-session fallback.
- Fresh SM enable failure degrades the current session to no-SM and releases deferred sends instead of leaving messages/IQs stuck forever.
- Counter handling restores prior server ack state from the queued tail and uses modulo-aware XEP-0198 deltas.
- Fallback retries add/preserve XEP-0203 delay metadata for message stanzas.
- WASM/browser handoff uses an opaque Rust-owned resume-state handle, disposes it after handoff/replacement/clear, and materializes the heavy queued snapshot only at disconnect boundaries.
- CUE coverage includes the XEP-0198 WebSocket C2S scenario and advertised-feature coverage checks.

## Review Comments Addressed

- Preserved prior `server_h` when rebuilding `SmState` from `SmResumeState`.
- Emitted `MessageDeliveryEvent::Failed` for unhandled message stanzas when resume is refused.
- Kept fallback replay state available across drops during failed-resume fresh bind/enable flow.
- Avoided repeated deep cloning of queued XML resume state in the WASM driver.
- Typed and disposed owned WASM resume-state handles in the browser client.
- Follow-up review pass made these ownership and final-publish boundaries explicit at the commented lines.

## XEP Constraints Checked

- XEP-0198: `<resume/>` and `<resumed/>` require `previd` and `h`.
- XEP-0198: successful resume processes `h` like an ack and resends unhandled stanzas.
- XEP-0198: failed resume may include `h`; handled stanzas must not be retried.
- XEP-0198 counters are modulo u32 values, so ack validation must be relative to the previous handled count.
- XEP-0203: retry after session-state discard should carry the original send time on delayed message resend.

## Verification

- `cargo fmt --manifest-path server/Cargo.toml --all --check`
- `cargo test -p waddle-xmpp-client`
- `cargo check -p waddle-xmpp-client-wasm`
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm -- -D warnings`
- `cargo test -p waddle-xmpp-client-wasm`
- `REBUILD_WASM=1 bun run wasm:build`
- `bun run lint` in `chat/`
- `bun run build` in `chat/`
- `bun test` in `chat/`
- `cargo test -p waddle-server --test xmpp_e2e_cue`
- Two adversarial review subagents found no actionable issues in the final diff.

## Not Run

- Full server workspace test suite.

Related: #459