### PR TITLE
fix(server): skip mam query frames during sm offline promotion

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -159,5 +159,62 @@ pub(super) async fn initialize(
             (),
         )
         .await?;
+    let deleted_mam_frames = delete_legacy_mam_query_frames(storage).await?;
+    if deleted_mam_frames > 0 {
+        info!(
+            deleted = deleted_mam_frames,
+            "pending_delivery startup cleanup removed XEP-0313 MAM query frames"
+        );
+    }
     Ok(())
+}
+
+async fn delete_legacy_mam_query_frames(
+    storage: &DatabasePendingDeliveryStorage,
+) -> Result<u64, PendingStorageError> {
+    let row_ids = {
+        let mut rows = storage
+            .query(
+                "SELECT row_id, transient_xml \
+                 FROM pending_delivery \
+                 WHERE payload_kind = 'transient' \
+                   AND transient_xml IS NOT NULL",
+                (),
+            )
+            .await?;
+        let mut row_ids = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?
+        {
+            let row_id: String = row
+                .get(0)
+                .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+            let xml: String = row
+                .get(1)
+                .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+            let Ok(element) = xml.parse::<xmpp_parsers::minidom::Element>() else {
+                continue;
+            };
+            let Ok(message) = xmpp_parsers::message::Message::try_from(element) else {
+                continue;
+            };
+            if waddle_xmpp_core::mam::is_mam_query_response_message(&message) {
+                row_ids.push(row_id);
+            }
+        }
+        row_ids
+    };
+
+    let mut deleted = 0;
+    for row_id in row_ids {
+        deleted += storage
+            .execute(
+                "DELETE FROM pending_delivery WHERE row_id = ?",
+                crate::db_params![row_id],
+            )
+            .await?;
+    }
+    Ok(deleted)
 }

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+const LEGACY_MAM_CLEANUP_MARKER: &str = "legacy_mam_query_frames_v1";
+const LEGACY_MAM_CLEANUP_DELETE_BATCH: usize = 128;
+
 pub(super) async fn initialize(
     storage: &DatabasePendingDeliveryStorage,
 ) -> Result<(), PendingStorageError> {
@@ -159,19 +162,106 @@ pub(super) async fn initialize(
             (),
         )
         .await?;
-    let deleted_mam_frames = delete_legacy_mam_query_frames(storage).await?;
-    if deleted_mam_frames > 0 {
-        info!(
-            deleted = deleted_mam_frames,
-            "pending_delivery startup cleanup removed XEP-0313 MAM query frames"
-        );
+    ensure_startup_migration_marker_table(storage).await?;
+    if !startup_migration_marker_completed(storage, LEGACY_MAM_CLEANUP_MARKER).await? {
+        let deleted_mam_frames = delete_legacy_mam_query_frames(storage).await?;
+        mark_startup_migration_completed(storage, LEGACY_MAM_CLEANUP_MARKER).await?;
+        if deleted_mam_frames > 0 {
+            info!(
+                deleted = deleted_mam_frames,
+                "pending_delivery startup cleanup removed XEP-0313 MAM query frames"
+            );
+        }
     }
     Ok(())
+}
+
+async fn ensure_startup_migration_marker_table(
+    storage: &DatabasePendingDeliveryStorage,
+) -> Result<(), PendingStorageError> {
+    storage
+        .execute(
+            "CREATE TABLE IF NOT EXISTS pending_delivery_startup_migrations (\
+                name TEXT PRIMARY KEY, \
+                completed_at INTEGER NOT NULL\
+             )",
+            (),
+        )
+        .await?;
+    Ok(())
+}
+
+async fn startup_migration_marker_completed(
+    storage: &DatabasePendingDeliveryStorage,
+    marker: &str,
+) -> Result<bool, PendingStorageError> {
+    let mut rows = storage
+        .query(
+            "SELECT 1 FROM pending_delivery_startup_migrations \
+             WHERE name = ? \
+             LIMIT 1",
+            crate::db_params![marker],
+        )
+        .await?;
+    Ok(rows
+        .next()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?
+        .is_some())
+}
+
+async fn mark_startup_migration_completed(
+    storage: &DatabasePendingDeliveryStorage,
+    marker: &str,
+) -> Result<(), PendingStorageError> {
+    let sql = match storage.db.driver() {
+        DatabaseDriver::Postgres => {
+            "INSERT INTO pending_delivery_startup_migrations (name, completed_at) \
+             VALUES (?, ?) \
+             ON CONFLICT (name) DO NOTHING"
+        }
+        DatabaseDriver::Sqlite => {
+            "INSERT OR IGNORE INTO pending_delivery_startup_migrations (name, completed_at) \
+             VALUES (?, ?)"
+        }
+    };
+    storage
+        .execute(
+            sql,
+            crate::db_params![marker, chrono::Utc::now().timestamp_millis()],
+        )
+        .await?;
+    Ok(())
+}
+
+async fn legacy_mam_query_frame_candidates_exist(
+    storage: &DatabasePendingDeliveryStorage,
+) -> Result<bool, PendingStorageError> {
+    let mut rows = storage
+        .query(
+            "SELECT 1 \
+             FROM pending_delivery \
+             WHERE payload_kind = 'transient' \
+               AND transient_xml IS NOT NULL \
+               AND transient_xml LIKE '%urn:xmpp:mam:2%' \
+             LIMIT 1",
+            (),
+        )
+        .await?;
+    Ok(rows
+        .next()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?
+        .is_some())
 }
 
 async fn delete_legacy_mam_query_frames(
     storage: &DatabasePendingDeliveryStorage,
 ) -> Result<u64, PendingStorageError> {
+    if !legacy_mam_query_frame_candidates_exist(storage).await? {
+        return Ok(0);
+    }
+
     let row_ids = {
         let mut rows = storage
             .query(
@@ -208,14 +298,38 @@ async fn delete_legacy_mam_query_frames(
         row_ids
     };
 
-    let mut deleted = 0;
-    for row_id in row_ids {
-        deleted += storage
-            .execute(
-                "DELETE FROM pending_delivery WHERE row_id = ?",
-                crate::db_params![row_id],
-            )
-            .await?;
+    delete_legacy_mam_query_frame_rows(storage, &row_ids).await
+}
+
+async fn delete_legacy_mam_query_frame_rows(
+    storage: &DatabasePendingDeliveryStorage,
+    row_ids: &[String],
+) -> Result<u64, PendingStorageError> {
+    if row_ids.is_empty() {
+        return Ok(0);
     }
+
+    let mut tx = storage
+        .db
+        .begin()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+    let mut deleted = 0;
+    for chunk in row_ids.chunks(LEGACY_MAM_CLEANUP_DELETE_BATCH) {
+        let placeholders = vec!["?"; chunk.len()].join(", ");
+        let sql = format!("DELETE FROM pending_delivery WHERE row_id IN ({placeholders})");
+        let params = chunk
+            .iter()
+            .cloned()
+            .map(crate::db::Value::from)
+            .collect::<Vec<_>>();
+        deleted += tx
+            .execute(&sql, params)
+            .await
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+    }
+    tx.commit()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?;
     Ok(deleted)
 }

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -178,7 +178,8 @@ async fn delete_legacy_mam_query_frames(
                 "SELECT row_id, transient_xml \
                  FROM pending_delivery \
                  WHERE payload_kind = 'transient' \
-                   AND transient_xml IS NOT NULL",
+                   AND transient_xml IS NOT NULL \
+                   AND transient_xml LIKE '%urn:xmpp:mam:2%'",
                 (),
             )
             .await?;

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 const LEGACY_MAM_CLEANUP_MARKER: &str = "legacy_mam_query_frames_v1";
+const LEGACY_MAM_CLEANUP_SELECT_BATCH: i64 = 128;
 const LEGACY_MAM_CLEANUP_DELETE_BATCH: usize = 128;
 
 pub(super) async fn initialize(
@@ -15,10 +16,7 @@ pub(super) async fn initialize(
     // `sm_persistence/schema.rs` already uses this driver-aware
     // selector for the same reason. SQLite `INTEGER` is dynamic-width,
     // so the same DDL stays correct there.
-    let bigint = match storage.db.driver() {
-        DatabaseDriver::Postgres => "BIGINT",
-        DatabaseDriver::Sqlite => "INTEGER",
-    };
+    let bigint = timestamp_millis_sql_type(storage.db.driver());
     storage
         .execute(
             &format!(
@@ -51,50 +49,12 @@ pub(super) async fn initialize(
     // `ALTER COLUMN ... TYPE BIGINT` that still takes ACCESS EXCLUSIVE
     // even when the column is already BIGINT.
     if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
-        // Constrain by `table_schema = current_schema()` so the probe
-        // looks at the same table the unqualified `ALTER TABLE
-        // pending_delivery` below would hit (which resolves via
-        // `search_path`). Without this, in databases that contain
-        // `pending_delivery` in multiple schemas, the probe could read
-        // a sibling table's type and incorrectly skip the widening
-        // (leaving the overflow bug in place) or trigger an ALTER
-        // against a table whose type was already correct.
-        let mut rows = storage
-            .query(
-                "SELECT data_type \
-                 FROM information_schema.columns \
-                 WHERE table_schema = current_schema() \
-                   AND table_name = 'pending_delivery' \
-                   AND column_name = 'original_receipt_at'",
-                (),
-            )
-            .await?;
-        let current_type: Option<String> = match rows
-            .next()
-            .await
-            .map_err(|error| PendingStorageError::Other(error.to_string()))?
-        {
-            Some(row) => row
-                .get(0)
-                .map_err(|error| PendingStorageError::Other(error.to_string()))?,
-            None => None,
-        };
-        // `information_schema.columns.data_type` reports `integer` for
-        // int4 and `bigint` for int8 — case is lowercase per the SQL
-        // standard. Compare lowercase to be defensive against any
-        // future Postgres surface changes.
-        let needs_widen = current_type
-            .as_deref()
-            .is_some_and(|t| !t.eq_ignore_ascii_case("bigint"));
-        if needs_widen {
-            storage
-                .execute(
-                    "ALTER TABLE pending_delivery \
-                     ALTER COLUMN original_receipt_at TYPE BIGINT",
-                    (),
-                )
-                .await?;
-        }
+        widen_postgres_timestamp_millis_column_to_bigint(
+            storage,
+            "pending_delivery",
+            "original_receipt_at",
+        )
+        .await?;
     }
     // Idempotent column-add migration for the locked Q7b
     // outbound_sequence column. Tables created by an older
@@ -179,15 +139,75 @@ pub(super) async fn initialize(
 async fn ensure_startup_migration_marker_table(
     storage: &DatabasePendingDeliveryStorage,
 ) -> Result<(), PendingStorageError> {
+    let completed_at_type = timestamp_millis_sql_type(storage.db.driver());
     storage
         .execute(
-            "CREATE TABLE IF NOT EXISTS pending_delivery_startup_migrations (\
+            &format!(
+                "CREATE TABLE IF NOT EXISTS pending_delivery_startup_migrations (\
                 name TEXT PRIMARY KEY, \
-                completed_at INTEGER NOT NULL\
-             )",
+                completed_at {completed_at_type} NOT NULL\
+             )"
+            ),
             (),
         )
         .await?;
+    if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
+        widen_postgres_timestamp_millis_column_to_bigint(
+            storage,
+            "pending_delivery_startup_migrations",
+            "completed_at",
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn timestamp_millis_sql_type(driver: DatabaseDriver) -> &'static str {
+    match driver {
+        DatabaseDriver::Postgres => "BIGINT",
+        DatabaseDriver::Sqlite => "INTEGER",
+    }
+}
+
+async fn widen_postgres_timestamp_millis_column_to_bigint(
+    storage: &DatabasePendingDeliveryStorage,
+    table: &'static str,
+    column: &'static str,
+) -> Result<(), PendingStorageError> {
+    // Constrain by `table_schema = current_schema()` so the probe
+    // looks at the same table the unqualified `ALTER TABLE` below
+    // would hit via `search_path`.
+    let mut rows = storage
+        .query(
+            "SELECT data_type \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = ? \
+               AND column_name = ?",
+            crate::db_params![table, column],
+        )
+        .await?;
+    let current_type: Option<String> = match rows
+        .next()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?
+    {
+        Some(row) => row
+            .get(0)
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?,
+        None => None,
+    };
+    let needs_widen = current_type
+        .as_deref()
+        .is_some_and(|t| !t.eq_ignore_ascii_case("bigint"));
+    if needs_widen {
+        storage
+            .execute(
+                &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
+                (),
+            )
+            .await?;
+    }
     Ok(())
 }
 
@@ -234,57 +254,20 @@ async fn mark_startup_migration_completed(
     Ok(())
 }
 
-async fn legacy_mam_query_frame_candidates_exist(
-    storage: &DatabasePendingDeliveryStorage,
-) -> Result<bool, PendingStorageError> {
-    let mut rows = storage
-        .query(
-            "SELECT 1 \
-             FROM pending_delivery \
-             WHERE payload_kind = 'transient' \
-               AND transient_xml IS NOT NULL \
-               AND transient_xml LIKE '%urn:xmpp:mam:2%' \
-             LIMIT 1",
-            (),
-        )
-        .await?;
-    Ok(rows
-        .next()
-        .await
-        .map_err(|error| PendingStorageError::Other(error.to_string()))?
-        .is_some())
-}
-
 async fn delete_legacy_mam_query_frames(
     storage: &DatabasePendingDeliveryStorage,
 ) -> Result<u64, PendingStorageError> {
-    if !legacy_mam_query_frame_candidates_exist(storage).await? {
-        return Ok(0);
-    }
+    let mut after_row_id = None;
+    let mut deleted = 0;
+    loop {
+        let candidates = legacy_mam_query_frame_candidate_batch(storage, after_row_id).await?;
+        let Some((last_row_id, _)) = candidates.last() else {
+            break;
+        };
+        after_row_id = Some(last_row_id.clone());
 
-    let row_ids = {
-        let mut rows = storage
-            .query(
-                "SELECT row_id, transient_xml \
-                 FROM pending_delivery \
-                 WHERE payload_kind = 'transient' \
-                   AND transient_xml IS NOT NULL \
-                   AND transient_xml LIKE '%urn:xmpp:mam:2%'",
-                (),
-            )
-            .await?;
         let mut row_ids = Vec::new();
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|error| PendingStorageError::Other(error.to_string()))?
-        {
-            let row_id: String = row
-                .get(0)
-                .map_err(|error| PendingStorageError::Other(error.to_string()))?;
-            let xml: String = row
-                .get(1)
-                .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+        for (row_id, xml) in candidates {
             let Ok(element) = xml.parse::<xmpp_parsers::minidom::Element>() else {
                 continue;
             };
@@ -295,10 +278,55 @@ async fn delete_legacy_mam_query_frames(
                 row_ids.push(row_id);
             }
         }
-        row_ids
-    };
+        deleted += delete_legacy_mam_query_frame_rows(storage, &row_ids).await?;
+    }
 
-    delete_legacy_mam_query_frame_rows(storage, &row_ids).await
+    Ok(deleted)
+}
+
+async fn legacy_mam_query_frame_candidate_batch(
+    storage: &DatabasePendingDeliveryStorage,
+    after_row_id: Option<String>,
+) -> Result<Vec<(String, String)>, PendingStorageError> {
+    let (sql, params) = match after_row_id {
+        Some(row_id) => (
+            "SELECT row_id, transient_xml \
+             FROM pending_delivery \
+             WHERE payload_kind = 'transient' \
+               AND transient_xml IS NOT NULL \
+               AND transient_xml LIKE '%urn:xmpp:mam:2%' \
+               AND row_id > ? \
+             ORDER BY row_id \
+             LIMIT ?",
+            crate::db_params![row_id, LEGACY_MAM_CLEANUP_SELECT_BATCH],
+        ),
+        None => (
+            "SELECT row_id, transient_xml \
+             FROM pending_delivery \
+             WHERE payload_kind = 'transient' \
+               AND transient_xml IS NOT NULL \
+               AND transient_xml LIKE '%urn:xmpp:mam:2%' \
+             ORDER BY row_id \
+             LIMIT ?",
+            crate::db_params![LEGACY_MAM_CLEANUP_SELECT_BATCH],
+        ),
+    };
+    let mut rows = storage.query(sql, params).await?;
+    let mut candidates = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| PendingStorageError::Other(error.to_string()))?
+    {
+        let row_id: String = row
+            .get(0)
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+        let xml: String = row
+            .get(1)
+            .map_err(|error| PendingStorageError::Other(error.to_string()))?;
+        candidates.push((row_id, xml));
+    }
+    Ok(candidates)
 }
 
 async fn delete_legacy_mam_query_frame_rows(

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -151,24 +151,32 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
         )
         .await
         .expect("create legacy table");
-        for (row_id, xml) in [
+        let mut legacy_rows = vec![
             (
-                "mam-result",
+                "mam-result".to_string(),
                 mam_query_frame_xml("alice@example.com/web", "result"),
             ),
             (
-                "mam-fin",
+                "mam-fin".to_string(),
                 mam_query_frame_xml("alice@example.com/web", "fin"),
             ),
             (
-                "normal-message",
+                "normal-message".to_string(),
                 transient_message_xml("alice@example.com", "keep"),
             ),
             (
-                "body-with-mam-payload",
+                "body-with-mam-payload".to_string(),
                 transient_message_with_mam_payload_xml("alice@example.com", "keep-with-payload"),
             ),
-        ] {
+        ];
+        for i in 0..140 {
+            legacy_rows.push((
+                format!("mam-result-{i:03}"),
+                mam_query_frame_xml("alice@example.com/web", "result"),
+            ));
+        }
+
+        for (row_id, xml) in legacy_rows {
             conn.execute(
                 "INSERT INTO pending_delivery (
                     row_id, recipient_jid, original_receipt_at, payload_kind,
@@ -210,7 +218,7 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
     let conn = db.guard().await.expect("db guard");
     let mut marker_rows = conn
         .query(
-            "SELECT COUNT(*) FROM pending_delivery_startup_migrations \
+            "SELECT completed_at FROM pending_delivery_startup_migrations \
              WHERE name = 'legacy_mam_query_frames_v1'",
             (),
         )
@@ -220,9 +228,9 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
         .next()
         .await
         .expect("read cleanup marker")
-        .expect("cleanup marker count row");
-    let marker_count: i64 = marker_row.get(0).expect("cleanup marker count");
-    assert_eq!(marker_count, 1);
+        .expect("cleanup marker row");
+    let completed_at: i64 = marker_row.get(0).expect("cleanup marker timestamp");
+    assert!(completed_at > i64::from(i32::MAX));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -200,6 +200,29 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
         .collect::<Vec<_>>();
     bodies.sort_unstable();
     assert_eq!(bodies, ["keep", "keep-with-payload"]);
+
+    let db = crate::db::Database::from_config(
+        "legacy_pending_delivery_marker",
+        &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Sqlite, url.clone()),
+    )
+    .await
+    .expect("open cleaned db");
+    let conn = db.guard().await.expect("db guard");
+    let mut marker_rows = conn
+        .query(
+            "SELECT COUNT(*) FROM pending_delivery_startup_migrations \
+             WHERE name = 'legacy_mam_query_frames_v1'",
+            (),
+        )
+        .await
+        .expect("query cleanup marker");
+    let marker_row = marker_rows
+        .next()
+        .await
+        .expect("read cleanup marker")
+        .expect("cleanup marker count row");
+    let marker_count: i64 = marker_row.get(0).expect("cleanup marker count");
+    assert_eq!(marker_count, 1);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -46,9 +46,50 @@ fn mam_query_frame_xml(recipient: &str, child_name: &str) -> String {
     let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
     m.from = Some("alice@example.com".parse::<jid::Jid>().expect("jid"));
     m.type_ = MessageType::Normal;
+    let payload = match child_name {
+        "result" => {
+            xmpp_parsers::minidom::Element::builder("result", waddle_xmpp_core::mam::MAM_NS)
+                .attr("queryid", "q1")
+                .attr("id", "archive-id-1")
+                .append(
+                    xmpp_parsers::minidom::Element::builder(
+                        "forwarded",
+                        waddle_xmpp_core::mam::FORWARD_NS,
+                    )
+                    .build(),
+                )
+                .build()
+        }
+        "fin" => xmpp_parsers::minidom::Element::builder("fin", waddle_xmpp_core::mam::MAM_NS)
+            .append(
+                xmpp_parsers::minidom::Element::builder("set", waddle_xmpp_core::mam::RSM_NS)
+                    .build(),
+            )
+            .build(),
+        other => {
+            xmpp_parsers::minidom::Element::builder(other, waddle_xmpp_core::mam::MAM_NS).build()
+        }
+    };
+    m.payloads.push(payload);
+    message_xml(m)
+}
+
+fn transient_message_with_mam_payload_xml(recipient: &str, body: &str) -> String {
+    let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
+    m.from = Some("bob@elsewhere/x".parse::<jid::Jid>().expect("jid"));
+    m.type_ = MessageType::Chat;
+    m.bodies.insert(String::new(), Body(body.to_string()));
     m.payloads.push(
-        xmpp_parsers::minidom::Element::builder(child_name, waddle_xmpp_core::mam::MAM_NS)
+        xmpp_parsers::minidom::Element::builder("result", waddle_xmpp_core::mam::MAM_NS)
             .attr("queryid", "q1")
+            .attr("id", "archive-id-1")
+            .append(
+                xmpp_parsers::minidom::Element::builder(
+                    "forwarded",
+                    waddle_xmpp_core::mam::FORWARD_NS,
+                )
+                .build(),
+            )
             .build(),
     );
     message_xml(m)
@@ -123,6 +164,10 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
                 "normal-message",
                 transient_message_xml("alice@example.com", "keep"),
             ),
+            (
+                "body-with-mam-payload",
+                transient_message_with_mam_payload_xml("alice@example.com", "keep-with-payload"),
+            ),
         ] {
             conn.execute(
                 "INSERT INTO pending_delivery (
@@ -144,12 +189,17 @@ async fn db_storage_startup_deletes_legacy_mam_query_frames() {
         .await
         .expect("list cleaned rows");
 
-    assert_eq!(rows.len(), 1);
-    let body = match &rows[0].payload {
-        PendingPayload::Transient(message) => message.bodies.get("").map(|body| body.0.as_str()),
-        PendingPayload::Archived(_) => None,
-    };
-    assert_eq!(body, Some("keep"));
+    let mut bodies = rows
+        .iter()
+        .filter_map(|row| match &row.payload {
+            PendingPayload::Transient(message) => {
+                message.bodies.get("").map(|body| body.0.as_str())
+            }
+            PendingPayload::Archived(_) => None,
+        })
+        .collect::<Vec<_>>();
+    bodies.sort_unstable();
+    assert_eq!(bodies, ["keep", "keep-with-payload"]);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -27,6 +27,33 @@ fn transient_row(recipient: &str, body: &str) -> PendingRow {
     }
 }
 
+fn message_xml(message: Message) -> String {
+    let element: xmpp_parsers::minidom::Element = message.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize message");
+    String::from_utf8(buf).expect("utf-8 xml")
+}
+
+fn transient_message_xml(recipient: &str, body: &str) -> String {
+    let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
+    m.from = Some("bob@elsewhere/x".parse::<jid::Jid>().expect("jid"));
+    m.type_ = MessageType::Chat;
+    m.bodies.insert(String::new(), Body(body.to_string()));
+    message_xml(m)
+}
+
+fn mam_query_frame_xml(recipient: &str, child_name: &str) -> String {
+    let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
+    m.from = Some("alice@example.com".parse::<jid::Jid>().expect("jid"));
+    m.type_ = MessageType::Normal;
+    m.payloads.push(
+        xmpp_parsers::minidom::Element::builder(child_name, waddle_xmpp_core::mam::MAM_NS)
+            .attr("queryid", "q1")
+            .build(),
+    );
+    message_xml(m)
+}
+
 #[tokio::test]
 async fn flush_with_no_rows_is_noop() {
     let storage: Arc<dyn PendingDeliveryStorage> =
@@ -46,6 +73,83 @@ async fn flush_with_no_rows_is_noop() {
     )
     .await;
     assert_eq!(outcome, FlushOutcome::default());
+}
+
+#[tokio::test]
+async fn db_storage_startup_deletes_legacy_mam_query_frames() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir
+        .path()
+        .join("pending_delivery-cleanup.sqlite")
+        .to_str()
+        .expect("utf-8 path")
+        .to_string();
+    let url = format!("sqlite://{path}");
+    let receipt_ms = Utc::now().timestamp_millis();
+
+    {
+        let db = crate::db::Database::from_config(
+            "legacy_pending_delivery",
+            &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Sqlite, url.clone()),
+        )
+        .await
+        .expect("open legacy db");
+        let conn = db.guard().await.expect("db guard");
+        conn.execute(
+            "CREATE TABLE pending_delivery (
+                row_id TEXT PRIMARY KEY,
+                recipient_jid TEXT NOT NULL,
+                original_receipt_at INTEGER NOT NULL,
+                payload_kind TEXT NOT NULL,
+                archive_stanza_by TEXT,
+                archive_stanza_id TEXT,
+                transient_xml TEXT,
+                flushed_in_session TEXT
+            )",
+            (),
+        )
+        .await
+        .expect("create legacy table");
+        for (row_id, xml) in [
+            (
+                "mam-result",
+                mam_query_frame_xml("alice@example.com/web", "result"),
+            ),
+            (
+                "mam-fin",
+                mam_query_frame_xml("alice@example.com/web", "fin"),
+            ),
+            (
+                "normal-message",
+                transient_message_xml("alice@example.com", "keep"),
+            ),
+        ] {
+            conn.execute(
+                "INSERT INTO pending_delivery (
+                    row_id, recipient_jid, original_receipt_at, payload_kind,
+                    archive_stanza_by, archive_stanza_id, transient_xml, flushed_in_session
+                 ) VALUES (?, ?, ?, 'transient', NULL, NULL, ?, NULL)",
+                crate::db_params![row_id, "alice@example.com", receipt_ms, xml],
+            )
+            .await
+            .expect("insert legacy row");
+        }
+    }
+
+    let storage = DatabasePendingDeliveryStorage::open(Some(&url), QuotaPolicy::Unlimited)
+        .await
+        .expect("open storage with startup cleanup");
+    let rows = storage
+        .list(&bare("alice@example.com"))
+        .await
+        .expect("list cleaned rows");
+
+    assert_eq!(rows.len(), 1);
+    let body = match &rows[0].payload {
+        PendingPayload::Transient(message) => message.bodies.get("").map(|body| body.0.as_str()),
+        PendingPayload::Archived(_) => None,
+    };
+    assert_eq!(body, Some("keep"));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -140,7 +140,8 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     state.deps.auth_state.xmpp_domain.as_str(),
                 )
                 .await;
-                if summary.queued + summary.redelivered + summary.bounced > 0
+                if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
+                    > 0
                     || summary.storage_failed > 0
                 {
                     info!(
@@ -149,6 +150,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         queued = summary.queued,
                         bounced = summary.bounced,
                         dropped = summary.dropped,
+                        not_promotable = summary.not_promotable,
                         unparseable = summary.unparseable,
                         storage_failed = summary.storage_failed,
                         "SM janitor: Q6 promotion completed"

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -102,7 +102,13 @@ pub async fn promote_session_unacked(
 
     debug!(
         stream_id = %session.stream_id,
-        ?summary,
+        redelivered = summary.redelivered,
+        queued = summary.queued,
+        bounced = summary.bounced,
+        dropped = summary.dropped,
+        not_promotable = summary.not_promotable,
+        unparseable = summary.unparseable,
+        storage_failed = summary.storage_failed,
         "Q6 promotion: session summary"
     );
     summary
@@ -124,6 +130,11 @@ async fn promote_one(
     sequence: u32,
     ctx: PromotionContext<'_>,
 ) -> PromotedOutcome {
+    if waddle_xmpp_core::mam::is_mam_query_response_message(&message) {
+        waddle_xmpp::prometheus::increment_sm_promotion_not_promotable();
+        return PromotedOutcome::NotPromotable;
+    }
+
     let routing: DmRouting = classify_dm_intake(&message, ctx.online, ctx.blocklist);
 
     // Step 1: alt-resource — if the classifier says live-deliver,

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -74,9 +74,54 @@ fn mam_replay_xml(child_name: &str) -> String {
     ));
     m.from = Some("alice@example.com".parse::<jid::Jid>().unwrap());
     m.type_ = xmpp_parsers::message::MessageType::Normal;
+    let payload = match child_name {
+        "result" => {
+            xmpp_parsers::minidom::Element::builder("result", waddle_xmpp_core::mam::MAM_NS)
+                .attr("queryid", "q1")
+                .attr("id", "archive-id-1")
+                .append(
+                    xmpp_parsers::minidom::Element::builder(
+                        "forwarded",
+                        waddle_xmpp_core::mam::FORWARD_NS,
+                    )
+                    .build(),
+                )
+                .build()
+        }
+        "fin" => xmpp_parsers::minidom::Element::builder("fin", waddle_xmpp_core::mam::MAM_NS)
+            .append(
+                xmpp_parsers::minidom::Element::builder("set", waddle_xmpp_core::mam::RSM_NS)
+                    .build(),
+            )
+            .build(),
+        other => {
+            xmpp_parsers::minidom::Element::builder(other, waddle_xmpp_core::mam::MAM_NS).build()
+        }
+    };
+    m.payloads.push(payload);
+    let element: xmpp_parsers::minidom::Element = m.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn dm_with_mam_payload_xml(from: &str, to: &str, body: &str) -> String {
+    let mut m = xmpp_parsers::message::Message::new(Some(to.parse::<jid::Jid>().unwrap()));
+    m.from = Some(from.parse::<jid::Jid>().unwrap());
+    m.type_ = xmpp_parsers::message::MessageType::Chat;
+    m.bodies
+        .insert(String::new(), xmpp_parsers::message::Body(body.to_string()));
     m.payloads.push(
-        xmpp_parsers::minidom::Element::builder(child_name, waddle_xmpp_core::mam::MAM_NS)
+        xmpp_parsers::minidom::Element::builder("result", waddle_xmpp_core::mam::MAM_NS)
             .attr("queryid", "q1")
+            .attr("id", "archive-id-1")
+            .append(
+                xmpp_parsers::minidom::Element::builder(
+                    "forwarded",
+                    waddle_xmpp_core::mam::FORWARD_NS,
+                )
+                .build(),
+            )
             .build(),
     );
     let element: xmpp_parsers::minidom::Element = m.into();
@@ -109,6 +154,36 @@ async fn promotes_to_pending_delivery_when_no_alt_resource() {
 
     assert_eq!(summary.queued, 1);
     assert_eq!(summary.redelivered, 0);
+    assert_eq!(summary.bounced, 0);
+    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn dm_with_mam_payload_is_still_promoted_to_pending_delivery() {
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let session = detached_session_with_unacked(
+        "stream-1",
+        full("alice@example.com/laptop"),
+        vec![dm_with_mam_payload_xml(
+            "bob@elsewhere/x",
+            "alice@example.com",
+            "keep despite extension",
+        )],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+
+    assert_eq!(summary.not_promotable, 0);
+    assert_eq!(summary.queued, 1);
     assert_eq!(summary.bounced, 0);
     assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
 }

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -68,6 +68,23 @@ fn dm_xml(from: &str, to: &str, body: &str) -> String {
     String::from_utf8(buf).unwrap()
 }
 
+fn mam_replay_xml(child_name: &str) -> String {
+    let mut m = xmpp_parsers::message::Message::new(Some(
+        "alice@example.com/web".parse::<jid::Jid>().unwrap(),
+    ));
+    m.from = Some("alice@example.com".parse::<jid::Jid>().unwrap());
+    m.type_ = xmpp_parsers::message::MessageType::Normal;
+    m.payloads.push(
+        xmpp_parsers::minidom::Element::builder(child_name, waddle_xmpp_core::mam::MAM_NS)
+            .attr("queryid", "q1")
+            .build(),
+    );
+    let element: xmpp_parsers::minidom::Element = m.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
 #[tokio::test]
 async fn promotes_to_pending_delivery_when_no_alt_resource() {
     // Locked Q6 = B step 2: alt-resource fails (no online
@@ -94,6 +111,58 @@ async fn promotes_to_pending_delivery_when_no_alt_resource() {
     assert_eq!(summary.redelivered, 0);
     assert_eq!(summary.bounced, 0);
     assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn mam_result_frame_is_not_promoted_to_pending_delivery() {
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let session = detached_session_with_unacked(
+        "stream-1",
+        full("alice@example.com/web"),
+        vec![mam_replay_xml("result")],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+
+    assert_eq!(summary.not_promotable, 1);
+    assert_eq!(summary.queued, 0);
+    assert_eq!(summary.bounced, 0);
+    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn mam_fin_frame_is_not_promoted_to_pending_delivery() {
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let session = detached_session_with_unacked(
+        "stream-1",
+        full("alice@example.com/web"),
+        vec![mam_replay_xml("fin")],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+
+    assert_eq!(summary.not_promotable, 1);
+    assert_eq!(summary.queued, 0);
+    assert_eq!(summary.bounced, 0);
+    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -130,6 +130,57 @@ fn dm_with_mam_payload_xml(from: &str, to: &str, body: &str) -> String {
     String::from_utf8(buf).unwrap()
 }
 
+fn sm_promotion_metric_test_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
+
+fn prometheus_counter_value(rendered: &str, name: &str) -> u64 {
+    rendered
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix(name)
+                .and_then(|rest| rest.trim().parse::<u64>().ok())
+        })
+        .unwrap_or_else(|| panic!("missing prometheus counter {name}"))
+}
+
+async fn assert_mam_frame_not_promoted_to_pending_delivery(child_name: &str) {
+    let _guard = sm_promotion_metric_test_lock().lock().await;
+    waddle_xmpp::prometheus::reset_metrics_for_test();
+
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let session = detached_session_with_unacked(
+        "stream-1",
+        full("alice@example.com/web"),
+        vec![mam_replay_xml(child_name)],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+
+    assert_eq!(summary.not_promotable, 1);
+    assert_eq!(summary.queued, 0);
+    assert_eq!(summary.bounced, 0);
+    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+
+    let rendered = waddle_xmpp::prometheus::render_metrics();
+    assert_eq!(
+        prometheus_counter_value(&rendered, "waddle_sm_promotion_not_promotable_total"),
+        1
+    );
+
+    waddle_xmpp::prometheus::reset_metrics_for_test();
+}
+
 #[tokio::test]
 async fn promotes_to_pending_delivery_when_no_alt_resource() {
     // Locked Q6 = B step 2: alt-resource fails (no online
@@ -190,54 +241,12 @@ async fn dm_with_mam_payload_is_still_promoted_to_pending_delivery() {
 
 #[tokio::test]
 async fn mam_result_frame_is_not_promoted_to_pending_delivery() {
-    let storage: Arc<dyn PendingDeliveryStorage> =
-        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
-    let registry = ConnectionRegistry::new();
-    let session = detached_session_with_unacked(
-        "stream-1",
-        full("alice@example.com/web"),
-        vec![mam_replay_xml("result")],
-    );
-
-    let summary = promote_session_unacked(
-        &session,
-        &registry,
-        &storage,
-        &Blocklist::empty(),
-        "example.com",
-    )
-    .await;
-
-    assert_eq!(summary.not_promotable, 1);
-    assert_eq!(summary.queued, 0);
-    assert_eq!(summary.bounced, 0);
-    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+    assert_mam_frame_not_promoted_to_pending_delivery("result").await;
 }
 
 #[tokio::test]
 async fn mam_fin_frame_is_not_promoted_to_pending_delivery() {
-    let storage: Arc<dyn PendingDeliveryStorage> =
-        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
-    let registry = ConnectionRegistry::new();
-    let session = detached_session_with_unacked(
-        "stream-1",
-        full("alice@example.com/web"),
-        vec![mam_replay_xml("fin")],
-    );
-
-    let summary = promote_session_unacked(
-        &session,
-        &registry,
-        &storage,
-        &Blocklist::empty(),
-        "example.com",
-    )
-    .await;
-
-    assert_eq!(summary.not_promotable, 1);
-    assert_eq!(summary.queued, 0);
-    assert_eq!(summary.bounced, 0);
-    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 0);
+    assert_mam_frame_not_promoted_to_pending_delivery("fin").await;
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/sm_promotion/types.rs
+++ b/server/crates/waddle-server/src/sm_promotion/types.rs
@@ -15,6 +15,9 @@ pub enum PromotedOutcome {
     /// `<no-store/>`, chat-states-only, error-type to fully-offline
     /// recipient per RFC 6121 §8.5.2.1.4).
     Dropped,
+    /// Valid stanza that intentionally bypassed Q6 sinks because it
+    /// has no XEP-0160 offline-delivery semantics.
+    NotPromotable,
     /// Skipped — stanza could not be parsed back to a typed value
     /// (corrupt unacked queue entry). Logged for operator visibility.
     Unparseable,
@@ -35,6 +38,7 @@ pub struct PromotionSummary {
     pub queued: u32,
     pub bounced: u32,
     pub dropped: u32,
+    pub not_promotable: u32,
     pub unparseable: u32,
     /// Number of stanzas that failed to insert into pending storage.
     /// Non-zero means the session's promotion was lossy: the caller
@@ -50,6 +54,7 @@ impl PromotionSummary {
             PromotedOutcome::Queued => self.queued += 1,
             PromotedOutcome::Bounced => self.bounced += 1,
             PromotedOutcome::Dropped => self.dropped += 1,
+            PromotedOutcome::NotPromotable => self.not_promotable += 1,
             PromotedOutcome::Unparseable => self.unparseable += 1,
             PromotedOutcome::StorageFailure => self.storage_failed += 1,
         }

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -33,8 +33,9 @@ pub use domain::{
 };
 pub use error::{CoreError, CoreResult};
 pub use mam::{
-    build_fin_iq, build_result_messages, is_mam_query, parse_mam_query, ArchivedMessage, MamQuery,
-    MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS, RSM_NS, STANZA_ID_NS,
+    build_fin_iq, build_result_messages, is_mam_query, is_mam_query_response_message,
+    parse_mam_query, ArchivedMessage, MamQuery, MamResult, DATA_FORMS_NS, FORWARD_NS, MAM_NS,
+    RSM_NS, STANZA_ID_NS,
 };
 pub use parser_utils::{ensure_thread_element, extract_thread_parent, reattach_thread_parent};
 pub use presence::{

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -44,6 +44,15 @@ pub const DATA_FORMS_NS: &str = "jabber:x:data";
 /// Stanza ID namespace (XEP-0359).
 pub const STANZA_ID_NS: &str = "urn:xmpp:sid:0";
 
+/// `true` when a message is a query-scoped MAM response envelope, not
+/// an offline-deliverable user message.
+pub fn is_mam_query_response_message(message: &xmpp_parsers::message::Message) -> bool {
+    message
+        .payloads
+        .iter()
+        .any(|payload| matches!(payload.name(), "result" | "fin") && payload.ns() == MAM_NS)
+}
+
 /// Forward namespace (XEP-0297).
 pub const FORWARD_NS: &str = "urn:xmpp:forward:0";
 

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -47,10 +47,38 @@ pub const STANZA_ID_NS: &str = "urn:xmpp:sid:0";
 /// `true` when a message is a query-scoped MAM response envelope, not
 /// an offline-deliverable user message.
 pub fn is_mam_query_response_message(message: &xmpp_parsers::message::Message) -> bool {
-    message
-        .payloads
-        .iter()
-        .any(|payload| matches!(payload.name(), "result" | "fin") && payload.ns() == MAM_NS)
+    if message.type_ != xmpp_parsers::message::MessageType::Normal
+        || !message.bodies.is_empty()
+        || !message.subjects.is_empty()
+        || message.thread.is_some()
+        || message.payloads.len() != 1
+    {
+        return false;
+    }
+
+    let payload = &message.payloads[0];
+    if payload.ns() != MAM_NS {
+        return false;
+    }
+
+    match payload.name() {
+        "result" => is_mam_result_payload(payload),
+        "fin" => is_mam_fin_payload(payload),
+        _ => false,
+    }
+}
+
+fn is_mam_result_payload(payload: &minidom::Element) -> bool {
+    payload.attr("id").is_some()
+        && payload
+            .children()
+            .any(|child| child.name() == "forwarded" && child.ns() == FORWARD_NS)
+}
+
+fn is_mam_fin_payload(payload: &minidom::Element) -> bool {
+    payload
+        .children()
+        .any(|child| child.name() == "set" && child.ns() == RSM_NS)
 }
 
 /// Forward namespace (XEP-0297).

--- a/server/crates/waddle-xmpp-core/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/tests.rs
@@ -43,6 +43,33 @@ fn message_type_default_matches_rfc6121_5_2_2() {
 }
 
 #[test]
+fn identifies_mam_query_response_messages() {
+    for child in ["result", "fin"] {
+        let mut message = Message::new(Some(jid("alice@example.com/web")));
+        message.payloads.push(
+            Element::builder(child, MAM_NS)
+                .attr("queryid", "query-1")
+                .build(),
+        );
+
+        assert!(is_mam_query_response_message(&message));
+    }
+}
+
+#[test]
+fn ordinary_messages_are_not_mam_query_responses() {
+    let mut message = Message::new(Some(jid("alice@example.com")));
+    message.type_ = MessageType::Chat;
+    message.payloads.push(
+        Element::builder("result", "urn:example:not-mam")
+            .attr("queryid", "query-1")
+            .build(),
+    );
+
+    assert!(!is_mam_query_response_message(&message));
+}
+
+#[test]
 fn parses_mam_query_with_form_and_rsm() {
     let iq = Iq {
         from: None,

--- a/server/crates/waddle-xmpp-core/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/tests.rs
@@ -44,16 +44,25 @@ fn message_type_default_matches_rfc6121_5_2_2() {
 
 #[test]
 fn identifies_mam_query_response_messages() {
-    for child in ["result", "fin"] {
-        let mut message = Message::new(Some(jid("alice@example.com/web")));
-        message.payloads.push(
-            Element::builder(child, MAM_NS)
-                .attr("queryid", "query-1")
-                .build(),
-        );
+    let mut result_message = Message::new(Some(jid("alice@example.com/web")));
+    result_message.type_ = MessageType::Normal;
+    result_message.payloads.push(
+        Element::builder("result", MAM_NS)
+            .attr("queryid", "query-1")
+            .attr("id", "archive-id-1")
+            .append(Element::builder("forwarded", FORWARD_NS).build())
+            .build(),
+    );
+    assert!(is_mam_query_response_message(&result_message));
 
-        assert!(is_mam_query_response_message(&message));
-    }
+    let mut fin_message = Message::new(Some(jid("alice@example.com/web")));
+    fin_message.type_ = MessageType::Normal;
+    fin_message.payloads.push(
+        Element::builder("fin", MAM_NS)
+            .append(Element::builder("set", RSM_NS).build())
+            .build(),
+    );
+    assert!(is_mam_query_response_message(&fin_message));
 }
 
 #[test]
@@ -63,6 +72,24 @@ fn ordinary_messages_are_not_mam_query_responses() {
     message.payloads.push(
         Element::builder("result", "urn:example:not-mam")
             .attr("queryid", "query-1")
+            .build(),
+    );
+
+    assert!(!is_mam_query_response_message(&message));
+}
+
+#[test]
+fn body_messages_with_mam_payload_are_not_mam_query_responses() {
+    let mut message = Message::new(Some(jid("alice@example.com")));
+    message.type_ = MessageType::Chat;
+    message
+        .bodies
+        .insert(String::new(), xmpp_parsers::message::Body("keep me".into()));
+    message.payloads.push(
+        Element::builder("result", MAM_NS)
+            .attr("queryid", "query-1")
+            .attr("id", "archive-id-1")
+            .append(Element::builder("forwarded", FORWARD_NS).build())
             .build(),
     );
 

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -185,6 +185,31 @@ pub fn increment_sm_resume_window_clamped() {
     SM_RESUME_WINDOW_CLAMPED.fetch_add(1, Ordering::Relaxed);
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+pub fn reset_metrics_for_test() {
+    CONNECTED_USERS.store(0, Ordering::Release);
+    ROOM_COUNT.store(0, Ordering::Release);
+    MESSAGES_TOTAL.store(0, Ordering::Release);
+    CURRENT_SECOND.store(0, Ordering::Release);
+    CURRENT_SECOND_MESSAGES.store(0, Ordering::Release);
+    LAST_SECOND_MESSAGES.store(0, Ordering::Release);
+    BROADCAST_DELIVERED.store(0, Ordering::Release);
+    BROADCAST_NOT_CONNECTED.store(0, Ordering::Release);
+    BROADCAST_DROPPED_FULL.store(0, Ordering::Release);
+    BROADCAST_DROPPED_CLOSED.store(0, Ordering::Release);
+    SM_UNACKED_EVICTED.store(0, Ordering::Release);
+    PENDING_DELIVERY_QUOTA_EXCEEDED.store(0, Ordering::Release);
+    PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.store(0, Ordering::Release);
+    PENDING_DELIVERY_AGED_OUT.store(0, Ordering::Release);
+    PENDING_DELIVERY_UNRESOLVED_POISON_PILL.store(0, Ordering::Release);
+    SM_PROMOTION_STORAGE_FAILED.store(0, Ordering::Release);
+    SM_PROMOTION_NOT_PROMOTABLE.store(0, Ordering::Release);
+    SM_PROMOTION_BLOCKLIST_FAILED.store(0, Ordering::Release);
+    SM_PROMOTION_DEAD_LETTERED.store(0, Ordering::Release);
+    SM_DRAIN_TIMEOUT.store(0, Ordering::Release);
+    SM_RESUME_WINDOW_CLAMPED.store(0, Ordering::Release);
+}
+
 pub fn render_metrics() -> String {
     let now = unix_timestamp_secs();
     rotate_second_bucket(now);
@@ -299,29 +324,6 @@ mod tests {
     fn test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    fn reset_metrics_for_test() {
-        CONNECTED_USERS.store(0, Ordering::Release);
-        ROOM_COUNT.store(0, Ordering::Release);
-        MESSAGES_TOTAL.store(0, Ordering::Release);
-        CURRENT_SECOND.store(0, Ordering::Release);
-        CURRENT_SECOND_MESSAGES.store(0, Ordering::Release);
-        LAST_SECOND_MESSAGES.store(0, Ordering::Release);
-        BROADCAST_DELIVERED.store(0, Ordering::Release);
-        BROADCAST_NOT_CONNECTED.store(0, Ordering::Release);
-        BROADCAST_DROPPED_FULL.store(0, Ordering::Release);
-        BROADCAST_DROPPED_CLOSED.store(0, Ordering::Release);
-        SM_UNACKED_EVICTED.store(0, Ordering::Release);
-        PENDING_DELIVERY_QUOTA_EXCEEDED.store(0, Ordering::Release);
-        PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.store(0, Ordering::Release);
-        PENDING_DELIVERY_AGED_OUT.store(0, Ordering::Release);
-        PENDING_DELIVERY_UNRESOLVED_POISON_PILL.store(0, Ordering::Release);
-        SM_PROMOTION_STORAGE_FAILED.store(0, Ordering::Release);
-        SM_PROMOTION_BLOCKLIST_FAILED.store(0, Ordering::Release);
-        SM_PROMOTION_DEAD_LETTERED.store(0, Ordering::Release);
-        SM_DRAIN_TIMEOUT.store(0, Ordering::Release);
-        SM_RESUME_WINDOW_CLAMPED.store(0, Ordering::Release);
     }
 
     #[test]
@@ -462,6 +464,18 @@ mod tests {
         assert!(rendered.contains("waddle_sm_promotion_storage_failed_total 2"));
         assert!(rendered.contains("waddle_sm_promotion_not_promotable_total 1"));
         assert!(rendered.contains("waddle_sm_resume_window_clamped_total 1"));
+    }
+
+    #[test]
+    fn test_reset_metrics_for_test_clears_sm_promotion_not_promotable() {
+        let _guard = test_lock().lock().unwrap();
+        reset_metrics_for_test();
+
+        increment_sm_promotion_not_promotable();
+        reset_metrics_for_test();
+
+        let rendered = render_metrics();
+        assert!(rendered.contains("waddle_sm_promotion_not_promotable_total 0"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -53,6 +53,11 @@ static PENDING_DELIVERY_UNRESOLVED_POISON_PILL: AtomicU64 = AtomicU64::new(0);
 // pending_delivery insert error and preserved the durable SM row for
 // retry (issue #209 PR #346 + finding #14 dead-letter cap).
 static SM_PROMOTION_STORAGE_FAILED: AtomicU64 = AtomicU64::new(0);
+// `sm_promotion_not_promotable`: Q6 promotion saw an unacked stanza
+// that is valid XMPP but not an XEP-0160 offline-message candidate.
+// This is expected for XEP-0313 MAM result/fin frames addressed to
+// stale full-JID resources.
+static SM_PROMOTION_NOT_PROMOTABLE: AtomicU64 = AtomicU64::new(0);
 // `sm_promotion_blocklist_failed`: blocklist storage load failed
 // during Q6 promotion; the session was skipped fail-closed.
 static SM_PROMOTION_BLOCKLIST_FAILED: AtomicU64 = AtomicU64::new(0);
@@ -160,6 +165,10 @@ pub fn add_sm_promotion_storage_failed(n: u64) {
     SM_PROMOTION_STORAGE_FAILED.fetch_add(n, Ordering::Relaxed);
 }
 
+pub fn increment_sm_promotion_not_promotable() {
+    SM_PROMOTION_NOT_PROMOTABLE.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn increment_sm_promotion_blocklist_failed() {
     SM_PROMOTION_BLOCKLIST_FAILED.fetch_add(1, Ordering::Relaxed);
 }
@@ -194,6 +203,7 @@ pub fn render_metrics() -> String {
     let pending_aged_out = PENDING_DELIVERY_AGED_OUT.load(Ordering::Relaxed);
     let pending_poison_pill = PENDING_DELIVERY_UNRESOLVED_POISON_PILL.load(Ordering::Relaxed);
     let sm_promotion_storage_failed = SM_PROMOTION_STORAGE_FAILED.load(Ordering::Relaxed);
+    let sm_promotion_not_promotable = SM_PROMOTION_NOT_PROMOTABLE.load(Ordering::Relaxed);
     let sm_promotion_blocklist_failed = SM_PROMOTION_BLOCKLIST_FAILED.load(Ordering::Relaxed);
     let sm_promotion_dead_lettered = SM_PROMOTION_DEAD_LETTERED.load(Ordering::Relaxed);
     let sm_drain_timeout = SM_DRAIN_TIMEOUT.load(Ordering::Relaxed);
@@ -243,6 +253,9 @@ pub fn render_metrics() -> String {
             "# HELP waddle_sm_promotion_storage_failed_total Q6 promotion encountered a transient pending_delivery insert error; durable SM row preserved for retry.\n",
             "# TYPE waddle_sm_promotion_storage_failed_total counter\n",
             "waddle_sm_promotion_storage_failed_total {sm_promotion_storage_failed}\n",
+            "# HELP waddle_sm_promotion_not_promotable_total Q6 promotion skipped a valid stanza that must not enter XEP-0160 offline storage, such as XEP-0313 MAM result/fin frames.\n",
+            "# TYPE waddle_sm_promotion_not_promotable_total counter\n",
+            "waddle_sm_promotion_not_promotable_total {sm_promotion_not_promotable}\n",
             "# HELP waddle_sm_promotion_blocklist_failed_total Q6 promotion skipped a session because its blocklist load failed (fail-closed XEP-0191 policy).\n",
             "# TYPE waddle_sm_promotion_blocklist_failed_total counter\n",
             "waddle_sm_promotion_blocklist_failed_total {sm_promotion_blocklist_failed}\n",
@@ -270,6 +283,7 @@ pub fn render_metrics() -> String {
         pending_aged_out = pending_aged_out,
         pending_poison_pill = pending_poison_pill,
         sm_promotion_storage_failed = sm_promotion_storage_failed,
+        sm_promotion_not_promotable = sm_promotion_not_promotable,
         sm_promotion_blocklist_failed = sm_promotion_blocklist_failed,
         sm_promotion_dead_lettered = sm_promotion_dead_lettered,
         sm_drain_timeout = sm_drain_timeout,
@@ -413,6 +427,7 @@ mod tests {
         add_pending_delivery_aged_out(3);
         increment_pending_delivery_unresolved_poison_pill();
         add_sm_promotion_storage_failed(2);
+        increment_sm_promotion_not_promotable();
         increment_sm_promotion_blocklist_failed();
         increment_sm_promotion_dead_lettered();
         increment_sm_drain_timeout();
@@ -426,6 +441,7 @@ mod tests {
             "waddle_pending_delivery_aged_out_total",
             "waddle_pending_delivery_unresolved_poison_pill_total",
             "waddle_sm_promotion_storage_failed_total",
+            "waddle_sm_promotion_not_promotable_total",
             "waddle_sm_promotion_blocklist_failed_total",
             "waddle_sm_promotion_dead_lettered_total",
             "waddle_sm_drain_timeout_total",
@@ -444,6 +460,7 @@ mod tests {
         assert!(rendered.contains("waddle_pending_delivery_orphan_claims_released_total 7"));
         assert!(rendered.contains("waddle_pending_delivery_aged_out_total 3"));
         assert!(rendered.contains("waddle_sm_promotion_storage_failed_total 2"));
+        assert!(rendered.contains("waddle_sm_promotion_not_promotable_total 1"));
         assert!(rendered.contains("waddle_sm_resume_window_clamped_total 1"));
     }
 


### PR DESCRIPTION
## Summary

Fixes #460.

- Add a shared typed MAM response classifier in `waddle-xmpp-core` for XEP-0313 query response envelopes.
- Tighten that classifier to pure XEP-shaped response envelopes only: normal message, no body/subject/thread, exactly one MAM payload, `<result id=...><forwarded xmlns="urn:xmpp:forward:0"/></result>` or defensive `<fin><set xmlns="http://jabber.org/protocol/rsm"/></fin>`.
- Keep ordinary offline-deliverable messages eligible for XEP-0160 even if they carry a MAM-looking extension payload.
- Teach SM Q6 expiry promotion to classify MAM query response frames as `NotPromotable` before DM/offline routing.
- Keep those frames out of XEP-0160 `pending_delivery` and out of service-unavailable bounce construction.
- Add a typed startup cleanup for legacy transient `pending_delivery` rows by parsing stored XML into `Message` and applying the same MAM classifier.
- Gate the cleanup with a dedicated `pending_delivery_startup_migrations` marker so healthy restarts do not repeatedly scan/parse the queue after the repair has completed.
- Store startup migration marker timestamps as Postgres `BIGINT` / SQLite `INTEGER`, with an online Postgres widening probe for existing marker tables.
- Read legacy MAM cleanup candidates in bounded `row_id` pages before parsing XML, and delete matching legacy rows in transactional batches.
- Add a dedicated `waddle_sm_promotion_not_promotable_total` metric and include `not_promotable` in SM promotion summaries/logging.

## Review Feedback Addressed

- MAM result/fin promotion tests now assert `waddle_sm_promotion_not_promotable_total` increments exactly once.
- `reset_metrics_for_test()` now resets `SM_PROMOTION_NOT_PROMOTABLE` and is exposed only for tests / `test-utils` consumers.
- Legacy cleanup is now one-shot marker-gated, has bounded candidate reads, and batches deletes inside one transaction.
- `pending_delivery_startup_migrations.completed_at` is now driver-aware: Postgres gets `BIGINT`, SQLite keeps dynamic-width `INTEGER`, and existing Postgres `integer` columns are widened before inserting `timestamp_millis()`.
- The startup cleanup no longer selects all matching `transient_xml` rows at once; it pages by `row_id` with `LIMIT` so the DB adapter only materializes a bounded candidate set per iteration.
- The cleanup regression now seeds more rows than a cleanup page and preserves a normal chat message with a MAM-looking payload while deleting only strict XEP-0313 query response frames.
- The earlier broad MAM payload classifier finding is already addressed by the strict XEP-shaped envelope predicate in `waddle-xmpp-core`.

## XEP Compliance Notes

- XEP-0313 MAM result messages contain a `{urn:xmpp:mam:2}result` element with an archive `id` and an XEP-0297 `{urn:xmpp:forward:0}forwarded` child.
- XEP-0313 final query metadata is an IQ result containing `{urn:xmpp:mam:2}fin` with an XEP-0059 RSM `{http://jabber.org/protocol/rsm}set` child. The `<fin/>` message handling here remains defensive cleanup for legacy bad rows, not a new wire behavior.
- XEP-0313 query response frames are scoped replies to the requesting resource. They are not user-to-user offline messages.
- XEP-0160 offline storage applies to offline message delivery, not stale resource-scoped MAM query responses.
- XEP-0198 expiry still gives every unacked stanza a terminal classification; this PR makes the terminal classification explicit instead of storing or bouncing MAM query frames.
- No out-of-band API or Waddle-specific protocol namespace is introduced.

## Tests

- `cargo fmt --all`
- `cargo test -p waddle-xmpp-core mam_query_response`
- `cargo test -p waddle-server dm_with_mam_payload_is_still_promoted_to_pending_delivery`
- `cargo test -p waddle-server db_storage_startup_deletes_legacy_mam_query_frames`
- `cargo test -p waddle-server mam_`
- `cargo test -p waddle-server sm_promotion`
- `cargo test -p waddle-xmpp-core mam`
- `cargo test -p waddle-xmpp --features test-utils test_reset_metrics_for_test_clears_sm_promotion_not_promotable`
- `cargo test -p waddle-xmpp --features test-utils test_issue_209_finding_11_metric_families_render`
- `cargo test -p waddle-xmpp --features test-utils --test xep0160_offline_message_handling`
- `cargo test -p waddle-server --test xep0313_mam_integration`
- `cargo test -p waddle-server --test xmpp_e2e_cue`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p waddle-server pending_delivery`
- `cargo clippy -p waddle-xmpp-core --tests -- -D warnings`
- `cargo clippy -p waddle-xmpp --features test-utils --tests -- -D warnings`
- `cargo clippy -p waddle-server --tests -- -D warnings`
- `cargo test -p waddle-xmpp-core`
- `cargo test -p waddle-server`

## Cleanup Notes

The legacy cleanup remains typed at the protocol boundary: it reads bounded candidate transient rows, parses them as XMPP `Message`, and deletes only rows whose parsed payload is a MAM response envelope. SQL only narrows the candidate set to rows containing the MAM namespace; it is not the source of protocol truth. The one-shot marker table is intentionally separate from `_migrations` because `pending_delivery` can share `WADDLE_DATABASE_URL`, where `_migrations` belongs to the main schema runner.
