### PR TITLE
fix(chat): reconcile reconnect gaps from mam watermarks

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -23,6 +23,7 @@ import type {
   LiveRoomMessage,
   MamHistoryPage,
   MamPageParam,
+  MamThreadPageParam,
   MessageSearchResult,
   PresenceUpdateEvent,
   ReactionEvent,
@@ -96,6 +97,61 @@ function roomActivityEventFromMessage(message: LiveRoomMessage): RoomActivityEve
   if (message.mentions) activity.mentions = message.mentions;
   if (message.broadcastMention) activity.broadcastMention = message.broadcastMention;
   return activity;
+}
+
+function isMamPageComplete(page: WasmMamPage | null | undefined): boolean {
+  const compat = page as (WasmMamPage & { complete?: boolean }) | null | undefined;
+  return !!(compat?.is_complete ?? compat?.complete);
+}
+
+function pageLastArchiveId(page: WasmMamPage | null | undefined): string | undefined {
+  const compat = page as (WasmMamPage & { lastArchiveId?: string }) | null | undefined;
+  return compat?.last_id ?? compat?.lastArchiveId;
+}
+
+function pageFirstArchiveId(page: WasmMamPage | null | undefined): string | undefined {
+  const compat = page as (WasmMamPage & { firstArchiveId?: string }) | null | undefined;
+  return compat?.first_id ?? compat?.firstArchiveId;
+}
+
+function compareTimestamps(left: string, right: string): number {
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (Number.isFinite(leftMs) && Number.isFinite(rightMs)) {
+    return leftMs === rightMs ? 0 : leftMs < rightMs ? -1 : 1;
+  }
+  return left.localeCompare(right);
+}
+
+function pageCrossesSince(page: WasmMamPage | null | undefined, since: string): boolean {
+  return (page?.messages ?? []).some((message) => typeof message.timestamp === "string" && compareTimestamps(message.timestamp, since) < 0);
+}
+
+function messageSeenIds(message: Pick<LiveDmMessage | LiveRoomMessage, "id" | "wireIds">): string[] {
+  return Array.from(new Set([message.id, ...(message.wireIds ?? [])].filter(Boolean)));
+}
+
+function rawMessageSeenIds(message: WasmMessage): string[] {
+  return Array.from(new Set([
+    message.id,
+    message.origin_id,
+    message.stanza_id,
+    ...(message.stanza_ids?.map((stanzaId) => stanzaId.id) ?? []),
+  ].filter((value): value is string => !!value)));
+}
+
+function shouldSkipCatchupMessage(
+  message: Pick<LiveDmMessage | LiveRoomMessage, "createdAt" | "id" | "wireIds">,
+  since?: string,
+  seenIds?: ReadonlyArray<string>,
+): boolean {
+  const seen = new Set(seenIds ?? []);
+  if (seen.size > 0 && messageSeenIds(message).some((id) => seen.has(id))) return true;
+  if (!since) return false;
+  const order = compareTimestamps(message.createdAt, since);
+  if (order < 0) return true;
+  if (order > 0) return false;
+  return false;
 }
 
 type WasmModule = typeof import("@waddle/xmpp-client-wasm");
@@ -830,15 +886,29 @@ export class BrowserXmppClient {
     const selfBare = barePeerJid(this.session.jid);
     return { messages: page.messages.map((message) => dmMessageFromArchived(message, selfBare)).filter((message): message is LiveDmMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
+  private recordRoomMamWatermarks(messages: ReadonlyArray<LiveRoomMessage>) {
+    for (const message of messages) {
+      this.catchup.recordRoomSeen(message.roomJid, message.createdAt, message.archiveId, messageSeenIds(message));
+    }
+  }
+  private recordDmMamWatermarks(messages: ReadonlyArray<LiveDmMessage>) {
+    for (const message of messages) {
+      this.catchup.recordDmSeen(message.peerJid, message.createdAt, message.archiveId, messageSeenIds(message));
+    }
+  }
 
   async queryMam(spaceId: string, channelId: string, max = 50): Promise<LiveRoomMessage[]> { const page = await this.queryMamPage(spaceId, channelId, max, { type: "latest" }); return page.messages; }
   async queryMamPage(spaceId: string, channelId: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
-    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_page?.(this.roomJidForChannel(channelId), max, pageParam) as WasmMamPage; return page ? this.roomMamPageToMessages(page) : { messages: [], complete: true };
+    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_page?.(this.roomJidForChannel(channelId), max, pageParam) as WasmMamPage;
+    if (!page) return { messages: [], complete: true };
+    const result = this.roomMamPageToMessages(page);
+    this.recordRoomMamWatermarks(result.messages);
+    return result;
   }
   async queryMamByThread(spaceId: string, channelId: string, threadId: string, max = 100): Promise<LiveRoomMessage[]> {
     await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, null) as WasmMamPage; return page ? this.roomMamPageToMessages(page).messages : [];
   }
-  async queryMamThreadPage(spaceId: string, channelId: string, threadId: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
+  async queryMamThreadPage(spaceId: string, channelId: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
     if (!threadId) return { messages: [], complete: true };
     await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage; return page ? this.roomMamPageToMessages(page) : { messages: [], complete: true };
   }
@@ -850,7 +920,13 @@ export class BrowserXmppClient {
     return parsed.filter((message) => !!message.body).map((message, index) => ({ id: message.id, ...(page?.messages[index]?.mam_id ? { archiveId: page.messages[index].mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), roomJid: message.roomJid }));
   }
   async queryPersonalMam(peerJid: string, max = 100): Promise<LiveDmMessage[]> { const page = await this.queryPersonalMamPage(peerJid, max, { type: "latest" }); return page.messages; }
-  async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> { const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_page?.(barePeerJid(peerJid), max, pageParam) as WasmMamPage; return page ? this.dmMamPageToMessages(page) : { messages: [], complete: true }; }
+  async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
+    const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_dm_history_page?.(barePeerJid(peerJid), max, pageParam) as WasmMamPage;
+    if (!page) return { messages: [], complete: true };
+    const result = this.dmMamPageToMessages(page);
+    this.recordDmMamWatermarks(result.messages);
+    return result;
+  }
   async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
     const xmpp = await this.requireConnectedXmpp();
@@ -903,7 +979,7 @@ export class BrowserXmppClient {
     this.emitStatus({ state: "online", detail: countQueuedMessages(this.queueScope) > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
     const catchupEntries = this.catchup.onSessionStarted();
     if (lifecycle.type === "fresh") { this.inflightQueuedIds.clear(); void this.enableCarbons(xmpp); }
-    else if (catchupEntries.length > 0) { void this.runReconnectCatchup(xmpp, catchupEntries); }
+    if (catchupEntries.length > 0) { void this.runReconnectCatchup(xmpp, catchupEntries); }
     this.emitSessionLifecycle(lifecycle); void this.flushQueuedDirectMessages(); if (this.currentRoom) void this.flushQueuedRoomMessages(this.currentRoom);
     if (this.onceConnected) { const done = this.onceConnected; this.onceConnected = null; this.onceConnectFailed = null; done(); }
   }
@@ -951,47 +1027,27 @@ export class BrowserXmppClient {
     if (message.is_muc) {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage);
       if (!converted) return;
-      this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt);
+      this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.activityHandler?.(roomActivityEventFromMessage(converted)); return; }
       this.messageHandler?.(converted); return;
     }
     const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid));
     if (converted) {
-      this.catchup.recordDmSeen(converted.peerJid, converted.createdAt);
+      this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       this.directMessageHandler?.(converted);
     }
   }
   private async runReconnectCatchup(
     xmpp: XmppClientInstance,
-    entries: Array<{ kind: "dm" | "room"; key: string }>,
+    entries: Array<{ kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] }>,
   ) {
     for (const entry of entries) {
       if (this.xmpp !== xmpp) return;
       try {
         if (entry.kind === "dm") {
-          const since = this.catchup.getDmLastSeen(entry.key);
-          if (!since || !xmpp.fetch_dm_history_page) continue;
-          const page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "latest" }) as WasmMamPage;
-          for (const message of page?.messages ?? []) {
-            const converted = dmMessageFromArchived(message, barePeerJid(this.session.jid));
-            if (!converted || converted.createdAt <= since) continue;
-            this.catchup.recordDmSeen(converted.peerJid, converted.createdAt);
-            this.directMessageHandler?.(converted);
-          }
+          await this.runDmReconnectCatchup(xmpp, entry);
         } else {
-          const since = this.catchup.getRoomLastSeen(entry.key);
-          if (!since || !xmpp.fetch_room_history_page) continue;
-          const page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "latest" }) as WasmMamPage;
-          for (const message of page?.messages ?? []) {
-            const converted = roomMessageFromArchived(message);
-            if (!converted || converted.createdAt <= since) continue;
-            this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt);
-            if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) {
-              this.activityHandler?.(roomActivityEventFromMessage(converted));
-            } else {
-              this.messageHandler?.(converted);
-            }
-          }
+          await this.runRoomReconnectCatchup(xmpp, entry);
         }
       } catch (error) {
         this.emitError({
@@ -1002,6 +1058,102 @@ export class BrowserXmppClient {
         });
       }
     }
+  }
+  private async runDmReconnectCatchup(
+    xmpp: XmppClientInstance,
+    entry: { key: string; after?: string; since?: string; seenIds?: string[] },
+  ) {
+    if (!xmpp.fetch_dm_history_page) return;
+    if (entry.after) {
+      let after: string | undefined = entry.after;
+      for (let guard = 0; after && guard < 50; guard += 1) {
+        const page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds);
+        if (isMamPageComplete(page) || !nextAfter || nextAfter === after) return;
+        after = nextAfter;
+      }
+      return;
+    }
+    const since = entry.since ?? this.catchup.getDmLastSeen(entry.key);
+    if (!since) return;
+    await this.runDmTimestampCatchup(xmpp, entry.key, since, entry.seenIds);
+  }
+  private async runRoomReconnectCatchup(
+    xmpp: XmppClientInstance,
+    entry: { key: string; after?: string; since?: string; seenIds?: string[] },
+  ) {
+    if (!xmpp.fetch_room_history_page) return;
+    if (entry.after) {
+      let after: string | undefined = entry.after;
+      for (let guard = 0; after && guard < 50; guard += 1) {
+        const page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
+        const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds);
+        if (isMamPageComplete(page) || !nextAfter || nextAfter === after) return;
+        after = nextAfter;
+      }
+      return;
+    }
+    const since = entry.since ?? this.catchup.getRoomLastSeen(entry.key);
+    if (!since) return;
+    await this.runRoomTimestampCatchup(xmpp, entry.key, since, entry.seenIds);
+  }
+  private async runDmTimestampCatchup(
+    xmpp: XmppClientInstance,
+    peerJid: string,
+    since: string,
+    seenIds?: ReadonlyArray<string>,
+  ) {
+    let pageParam: MamPageParam = { type: "latest" };
+    for (let guard = 0; guard < 50; guard += 1) {
+      const page = await xmpp.fetch_dm_history_page?.(peerJid, 100, pageParam) as WasmMamPage;
+      this.applyDmCatchupPage(page, since, seenIds);
+      if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
+      const firstArchiveId = pageFirstArchiveId(page);
+      if (!firstArchiveId || pageParam.type === "before" && pageParam.before === firstArchiveId) return;
+      pageParam = { type: "before", before: firstArchiveId };
+    }
+  }
+  private async runRoomTimestampCatchup(
+    xmpp: XmppClientInstance,
+    roomJid: string,
+    since: string,
+    seenIds?: ReadonlyArray<string>,
+  ) {
+    let pageParam: MamPageParam = { type: "latest" };
+    for (let guard = 0; guard < 50; guard += 1) {
+      const page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam) as WasmMamPage;
+      this.applyRoomCatchupPage(page, since, seenIds);
+      if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
+      const firstArchiveId = pageFirstArchiveId(page);
+      if (!firstArchiveId || pageParam.type === "before" && pageParam.before === firstArchiveId) return;
+      pageParam = { type: "before", before: firstArchiveId };
+    }
+  }
+  private applyDmCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
+    let lastArchiveId = pageLastArchiveId(page);
+    for (const message of page?.messages ?? []) {
+      const converted = dmMessageFromArchived(message, barePeerJid(this.session.jid));
+      if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
+      this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
+      this.directMessageHandler?.(converted);
+      lastArchiveId = converted.archiveId ?? lastArchiveId;
+    }
+    return lastArchiveId;
+  }
+  private applyRoomCatchupPage(page: WasmMamPage | null | undefined, since?: string, seenIds?: ReadonlyArray<string>): string | undefined {
+    let lastArchiveId = pageLastArchiveId(page);
+    for (const message of page?.messages ?? []) {
+      const converted = roomMessageFromArchived(message);
+      if (!converted || shouldSkipCatchupMessage(converted, since, seenIds)) continue;
+      this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
+      if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) {
+        this.activityHandler?.(roomActivityEventFromMessage(converted));
+      } else {
+        this.messageHandler?.(converted);
+      }
+      lastArchiveId = converted.archiveId ?? lastArchiveId;
+    }
+    return lastArchiveId;
   }
   private wireEvents(xmpp: XmppClientInstance & { enableKeepAlive?: (opts: { interval: number; timeout: number }) => void; disableKeepAlive?: () => void }) {
     xmpp.set_on_connected?.(() => { if (this.xmpp !== xmpp) return; void this.enableCarbons(xmpp); });

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -906,11 +906,19 @@ export class BrowserXmppClient {
     return result;
   }
   async queryMamByThread(spaceId: string, channelId: string, threadId: string, max = 100): Promise<LiveRoomMessage[]> {
-    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, null) as WasmMamPage; return page ? this.roomMamPageToMessages(page).messages : [];
+    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, null) as WasmMamPage;
+    if (!page) return [];
+    const result = this.roomMamPageToMessages(page);
+    this.recordRoomMamWatermarks(result.messages);
+    return result.messages;
   }
   async queryMamThreadPage(spaceId: string, channelId: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> {
     if (!threadId) return { messages: [], complete: true };
-    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage; return page ? this.roomMamPageToMessages(page) : { messages: [], complete: true };
+    await this.connect(); await this.switchRoom(spaceId, channelId); const xmpp = await this.requireConnectedXmpp(); const page = await xmpp.fetch_room_history_by_thread?.(this.roomJidForChannel(channelId), threadId, max, pageParam.type === "before" ? pageParam.before : null) as WasmMamPage;
+    if (!page) return { messages: [], complete: true };
+    const result = this.roomMamPageToMessages(page);
+    this.recordRoomMamWatermarks(result.messages);
+    return result;
   }
   async searchMessages(_spaceId: string, channelId: string, query: string, max = 20): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
@@ -1066,10 +1074,14 @@ export class BrowserXmppClient {
     if (!xmpp.fetch_dm_history_page) return;
     if (entry.after) {
       let after: string | undefined = entry.after;
-      for (let guard = 0; after && guard < 50; guard += 1) {
+      const seenAfter = new Set<string>();
+      while (after) {
+        if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
+        seenAfter.add(after);
         const page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
         const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds);
-        if (isMamPageComplete(page) || !nextAfter || nextAfter === after) return;
+        if (isMamPageComplete(page)) return;
+        if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
       }
       return;
@@ -1085,10 +1097,14 @@ export class BrowserXmppClient {
     if (!xmpp.fetch_room_history_page) return;
     if (entry.after) {
       let after: string | undefined = entry.after;
-      for (let guard = 0; after && guard < 50; guard += 1) {
+      const seenAfter = new Set<string>();
+      while (after) {
+        if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
+        seenAfter.add(after);
         const page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after }) as WasmMamPage;
         const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds);
-        if (isMamPageComplete(page) || !nextAfter || nextAfter === after) return;
+        if (isMamPageComplete(page)) return;
+        if (!nextAfter) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
       }
       return;
@@ -1104,12 +1120,15 @@ export class BrowserXmppClient {
     seenIds?: ReadonlyArray<string>,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
-    for (let guard = 0; guard < 50; guard += 1) {
+    const seenBefore = new Set<string>();
+    while (true) {
       const page = await xmpp.fetch_dm_history_page?.(peerJid, 100, pageParam) as WasmMamPage;
       this.applyDmCatchupPage(page, since, seenIds);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
       const firstArchiveId = pageFirstArchiveId(page);
-      if (!firstArchiveId || pageParam.type === "before" && pageParam.before === firstArchiveId) return;
+      if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${peerJid}`);
+      if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${peerJid}`);
+      seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
   }
@@ -1120,12 +1139,15 @@ export class BrowserXmppClient {
     seenIds?: ReadonlyArray<string>,
   ) {
     let pageParam: MamPageParam = { type: "latest" };
-    for (let guard = 0; guard < 50; guard += 1) {
+    const seenBefore = new Set<string>();
+    while (true) {
       const page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam) as WasmMamPage;
       this.applyRoomCatchupPage(page, since, seenIds);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) return;
       const firstArchiveId = pageFirstArchiveId(page);
-      if (!firstArchiveId || pageParam.type === "before" && pageParam.before === firstArchiveId) return;
+      if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${roomJid}`);
+      if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${roomJid}`);
+      seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
   }

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -10,7 +10,8 @@
  *      conversation (DM peer bare JID or MUC room bare JID).
  *   2. Distinguish the very first `session:started` (initial login — nothing
  *      to catch up on) from subsequent ones (resume — catch up on all
- *      tracked conversations via `MAM start=lastSeen`).
+ *      tracked conversations via XEP-0059 `after` when an archive UID is
+ *      known, or a timestamp fallback for conversations seen only live).
  *
  * DM peers and rooms are tracked in separate namespaces so the two can never
  * collide even if a bare JID were somehow valid in both worlds.
@@ -19,12 +20,18 @@
  * zero state of its own and the logic is trivially testable.
  */
 type CatchupEntry =
-  | { kind: "dm"; key: string }
-  | { kind: "room"; key: string };
+  | { kind: "dm"; key: string; after?: string; since?: string; seenIds?: string[] }
+  | { kind: "room"; key: string; after?: string; since?: string; seenIds?: string[] };
+
+type SeenCursor = {
+  timestamp: string;
+  archiveId?: string;
+  seenIds?: string[];
+};
 
 export class ReconnectCatchup {
-  private readonly dmLastSeen = new Map<string, string>();
-  private readonly roomLastSeen = new Map<string, string>();
+  private readonly dmLastSeen = new Map<string, SeenCursor>();
+  private readonly roomLastSeen = new Map<string, SeenCursor>();
   private sessionStartedOnce = false;
 
   /**
@@ -32,21 +39,21 @@ export class ReconnectCatchup {
    * advances the cursor — out-of-order or older arrivals are ignored so the
    * next catch-up can't re-pull already-applied messages.
    */
-  recordDmSeen(peerBareJid: string, timestamp: string): void {
-    advance(this.dmLastSeen, peerBareJid, timestamp);
+  recordDmSeen(peerBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>): void {
+    advance(this.dmLastSeen, peerBareJid, timestamp, archiveId, seenIds);
   }
 
   /** As `recordDmSeen`, but for a MUC room JID. */
-  recordRoomSeen(roomBareJid: string, timestamp: string): void {
-    advance(this.roomLastSeen, roomBareJid, timestamp);
+  recordRoomSeen(roomBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>): void {
+    advance(this.roomLastSeen, roomBareJid, timestamp, archiveId, seenIds);
   }
 
   getDmLastSeen(peerBareJid: string): string | undefined {
-    return this.dmLastSeen.get(peerBareJid);
+    return this.dmLastSeen.get(peerBareJid)?.timestamp;
   }
 
   getRoomLastSeen(roomBareJid: string): string | undefined {
-    return this.roomLastSeen.get(roomBareJid);
+    return this.roomLastSeen.get(roomBareJid)?.timestamp;
   }
 
   /**
@@ -61,8 +68,12 @@ export class ReconnectCatchup {
       return [];
     }
     const entries: CatchupEntry[] = [];
-    for (const key of this.dmLastSeen.keys()) entries.push({ kind: "dm", key });
-    for (const key of this.roomLastSeen.keys()) entries.push({ kind: "room", key });
+    for (const [key, cursor] of this.dmLastSeen) {
+      entries.push(catchupEntry("dm", key, cursor));
+    }
+    for (const [key, cursor] of this.roomLastSeen) {
+      entries.push(catchupEntry("room", key, cursor));
+    }
     return entries;
   }
 
@@ -74,9 +85,76 @@ export class ReconnectCatchup {
   }
 }
 
-function advance(map: Map<string, string>, key: string, timestamp: string): void {
-  const current = map.get(key);
-  if (current === undefined || timestamp > current) {
-    map.set(key, timestamp);
+function catchupEntry(kind: "dm", key: string, cursor: SeenCursor): CatchupEntry;
+function catchupEntry(kind: "room", key: string, cursor: SeenCursor): CatchupEntry;
+function catchupEntry(kind: "dm" | "room", key: string, cursor: SeenCursor): CatchupEntry {
+  if (!cursor.archiveId) {
+    return {
+      kind,
+      key,
+      since: cursor.timestamp,
+      ...(cursor.seenIds?.length ? { seenIds: cursor.seenIds } : {}),
+    };
   }
+  return {
+    kind,
+    key,
+    after: cursor.archiveId,
+    ...(cursor.seenIds?.length ? { seenIds: cursor.seenIds } : {}),
+  };
+}
+
+function advance(
+  map: Map<string, SeenCursor>,
+  key: string,
+  timestamp: string,
+  archiveId?: string,
+  seenIds?: ReadonlyArray<string>,
+): void {
+  const normalizedTimestamp = normalizeTimestamp(timestamp);
+  const current = map.get(key);
+  const ordering = current ? compareTimestamps(normalizedTimestamp, current.timestamp) : 1;
+  if (current === undefined || ordering > 0) {
+    const nextArchiveId = archiveId ?? current?.archiveId;
+    map.set(key, {
+      timestamp: normalizedTimestamp,
+      ...(nextArchiveId ? { archiveId: nextArchiveId } : {}),
+      ...nonEmptySeenIds(seenIds),
+    });
+    return;
+  }
+  if (ordering === 0) {
+    const nextSeenIds = mergeSeenIds(current.seenIds, seenIds);
+    map.set(key, {
+      ...current,
+      ...(archiveId ? { archiveId } : {}),
+      ...nonEmptySeenIds(nextSeenIds),
+    });
+  }
+}
+
+function nonEmptySeenIds(seenIds: ReadonlyArray<string> | undefined): Partial<Pick<SeenCursor, "seenIds">> {
+  const normalized = mergeSeenIds(undefined, seenIds);
+  return normalized.length > 0 ? { seenIds: normalized } : {};
+}
+
+function mergeSeenIds(
+  current: ReadonlyArray<string> | undefined,
+  next: ReadonlyArray<string> | undefined,
+): string[] {
+  return Array.from(new Set([...(current ?? []), ...(next ?? [])].filter(Boolean)));
+}
+
+function normalizeTimestamp(timestamp: string): string {
+  const timestampMs = Date.parse(timestamp);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs).toISOString() : timestamp;
+}
+
+function compareTimestamps(left: string, right: string): number {
+  const leftMs = Date.parse(left);
+  const rightMs = Date.parse(right);
+  if (Number.isFinite(leftMs) && Number.isFinite(rightMs)) {
+    return leftMs === rightMs ? 0 : leftMs < rightMs ? -1 : 1;
+  }
+  return left.localeCompare(right);
 }

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -20,6 +20,11 @@ export type SessionLifecycleEvent = { type: "resumed" } | { type: "fresh" };
 
 export type MamPageParam =
   | { type: "latest" }
+  | { type: "before"; before: string }
+  | { type: "after"; after: string };
+
+export type MamThreadPageParam =
+  | { type: "latest" }
   | { type: "before"; before: string };
 
 export interface MamHistoryPage<T> {
@@ -87,6 +92,8 @@ export interface ReplyPreview {
 
 export interface LiveRoomMessage {
   id: string;
+  /** XEP-0313 archive UID from the MAM result envelope, when known. */
+  archiveId?: string;
   wireIds?: string[];
   /** XEP-0308 correction target: original sender message id/origin-id. */
   correctionTargetId?: string;
@@ -153,6 +160,8 @@ export interface LiveRoomMessage {
 /** A direct message received/sent via type:"chat" stanzas */
 export interface LiveDmMessage {
   id: string;
+  /** XEP-0313 archive UID from the MAM result envelope, when known. */
+  archiveId?: string;
   wireIds?: string[];
   /** XEP-0308 correction target: original sender message id/origin-id. */
   correctionTargetId?: string;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -276,6 +276,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
   if (activeRetractionTarget) {
     return {
       id: roomPrimaryId,
+      archiveId: message.mam_id,
       fromJid,
       roomJid,
       nick,
@@ -293,6 +294,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
   if (message.reaction_target_id) {
     return {
       id: roomPrimaryId,
+      archiveId: message.mam_id,
       roomJid,
       nick,
       body: "",
@@ -309,6 +311,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
   if (message.pin_event) {
     return {
       id: message.id ?? message.stanza_id ?? message.mam_id,
+      archiveId: message.mam_id,
       roomJid,
       nick: "",
       body: message.body ?? "",
@@ -327,6 +330,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
   }
   const base: LiveRoomMessage = {
     id: roomPrimaryId,
+    archiveId: message.mam_id,
     fromJid,
     roomJid,
     nick,
@@ -380,6 +384,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
   if (message.retracts_id) {
     return {
       id: dmPrimaryId,
+      archiveId: message.mam_id,
       peerJid,
       fromJid,
       nick,
@@ -393,6 +398,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
   if (message.reaction_target_id) {
     return {
       id: dmPrimaryId,
+      archiveId: message.mam_id,
       peerJid,
       fromJid,
       nick,
@@ -413,6 +419,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
   if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.thread && !message.is_retracted) return null;
   const base: LiveDmMessage = {
     id: dmPrimaryId,
+    archiveId: message.mam_id,
     peerJid,
     fromJid,
     nick,

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -60,6 +60,21 @@ function roomWasmMessage(partial: Record<string, unknown> = {}) {
   };
 }
 
+function dmWasmMessage(partial: Record<string, unknown> = {}) {
+  return {
+    mam_id: "mam-dm-1",
+    id: "dm-1",
+    from: "bob@example.com/phone",
+    to: "alice@example.com/desktop",
+    message_type: "chat",
+    body: "hello from dm",
+    timestamp: "2024-01-01T00:00:01.000Z",
+    reaction_emojis: [],
+    shared_files: [],
+    ...partial,
+  };
+}
+
 function dmMessage(partial: Partial<LiveDmMessage> = {}): LiveDmMessage {
   return {
     id: "dm-1",
@@ -73,8 +88,8 @@ function dmMessage(partial: Partial<LiveDmMessage> = {}): LiveDmMessage {
   };
 }
 
-async function settleReconnectCatchup(): Promise<void> {
-  for (let i = 0; i < 6; i += 1) await Promise.resolve();
+async function settleReconnectCatchup(turns = 6): Promise<void> {
+  for (let i = 0; i < turns; i += 1) await Promise.resolve();
 }
 
 const originalWindow = globalThis.window;
@@ -644,6 +659,53 @@ describe("client keepalive lifecycle", () => {
     expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-same-time-missed" }));
   });
 
+  test("timestamp fallback continues beyond fifty pages until it crosses the last seen timestamp", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", undefined, ["dm-seen"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    const newestIndex = 51;
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string; before?: string }) => {
+      const index = pageParam.type === "latest"
+        ? newestIndex
+        : Number(pageParam.before?.replace("mam-", "") ?? "1") - 1;
+      return {
+        messages: [dmWasmMessage({
+          mam_id: `mam-${index}`,
+          id: `dm-${index}`,
+          body: index === 0 ? "older than boundary" : `missed page ${index}`,
+          timestamp: index === 0
+            ? "2023-12-31T23:59:59.000Z"
+            : new Date(Date.UTC(2024, 0, 1, 0, 0, index)).toISOString(),
+        })],
+        first_id: `mam-${index}`,
+        last_id: `mam-${index}`,
+        is_complete: false,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup(newestIndex + 20);
+
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(newestIndex + 1);
+    expect(dmHandler).toHaveBeenCalledTimes(newestIndex);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-1" }));
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-51" }));
+  });
+
   test("stale archive cursor catch-up filters live messages already seen after that cursor", async () => {
     const client = new BrowserXmppClient(session());
     const catchup = (client as unknown as {
@@ -805,6 +867,51 @@ describe("client keepalive lifecycle", () => {
     expect(dmHandler).toHaveBeenCalledTimes(2);
   });
 
+  test("pages tracked DM catch-up forward beyond fifty pages until MAM is complete", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", "mam-0");
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    const finalPage = 51;
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string; after?: string }) => {
+      const index = Number(pageParam.after?.replace("mam-", "") ?? "0") + 1;
+      return {
+        messages: [dmWasmMessage({
+          mam_id: `mam-${index}`,
+          id: `dm-${index}`,
+          body: `missed page ${index}`,
+          timestamp: new Date(Date.UTC(2024, 0, 1, 0, 0, index)).toISOString(),
+        })],
+        last_id: `mam-${index}`,
+        is_complete: index === finalPage,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup(finalPage + 20);
+
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(finalPage);
+    expect(fetchDmHistoryPage).toHaveBeenLastCalledWith("bob@example.com", 100, {
+      type: "after",
+      after: "mam-50",
+    });
+    expect(dmHandler).toHaveBeenCalledTimes(finalPage);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-51" }));
+  });
+
   test("queryPersonalMamPage seeds reconnect catch-up from XEP-0313 archive ids", async () => {
     const client = new BrowserXmppClient(session());
     (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
@@ -833,6 +940,68 @@ describe("client keepalive lifecycle", () => {
 
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
       { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", seenIds: ["dm-loaded-1"] },
+    ]);
+  });
+
+  test("queryMamThreadPage seeds room reconnect catch-up from XEP-0313 archive ids", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
+    const fetchRoomHistoryByThread = mock(async () => ({
+      messages: [roomWasmMessage({
+        mam_id: "mam-thread-1",
+        id: "room-thread-1",
+        from: `${roomJid}/bob`,
+        body: "thread history",
+        timestamp: "2024-01-01T00:00:01.000Z",
+        thread: "thread-1",
+      })],
+      last_id: "mam-thread-1",
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_by_thread: fetchRoomHistoryByThread,
+    }) as unknown as Agent;
+
+    await client.queryMamThreadPage("w1", "c1", "thread-1", 100, { type: "latest" });
+
+    expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
+    expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
+      { kind: "room", key: roomJid, after: "mam-thread-1", seenIds: ["room-thread-1"] },
+    ]);
+  });
+
+  test("queryMamByThread seeds room reconnect catch-up from XEP-0313 archive ids", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
+    const fetchRoomHistoryByThread = mock(async () => ({
+      messages: [roomWasmMessage({
+        mam_id: "mam-thread-list-1",
+        id: "room-thread-list-1",
+        from: `${roomJid}/bob`,
+        body: "thread list history",
+        timestamp: "2024-01-01T00:00:01.000Z",
+        thread: "thread-1",
+      })],
+      last_id: "mam-thread-list-1",
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_by_thread: fetchRoomHistoryByThread,
+    }) as unknown as Agent;
+
+    await client.queryMamByThread("w1", "c1", "thread-1", 100);
+
+    expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
+    expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
+      { kind: "room", key: roomJid, after: "mam-thread-list-1", seenIds: ["room-thread-list-1"] },
     ]);
   });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -73,6 +73,10 @@ function dmMessage(partial: Partial<LiveDmMessage> = {}): LiveDmMessage {
   };
 }
 
+async function settleReconnectCatchup(): Promise<void> {
+  for (let i = 0; i < 6; i += 1) await Promise.resolve();
+}
+
 const originalWindow = globalThis.window;
 const originalLocalStorage = globalThis.localStorage;
 
@@ -418,6 +422,735 @@ describe("client keepalive lifecycle", () => {
       id: "dm-2",
       body: "missed while suspended",
       peerJid: "bob@example.com",
+    }));
+  });
+
+  test("runs tracked catch-up on subsequent fresh session starts", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", undefined, ["dm-already-seen"]);
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [{
+        mam_id: "mam-fresh-2",
+        id: "dm-fresh-2",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/desktop",
+        message_type: "chat",
+        body: "fresh reconnect catch-up",
+        timestamp: "2024-01-01T00:00:01.000Z",
+        reaction_emojis: [],
+        shared_files: [],
+      }],
+      is_complete: true,
+    }));
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("session:started");
+    await settleReconnectCatchup();
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(0);
+
+    xmpp.emit("session:started");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(1);
+    expect(fetchDmHistoryPage).toHaveBeenCalledWith("bob@example.com", 100, { type: "latest" });
+  });
+
+  test("timestamp fallback catch-up skips already-seen messages and learns archive ids", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", undefined, ["dm-already-seen"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [
+        {
+          mam_id: "mam-already-seen",
+          id: "dm-already-seen",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "already seen",
+          timestamp: "2024-01-01T01:00:00+01:00",
+          reaction_emojis: [],
+          shared_files: [],
+        },
+        {
+          mam_id: "mam-newer",
+          id: "dm-newer",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "newer missed message",
+          timestamp: "2024-01-01T00:00:01.000Z",
+          reaction_emojis: [],
+          shared_files: [],
+        },
+      ],
+      last_id: "mam-newer",
+      is_complete: true,
+    }));
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(dmHandler).toHaveBeenCalledTimes(1);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-newer",
+      body: "newer missed message",
+      peerJid: "bob@example.com",
+    }));
+    expect(catchup.onSessionStarted()).toEqual([
+      { kind: "dm", key: "bob@example.com", after: "mam-newer", seenIds: ["dm-newer"] },
+    ]);
+  });
+
+  test("timestamp fallback pages backward until it crosses the last seen timestamp", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", undefined, ["dm-seen"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string; before?: string }) => {
+      if (pageParam.type === "latest") {
+        return {
+          messages: [{
+            mam_id: "mam-newer-2",
+            id: "dm-newer-2",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            message_type: "chat",
+            body: "newest missed message",
+            timestamp: "2024-01-01T00:00:03.000Z",
+            reaction_emojis: [],
+            shared_files: [],
+          }],
+          first_id: "mam-newer-2",
+          last_id: "mam-newer-2",
+          is_complete: false,
+        };
+      }
+      if (pageParam.before === "mam-newer-2") {
+        return {
+          messages: [
+            {
+              mam_id: "mam-same-time-missed",
+              id: "dm-same-time-missed",
+              from: "bob@example.com/phone",
+              to: "alice@example.com/desktop",
+              message_type: "chat",
+              body: "same timestamp missed message",
+              timestamp: "2024-01-01T00:00:00.000Z",
+              reaction_emojis: [],
+              shared_files: [],
+            },
+            {
+              mam_id: "mam-seen",
+              id: "dm-seen",
+              from: "bob@example.com/phone",
+              to: "alice@example.com/desktop",
+              message_type: "chat",
+              body: "seen boundary",
+              timestamp: "2024-01-01T00:00:00.000Z",
+              reaction_emojis: [],
+              shared_files: [],
+            },
+            {
+              mam_id: "mam-newer-1",
+              id: "dm-newer-1",
+              from: "bob@example.com/phone",
+              to: "alice@example.com/desktop",
+              message_type: "chat",
+              body: "older missed message beyond first page",
+              timestamp: "2024-01-01T00:00:02.000Z",
+              reaction_emojis: [],
+              shared_files: [],
+            },
+          ],
+          first_id: "mam-same-time-missed",
+          last_id: "mam-newer-1",
+          is_complete: false,
+        };
+      }
+      return {
+        messages: [
+          {
+            mam_id: "mam-older-than-boundary",
+            id: "dm-older-than-boundary",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            message_type: "chat",
+            body: "older than boundary",
+            timestamp: "2023-12-31T23:59:59.000Z",
+            reaction_emojis: [],
+            shared_files: [],
+          },
+        ],
+        first_id: "mam-older-than-boundary",
+        last_id: "mam-newer-1",
+        is_complete: false,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(1, "bob@example.com", 100, { type: "latest" });
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(2, "bob@example.com", 100, {
+      type: "before",
+      before: "mam-newer-2",
+    });
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(3, "bob@example.com", 100, {
+      type: "before",
+      before: "mam-same-time-missed",
+    });
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(3);
+    expect(dmHandler).toHaveBeenCalledTimes(3);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-newer-2" }));
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-newer-1" }));
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-same-time-missed" }));
+  });
+
+  test("stale archive cursor catch-up filters live messages already seen after that cursor", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", "mam-1");
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:01.000Z", undefined, ["dm-live-already-seen"]);
+    catchup.onSessionStarted();
+    const dmHandler = mock(() => undefined);
+    client.setDirectMessageHandler(dmHandler);
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [
+        {
+          mam_id: "mam-between-archive-and-live",
+          id: "dm-between-archive-and-live",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "missed between archived cursor and live watermark",
+          timestamp: "2024-01-01T00:00:00.500Z",
+          reaction_emojis: [],
+          shared_files: [],
+        },
+        {
+          mam_id: "mam-2",
+          id: "dm-live-already-seen",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "already seen live",
+          timestamp: "2024-01-01T00:00:01.000Z",
+          reaction_emojis: [],
+          shared_files: [],
+        },
+        {
+          mam_id: "mam-3",
+          id: "dm-actually-missed",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "actually missed",
+          timestamp: "2024-01-01T00:00:02.000Z",
+          reaction_emojis: [],
+          shared_files: [],
+        },
+      ],
+      last_id: "mam-3",
+      is_complete: true,
+    }));
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchDmHistoryPage).toHaveBeenCalledWith("bob@example.com", 100, {
+      type: "after",
+      after: "mam-1",
+    });
+    expect(dmHandler).toHaveBeenCalledTimes(2);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-between-archive-and-live",
+      body: "missed between archived cursor and live watermark",
+    }));
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-actually-missed",
+      body: "actually missed",
+    }));
+  });
+
+  test("pages tracked DM catch-up forward from the last MAM archive id", async () => {
+    const client = new BrowserXmppClient(session());
+    const catchup = (client as unknown as {
+      catchup: {
+        recordDmSeen: (peer: string, ts: string, archiveId?: string) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordDmSeen("bob@example.com", "2024-01-01T00:00:00.000Z", "mam-1");
+    catchup.onSessionStarted();
+    let resolveSecondCatchup: () => void = () => undefined;
+    const secondCatchupHandled = new Promise<void>((resolve) => {
+      resolveSecondCatchup = resolve;
+    });
+    const dmHandler = mock((message: LiveDmMessage) => {
+      if (message.id === "dm-3") resolveSecondCatchup();
+    });
+    client.setDirectMessageHandler(dmHandler);
+    const fetchDmHistoryPage = mock(async (_peer: string, _max: number, pageParam: { type: string; after?: string }) => {
+      if (pageParam.after === "mam-1") {
+        return {
+          messages: [{
+            mam_id: "mam-2",
+            id: "dm-2",
+            from: "bob@example.com/phone",
+            to: "alice@example.com/desktop",
+            message_type: "chat",
+            body: "first missed page",
+            timestamp: "2024-01-01T00:00:01.000Z",
+            reaction_emojis: [],
+            shared_files: [],
+          }],
+          last_id: "mam-2",
+          is_complete: false,
+        };
+      }
+      return {
+        messages: [{
+          mam_id: "mam-3",
+          id: "dm-3",
+          from: "bob@example.com/phone",
+          to: "alice@example.com/desktop",
+          message_type: "chat",
+          body: "second missed page",
+          timestamp: "2024-01-01T00:00:02.000Z",
+          reaction_emojis: [],
+          shared_files: [],
+        }],
+        last_id: "mam-3",
+        is_complete: true,
+      };
+    });
+
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await secondCatchupHandled;
+
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(1, "bob@example.com", 100, {
+      type: "after",
+      after: "mam-1",
+    });
+    expect(fetchDmHistoryPage).toHaveBeenNthCalledWith(2, "bob@example.com", 100, {
+      type: "after",
+      after: "mam-2",
+    });
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(2);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-2",
+      body: "first missed page",
+      peerJid: "bob@example.com",
+    }));
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "dm-3",
+      body: "second missed page",
+      peerJid: "bob@example.com",
+    }));
+    expect(dmHandler).toHaveBeenCalledTimes(2);
+  });
+
+  test("queryPersonalMamPage seeds reconnect catch-up from XEP-0313 archive ids", async () => {
+    const client = new BrowserXmppClient(session());
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
+    const fetchDmHistoryPage = mock(async () => ({
+      messages: [{
+        mam_id: "mam-loaded-1",
+        id: "dm-loaded-1",
+        from: "bob@example.com/phone",
+        to: "alice@example.com/desktop",
+        message_type: "chat",
+        body: "loaded from mam",
+        timestamp: "2024-01-01T00:00:01.000Z",
+        reaction_emojis: [],
+        shared_files: [],
+      }],
+      last_id: "mam-loaded-1",
+      is_complete: true,
+    }));
+    (client as unknown as { xmpp: Agent }).xmpp = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+
+    await client.queryPersonalMamPage("bob@example.com", 100, { type: "latest" });
+
+    expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
+      { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", seenIds: ["dm-loaded-1"] },
+    ]);
+  });
+
+  test("room timestamp fallback skips already-seen messages and learns archive ids", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const catchup = (client as unknown as {
+      catchup: {
+        recordRoomSeen: (room: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:00.000Z", undefined, ["room-seen"]);
+    catchup.onSessionStarted();
+    const activityHandler = mock(() => undefined);
+    client.setActivityHandler(activityHandler);
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [
+        roomWasmMessage({
+          mam_id: "mam-room-seen",
+          id: "room-seen",
+          from: `${roomJid}/bob`,
+          body: "already seen room message",
+          timestamp: "2024-01-01T01:00:00+01:00",
+        }),
+        roomWasmMessage({
+          mam_id: "mam-room-newer",
+          id: "room-newer",
+          from: `${roomJid}/bob`,
+          body: "newer missed room message",
+          timestamp: "2024-01-01T00:00:01.000Z",
+        }),
+      ],
+      last_id: "mam-room-newer",
+      is_complete: true,
+    }));
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(activityHandler).toHaveBeenCalledTimes(1);
+    expect(activityHandler).toHaveBeenCalledWith(expect.objectContaining({
+      roomJid,
+      body: "newer missed room message",
+    }));
+    expect(catchup.onSessionStarted()).toEqual([
+      { kind: "room", key: roomJid, after: "mam-room-newer", seenIds: ["room-newer"] },
+    ]);
+  });
+
+  test("room timestamp fallback pages backward until it crosses the last seen timestamp", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    const catchup = (client as unknown as {
+      catchup: {
+        recordRoomSeen: (room: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+      };
+    }).catchup;
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:00.000Z", undefined, ["room-seen"]);
+    (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted();
+    const roomHandler = mock(() => undefined);
+    client.setMessageHandler(roomHandler);
+    const fetchRoomHistoryPage = mock(async (_room: string, _max: number, pageParam: { type: string; before?: string }) => {
+      if (pageParam.type === "latest") {
+        return {
+          messages: [roomWasmMessage({
+            mam_id: "mam-room-newer-2",
+            id: "room-newer-2",
+            from: `${roomJid}/bob`,
+            body: "newest missed room message",
+            timestamp: "2024-01-01T00:00:03.000Z",
+          })],
+          first_id: "mam-room-newer-2",
+          last_id: "mam-room-newer-2",
+          is_complete: false,
+        };
+      }
+      if (pageParam.before === "mam-room-newer-2") {
+        return {
+          messages: [
+            roomWasmMessage({
+              mam_id: "mam-room-same-time-missed",
+              id: "room-same-time-missed",
+              from: `${roomJid}/bob`,
+              body: "same timestamp missed room message",
+              timestamp: "2024-01-01T00:00:00.000Z",
+            }),
+            roomWasmMessage({
+              mam_id: "mam-room-seen",
+              id: "room-seen",
+              from: `${roomJid}/bob`,
+              body: "seen room boundary",
+              timestamp: "2024-01-01T00:00:00.000Z",
+            }),
+            roomWasmMessage({
+              mam_id: "mam-room-newer-1",
+              id: "room-newer-1",
+              from: `${roomJid}/bob`,
+              body: "older missed room message beyond first page",
+              timestamp: "2024-01-01T00:00:02.000Z",
+            }),
+          ],
+          first_id: "mam-room-same-time-missed",
+          last_id: "mam-room-newer-1",
+          is_complete: false,
+        };
+      }
+      return {
+        messages: [
+          roomWasmMessage({
+            mam_id: "mam-room-older-than-boundary",
+            id: "room-older-than-boundary",
+            from: `${roomJid}/bob`,
+            body: "older than room boundary",
+            timestamp: "2023-12-31T23:59:59.000Z",
+          }),
+        ],
+        first_id: "mam-room-older-than-boundary",
+        last_id: "mam-room-newer-1",
+        is_complete: false,
+      };
+    });
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(1, roomJid, 100, { type: "latest" });
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(2, roomJid, 100, {
+      type: "before",
+      before: "mam-room-newer-2",
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(3, roomJid, 100, {
+      type: "before",
+      before: "mam-room-same-time-missed",
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(3);
+    expect(roomHandler).toHaveBeenCalledTimes(3);
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-newer-2" }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-newer-1" }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-same-time-missed" }));
+  });
+
+  test("room stale archive cursor catch-up filters live activity already seen after that cursor", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const catchup = (client as unknown as {
+      catchup: {
+        recordRoomSeen: (room: string, ts: string, archiveId?: string, seenIds?: string[]) => void;
+        onSessionStarted: () => unknown[];
+      };
+    }).catchup;
+    catchup.recordRoomSeen(roomJid, "2024-01-01T00:00:00.000Z", "mam-room-1");
+    catchup.onSessionStarted();
+    const activityHandler = mock(() => undefined);
+    const fetchRoomHistoryPage = mock(async () => ({
+      messages: [
+        roomWasmMessage({
+          mam_id: "mam-room-between-archive-and-live",
+          id: "room-between-archive-and-live",
+          from: `${roomJid}/bob`,
+          body: "missed room message between archived cursor and live watermark",
+          timestamp: "2024-01-01T00:00:00.500Z",
+        }),
+        roomWasmMessage({
+          mam_id: "mam-room-2",
+          id: undefined,
+          from: `${roomJid}/bob`,
+          body: "already seen room live",
+          timestamp: "2024-01-01T00:00:01.000Z",
+          stanza_id: "foreign-stanza-id",
+          stanza_id_by: "archive.example.com",
+          stanza_ids: [
+            { id: "foreign-stanza-id", by: "archive.example.com" },
+            { id: "room-scoped-already-seen", by: roomJid },
+          ],
+        }),
+        roomWasmMessage({
+          mam_id: "mam-room-3",
+          id: "room-actually-missed",
+          from: `${roomJid}/bob`,
+          body: "actually missed room message",
+          timestamp: "2024-01-01T00:00:02.000Z",
+        }),
+      ],
+      last_id: "mam-room-3",
+      is_complete: true,
+    }));
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+    xmpp.emit("message", roomWasmMessage({
+      id: undefined,
+      mam_id: "live-fallback-only",
+      from: `${roomJid}/bob`,
+      body: "already seen room live",
+      timestamp: "2024-01-01T00:00:01.000Z",
+      stanza_id: "foreign-stanza-id",
+      stanza_id_by: "archive.example.com",
+      stanza_ids: [
+        { id: "foreign-stanza-id", by: "archive.example.com" },
+        { id: "room-scoped-already-seen", by: roomJid },
+      ],
+    }));
+    client.setActivityHandler(activityHandler);
+
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchRoomHistoryPage).toHaveBeenCalledWith(roomJid, 100, {
+      type: "after",
+      after: "mam-room-1",
+    });
+    expect(activityHandler).toHaveBeenCalledTimes(2);
+    expect(activityHandler).toHaveBeenCalledWith(expect.objectContaining({
+      roomJid,
+      body: "missed room message between archived cursor and live watermark",
+    }));
+    expect(activityHandler).toHaveBeenCalledWith(expect.objectContaining({
+      roomJid,
+      body: "actually missed room message",
+    }));
+  });
+
+  test("pages tracked room catch-up forward from the last MAM archive id", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    (client as unknown as { connect: () => Promise<void> }).connect = async () => undefined;
+    (client as unknown as { switchRoom: () => Promise<void> }).switchRoom = async () => undefined;
+    (client as unknown as { connected: boolean }).connected = true;
+    const catchup = (client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup;
+    catchup.onSessionStarted();
+    const roomHandler = mock(() => undefined);
+    client.setMessageHandler(roomHandler);
+    const fetchRoomHistoryPage = mock(async (_room: string, _max: number, pageParam: { type: string; after?: string }) => {
+      if (pageParam.type === "latest") {
+        return {
+          messages: [roomWasmMessage({
+            mam_id: "mam-room-1",
+            id: "room-1",
+            from: `${roomJid}/bob`,
+            body: "loaded room history",
+            timestamp: "2024-01-01T00:00:00.000Z",
+          })],
+          last_id: "mam-room-1",
+          is_complete: true,
+        };
+      }
+      if (pageParam.after === "mam-room-1") {
+        return {
+          messages: [roomWasmMessage({
+            mam_id: "mam-room-2",
+            id: "room-2",
+            from: `${roomJid}/bob`,
+            body: "first missed room page",
+            timestamp: "2024-01-01T00:00:01.000Z",
+          })],
+          last_id: "mam-room-2",
+          is_complete: false,
+        };
+      }
+      return {
+        messages: [roomWasmMessage({
+          mam_id: "mam-room-3",
+          id: "room-3",
+          from: `${roomJid}/bob`,
+          body: "second missed room page",
+          timestamp: "2024-01-01T00:00:02.000Z",
+        })],
+        last_id: "mam-room-3",
+        is_complete: true,
+      };
+    });
+    const xmpp = Object.assign(new EventEmitter(), {
+      fetch_room_history_page: fetchRoomHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
+
+    await client.queryMamPage("w1", "c1", 100, { type: "latest" });
+    expect(catchup.onSessionStarted()).toEqual([
+      { kind: "room", key: roomJid, after: "mam-room-1", seenIds: ["room-1"] },
+    ]);
+
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+    xmpp.emit("stream:management:resumed");
+    await settleReconnectCatchup();
+
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(2, roomJid, 100, {
+      type: "after",
+      after: "mam-room-1",
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenNthCalledWith(3, roomJid, 100, {
+      type: "after",
+      after: "mam-room-2",
+    });
+    expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(3);
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "room-2",
+      body: "first missed room page",
+      roomJid,
+    }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({
+      id: "room-3",
+      body: "second missed room page",
+      roomJid,
     }));
   });
 });

--- a/chat/tests/reconnect-catchup.test.ts
+++ b/chat/tests/reconnect-catchup.test.ts
@@ -18,8 +18,8 @@ describe("ReconnectCatchup", () => {
 
   test("subsequent onSessionStarted returns all tracked conversations with their kind", () => {
     const c = new ReconnectCatchup();
-    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
-    c.recordRoomSeen("general@muc.example.com", "2024-01-02T00:00:00Z");
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z", "dm-arch-1");
+    c.recordRoomSeen("general@muc.example.com", "2024-01-02T00:00:00Z", "room-arch-1");
 
     // First session:started = initial login; skip catch-up.
     c.onSessionStarted();
@@ -27,10 +27,15 @@ describe("ReconnectCatchup", () => {
     const entries = c.onSessionStarted();
 
     expect(entries).toHaveLength(2);
-    expect(entries).toContainEqual({ kind: "dm", key: "bob@example.com" });
+    expect(entries).toContainEqual({
+      kind: "dm",
+      key: "bob@example.com",
+      after: "dm-arch-1",
+    });
     expect(entries).toContainEqual({
       kind: "room",
       key: "general@muc.example.com",
+      after: "room-arch-1",
     });
   });
 
@@ -39,7 +44,110 @@ describe("ReconnectCatchup", () => {
     c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
     c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z");
 
-    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00Z");
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00.000Z");
+  });
+
+  test("subsequent onSessionStarted falls back to timestamp when no archive id is known", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      { kind: "dm", key: "bob@example.com", since: "2024-01-01T00:00:00.000Z" },
+    ]);
+  });
+
+  test("timestamp fallback carries seen ids for exact-boundary dedupe", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z", undefined, ["dm-1"]);
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z", undefined, ["dm-2"]);
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      {
+        kind: "dm",
+        key: "bob@example.com",
+        since: "2024-01-01T00:00:00.000Z",
+        seenIds: ["dm-1", "dm-2"],
+      },
+    ]);
+  });
+
+  test("timestamp fallback normalizes equivalent RFC3339 instants before merging seen ids", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z", undefined, ["dm-1"]);
+    c.recordDmSeen("bob@example.com", "2024-01-01T01:00:00+01:00", undefined, ["dm-2"]);
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      {
+        kind: "dm",
+        key: "bob@example.com",
+        since: "2024-01-01T00:00:00.000Z",
+        seenIds: ["dm-1", "dm-2"],
+      },
+    ]);
+  });
+
+  test("recordSeen fills archive id for the current timestamp without rewinding time", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z");
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2");
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-2" },
+    ]);
+  });
+
+  test("recordSeen advances archive id for repeated archived messages at the current timestamp", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-1");
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2");
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-2" },
+    ]);
+  });
+
+  test("newer live timestamps do not discard the last authoritative archive id", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2");
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:01Z", undefined, ["dm-live-3"]);
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      {
+        kind: "dm",
+        key: "bob@example.com",
+        after: "dm-arch-2",
+        seenIds: ["dm-live-3"],
+      },
+    ]);
+  });
+
+  test("same-timestamp live ids remain available when catch-up can use an archive cursor", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z", "dm-arch-2");
+    c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00.000+00:00", undefined, ["dm-live-same-time"]);
+
+    c.onSessionStarted();
+
+    expect(c.onSessionStarted()).toEqual([
+      {
+        kind: "dm",
+        key: "bob@example.com",
+        after: "dm-arch-2",
+        seenIds: ["dm-live-same-time"],
+      },
+    ]);
   });
 
   test("recordSeen ignores out-of-order (older) timestamps", () => {
@@ -50,7 +158,7 @@ describe("ReconnectCatchup", () => {
     c.recordDmSeen("bob@example.com", "2024-01-02T00:00:00Z");
     c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");
 
-    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00Z");
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00.000Z");
   });
 
   test("DM and room namespaces are independent — same JID in both kinds does not collide", () => {
@@ -60,8 +168,8 @@ describe("ReconnectCatchup", () => {
     c.recordDmSeen("foo@bar", "2024-01-01T00:00:00Z");
     c.recordRoomSeen("foo@bar", "2024-02-02T00:00:00Z");
 
-    expect(c.getDmLastSeen("foo@bar")).toBe("2024-01-01T00:00:00Z");
-    expect(c.getRoomLastSeen("foo@bar")).toBe("2024-02-02T00:00:00Z");
+    expect(c.getDmLastSeen("foo@bar")).toBe("2024-01-01T00:00:00.000Z");
+    expect(c.getRoomLastSeen("foo@bar")).toBe("2024-02-02T00:00:00.000Z");
   });
 
   test("getDmLastSeen returns undefined for untracked peers", () => {

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -324,6 +324,11 @@ enum Step {
         id: Option<String>,
         max: u32,
         after: Option<String>,
+        #[serde(default, rename = "afterFrom")]
+        after_from: Option<String>,
+        before: Option<String>,
+        #[serde(default, rename = "beforeFrom")]
+        before_from: Option<String>,
         #[serde(rename = "with")]
         with_jid: Option<String>,
         fulltext: Option<String>,
@@ -347,6 +352,8 @@ enum Step {
         elements: Vec<XmlElementSpec>,
         #[serde(default, rename = "absentElements")]
         absent_elements: Vec<XmlElementSpec>,
+        #[serde(default)]
+        captures: Vec<AttributeCapture>,
     },
     #[serde(rename = "expectNoMamResult")]
     ExpectNoMamResult {
@@ -1309,6 +1316,9 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             id,
             max,
             after,
+            after_from,
+            before,
+            before_from,
             with_jid,
             fulltext,
             ids,
@@ -1326,10 +1336,40 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                     .ok_or_else(|| anyhow!("unknown captured MAM id {capture}"))?;
                 query_ids.push(value.clone());
             }
+            let after_cursor = match (after.as_deref(), after_from.as_deref()) {
+                (Some(_), Some(_)) => {
+                    return Err(anyhow!("queryMam cannot set both after and afterFrom"));
+                }
+                (Some(after), None) => Some(after.to_string()),
+                (None, Some(capture)) => Some(
+                    ctx.captures
+                        .get(capture)
+                        .ok_or_else(|| anyhow!("unknown captured MAM after cursor {capture}"))?
+                        .clone(),
+                ),
+                (None, None) => None,
+            };
+            let before_cursor = match (before.as_deref(), before_from.as_deref()) {
+                (Some(_), Some(_)) => {
+                    return Err(anyhow!("queryMam cannot set both before and beforeFrom"));
+                }
+                (Some(before), None) => Some(before.to_string()),
+                (None, Some(capture)) => Some(
+                    ctx.captures
+                        .get(capture)
+                        .ok_or_else(|| anyhow!("unknown captured MAM before cursor {capture}"))?
+                        .clone(),
+                ),
+                (None, None) => None,
+            };
+            if after_cursor.is_some() && before_cursor.is_some() {
+                return Err(anyhow!("queryMam cannot set both after and before cursors"));
+            }
             let query = mam_query_element(
                 &id,
                 *max,
-                after.as_deref(),
+                after_cursor.as_deref(),
+                before_cursor.as_deref(),
                 with_jid.as_deref(),
                 fulltext.as_deref(),
                 &query_ids,
@@ -1383,6 +1423,7 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
             absent,
             elements,
             absent_elements,
+            captures,
         } => {
             let payload_expectations = payload_expectations(payloads, ctx)?;
             let payload_element_expectations = payload_element_expectations(payloads);
@@ -1441,6 +1482,10 @@ async fn execute_step(ctx: &mut ScenarioContext, step: &Step) -> Result<()> {
                 &captures_snapshot,
                 "MAM result elements",
             )?;
+            for capture in captures {
+                let value = extract_attr_capture(&frame, capture)?;
+                ctx.captures.insert(capture.capture_as.clone(), value);
+            }
         }
         Step::ExpectNoMamResult {
             body,
@@ -1690,6 +1735,7 @@ fn mam_query_element(
     query_id: &str,
     max: u32,
     after: Option<&str>,
+    before: Option<&str>,
     with_jid: Option<&str>,
     fulltext: Option<&str>,
     ids: &[String],
@@ -1706,6 +1752,9 @@ fn mam_query_element(
     );
     if let Some(after) = after {
         rsm = rsm.append(Element::builder("after", RSM_NS).append(after).build());
+    }
+    if let Some(before) = before {
+        rsm = rsm.append(Element::builder("before", RSM_NS).append(before).build());
     }
 
     let has_form = with_jid.is_some() || fulltext.is_some() || !ids.is_empty();

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/schema.cue
@@ -221,6 +221,9 @@ package xmpp_e2e_scenarios
 	id?:     string
 	max:     *50 | int & >=1 & <=4294967295
 	after?:  string
+	afterFrom?: string
+	before?: string
+	beforeFrom?: string
 	with?:   string
 	fulltext?: string
 	ids?: [...string]
@@ -236,6 +239,7 @@ package xmpp_e2e_scenarios
 	absent?: [...string]
 	elements?: [...#XmlElement]
 	absentElements?: [...#XmlElement]
+	captures?: [...#AttributeCapture]
 	...
 }
 

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue
@@ -1,0 +1,300 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0313-reconnect-after-catchup"
+	xeps: ["XEP-0045", "XEP-0059", "XEP-0160", "XEP-0297", "XEP-0313"]
+	users: {
+			alice: devices: phone: #Actor & {
+				user:     "alice"
+				device:   "phone"
+				username: "admin"
+				resource: "phone"
+				domain:   scenario.domain
+			}
+		bob: devices: phone: #Actor & {
+			user:     "bob"
+			device:   "phone"
+			username: "bob"
+			resource: "phone"
+			domain:   scenario.domain
+		}
+	}
+
+	let alicePhone = users.alice.devices.phone
+	let bobPhone = users.bob.devices.phone
+	let roomJid = "cue-reconnect-after@muc.\(scenario.domain)"
+
+	steps: [
+		#SendMessage & {
+			from: alicePhone
+			to:   bobPhone
+			id:   "cue-before-gap"
+			body: "before reconnect gap"
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			from:   alicePhone
+			body:   "before reconnect gap"
+		},
+		#QueryMam & {
+			actor:   bobPhone
+			archive: bobPhone.bareJid
+			id:      "cue-baseline-mam"
+			max:     1
+		},
+		#ExpectMamResult & {
+			body: "before reconnect gap"
+			captures: [#AttributeCapture & {
+				as:      "baselineMamId"
+				element: "result"
+				ns:      "urn:xmpp:mam:2"
+				name:    "id"
+			}]
+		},
+		#DisconnectActor & {
+			actor: bobPhone
+		},
+		#SendMessage & {
+			from:  alicePhone
+			toJid: bobPhone.bareJid
+			id:    "cue-gap-one"
+			body:  "missed reconnect gap one"
+		},
+		#SendMessage & {
+			from:  alicePhone
+			toJid: bobPhone.bareJid
+			id:    "cue-gap-two"
+			body:  "missed reconnect gap two"
+		},
+		#ConnectActor & {
+			actor: bobPhone
+		},
+		#SendPresence & {
+			actor: bobPhone
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   "missed reconnect gap one"
+			elements: [#XmlElement & {
+				name: "delay"
+				ns:   "urn:xmpp:delay"
+				attrsPresent: ["stamp"]
+			}]
+		},
+		#ExpectMessage & {
+			target: bobPhone
+			body:   "missed reconnect gap two"
+			elements: [#XmlElement & {
+				name: "delay"
+				ns:   "urn:xmpp:delay"
+				attrsPresent: ["stamp"]
+			}]
+		},
+		#QueryMam & {
+			actor:     bobPhone
+			archive:   bobPhone.bareJid
+			id:        "cue-after-baseline"
+			max:       1
+			afterFrom: "baselineMamId"
+		},
+		#ExpectMamResult & {
+			body: "missed reconnect gap one"
+			captures: [#AttributeCapture & {
+				as:      "gapOneMamId"
+				element: "result"
+				ns:      "urn:xmpp:mam:2"
+				name:    "id"
+			}]
+		},
+		#ExpectNoMamResult & {
+			body: "missed reconnect gap two"
+		},
+		#QueryMam & {
+			actor:     bobPhone
+			archive:   bobPhone.bareJid
+			id:        "cue-after-gap-one"
+			max:       1
+			afterFrom: "gapOneMamId"
+		},
+			#ExpectMamResult & {
+				body: "missed reconnect gap two"
+			},
+			#QueryMam & {
+				actor:   bobPhone
+				archive: bobPhone.bareJid
+				id:      "cue-latest-before-walk"
+				max:     1
+				before:  ""
+			},
+			#ExpectMamResult & {
+				body: "missed reconnect gap two"
+				captures: [#AttributeCapture & {
+					as:      "gapTwoMamId"
+					element: "result"
+					ns:      "urn:xmpp:mam:2"
+					name:    "id"
+				}]
+			},
+			#QueryMam & {
+				actor:      bobPhone
+				archive:    bobPhone.bareJid
+				id:         "cue-before-gap-two"
+				max:        1
+				beforeFrom: "gapTwoMamId"
+			},
+			#ExpectMamResult & {
+				body: "missed reconnect gap one"
+			},
+			#JoinMuc & {actor: alicePhone, room: roomJid, nick: "alice-phone"},
+			#ExpectFrame & {
+				target:   alicePhone
+				contains: ["from=\"\(roomJid)\"", "<subject></subject>"]
+			},
+			#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
+			#ExpectPresence & {
+				target:   bobPhone
+				contains: ["from=\"\(roomJid)/alice-phone\""]
+			},
+			#ExpectFrame & {
+				target:   bobPhone
+				contains: ["from=\"\(roomJid)\"", "<subject></subject>"]
+			},
+			#ExpectPresence & {
+				target:   alicePhone
+				contains: ["from=\"\(roomJid)/bob-phone\""]
+			},
+			#SendMessage & {
+				from:  alicePhone
+				toJid: roomJid
+				type:  "groupchat"
+				id:    "cue-room-before-gap"
+				body:  "room before reconnect gap"
+			},
+			#ExpectMessage & {
+				target: alicePhone
+				body:   "room before reconnect gap"
+			},
+			#ExpectMessage & {
+				target: bobPhone
+				body:   "room before reconnect gap"
+			},
+			#ExpectFrame & {
+				target:   bobPhone
+				contains: ["urn:waddle:inbox:0", "cue-room-before-gap"]
+			},
+			#QueryMam & {
+				actor:   bobPhone
+				archive: roomJid
+				id:      "cue-room-baseline-mam"
+				max:     1
+				before:  ""
+			},
+			#ExpectMamResult & {
+				body: "room before reconnect gap"
+				elements: [#XmlElement & {
+					name: "stanza-id"
+					ns:   "urn:xmpp:sid:0"
+					attrs: by: roomJid
+					attrsPresent: ["id"]
+				}]
+				captures: [#AttributeCapture & {
+					as:      "roomBaselineMamId"
+					element: "result"
+					ns:      "urn:xmpp:mam:2"
+					name:    "id"
+				}]
+			},
+			#DisconnectActor & {
+				actor: bobPhone
+			},
+			#SendMessage & {
+				from:  alicePhone
+				toJid: roomJid
+				type:  "groupchat"
+				id:    "cue-room-gap-one"
+				body:  "room missed reconnect gap one"
+			},
+			#ExpectMessage & {
+				target: alicePhone
+				body:   "room missed reconnect gap one"
+			},
+			#SendMessage & {
+				from:  alicePhone
+				toJid: roomJid
+				type:  "groupchat"
+				id:    "cue-room-gap-two"
+				body:  "room missed reconnect gap two"
+			},
+			#ExpectMessage & {
+				target: alicePhone
+				body:   "room missed reconnect gap two"
+			},
+			#ConnectActor & {
+				actor: bobPhone
+			},
+			#JoinMuc & {actor: bobPhone, room: roomJid, nick: "bob-phone"},
+			#ExpectPresence & {
+				target:   bobPhone
+				contains: ["from=\"\(roomJid)/alice-phone\""]
+			},
+			#ExpectFrame & {
+				target:   bobPhone
+				contains: ["from=\"\(roomJid)\"", "<subject></subject>"]
+			},
+			#ExpectPresence & {
+				target:   alicePhone
+				contains: ["from=\"\(roomJid)/bob-phone\""]
+			},
+			#ExpectNoStanza & {
+				target: bobPhone
+				body:   "room missed reconnect gap one"
+				millis: 250
+			},
+			#ExpectNoStanza & {
+				target: bobPhone
+				body:   "room missed reconnect gap two"
+				millis: 250
+			},
+			#QueryMam & {
+				actor:     bobPhone
+				archive:   roomJid
+				id:        "cue-room-after-baseline"
+				max:       1
+				afterFrom: "roomBaselineMamId"
+			},
+			#ExpectMamResult & {
+				body: "room missed reconnect gap one"
+				elements: [#XmlElement & {
+					name: "stanza-id"
+					ns:   "urn:xmpp:sid:0"
+					attrs: by: roomJid
+					attrsPresent: ["id"]
+				}]
+				captures: [#AttributeCapture & {
+					as:      "roomGapOneMamId"
+					element: "result"
+					ns:      "urn:xmpp:mam:2"
+					name:    "id"
+				}]
+			},
+			#ExpectNoMamResult & {
+				body: "room missed reconnect gap two"
+			},
+			#QueryMam & {
+				actor:     bobPhone
+				archive:   roomJid
+				id:        "cue-room-after-gap-one"
+				max:       1
+				afterFrom: "roomGapOneMamId"
+			},
+			#ExpectMamResult & {
+				body: "room missed reconnect gap two"
+				elements: [#XmlElement & {
+					name: "stanza-id"
+					ns:   "urn:xmpp:sid:0"
+					attrs: by: roomJid
+					attrsPresent: ["id"]
+				}]
+			},
+		]
+	}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_history.rs
@@ -65,17 +65,10 @@ impl WaddleClient {
         future_to_promise(async move {
             let page: WaddleMamPageParam = serde_wasm_bindgen::from_value(page_param)
                 .map_err(|err| js_error(err.to_string()))?;
-            let before = match page.kind.as_str() {
-                "latest" => Some(String::new()),
-                "before" => page.before,
-                _ => return Err(js_error("invalid page param type")),
-            };
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
             let mut builder = MamIqBuilder::new(&iq_id, &query_id, max).to_jid(&room_jid);
-            if let Some(b) = before.as_deref() {
-                builder = builder.before(b);
-            }
+            builder = apply_page_param(builder, &page)?;
             let iq = builder.build();
             let result = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(result))
@@ -92,17 +85,10 @@ impl WaddleClient {
         future_to_promise(async move {
             let page: WaddleMamPageParam = serde_wasm_bindgen::from_value(page_param)
                 .map_err(|err| js_error(err.to_string()))?;
-            let before = match page.kind.as_str() {
-                "latest" => Some(String::new()),
-                "before" => page.before,
-                _ => return Err(js_error("invalid page param type")),
-            };
             let query_id = uuid::Uuid::new_v4().to_string();
             let iq_id = uuid::Uuid::new_v4().to_string();
             let mut builder = MamIqBuilder::new(&iq_id, &query_id, max).with_jid(&peer_jid);
-            if let Some(b) = before.as_deref() {
-                builder = builder.before(b);
-            }
+            builder = apply_page_param(builder, &page)?;
             let iq = builder.build();
             let result = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(result))
@@ -224,5 +210,51 @@ impl WaddleClient {
             let page = send_mam_query_command(inner, iq, query_id).await?;
             to_js_value(&mam_page_to_js(page))
         })
+    }
+}
+
+fn apply_page_param<'a>(
+    builder: MamIqBuilder<'a>,
+    page: &'a WaddleMamPageParam,
+) -> Result<MamIqBuilder<'a>, JsValue> {
+    Ok(match page.kind.as_str() {
+        "latest" => builder.before(""),
+        "before" => match page.before.as_deref() {
+            Some(before) => builder.before(before),
+            None => return Err(js_error("missing before page cursor")),
+        },
+        "after" => match page.after.as_deref() {
+            Some(after) => builder.after(after),
+            None => return Err(js_error("missing after page cursor")),
+        },
+        _ => return Err(js_error("invalid page param type")),
+    })
+}
+
+#[cfg(test)]
+mod client_history_tests {
+    use super::*;
+
+    const TEST_MAM_NS: &str = "urn:xmpp:mam:2";
+    const TEST_RSM_NS: &str = "http://jabber.org/protocol/rsm";
+
+    #[test]
+    fn page_param_after_builds_rsm_after_query() {
+        let page = WaddleMamPageParam {
+            kind: "after".to_string(),
+            before: None,
+            after: Some("cursor-1".to_string()),
+        };
+
+        let iq = apply_page_param(MamIqBuilder::new("iq-1", "query-1", 10), &page)
+            .expect("after page param should apply")
+            .build();
+
+        let after = iq
+            .get_child("query", TEST_MAM_NS)
+            .and_then(|query| query.get_child("set", TEST_RSM_NS))
+            .and_then(|set| set.get_child("after", TEST_RSM_NS))
+            .map(|element| element.text());
+        assert_eq!(after.as_deref(), Some("cursor-1"));
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -481,6 +481,7 @@ pub struct WaddleMamPageParam {
     #[serde(rename = "type")]
     pub kind: String,
     pub before: Option<String>,
+    pub after: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp404b12";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp4p32od";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp4p32od";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp4p32od";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp404b12";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp4p32od";


### PR DESCRIPTION
## Status

Ready for review. This completes the remaining #459 in-memory reconnect reconciliation slice with XMPP-native MAM/RSM recovery only.

## What Changed

- Track per-DM and per-room in-memory reconnect watermarks using XEP-0313 MAM archive result IDs where available.
- Resume catch-up from known archive IDs with XEP-0059 RSM `<after/>`, paging until MAM completion or cursor progress stops.
- Remove the fixed local 50-page reconnect catch-up cap; incomplete pages now either advance the RSM cursor or surface a recoverable history error instead of silently truncating the gap.
- Keep a timestamp fallback only for live-only cursors with no archive UID; the fallback walks `latest` / `<before/>` pages until it crosses a normalized timestamp boundary.
- Preserve exact-boundary seen IDs so same-timestamp already-seen messages are deduped without dropping same-timestamp missed messages.
- Normalize RFC3339 timestamp comparisons before ordering/equality checks.
- Record all live XEP-0359 stanza IDs for room messages so room-scoped archived replays dedupe correctly even when another stanza-id appears first.
- Seed room reconnect watermarks from thread MAM reads as well as regular room history, so thread-only views are covered.
- Add WASM bridge support for `{ type: "after" }` MAM page params.
- Extend the CUE e2e MAM harness with captured `afterFrom`, `before`, and `beforeFrom` cursors.

## XEP Notes

- XEP-0313 MAM result `id` is treated as the authoritative archive UID reconnect watermark.
- XEP-0059 RSM `<after/>` is used for forward catch-up from a known archive UID.
- XEP-0059 RSM `<before/>` is used only for the no-archive-UID timestamp fallback overlap scan.
- MAM result-set completion follows the server's XEP-0313/RSM completion/progress signal, not a client-local message budget.
- XEP-0359 stanza IDs are stable duplicate-detection IDs, not MAM watermarks.
- MUC gaps are not assumed to be live-replayed after rejoin; the CUE scenario asserts no live gap stanza after rejoin before proving recovery through MAM/RSM.
- No custom namespace or out-of-band recovery API was added.

## Tests

- `bun test chat/tests/client-send-readiness.test.ts`
- `bun test`
- `bun run lint` in `chat/`
- `bun run build` in `chat/`
- `cargo test -p waddle-xmpp-client-wasm`
- `cargo test -p waddle-server --test xmpp_e2e_cue`
- `cargo clippy -p waddle-xmpp-client-wasm --tests -- -D warnings`
- `cargo clippy -p waddle-server --tests -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
- `REBUILD_WASM=1 bun run wasm:build`

## Review

Multiple adversarial code/test reviews were run. Findings were fixed for same-timestamp live IDs, room-scoped XEP-0359 dedupe, normalized timestamp comparisons, intermediate same-timestamp fallback pages, exact fetch/handler counts, CUE MUC reconnect coverage, silent page-cap truncation, and thread-only MAM watermark seeding.

Related: #459
