### PR TITLE
fix(chat): enforce overflow-x: hidden on .chat-pane-scroll permanently

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -982,7 +982,7 @@ function dayDividerLabel(createdAt: string): string {
     <div
       v-if="isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
       :ref="setMessagesContainer"
-      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-[var(--chat-content-inline)]"
+      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 px-[var(--chat-content-inline)]"
       @scroll="updateCurrentDayMarker"
     >
       <div v-if="isLoadingMessages" class="type-caption flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -144,7 +144,7 @@ function dmSecondaryText(conversation: { peerUsername?: string; peerJid: string;
 </script>
 
 <template>
-  <div class="chat-pane-scroll flex-1 overflow-auto bg-background px-[var(--chat-content-inline)] py-6">
+  <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
     <div class="mx-auto grid w-full max-w-6xl gap-6">
       <header class="flex items-center justify-between gap-4">
         <div>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -332,20 +332,29 @@ function reactionAriaLabel(emoji: string, nicks: readonly string[]): string {
 // Reaction tooltip is teleported to <body> so that pane-level
 // `overflow-x: hidden` (`.chat-pane-scroll`) cannot clip it. The chip stays
 // in place; on hover/focus we capture the chip's bounding rect and render a
-// fixed-position panel above it. Hiding on scroll/blur keeps the panel from
-// drifting away from its anchor.
+// fixed-position panel above it. Touch devices use the action sheet instead;
+// keyboard reveal is gated on `:focus-visible` so a mouse click does not
+// briefly flash the tooltip alongside the just-applied reaction.
 const hoveredReaction = ref<{
   emoji: string;
   nicks: readonly string[];
   rect: DOMRect;
 } | null>(null);
 
-const REACTION_TOOLTIP_HALF_WIDTH = 160; // matches the 20rem max-width
+const REACTION_TOOLTIP_HALF_WIDTH = 144; // matches max-w-[18rem]
 const REACTION_TOOLTIP_GAP = 8;
 
-function showReactionTooltip(emoji: string, nicks: readonly string[], event: Event) {
+function showReactionFromPointer(emoji: string, nicks: readonly string[], event: PointerEvent) {
+  if (event.pointerType !== "mouse") return;
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) return;
+  hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
+}
+
+function showReactionFromFocus(emoji: string, nicks: readonly string[], event: FocusEvent) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  if (!target.matches(":focus-visible")) return;
   hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
 }
 
@@ -685,9 +694,9 @@ onBeforeUnmount(() => {
         class="chat-reaction-chip type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
         :aria-label="reactionAriaLabel(emoji, nicks)"
         @click="emit('react', message.id, emoji)"
-        @mouseenter="(event) => showReactionTooltip(emoji, nicks, event)"
-        @mouseleave="() => hideReactionTooltip(emoji)"
-        @focusin="(event) => showReactionTooltip(emoji, nicks, event)"
+        @pointerenter="(event) => showReactionFromPointer(emoji, nicks, event)"
+        @pointerleave="() => hideReactionTooltip(emoji)"
+        @focusin="(event) => showReactionFromFocus(emoji, nicks, event)"
         @focusout="() => hideReactionTooltip(emoji)"
       >
         <span>{{ emoji }}</span>
@@ -926,7 +935,7 @@ onBeforeUnmount(() => {
     <div
       v-if="hoveredReaction && reactionTooltipStyle"
       aria-hidden="true"
-      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-xs -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
+      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-[18rem] -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
       :style="reactionTooltipStyle"
     >
       <span class="text-lg leading-none" aria-hidden="true">{{ hoveredReaction.emoji }}</span>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -345,7 +345,11 @@ const REACTION_TOOLTIP_HALF_WIDTH = 144; // matches max-w-[18rem]
 const REACTION_TOOLTIP_GAP = 8;
 
 function showReactionFromPointer(emoji: string, nicks: readonly string[], event: PointerEvent) {
-  if (event.pointerType !== "mouse") return;
+  // Touch: skip — touch devices use the action sheet for reactions and the
+  // synthesized pointerenter has no matching pointerleave on tap.
+  // Mouse + pen (stylus): show — both fire pointerleave reliably and
+  // benefit from the hover affordance.
+  if (event.pointerType !== "mouse" && event.pointerType !== "pen") return;
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) return;
   hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -329,6 +329,58 @@ function reactionAriaLabel(emoji: string, nicks: readonly string[]): string {
   return `${formatReactors(nicks)} reacted with ${emoji}`;
 }
 
+// Reaction tooltip is teleported to <body> so that pane-level
+// `overflow-x: hidden` (`.chat-pane-scroll`) cannot clip it. The chip stays
+// in place; on hover/focus we capture the chip's bounding rect and render a
+// fixed-position panel above it. Hiding on scroll/blur keeps the panel from
+// drifting away from its anchor.
+const hoveredReaction = ref<{
+  emoji: string;
+  nicks: readonly string[];
+  rect: DOMRect;
+} | null>(null);
+
+const REACTION_TOOLTIP_HALF_WIDTH = 160; // matches the 20rem max-width
+const REACTION_TOOLTIP_GAP = 8;
+
+function showReactionTooltip(emoji: string, nicks: readonly string[], event: Event) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
+}
+
+function hideReactionTooltip(emoji: string) {
+  if (hoveredReaction.value?.emoji === emoji) hoveredReaction.value = null;
+}
+
+const reactionTooltipStyle = computed(() => {
+  const hover = hoveredReaction.value;
+  if (!hover) return null;
+  const viewportWidth = typeof window === "undefined" ? hover.rect.right + REACTION_TOOLTIP_HALF_WIDTH : window.innerWidth;
+  const wantedCenter = hover.rect.left + hover.rect.width / 2;
+  const minCenter = REACTION_TOOLTIP_HALF_WIDTH + REACTION_TOOLTIP_GAP;
+  const maxCenter = viewportWidth - REACTION_TOOLTIP_HALF_WIDTH - REACTION_TOOLTIP_GAP;
+  const clampedCenter = Math.max(minCenter, Math.min(maxCenter, wantedCenter));
+  return {
+    top: `${hover.rect.top - REACTION_TOOLTIP_GAP}px`,
+    left: `${clampedCenter}px`,
+  };
+});
+
+function onReactionTooltipScroll() {
+  hoveredReaction.value = null;
+}
+
+watch(hoveredReaction, (next) => {
+  if (typeof window === "undefined") return;
+  if (next) {
+    window.addEventListener("scroll", onReactionTooltipScroll, true);
+  }
+  else {
+    window.removeEventListener("scroll", onReactionTooltipScroll, true);
+  }
+});
+
 function startReplyFromMenu() {
   emit("reply", props.message);
   closePicker(true);
@@ -395,6 +447,7 @@ onBeforeUnmount(() => {
 onBeforeUnmount(() => {
   if (typeof window === "undefined") return;
   window.removeEventListener("keydown", onWindowKeydown);
+  window.removeEventListener("scroll", onReactionTooltipScroll, true);
 });
 
 </script>
@@ -629,21 +682,16 @@ onBeforeUnmount(() => {
         v-for="(nicks, emoji) in message.reactions"
         :key="emoji"
         type="button"
-        class="chat-reaction-chip group/reaction relative type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
+        class="chat-reaction-chip type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
         :aria-label="reactionAriaLabel(emoji, nicks)"
         @click="emit('react', message.id, emoji)"
+        @mouseenter="(event) => showReactionTooltip(emoji, nicks, event)"
+        @mouseleave="() => hideReactionTooltip(emoji)"
+        @focusin="(event) => showReactionTooltip(emoji, nicks, event)"
+        @focusout="() => hideReactionTooltip(emoji)"
       >
         <span>{{ emoji }}</span>
         <span class="type-meta type-numeric text-muted-foreground">{{ nicks.length }}</span>
-        <span
-          aria-hidden="true"
-          class="chat-reaction-tooltip pointer-events-none absolute bottom-full left-1/2 z-popover mb-1 hidden -translate-x-1/2 max-w-xs rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md group-hover/reaction:flex group-focus-visible/reaction:flex flex-col items-center gap-0.5"
-        >
-          <span class="text-lg leading-none" aria-hidden="true">{{ emoji }}</span>
-          <span class="type-meta text-center text-muted-foreground">
-            {{ formatReactors(nicks) }}
-          </span>
-        </span>
       </button>
     </div>
 
@@ -868,6 +916,23 @@ onBeforeUnmount(() => {
           />
         </template>
       </div>
+    </div>
+  </Teleport>
+
+  <!-- Reaction tooltip: teleported so it escapes `.chat-pane-scroll`'s
+       `overflow-x: hidden`. Anchored above the hovered chip via the captured
+       rect. -->
+  <Teleport to="body">
+    <div
+      v-if="hoveredReaction && reactionTooltipStyle"
+      aria-hidden="true"
+      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-xs -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
+      :style="reactionTooltipStyle"
+    >
+      <span class="text-lg leading-none" aria-hidden="true">{{ hoveredReaction.emoji }}</span>
+      <span class="type-meta text-center text-muted-foreground">
+        {{ formatReactors(hoveredReaction.nicks) }}
+      </span>
     </div>
   </Teleport>
 </template>

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -612,7 +612,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     <div
       v-else
       :ref="setScrollContainerRef"
-      class="chat-pane-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-3 py-4 lg:px-4"
+      class="chat-pane-scroll flex-1 min-h-0 px-3 py-4 lg:px-4"
       @scroll="updateCurrentDayMarker"
     >
       <div class="type-caption text-center py-10 text-muted-foreground">

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -107,7 +107,7 @@ defineExpose({ scrollElement, scrollToMessageId, scrollToPinnedEdge });
 <template>
   <div
     ref="scrollElement"
-    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 px-[var(--chat-content-inline)]"
     :aria-label="ariaLabel"
     @scroll="(event) => { emit('scroll', event); maybeLoadOlder(); }"
   >

--- a/chat/src/components/ui/AppDrawer.vue
+++ b/chat/src/components/ui/AppDrawer.vue
@@ -44,7 +44,7 @@ function close() {
               <X class="w-4 h-4" />
             </button>
           </div>
-          <div class="chat-pane-scroll flex-1 min-h-0 overflow-auto">
+          <div class="chat-pane-scroll flex-1 min-h-0">
             <slot />
           </div>
         </div>

--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -42,6 +42,13 @@
 
 .chat-pane-scroll {
   scrollbar-gutter: stable;
+  /* Chat panes never scroll horizontally — long text wraps via
+   * `.styled-body { overflow-wrap: anywhere }` and `<pre>` blocks carry
+   * their own internal `overflow-x: auto`. Enforcing the rule here means
+   * future scroll panes inherit the guarantee without each component
+   * having to remember the right Tailwind utility. */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .chat-message-scroll {


### PR DESCRIPTION
## Why this keeps regressing

Three commits since 14 May tried to kill the chat horizontal scrollbar:

- `0836d60f` first switched the message panes from `overflow-auto` → `overflow-x-hidden overflow-y-auto`
- `0b41dd72` reverted `VirtualTimeline.vue` to `overflow-auto` after PR review worried about clipping the reaction tooltip
- `8f6a7b81` (#496) restored the wrap fix on `MessageBody`, `ContentArea`, `ThreadPanel`, and `rich-text.css`, but **missed `VirtualTimeline.vue`** — the actual scroll container the user sees when there are messages

The `overflow-x-hidden` containers in `ContentArea.vue:985` and `ThreadPanel.vue:615` are only used for empty/loading states. The live scroll container is `VirtualTimeline.vue:110`, which still used `overflow-auto` and produced the horizontal scrollbar.

## Plan

Three layered changes so this can't drift again:

1. **CSS-level guarantee** — `.chat-pane-scroll` itself enforces `overflow: hidden auto`. Future scroll panes inherit the protection automatically; horizontal scroll requires a deliberate inline override.
2. **Remove redundant inline overflow utilities** from every `.chat-pane-scroll` element: `VirtualTimeline.vue:110`, `ContentArea.vue:985`, `ThreadPanel.vue:615`, `HomeDashboard.vue:147`, `AppDrawer.vue:47`. (The last two were only caught by the adversarial CSS reviewer — Tailwind `@layer utilities` wins over the new `@layer components` rule, so any surviving `overflow-auto` utility silently re-enables horizontal scroll on that pane.)
3. **Teleport the reaction tooltip** in `MessageCard.vue` to `<body>` (same pattern as the existing action-sheet teleport). The tooltip extending past the chip horizontally was the trigger for two prior reverts; teleporting removes that concern permanently. Hover/focus captures the chip's bounding rect; the tooltip renders `position: fixed` above the chip with horizontal clamping to the viewport; a window scroll listener hides it if the chip moves out from under the cursor without firing pointerleave.

### Adversarial-review fixes folded in

- Touch tap fires a synthetic `pointerenter` with no matching `pointerleave`, leaving the tooltip pinned. Switched the pointer handler to `pointerType` ∈ {mouse, pen} so touch falls through to the action sheet (and stylus still gets the hover affordance).
- `@focusin` fires on mouse-click focus too, briefly flashing the tooltip after every mouse react. Gated the focus path on `target.matches(":focus-visible")` so only keyboard focus reveals the tooltip.
- Aligned the tooltip width clamp with Tailwind v4 (`max-w-xs` resolves to 18rem there, not v3's 20rem) by switching to explicit `max-w-[18rem]` and `REACTION_TOOLTIP_HALF_WIDTH = 144`.

## Test plan

- [x] `bun test` (761 pass)
- [x] `bun run lint` (knip clean)
- [x] `bunx astro check` (0 errors)
- [ ] Open a channel with a long URL/slug message — body wraps, no horizontal scrollbar
- [ ] Hover a reaction emoji chip near the right edge of the message lane — tooltip shows in full, not clipped
- [ ] Same for thread panel and DM panel
- [ ] Same for HomeDashboard and AppDrawer
- [ ] Mouse-click a chip — no tooltip flash; tap a chip on touch — no stuck tooltip; tab to a chip — tooltip shows; stylus hover — tooltip shows
- [ ] Scrolling while hovered hides the tooltip cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)