### PR TITLE
refactor(server): isolate websocket registration boundary

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -3,13 +3,11 @@ use super::{
     cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
     outbound::handle_outbound_stanza,
+    registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
     send::{send_ws_message, send_ws_text_frames},
-    session_init::{build_internal_server_error_stream_error, load_blocklist_for_bind},
+    session_init::build_internal_server_error_stream_error,
     state::WsConnState,
-    stream_management::{
-        finalize_sm_after_registry_registration, is_countable_stanza, sm_show_name,
-        SmRegistrationFinalization,
-    },
+    stream_management::{is_countable_stanza, SmRegistrationFinalization},
 };
 
 /// Create the WebSocket router
@@ -86,137 +84,34 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         // has marked the connection Closing.
                         conn.sync_state_machine_phase();
 
-                        // Register connection after successful authentication AND resource binding
-                        // This ensures the JID in ConnectionRegistry matches the JID stored in MUC room occupants
-                        if let Some(jid) = conn.phase.bound_jid().cloned() {
-                            if let Some(tx) = pending_tx.take() {
-                                // Mirror the bind transition into the
-                                // per-connection state machine (#229
-                                // PR11). The SM stays `None` until
-                                // here so unauthenticated traffic
-                                // can't reach `on_peer_stanza`. We
-                                // detect SM-resume vs fresh bind from
-                                // whether `pending_resume_stream_id`
-                                // was just consumed below.
-                                let resumed = conn.pending_resume_stream_id.is_some();
-                                // Seed the SM's XEP-0191 session-state
-                                // snapshot (#229 PR13).
-                                //
-                                // Fresh bind: load from
-                                // `DatabaseBlockingStorage`. On Err we
-                                // FAIL the bind via a stream-error
-                                // close rather than silently
-                                // initializing an empty list — a
-                                // session-long fail-open would bypass
-                                // XEP-0191 for the entire connection
-                                // (Codex P1 / Qodo P1 review).
-                                //
-                                // XEP-0198 resume: the previous
-                                // session was detached/dropped, but we
-                                // deliberately do NOT re-read from DB.
-                                // Re-reading would let blocklist
-                                // mutations from other resources
-                                // during the detach window leak into
-                                // the resumed stream, contradicting
-                                // the snapshot semantic. The resumed
-                                // session starts with an empty
-                                // snapshot; subsequent XEP-0191
-                                // IQ-set traffic on the resumed stream
-                                // re-populates it via the SM's
-                                // internal blocklist mutators.
-                                let blocklist = if resumed {
-                                    Blocklist::empty()
-                                } else {
-                                    match load_blocklist_for_bind(
-                                        &state.deps.app_state.db_pool,
-                                        &jid,
-                                    )
-                                    .await
-                                    {
-                                        Ok(bl) => bl,
-                                        Err(error) => {
-                                            error!(
-                                                jid = %jid,
-                                                %error,
-                                                "Failed to load XEP-0191 blocklist at \
-                                                 bind; failing the bind to avoid a \
-                                                 session-long fail-open. Client should \
-                                                 reconnect."
-                                            );
-                                            let stream_error =
-                                                build_internal_server_error_stream_error(
-                                                    "Session initialization failed; \
-                                                     please reconnect.",
-                                                );
-                                            let _ = send_ws_message(
-                                                &mut ws_sender,
-                                                Message::Text(stream_error),
-                                                "Failed to send blocklist-load \
-                                                 stream error",
-                                            )
-                                            .await;
-                                            break;
-                                        }
-                                    }
-                                };
-                                conn.ensure_state_machine(
-                                    &domain,
-                                    &state.deps.protocol.dispatcher,
-                                    jid.clone(),
-                                    resumed,
-                                    blocklist,
+                        // Register the connection after successful authentication
+                        // and resource binding. This keeps the transport loop
+                        // focused on WebSocket I/O while the registration module
+                        // owns registry publication and post-registration SM
+                        // finalization.
+                        match register_bound_connection_after_frame(
+                            state.as_ref(),
+                            &domain,
+                            &mut conn,
+                            &mut pending_tx,
+                        )
+                        .await
+                        {
+                            RegistrationAfterFrame::Unchanged => {}
+                            RegistrationAfterFrame::SessionInitializationFailed => {
+                                let stream_error = build_internal_server_error_stream_error(
+                                    "Session initialization failed; please reconnect.",
                                 );
-                                let owner = state.deps.protocol.connection_registry.register_with_stream_state(
-                                    jid.clone(),
-                                    tx,
-                                    conn.carbons_enabled,
-                                    conn.roster_interested,
-                                );
-                                conn.registry_owner = Some(owner.clone());
-                                // Publish the SM stream id onto the freshly-registered entry
-                                // so the offline-flush path keys claims by the XEP-0198
-                                // session id, not the resource JID. Locked Q7b SM-ack
-                                // lifecycle (issue #209). For a fresh bind without SM
-                                // enabled, sm_state.stream_id is None — the flush path
-                                // falls back to delete-on-push for non-SM sessions.
-                                if let Some(entry) = state
-                                    .deps
-                                    .protocol
-                                    .connection_registry
-                                    .get_entry(&jid)
-                                {
-                                    entry.set_sm_stream_id(
-                                        conn.sm_state
-                                            .stream_id
-                                            .clone()
-                                            .map(waddle_xmpp::pending_delivery::SmSessionId::new),
-                                    );
-                                }
-                                if conn.presence_available {
-                                    state
-                                        .deps
-                                        .protocol
-                                        .connection_registry
-                                        .update_presence(&jid, true, 0);
-                                    state
-                                        .deps
-                                        .protocol
-                                        .connection_registry
-                                        .update_presence_state(
-                                            &jid,
-                                            conn.presence_show.as_ref().map(sm_show_name).map(str::to_string),
-                                            conn.presence_status.clone(),
-                                            conn.presence_priority,
-                                        );
-                                }
-                                match finalize_sm_after_registry_registration(
-                                    state.as_ref(),
-                                    &mut conn,
-                                    &jid,
-                                    &owner,
+                                let _ = send_ws_message(
+                                    &mut ws_sender,
+                                    Message::Text(stream_error),
+                                    "Failed to send blocklist-load stream error",
                                 )
-                                .await
-                                {
+                                .await;
+                                break;
+                            }
+                            RegistrationAfterFrame::Registered(sm_finalization) => {
+                                match sm_finalization {
                                     SmRegistrationFinalization::KeepExistingResponses => {}
                                     SmRegistrationFinalization::ReplaceWithResumed {
                                         resumed,
@@ -231,12 +126,6 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                                         responses = vec![failed.to_xml()];
                                     }
                                 }
-                                info!(
-                                    jid = %jid,
-                                    resumed = conn.phase.is_resumed(),
-                                    carbons_enabled = conn.carbons_enabled,
-                                    "WebSocket connection registered"
-                                );
                             }
                         }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -75,6 +75,7 @@ mod frame;
 mod interpret_loop;
 mod outbound;
 mod parse_errors;
+mod registration;
 mod replay;
 mod resource_binding;
 mod sasl;

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -94,7 +94,7 @@ pub(super) async fn register_bound_connection_after_frame(
             .deps
             .protocol
             .connection_registry
-            .update_presence(&jid, true, 0);
+            .update_presence(&jid, true, conn.presence_priority);
         state
             .deps
             .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -1,0 +1,122 @@
+use super::*;
+use super::{
+    session_init::load_blocklist_for_bind,
+    state::WsConnState,
+    stream_management::{
+        finalize_sm_after_registry_registration, sm_show_name, SmRegistrationFinalization,
+    },
+};
+
+pub(super) enum RegistrationAfterFrame {
+    Unchanged,
+    Registered(SmRegistrationFinalization),
+    SessionInitializationFailed,
+}
+
+pub(super) async fn register_bound_connection_after_frame(
+    state: &WebSocketState,
+    domain: &str,
+    conn: &mut WsConnState,
+    pending_tx: &mut Option<mpsc::Sender<OutboundStanza>>,
+) -> RegistrationAfterFrame {
+    let Some(jid) = conn.phase.bound_jid().cloned() else {
+        return RegistrationAfterFrame::Unchanged;
+    };
+    let Some(tx) = pending_tx.take() else {
+        return RegistrationAfterFrame::Unchanged;
+    };
+
+    // Mirror the bind transition into the per-connection state machine (#229
+    // PR11). The SM stays `None` until here so unauthenticated traffic can't
+    // reach `on_peer_stanza`. We detect SM-resume vs fresh bind from whether
+    // `pending_resume_stream_id` is waiting to be consumed below.
+    let resumed = conn.pending_resume_stream_id.is_some();
+
+    let blocklist = if resumed {
+        // XEP-0198 resume: the previous session was detached/dropped, but we
+        // deliberately do NOT re-read from DB. Re-reading would let blocklist
+        // mutations from other resources during the detach window leak into
+        // the resumed stream, contradicting the snapshot semantic. The resumed
+        // session starts with an empty snapshot; subsequent XEP-0191 IQ-set
+        // traffic on the resumed stream re-populates it via the SM's internal
+        // blocklist mutators.
+        Blocklist::empty()
+    } else {
+        match load_blocklist_for_bind(&state.deps.app_state.db_pool, &jid).await {
+            Ok(blocklist) => blocklist,
+            Err(error) => {
+                error!(
+                    jid = %jid,
+                    %error,
+                    "Failed to load XEP-0191 blocklist at bind; failing the bind to avoid a \
+                     session-long fail-open. Client should reconnect."
+                );
+                return RegistrationAfterFrame::SessionInitializationFailed;
+            }
+        }
+    };
+
+    conn.ensure_state_machine(
+        domain,
+        &state.deps.protocol.dispatcher,
+        jid.clone(),
+        resumed,
+        blocklist,
+    );
+
+    let owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register_with_stream_state(
+            jid.clone(),
+            tx,
+            conn.carbons_enabled,
+            conn.roster_interested,
+        );
+    conn.registry_owner = Some(owner.clone());
+
+    // Publish the SM stream id onto the freshly-registered entry so the
+    // offline-flush path keys claims by the XEP-0198 session id, not the
+    // resource JID. For a fresh bind without SM enabled, sm_state.stream_id is
+    // None and the flush path falls back to delete-on-push for non-SM sessions.
+    if let Some(entry) = state.deps.protocol.connection_registry.get_entry(&jid) {
+        entry.set_sm_stream_id(
+            conn.sm_state
+                .stream_id
+                .clone()
+                .map(waddle_xmpp::pending_delivery::SmSessionId::new),
+        );
+    }
+
+    if conn.presence_available {
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .update_presence(&jid, true, 0);
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .update_presence_state(
+                &jid,
+                conn.presence_show
+                    .as_ref()
+                    .map(sm_show_name)
+                    .map(str::to_string),
+                conn.presence_status.clone(),
+                conn.presence_priority,
+            );
+    }
+
+    let sm_finalization = finalize_sm_after_registry_registration(state, conn, &jid, &owner).await;
+    info!(
+        jid = %jid,
+        resumed = conn.phase.is_resumed(),
+        carbons_enabled = conn.carbons_enabled,
+        "WebSocket connection registered"
+    );
+
+    RegistrationAfterFrame::Registered(sm_finalization)
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -3,11 +3,12 @@ use super::{
     cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
     interpret_loop::build_interpret_deps,
+    registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
     replay::{drain_outbound_into_replay, drive_interpret_loop},
     send::{send_ws_message, send_ws_text_frames},
     session_init::load_blocklist_for_bind,
     state::WsConnState,
-    stream_management::is_countable_stanza,
+    stream_management::{is_countable_stanza, SmRegistrationFinalization},
     transport_xml::{build_stream_features_xml, sasl_failure_xml, sasl_success_xml},
 };
 use crate::config::ServerConfig;
@@ -681,6 +682,225 @@ async fn ensure_state_machine_initializes_sm_in_ready_phase() {
     let sm = conn.state_machine.as_ref().expect("SM initialized");
     assert!(matches!(sm.phase(), ConnectionPhase::Ready { .. }));
     assert_eq!(sm.phase().bound_jid(), Some(&jid));
+}
+
+#[tokio::test]
+async fn register_bound_connection_after_frame_registers_ready_connection_once() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    conn.carbons_enabled = true;
+    conn.roster_interested = true;
+    conn.presence_available = true;
+    conn.presence_show = Some(xmpp_parsers::presence::Show::Chat);
+    conn.presence_status = Some("ready".to_string());
+    conn.presence_priority = 7;
+
+    let result = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        RegistrationAfterFrame::Registered(SmRegistrationFinalization::KeepExistingResponses)
+    ));
+    assert!(
+        pending_tx.is_none(),
+        "registration consumes the one-shot sender"
+    );
+    assert!(
+        conn.registry_owner.is_some(),
+        "registry ownership is tracked"
+    );
+
+    let sm = conn
+        .state_machine
+        .as_ref()
+        .expect("state machine initialized");
+    assert!(matches!(sm.phase(), ConnectionPhase::Ready { .. }));
+    assert_eq!(sm.phase().bound_jid(), Some(&jid));
+
+    let entry = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_entry(&jid)
+        .expect("registered connection");
+    assert!(entry.is_carbons_enabled());
+    assert!(entry
+        .roster_interested
+        .load(std::sync::atomic::Ordering::Relaxed));
+    assert!(entry.is_presence_available());
+    assert_eq!(entry.presence_priority(), 7);
+
+    let presence = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_presence_state(&jid)
+        .expect("presence state restored");
+    assert_eq!(presence.show.as_deref(), Some("chat"));
+    assert_eq!(presence.status.as_deref(), Some("ready"));
+    assert_eq!(presence.priority, 7);
+
+    let second = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+    assert!(matches!(second, RegistrationAfterFrame::Unchanged));
+    assert_eq!(
+        state.deps.protocol.connection_registry.connection_count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn register_bound_connection_after_frame_completes_pending_resume_claim() {
+    use waddle_xmpp::stream_management::{
+        DetachedSession, DetachedUnackedStanza, SmSessionRegistry,
+    };
+
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let stream_id = "registration-resume-stream".to_string();
+    let session = create_test_session(state.as_ref(), "alice").await;
+
+    state
+        .deps
+        .protocol
+        .resumable_sessions
+        .insert(stream_id.clone(), session.clone());
+    state
+        .deps
+        .protocol
+        .sm_session_registry
+        .store_session(DetachedSession {
+            stream_id: stream_id.clone(),
+            user_id: session.user_id.clone(),
+            jid: jid.clone(),
+            inbound_count: 4,
+            outbound_count: 10,
+            last_acked: 8,
+            replay_gap_through: None,
+            unacked_stanzas: vec![
+                DetachedUnackedStanza {
+                    sequence: 9,
+                    stanza_xml: "<message id='m9'/>".to_string(),
+                    original_receipt_at: chrono::Utc::now(),
+                },
+                DetachedUnackedStanza {
+                    sequence: 10,
+                    stanza_xml: "<message id='m10'/>".to_string(),
+                    original_receipt_at: chrono::Utc::now(),
+                },
+            ],
+            max_resume_time: Some(300),
+            detached_at: std::time::Instant::now(),
+            carbons_enabled: true,
+            roster_interested: true,
+            presence_available: true,
+            presence_show: Some(xmpp_parsers::presence::Show::Chat),
+            presence_status: Some("back".to_string()),
+            presence_priority: 5,
+        })
+        .await
+        .expect("store detached session");
+
+    conn.phase = ConnectionPhase::authenticated(&jid);
+    conn.authenticated_session = Some(session.clone());
+    let resume_frame = format!("<resume xmlns='urn:xmpp:sm:3' previd='{stream_id}' h='9'/>");
+    let resume_responses =
+        handle_xmpp_frame(&resume_frame, "example.com", state.as_ref(), &mut conn).await;
+
+    assert!(!resume_responses.is_empty());
+    assert_eq!(
+        conn.pending_resume_stream_id.as_deref(),
+        Some(stream_id.as_str())
+    );
+    assert_eq!(conn.pending_resume_h, Some(9));
+    assert!(conn.suppress_sm_record_next_batch);
+
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+    let result = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+
+    match result {
+        RegistrationAfterFrame::Registered(SmRegistrationFinalization::ReplaceWithResumed {
+            resumed,
+            replay_after_h,
+        }) => {
+            assert_eq!(resumed.previd.as_str(), stream_id.as_str());
+            assert_eq!(resumed.h, 4);
+            assert_eq!(replay_after_h, 9);
+        }
+        _ => panic!("expected resumed finalization"),
+    }
+
+    assert!(
+        pending_tx.is_none(),
+        "registration consumes the one-shot sender"
+    );
+    assert!(conn.pending_resume_stream_id.is_none());
+    assert!(conn.pending_resume_h.is_none());
+    assert_eq!(
+        conn.sm_state.get_stanzas_to_resend(9),
+        vec!["<message id='m10'/>".to_string()]
+    );
+    assert!(state
+        .deps
+        .protocol
+        .resumable_sessions
+        .get(&stream_id)
+        .is_none());
+    assert!(state
+        .deps
+        .protocol
+        .sm_session_registry
+        .peek_session(&stream_id)
+        .await
+        .expect("peek detached session")
+        .is_none());
+
+    let entry = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_entry(&jid)
+        .expect("registered resumed connection");
+    assert!(entry.is_carbons_enabled());
+    assert!(entry
+        .roster_interested
+        .load(std::sync::atomic::Ordering::Relaxed));
+    assert!(entry.is_presence_available());
+    assert_eq!(entry.presence_priority(), 5);
+
+    let presence = state
+        .deps
+        .protocol
+        .connection_registry
+        .get_presence_state(&jid)
+        .expect("resumed presence state restored");
+    assert_eq!(presence.show.as_deref(), Some("chat"));
+    assert_eq!(presence.status.as_deref(), Some("back"));
+    assert_eq!(presence.priority, 5);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -4,6 +4,8 @@
 //! operational health dashboards and exposes them in Prometheus text format.
 
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(test)]
+use std::sync::{Mutex, OnceLock};
 
 static CONNECTED_USERS: AtomicU64 = AtomicU64::new(0);
 static ROOM_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -76,6 +78,13 @@ static SM_DRAIN_TIMEOUT: AtomicU64 = AtomicU64::new(0);
 // was silently lowered. Sustained non-zero indicates the cap is too
 // tight for the client population.
 static SM_RESUME_WINDOW_CLAMPED: AtomicU64 = AtomicU64::new(0);
+
+/// Serializes unit tests that mutate process-global metrics.
+#[cfg(test)]
+pub(crate) fn metrics_test_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
 
 fn unix_timestamp_secs() -> u64 {
     std::time::SystemTime::now()
@@ -320,16 +329,10 @@ pub fn render_metrics() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
-
-    fn test_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
 
     #[test]
     fn test_decrement_saturates_at_zero() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         decrement_connected_users();
@@ -341,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_increment_and_decrement_round_trip() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_connected_users();
@@ -357,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_rotate_second_bucket_moves_current_to_last() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         CURRENT_SECOND.store(100, Ordering::Release);
@@ -372,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_render_metrics_contains_expected_families() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_connected_users();
@@ -396,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_broadcast_counters_increment_and_render() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_broadcast_delivered();
@@ -422,7 +425,7 @@ mod tests {
     /// scraper accepts the line but dashboards lose the metric type.
     #[test]
     fn test_issue_209_finding_11_metric_families_render() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_pending_delivery_quota_exceeded();
@@ -469,7 +472,7 @@ mod tests {
 
     #[test]
     fn test_reset_metrics_for_test_clears_sm_promotion_not_promotable() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_sm_promotion_not_promotable();
@@ -481,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_sm_unacked_evicted_counter_increments_and_renders() {
-        let _guard = test_lock().lock().unwrap();
+        let _guard = metrics_test_lock().lock().unwrap();
         reset_metrics_for_test();
 
         increment_sm_unacked_evicted();

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -345,6 +345,8 @@ mod tests {
         // <resumed/> replays have holes".
         use crate::prometheus;
 
+        let _metrics_guard = prometheus::metrics_test_lock().lock().unwrap();
+
         // Baseline the counter since other tests run in the same process.
         let before_render = prometheus::render_metrics();
         let baseline = before_render
@@ -389,6 +391,8 @@ mod tests {
 
     #[test]
     fn test_evicted_unacked_stanza_blocks_resume_until_client_h_covers_gap() {
+        let _metrics_guard = crate::prometheus::metrics_test_lock().lock().unwrap();
+
         let mut state = StreamManagementState::with_config(3, 5);
         state.enable("tiny-cap".to_string(), true, Some(300));
 


### PR DESCRIPTION
## Plan

Follow-up slice for #350 after PR #487.

- Keep WebSocket endpoint, route wiring, XMPP wire shapes, and runtime behavior unchanged.
- Lock behavior with the existing websocket/XEP-0198 tests before moving code.
- Extract the post-bind/post-resume registration path out of connection.rs into a focused registration module.
- Move blocklist loading, state-machine initialization, connection-registry publication, SM stream-id publication, restored-presence publication, and the existing typed SM finalization call behind that boundary.
- Keep WebSocket text serialization and sending in connection.rs.
- Keep protocol outcomes typed; do not introduce stringly protocol payloads or out-of-band APIs.
- Stabilize the XEP integration CI test that asserts the process-global SM replay-eviction metric.
- Add focused regression coverage for the extracted registration boundary.

## Cleanup Done

- Added server/crates/waddle-server/src/server/routes/websocket/registration.rs.
- Moved registration-time blocklist seeding, state machine setup, connection-registry publication, SM stream id publication, restored presence publication, and typed SM finalization into the registration module.
- Reduced connection.rs so it owns transport I/O, frame dispatch, outbound replay recording, and final XML serialization to WebSocket text frames.
- Kept SmRegistrationFinalization as the typed handoff; registration.rs does not return serialized XMPP frames.
- Shared the prometheus unit-test metrics lock with stream-management tests so the SM eviction metric assertion remains exact under concurrent test execution.
- Added direct tests for fresh post-bind registration and pending XEP-0198 resume finalization through the registration boundary.
- Fixed restored available presence priority publication so the live connection registry and rich presence-state snapshot agree.

## XEP Review

- XEP-0198 section 5 requires resume to return resume/failure semantics and replay unhandled stanzas after applying h. This slice keeps the existing stream_management finalization behavior unchanged.
- RFC 6121 presence priority is restored into the live registry entry when a resumed or freshly restored available resource is registered.
- No new XMPP namespace, feature advertisement, or wire shape is introduced.

## CI Fix

- GitHub Actions failed nixXmppXepIntegration on the PR merge ref because stream_management::state::tests::test_record_outbound_surfaces_eviction_to_metric asserted an exact global counter delta while another concurrent state test also evicted from the replay queue.
- The fix serializes metric-mutating unit tests with the shared test-only metrics lock rather than weakening the assertion.

## Verification

- [x] cargo fmt
- [x] cargo test -p waddle-server register_bound_connection_after_frame
- [x] cargo test -p waddle-server sm_resume
- [x] cargo test -p waddle-server --test rfc6121_presence_ws
- [x] cargo test -p waddle-server server::routes::websocket
- [x] cargo test -p waddle-xmpp --test xep0198_session_registry
- [x] cargo test -p waddle-xmpp stream_management::state::tests -- --test-threads=8
- [x] cargo test -p waddle-xmpp --tests --verbose
- [x] cargo clippy -p waddle-server --tests -- -D warnings
- [x] cargo clippy -p waddle-xmpp --tests -- -D warnings
- [x] git diff --check

## Notes

Qodo rule loading was skipped because this environment has no ~/.qodo/config.json.
