### PR TITLE
fix(chat): pin grouped message timestamps to a single line

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -80,7 +80,6 @@ export function useChannelMessages(
   const mentionedChannelCounts = ref<Record<string, number>>({});
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
   const roomAvatarHashes = ref<Record<string, string>>({});
-  let slowModeTimer: ReturnType<typeof setInterval> | null = null;
 
   const chatStates = useChannelChatStates({
     xmppClient,
@@ -295,20 +294,6 @@ export function useChannelMessages(
       // XEP-0486: Track room avatar hashes from presence
       client.setRoomAvatarHandler((roomJid, hash) => {
         roomAvatarHashes.value = { ...roomAvatarHashes.value, [roomJid]: hash };
-      });
-      client.setSlowModeHandler((seconds) => {
-        slowModeCooldown.value = seconds;
-        if (slowModeTimer) clearInterval(slowModeTimer);
-        slowModeTimer = setInterval(() => {
-          slowModeCooldown.value--;
-          if (slowModeCooldown.value <= 0) {
-            slowModeCooldown.value = 0;
-            if (slowModeTimer) {
-              clearInterval(slowModeTimer);
-              slowModeTimer = null;
-            }
-          }
-        }, 1000);
       });
     } else {
       // $xmppStatus is reset by XmppProvider on logout/unmount.

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -100,20 +100,26 @@ export function isFeedTimelineMessage(message: TimelineMessage): boolean {
   return !message.threadId || message.id === message.threadId;
 }
 
+const TIMELINE_STAMP_FORMATTER = new Intl.DateTimeFormat("en", {
+  hour: "2-digit",
+  minute: "2-digit",
+  month: "short",
+  day: "numeric",
+  hour12: false,
+});
+
+const TIMELINE_TIME_OF_DAY_FORMATTER = new Intl.DateTimeFormat("en", {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
 export function formatTimelineStamp(value: string) {
-  return new Intl.DateTimeFormat("en", {
-    hour: "2-digit",
-    minute: "2-digit",
-    month: "short",
-    day: "numeric",
-  }).format(new Date(value));
+  return TIMELINE_STAMP_FORMATTER.format(new Date(value));
 }
 
 export function formatTimelineTimeOfDay(value: string) {
-  return new Intl.DateTimeFormat("en", {
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(new Date(value));
+  return TIMELINE_TIME_OF_DAY_FORMATTER.format(new Date(value));
 }
 
 const DAY_DIVIDER_FORMATTER = new Intl.DateTimeFormat("en", {

--- a/chat/src/components/XmppProvider.vue
+++ b/chat/src/components/XmppProvider.vue
@@ -3,7 +3,6 @@ import { onMounted, onUnmounted } from "vue";
 import { useSessionAuth } from "@/auth/session";
 import { BrowserXmppClient } from "@/lib/xmpp-client";
 import { connectionStore } from "@/lib/connection-store";
-import { createServerAuth } from "@/lib/server-auth";
 import { $xmppStatus, OFFLINE_SNAPSHOT } from "@/stores/xmpp-status";
 import { installInstrumentation } from "@/lib/xmpp/xmpp-instrumentation";
 
@@ -33,16 +32,6 @@ async function bootstrap() {
     // `onStatus` hook fires alongside it. Safe to install even when
     // Faro isn't initialized; `@/lib/telemetry` no-ops until bootstrap.
     installInstrumentation(client);
-    const serverUrl = auth.activeServerUrl.value;
-    client.setRefreshSession(async () => {
-      const serverAuth = createServerAuth(serverUrl);
-      const refreshed = await serverAuth.getSession(auth.session.value?.session_id);
-      if (refreshed && !refreshed.is_expired) {
-        auth.session.value = refreshed;
-        syncStoreFromAuth();
-      }
-      return refreshed;
-    });
     // The status handler is owned here — XmppProvider is persisted across
     // route changes (transition:persist), so there is exactly one writer to
     // $xmppStatus for the lifetime of the client. Transient consumers

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -237,7 +237,6 @@ export class BrowserXmppClient {
   private roomMemberJids: Record<string, string> = {};
   private memberJidHandler: ((nick: string, bareJid: string) => void) | null = null;
   private hatsHandler: ((hats: RoomHats) => void) | null = null;
-  private slowModeHandler: ((seconds: number) => void) | null = null;
   private activityHandler: ((event: RoomActivityEvent) => void) | null = null;
   private inboxPushHandler: ((entry: InboxEntry) => void) | null = null;
   private roomAvatarHandler: ((roomJid: string, hash: string) => void) | null = null;
@@ -252,7 +251,6 @@ export class BrowserXmppClient {
   private connectPromise: Promise<void> | null = null;
   private connected = false;
   private destroying = false;
-  private refreshSession: (() => Promise<WaddleSession | null>) | null = null;
   private currentRoom: string | null = null;
   private roomSwitchPromise: Promise<void> | null = null;
   private roomSwitchTarget: string | null = null;
@@ -297,7 +295,6 @@ export class BrowserXmppClient {
   setPresenceUpdateHandler(h: (event: PresenceUpdateEvent) => void) { this.presenceUpdateHandler = h; }
   setMemberJidHandler(h: (nick: string, bareJid: string) => void) { this.memberJidHandler = h; }
   setHatsHandler(h: (hats: RoomHats) => void) { this.hatsHandler = h; }
-  setSlowModeHandler(h: (seconds: number) => void) { this.slowModeHandler = h; }
   setActivityHandler(h: (event: RoomActivityEvent) => void) { this.activityHandler = h; }
   setInboxPushHandler(h: (entry: InboxEntry) => void) { this.inboxPushHandler = h; }
   setRoomAvatarHandler(h: (roomJid: string, hash: string) => void) { this.roomAvatarHandler = h; }
@@ -308,7 +305,6 @@ export class BrowserXmppClient {
   setMessageDeliveryFailureHandler(h: (messageId: string) => void) { this.messageDeliveryFailureHandler = h; }
   setQueuedMessageStatusHandler(h: (messageId: string, status: "queued" | "sending") => void) { this.queuedMessageStatusHandler = h; }
   setSessionLifecycleHandler(h: (event: SessionLifecycleEvent) => void) { this.sessionLifecycleHandler = h; }
-  setRefreshSession(fn: () => Promise<WaddleSession | null>) { this.refreshSession = fn; }
 
   onMessageAcked(hook: (id: string, meta: { kind: "room" | "dm"; latencyMs: number }) => void) { this.messageAckHooks.push(hook); }
   onMessageDeliveryFailed(hook: (id: string, meta: { kind: "room" | "dm" }) => void) { this.messageFailHooks.push(hook); }

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -8,7 +8,6 @@ const NS_FORUMS_0 = "urn:xmpp:forums:0";
 const NS_MUC = "http://jabber.org/protocol/muc";
 const NS_SPACES_0 = "urn:xmpp:spaces:0";
 const NS_PUBSUB = "http://jabber.org/protocol/pubsub";
-const NS_PUBSUB_METADATA = `${NS_PUBSUB}#meta-data`;
 const DISCO_INFO_NS = "http://jabber.org/protocol/disco#info";
 const DISCO_ITEMS_NS = "http://jabber.org/protocol/disco#items";
 const DATAFORM_NS = "jabber:x:data";

--- a/chat/src/lib/xmpp/extensions/encrypted-file.ts
+++ b/chat/src/lib/xmpp/extensions/encrypted-file.ts
@@ -3,8 +3,6 @@
  *
  * Shared type definitions used by the chat UI and attachment helpers.
  */
-const NS_ESFS_0 = "urn:xmpp:esfs:0";
-const NS_HASHES_2 = "urn:xmpp:hashes:2";
 
 /** Closed set of ciphers Waddle understands end-to-end. */
 export type EncryptedFileCipher =

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -272,17 +272,21 @@
  * inside MessageCard via v-if. The avatar slot becomes a hover-revealed
  * timestamp gutter so the user can still read the per-message time. */
 .chat-message-grouped {
+  min-height: var(--chat-message-first-line-box);
   margin-block-start: calc(-1 * var(--chat-message-row-gap, var(--space-xs)));
 }
 
 .chat-message-time-gutter {
   display: flex;
+  height: var(--chat-message-first-line-box);
   align-items: center;
   justify-content: center;
   opacity: 0;
   transition: opacity 0.12s ease-out;
   font-variant-numeric: tabular-nums;
   pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .chat-message-grouped:hover .chat-message-time-gutter,

--- a/chat/tests/helpers/xmpp-client-mock.ts
+++ b/chat/tests/helpers/xmpp-client-mock.ts
@@ -17,6 +17,5 @@ export function handlerStubs() {
     setLastSeenHandler: () => {},
     setActivityHandler: () => {},
     setRoomAvatarHandler: () => {},
-    setSlowModeHandler: () => {},
   };
 }

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -896,7 +896,6 @@ describe("XEP-0198 self-echo reconciliation (group chat)", () => {
       setLastSeenHandler() {},
       setActivityHandler() {},
       setRoomAvatarHandler() {},
-      setSlowModeHandler() {},
     } as never;
     await nextTick();
 


### PR DESCRIPTION
## Summary

- Switch `formatTimelineTimeOfDay` (and `formatTimelineStamp`) in `chat/src/channels/timeline.ts` to a cached `Intl.DateTimeFormat` with `hour12: false`, so the per-message timestamp renders as "13:17" everywhere instead of locale-flipping to "01:17 PM". The 12h locale rendering was wide enough to wrap inside the avatar-column gutter, which yanked the row height taller than its body.
- Constrain the grouped-row time gutter to `height: var(--chat-message-first-line-box)` and add `white-space: nowrap` + `overflow: hidden` so any future formatter change still can't reflow the row.
- Lower `.chat-message-grouped` `min-height` from the avatar-cell minimum (`avatar-size + space-xs`) to `first-line-box`. Without an avatar in grouped rows, the old minimum left a tall whitespace pocket below the single body line, which made the hover bubble look chunky and pushed the gutter timestamp visually below the body baseline.

## Incidental dead-code cleanup

The TypeScript compile surfaced ts(6133) warnings for handlers and namespace constants that were written but never read. Cleaned up in the same pass:

- `BrowserXmppClient`: removed the `slowModeHandler` / `setSlowModeHandler` and `refreshSession` / `setRefreshSession` pair. Both setters were called externally (from `XmppProvider.vue` and `useChannelMessages` respectively) but `client.ts` never invoked the stored callbacks, so the features were dead end-to-end already. Orphaned callers and the now-stale slow-mode cooldown timer in `useChannelMessages` are removed, along with the test mock stubs in `tests/helpers/xmpp-client-mock.ts` and `tests/sm-delivery.test.ts`. `slowModeCooldown` is still exported from `useChannelMessages` and consumed by the composer/UI as a ref initialised to `0`; the UI surface is preserved.
- `xmpp/discovery.ts`: removed unused `NS_PUBSUB_METADATA`.
- `xmpp/extensions/encrypted-file.ts`: removed unused `NS_ESFS_0` and `NS_HASHES_2`.

### Known follow-ups (out of scope for this PR)

- **XEP-0500 slow-mode end-to-end**: the server (`server/crates/waddle-xmpp/src/xep/xep0500.rs`) already emits the policy-violation cue, but no client surface ever parsed it. A follow-up needs to add the stanza decoder in `client.ts` and re-add a typed `SlowModeEvent` plumbing into `useChannelMessages` to drive the cooldown ref.
- **Session refresh on XMPP-side expiry**: the removed `setRefreshSession` was the only renewal hook. If/when we wire stream-error → re-auth, the new path can re-introduce a typed `refreshSession` injection (or move it into the session/auth module directly) rather than restoring the dead stub.

## Test plan

- [x] `bun test` — 773 pass / 0 fail
- [x] `bun run lint` — knip clean
- [x] `bun x astro check` — 0 errors / 0 warnings / 0 hints
- [x] Visual verification in `wrangler dev --local`: grouped-row hover gutter shows "13:17" on a single line, the hover bubble height matches the body line, and the gutter timestamp sits on the same baseline as the body's first text line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)