### PR TITLE
fix(chat): let messages fill the content pane width

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -982,7 +982,7 @@ function dayDividerLabel(createdAt: string): string {
     <div
       v-if="isLoadingMessages || !channel && !dmPeer || feedMessages.length === 0"
       :ref="setMessagesContainer"
-      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-[var(--chat-content-inline)]"
+      class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 px-[var(--chat-content-inline)]"
       @scroll="updateCurrentDayMarker"
     >
       <div v-if="isLoadingMessages" class="type-caption flex flex-col items-center justify-center gap-3 py-16 text-center text-muted-foreground">

--- a/chat/src/components/chat/ExtensionRouteView.vue
+++ b/chat/src/components/chat/ExtensionRouteView.vue
@@ -166,7 +166,7 @@ onMounted(focusPanel);
         <article
           v-for="item in items"
           :key="item.id ?? itemTitle(item)"
-          class="rounded-md border border-border bg-card p-3 shadow-sm"
+          class="min-w-0 rounded-md border border-border bg-card p-3 shadow-sm"
         >
           <div class="flex min-w-0 items-start justify-between gap-3">
             <div class="min-w-0">
@@ -186,7 +186,7 @@ onMounted(focusPanel);
               <ExternalLink class="h-3.5 w-3.5" />
             </a>
           </div>
-          <p v-if="item.description" class="type-caption mt-2 whitespace-pre-line text-card-foreground">
+          <p v-if="item.description" class="type-caption mt-2 whitespace-pre-line break-words [overflow-wrap:anywhere] text-card-foreground">
             {{ item.description }}
           </p>
           <dl v-if="item.fields.length > 0" class="mt-3 grid gap-1">

--- a/chat/src/components/chat/ExtensionRouteView.vue
+++ b/chat/src/components/chat/ExtensionRouteView.vue
@@ -161,7 +161,6 @@ onMounted(focusPanel);
       </div>
       <div
         v-else
-        class="chat-message-lane"
         :class="route?.surface === 'gallery' ? 'grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3' : 'grid gap-2'"
       >
         <article

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -144,7 +144,7 @@ function dmSecondaryText(conversation: { peerUsername?: string; peerJid: string;
 </script>
 
 <template>
-  <div class="chat-pane-scroll flex-1 overflow-auto bg-background px-[var(--chat-content-inline)] py-6">
+  <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
     <div class="mx-auto grid w-full max-w-6xl gap-6">
       <header class="flex items-center justify-between gap-4">
         <div>

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -200,7 +200,7 @@ watch(
               {{ card.presentation.primaryValue }}
             </span>
           </span>
-          <span class="type-control block break-words text-foreground">
+          <span class="type-control block text-foreground">
             {{ card.presentation.title }}
           </span>
           <a
@@ -214,7 +214,7 @@ watch(
             <span class="min-w-0 truncate">{{ card.presentation.primaryUrl }}</span>
             <ExternalLink class="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
           </a>
-          <span v-if="card.presentation.summary" class="type-caption mt-1 block break-words text-muted-foreground">
+          <span v-if="card.presentation.summary" class="type-caption mt-1 block text-muted-foreground">
             {{ card.presentation.summary }}
           </span>
           <span
@@ -226,7 +226,7 @@ watch(
               :key="`${card.annotation.annotationId}:option:${option.id}`"
               class="type-caption flex min-w-0 items-center justify-between gap-3 rounded-md bg-background/70 px-2 py-1.5 text-foreground ring-1 ring-border/70"
             >
-              <span class="min-w-0 break-words">{{ option.label }}</span>
+              <span class="min-w-0">{{ option.label }}</span>
               <span v-if="option.value !== undefined" class="type-numeric text-muted-foreground">{{ option.value }}</span>
             </span>
           </span>
@@ -239,7 +239,7 @@ watch(
               :key="`${card.annotation.annotationId}:${detail.label}:${detail.value}`"
             >
               <dt class="type-meta text-muted-foreground/70">{{ detail.label }}</dt>
-              <dd class="type-caption min-w-0 break-words text-foreground/85" :title="detail.value">{{ detail.value }}</dd>
+              <dd class="type-caption min-w-0 text-foreground/85" :title="detail.value">{{ detail.value }}</dd>
             </template>
           </dl>
           <!-- Action buttons: only shown in non-compact (timeline) mode -->

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -332,20 +332,29 @@ function reactionAriaLabel(emoji: string, nicks: readonly string[]): string {
 // Reaction tooltip is teleported to <body> so that pane-level
 // `overflow-x: hidden` (`.chat-pane-scroll`) cannot clip it. The chip stays
 // in place; on hover/focus we capture the chip's bounding rect and render a
-// fixed-position panel above it. Hiding on scroll/blur keeps the panel from
-// drifting away from its anchor.
+// fixed-position panel above it. Touch devices use the action sheet instead;
+// keyboard reveal is gated on `:focus-visible` so a mouse click does not
+// briefly flash the tooltip alongside the just-applied reaction.
 const hoveredReaction = ref<{
   emoji: string;
   nicks: readonly string[];
   rect: DOMRect;
 } | null>(null);
 
-const REACTION_TOOLTIP_HALF_WIDTH = 160; // matches the 20rem max-width
+const REACTION_TOOLTIP_HALF_WIDTH = 144; // matches max-w-[18rem]
 const REACTION_TOOLTIP_GAP = 8;
 
-function showReactionTooltip(emoji: string, nicks: readonly string[], event: Event) {
+function showReactionFromPointer(emoji: string, nicks: readonly string[], event: PointerEvent) {
+  if (event.pointerType !== "mouse") return;
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) return;
+  hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
+}
+
+function showReactionFromFocus(emoji: string, nicks: readonly string[], event: FocusEvent) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  if (!target.matches(":focus-visible")) return;
   hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
 }
 
@@ -685,9 +694,9 @@ onBeforeUnmount(() => {
         class="chat-reaction-chip type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
         :aria-label="reactionAriaLabel(emoji, nicks)"
         @click="emit('react', message.id, emoji)"
-        @mouseenter="(event) => showReactionTooltip(emoji, nicks, event)"
-        @mouseleave="() => hideReactionTooltip(emoji)"
-        @focusin="(event) => showReactionTooltip(emoji, nicks, event)"
+        @pointerenter="(event) => showReactionFromPointer(emoji, nicks, event)"
+        @pointerleave="() => hideReactionTooltip(emoji)"
+        @focusin="(event) => showReactionFromFocus(emoji, nicks, event)"
         @focusout="() => hideReactionTooltip(emoji)"
       >
         <span>{{ emoji }}</span>
@@ -926,7 +935,7 @@ onBeforeUnmount(() => {
     <div
       v-if="hoveredReaction && reactionTooltipStyle"
       aria-hidden="true"
-      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-xs -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
+      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-[18rem] -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
       :style="reactionTooltipStyle"
     >
       <span class="text-lg leading-none" aria-hidden="true">{{ hoveredReaction.emoji }}</span>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -345,7 +345,11 @@ const REACTION_TOOLTIP_HALF_WIDTH = 144; // matches max-w-[18rem]
 const REACTION_TOOLTIP_GAP = 8;
 
 function showReactionFromPointer(emoji: string, nicks: readonly string[], event: PointerEvent) {
-  if (event.pointerType !== "mouse") return;
+  // Touch: skip — touch devices use the action sheet for reactions and the
+  // synthesized pointerenter has no matching pointerleave on tap.
+  // Mouse + pen (stylus): show — both fire pointerleave reliably and
+  // benefit from the hover affordance.
+  if (event.pointerType !== "mouse" && event.pointerType !== "pen") return;
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) return;
   hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -329,6 +329,58 @@ function reactionAriaLabel(emoji: string, nicks: readonly string[]): string {
   return `${formatReactors(nicks)} reacted with ${emoji}`;
 }
 
+// Reaction tooltip is teleported to <body> so that pane-level
+// `overflow-x: hidden` (`.chat-pane-scroll`) cannot clip it. The chip stays
+// in place; on hover/focus we capture the chip's bounding rect and render a
+// fixed-position panel above it. Hiding on scroll/blur keeps the panel from
+// drifting away from its anchor.
+const hoveredReaction = ref<{
+  emoji: string;
+  nicks: readonly string[];
+  rect: DOMRect;
+} | null>(null);
+
+const REACTION_TOOLTIP_HALF_WIDTH = 160; // matches the 20rem max-width
+const REACTION_TOOLTIP_GAP = 8;
+
+function showReactionTooltip(emoji: string, nicks: readonly string[], event: Event) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  hoveredReaction.value = { emoji, nicks, rect: target.getBoundingClientRect() };
+}
+
+function hideReactionTooltip(emoji: string) {
+  if (hoveredReaction.value?.emoji === emoji) hoveredReaction.value = null;
+}
+
+const reactionTooltipStyle = computed(() => {
+  const hover = hoveredReaction.value;
+  if (!hover) return null;
+  const viewportWidth = typeof window === "undefined" ? hover.rect.right + REACTION_TOOLTIP_HALF_WIDTH : window.innerWidth;
+  const wantedCenter = hover.rect.left + hover.rect.width / 2;
+  const minCenter = REACTION_TOOLTIP_HALF_WIDTH + REACTION_TOOLTIP_GAP;
+  const maxCenter = viewportWidth - REACTION_TOOLTIP_HALF_WIDTH - REACTION_TOOLTIP_GAP;
+  const clampedCenter = Math.max(minCenter, Math.min(maxCenter, wantedCenter));
+  return {
+    top: `${hover.rect.top - REACTION_TOOLTIP_GAP}px`,
+    left: `${clampedCenter}px`,
+  };
+});
+
+function onReactionTooltipScroll() {
+  hoveredReaction.value = null;
+}
+
+watch(hoveredReaction, (next) => {
+  if (typeof window === "undefined") return;
+  if (next) {
+    window.addEventListener("scroll", onReactionTooltipScroll, true);
+  }
+  else {
+    window.removeEventListener("scroll", onReactionTooltipScroll, true);
+  }
+});
+
 function startReplyFromMenu() {
   emit("reply", props.message);
   closePicker(true);
@@ -395,6 +447,7 @@ onBeforeUnmount(() => {
 onBeforeUnmount(() => {
   if (typeof window === "undefined") return;
   window.removeEventListener("keydown", onWindowKeydown);
+  window.removeEventListener("scroll", onReactionTooltipScroll, true);
 });
 
 </script>
@@ -629,21 +682,16 @@ onBeforeUnmount(() => {
         v-for="(nicks, emoji) in message.reactions"
         :key="emoji"
         type="button"
-        class="chat-reaction-chip group/reaction relative type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
+        class="chat-reaction-chip type-caption inline-flex h-7 items-center gap-1 px-2 rounded-lg bg-muted/60 hover:bg-muted transition-all duration-200"
         :aria-label="reactionAriaLabel(emoji, nicks)"
         @click="emit('react', message.id, emoji)"
+        @mouseenter="(event) => showReactionTooltip(emoji, nicks, event)"
+        @mouseleave="() => hideReactionTooltip(emoji)"
+        @focusin="(event) => showReactionTooltip(emoji, nicks, event)"
+        @focusout="() => hideReactionTooltip(emoji)"
       >
         <span>{{ emoji }}</span>
         <span class="type-meta type-numeric text-muted-foreground">{{ nicks.length }}</span>
-        <span
-          aria-hidden="true"
-          class="chat-reaction-tooltip pointer-events-none absolute bottom-full left-1/2 z-popover mb-1 hidden -translate-x-1/2 max-w-xs rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md group-hover/reaction:flex group-focus-visible/reaction:flex flex-col items-center gap-0.5"
-        >
-          <span class="text-lg leading-none" aria-hidden="true">{{ emoji }}</span>
-          <span class="type-meta text-center text-muted-foreground">
-            {{ formatReactors(nicks) }}
-          </span>
-        </span>
       </button>
     </div>
 
@@ -868,6 +916,23 @@ onBeforeUnmount(() => {
           />
         </template>
       </div>
+    </div>
+  </Teleport>
+
+  <!-- Reaction tooltip: teleported so it escapes `.chat-pane-scroll`'s
+       `overflow-x: hidden`. Anchored above the hovered chip via the captured
+       rect. -->
+  <Teleport to="body">
+    <div
+      v-if="hoveredReaction && reactionTooltipStyle"
+      aria-hidden="true"
+      class="chat-reaction-tooltip pointer-events-none fixed z-popover flex max-w-xs -translate-x-1/2 -translate-y-full flex-col items-center gap-0.5 rounded-md border border-border bg-popover px-2 py-1.5 text-popover-foreground shadow-md"
+      :style="reactionTooltipStyle"
+    >
+      <span class="text-lg leading-none" aria-hidden="true">{{ hoveredReaction.emoji }}</span>
+      <span class="type-meta text-center text-muted-foreground">
+        {{ formatReactors(hoveredReaction.nicks) }}
+      </span>
     </div>
   </Teleport>
 </template>

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -612,7 +612,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
     <div
       v-else
       :ref="setScrollContainerRef"
-      class="chat-pane-scroll flex-1 min-h-0 overflow-x-hidden overflow-y-auto px-3 py-4 lg:px-4"
+      class="chat-pane-scroll flex-1 min-h-0 px-3 py-4 lg:px-4"
       @scroll="updateCurrentDayMarker"
     >
       <div class="type-caption text-center py-10 text-muted-foreground">

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<{
   ariaLabel: string;
   contentClass?: string;
 }>(), {
-  contentClass: "chat-message-lane chat-message-list",
+  contentClass: "chat-message-list",
 });
 
 const emit = defineEmits<{

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -107,7 +107,7 @@ defineExpose({ scrollElement, scrollToMessageId, scrollToPinnedEdge });
 <template>
   <div
     ref="scrollElement"
-    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 overflow-auto px-[var(--chat-content-inline)]"
+    class="chat-pane-scroll chat-message-scroll flex-1 min-h-0 px-[var(--chat-content-inline)]"
     :aria-label="ariaLabel"
     @scroll="(event) => { emit('scroll', event); maybeLoadOlder(); }"
   >

--- a/chat/src/components/ui/AppDrawer.vue
+++ b/chat/src/components/ui/AppDrawer.vue
@@ -44,7 +44,7 @@ function close() {
               <X class="w-4 h-4" />
             </button>
           </div>
-          <div class="chat-pane-scroll flex-1 min-h-0 overflow-auto">
+          <div class="chat-pane-scroll flex-1 min-h-0">
             <slot />
           </div>
         </div>

--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -42,6 +42,13 @@
 
 .chat-pane-scroll {
   scrollbar-gutter: stable;
+  /* Chat panes never scroll horizontally — long text wraps via
+   * `.styled-body { overflow-wrap: anywhere }` and `<pre>` blocks carry
+   * their own internal `overflow-x: auto`. Enforcing the rule here means
+   * future scroll panes inherit the guarantee without each component
+   * having to remember the right Tailwind utility. */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .chat-message-scroll {

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -104,7 +104,6 @@
 .chat-message-body-stack > .chat-message-fill {
   width: 100%;
   align-self: stretch;
-  max-width: var(--chat-readable-measure);
 }
 
 .chat-forum-topic-card {

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -376,11 +376,16 @@
 .chat-github-card {
   width: var(--chat-attachment-card-width);
   max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .chat-extension-card {
   width: var(--chat-attachment-card-width);
   max-width: 100%;
+  /* `overflow-wrap: anywhere` (inherits) so long unbreakable URLs in the
+   * card body / field rows shrink to wrap, instead of pushing the card
+   * past the message lane and getting clipped by `.chat-pane-scroll`. */
+  overflow-wrap: anywhere;
 }
 
 .chat-attachment-card,


### PR DESCRIPTION
## Why

On wide screens the message timeline was capped at ~960px even when the threads pane was closed, leaving a large empty gutter to the right of every message. Two CSS rules were responsible:

- `.chat-message-lane` (controls.css:180) — `width: min(100%, clamp(42rem, 68vw, 60rem))` capped the lane the message list lives in.
- `.chat-message-body-stack > .chat-message-fill` (messages.css:107) — `max-width: var(--chat-readable-measure)` (72ch) capped each message body.

## Plan

Drop both caps from the message timeline:

1. `VirtualTimeline.contentClass` default is now just `chat-message-list` (lane class kept available for banners/headers that benefit from a bounded prose measure).
2. `.chat-message-body-stack > .chat-message-fill` no longer caps width — `width: 100%` + the parent's `min-width: 0` lets the body fill the lane.

The threads-pane case is automatic: `ThreadPanel` is a sibling flex item with its own `--chat-thread-width`. When open it shrinks `ContentArea` naturally, so messages reflow into the remaining width without any conditional CSS.

## Test plan

- [x] `bun test` (761 pass)
- [x] `bun run lint` (knip clean)
- [x] `bunx astro check` (0 errors)
- [ ] Open a channel on a wide screen — messages span the full pane width with no right-hand gutter
- [ ] Open the threads pane — message lane reflows into the remaining width
- [ ] Banners (connection notice, error, search) still respect the lane class for short-prose readability
- [ ] Mobile / narrow widths unchanged (the `clamp()` floor was 42rem; now bounded by viewport)

🤖 Generated with [Claude Code](https://claude.com/claude-code)