### PR TITLE
fix(server): deduplicate mam retries by origin-id

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -119,6 +119,9 @@ use waddle_xmpp::xep::{
 };
 use waddle_xmpp::xep0201::set_thread_id;
 use waddle_xmpp::Stanza;
+use waddle_xmpp_core::xep0359::{
+    add_stanza_id as replace_stanza_id, extract_stanza_id_by, StanzaId as Xep0359StanzaId,
+};
 use xmpp_parsers::message::{Message, MessageType as XmppMessageType};
 use xmpp_parsers::minidom::Element;
 use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
@@ -196,6 +199,106 @@ pub async fn interpret(events: Vec<OutboundEvent>, deps: &Deps<'_>) -> Interpret
 /// to prevent runaway recursion. See PR15 design notes.
 const MAX_RECIPIENT_PASS_DEPTH: u8 = 1;
 
+#[derive(Clone, Debug)]
+pub(super) struct ArchiveIdRewrite {
+    by: Jid,
+    from_id: String,
+    to_id: String,
+}
+
+impl ArchiveIdRewrite {
+    pub(super) fn from_store_result(
+        by: Jid,
+        requested_id: String,
+        stored_id: String,
+    ) -> Option<Self> {
+        if requested_id.is_empty() || requested_id == stored_id {
+            return None;
+        }
+        Some(Self {
+            by,
+            from_id: requested_id,
+            to_id: stored_id,
+        })
+    }
+
+    fn rewritten_id_for(&self, by: &Jid, id: &str) -> Option<&str> {
+        (&self.by == by && self.from_id == id).then_some(self.to_id.as_str())
+    }
+}
+
+fn apply_archive_id_rewrites(event: &mut OutboundEvent, rewrites: &[ArchiveIdRewrite]) {
+    if rewrites.is_empty() {
+        return;
+    }
+    match event {
+        OutboundEvent::SendStanza(stanza) | OutboundEvent::RouteToConnection { stanza, .. } => {
+            rewrite_stanza_archive_ids(stanza, rewrites);
+        }
+        OutboundEvent::DispatchToRoom { message, .. }
+        | OutboundEvent::ArchiveGroupchat { message, .. }
+        | OutboundEvent::ArchiveDirect { message, .. }
+        | OutboundEvent::ProjectGroupchatInbox { message, .. }
+        | OutboundEvent::SendCarbons { message, .. }
+        | OutboundEvent::RequestEnrichment { message, .. }
+        | OutboundEvent::ApplyGroupchatRetractionTombstone {
+            retraction_message: message,
+            ..
+        } => {
+            rewrite_message_archive_ids(message, rewrites);
+        }
+        OutboundEvent::ProjectInbox {
+            message,
+            archive_ref,
+            ..
+        } => {
+            rewrite_message_archive_ids(message, rewrites);
+            rewrite_stanza_id(archive_ref, rewrites);
+        }
+        OutboundEvent::QueueOfflineDelivery {
+            payload,
+            original_message,
+            ..
+        } => {
+            match payload {
+                waddle_xmpp::pending_delivery::PendingPayload::Archived(stanza_id) => {
+                    rewrite_stanza_id(stanza_id, rewrites);
+                }
+                waddle_xmpp::pending_delivery::PendingPayload::Transient(message) => {
+                    rewrite_message_archive_ids(message, rewrites);
+                }
+            }
+            rewrite_message_archive_ids(original_message, rewrites);
+        }
+        _ => {}
+    }
+}
+
+fn rewrite_stanza_archive_ids(stanza: &mut Stanza, rewrites: &[ArchiveIdRewrite]) {
+    if let Stanza::Message(message) = stanza {
+        rewrite_message_archive_ids(message, rewrites);
+    }
+}
+
+fn rewrite_message_archive_ids(message: &mut Message, rewrites: &[ArchiveIdRewrite]) {
+    for rewrite in rewrites {
+        if extract_stanza_id_by(message, &rewrite.by).as_deref() == Some(rewrite.from_id.as_str()) {
+            replace_stanza_id(
+                message,
+                &Xep0359StanzaId::new(rewrite.to_id.clone(), rewrite.by.clone()),
+            );
+        }
+    }
+}
+
+fn rewrite_stanza_id(stanza_id: &mut Xep0359StanzaId, rewrites: &[ArchiveIdRewrite]) {
+    for rewrite in rewrites {
+        if let Some(rewritten) = rewrite.rewritten_id_for(&stanza_id.by, stanza_id.id.as_str()) {
+            stanza_id.id = rewritten.to_owned();
+        }
+    }
+}
+
 /// Internal entry point that threads the recursion depth. The public
 /// [`interpret`] starts at depth 0; the offline-recipient pass
 /// re-enters at depth 1 via [`run_headless_recipient_pass`].
@@ -206,8 +309,10 @@ async fn interpret_with_depth(
 ) -> InterpretOutcome {
     let registry = deps.connection_registry;
     let mut outcome = InterpretOutcome::default();
+    let mut archive_id_rewrites: Vec<ArchiveIdRewrite> = Vec::new();
 
-    for event in events {
+    for mut event in events {
+        apply_archive_id_rewrites(&mut event, &archive_id_rewrites);
         match event {
             OutboundEvent::SendStanza(stanza) => match stanza.to_element_string() {
                 Ok(xml) => outcome.frames.push(xml),
@@ -315,8 +420,12 @@ async fn interpret_with_depth(
                 message,
                 sender_nickname_generation,
             } => {
-                archive_groupchat_event(deps, room, sender, message, sender_nickname_generation)
-                    .await;
+                if let Some(rewrite) =
+                    archive_groupchat_event(deps, room, sender, message, sender_nickname_generation)
+                        .await
+                {
+                    archive_id_rewrites.push(rewrite);
+                }
             }
             OutboundEvent::ApplyPinChange { room, request } => {
                 apply_pin_change_event(registry, deps, room, request, recursion_depth).await;
@@ -390,7 +499,9 @@ async fn interpret_with_depth(
                 to,
                 message,
             } => {
-                archive_direct(deps, archive_jid, from, to, message).await;
+                if let Some(rewrite) = archive_direct(deps, archive_jid, from, to, message).await {
+                    archive_id_rewrites.push(rewrite);
+                }
             }
             OutboundEvent::RequestEnrichment { id, message } => {
                 let enriched = enrich_message_event(deps, *message).await;

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -6,14 +6,14 @@ pub(super) async fn archive_groupchat_event(
     sender: FullJid,
     message: Box<Message>,
     sender_nickname_generation: u64,
-) {
+) -> Option<ArchiveIdRewrite> {
     let Some(mam_storage) = deps.mam_storage else {
         debug!(
             room = %room,
             sender = %sender,
             "ArchiveGroupchat: no mam_storage in Deps; skipping (test fixture?)"
         );
-        return;
+        return None;
     };
     // Per XEP-0313 §5.1.3 the eligibility check ran inside
     // `MucArchiveHandler` before this event was emitted —
@@ -30,11 +30,12 @@ pub(super) async fn archive_groupchat_event(
             .await
         {
             Some(id) => id,
-            None => return,
+            None => return None,
         };
     debug!(
         room = %room,
-        archive_id,
+        archive_id = %archive_id.stored_id,
         "ArchiveGroupchat: persisted"
     );
+    archive_id.rewrite
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -6,7 +6,7 @@ pub(super) async fn archive_direct(
     from: BareJid,
     to: BareJid,
     message: Box<Message>,
-) {
+) -> Option<ArchiveIdRewrite> {
     let Some(mam_storage) = deps.mam_storage else {
         debug!(
             archive_jid = %archive_jid,
@@ -14,7 +14,7 @@ pub(super) async fn archive_direct(
             to = %to,
             "ArchiveDirect: no mam_storage in Deps; skipping (test fixture?)"
         );
-        return;
+        return None;
     };
     // Per XEP-0313 §5.1.3, the eligibility check is
     // upstream (ArchiveHandler) — the interpreter just
@@ -28,6 +28,7 @@ pub(super) async fn archive_direct(
         jid::Jid::from(to.clone()),
         &message,
     );
+    let requested_archive_id = archived.id.clone();
     match mam_storage.store_message(&archive_jid, &archived).await {
         Ok(archive_id) => {
             debug!(
@@ -35,6 +36,13 @@ pub(super) async fn archive_direct(
                 archive_id,
                 "ArchiveDirect: persisted"
             );
+            let rewrite = ArchiveIdRewrite::from_store_result(
+                jid::Jid::from(archive_jid.clone()),
+                requested_archive_id,
+                archive_id,
+            );
+            apply_direct_retraction_tombstone(deps, &archive_jid, &message).await;
+            rewrite
         }
         Err(error) => {
             // Archive errors must not block dispatch — the
@@ -47,9 +55,17 @@ pub(super) async fn archive_direct(
                 %error,
                 "ArchiveDirect: store_message failed; dropping archive write"
             );
+            apply_direct_retraction_tombstone(deps, &archive_jid, &message).await;
+            None
         }
     }
+}
 
+async fn apply_direct_retraction_tombstone(
+    deps: &Deps<'_>,
+    archive_jid: &BareJid,
+    message: &Message,
+) {
     // XEP-0424 §"prevent further distribution": when the
     // archived message is itself a retraction *request*,
     // replace the target message in this archive with a
@@ -63,15 +79,17 @@ pub(super) async fn archive_direct(
     // archive write so both sender's and recipient's
     // archives observe the tombstone independently.
     if let Some(waddle_xmpp::xep::xep0424::RetractionKind::Request(retraction)) =
-        waddle_xmpp::xep::xep0424::extract_retraction_from_message(&message)
+        waddle_xmpp::xep::xep0424::extract_retraction_from_message(message)
     {
-        apply_retraction_tombstone(
-            mam_storage,
-            deps.sm_session_registry,
-            &archive_jid,
-            &retraction.retracts_id,
-            &message,
-        )
-        .await;
+        if let Some(mam_storage) = deps.mam_storage {
+            apply_retraction_tombstone(
+                mam_storage,
+                deps.sm_session_registry,
+                archive_jid,
+                &retraction.retracts_id,
+                message,
+            )
+            .await;
+        }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -5,7 +5,7 @@ pub(super) async fn archive_groupchat_message(
     room: &BareJid,
     message: &Message,
     sender_nickname_generation: u64,
-) -> Option<String> {
+) -> Option<ArchiveStoreResult> {
     let archive_clone = message.clone();
     let archive_id = match extract_room_stanza_id(&archive_clone, room) {
         Some(id) => id,
@@ -56,7 +56,7 @@ pub(super) async fn finish_archive_groupchat_message(
     archive_clone: Message,
     archive_id: String,
     sender_nickname_generation: u64,
-) -> Option<String> {
+) -> Option<ArchiveStoreResult> {
     // RFC 6121 §5.2.3: `<body>` is optional. Preserve the
     // None-vs-empty distinction so subject-only / reaction-only
     // groupchat messages don't materialize a fake empty body in the
@@ -96,7 +96,7 @@ pub(super) async fn finish_archive_groupchat_message(
         .clone()
         .map(|id| waddle_xmpp_core::xep0359::StanzaId::new(id, room_jid_full.clone()));
     let archived = MamArchivedMessage {
-        id: archive_id,
+        id: archive_id.clone(),
         timestamp: chrono::Utc::now(),
         from: from_jid,
         to: room_jid_full,
@@ -115,7 +115,14 @@ pub(super) async fn finish_archive_groupchat_message(
     };
 
     match mam_storage.store_message(room, &archived).await {
-        Ok(archive_id) => Some(archive_id),
+        Ok(stored_id) => Some(ArchiveStoreResult {
+            rewrite: ArchiveIdRewrite::from_store_result(
+                jid::Jid::from(room.clone()),
+                archive_id,
+                stored_id.clone(),
+            ),
+            stored_id,
+        }),
         Err(error) => {
             warn!(
                 room = %room,
@@ -125,6 +132,11 @@ pub(super) async fn finish_archive_groupchat_message(
             None
         }
     }
+}
+
+pub(super) struct ArchiveStoreResult {
+    pub stored_id: String,
+    pub rewrite: Option<ArchiveIdRewrite>,
 }
 
 pub(super) async fn apply_groupchat_retraction_tombstone(

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -100,9 +100,9 @@ pub(super) async fn broadcast_room_system_message_event(
     // user-authored messages; system messages are never corrected.
     if let Some(mam_storage) = deps.mam_storage {
         match archive_groupchat_message(mam_storage, &room, &message, 0).await {
-            Some(_) => debug!(
+            Some(result) => debug!(
                 room = %room,
-                stanza_id,
+                stanza_id = %result.stored_id,
                 "BroadcastRoomSystemMessage: archived"
             ),
             None => debug!(

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -429,7 +429,11 @@ async fn origin_id_dedup_rewrites_downstream_archive_refs_to_existing_mam_id() {
         .await
         .expect("seed original archive row");
 
-    let mut retry = chat_msg("alice@example.com/web-new", "bob@example.com", "retry copy");
+    let mut retry = chat_msg(
+        "alice@example.com/web-new",
+        "bob@example.com",
+        "original copy",
+    );
     retry
         .payloads
         .push(build_origin_id_element(origin_id.as_str()));
@@ -476,6 +480,86 @@ async fn origin_id_dedup_rewrites_downstream_archive_refs_to_existing_mam_id() {
         !outcome.frames[0].contains("fresh-retry-archive-id"),
         "wire stanza-id must not point at the skipped duplicate row"
     );
+}
+
+#[tokio::test]
+async fn origin_id_collision_with_distinct_content_keeps_fresh_archive_refs() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
+    use waddle_xmpp_core::xep0359::{
+        build_origin_id_element, build_stanza_id_element, OriginId, StanzaId,
+    };
+
+    let registry = ConnectionRegistry::new();
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+    let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+    let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+    let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
+    let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
+    let origin_id = OriginId::new("retry-origin-collision");
+
+    mam_concrete
+        .store_message(
+            &alice,
+            &ArchivedMessage {
+                id: "existing-archive-id".to_string(),
+                body: Some("original copy".to_string()),
+                origin_id: Some(origin_id.clone()),
+                message_type: xmpp_parsers::message::MessageType::Chat,
+                ..ArchivedMessage::for_test(
+                    "alice@example.com/web-old".parse().expect("jid"),
+                    "bob@example.com".parse().expect("jid"),
+                )
+            },
+        )
+        .await
+        .expect("seed original archive row");
+
+    let mut distinct = chat_msg(
+        "alice@example.com/web-new",
+        "bob@example.com",
+        "new content",
+    );
+    distinct
+        .payloads
+        .push(build_origin_id_element(origin_id.as_str()));
+    distinct.payloads.push(build_stanza_id_element(
+        "fresh-distinct-archive-id",
+        &jid::Jid::from(alice.clone()),
+    ));
+
+    let events = vec![
+        OutboundEvent::ArchiveDirect {
+            archive_jid: alice.clone(),
+            from: alice.clone(),
+            to: bob.clone(),
+            message: Box::new(distinct.clone()),
+        },
+        OutboundEvent::ProjectInbox {
+            owner: alice.clone(),
+            peer: bob,
+            message: Box::new(distinct.clone()),
+            archive_ref: StanzaId::new("fresh-distinct-archive-id", jid::Jid::from(alice.clone())),
+            increment_unread: false,
+        },
+        OutboundEvent::SendStanza(Box::new(Stanza::Message(distinct))),
+    ];
+    let outcome = interpret(events, &deps).await;
+
+    assert_eq!(
+        mam_concrete.count_messages(&alice).await.expect("count"),
+        2,
+        "origin-id reuse with distinct content must archive a new MAM row"
+    );
+    let entries = inbox_concrete.list(&alice).await.expect("inbox list");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].last_stanza_id, "fresh-distinct-archive-id");
+    assert_eq!(outcome.frames.len(), 1);
+    assert!(outcome.frames[0].contains("fresh-distinct-archive-id"));
+    assert!(!outcome.frames[0].contains("existing-archive-id"));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -394,6 +394,91 @@ async fn xep_0359_archive_ref_pivots_inbox_row_to_mam_row_via_archive_or_stanza_
 }
 
 #[tokio::test]
+async fn origin_id_dedup_rewrites_downstream_archive_refs_to_existing_mam_id() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage};
+    use waddle_xmpp_core::xep0359::{
+        build_origin_id_element, build_stanza_id_element, OriginId, StanzaId,
+    };
+
+    let registry = ConnectionRegistry::new();
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+    let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+    let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+    let alice: jid::BareJid = "alice@example.com".parse().expect("bare");
+    let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
+    let origin_id = OriginId::new("retry-origin-1");
+
+    mam_concrete
+        .store_message(
+            &alice,
+            &ArchivedMessage {
+                id: "existing-archive-id".to_string(),
+                body: Some("original copy".to_string()),
+                origin_id: Some(origin_id.clone()),
+                message_type: xmpp_parsers::message::MessageType::Chat,
+                ..ArchivedMessage::for_test(
+                    "alice@example.com/web-old".parse().expect("jid"),
+                    "bob@example.com".parse().expect("jid"),
+                )
+            },
+        )
+        .await
+        .expect("seed original archive row");
+
+    let mut retry = chat_msg("alice@example.com/web-new", "bob@example.com", "retry copy");
+    retry
+        .payloads
+        .push(build_origin_id_element(origin_id.as_str()));
+    retry.payloads.push(build_stanza_id_element(
+        "fresh-retry-archive-id",
+        &jid::Jid::from(alice.clone()),
+    ));
+
+    let events = vec![
+        OutboundEvent::ArchiveDirect {
+            archive_jid: alice.clone(),
+            from: alice.clone(),
+            to: bob.clone(),
+            message: Box::new(retry.clone()),
+        },
+        OutboundEvent::ProjectInbox {
+            owner: alice.clone(),
+            peer: bob,
+            message: Box::new(retry.clone()),
+            archive_ref: StanzaId::new("fresh-retry-archive-id", jid::Jid::from(alice.clone())),
+            increment_unread: false,
+        },
+        OutboundEvent::SendStanza(Box::new(Stanza::Message(retry))),
+    ];
+    let outcome = interpret(events, &deps).await;
+
+    assert_eq!(
+        mam_concrete.count_messages(&alice).await.expect("count"),
+        1,
+        "origin-id retry must not insert a second MAM row"
+    );
+    let entries = inbox_concrete.list(&alice).await.expect("inbox list");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].last_stanza_id, "existing-archive-id",
+        "downstream inbox projection must point at the retained MAM row"
+    );
+    assert_eq!(outcome.frames.len(), 1);
+    assert!(
+        outcome.frames[0].contains("existing-archive-id"),
+        "wire stanza-id must name the retained MAM row"
+    );
+    assert!(
+        !outcome.frames[0].contains("fresh-retry-archive-id"),
+        "wire stanza-id must not point at the skipped duplicate row"
+    );
+}
+
+#[tokio::test]
 async fn xep_0313_archive_direct_writes_one_entry_per_event() {
     // Sender pass + recipient pass on the same dispatch (true
     // local-to-local) emit two events with distinct archive_jids

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -8,6 +8,7 @@
 
 mod error;
 mod in_memory;
+mod origin_dedup;
 mod query_semantics;
 mod sqlx_store;
 mod tombstone;

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -10,6 +10,7 @@ use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
 
 use crate::xep::matches_fulltext;
 
+use super::origin_dedup::origin_id_dedup_match;
 use super::query_semantics::{
     archive_order_after, archive_order_before, jid_matches_with_filter, matches_thread_filter,
     missing_requested_id, uses_backward_pagination,
@@ -39,6 +40,16 @@ impl MamStorage for InMemoryMamStorage {
         archive_jid: &BareJid,
         message: &ArchivedMessage,
     ) -> Result<String, MamStorageError> {
+        let archive_jid_str = archive_jid.to_string();
+        let mut entries = self.entries.write().await;
+        if message.origin_id.is_some() {
+            if let Some((_, existing)) = entries.iter().find(|(jid, existing)| {
+                jid == &archive_jid_str && origin_id_dedup_match(existing, message)
+            }) {
+                return Ok(existing.id.clone());
+            }
+        }
+
         let archive_id = if message.id.is_empty() {
             Self::generate_archive_id()
         } else {
@@ -48,8 +59,7 @@ impl MamStorage for InMemoryMamStorage {
         let mut stored = message.clone();
         stored.id = archive_id.clone();
 
-        let mut entries = self.entries.write().await;
-        entries.push((archive_jid.to_string(), stored));
+        entries.push((archive_jid_str, stored));
         Ok(archive_id)
     }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -12,7 +12,9 @@ pub(super) fn origin_id_dedup_match(
         return false;
     };
 
-    existing_origin_id == incoming_origin_id && sender_scope_matches(existing, incoming)
+    existing_origin_id == incoming_origin_id
+        && sender_scope_matches(existing, incoming)
+        && archived_content_matches(existing, incoming)
 }
 
 fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
@@ -27,4 +29,18 @@ fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) 
                 && existing.to.to_bare() == incoming.to.to_bare()
         }
     }
+}
+
+fn archived_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
+    // Fresh-session retries are re-stamped by the server before this
+    // storage boundary, so archive primary key, timestamp, stanza-id,
+    // and raw replay XML are intentionally excluded. The projected
+    // MAM content must still match before origin-id is accepted as a
+    // retry key; a reused origin-id with new content is a distinct
+    // message and must be archived separately.
+    existing.body == incoming.body
+        && existing.thread == incoming.thread
+        && existing.reply == incoming.reply
+        && existing.message_type == incoming.message_type
+        && existing.rich == incoming.rich
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -1,0 +1,27 @@
+use waddle_xmpp_core::mam::ArchivedMessage;
+use xmpp_parsers::message::MessageType;
+
+pub(super) fn origin_id_dedup_match(
+    existing: &ArchivedMessage,
+    incoming: &ArchivedMessage,
+) -> bool {
+    let Some(existing_origin_id) = existing.origin_id.as_ref() else {
+        return false;
+    };
+    let Some(incoming_origin_id) = incoming.origin_id.as_ref() else {
+        return false;
+    };
+
+    existing_origin_id == incoming_origin_id && sender_scope_matches(existing, incoming)
+}
+
+fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
+    match (&existing.message_type, &incoming.message_type) {
+        (MessageType::Groupchat, MessageType::Groupchat) => {
+            existing.from == incoming.from
+                && existing.nickname_generation == incoming.nickname_generation
+        }
+        (MessageType::Groupchat, _) | (_, MessageType::Groupchat) => false,
+        _ => existing.from.to_bare() == incoming.from.to_bare(),
+    }
+}

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -22,6 +22,9 @@ fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) 
                 && existing.nickname_generation == incoming.nickname_generation
         }
         (MessageType::Groupchat, _) | (_, MessageType::Groupchat) => false,
-        _ => existing.from.to_bare() == incoming.from.to_bare(),
+        _ => {
+            existing.from.to_bare() == incoming.from.to_bare()
+                && existing.to.to_bare() == incoming.to.to_bare()
+        }
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
@@ -59,6 +59,8 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_thread
     ON mam_messages(room_jid, thread_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
     ON mam_messages(room_jid, reply_to_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_mam_room_origin
+    ON mam_messages(room_jid, origin_id);
 "#;
 
 // See `SQLITE_MAM_SCHEMA` for the body-nullability rationale.
@@ -92,6 +94,8 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_thread
     ON mam_messages(room_jid, thread_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
     ON mam_messages(room_jid, reply_to_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_mam_room_origin
+    ON mam_messages(room_jid, origin_id);
 "#;
 
 pub(super) fn infer_driver(database_url: &str) -> Result<MamDatabaseDriver, MamStorageError> {
@@ -267,6 +271,7 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
         "CREATE INDEX IF NOT EXISTS idx_mam_room_id ON mam_messages(room_jid, id)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_thread ON mam_messages(room_jid, thread_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to ON mam_messages(room_jid, reply_to_id, timestamp DESC)",
+        "CREATE INDEX IF NOT EXISTS idx_mam_room_origin ON mam_messages(room_jid, origin_id)",
     ] {
         sqlx::query(statement).execute(&mut *tx).await?;
     }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     rich_payload TEXT,
     nickname_generation INTEGER,
     parent_thread_id TEXT,
+    origin_dedup_fingerprint TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -64,10 +65,12 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_origin
 "#;
 
 const SQLITE_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique
-    ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1))
-    WHERE origin_id IS NOT NULL AND message_type = 'groupchat';
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_unique;
+DROP INDEX IF EXISTS idx_mam_origin_direct_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique
+    ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1), origin_dedup_fingerprint)
+    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique
     ON mam_messages(
         room_jid,
         origin_id,
@@ -78,9 +81,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique
         CASE
             WHEN instr(to_jid, '/') = 0 THEN to_jid
             ELSE substr(to_jid, 1, instr(to_jid, '/') - 1)
-        END
+        END,
+        origin_dedup_fingerprint
     )
-    WHERE origin_id IS NOT NULL AND message_type <> 'groupchat';
+    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type <> 'groupchat';
 "#;
 
 // See `SQLITE_MAM_SCHEMA` for the body-nullability rationale.
@@ -102,6 +106,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     rich_payload TEXT,
     nickname_generation BIGINT,
     parent_thread_id TEXT,
+    origin_dedup_fingerprint TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_mam_room_timestamp
@@ -119,17 +124,20 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_origin
 "#;
 
 const POSTGRES_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique
-    ON mam_messages(room_jid, origin_id, from_jid, (COALESCE(nickname_generation, -1)))
-    WHERE origin_id IS NOT NULL AND message_type = 'groupchat';
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_unique;
+DROP INDEX IF EXISTS idx_mam_origin_direct_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique
+    ON mam_messages(room_jid, origin_id, from_jid, (COALESCE(nickname_generation, -1)), origin_dedup_fingerprint)
+    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique
     ON mam_messages(
         room_jid,
         origin_id,
         (split_part(from_jid, '/', 1)),
-        (split_part(to_jid, '/', 1))
+        (split_part(to_jid, '/', 1)),
+        origin_dedup_fingerprint
     )
-    WHERE origin_id IS NOT NULL AND message_type <> 'groupchat';
+    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type <> 'groupchat';
 "#;
 
 pub(super) fn infer_driver(database_url: &str) -> Result<MamDatabaseDriver, MamStorageError> {
@@ -230,6 +238,7 @@ pub(super) async fn ensure_sqlite_schema(pool: &SqlitePool) -> Result<(), MamSto
     ensure_sqlite_column(pool, "stanza_xml", "TEXT").await?;
     ensure_sqlite_column(pool, "nickname_generation", "INTEGER").await?;
     ensure_sqlite_column(pool, "parent_thread_id", "TEXT").await?;
+    ensure_sqlite_column(pool, "origin_dedup_fingerprint", "TEXT").await?;
     // Same body-NULL constraint risk as Postgres (see
     // `ensure_postgres_schema`): SQLite tables created before #228
     // retained `body TEXT NOT NULL` and `CREATE TABLE IF NOT EXISTS`
@@ -290,13 +299,14 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
             rich_payload TEXT,
             nickname_generation INTEGER,
             parent_thread_id TEXT,
+            origin_dedup_fingerprint TEXT,
             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"#,
         r#"INSERT INTO mam_messages__new
             SELECT id, room_jid, timestamp, from_jid, to_jid, body,
                    stanza_id, thread_id, reply_to_id, reply_to_jid,
                    origin_id, message_type, stanza_xml, rich_payload,
-                   nickname_generation, parent_thread_id, created_at
+                   nickname_generation, parent_thread_id, origin_dedup_fingerprint, created_at
             FROM mam_messages"#,
         "DROP TABLE mam_messages",
         "ALTER TABLE mam_messages__new RENAME TO mam_messages",
@@ -307,8 +317,8 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
         "CREATE INDEX IF NOT EXISTS idx_mam_room_thread ON mam_messages(room_jid, thread_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to ON mam_messages(room_jid, reply_to_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_origin ON mam_messages(room_jid, origin_id)",
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1)) WHERE origin_id IS NOT NULL AND message_type = 'groupchat'",
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique ON mam_messages(room_jid, origin_id, CASE WHEN instr(from_jid, '/') = 0 THEN from_jid ELSE substr(from_jid, 1, instr(from_jid, '/') - 1) END, CASE WHEN instr(to_jid, '/') = 0 THEN to_jid ELSE substr(to_jid, 1, instr(to_jid, '/') - 1) END) WHERE origin_id IS NOT NULL AND message_type <> 'groupchat'",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1), origin_dedup_fingerprint) WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat'",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique ON mam_messages(room_jid, origin_id, CASE WHEN instr(from_jid, '/') = 0 THEN from_jid ELSE substr(from_jid, 1, instr(from_jid, '/') - 1) END, CASE WHEN instr(to_jid, '/') = 0 THEN to_jid ELSE substr(to_jid, 1, instr(to_jid, '/') - 1) END, origin_dedup_fingerprint) WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type <> 'groupchat'",
     ] {
         sqlx::query(statement).execute(&mut *tx).await?;
     }
@@ -328,6 +338,9 @@ pub(super) async fn ensure_postgres_schema(pool: &PgPool) -> Result<(), MamStora
         .execute(pool)
         .await?;
     sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS parent_thread_id TEXT")
+        .execute(pool)
+        .await?;
+    sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS origin_dedup_fingerprint TEXT")
         .execute(pool)
         .await?;
     // RFC 6121 §5.2.3 / XEP-0313 §3: `body` is nullable. Older

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
@@ -63,6 +63,26 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_origin
     ON mam_messages(room_jid, origin_id);
 "#;
 
+const SQLITE_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique
+    ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1))
+    WHERE origin_id IS NOT NULL AND message_type = 'groupchat';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique
+    ON mam_messages(
+        room_jid,
+        origin_id,
+        CASE
+            WHEN instr(from_jid, '/') = 0 THEN from_jid
+            ELSE substr(from_jid, 1, instr(from_jid, '/') - 1)
+        END,
+        CASE
+            WHEN instr(to_jid, '/') = 0 THEN to_jid
+            ELSE substr(to_jid, 1, instr(to_jid, '/') - 1)
+        END
+    )
+    WHERE origin_id IS NOT NULL AND message_type <> 'groupchat';
+"#;
+
 // See `SQLITE_MAM_SCHEMA` for the body-nullability rationale.
 const POSTGRES_MAM_SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS mam_messages (
@@ -96,6 +116,20 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
     ON mam_messages(room_jid, reply_to_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_mam_room_origin
     ON mam_messages(room_jid, origin_id);
+"#;
+
+const POSTGRES_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique
+    ON mam_messages(room_jid, origin_id, from_jid, (COALESCE(nickname_generation, -1)))
+    WHERE origin_id IS NOT NULL AND message_type = 'groupchat';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique
+    ON mam_messages(
+        room_jid,
+        origin_id,
+        (split_part(from_jid, '/', 1)),
+        (split_part(to_jid, '/', 1))
+    )
+    WHERE origin_id IS NOT NULL AND message_type <> 'groupchat';
 "#;
 
 pub(super) fn infer_driver(database_url: &str) -> Result<MamDatabaseDriver, MamStorageError> {
@@ -203,7 +237,8 @@ pub(super) async fn ensure_sqlite_schema(pool: &SqlitePool) -> Result<(), MamSto
     // `ALTER COLUMN ... DROP NOT NULL` — relaxing the constraint
     // requires the 12-step table rebuild. Detect the legacy shape
     // and rebuild only when needed.
-    ensure_sqlite_body_nullable(pool).await
+    ensure_sqlite_body_nullable(pool).await?;
+    execute_sqlite_batch(pool, SQLITE_MAM_ORIGIN_DEDUP_INDEXES).await
 }
 
 async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorageError> {
@@ -272,6 +307,8 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
         "CREATE INDEX IF NOT EXISTS idx_mam_room_thread ON mam_messages(room_jid, thread_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to ON mam_messages(room_jid, reply_to_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_origin ON mam_messages(room_jid, origin_id)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_unique ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1)) WHERE origin_id IS NOT NULL AND message_type = 'groupchat'",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_unique ON mam_messages(room_jid, origin_id, CASE WHEN instr(from_jid, '/') = 0 THEN from_jid ELSE substr(from_jid, 1, instr(from_jid, '/') - 1) END, CASE WHEN instr(to_jid, '/') = 0 THEN to_jid ELSE substr(to_jid, 1, instr(to_jid, '/') - 1) END) WHERE origin_id IS NOT NULL AND message_type <> 'groupchat'",
     ] {
         sqlx::query(statement).execute(&mut *tx).await?;
     }
@@ -329,5 +366,5 @@ pub(super) async fn ensure_postgres_schema(pool: &PgPool) -> Result<(), MamStora
             .execute(pool)
             .await?;
     }
-    Ok(())
+    execute_postgres_batch(pool, POSTGRES_MAM_ORIGIN_DEDUP_INDEXES).await
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -79,7 +79,14 @@ pub(super) async fn store_message(
                             .map(|p| p.as_str()),
                     );
             });
-            query.build().execute(pool).await?;
+            if let Err(error) = query.build().execute(pool).await {
+                if let Some(existing_archive_id) =
+                    find_existing_origin_id_match(backend, archive_jid, message).await?
+                {
+                    return Ok(existing_archive_id);
+                }
+                return Err(error.into());
+            }
         }
         MamDatabaseBackend::Postgres(pool) => {
             let mut query = QueryBuilder::<Postgres>::new(
@@ -110,7 +117,14 @@ pub(super) async fn store_message(
                             .map(|p| p.as_str()),
                     );
             });
-            query.build().execute(pool).await?;
+            if let Err(error) = query.build().execute(pool).await {
+                if let Some(existing_archive_id) =
+                    find_existing_origin_id_match(backend, archive_jid, message).await?
+                {
+                    return Ok(existing_archive_id);
+                }
+                return Err(error.into());
+            }
         }
     }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -1,19 +1,18 @@
-use jid::BareJid;
+use std::str::FromStr;
+
+use jid::{BareJid, Jid};
+use sha2::{Digest, Sha256};
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Postgres, QueryBuilder, Sqlite};
-use tracing::debug;
+use sqlx::{Postgres, QueryBuilder, Row, Sqlite};
+use tracing::{debug, warn};
 use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
+use xmpp_parsers::message::MessageType;
 
-use crate::mam::storage::origin_dedup::origin_id_dedup_match;
 use crate::mam::storage::MamStorageError;
 
-use super::decode::{
-    decode_postgres_message_row, decode_sqlite_message_row, encode_nickname_generation,
-    encode_rich_payload,
-};
-use super::schema::SELECT_COLUMNS;
+use super::decode::{encode_nickname_generation, encode_rich_payload};
 use super::MamDatabaseBackend;
 
 pub(super) async fn store_message(
@@ -21,8 +20,20 @@ pub(super) async fn store_message(
     archive_jid: &BareJid,
     message: &ArchivedMessage,
 ) -> Result<String, MamStorageError> {
-    if let Some(existing_archive_id) =
-        find_existing_origin_id_match(backend, archive_jid, message).await?
+    let rich_payload = encode_rich_payload(message)?;
+    let origin_dedup_fingerprint = message
+        .origin_id
+        .as_ref()
+        .map(|_| origin_dedup_fingerprint(message, rich_payload.as_deref()));
+
+    if let Some(existing_archive_id) = find_existing_origin_id_match(
+        backend,
+        archive_jid,
+        message,
+        rich_payload.as_deref(),
+        origin_dedup_fingerprint.as_deref(),
+    )
+    .await?
     {
         return Ok(existing_archive_id);
     }
@@ -36,7 +47,6 @@ pub(super) async fn store_message(
     // enum to its canonical wire literal exactly once, here at
     // the SQL bind site.
     let message_type = waddle_xmpp_core::mam::message_type_wire_str(&message.message_type);
-    let rich_payload = encode_rich_payload(message)?;
     let nickname_generation = encode_nickname_generation(message.nickname_generation)?;
 
     let archive_jid_str = archive_jid.to_string();
@@ -52,7 +62,7 @@ pub(super) async fn store_message(
     match backend {
         MamDatabaseBackend::Sqlite(pool) => {
             let mut query = QueryBuilder::<Sqlite>::new(
-                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id) ",
+                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
             );
             query.push_values(std::iter::once(()), |mut builder, _| {
                 builder
@@ -77,11 +87,18 @@ pub(super) async fn store_message(
                             .as_ref()
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
-                    );
+                    )
+                    .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
-                if let Some(existing_archive_id) =
-                    find_existing_origin_id_match(backend, archive_jid, message).await?
+                if let Some(existing_archive_id) = find_existing_origin_id_match(
+                    backend,
+                    archive_jid,
+                    message,
+                    rich_payload.as_deref(),
+                    origin_dedup_fingerprint.as_deref(),
+                )
+                .await?
                 {
                     return Ok(existing_archive_id);
                 }
@@ -90,7 +107,7 @@ pub(super) async fn store_message(
         }
         MamDatabaseBackend::Postgres(pool) => {
             let mut query = QueryBuilder::<Postgres>::new(
-                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id) ",
+                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
             );
             query.push_values(std::iter::once(()), |mut builder, _| {
                 builder
@@ -115,11 +132,18 @@ pub(super) async fn store_message(
                             .as_ref()
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
-                    );
+                    )
+                    .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
-                if let Some(existing_archive_id) =
-                    find_existing_origin_id_match(backend, archive_jid, message).await?
+                if let Some(existing_archive_id) = find_existing_origin_id_match(
+                    backend,
+                    archive_jid,
+                    message,
+                    rich_payload.as_deref(),
+                    origin_dedup_fingerprint.as_deref(),
+                )
+                .await?
                 {
                     return Ok(existing_archive_id);
                 }
@@ -136,6 +160,8 @@ async fn find_existing_origin_id_match(
     backend: &MamDatabaseBackend,
     archive_jid: &BareJid,
     message: &ArchivedMessage,
+    incoming_rich_payload: Option<&str>,
+    origin_dedup_fingerprint: Option<&str>,
 ) -> Result<Option<String>, MamStorageError> {
     let Some(origin_id) = message.origin_id.as_ref() else {
         return Ok(None);
@@ -144,35 +170,45 @@ async fn find_existing_origin_id_match(
 
     match backend {
         MamDatabaseBackend::Sqlite(pool) => {
-            let mut builder = QueryBuilder::<Sqlite>::new(format!(
-                "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
-            ));
-            builder
-                .push_bind(archive_jid_str.as_str())
-                .push(" AND origin_id = ")
-                .push_bind(origin_id.as_str())
-                .push(" ORDER BY timestamp ASC, id ASC");
+            let mut builder = QueryBuilder::<Sqlite>::new(
+                "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
+                 reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
+                 FROM mam_messages WHERE room_jid = ",
+            );
+            push_origin_dedup_filter(
+                &mut builder,
+                archive_jid_str.as_str(),
+                origin_id.as_str(),
+                origin_dedup_fingerprint,
+            );
             let rows: Vec<SqliteRow> = builder.build().fetch_all(pool).await?;
             for row in rows {
-                let existing = decode_sqlite_message_row(&row)?;
-                if origin_id_dedup_match(&existing, message) {
+                let Some(existing) = OriginDedupRow::from_sqlite(&row) else {
+                    continue;
+                };
+                if existing.matches(message, incoming_rich_payload) {
                     return Ok(Some(existing.id));
                 }
             }
         }
         MamDatabaseBackend::Postgres(pool) => {
-            let mut builder = QueryBuilder::<Postgres>::new(format!(
-                "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
-            ));
-            builder
-                .push_bind(archive_jid_str.as_str())
-                .push(" AND origin_id = ")
-                .push_bind(origin_id.as_str())
-                .push(" ORDER BY timestamp ASC, id ASC");
+            let mut builder = QueryBuilder::<Postgres>::new(
+                "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
+                 reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
+                 FROM mam_messages WHERE room_jid = ",
+            );
+            push_origin_dedup_filter(
+                &mut builder,
+                archive_jid_str.as_str(),
+                origin_id.as_str(),
+                origin_dedup_fingerprint,
+            );
             let rows: Vec<PgRow> = builder.build().fetch_all(pool).await?;
             for row in rows {
-                let existing = decode_postgres_message_row(&row)?;
-                if origin_id_dedup_match(&existing, message) {
+                let Some(existing) = OriginDedupRow::from_postgres(&row) else {
+                    continue;
+                };
+                if existing.matches(message, incoming_rich_payload) {
                     return Ok(Some(existing.id));
                 }
             }
@@ -180,6 +216,263 @@ async fn find_existing_origin_id_match(
     }
 
     Ok(None)
+}
+
+fn push_origin_dedup_filter<'args, DB>(
+    builder: &mut QueryBuilder<'args, DB>,
+    archive_jid: &'args str,
+    origin_id: &'args str,
+    origin_dedup_fingerprint: Option<&'args str>,
+) where
+    DB: sqlx::Database,
+    &'args str: sqlx::Encode<'args, DB> + sqlx::Type<DB>,
+{
+    builder
+        .push_bind(archive_jid)
+        .push(" AND origin_id = ")
+        .push_bind(origin_id);
+    if let Some(fingerprint) = origin_dedup_fingerprint {
+        builder
+            .push(" AND (origin_dedup_fingerprint = ")
+            .push_bind(fingerprint)
+            .push(" OR origin_dedup_fingerprint IS NULL)");
+    }
+    builder.push(" ORDER BY timestamp ASC, id ASC");
+}
+
+struct OriginDedupRow {
+    id: String,
+    from: Jid,
+    to: Jid,
+    body: Option<String>,
+    thread_id: Option<String>,
+    parent_thread_id: Option<String>,
+    reply_to_id: Option<String>,
+    reply_to_jid: Option<Jid>,
+    message_type: MessageType,
+    rich_payload: Option<String>,
+    nickname_generation: Option<u64>,
+}
+
+impl OriginDedupRow {
+    fn from_sqlite(row: &SqliteRow) -> Option<Self> {
+        Self::from_parts(OriginDedupRawRow {
+            id: row.try_get("id"),
+            from_raw: row.try_get("from_jid"),
+            to_raw: row.try_get("to_jid"),
+            body: row.try_get("body"),
+            thread_id: row.try_get("thread_id"),
+            parent_thread_id: row.try_get("parent_thread_id"),
+            reply_to_id: row.try_get("reply_to_id"),
+            reply_to_jid_raw: row.try_get("reply_to_jid"),
+            message_type_raw: row.try_get("message_type"),
+            rich_payload: row.try_get("rich_payload"),
+            nickname_generation_raw: row.try_get::<Option<i64>, _>("nickname_generation"),
+        })
+    }
+
+    fn from_postgres(row: &PgRow) -> Option<Self> {
+        Self::from_parts(OriginDedupRawRow {
+            id: row.try_get("id"),
+            from_raw: row.try_get("from_jid"),
+            to_raw: row.try_get("to_jid"),
+            body: row.try_get("body"),
+            thread_id: row.try_get("thread_id"),
+            parent_thread_id: row.try_get("parent_thread_id"),
+            reply_to_id: row.try_get("reply_to_id"),
+            reply_to_jid_raw: row.try_get("reply_to_jid"),
+            message_type_raw: row.try_get("message_type"),
+            rich_payload: row.try_get("rich_payload"),
+            nickname_generation_raw: row.try_get::<Option<i64>, _>("nickname_generation"),
+        })
+    }
+
+    fn from_parts(raw: OriginDedupRawRow) -> Option<Self> {
+        let id = read_dedup_column("id", raw.id)?;
+        let from_raw = read_dedup_column("from_jid", raw.from_raw)?;
+        let to_raw = read_dedup_column("to_jid", raw.to_raw)?;
+        let body = read_dedup_column("body", raw.body)?;
+        let thread_id = read_dedup_column("thread_id", raw.thread_id)?;
+        let parent_thread_id = read_dedup_column("parent_thread_id", raw.parent_thread_id)?;
+        let reply_to_id = read_dedup_column("reply_to_id", raw.reply_to_id)?;
+        let reply_to_jid_raw = read_dedup_column("reply_to_jid", raw.reply_to_jid_raw)?;
+        let message_type_raw = read_dedup_column("message_type", raw.message_type_raw)?;
+        let rich_payload = read_dedup_column("rich_payload", raw.rich_payload)?;
+        let nickname_generation_raw =
+            read_dedup_column("nickname_generation", raw.nickname_generation_raw)?;
+
+        let from = parse_dedup_jid(&id, "from_jid", &from_raw)?;
+        let to = parse_dedup_jid(&id, "to_jid", &to_raw)?;
+        let reply_to_jid = match reply_to_jid_raw.as_deref() {
+            Some(raw) => Some(parse_dedup_jid(&id, "reply_to_jid", raw)?),
+            None => None,
+        };
+        let message_type = match MessageType::from_str(message_type_raw.as_str()) {
+            Ok(message_type) => message_type,
+            Err(error) => {
+                warn!(
+                    archive_id = %id,
+                    column = "message_type",
+                    %error,
+                    "MAM origin-id dedup candidate is malformed; skipping"
+                );
+                return None;
+            }
+        };
+        let nickname_generation = match nickname_generation_raw.map(u64::try_from).transpose() {
+            Ok(value) => value,
+            Err(error) => {
+                warn!(
+                    archive_id = %id,
+                    column = "nickname_generation",
+                    %error,
+                    "MAM origin-id dedup candidate is malformed; skipping"
+                );
+                return None;
+            }
+        };
+
+        Some(Self {
+            id,
+            from,
+            to,
+            body,
+            thread_id,
+            parent_thread_id,
+            reply_to_id,
+            reply_to_jid,
+            message_type,
+            rich_payload,
+            nickname_generation,
+        })
+    }
+
+    fn matches(&self, incoming: &ArchivedMessage, incoming_rich_payload: Option<&str>) -> bool {
+        self.sender_scope_matches(incoming)
+            && self.body.as_deref() == incoming.body.as_deref()
+            && self.thread_id.as_deref()
+                == incoming.thread.as_ref().map(|thread| thread.id.as_str())
+            && self.parent_thread_id.as_deref()
+                == incoming
+                    .thread
+                    .as_ref()
+                    .and_then(|thread| thread.parent.as_ref())
+                    .map(|parent| parent.as_str())
+            && self.reply_to_id.as_deref() == incoming.reply.as_ref().map(|reply| reply.id.as_str())
+            && self.reply_to_jid.as_ref()
+                == incoming.reply.as_ref().and_then(|reply| reply.to.as_ref())
+            && self.message_type == incoming.message_type
+            && self.rich_payload.as_deref() == incoming_rich_payload
+    }
+
+    fn sender_scope_matches(&self, incoming: &ArchivedMessage) -> bool {
+        match (&self.message_type, &incoming.message_type) {
+            (MessageType::Groupchat, MessageType::Groupchat) => {
+                self.from == incoming.from
+                    && self.nickname_generation == incoming.nickname_generation
+            }
+            (MessageType::Groupchat, _) | (_, MessageType::Groupchat) => false,
+            _ => {
+                self.from.to_bare() == incoming.from.to_bare()
+                    && self.to.to_bare() == incoming.to.to_bare()
+            }
+        }
+    }
+}
+
+struct OriginDedupRawRow {
+    id: Result<String, sqlx::Error>,
+    from_raw: Result<String, sqlx::Error>,
+    to_raw: Result<String, sqlx::Error>,
+    body: Result<Option<String>, sqlx::Error>,
+    thread_id: Result<Option<String>, sqlx::Error>,
+    parent_thread_id: Result<Option<String>, sqlx::Error>,
+    reply_to_id: Result<Option<String>, sqlx::Error>,
+    reply_to_jid_raw: Result<Option<String>, sqlx::Error>,
+    message_type_raw: Result<String, sqlx::Error>,
+    rich_payload: Result<Option<String>, sqlx::Error>,
+    nickname_generation_raw: Result<Option<i64>, sqlx::Error>,
+}
+
+fn read_dedup_column<T>(column: &'static str, result: Result<T, sqlx::Error>) -> Option<T> {
+    match result {
+        Ok(value) => Some(value),
+        Err(error) => {
+            warn!(
+                column,
+                %error,
+                "MAM origin-id dedup candidate could not be read; skipping"
+            );
+            None
+        }
+    }
+}
+
+fn parse_dedup_jid(archive_id: &str, column: &'static str, value: &str) -> Option<Jid> {
+    match value.parse::<Jid>() {
+        Ok(jid) => Some(jid),
+        Err(error) => {
+            warn!(
+                archive_id,
+                column,
+                %error,
+                "MAM origin-id dedup candidate is malformed; skipping"
+            );
+            None
+        }
+    }
+}
+
+fn origin_dedup_fingerprint(message: &ArchivedMessage, rich_payload: Option<&str>) -> String {
+    let mut hasher = Sha256::new();
+    update_hash_part(
+        &mut hasher,
+        "message_type",
+        Some(waddle_xmpp_core::mam::message_type_wire_str(
+            &message.message_type,
+        )),
+    );
+    update_hash_part(&mut hasher, "body", message.body.as_deref());
+    update_hash_part(
+        &mut hasher,
+        "thread_id",
+        message.thread.as_ref().map(|thread| thread.id.as_str()),
+    );
+    update_hash_part(
+        &mut hasher,
+        "parent_thread_id",
+        message
+            .thread
+            .as_ref()
+            .and_then(|thread| thread.parent.as_ref())
+            .map(|parent| parent.as_str()),
+    );
+    update_hash_part(
+        &mut hasher,
+        "reply_to_id",
+        message.reply.as_ref().map(|reply| reply.id.as_str()),
+    );
+    let reply_to_jid = message
+        .reply
+        .as_ref()
+        .and_then(|reply| reply.to.as_ref())
+        .map(|jid| jid.to_string());
+    update_hash_part(&mut hasher, "reply_to_jid", reply_to_jid.as_deref());
+    update_hash_part(&mut hasher, "rich_payload", rich_payload);
+    format!("{:x}", hasher.finalize())
+}
+
+fn update_hash_part(hasher: &mut Sha256, label: &str, value: Option<&str>) {
+    hasher.update(label.as_bytes());
+    hasher.update([0]);
+    match value {
+        Some(value) => {
+            hasher.update([1]);
+            hasher.update(value.len().to_le_bytes());
+            hasher.update(value.as_bytes());
+        }
+        None => hasher.update([0]),
+    }
 }
 
 pub(super) async fn replace_with_tombstone(
@@ -202,7 +495,7 @@ pub(super) async fn replace_with_tombstone(
     let rows = match backend {
         MamDatabaseBackend::Sqlite(pool) => {
             let mut builder = QueryBuilder::<Sqlite>::new(
-                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
             );
             builder
                 .push_bind(encoded.as_str())
@@ -212,7 +505,7 @@ pub(super) async fn replace_with_tombstone(
         }
         MamDatabaseBackend::Postgres(pool) => {
             let mut builder = QueryBuilder::<Postgres>::new(
-                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, rich_payload = ",
+                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
             );
             builder
                 .push_bind(encoded.as_str())

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -1,12 +1,19 @@
 use jid::BareJid;
+use sqlx::postgres::PgRow;
+use sqlx::sqlite::SqliteRow;
 use sqlx::{Postgres, QueryBuilder, Sqlite};
 use tracing::debug;
 use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
 
+use crate::mam::storage::origin_dedup::origin_id_dedup_match;
 use crate::mam::storage::MamStorageError;
 
-use super::decode::{encode_nickname_generation, encode_rich_payload};
+use super::decode::{
+    decode_postgres_message_row, decode_sqlite_message_row, encode_nickname_generation,
+    encode_rich_payload,
+};
+use super::schema::SELECT_COLUMNS;
 use super::MamDatabaseBackend;
 
 pub(super) async fn store_message(
@@ -14,6 +21,12 @@ pub(super) async fn store_message(
     archive_jid: &BareJid,
     message: &ArchivedMessage,
 ) -> Result<String, MamStorageError> {
+    if let Some(existing_archive_id) =
+        find_existing_origin_id_match(backend, archive_jid, message).await?
+    {
+        return Ok(existing_archive_id);
+    }
+
     let archive_id = if message.id.is_empty() {
         Uuid::now_v7().to_string()
     } else {
@@ -103,6 +116,56 @@ pub(super) async fn store_message(
 
     debug!(archive_id = %archive_id, "Message stored in MAM archive");
     Ok(archive_id)
+}
+
+async fn find_existing_origin_id_match(
+    backend: &MamDatabaseBackend,
+    archive_jid: &BareJid,
+    message: &ArchivedMessage,
+) -> Result<Option<String>, MamStorageError> {
+    let Some(origin_id) = message.origin_id.as_ref() else {
+        return Ok(None);
+    };
+    let archive_jid_str = archive_jid.to_string();
+
+    match backend {
+        MamDatabaseBackend::Sqlite(pool) => {
+            let mut builder = QueryBuilder::<Sqlite>::new(format!(
+                "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+            ));
+            builder
+                .push_bind(archive_jid_str.as_str())
+                .push(" AND origin_id = ")
+                .push_bind(origin_id.as_str())
+                .push(" ORDER BY timestamp ASC, id ASC");
+            let rows: Vec<SqliteRow> = builder.build().fetch_all(pool).await?;
+            for row in rows {
+                let existing = decode_sqlite_message_row(&row)?;
+                if origin_id_dedup_match(&existing, message) {
+                    return Ok(Some(existing.id));
+                }
+            }
+        }
+        MamDatabaseBackend::Postgres(pool) => {
+            let mut builder = QueryBuilder::<Postgres>::new(format!(
+                "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+            ));
+            builder
+                .push_bind(archive_jid_str.as_str())
+                .push(" AND origin_id = ")
+                .push_bind(origin_id.as_str())
+                .push(" ORDER BY timestamp ASC, id ASC");
+            let rows: Vec<PgRow> = builder.build().fetch_all(pool).await?;
+            for row in rows {
+                let existing = decode_postgres_message_row(&row)?;
+                if origin_id_dedup_match(&existing, message) {
+                    return Ok(Some(existing.id));
+                }
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 pub(super) async fn replace_with_tombstone(

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -62,6 +62,154 @@ async fn test_store_and_retrieve_message() {
 }
 
 #[tokio::test]
+async fn test_sqlite_deduplicates_origin_id_within_archive_sender_scope() {
+    let storage = create_test_storage().await;
+    assert_deduplicates_origin_id_within_archive_sender_scope(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_deduplicates_origin_id_within_archive_sender_scope() {
+    let storage = InMemoryMamStorage::new();
+    assert_deduplicates_origin_id_within_archive_sender_scope(&storage).await;
+}
+
+async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn MamStorage) {
+    let archive = bare("room@conference.example.com");
+    let archive_jid = jid("room@conference.example.com");
+    let origin_id = waddle_xmpp_core::xep0359::OriginId::new("client-origin-1");
+
+    let first = ArchivedMessage {
+        id: "archive-first".to_string(),
+        body: Some("first copy".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+    let retry = ArchivedMessage {
+        id: "archive-retry".to_string(),
+        body: Some("retry copy".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+    let other_sender = ArchivedMessage {
+        id: "archive-other-sender".to_string(),
+        body: Some("other sender".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(jid("room@conference.example.com/bob"), archive_jid.clone())
+    };
+    let same_nick_next_generation = ArchivedMessage {
+        id: "archive-next-generation".to_string(),
+        body: Some("same nick next generation".to_string()),
+        origin_id: Some(origin_id),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(8),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid)
+    };
+
+    let first_id = storage.store_message(&archive, &first).await.unwrap();
+    let retry_id = storage.store_message(&archive, &retry).await.unwrap();
+    let other_sender_id = storage
+        .store_message(&archive, &other_sender)
+        .await
+        .unwrap();
+    let next_generation_id = storage
+        .store_message(&archive, &same_nick_next_generation)
+        .await
+        .unwrap();
+
+    assert_eq!(first_id, "archive-first");
+    assert_eq!(
+        retry_id, first_id,
+        "same archive + same sender + same XEP-0359 origin-id must return the existing archive row"
+    );
+    assert_eq!(other_sender_id, "archive-other-sender");
+    assert_eq!(next_generation_id, "archive-next-generation");
+
+    let result = storage
+        .query_messages(&archive, &MamQuery::default())
+        .await
+        .unwrap();
+    let ids: Vec<&str> = result
+        .messages
+        .iter()
+        .map(|message| message.id.as_str())
+        .collect();
+    assert_eq!(
+        ids,
+        vec![
+            "archive-first",
+            "archive-other-sender",
+            "archive-next-generation"
+        ]
+    );
+    assert_eq!(result.count, Some(3));
+
+    let stored = storage
+        .get_message("archive-first")
+        .await
+        .unwrap()
+        .expect("first row remains");
+    assert_eq!(stored.body.as_deref(), Some("first copy"));
+}
+
+#[tokio::test]
+async fn test_sqlite_origin_id_dedup_uses_bare_sender_for_direct_messages() {
+    let storage = create_test_storage().await;
+    assert_origin_id_dedup_uses_bare_sender_for_direct_messages(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_origin_id_dedup_uses_bare_sender_for_direct_messages() {
+    let storage = InMemoryMamStorage::new();
+    assert_origin_id_dedup_uses_bare_sender_for_direct_messages(&storage).await;
+}
+
+async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &dyn MamStorage) {
+    let archive = bare("alice@example.com");
+    let origin_id = waddle_xmpp_core::xep0359::OriginId::new("client-origin-dm-1");
+    let first = ArchivedMessage {
+        id: "dm-archive-first".to_string(),
+        body: Some("sent before reconnect".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Chat,
+        ..ArchivedMessage::for_test(jid("alice@example.com/web-old"), jid("bob@example.com"))
+    };
+    let retry_from_new_resource = ArchivedMessage {
+        id: "dm-archive-retry".to_string(),
+        body: Some("sent after reconnect".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Chat,
+        ..ArchivedMessage::for_test(jid("alice@example.com/web-new"), jid("bob@example.com"))
+    };
+    let different_sender = ArchivedMessage {
+        id: "dm-other-sender".to_string(),
+        body: Some("colliding contact origin-id".to_string()),
+        origin_id: Some(origin_id),
+        message_type: xmpp_parsers::message::MessageType::Chat,
+        ..ArchivedMessage::for_test(jid("bob@example.com/phone"), jid("alice@example.com"))
+    };
+
+    let first_id = storage.store_message(&archive, &first).await.unwrap();
+    let retry_id = storage
+        .store_message(&archive, &retry_from_new_resource)
+        .await
+        .unwrap();
+    let different_sender_id = storage
+        .store_message(&archive, &different_sender)
+        .await
+        .unwrap();
+
+    assert_eq!(retry_id, first_id);
+    assert_eq!(different_sender_id, "dm-other-sender");
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 2);
+}
+
+#[tokio::test]
 async fn test_store_and_retrieve_reply_thread_metadata() {
     let storage = create_test_storage().await;
 

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -186,6 +186,13 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
         message_type: xmpp_parsers::message::MessageType::Chat,
         ..ArchivedMessage::for_test(jid("alice@example.com/web-new"), jid("bob@example.com"))
     };
+    let same_sender_different_recipient = ArchivedMessage {
+        id: "dm-different-recipient".to_string(),
+        body: Some("same origin-id different peer".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Chat,
+        ..ArchivedMessage::for_test(jid("alice@example.com/web-new"), jid("carol@example.com"))
+    };
     let different_sender = ArchivedMessage {
         id: "dm-other-sender".to_string(),
         body: Some("colliding contact origin-id".to_string()),
@@ -199,14 +206,19 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
         .store_message(&archive, &retry_from_new_resource)
         .await
         .unwrap();
+    let different_recipient_id = storage
+        .store_message(&archive, &same_sender_different_recipient)
+        .await
+        .unwrap();
     let different_sender_id = storage
         .store_message(&archive, &different_sender)
         .await
         .unwrap();
 
     assert_eq!(retry_id, first_id);
+    assert_eq!(different_recipient_id, "dm-different-recipient");
     assert_eq!(different_sender_id, "dm-other-sender");
-    assert_eq!(storage.count_messages(&archive).await.unwrap(), 2);
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 3);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -88,7 +88,15 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
     };
     let retry = ArchivedMessage {
         id: "archive-retry".to_string(),
-        body: Some("retry copy".to_string()),
+        body: Some("first copy".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+    let same_sender_different_body = ArchivedMessage {
+        id: "archive-distinct-body".to_string(),
+        body: Some("distinct send with reused origin-id".to_string()),
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
         nickname_generation: Some(7),
@@ -113,6 +121,10 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
 
     let first_id = storage.store_message(&archive, &first).await.unwrap();
     let retry_id = storage.store_message(&archive, &retry).await.unwrap();
+    let distinct_body_id = storage
+        .store_message(&archive, &same_sender_different_body)
+        .await
+        .unwrap();
     let other_sender_id = storage
         .store_message(&archive, &other_sender)
         .await
@@ -127,6 +139,7 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         retry_id, first_id,
         "same archive + same sender + same XEP-0359 origin-id must return the existing archive row"
     );
+    assert_eq!(distinct_body_id, "archive-distinct-body");
     assert_eq!(other_sender_id, "archive-other-sender");
     assert_eq!(next_generation_id, "archive-next-generation");
 
@@ -143,11 +156,12 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         ids,
         vec![
             "archive-first",
+            "archive-distinct-body",
             "archive-other-sender",
             "archive-next-generation"
         ]
     );
-    assert_eq!(result.count, Some(3));
+    assert_eq!(result.count, Some(4));
 
     let stored = storage
         .get_message("archive-first")
@@ -181,7 +195,14 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
     };
     let retry_from_new_resource = ArchivedMessage {
         id: "dm-archive-retry".to_string(),
-        body: Some("sent after reconnect".to_string()),
+        body: Some("sent before reconnect".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Chat,
+        ..ArchivedMessage::for_test(jid("alice@example.com/web-new"), jid("bob@example.com"))
+    };
+    let same_sender_distinct_body = ArchivedMessage {
+        id: "dm-distinct-body".to_string(),
+        body: Some("distinct send with reused origin-id".to_string()),
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Chat,
         ..ArchivedMessage::for_test(jid("alice@example.com/web-new"), jid("bob@example.com"))
@@ -210,6 +231,10 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
         .store_message(&archive, &same_sender_different_recipient)
         .await
         .unwrap();
+    let distinct_body_id = storage
+        .store_message(&archive, &same_sender_distinct_body)
+        .await
+        .unwrap();
     let different_sender_id = storage
         .store_message(&archive, &different_sender)
         .await
@@ -217,8 +242,9 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
 
     assert_eq!(retry_id, first_id);
     assert_eq!(different_recipient_id, "dm-different-recipient");
+    assert_eq!(distinct_body_id, "dm-distinct-body");
     assert_eq!(different_sender_id, "dm-other-sender");
-    assert_eq!(storage.count_messages(&archive).await.unwrap(), 3);
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 4);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Status

Ready for review. This continues the remaining #459 recovery plan by making fresh-session retry archive writes idempotent when they reuse stable XEP-0359 origin-id values, without letting origin-id become the authoritative archive reference or message identity.

## Completed

- Added shared typed MAM origin-id dedup predicate for SQL and in-memory storage.
- Deduplicates only within a scoped trusted sender context:
  - groupchat: same archive, same occupant JID, same nickname generation, same origin-id
  - direct chat/normal: same archive, same bare sender JID, same bare recipient JID, same origin-id
- Requires the projected MAM content to match before origin-id is treated as a retry key; reused origin-id with distinct content inserts a new row and keeps the fresh stanza-id.
- Returns the existing archive ID instead of inserting a duplicate retry row for exact retries.
- Rewrites later same-dispatch archive references to the retained MAM ID so inbox projections, offline payloads, carbons, routed stanzas, and serialized frames do not point at a skipped retry row.
- Adds SQLite/Postgres partial unique indexes over archive, sender scope, and content fingerprint, plus lookup-after-conflict so concurrent exact retry inserts converge on the retained archive row.
- The SQL dedup lookup now reads only the columns needed for the retry decision and skips malformed candidate rows instead of failing the write path.
- Preserves authoritative XEP-0313 archive IDs and server/room XEP-0359 stanza-id semantics.
- Added/updated regressions for direct-recipient scoping, distinct-content origin-id collisions, legacy SQLite schema migration, and downstream reference rewriting.

## XEP Notes

- XEP-0359 origin-id is sender-originated and spoofable, so this PR uses it only for scoped retry correlation.
- XEP-0313 archive IDs and server-assigned stanza-id values remain authoritative; this PR does not use origin-id as a MAM watermark or moderation/reaction/pin target.
- XEP-0313 requires server-assigned archive UIDs to be unique within the archive and XEP-0359 stanza-id by the archive entity to name that archive entry; same-dispatch rewrites keep those references aligned after exact retry dedup.
- No wire-shape changes and no out-of-band API.

## Tests

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p waddle-xmpp --features test-utils mam::storage::tests`
- `cargo test -p waddle-xmpp --features test-utils`
- `cargo test -p waddle-server origin_id_`
- `cargo test -p waddle-server --test xep0313_mam_integration`
- `cargo test -p waddle-server --test xmpp_e2e_cue`
- `cargo clippy -p waddle-xmpp --features test-utils --tests -- -D warnings`
- `cargo clippy -p waddle-server --tests -- -D warnings`

Related: #459