### PR TITLE
fix(chat): place thread root at the oldest end and add a "Thread start" accent

### DIFF
--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -88,7 +88,13 @@ const orderedChildren = computed(() => {
 });
 const orderedThreadMessages = computed(() => {
   const root = activeEntry.value?.root;
-  return root ? [root, ...orderedChildren.value] : [...orderedChildren.value];
+  if (!root) return [...orderedChildren.value];
+  // The root is always the oldest message in the thread. Place it at whichever
+  // end of the rendered list represents "oldest" for the active scroll mode:
+  // bottom in social/top-pinned mode, top in chat/bottom-pinned mode.
+  return isTopPinnedScrollDirection(scrollDirectionMode.value)
+    ? [...orderedChildren.value, root]
+    : [root, ...orderedChildren.value];
 });
 const newestThreadMessageId = computed(() =>
   activeEntry.value?.directChildren.at(-1)?.id
@@ -503,26 +509,32 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
       @load-older="activeThreadId && emit('loadOlder', activeThreadId)"
     >
       <template #item="{ item: message }">
-        <MessageCard
+        <div
           v-if="message.id === activeEntry.root?.id"
-          :message="message"
-          :current-user="currentUser"
-          :current-user-jid="currentUserJid"
-          :avatar-url="avatarUrlByAuthor[message.author] ?? null"
-          :hats="hatsFor(message.author)"
-          :presence="presenceFor(message.author)"
-          :last-seen="roomLastSeen[message.author]"
-          :author-jid="authorJidByNick?.[message.author]"
-          :thread-reply-count="activeEntry.count"
-          hide-thread-chip
-          :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
-          :invoke-extension-action="props.invokeExtensionAction"
-          @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
-          @retract="(id) => emit('retractMessage', id)"
-          @react="(id, emoji) => emit('reactMessage', id, emoji)"
-          @reply="beginReplyInThread"
-          @open-thread="onOpenThreadFromCard"
-        />
+          class="chat-thread-root"
+          aria-label="Thread root message"
+        >
+          <span class="chat-thread-root__label type-section-label">Thread start</span>
+          <MessageCard
+            :message="message"
+            :current-user="currentUser"
+            :current-user-jid="currentUserJid"
+            :avatar-url="avatarUrlByAuthor[message.author] ?? null"
+            :hats="hatsFor(message.author)"
+            :presence="presenceFor(message.author)"
+            :last-seen="roomLastSeen[message.author]"
+            :author-jid="authorJidByNick?.[message.author]"
+            :thread-reply-count="activeEntry.count"
+            hide-thread-chip
+            :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
+            :invoke-extension-action="props.invokeExtensionAction"
+            @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
+            @retract="(id) => emit('retractMessage', id)"
+            @react="(id, emoji) => emit('reactMessage', id, emoji)"
+            @reply="beginReplyInThread"
+            @open-thread="onOpenThreadFromCard"
+          />
+        </div>
         <template v-else>
           <div
             v-if="showDayDividerBefore(message.id)"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -143,7 +143,13 @@ function dayDividerLabel(createdAt: string): string {
 const isTopPinned = computed(() =>
   isTopPinnedScrollDirection(scrollDirectionMode.value),
 );
-const olderSentinelPosition = computed(() => scrollDirectionMode.value === "social" ? "end" : "start");
+// Older replies paginate at the chronologically-older end of the list. In
+// social mode the root is appended after the loaded replies, so the sentinel
+// has to sit one slot inboard of the trailing root rather than below it.
+const olderSentinelPosition = computed<"start" | "end" | "before-end">(() => {
+  if (scrollDirectionMode.value !== "social") return "start";
+  return activeEntry.value?.root ? "before-end" : "end";
+});
 
 const scrollContainerRef = ref<HTMLElement | null>(null);
 const virtualTimelineEdgeScroller: Ref<((mode: ScrollDirectionMode) => boolean | Promise<boolean>) | null> = ref(null);
@@ -509,32 +515,41 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
       @load-older="activeThreadId && emit('loadOlder', activeThreadId)"
     >
       <template #item="{ item: message }">
-        <div
-          v-if="message.id === activeEntry.root?.id"
-          class="chat-thread-root"
-          aria-label="Thread root message"
-        >
-          <span class="chat-thread-root__label type-section-label">Thread start</span>
-          <MessageCard
-            :message="message"
-            :current-user="currentUser"
-            :current-user-jid="currentUserJid"
-            :avatar-url="avatarUrlByAuthor[message.author] ?? null"
-            :hats="hatsFor(message.author)"
-            :presence="presenceFor(message.author)"
-            :last-seen="roomLastSeen[message.author]"
-            :author-jid="authorJidByNick?.[message.author]"
-            :thread-reply-count="activeEntry.count"
-            hide-thread-chip
-            :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
-            :invoke-extension-action="props.invokeExtensionAction"
-            @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
-            @retract="(id) => emit('retractMessage', id)"
-            @react="(id, emoji) => emit('reactMessage', id, emoji)"
-            @reply="beginReplyInThread"
-            @open-thread="onOpenThreadFromCard"
-          />
-        </div>
+        <template v-if="message.id === activeEntry.root?.id">
+          <div
+            v-if="showDayDividerBefore(message.id)"
+            class="chat-day-divider type-section-label"
+            :data-day-marker-created-at="message.createdAt"
+            role="separator"
+            :aria-label="dayDividerLabel(message.createdAt)"
+          >
+            <div class="chat-day-divider__rule" />
+            <span class="chat-day-divider__label">{{ dayDividerLabel(message.createdAt) }}</span>
+            <div class="chat-day-divider__rule" />
+          </div>
+          <div class="chat-thread-root" aria-label="Thread root message">
+            <span class="chat-thread-root__label type-section-label">Thread start</span>
+            <MessageCard
+              :message="message"
+              :current-user="currentUser"
+              :current-user-jid="currentUserJid"
+              :avatar-url="avatarUrlByAuthor[message.author] ?? null"
+              :hats="hatsFor(message.author)"
+              :presence="presenceFor(message.author)"
+              :last-seen="roomLastSeen[message.author]"
+              :author-jid="authorJidByNick?.[message.author]"
+              :thread-reply-count="activeEntry.count"
+              hide-thread-chip
+              :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
+              :invoke-extension-action="props.invokeExtensionAction"
+              @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
+              @retract="(id) => emit('retractMessage', id)"
+              @react="(id, emoji) => emit('reactMessage', id, emoji)"
+              @reply="beginReplyInThread"
+              @open-thread="onOpenThreadFromCard"
+            />
+          </div>
+        </template>
         <template v-else>
           <div
             v-if="showDayDividerBefore(message.id)"

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -11,7 +11,12 @@ const props = withDefaults(defineProps<{
   items: TimelineMessage[];
   hasOlder: boolean;
   loadingOlder: boolean;
-  sentinelPosition: "start" | "end";
+  // "start" / "end" anchor the older-history sentinel to the edge of the
+  // virtualized list. "before-end" parks it one slot in from the end so the
+  // sentinel can sit between the loaded items and a non-paginated trailing
+  // anchor (e.g. the thread root rendered at the chronologically-oldest end
+  // in social mode).
+  sentinelPosition: "start" | "end" | "before-end";
   ariaLabel: string;
   contentClass?: string;
 }>(), {
@@ -26,14 +31,30 @@ const emit = defineEmits<{
 const scrollElement = ref<HTMLDivElement | null>(null);
 const hasOlderSentinel = computed(() => props.hasOlder || props.loadingOlder);
 const rowCount = computed(() => props.items.length + (hasOlderSentinel.value ? 1 : 0));
-const sentinelIndex = computed(() =>
-  !hasOlderSentinel.value ? -1 : props.sentinelPosition === "start" ? 0 : rowCount.value - 1,
-);
+const sentinelIndex = computed(() => {
+  if (!hasOlderSentinel.value) return -1;
+  if (props.sentinelPosition === "start") return 0;
+  if (props.sentinelPosition === "before-end") return Math.max(0, rowCount.value - 2);
+  return rowCount.value - 1;
+});
+
+function itemIndexForVirtualIndex(index: number): number {
+  if (!hasOlderSentinel.value) return index;
+  if (props.sentinelPosition === "start") return index - 1;
+  if (props.sentinelPosition === "before-end") return index < sentinelIndex.value ? index : index - 1;
+  return index;
+}
+
+function virtualIndexForItemIndex(itemIndex: number): number {
+  if (!hasOlderSentinel.value) return itemIndex;
+  if (props.sentinelPosition === "start") return itemIndex + 1;
+  if (props.sentinelPosition === "before-end") return itemIndex < sentinelIndex.value ? itemIndex : itemIndex + 1;
+  return itemIndex;
+}
 
 function itemForVirtualIndex(index: number): TimelineMessage | null {
   if (index === sentinelIndex.value) return null;
-  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
-  return props.items[index - offset] ?? null;
+  return props.items[itemIndexForVirtualIndex(index)] ?? null;
 }
 
 const virtualizer = useVirtualizer(computed(() => ({
@@ -65,8 +86,7 @@ watch(
 async function scrollToMessageId(messageId: string, align: "start" | "center" | "end" = "center") {
   const index = props.items.findIndex((item) => item.id === messageId);
   if (index === -1) return false;
-  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
-  virtualizer.value.scrollToIndex(index + offset, { align });
+  virtualizer.value.scrollToIndex(virtualIndexForItemIndex(index), { align });
   await nextTick();
   return true;
 }
@@ -74,8 +94,7 @@ async function scrollToMessageId(messageId: string, align: "start" | "center" | 
 async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
   if (props.items.length === 0) return false;
   const itemIndex = isTopPinnedScrollDirection(mode) ? 0 : props.items.length - 1;
-  const offset = hasOlderSentinel.value && props.sentinelPosition === "start" ? 1 : 0;
-  virtualizer.value.scrollToIndex(itemIndex + offset, {
+  virtualizer.value.scrollToIndex(virtualIndexForItemIndex(itemIndex), {
     align: isTopPinnedScrollDirection(mode) ? "start" : "end",
   });
   await nextTick();

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -310,6 +310,29 @@
   padding-block: var(--space-2xs) var(--space-sm);
 }
 
+.chat-thread-root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  padding-block: var(--space-sm);
+  padding-inline: var(--space-sm);
+  margin-block: var(--space-xs);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--primary) 5%, transparent);
+  box-shadow: inset 2px 0 0 0 color-mix(in oklab, var(--primary) 55%, transparent);
+}
+
+.chat-thread-root__label {
+  align-self: flex-start;
+  padding-inline-start: var(--chat-thread-action-indent);
+  color: var(--primary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.6875rem;
+  line-height: 1;
+}
+
 .chat-accordion-bar {
   display: none;
 }


### PR DESCRIPTION
In social/top-pinned scroll mode the thread root was rendered above the
newest replies, which read backwards (oldest above newest). Render the
root at whichever end represents the chronologically oldest position for
the active scroll mode: bottom in social mode, top in chat mode. Wrap
the root card in a subtle tinted container with a "Thread start" label
so it reads as the conversation origin instead of just another message.