### PR TITLE
fix(chat): hide extension rail on mobile; surface routes in Details drawer

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
+import { computed } from "vue";
+import { Grid3X3, Link2, ListChecks } from "lucide-vue-next";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
+import { extensionRouteRailItems, type ExtensionRouteRailIcon } from "./extension-route-rail-model";
+import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 
 const props = defineProps<{
@@ -24,6 +28,9 @@ const {
   displayedMemberState,
   memberCountLabel,
   computedChannelUnreadMap,
+  channelExtensionRoutes,
+  activeExtensionRouteKey,
+  activeRightPanel,
   openUserSettings,
   handleLogout,
   handleRequestNotifications,
@@ -31,9 +38,31 @@ const {
   selectChannel,
   onSelectThread,
   selectDm,
+  selectExtensionRoute,
   openCreateChannelDialog,
   openChannelEdit,
 } = props.controller;
+
+const drawerExtensionRoutes = computed(() =>
+  extensionRouteRailItems(
+    channelExtensionRoutes.value,
+    activeExtensionRouteKey.value,
+    activeRightPanel.value === "extension",
+  ),
+);
+
+function routeIcon(icon: ExtensionRouteRailIcon) {
+  if (icon === "links") return Link2;
+  if (icon === "gallery") return Grid3X3;
+  return ListChecks;
+}
+
+function openExtensionRoute(route: DiscoveredExtensionRoute) {
+  const channel = waddles.currentChannel.value;
+  if (!channel) return;
+  ui.showMobileDetails.value = false;
+  void selectExtensionRoute(channel.id, route);
+}
 </script>
 
 <template>
@@ -138,6 +167,27 @@ const {
             @click="ui.showMobileDetails.value = false; ui.showMembers.value = true"
           >
             Members ({{ memberCountLabel }})
+          </button>
+        </div>
+
+        <div
+          v-if="ui.sidebarMode.value === 'channels'
+            && waddles.currentChannel.value
+            && drawerExtensionRoutes.length > 0"
+          class="flex flex-col gap-1.5"
+        >
+          <h4 class="type-pane-title">Extensions</h4>
+          <button
+            v-for="item in drawerExtensionRoutes"
+            :key="item.key"
+            type="button"
+            class="type-control flex h-9 w-full items-center gap-2 rounded-lg border border-border px-3 hover:bg-muted transition-colors"
+            :class="item.isActive ? 'bg-muted' : ''"
+            :aria-current="item.isActive ? 'page' : undefined"
+            @click="openExtensionRoute(item.route)"
+          >
+            <component :is="routeIcon(item.icon)" class="h-4 w-4" aria-hidden="true" />
+            <span class="truncate text-left">{{ item.label }}</span>
           </button>
         </div>
       </div>

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { Grid3X3, Link2, ListChecks } from "lucide-vue-next";
 import WaddlesSidebar from "@/components/chat/WaddlesSidebar.vue";
 import TopicsPanel from "@/components/chat/TopicsPanel.vue";
 import DmPanel from "@/components/chat/DmPanel.vue";
 import SettingsMobileHeader from "@/components/chat/SettingsMobileHeader.vue";
 import ProfilePanel from "@/components/chat/ProfilePanel.vue";
 import AppDrawer from "@/components/ui/AppDrawer.vue";
-import { extensionRouteRailItems, type ExtensionRouteRailIcon } from "./extension-route-rail-model";
+import { extensionRouteIconComponent, extensionRouteRailItems } from "./extension-route-rail-model";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 
@@ -50,12 +49,6 @@ const drawerExtensionRoutes = computed(() =>
     activeRightPanel.value === "extension",
   ),
 );
-
-function routeIcon(icon: ExtensionRouteRailIcon) {
-  if (icon === "links") return Link2;
-  if (icon === "gallery") return Grid3X3;
-  return ListChecks;
-}
 
 function openExtensionRoute(route: DiscoveredExtensionRoute) {
   const channel = waddles.currentChannel.value;
@@ -186,7 +179,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
             :aria-current="item.isActive ? 'page' : undefined"
             @click="openExtensionRoute(item.route)"
           >
-            <component :is="routeIcon(item.icon)" class="h-4 w-4" aria-hidden="true" />
+            <component :is="extensionRouteIconComponent(item.icon)" class="h-4 w-4" aria-hidden="true" />
             <span class="truncate text-left">{{ item.label }}</span>
           </button>
         </div>

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -174,15 +174,15 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           v-if="ui.sidebarMode.value === 'channels'
             && waddles.currentChannel.value
             && drawerExtensionRoutes.length > 0"
-          class="flex flex-col gap-1.5"
+          class="flex flex-col gap-1.5 border-t border-border pt-4"
         >
-          <h4 class="type-pane-title">Extensions</h4>
+          <h3 class="type-section-label text-muted-foreground">Extensions</h3>
           <button
             v-for="item in drawerExtensionRoutes"
             :key="item.key"
             type="button"
             class="type-control flex h-9 w-full items-center gap-2 rounded-lg border border-border px-3 hover:bg-muted transition-colors"
-            :class="item.isActive ? 'bg-muted' : ''"
+            :class="item.isActive ? 'border-primary/30 bg-primary/10 text-primary' : ''"
             :aria-current="item.isActive ? 'page' : undefined"
             @click="openExtensionRoute(item.route)"
           >

--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -164,9 +164,7 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
         </div>
 
         <div
-          v-if="ui.sidebarMode.value === 'channels'
-            && waddles.currentChannel.value
-            && drawerExtensionRoutes.length > 0"
+          v-if="drawerExtensionRoutes.length > 0"
           class="flex flex-col gap-1.5 border-t border-border pt-4"
         >
           <h3 class="type-section-label text-muted-foreground">Extensions</h3>

--- a/chat/src/components/chat/ExtensionRouteRail.vue
+++ b/chat/src/components/chat/ExtensionRouteRail.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { Grid3X3, Link2, ListChecks } from "lucide-vue-next";
 import { computed } from "vue";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
-import { extensionRouteRailItems, type ExtensionRouteRailIcon } from "./extension-route-rail-model";
+import { extensionRouteIconComponent, extensionRouteRailItems } from "./extension-route-rail-model";
 
 const props = defineProps<{
   routes: DiscoveredExtensionRoute[];
@@ -15,12 +14,6 @@ const emit = defineEmits<{
 }>();
 
 const items = computed(() => extensionRouteRailItems(props.routes, props.activeRoute, !!props.active));
-
-function routeIcon(icon: ExtensionRouteRailIcon) {
-  if (icon === "links") return Link2;
-  if (icon === "gallery") return Grid3X3;
-  return ListChecks;
-}
 </script>
 
 <template>
@@ -40,7 +33,7 @@ function routeIcon(icon: ExtensionRouteRailIcon) {
       :aria-current="item.isActive ? 'page' : undefined"
       @click="emit('selectRoute', item.route)"
     >
-      <component :is="routeIcon(item.icon)" class="h-4 w-4" aria-hidden="true" />
+      <component :is="extensionRouteIconComponent(item.icon)" class="h-4 w-4" aria-hidden="true" />
     </button>
   </aside>
 </template>

--- a/chat/src/components/chat/extension-route-rail-model.ts
+++ b/chat/src/components/chat/extension-route-rail-model.ts
@@ -1,6 +1,14 @@
+import { Grid3X3, Link2, ListChecks } from "lucide-vue-next";
+import type { Component } from "vue";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
 
-export type ExtensionRouteRailIcon = "gallery" | "links" | "list";
+type ExtensionRouteRailIcon = "gallery" | "links" | "list";
+
+export function extensionRouteIconComponent(icon: ExtensionRouteRailIcon): Component {
+  if (icon === "links") return Link2;
+  if (icon === "gallery") return Grid3X3;
+  return ListChecks;
+}
 
 interface ExtensionRouteRailItem {
   key: string;

--- a/chat/src/styles/global/shell.css
+++ b/chat/src/styles/global/shell.css
@@ -186,7 +186,7 @@
 }
 
 @media (max-width: 63.999rem) {
-  .chat-workspace--right-panel-active .extension-route-rail {
+  .extension-route-rail {
     display: none;
   }
 }


### PR DESCRIPTION
## Context

On mobile the right-edge "extension route rail" (`ExtensionRouteRail.vue`) was rendered whenever the current channel exposed any extension routes, eating ~48px of horizontal space against the right edge of the screen — see screenshot in the originating chat. Previously the rail only hid on mobile when a right panel was already active, which is the wrong default — most of the time no right panel is open and the rail is just sitting there.

This PR makes the rail behave like the left waddle rail on mobile: not rendered. Because the rail is the only entry point to extension routes, the routes are surfaced inside the existing right-side mobile "Details" drawer (the one opened from the mobile header's Members button, alongside Edit channel / Members).

## Changes

**1. Hide the rail unconditionally on mobile** (`chat/src/styles/global/shell.css`)

Drop the `.chat-workspace--right-panel-active` qualifier so `.extension-route-rail` is gone on any viewport below `64rem`. Desktop is unaffected.

**2. Add an Extensions section to the mobile Details drawer** (`chat/src/components/chat/ChatMobileDrawers.vue`)

Renders one button per discovered extension route, scoped to channel mode and only when the current channel actually exposes routes. Tapping a route closes the drawer and invokes the same `controller.selectExtensionRoute(channelId, route)` code path the desktop rail uses, handing off to the full-screen extension panel.

The section uses a `border-t` separator and a `type-section-label` heading so it's visually distinct from the Edit channel / Members group above it. Active route is styled with a primary-tinted background/border/text so it's distinguishable from inactive-hover (`bg-muted`).

**3. Hoist the icon-component mapping** (`chat/src/components/chat/extension-route-rail-model.ts`, `ExtensionRouteRail.vue`, `ChatMobileDrawers.vue`)

The previously-duplicated `ExtensionRouteRailIcon → Lucide component` switch is now a single `extensionRouteIconComponent` exported from the model, so the desktop rail and mobile drawer can't drift on iconography.

## Adversarial review summary

Ran three adversarial reviewers (UX/a11y, code quality / Vue idioms, edge cases / state machine). Addressed in this PR:

- Drawer heading was `h4` underneath an `h3` for the space name — fixed to `h3` + `type-section-label`.
- No visual separator between Members/Edit and Extensions — added `border-t pt-4`.
- Active-state collided with hover (both `bg-muted`) — active now uses `border-primary/30 bg-primary/10 text-primary`.
- `routeIcon` helper was duplicated across two surfaces — hoisted into the shared model.

Consciously deferred (pre-existing patterns, broader cleanup if needed):

- Touch target `h-9` (36px) matches the existing Edit channel / Members buttons in the same drawer.
- Drawer→panel hand-off doesn't move focus to the panel root — same gap exists for thread/pinned panels.
- `selectExtensionRoute` doesn't clear `activeThreadStack` — pre-existing state-machine inconsistency shared with the desktop rail click path.

## Test plan

- [x] `bun test` — no new failures (1 pre-existing failure: `tests/startup-loading.test.ts` requires `dist/` build output which isn't present locally; unrelated to this PR).
- [x] `bunx knip` — exit 0, no new findings.
- [x] `bunx vue-tsc --noEmit` — clean.
- [ ] Manual smoke on a narrow viewport: rail gone; Members icon opens the Details drawer; Extensions section lists each route with icon and label; tapping a route closes the drawer and opens the extension panel full-screen; close/Escape returns to the channel.
- [ ] Manual smoke at ≥1024px: desktop right-edge rail reappears unchanged.