### PR TITLE
fix(chat): wrap long message text instead of scrolling the pane

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -982,7 +982,7 @@ function dayDividerLabel(createdAt: string): string {
     <div
       v-if="isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
       :ref="setMessagesContainer"
-      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-[var(--chat-content-inline)]"
       @scroll="updateCurrentDayMarker"
     >
       <div v-if="isLoadingMessages" class="type-caption flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -115,7 +115,7 @@ watch(
       v-if="shouldRenderTextBody"
       ref="styledBodyRef"
       :class="[
-        'type-message-body wrap-anywhere styled-body',
+        'type-message-body styled-body',
         compact ? 'type-field-sm line-clamp-3' : '',
       ]"
       v-html="styledHtml"

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -115,7 +115,7 @@ watch(
       v-if="shouldRenderTextBody"
       ref="styledBodyRef"
       :class="[
-        'type-message-body break-words styled-body',
+        'type-message-body wrap-anywhere styled-body',
         compact ? 'type-field-sm line-clamp-3' : '',
       ]"
       v-html="styledHtml"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -585,7 +585,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     <div
       v-else
       :ref="setScrollContainerRef"
-      class="chat-pane-scroll flex-1 min-h-0 overflow-auto px-3 py-4 lg:px-4"
+      class="chat-pane-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-3 py-4 lg:px-4"
       @scroll="updateCurrentDayMarker"
     >
       <div class="type-caption text-center py-10 text-muted-foreground">

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -88,7 +88,7 @@ defineExpose({ scrollElement, scrollToMessageId, scrollToPinnedEdge });
 <template>
   <div
     ref="scrollElement"
-    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-[var(--chat-content-inline)]"
     :aria-label="ariaLabel"
     @scroll="(event) => { emit('scroll', event); maybeLoadOlder(); }"
   >

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -88,7 +88,7 @@ defineExpose({ scrollElement, scrollToMessageId, scrollToPinnedEdge });
 <template>
   <div
     ref="scrollElement"
-    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-[var(--chat-content-inline)]"
+    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
     :aria-label="ariaLabel"
     @scroll="(event) => { emit('scroll', event); maybeLoadOlder(); }"
   >

--- a/chat/src/styles/global/rich-text.css
+++ b/chat/src/styles/global/rich-text.css
@@ -13,6 +13,15 @@
 }
 
 /* Rich text rendered from XEP metadata and TipTap composer nodes. */
+/* `overflow-wrap: anywhere` (not `break-word`) is required so an unbreakable
+   token shrinks the box's min-content intrinsic size to a single character —
+   otherwise long URLs/slugs hold the message body wider than the pane and
+   produce a horizontal scrollbar on flex/grid layouts. The composer applies
+   the same rule on `.ProseMirror` (see ChatEditor.vue). */
+.styled-body {
+  overflow-wrap: anywhere;
+  min-width: 0;
+}
 :where(.styled-body, .chat-editor .ProseMirror) p {
   margin: 0;
 }


### PR DESCRIPTION
## Summary

- The rendered message body used `break-words` (`overflow-wrap: break-word`), which does NOT shrink a box's min-content intrinsic size. Unbreakable tokens (long URLs, slugs, identifiers) therefore kept the body wider than the pane in the flex/grid layout, even though `min-w-0` was set on ancestors. The composer already used `overflow-wrap: anywhere` (`chat/src/components/chat/ChatEditor.vue:131`), which is why the editor wrapped but incoming messages did not. Switched `MessageBody.vue` to `wrap-anywhere`.
- Defense in depth: the message-list scroll containers were `overflow-auto` (both axes). For a vertical chat list there's no scenario where horizontal pane scrolling is correct — code blocks carry their own internal `overflow-x: auto`. Switched the message list, the empty/loading branch in `ContentArea`, and the thread panel scroll container to `overflow-x-hidden overflow-y-auto`.

## Why this is the fix, not a workaround

`overflow-wrap: break-word` only inserts a soft-break opportunity when a word would overflow AND is alone on a line, and per spec the introduced break does not affect intrinsic min-content sizing — so flex/grid items still resolve their minimum cross-axis size to the longest unbreakable token. `overflow-wrap: anywhere` is identical for wrapping, but breaks DO count toward min-content, letting the body shrink to the available pane width and re-flow.

## Test plan

- [ ] Send a message containing a long URL (e.g. `https://example.com/very/long/path-without-spaces/that/exceeds/the/pane/width`) on a mobile viewport and on desktop — the URL should wrap, no pane-level horizontal scroll.
- [ ] Send a message containing a single very long word/slug (no spaces, > pane width) — it should wrap mid-word.
- [ ] Send a fenced code block whose lines exceed the pane — the `<pre>` should still scroll horizontally inside itself; the pane should not.
- [ ] Confirm normal prose, threads, replies, and the loading/empty states render unchanged.
- [ ] `bun test` and `bunx astro check` in `chat/` stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)