### PR TITLE
fix(ci): restore server workflow path filters

### DIFF
--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -6,6 +6,42 @@ on:
   push:
     branches:
     - main
+    paths:
+    - .github/workflows/waddle-server-*.yml
+    - .github/workflows/waddle-server-default.yml
+    - .gitignore
+    - .gitignore/**
+    - .rules.cue
+    - .rules.cue/**
+    - cue.mod/**
+    - cuenv.lock
+    - cuenv.lock/**
+    - env.cue
+    - env.cue/**
+    - flake.lock
+    - flake.lock/**
+    - flake.nix
+    - flake.nix/**
+    - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml
+    - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml/**
+    - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml
+    - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml/**
+    - infrastructure/waddle.cloud/gitops/waddle-server/**
+    - server/**/env.cue
+    - server/Cargo.lock
+    - server/Cargo.lock/**
+    - server/Cargo.toml
+    - server/Cargo.toml/**
+    - server/charts/waddle-server/**
+    - server/crates/**
+    - server/deployment.cue
+    - server/deployment.cue/**
+    - server/env.cue
+    - server/extensions/**
+    - server/rust-toolchain.toml
+    - server/rust-toolchain.toml/**
+    - server/schema/**
+    - server/wit/**
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/waddle-server-pullrequest.yml
+++ b/.github/workflows/waddle-server-pullrequest.yml
@@ -3,7 +3,43 @@
 
 name: waddle-server-pullRequest
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+    - .github/workflows/waddle-server-*.yml
+    - .github/workflows/waddle-server-pullrequest.yml
+    - .gitignore
+    - .gitignore/**
+    - .rules.cue
+    - .rules.cue/**
+    - cue.mod/**
+    - cuenv.lock
+    - cuenv.lock/**
+    - env.cue
+    - env.cue/**
+    - flake.lock
+    - flake.lock/**
+    - flake.nix
+    - flake.nix/**
+    - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml
+    - infrastructure/waddle.cloud/gitops/kustomization-infra-waddle-server.yaml/**
+    - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml
+    - infrastructure/waddle.cloud/gitops/waddle-server-source.yaml/**
+    - infrastructure/waddle.cloud/gitops/waddle-server/**
+    - server/**/env.cue
+    - server/Cargo.lock
+    - server/Cargo.lock/**
+    - server/Cargo.toml
+    - server/Cargo.toml/**
+    - server/charts/waddle-server/**
+    - server/crates/**
+    - server/deployment.cue
+    - server/deployment.cue/**
+    - server/env.cue
+    - server/extensions/**
+    - server/rust-toolchain.toml
+    - server/rust-toolchain.toml/**
+    - server/schema/**
+    - server/wit/**
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/waddle-server-xmppcompliance.yml
+++ b/.github/workflows/waddle-server-xmppcompliance.yml
@@ -6,9 +6,47 @@ on:
   push:
     branches:
     - main
+    paths:
+    - .github/workflows/waddle-server-xmppcompliance.yml
+    - cue.mod/**
+    - flake.lock
+    - flake.lock/**
+    - flake.nix
+    - flake.nix/**
+    - server/Cargo.lock
+    - server/Cargo.lock/**
+    - server/Cargo.toml
+    - server/Cargo.toml/**
+    - server/charts/waddle-server/**
+    - server/crates/**
+    - server/env.cue
+    - server/extensions/**
+    - server/rust-toolchain.toml
+    - server/rust-toolchain.toml/**
+    - server/schema/**
+    - server/wit/**
   pull_request:
     branches:
     - main
+    paths:
+    - .github/workflows/waddle-server-xmppcompliance.yml
+    - cue.mod/**
+    - flake.lock
+    - flake.lock/**
+    - flake.nix
+    - flake.nix/**
+    - server/Cargo.lock
+    - server/Cargo.lock/**
+    - server/Cargo.toml
+    - server/Cargo.toml/**
+    - server/charts/waddle-server/**
+    - server/crates/**
+    - server/env.cue
+    - server/extensions/**
+    - server/rust-toolchain.toml
+    - server/rust-toolchain.toml/**
+    - server/schema/**
+    - server/wit/**
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -9,6 +9,6 @@ deps: {
 }
 custom: {
 	"github.com/cuenv/cuenv": {
-		version: "0.41.1"
+		version: "0.41.3"
 	}
 }

--- a/server/env.cue
+++ b/server/env.cue
@@ -10,6 +10,7 @@ import (
 let _rustInputs = [
 	"Cargo.toml",
 	"Cargo.lock",
+	"rust-toolchain.toml",
 	"crates/**",
 	"extensions/**",
 	"wit/**",
@@ -20,6 +21,7 @@ let _nixInputs = [
 	"../flake.lock",
 	"Cargo.toml",
 	"Cargo.lock",
+	"rust-toolchain.toml",
 	"crates/**",
 	"extensions/**",
 	"wit/**",
@@ -133,7 +135,6 @@ schema.#Project & {
 				defaultBranch: true
 				manual:        true
 			}
-			derivePaths: false
 			provider: github: {
 				permissions: {
 					"id-token":      "write"
@@ -174,9 +175,6 @@ schema.#Project & {
 				pullRequest: true
 			}
 			mode: "expanded"
-			// cuenv currently emits parent-directory inputs as server/../... in
-			// GitHub path filters, which do not reliably match repo-root files.
-			derivePaths: false
 			provider: github: permissions: {
 				"id-token":      "write"
 				contents:        "read"
@@ -194,9 +192,6 @@ schema.#Project & {
 				pullRequest:   true
 				manual:        true
 			}
-			// Keep this broad until cuenv canonicalizes ../ inputs in derived
-			// GitHub path filters; these Nix checks depend on repo-root flake files.
-			derivePaths: false
 			provider: github: permissions: {
 				"id-token":      "write"
 				contents:        "read"
@@ -216,7 +211,11 @@ schema.#Project & {
 		checkCiDrift: schema.#Task & {
 			command: "cuenv"
 			args: ["sync", "ci", "--check", "-A"]
-			inputs: ["**/env.cue", "deployment.cue"]
+			inputs: [
+				"**/env.cue",
+				"deployment.cue",
+				"../.github/workflows/waddle-server-*.yml",
+			]
 		}
 
 		checkRootSyncDrift: schema.#Task & {
@@ -728,7 +727,7 @@ schema.#Project & {
 		nixXmppServerTests: schema.#Task & {
 			command: "nix"
 			args: ["build", "--print-build-logs", "../#checks.x86_64-linux.waddle-server-xmpp-server-tests"]
-			inputs: _nixInputs
+			inputs: list.Concat([_nixInputs, _chartInputs])
 		}
 
 		nixXmppXepIntegration: schema.#Task & {


### PR DESCRIPTION
## Summary

- Restores derived GitHub Actions `paths` filters for the server cuenv workflows by removing stale `derivePaths: false` overrides from `server/env.cue`.
- Deletes the old comments about `server/../...` generated path filters; current cuenv normalizes parent inputs into repo-relative filters.
- Adds missing source inputs so restored filters cover real CI dependencies:
  - `server/rust-toolchain.toml` for Rust/Nix toolchain changes.
  - `server/charts/waddle-server/**` for the XMPP server test check that reads chart files.
  - `.github/workflows/waddle-server-*.yml` for the PR/default drift guard.
- Regenerates the cuenv-managed server workflows and updates the cuenv module version marker to `0.41.3`.

## Plan

- [x] Open draft PR before implementation.
- [x] Review the change against `./xeps`.
- [x] Restore derived server workflow path filters in CUE.
- [x] Remove stale workaround comments.
- [x] Regenerate generated server workflows with cuenv.
- [x] Verify generated filters are normalized and contain no `../` path entries.
- [x] Run server CI sync drift check.
- [x] Run adversarial reviews for cuenv/source correctness, GitHub Actions trigger behavior, and CI blast radius until no real actionable issues remain.

## XEP Review

This is CI generation plumbing only. No XMPP stanza, namespace, or protocol behavior changed.

## Verification

- `cuenv sync ci --path server`
- `cuenv sync ci --check --path server`
- `git diff --check`
- `rg -n "^    paths:|rust-toolchain|charts/waddle-server|waddle-server-\\*.yml" .github/workflows/waddle-server-*.yml server/env.cue`
- Adversarial review round 1 found missing `server/rust-toolchain.toml`; fixed.
- Adversarial review round 2 found missing XMPP chart input; fixed.
- Adversarial review round 3 found missing sibling server workflow YAML trigger for drift guard; fixed.
- Final adversarial review found no remaining actionable issues.
- GitHub PR checks for #501 passed after marking the PR ready.
