### PR TITLE
refactor(server): isolate websocket stream management boundary

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1,12 +1,14 @@
 use super::*;
 use super::{
-    cleanup::{cleanup_connection_shutdown, cleanup_invalidated_detached_session},
+    cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
     outbound::handle_outbound_stanza,
     send::{send_ws_message, send_ws_text_frames},
     session_init::{build_internal_server_error_stream_error, load_blocklist_for_bind},
     state::WsConnState,
-    stream_management::{is_countable_stanza, sm_show_name},
+    stream_management::{
+        finalize_sm_after_registry_registration, is_countable_stanza, sm_show_name,
+    },
 };
 
 /// Create the WebSocket router
@@ -206,134 +208,14 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                             conn.presence_priority,
                                         );
                                 }
-                                if let Some(stream_id) = conn.pending_resume_stream_id.take() {
-                                    let resume_h = conn.pending_resume_h.take();
-                                    let completion = match resume_h {
-                                        Some(h) => state
-                                            .deps
-                                            .protocol
-                                            .sm_session_registry
-                                            .complete_claim_if_resumable(&stream_id, h)
-                                            .await,
-                                        None => state
-                                            .deps
-                                            .protocol
-                                            .sm_session_registry
-                                            .complete_claim(&stream_id)
-                                            .await,
-                                    };
-                                    let mut remove_resumable_sidecar = true;
-                                    match completion {
-                                        Ok(Some(SmClaimCompletion::Resumed(detached))) => {
-                                            if let Some(h) = resume_h {
-                                                conn.sm_state.restore_from_session(&detached);
-                                                conn.sm_state.acknowledge(h);
-                                                responses = vec![
-                                                    waddle_xmpp::stream_management::SmResumed::new(
-                                                        stream_id.clone(),
-                                                        conn.sm_state.get_inbound_count(),
-                                                    )
-                                                    .to_xml(),
-                                                ];
-                                                responses
-                                                    .extend(conn.sm_state.get_stanzas_to_resend(h));
-                                            }
-                                        }
-                                        Ok(Some(SmClaimCompletion::ReplayWindowTruncated(
-                                            detached,
-                                        ))) => {
-                                            warn!(
-                                                stream_id = %stream_id,
-                                                jid = %jid,
-                                                client_h = ?resume_h,
-                                                replay_gap_through = ?detached.replay_gap_through,
-                                                "SM resume claim gained a replay gap before completion"
-                                            );
-                                            let _ = state
-                                                .deps
-                                                .protocol
-                                                .connection_registry
-                                                .unregister_if_owner(&jid, &owner);
-                                            conn.registry_owner = None;
-                                            conn.phase = ConnectionPhase::authenticated(&jid);
-                                            conn.state_machine = None;
-                                            conn.sm_state = StreamManagementState::new();
-                                            conn.suppress_sm_record_next_batch = false;
-                                            responses = vec![
-                                                waddle_xmpp::stream_management::SmFailed::resume_failed(
-                                                    "resource-constraint",
-                                                    detached.inbound_count,
-                                                )
-                                                .to_xml(),
-                                            ];
-                                            remove_resumable_sidecar = false;
-                                        }
-                                        Ok(Some(SmClaimCompletion::Expired(detached))) => {
-                                            warn!(stream_id = %stream_id, jid = %jid, "SM resume claim expired before completion");
-                                            cleanup_invalidated_detached_session(
-                                                state.as_ref(),
-                                                detached,
-                                                Some(&owner),
-                                            )
-                                            .await;
-                                            let _ = state
-                                                .deps
-                                                .protocol
-                                                .connection_registry
-                                                .unregister_if_owner(&jid, &owner);
-                                            conn.registry_owner = None;
-                                            conn.phase = ConnectionPhase::closing(Some(jid.clone()));
-                                            responses = vec![waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml()];
-                                        }
-                                        Ok(None) => {
-                                            warn!(stream_id = %stream_id, jid = %jid, "SM resume claim disappeared before completion");
-                                            let _ = state
-                                                .deps
-                                                .protocol
-                                                .connection_registry
-                                                .unregister_if_owner(&jid, &owner);
-                                            conn.registry_owner = None;
-                                            conn.phase = ConnectionPhase::closing(Some(jid.clone()));
-                                            responses = vec![waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml()];
-                                        }
-                                        Err(error) => {
-                                            warn!(stream_id = %stream_id, jid = %jid, error = %error, "Failed to complete SM resume claim");
-                                            let _ = state
-                                                .deps
-                                                .protocol
-                                                .connection_registry
-                                                .unregister_if_owner(&jid, &owner);
-                                            conn.registry_owner = None;
-                                            conn.phase = ConnectionPhase::closing(Some(jid.clone()));
-                                            responses = vec![waddle_xmpp::stream_management::SmFailed::with_condition("internal-server-error").to_xml()];
-                                        }
-                                    }
-                                    if remove_resumable_sidecar {
-                                        state.deps.protocol.resumable_sessions.remove(&stream_id);
-                                    }
-                                } else if !conn.phase.is_resumed() {
-                                    match state
-                                        .deps
-                                        .protocol
-                                        .sm_session_registry
-                                        .invalidate_sessions_for_jid(&jid)
-                                        .await
-                                    {
-                                        Ok(removed) => {
-                                            for detached in removed {
-                                                cleanup_invalidated_detached_session(
-                                                    state.as_ref(),
-                                                    detached,
-                                                    Some(&owner),
-                                                )
-                                                .await;
-                                            }
-                                        }
-                                        Err(error) => {
-                                            warn!(jid = %jid, error = %error, "Failed to invalidate older detached SM sessions for fresh bind");
-                                        }
-                                    }
-                                }
+                                responses = finalize_sm_after_registry_registration(
+                                    state.as_ref(),
+                                    &mut conn,
+                                    &jid,
+                                    &owner,
+                                    responses,
+                                )
+                                .await;
                                 info!(
                                     jid = %jid,
                                     resumed = conn.phase.is_resumed(),

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -8,6 +8,7 @@ use super::{
     state::WsConnState,
     stream_management::{
         finalize_sm_after_registry_registration, is_countable_stanza, sm_show_name,
+        SmRegistrationFinalization,
     },
 };
 
@@ -208,14 +209,28 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                             conn.presence_priority,
                                         );
                                 }
-                                responses = finalize_sm_after_registry_registration(
+                                match finalize_sm_after_registry_registration(
                                     state.as_ref(),
                                     &mut conn,
                                     &jid,
                                     &owner,
-                                    responses,
                                 )
-                                .await;
+                                .await
+                                {
+                                    SmRegistrationFinalization::KeepExistingResponses => {}
+                                    SmRegistrationFinalization::ReplaceWithResumed {
+                                        resumed,
+                                        replay_after_h,
+                                    } => {
+                                        responses = vec![resumed.to_xml()];
+                                        responses.extend(
+                                            conn.sm_state.get_stanzas_to_resend(replay_after_h),
+                                        );
+                                    }
+                                    SmRegistrationFinalization::ReplaceWithFailed(failed) => {
+                                        responses = vec![failed.to_xml()];
+                                    }
+                                }
                                 info!(
                                     jid = %jid,
                                     resumed = conn.phase.is_resumed(),

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -1,6 +1,7 @@
 use super::transport_xml::build_handled_count_too_high_stream_error;
 use super::*;
 use super::{cleanup::cleanup_invalidated_detached_session, state::WsConnState};
+use waddle_xmpp::stream_management::{SmFailed, SmResumed};
 
 /// Returns true if the frame is an XMPP stanza that counts toward XEP-0198
 /// handled/sent counters. Only `<iq>`, `<message>`, `<presence>` qualify;
@@ -45,25 +46,33 @@ pub(super) fn sm_show_name(show: &xmpp_parsers::presence::Show) -> &'static str 
 /// `handle_sm_resume` claims the detached session before bind so the old
 /// stream cannot be resumed twice, but detached fanout can still append
 /// stanzas during the claim-to-registration handoff. This boundary completes
-/// that claim under the stream registry lock, emits the final `<resumed/>` or
-/// XEP-0198 `<failed/>`, and invalidates superseded detached sessions for
-/// fresh binds.
+/// that claim under the stream registry lock, returns the typed final
+/// XEP-0198 outcome, and invalidates superseded detached sessions for fresh
+/// binds.
 pub(super) async fn finalize_sm_after_registry_registration(
     state: &WebSocketState,
     conn: &mut WsConnState,
     jid: &FullJid,
     owner: &Arc<std::sync::atomic::AtomicBool>,
-    responses: Vec<String>,
-) -> Vec<String> {
+) -> SmRegistrationFinalization {
     if let Some(stream_id) = conn.pending_resume_stream_id.take() {
-        return complete_pending_resume_claim(state, conn, jid, owner, stream_id, responses).await;
+        return complete_pending_resume_claim(state, conn, jid, owner, stream_id).await;
     }
 
     if !conn.phase.is_resumed() {
         invalidate_older_detached_sessions(state, jid, owner).await;
     }
 
-    responses
+    SmRegistrationFinalization::KeepExistingResponses
+}
+
+pub(super) enum SmRegistrationFinalization {
+    KeepExistingResponses,
+    ReplaceWithResumed {
+        resumed: SmResumed,
+        replay_after_h: u32,
+    },
+    ReplaceWithFailed(SmFailed),
 }
 
 async fn complete_pending_resume_claim(
@@ -72,8 +81,7 @@ async fn complete_pending_resume_claim(
     jid: &FullJid,
     owner: &Arc<std::sync::atomic::AtomicBool>,
     stream_id: String,
-    responses: Vec<String>,
-) -> Vec<String> {
+) -> SmRegistrationFinalization {
     let resume_h = conn.pending_resume_h.take();
     let completion = match resume_h {
         Some(h) => {
@@ -94,20 +102,17 @@ async fn complete_pending_resume_claim(
         }
     };
     let mut remove_resumable_sidecar = true;
-    let responses = match completion {
+    let finalization = match completion {
         Ok(Some(SmClaimCompletion::Resumed(detached))) => match resume_h {
             Some(h) => {
                 conn.sm_state.restore_from_session(&detached);
                 conn.sm_state.acknowledge(h);
-                let mut resumed = vec![waddle_xmpp::stream_management::SmResumed::new(
-                    stream_id.clone(),
-                    conn.sm_state.get_inbound_count(),
-                )
-                .to_xml()];
-                resumed.extend(conn.sm_state.get_stanzas_to_resend(h));
-                resumed
+                SmRegistrationFinalization::ReplaceWithResumed {
+                    resumed: SmResumed::new(stream_id.clone(), conn.sm_state.get_inbound_count()),
+                    replay_after_h: h,
+                }
             }
-            None => responses,
+            None => SmRegistrationFinalization::KeepExistingResponses,
         },
         Ok(Some(SmClaimCompletion::ReplayWindowTruncated(detached))) => {
             warn!(
@@ -119,40 +124,38 @@ async fn complete_pending_resume_claim(
             );
             reset_registered_resume_attempt(state, conn, jid, owner);
             remove_resumable_sidecar = false;
-            vec![waddle_xmpp::stream_management::SmFailed::resume_failed(
+            SmRegistrationFinalization::ReplaceWithFailed(SmFailed::resume_failed(
                 "resource-constraint",
                 detached.inbound_count,
-            )
-            .to_xml()]
+            ))
         }
         Ok(Some(SmClaimCompletion::Expired(detached))) => {
             warn!(stream_id = %stream_id, jid = %jid, "SM resume claim expired before completion");
             cleanup_invalidated_detached_session(state, detached, Some(owner)).await;
             close_registered_resume_attempt(state, conn, jid, owner);
-            vec![
-                waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml(),
-            ]
+            SmRegistrationFinalization::ReplaceWithFailed(SmFailed::with_condition(
+                "item-not-found",
+            ))
         }
         Ok(None) => {
             warn!(stream_id = %stream_id, jid = %jid, "SM resume claim disappeared before completion");
             close_registered_resume_attempt(state, conn, jid, owner);
-            vec![
-                waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml(),
-            ]
+            SmRegistrationFinalization::ReplaceWithFailed(SmFailed::with_condition(
+                "item-not-found",
+            ))
         }
         Err(error) => {
             warn!(stream_id = %stream_id, jid = %jid, error = %error, "Failed to complete SM resume claim");
             close_registered_resume_attempt(state, conn, jid, owner);
-            vec![
-                waddle_xmpp::stream_management::SmFailed::with_condition("internal-server-error")
-                    .to_xml(),
-            ]
+            SmRegistrationFinalization::ReplaceWithFailed(SmFailed::with_condition(
+                "internal-server-error",
+            ))
         }
     };
     if remove_resumable_sidecar {
         state.deps.protocol.resumable_sessions.remove(&stream_id);
     }
-    responses
+    finalization
 }
 
 async fn invalidate_older_detached_sessions(

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -1,5 +1,6 @@
 use super::transport_xml::build_handled_count_too_high_stream_error;
 use super::*;
+use super::{cleanup::cleanup_invalidated_detached_session, state::WsConnState};
 
 /// Returns true if the frame is an XMPP stanza that counts toward XEP-0198
 /// handled/sent counters. Only `<iq>`, `<message>`, `<presence>` qualify;
@@ -36,6 +37,178 @@ pub(super) fn sm_show_name(show: &xmpp_parsers::presence::Show) -> &'static str 
         xmpp_parsers::presence::Show::Dnd => "dnd",
         xmpp_parsers::presence::Show::Xa => "xa",
     }
+}
+
+/// Finish the XEP-0198 side effects that become safe only after the resumed
+/// or freshly-bound resource has been published to the connection registry.
+///
+/// `handle_sm_resume` claims the detached session before bind so the old
+/// stream cannot be resumed twice, but detached fanout can still append
+/// stanzas during the claim-to-registration handoff. This boundary completes
+/// that claim under the stream registry lock, emits the final `<resumed/>` or
+/// XEP-0198 `<failed/>`, and invalidates superseded detached sessions for
+/// fresh binds.
+pub(super) async fn finalize_sm_after_registry_registration(
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+    responses: Vec<String>,
+) -> Vec<String> {
+    if let Some(stream_id) = conn.pending_resume_stream_id.take() {
+        return complete_pending_resume_claim(state, conn, jid, owner, stream_id, responses).await;
+    }
+
+    if !conn.phase.is_resumed() {
+        invalidate_older_detached_sessions(state, jid, owner).await;
+    }
+
+    responses
+}
+
+async fn complete_pending_resume_claim(
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+    stream_id: String,
+    responses: Vec<String>,
+) -> Vec<String> {
+    let resume_h = conn.pending_resume_h.take();
+    let completion = match resume_h {
+        Some(h) => {
+            state
+                .deps
+                .protocol
+                .sm_session_registry
+                .complete_claim_if_resumable(&stream_id, h)
+                .await
+        }
+        None => {
+            state
+                .deps
+                .protocol
+                .sm_session_registry
+                .complete_claim(&stream_id)
+                .await
+        }
+    };
+    let mut remove_resumable_sidecar = true;
+    let responses = match completion {
+        Ok(Some(SmClaimCompletion::Resumed(detached))) => match resume_h {
+            Some(h) => {
+                conn.sm_state.restore_from_session(&detached);
+                conn.sm_state.acknowledge(h);
+                let mut resumed = vec![waddle_xmpp::stream_management::SmResumed::new(
+                    stream_id.clone(),
+                    conn.sm_state.get_inbound_count(),
+                )
+                .to_xml()];
+                resumed.extend(conn.sm_state.get_stanzas_to_resend(h));
+                resumed
+            }
+            None => responses,
+        },
+        Ok(Some(SmClaimCompletion::ReplayWindowTruncated(detached))) => {
+            warn!(
+                stream_id = %stream_id,
+                jid = %jid,
+                client_h = ?resume_h,
+                replay_gap_through = ?detached.replay_gap_through,
+                "SM resume claim gained a replay gap before completion"
+            );
+            reset_registered_resume_attempt(state, conn, jid, owner);
+            remove_resumable_sidecar = false;
+            vec![waddle_xmpp::stream_management::SmFailed::resume_failed(
+                "resource-constraint",
+                detached.inbound_count,
+            )
+            .to_xml()]
+        }
+        Ok(Some(SmClaimCompletion::Expired(detached))) => {
+            warn!(stream_id = %stream_id, jid = %jid, "SM resume claim expired before completion");
+            cleanup_invalidated_detached_session(state, detached, Some(owner)).await;
+            close_registered_resume_attempt(state, conn, jid, owner);
+            vec![
+                waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml(),
+            ]
+        }
+        Ok(None) => {
+            warn!(stream_id = %stream_id, jid = %jid, "SM resume claim disappeared before completion");
+            close_registered_resume_attempt(state, conn, jid, owner);
+            vec![
+                waddle_xmpp::stream_management::SmFailed::with_condition("item-not-found").to_xml(),
+            ]
+        }
+        Err(error) => {
+            warn!(stream_id = %stream_id, jid = %jid, error = %error, "Failed to complete SM resume claim");
+            close_registered_resume_attempt(state, conn, jid, owner);
+            vec![
+                waddle_xmpp::stream_management::SmFailed::with_condition("internal-server-error")
+                    .to_xml(),
+            ]
+        }
+    };
+    if remove_resumable_sidecar {
+        state.deps.protocol.resumable_sessions.remove(&stream_id);
+    }
+    responses
+}
+
+async fn invalidate_older_detached_sessions(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+) {
+    match state
+        .deps
+        .protocol
+        .sm_session_registry
+        .invalidate_sessions_for_jid(jid)
+        .await
+    {
+        Ok(removed) => {
+            for detached in removed {
+                cleanup_invalidated_detached_session(state, detached, Some(owner)).await;
+            }
+        }
+        Err(error) => {
+            warn!(jid = %jid, error = %error, "Failed to invalidate older detached SM sessions for fresh bind");
+        }
+    }
+}
+
+fn reset_registered_resume_attempt(
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+) {
+    let _ = state
+        .deps
+        .protocol
+        .connection_registry
+        .unregister_if_owner(jid, owner);
+    conn.registry_owner = None;
+    conn.phase = ConnectionPhase::authenticated(jid);
+    conn.state_machine = None;
+    conn.sm_state = StreamManagementState::new();
+    conn.suppress_sm_record_next_batch = false;
+}
+
+fn close_registered_resume_attempt(
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+) {
+    let _ = state
+        .deps
+        .protocol
+        .connection_registry
+        .unregister_if_owner(jid, owner);
+    conn.registry_owner = None;
+    conn.phase = ConnectionPhase::closing(Some(jid.clone()));
 }
 
 fn max_resume_secs_from_env() -> u32 {


### PR DESCRIPTION
## Plan

Slice of #350. Keep behavior unchanged while moving XEP-0198 resume/detach helpers out of the broad websocket connection module.

- Read the current websocket route structure after the merged #459 work.
- Use the existing websocket/XEP-0198 regression suite as the behavior lock for this move-only refactor.
- Extract the post-registration XEP-0198 resume-claim completion and fresh-bind detached-session invalidation path into `stream_management.rs`.
- Keep the public route endpoint, connection loop behavior, typed XMPP values, and existing wire shapes unchanged.

## Cleanup Plan

- Moved code before changing behavior.
- Deleted the moved branch logic from `connection.rs` instead of leaving wrappers behind.
- Kept function signatures typed; no string-built XML or out-of-band APIs.
- Stopped at one reviewable #350 slice rather than splitting the whole websocket route at once.

## Review Notes

- `connection.rs` still owns WebSocket transport, frame dispatch, registry publication, outbound writing, and final serialization to WebSocket text frames.
- `stream_management.rs` now owns the XEP-0198 registration aftermath: complete pending resume claims, preserve replay-gap sidecars, close expired/missing/error claims, and invalidate old detached sessions on fresh bind.
- The extracted finalization path now returns a typed `SmRegistrationFinalization` outcome instead of passing `Vec<String>` serialized protocol frames across the module boundary.
- `SmResumed` / `SmFailed` serialization stays in the connection loop next to the existing send/record boundary; replay frames are pulled from the existing SM state only at that boundary.

## Review Feedback Addressed

- Fixed Qodo finding: `finalize_sm_after_registry_registration` no longer accepts or returns `Vec<String>` protocol frames.
- Replaced the serialized response handoff with typed variants for keep-existing, resumed-with-replay-cursor, and failed-resume outcomes.

## Verification

- [x] cargo fmt
- [x] cargo test -p waddle-server server::routes::websocket
- [x] cargo test -p waddle-xmpp --test xep0198_session_registry
- [x] cargo clippy -p waddle-server --tests -- -D warnings
- [x] git diff --check
