### PR TITLE
fix(server): preserve postgres i64 storage range

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,7 +252,7 @@
               initdb -D "$PGDATA" -U waddle_test -A trust --no-locale --encoding=UTF8
               pg_ctl -D "$PGDATA" -o "-k $PGHOST -p $PGPORT -c listen_addresses=" -w start
               createdb -h "$PGHOST" -p "$PGPORT" -U waddle_test waddle_test
-              export WADDLE_TEST_POSTGRES_URL="postgresql://waddle_test@localhost:$PGPORT/waddle_test?host=$PGHOST"
+              export WADDLE_TEST_POSTGRES_URL="postgresql:///waddle_test?user=waddle_test&host=$PGHOST&port=$PGPORT"
             '';
           };
           workspaceArtifacts = craneLib.buildDepsOnly (

--- a/flake.nix
+++ b/flake.nix
@@ -232,6 +232,29 @@
               cp -R ${./server/charts} "$sourceRoot/charts"
             '';
           };
+          serverPostgresTestArgs = serverTestArgs // {
+            nativeBuildInputs = serverTestArgs.nativeBuildInputs ++ [
+              pkgs.postgresql
+            ];
+            preCheck = ''
+              export PGDATA="$TMPDIR/postgres-data"
+              export PGHOST="$TMPDIR/postgres-socket"
+              export PGPORT=55432
+              mkdir -p "$PGHOST"
+
+              cleanup_waddle_test_postgres() {
+                if [ -n "''${PGDATA:-}" ] && [ -d "$PGDATA" ]; then
+                  pg_ctl -D "$PGDATA" -m fast -w stop || true
+                fi
+              }
+              trap cleanup_waddle_test_postgres EXIT
+
+              initdb -D "$PGDATA" -U waddle_test -A trust --no-locale --encoding=UTF8
+              pg_ctl -D "$PGDATA" -o "-k $PGHOST -p $PGPORT -c listen_addresses=" -w start
+              createdb -h "$PGHOST" -p "$PGPORT" -U waddle_test waddle_test
+              export WADDLE_TEST_POSTGRES_URL="postgresql://waddle_test@localhost:$PGPORT/waddle_test?host=$PGHOST"
+            '';
+          };
           workspaceArtifacts = craneLib.buildDepsOnly (
             baseArgs
             // {
@@ -306,7 +329,7 @@
             }
           );
           waddle-server-test = craneLib.cargoTest (
-            serverTestArgs
+            serverPostgresTestArgs
             // {
               cargoArtifacts = workspaceAllFeaturesArtifacts;
               cargoExtraArgs = "--locked --workspace --all-features";
@@ -341,7 +364,7 @@
             }
           );
           waddle-server-xmpp-server-tests = craneLib.cargoTest (
-            serverTestArgs
+            serverPostgresTestArgs
             // {
               pname = "waddle-server-xmpp-server-tests";
               cargoArtifacts = serverTestArtifacts;

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -273,7 +273,7 @@ CREATE TABLE upload_slots (
     id TEXT PRIMARY KEY,
     requester_jid TEXT NOT NULL,
     filename TEXT NOT NULL,
-    size_bytes INTEGER NOT NULL,
+    size_bytes BIGINT NOT NULL,
     content_type TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'pending',
     storage_key TEXT,
@@ -459,6 +459,19 @@ CREATE INDEX idx_provider_webhook_deliveries_status
     ON provider_webhook_deliveries(status, attempts, created_at);
 "#;
 
+/// Widen XEP-0363 upload slot sizes for Postgres. The request size is
+/// accepted as `u64`, bounded by `WADDLE_MAX_UPLOAD_SIZE`, and then
+/// stored as an `i64`; Postgres `INTEGER` would reject configured
+/// maxima above int4 even though the Rust boundary accepts them.
+pub const V0006_UPLOAD_SIZES_BIGINT: &str = r#"
+SELECT 1;
+"#;
+
+pub const V0006_UPLOAD_SIZES_BIGINT_POSTGRES: &str = r#"
+ALTER TABLE upload_slots
+ALTER COLUMN size_bytes TYPE BIGINT;
+"#;
+
 /// Get all global migrations in order
 pub fn all() -> Vec<Migration> {
     vec![
@@ -494,6 +507,12 @@ pub fn all() -> Vec<Migration> {
             description: "Provider webhook delivery ledger".to_string(),
             sql_sqlite: V0005_PROVIDER_WEBHOOK_DELIVERY_LEDGER,
             sql_postgres: V0005_PROVIDER_WEBHOOK_DELIVERY_LEDGER_POSTGRES,
+        },
+        Migration {
+            version: 6,
+            description: "Widen upload slot sizes to bigint on Postgres".to_string(),
+            sql_sqlite: V0006_UPLOAD_SIZES_BIGINT,
+            sql_postgres: V0006_UPLOAD_SIZES_BIGINT_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::db::{Database, DatabaseDriver};
+use crate::db::{Database, DatabaseConfig, DatabaseDriver};
 
 #[tokio::test]
 async fn test_migration_runner_global() {
@@ -16,7 +16,7 @@ async fn test_migration_runner_global() {
 
     // Check version (global + shared waddle schema)
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1002));
+    assert_eq!(version, Some(1003));
 }
 
 #[tokio::test]
@@ -120,7 +120,7 @@ async fn test_waddle_v1002_adds_pin_permission_to_existing_v1001_schema() {
 
     let runner = MigrationRunner::waddle();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1002]);
+    assert_eq!(applied, vec![1002, 1003]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn
@@ -132,7 +132,7 @@ async fn test_waddle_v1002_adds_pin_permission_to_existing_v1001_schema() {
     assert_eq!(pin_permission, "admins-only");
 
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1002));
+    assert_eq!(version, Some(1003));
 }
 
 #[tokio::test]
@@ -209,14 +209,14 @@ async fn test_global_v0004_adds_policy_digest_to_existing_v0003_schema() {
     drop(conn);
 
     // `MigrationRunner::global()` composes global + waddle migrations,
-    // so the runner also reports applying 1001 and 1002 (the waddle
+    // so the runner also reports applying 1001 through 1003 (the waddle
     // schema tables) on top of V0004. The test's invariant is V0004
     // specifically, asserted via the `pragma_table_info` probe below;
     // the version list is included in the assertion so a future PR
     // that reorders or renumbers can't silently shift it.
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![4, 5, 1001, 1002]);
+    assert_eq!(applied, vec![4, 5, 6, 1001, 1002, 1003]);
 
     // Column exists.
     let conn = db.guard().await.unwrap();
@@ -278,7 +278,7 @@ async fn test_global_v0004_adds_policy_digest_to_existing_v0003_schema() {
     let version = runner.current_version(&db).await.unwrap();
     assert_eq!(
         version,
-        Some(1002),
+        Some(1003),
         "current version reflects the highest applied across global+waddle"
     );
 }
@@ -327,13 +327,13 @@ async fn test_incompatible_history_forces_hard_cut_reapply() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 1001, 1002, 1003]);
 
     let applied_again = runner.run(&db).await.unwrap();
     assert!(applied_again.is_empty());
 
     let version = runner.current_version(&db).await.unwrap();
-    assert_eq!(version, Some(1002));
+    assert_eq!(version, Some(1003));
 }
 
 #[tokio::test]
@@ -378,7 +378,7 @@ async fn test_incompatible_history_recreates_existing_owned_tables() {
 
     let runner = MigrationRunner::global();
     let applied = runner.run(&db).await.unwrap();
-    assert_eq!(applied, vec![1, 2, 3, 4, 5, 1001, 1002]);
+    assert_eq!(applied, vec![1, 2, 3, 4, 5, 6, 1001, 1002, 1003]);
 
     let conn = db.guard().await.unwrap();
     let mut rows = conn
@@ -508,4 +508,304 @@ fn postgres_channel_pin_permission_migration_is_hot_patch_safe() {
         waddle::V1002_ADD_CHANNEL_PIN_PERMISSION_POSTGRES.contains("ADD COLUMN IF NOT EXISTS"),
         "Postgres v1002 must tolerate prod databases where pin_permission was hot-patched before the migration was recorded"
     );
+}
+
+#[test]
+fn postgres_upload_and_attachment_sizes_are_bigint() {
+    assert!(
+        global::V0001_AUTH_BROKER_SCHEMA_POSTGRES.contains("size_bytes BIGINT NOT NULL"),
+        "fresh Postgres upload_slots.size_bytes must be BIGINT"
+    );
+    assert!(
+        global::V0006_UPLOAD_SIZES_BIGINT_POSTGRES.contains("ALTER COLUMN size_bytes TYPE BIGINT"),
+        "existing Postgres upload_slots.size_bytes must be widened online"
+    );
+    assert!(
+        waddle::V0001_SCHEMA_POSTGRES.contains("size_bytes BIGINT NOT NULL"),
+        "fresh Postgres attachments.size_bytes must be BIGINT"
+    );
+    assert!(
+        waddle::V1003_ATTACHMENT_SIZES_BIGINT_POSTGRES
+            .contains("ALTER COLUMN size_bytes TYPE BIGINT"),
+        "existing Postgres attachments.size_bytes must be widened online"
+    );
+}
+
+#[tokio::test]
+async fn postgres_v0006_widens_existing_upload_slot_size_bytes() {
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping: WADDLE_TEST_POSTGRES_URL not set \
+             (postgres-backed migration regression for upload_slots.size_bytes BIGINT)"
+        );
+        return;
+    };
+
+    let schema = unique_postgres_schema_name("upload_size");
+    let (db, admin) = open_isolated_postgres_database(&database_url, &schema).await;
+    let conn = db.guard().await.expect("postgres guard");
+    conn.execute(sql::migrations_table_sql(DatabaseDriver::Postgres), ())
+        .await
+        .expect("create migration table");
+    seed_applied_migrations(&conn, global::all().into_iter().filter(|m| m.version < 6)).await;
+    conn.execute(
+        r#"
+        CREATE TABLE upload_slots (
+            id TEXT PRIMARY KEY,
+            requester_jid TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            content_type TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            storage_key TEXT,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP::TEXT,
+            expires_at TEXT NOT NULL,
+            uploaded_at TEXT
+        )
+        "#,
+        (),
+    )
+    .await
+    .expect("create legacy upload_slots");
+    conn.execute(
+        "INSERT INTO upload_slots \
+         (id, requester_jid, filename, size_bytes, content_type, expires_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+        crate::db_params![
+            "slot-legacy",
+            "alice@example.com",
+            "legacy.bin",
+            i64::from(i32::MAX),
+            "application/octet-stream",
+            "2026-05-13T00:00:00Z"
+        ],
+    )
+    .await
+    .expect("seed legacy upload slot");
+    drop(conn);
+
+    let applied = MigrationRunner::global()
+        .run(&db)
+        .await
+        .expect("run global migration");
+    assert_eq!(applied, vec![6, 1001, 1002, 1003]);
+    assert_postgres_column_type(&db, "upload_slots", "size_bytes", "bigint").await;
+
+    let oversized_int4 = i64::from(i32::MAX) + 1;
+    let conn = db.guard().await.expect("postgres guard");
+    conn.execute(
+        "INSERT INTO upload_slots \
+         (id, requester_jid, filename, size_bytes, content_type, expires_at) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+        crate::db_params![
+            "slot-bigint",
+            "alice@example.com",
+            "bigint.bin",
+            oversized_int4,
+            "application/octet-stream",
+            "2026-05-13T00:00:00Z"
+        ],
+    )
+    .await
+    .expect("insert upload slot above int4 range");
+    let stored = query_i64(
+        &db,
+        "SELECT size_bytes FROM upload_slots WHERE id = ?",
+        "slot-bigint",
+    )
+    .await;
+    assert_eq!(stored, oversized_int4);
+    drop(conn);
+
+    drop_postgres_schema(&admin, &schema).await;
+}
+
+#[tokio::test]
+async fn postgres_v1003_widens_existing_attachment_size_bytes() {
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping: WADDLE_TEST_POSTGRES_URL not set \
+             (postgres-backed migration regression for attachments.size_bytes BIGINT)"
+        );
+        return;
+    };
+
+    let schema = unique_postgres_schema_name("attachment_size");
+    let (db, admin) = open_isolated_postgres_database(&database_url, &schema).await;
+    let conn = db.guard().await.expect("postgres guard");
+    conn.execute(sql::migrations_table_sql(DatabaseDriver::Postgres), ())
+        .await
+        .expect("create migration table");
+    seed_applied_migrations(
+        &conn,
+        waddle::all().into_iter().filter(|m| m.version < 1003),
+    )
+    .await;
+    conn.execute(
+        r#"
+        CREATE TABLE attachments (
+            id TEXT PRIMARY KEY,
+            message_id TEXT NOT NULL,
+            filename TEXT NOT NULL,
+            content_type TEXT NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            storage_key TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP::TEXT
+        )
+        "#,
+        (),
+    )
+    .await
+    .expect("create legacy attachments");
+    conn.execute(
+        "INSERT INTO attachments \
+         (id, message_id, filename, content_type, size_bytes, storage_key) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+        crate::db_params![
+            "attachment-legacy",
+            "message-1",
+            "legacy.bin",
+            "application/octet-stream",
+            i64::from(i32::MAX),
+            "legacy-key"
+        ],
+    )
+    .await
+    .expect("seed legacy attachment");
+    drop(conn);
+
+    let applied = MigrationRunner::waddle()
+        .run(&db)
+        .await
+        .expect("run waddle migration");
+    assert_eq!(applied, vec![1003]);
+    assert_postgres_column_type(&db, "attachments", "size_bytes", "bigint").await;
+
+    let oversized_int4 = i64::from(i32::MAX) + 1;
+    let conn = db.guard().await.expect("postgres guard");
+    conn.execute(
+        "INSERT INTO attachments \
+         (id, message_id, filename, content_type, size_bytes, storage_key) \
+         VALUES (?, ?, ?, ?, ?, ?)",
+        crate::db_params![
+            "attachment-bigint",
+            "message-2",
+            "bigint.bin",
+            "application/octet-stream",
+            oversized_int4,
+            "bigint-key"
+        ],
+    )
+    .await
+    .expect("insert attachment above int4 range");
+    let stored = query_i64(
+        &db,
+        "SELECT size_bytes FROM attachments WHERE id = ?",
+        "attachment-bigint",
+    )
+    .await;
+    assert_eq!(stored, oversized_int4);
+    drop(conn);
+
+    drop_postgres_schema(&admin, &schema).await;
+}
+
+async fn seed_applied_migrations(
+    conn: &crate::db::ConnectionGuard,
+    migrations: impl IntoIterator<Item = Migration>,
+) {
+    for migration in migrations {
+        conn.execute(
+            "INSERT INTO _migrations (version, description) VALUES (?, ?)",
+            crate::db_params![migration.version, migration.description],
+        )
+        .await
+        .expect("seed applied migration row");
+    }
+}
+
+async fn assert_postgres_column_type(
+    db: &Database,
+    table: &str,
+    column: &str,
+    expected_type: &str,
+) {
+    let conn = db.guard().await.expect("postgres guard");
+    let mut rows = conn
+        .query(
+            "SELECT data_type \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = ? \
+               AND column_name = ?",
+            crate::db_params![table, column],
+        )
+        .await
+        .expect("query information_schema column type");
+    let row = rows
+        .next()
+        .await
+        .expect("read column type")
+        .expect("column row");
+    let data_type: String = row.get(0).expect("decode column type");
+    assert_eq!(data_type, expected_type);
+}
+
+async fn query_i64(db: &Database, sql: &str, id: &str) -> i64 {
+    let conn = db.guard().await.expect("postgres guard");
+    let mut rows = conn
+        .query(sql, crate::db_params![id])
+        .await
+        .expect("query i64 value");
+    let row = rows.next().await.expect("read i64 row").expect("i64 row");
+    row.get(0).expect("decode i64 value")
+}
+
+async fn open_isolated_postgres_database(
+    database_url: &str,
+    schema: &str,
+) -> (Database, sqlx::PgPool) {
+    let admin = sqlx::PgPool::connect(database_url)
+        .await
+        .expect("connect postgres admin pool");
+    let create_schema = format!("CREATE SCHEMA {schema}");
+    sqlx::query(&create_schema)
+        .execute(&admin)
+        .await
+        .expect("create isolated postgres schema");
+
+    let scoped_url = postgres_url_with_search_path(database_url, schema);
+    let db = Database::from_config(
+        "isolated-postgres-migration-test",
+        &DatabaseConfig::new(DatabaseDriver::Postgres, scoped_url),
+    )
+    .await
+    .expect("open isolated postgres database");
+    (db, admin)
+}
+
+async fn drop_postgres_schema(admin: &sqlx::PgPool, schema: &str) {
+    let drop_schema = format!("DROP SCHEMA IF EXISTS {schema} CASCADE");
+    sqlx::query(&drop_schema)
+        .execute(admin)
+        .await
+        .expect("drop isolated postgres schema");
+}
+
+fn unique_postgres_schema_name(prefix: &str) -> String {
+    format!("waddle_test_{prefix}_{}", uuid::Uuid::new_v4().simple())
+}
+
+fn postgres_url_with_search_path(database_url: &str, schema: &str) -> String {
+    let mut url = url::Url::parse(database_url).expect("parse postgres url");
+    let retained: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(key, _)| key != "options")
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    url.query_pairs_mut()
+        .clear()
+        .extend_pairs(retained.iter().map(|(key, value)| (key, value)))
+        .append_pair("options", &format!("-c search_path={schema}"));
+    url.to_string()
 }

--- a/server/crates/waddle-server/src/db/migrations/waddle.rs
+++ b/server/crates/waddle-server/src/db/migrations/waddle.rs
@@ -131,7 +131,7 @@ CREATE TABLE attachments (
     message_id TEXT NOT NULL,
     filename TEXT NOT NULL,
     content_type TEXT NOT NULL,
-    size_bytes INTEGER NOT NULL,
+    size_bytes BIGINT NOT NULL,
     storage_key TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP::TEXT,
     FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE
@@ -154,6 +154,18 @@ ALTER TABLE channels
 ADD COLUMN IF NOT EXISTS pin_permission TEXT NOT NULL DEFAULT 'admins-only';
 "#;
 
+/// Widen attachment sizes for Postgres. SQLite `INTEGER` already
+/// stores dynamic-width integer values, while Postgres `INTEGER` is
+/// int4 and can reject valid Rust `i64` sizes.
+pub const V1003_ATTACHMENT_SIZES_BIGINT: &str = r#"
+SELECT 1;
+"#;
+
+pub const V1003_ATTACHMENT_SIZES_BIGINT_POSTGRES: &str = r#"
+ALTER TABLE attachments
+ALTER COLUMN size_bytes TYPE BIGINT;
+"#;
+
 /// Get all waddle schema migrations in order.
 ///
 /// Versions are intentionally offset from global migrations so a single
@@ -171,6 +183,12 @@ pub fn all() -> Vec<Migration> {
             description: "Add channel pin permission policy".to_string(),
             sql_sqlite: V1002_ADD_CHANNEL_PIN_PERMISSION,
             sql_postgres: V1002_ADD_CHANNEL_PIN_PERMISSION_POSTGRES,
+        },
+        Migration {
+            version: 1003,
+            description: "Widen attachment sizes to bigint on Postgres".to_string(),
+            sql_sqlite: V1003_ATTACHMENT_SIZES_BIGINT,
+            sql_postgres: V1003_ATTACHMENT_SIZES_BIGINT_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -8,6 +8,7 @@ pub mod blocking;
 mod migrations;
 mod pool;
 pub mod roster;
+mod schema;
 mod value;
 
 #[cfg(test)]
@@ -19,6 +20,7 @@ use backend::{connect_backend, DatabaseBackend};
 pub use backend::{ConnectionGuard, DatabaseDriver, Transaction};
 pub use migrations::MigrationRunner;
 pub use pool::{DatabasePool, PoolConfig, PoolHealth};
+pub use schema::{i64_sql_type, widen_postgres_i64_column_to_bigint};
 pub use value::{row_value, DbDecode, IntoParams, Row, Rows, Value, ValueExt};
 
 #[macro_export]

--- a/server/crates/waddle-server/src/db/schema.rs
+++ b/server/crates/waddle-server/src/db/schema.rs
@@ -1,0 +1,62 @@
+use super::{Database, DatabaseDriver, DatabaseError};
+
+pub fn i64_sql_type(driver: DatabaseDriver) -> &'static str {
+    match driver {
+        DatabaseDriver::Postgres => "BIGINT",
+        DatabaseDriver::Sqlite => "INTEGER",
+    }
+}
+
+pub async fn widen_postgres_i64_column_to_bigint(
+    db: &Database,
+    table: &'static str,
+    column: &'static str,
+) -> Result<(), DatabaseError> {
+    if !matches!(db.driver(), DatabaseDriver::Postgres) {
+        return Ok(());
+    }
+
+    validate_sql_identifier(table)?;
+    validate_sql_identifier(column)?;
+
+    let conn = db.guard().await?;
+    let mut rows = conn
+        .query(
+            "SELECT data_type \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = ? \
+               AND column_name = ?",
+            crate::db_params![table, column],
+        )
+        .await?;
+    let current_type: Option<String> = match rows.next().await? {
+        Some(row) => row.get(0)?,
+        None => None,
+    };
+    let needs_widen = current_type
+        .as_deref()
+        .is_some_and(|data_type| !data_type.eq_ignore_ascii_case("bigint"));
+    if needs_widen {
+        conn.execute(
+            &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
+            (),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn validate_sql_identifier(identifier: &str) -> Result<(), DatabaseError> {
+    let valid = !identifier.is_empty()
+        && identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_');
+    if valid {
+        Ok(())
+    } else {
+        Err(DatabaseError::QueryFailed(format!(
+            "invalid SQL identifier: {identifier}"
+        )))
+    }
+}

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), InboxStorageError> {
-    let i64_type = i64_sql_type(storage.db.driver());
+    let i64_type = crate::db::i64_sql_type(storage.db.driver());
 
     // Check if the table already exists with the old schema (missing thread_id column).
     let needs_migration = needs_thread_migration(storage).await?;
@@ -59,9 +59,9 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
             .await?;
     }
 
-    if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
-        widen_postgres_i64_column_to_bigint(storage, "inbox_entries", "last_updated").await?;
-    }
+    crate::db::widen_postgres_i64_column_to_bigint(&storage.db, "inbox_entries", "last_updated")
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
 
     storage.execute(
         "CREATE INDEX IF NOT EXISTS idx_inbox_entries_user_updated ON inbox_entries (user_jid, last_updated DESC)",
@@ -73,53 +73,6 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
         (),
     )
     .await?;
-    Ok(())
-}
-
-fn i64_sql_type(driver: DatabaseDriver) -> &'static str {
-    match driver {
-        DatabaseDriver::Postgres => "BIGINT",
-        DatabaseDriver::Sqlite => "INTEGER",
-    }
-}
-
-async fn widen_postgres_i64_column_to_bigint(
-    storage: &DatabaseInboxStorage,
-    table: &'static str,
-    column: &'static str,
-) -> Result<(), InboxStorageError> {
-    let mut rows = storage
-        .query(
-            "SELECT data_type \
-             FROM information_schema.columns \
-             WHERE table_schema = current_schema() \
-               AND table_name = ? \
-               AND column_name = ?",
-            crate::db_params![table, column],
-        )
-        .await
-        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
-    let current_type: Option<String> = match rows
-        .next()
-        .await
-        .map_err(|error| InboxStorageError::Other(error.to_string()))?
-    {
-        Some(row) => row
-            .get(0)
-            .map_err(|error| InboxStorageError::Other(error.to_string()))?,
-        None => None,
-    };
-    let needs_widen = current_type
-        .as_deref()
-        .is_some_and(|data_type| !data_type.eq_ignore_ascii_case("bigint"));
-    if needs_widen {
-        storage
-            .execute(
-                &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
-                (),
-            )
-            .await?;
-    }
     Ok(())
 }
 

--- a/server/crates/waddle-server/src/inbox/schema.rs
+++ b/server/crates/waddle-server/src/inbox/schema.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), InboxStorageError> {
+    let i64_type = i64_sql_type(storage.db.driver());
+
     // Check if the table already exists with the old schema (missing thread_id column).
     let needs_migration = needs_thread_migration(storage).await?;
 
@@ -34,14 +36,15 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
     } else {
         storage
             .execute(
-                r#"
+                &format!(
+                    r#"
             CREATE TABLE IF NOT EXISTS inbox_entries (
                 user_jid TEXT NOT NULL,
                 partner_jid TEXT NOT NULL,
                 thread_id TEXT NOT NULL DEFAULT '',
                 kind TEXT NOT NULL,
                 last_stanza_id TEXT NOT NULL,
-                last_updated INTEGER NOT NULL,
+                last_updated {i64_type} NOT NULL,
                 unread INTEGER NOT NULL DEFAULT 0,
                 preview TEXT,
                 thread_title TEXT,
@@ -50,9 +53,14 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
                 PRIMARY KEY (user_jid, partner_jid, thread_id)
             );
             "#,
+                ),
                 (),
             )
             .await?;
+    }
+
+    if matches!(storage.db.driver(), DatabaseDriver::Postgres) {
+        widen_postgres_i64_column_to_bigint(storage, "inbox_entries", "last_updated").await?;
     }
 
     storage.execute(
@@ -65,6 +73,53 @@ pub(super) async fn initialize(storage: &DatabaseInboxStorage) -> Result<(), Inb
         (),
     )
     .await?;
+    Ok(())
+}
+
+fn i64_sql_type(driver: DatabaseDriver) -> &'static str {
+    match driver {
+        DatabaseDriver::Postgres => "BIGINT",
+        DatabaseDriver::Sqlite => "INTEGER",
+    }
+}
+
+async fn widen_postgres_i64_column_to_bigint(
+    storage: &DatabaseInboxStorage,
+    table: &'static str,
+    column: &'static str,
+) -> Result<(), InboxStorageError> {
+    let mut rows = storage
+        .query(
+            "SELECT data_type \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = ? \
+               AND column_name = ?",
+            crate::db_params![table, column],
+        )
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+    let current_type: Option<String> = match rows
+        .next()
+        .await
+        .map_err(|error| InboxStorageError::Other(error.to_string()))?
+    {
+        Some(row) => row
+            .get(0)
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?,
+        None => None,
+    };
+    let needs_widen = current_type
+        .as_deref()
+        .is_some_and(|data_type| !data_type.eq_ignore_ascii_case("bigint"));
+    if needs_widen {
+        storage
+            .execute(
+                &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
+                (),
+            )
+            .await?;
+    }
     Ok(())
 }
 

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -166,3 +166,54 @@ async fn sqlx_inbox_storage_persists_file_backing() {
         let _ = std::fs::remove_file(cleanup);
     }
 }
+
+/// Regression for #456: `inbox_entries.last_updated` is an i64
+/// timestamp. Postgres `INTEGER` is int4, so fresh and existing
+/// Postgres tables must expose this column as BIGINT.
+#[tokio::test]
+async fn sqlx_inbox_postgres_handles_i32_overflow_last_updated() {
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping: WADDLE_TEST_POSTGRES_URL not set \
+             (postgres-backed regression for inbox_entries.last_updated BIGINT)"
+        );
+        return;
+    };
+
+    let storage = DatabaseInboxStorage::open(Some(&database_url))
+        .await
+        .expect("open postgres inbox storage");
+    let run_id = uuid::Uuid::new_v4();
+    let user = jid(&format!("inbox-{run_id}@example.com"));
+    let partner = jid(&format!("partner-{run_id}@example.com"));
+    let last_updated = i64::from(i32::MAX) + 86_400;
+
+    let stored = storage
+        .upsert(
+            &user,
+            InboxEntry::new(
+                partner.clone(),
+                ConversationKind::Direct,
+                format!("stanza-{run_id}"),
+                last_updated,
+            ),
+            false,
+        )
+        .await
+        .expect("BIGINT last_updated accepts values past i32::MAX");
+    assert_eq!(stored.last_updated, last_updated);
+
+    let listed = storage.list(&user).await.expect("list postgres inbox");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].partner, partner);
+    assert_eq!(listed[0].last_updated, last_updated);
+
+    let deleted = storage
+        .execute(
+            "DELETE FROM inbox_entries WHERE user_jid = ? AND partner_jid = ?",
+            crate::db_params![user.to_string(), partner.to_string()],
+        )
+        .await
+        .expect("cleanup inbox postgres row");
+    assert_eq!(deleted, 1);
+}

--- a/server/crates/waddle-server/src/server/routes/uploads.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads.rs
@@ -28,6 +28,9 @@ mod download;
 
 use download::download_handler;
 
+const DEFAULT_MAX_UPLOAD_SIZE: u64 = 10 * 1024 * 1024;
+pub(crate) const MAX_DATABASE_UPLOAD_SIZE: u64 = i64::MAX as u64;
+
 /// Extended application state for upload routes.
 ///
 /// File storage is delegated to the `BlobStorage` trait on `AppState`,
@@ -54,18 +57,25 @@ impl UploadState {
     }
 }
 
-fn configured_max_upload_size() -> u64 {
-    std::env::var("WADDLE_MAX_UPLOAD_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(10 * 1024 * 1024)
+pub(crate) fn max_upload_size() -> u64 {
+    max_upload_size_from_env_value(std::env::var("WADDLE_MAX_UPLOAD_SIZE").ok().as_deref())
+}
+
+pub(crate) fn upload_size_to_i64(size: u64) -> Option<i64> {
+    i64::try_from(size).ok()
+}
+
+fn max_upload_size_from_env_value(raw: Option<&str>) -> u64 {
+    raw.and_then(|s| s.parse::<u64>().ok())
+        .map(|size| size.min(MAX_DATABASE_UPLOAD_SIZE))
+        .unwrap_or(DEFAULT_MAX_UPLOAD_SIZE)
 }
 
 fn upload_body_limit() -> DefaultBodyLimit {
     // The upload handler extracts the request body as `Bytes`, so Axum's
     // default 2 MiB limit would reject larger uploads before our slot/size
     // validation runs. Keep the HTTP body cap aligned with the XMPP slot cap.
-    let limit = usize::try_from(configured_max_upload_size()).unwrap_or(usize::MAX);
+    let limit = usize::try_from(max_upload_size()).unwrap_or(usize::MAX);
     DefaultBodyLimit::max(limit)
 }
 

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -77,6 +77,25 @@ async fn create_expired_slot(state: &UploadState, slot_id: &str) {
         .unwrap();
 }
 
+#[test]
+fn upload_size_to_i64_rejects_values_outside_database_range() {
+    assert_eq!(upload_size_to_i64(i64::MAX as u64), Some(i64::MAX));
+    assert_eq!(upload_size_to_i64(i64::MAX as u64 + 1), None);
+}
+
+#[test]
+fn max_upload_size_is_capped_to_database_range() {
+    let configured = (i64::MAX as u64).saturating_add(1).to_string();
+    assert_eq!(
+        max_upload_size_from_env_value(Some(&configured)),
+        MAX_DATABASE_UPLOAD_SIZE
+    );
+    assert_eq!(
+        max_upload_size_from_env_value(Some("not-a-number")),
+        DEFAULT_MAX_UPLOAD_SIZE
+    );
+}
+
 #[tokio::test]
 async fn test_upload_to_valid_slot() {
     let (state, upload_dir) = create_test_upload_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -299,18 +299,25 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                 }
             };
 
-            // Check file size limits (default 10 MB)
-            let max_size: u64 = std::env::var("WADDLE_MAX_UPLOAD_SIZE")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(10 * 1024 * 1024);
-
+            // Check file size limits (default 10 MB). The helper also
+            // caps operator configuration to the database BIGINT range
+            // so accepted XEP-0363 sizes are stored losslessly.
+            let max_size = crate::server::routes::uploads::max_upload_size();
             if request.size > max_size {
                 return vec![build_upload_error(
                     id,
                     &UploadError::FileTooLarge { max_size },
                 )];
             }
+            let Some(size_bytes) = crate::server::routes::uploads::upload_size_to_i64(request.size)
+            else {
+                return vec![build_upload_error(
+                    id,
+                    &UploadError::FileTooLarge {
+                        max_size: crate::server::routes::uploads::MAX_DATABASE_UPLOAD_SIZE,
+                    },
+                )];
+            };
 
             let safe_filename = sanitize_filename(&request.filename);
             let content_type = effective_content_type(request.content_type.as_deref()).to_string();
@@ -335,7 +342,7 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                         slot_id.clone().into(),
                         sender_jid.to_bare().to_string().into(),
                         safe_filename.clone().into(),
-                        (request.size as i64).into(),
+                        size_bytes.into(),
                         content_type.clone().into(),
                         expires_at.into(),
                     ],

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -219,7 +219,7 @@ impl waddle_xmpp::AppState for XmppAppState {
 
     /// Get the maximum allowed file upload size in bytes.
     fn max_upload_size(&self) -> u64 {
-        super::xmpp_upload_state::max_upload_size()
+        super::routes::uploads::max_upload_size()
     }
 
     // =========================================================================

--- a/server/crates/waddle-server/src/server/xmpp_upload_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_upload_state.rs
@@ -22,7 +22,7 @@ pub(crate) async fn create_upload_slot(
         "Creating upload slot"
     );
 
-    let max_size = max_upload_size();
+    let max_size = crate::server::routes::uploads::max_upload_size();
     if size > max_size {
         warn!(
             jid = %requester_jid,
@@ -35,6 +35,12 @@ pub(crate) async fn create_upload_slot(
             max_size
         ))));
     }
+    let size_bytes = crate::server::routes::uploads::upload_size_to_i64(size).ok_or_else(|| {
+        XmppError::not_acceptable(Some(format!(
+            "File too large. Maximum size is {} bytes.",
+            crate::server::routes::uploads::MAX_DATABASE_UPLOAD_SIZE
+        )))
+    })?;
 
     let safe_filename = sanitize_filename(filename);
     let effective_type = effective_content_type(content_type).to_string();
@@ -51,7 +57,7 @@ pub(crate) async fn create_upload_slot(
                 Value::from(slot_id.clone()),
                 Value::from(requester_jid.to_string()),
                 Value::from(safe_filename),
-                Value::from(size as i64),
+                Value::from(size_bytes),
                 Value::from(effective_type.clone()),
                 Value::from(expires_at.to_rfc3339()),
             ],
@@ -74,13 +80,6 @@ pub(crate) async fn create_upload_slot(
         get_url,
         put_headers: vec![("Content-Type".to_string(), effective_type)],
     })
-}
-
-pub(crate) fn max_upload_size() -> u64 {
-    std::env::var("WADDLE_MAX_UPLOAD_SIZE")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(10 * 1024 * 1024)
 }
 
 fn upload_base_url(domain: &str) -> String {

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -46,12 +46,12 @@ type StreamLockMap = dashmap::DashMap<SmSessionId, Arc<tokio::sync::Mutex<()>>>;
 ///     stream_id TEXT PRIMARY KEY,
 ///     user_id TEXT NOT NULL,
 ///     full_jid TEXT NOT NULL,
-///     inbound_count INTEGER NOT NULL,
-///     outbound_count INTEGER NOT NULL,
-///     last_acked INTEGER NOT NULL,
-///     max_resume_secs INTEGER,
-///     detached_at_ms INTEGER NOT NULL,
-///     max_resume_duration_ms INTEGER NOT NULL,
+///     inbound_count BIGINT NOT NULL,
+///     outbound_count BIGINT NOT NULL,
+///     last_acked BIGINT NOT NULL,
+///     max_resume_secs BIGINT,
+///     detached_at_ms BIGINT NOT NULL,
+///     max_resume_duration_ms BIGINT NOT NULL,
 ///     carbons_enabled INTEGER NOT NULL,
 ///     roster_interested INTEGER NOT NULL,
 ///     presence_available INTEGER NOT NULL,
@@ -62,9 +62,9 @@ type StreamLockMap = dashmap::DashMap<SmSessionId, Arc<tokio::sync::Mutex<()>>>;
 ///
 /// CREATE TABLE sm_unacked (
 ///     stream_id TEXT NOT NULL,
-///     sequence INTEGER NOT NULL,
+///     sequence BIGINT NOT NULL,
 ///     stanza_xml TEXT NOT NULL,
-///     original_receipt_at_ms INTEGER NOT NULL,
+///     original_receipt_at_ms BIGINT NOT NULL,
 ///     PRIMARY KEY (stream_id, sequence)
 /// );
 /// ```

--- a/server/crates/waddle-server/src/sm_persistence/schema.rs
+++ b/server/crates/waddle-server/src/sm_persistence/schema.rs
@@ -26,10 +26,7 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
     // Driver-aware bigint type: Postgres INTEGER is i32 (overflows
     // for `timestamp_millis()` after Jan 2038); BIGINT is i64.
     // SQLite INTEGER is dynamically sized so the same DDL works.
-    let bigint = match storage.db.driver() {
-        DatabaseDriver::Postgres => "BIGINT",
-        DatabaseDriver::Sqlite => "INTEGER",
-    };
+    let bigint = i64_sql_type(storage.db.driver());
     storage
         .execute(
             &format!(
@@ -73,6 +70,7 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
             (),
         )
         .await?;
+    widen_existing_postgres_i64_columns(storage).await?;
     // Index on detached_at_ms + max_resume_duration_ms for the
     // janitor's expired-session sweep. We can't compute the
     // expiry timestamp directly in SQL portably, so the janitor
@@ -90,5 +88,74 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
         "promotion_attempts INTEGER NOT NULL DEFAULT 0",
     )
     .await?;
+    Ok(())
+}
+
+fn i64_sql_type(driver: DatabaseDriver) -> &'static str {
+    match driver {
+        DatabaseDriver::Postgres => "BIGINT",
+        DatabaseDriver::Sqlite => "INTEGER",
+    }
+}
+
+async fn widen_existing_postgres_i64_columns(
+    storage: &DatabaseSmPersistence,
+) -> Result<(), SmPersistenceError> {
+    if !matches!(storage.db.driver(), DatabaseDriver::Postgres) {
+        return Ok(());
+    }
+
+    for (table, column) in [
+        ("sm_sessions", "inbound_count"),
+        ("sm_sessions", "outbound_count"),
+        ("sm_sessions", "last_acked"),
+        ("sm_sessions", "max_resume_secs"),
+        ("sm_sessions", "detached_at_ms"),
+        ("sm_sessions", "max_resume_duration_ms"),
+        ("sm_unacked", "sequence"),
+        ("sm_unacked", "original_receipt_at_ms"),
+    ] {
+        widen_postgres_i64_column_to_bigint(storage, table, column).await?;
+    }
+
+    Ok(())
+}
+
+async fn widen_postgres_i64_column_to_bigint(
+    storage: &DatabaseSmPersistence,
+    table: &'static str,
+    column: &'static str,
+) -> Result<(), SmPersistenceError> {
+    let mut rows = storage
+        .query(
+            "SELECT data_type \
+             FROM information_schema.columns \
+             WHERE table_schema = current_schema() \
+               AND table_name = ? \
+               AND column_name = ?",
+            crate::db_params![table, column],
+        )
+        .await?;
+    let current_type: Option<String> = match rows
+        .next()
+        .await
+        .map_err(|error| SmPersistenceError::Other(error.to_string()))?
+    {
+        Some(row) => row
+            .get(0)
+            .map_err(|error| SmPersistenceError::Other(error.to_string()))?,
+        None => None,
+    };
+    let needs_widen = current_type
+        .as_deref()
+        .is_some_and(|data_type| !data_type.eq_ignore_ascii_case("bigint"));
+    if needs_widen {
+        storage
+            .execute(
+                &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
+                (),
+            )
+            .await?;
+    }
     Ok(())
 }

--- a/server/crates/waddle-server/src/sm_persistence/schema.rs
+++ b/server/crates/waddle-server/src/sm_persistence/schema.rs
@@ -26,7 +26,7 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
     // Driver-aware bigint type: Postgres INTEGER is i32 (overflows
     // for `timestamp_millis()` after Jan 2038); BIGINT is i64.
     // SQLite INTEGER is dynamically sized so the same DDL works.
-    let bigint = i64_sql_type(storage.db.driver());
+    let bigint = crate::db::i64_sql_type(storage.db.driver());
     storage
         .execute(
             &format!(
@@ -91,20 +91,9 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
     Ok(())
 }
 
-fn i64_sql_type(driver: DatabaseDriver) -> &'static str {
-    match driver {
-        DatabaseDriver::Postgres => "BIGINT",
-        DatabaseDriver::Sqlite => "INTEGER",
-    }
-}
-
 async fn widen_existing_postgres_i64_columns(
     storage: &DatabaseSmPersistence,
 ) -> Result<(), SmPersistenceError> {
-    if !matches!(storage.db.driver(), DatabaseDriver::Postgres) {
-        return Ok(());
-    }
-
     for (table, column) in [
         ("sm_sessions", "inbound_count"),
         ("sm_sessions", "outbound_count"),
@@ -115,47 +104,10 @@ async fn widen_existing_postgres_i64_columns(
         ("sm_unacked", "sequence"),
         ("sm_unacked", "original_receipt_at_ms"),
     ] {
-        widen_postgres_i64_column_to_bigint(storage, table, column).await?;
+        crate::db::widen_postgres_i64_column_to_bigint(&storage.db, table, column)
+            .await
+            .map_err(|error| SmPersistenceError::Other(error.to_string()))?;
     }
 
-    Ok(())
-}
-
-async fn widen_postgres_i64_column_to_bigint(
-    storage: &DatabaseSmPersistence,
-    table: &'static str,
-    column: &'static str,
-) -> Result<(), SmPersistenceError> {
-    let mut rows = storage
-        .query(
-            "SELECT data_type \
-             FROM information_schema.columns \
-             WHERE table_schema = current_schema() \
-               AND table_name = ? \
-               AND column_name = ?",
-            crate::db_params![table, column],
-        )
-        .await?;
-    let current_type: Option<String> = match rows
-        .next()
-        .await
-        .map_err(|error| SmPersistenceError::Other(error.to_string()))?
-    {
-        Some(row) => row
-            .get(0)
-            .map_err(|error| SmPersistenceError::Other(error.to_string()))?,
-        None => None,
-    };
-    let needs_widen = current_type
-        .as_deref()
-        .is_some_and(|data_type| !data_type.eq_ignore_ascii_case("bigint"));
-    if needs_widen {
-        storage
-            .execute(
-                &format!("ALTER TABLE {table} ALTER COLUMN {column} TYPE BIGINT"),
-                (),
-            )
-            .await?;
-    }
     Ok(())
 }

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -489,3 +489,62 @@ async fn list_all_sessions_with_unacked_skips_poison_pill_unacked_rows() {
         .map(|(_, u)| u);
     assert_eq!(beta_unacked.map(Vec::len), Some(0));
 }
+
+/// Regression for #456: existing Postgres SM tables created before
+/// the driver-aware BIGINT selector must be widened online. The test
+/// exercises both session timestamp fields and unacked receipt
+/// timestamps with values that do not fit in Postgres int4.
+#[tokio::test]
+async fn postgres_handles_i32_overflow_session_and_unacked_timestamps_ms() {
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!(
+            "skipping: WADDLE_TEST_POSTGRES_URL not set \
+             (postgres-backed regression for sm persistence BIGINT)"
+        );
+        return;
+    };
+
+    let storage = DatabaseSmPersistence::open(Some(&database_url))
+        .await
+        .expect("open postgres sm persistence");
+    let stream_id = format!("postgres-bigint-{}", uuid::Uuid::new_v4());
+    let receipt_ms: i64 = 1_778_000_000_000;
+    assert!(
+        receipt_ms > i64::from(i32::MAX),
+        "test value must exceed Postgres int4 range"
+    );
+    let receipt_at =
+        DateTime::<Utc>::from_timestamp_millis(receipt_ms).expect("valid receipt timestamp");
+
+    let mut session = fixture_session(&stream_id);
+    session.detached_at = receipt_at;
+    storage
+        .upsert_session(session.clone())
+        .await
+        .expect("BIGINT sm_sessions timestamps accept values past i32::MAX");
+    let loaded = storage
+        .get_session(&session.stream_id)
+        .await
+        .expect("load postgres sm session")
+        .expect("postgres sm session row");
+    assert_eq!(loaded.detached_at, receipt_at);
+
+    let mut unacked = fixture_unacked(&stream_id, 1);
+    unacked.original_receipt_at = receipt_at;
+    storage
+        .append_unacked(unacked)
+        .await
+        .expect("BIGINT sm_unacked original_receipt_at_ms accepts values past i32::MAX");
+
+    let listed = storage
+        .list_unacked(&SmSessionId::new(&stream_id))
+        .await
+        .expect("list postgres unacked stanzas");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].original_receipt_at, receipt_at);
+
+    storage
+        .delete_session(&SmSessionId::new(&stream_id))
+        .await
+        .expect("cleanup postgres sm rows");
+}


### PR DESCRIPTION
## Summary

Fixes #456.

Postgres `INTEGER` is int4, so server storage that accepts Rust `i64` values now uses Postgres `BIGINT` instead of relying on SQLite's dynamic-width `INTEGER` behavior.

## Implementation

- Widened `inbox_entries.last_updated` for fresh Postgres inbox tables and existing Postgres inbox tables.
- Widened existing Postgres XEP-0198 stream-management counters and millisecond timestamp columns, including `sm_unacked.original_receipt_at_ms`.
- Audited adjacent protocol-sized values and widened XEP-0363 upload storage:
  - `upload_slots.size_bytes` fresh schema plus global migration V0006.
  - `attachments.size_bytes` fresh schema plus waddle migration V1003.
- Replaced upload-size `as i64` casts with checked conversion and capped `WADDLE_MAX_UPLOAD_SIZE` to the database range.
- Added live Postgres regression tests for values above `i32::MAX`.
- Updated the Nix server test derivations to start an isolated local Postgres instance and export `WADDLE_TEST_POSTGRES_URL`, so the Postgres regressions run in CI.
- Addressed review feedback by centralizing the shared `i64` SQL type and Postgres BIGINT widening helper under `crate::db`.
- Addressed review feedback by making the Nix Postgres test DSN explicitly socket-based instead of visually implying localhost TCP.

## XEP Notes

No XMPP wire shape or namespace behavior changes in this PR.

- XEP-0198 behavior remains unchanged; this fixes durable storage for stream-management counters and original receipt timestamps used by resume/offline handling.
- XEP-0363 upload slot behavior remains unchanged; accepted file sizes are now stored losslessly instead of being narrowed at the Postgres boundary.
- No out-of-band API was added.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p waddle-server server::routes::uploads::tests`
- `cargo test -p waddle-server db::migrations::tests`
- `cargo test -p waddle-server inbox::tests`
- `cargo test -p waddle-server sm_persistence::tests`
- `cargo clippy -p waddle-server --tests -- -D warnings`
- `cargo test -p waddle-server`
- Adversarial review pass from the initial implementation: no actionable findings remaining.

## Not Tested Locally

- `nix build` / `nix eval`: `nix` is not installed on this machine. CI will exercise the Nix Postgres harness.
