### PR TITLE
fix(infra): keep latest server rollout from oom killing

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
         memory: 512Mi
       limits:
         cpu: "1"
-        memory: 1Gi
+        memory: 4Gi
     config:
       baseUrl: https://xmpp.waddle.social
       corsOrigins: https://waddle.chat,http://localhost:4321


### PR DESCRIPTION
## Plan

- Raise the production `waddle-server` memory limit from `1Gi` to `4Gi`.
- Keep the CPU limit at `1` because the rollout failure is OOMKilled exit 137, not CPU starvation.
- Preserve GitOps parity with the live emergency hotfix so `infra-waddle-server` can be resumed after this lands.

## Live findings

- Latest image was applied but initially failed to become ready.
- `1Gi` pod OOMKilled during startup.
- Tested `2Gi` live; it also OOMKilled while restoring persisted XEP-0198 state.
- Startup logs showed the restore query returning roughly 156k `sm_sessions` / `sm_unacked` rows.
- `4Gi` live hotfix succeeded: deployment rolled out and the latest image pod is ready.

## CPU investigation

CPU limit stays at `1`. Kubernetes reported OOMKilled exit 137, and there were no CPU-specific termination reasons. Metrics API is unavailable, so `kubectl top` could not provide time-series usage, but the failure mode and successful 4Gi rollout point to memory pressure rather than CPU pressure.

## Operational note

`flux-system/infra-waddle-server` was temporarily suspended to prevent the source-controller retry loop from reverting the live HelmRelease back to `1Gi` before this GitOps change is merged. Resume it after this PR lands.

## Verification

- `git diff --check`
- `kubectl apply --dry-run=server -f infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml`
- Live hotfix: `HelmRelease/waddle-server` upgraded successfully with `4Gi`
- Live rollout: `Deployment/waddle-server` rolled out successfully
- Live endpoint: only latest pod is ready/serving

## Not tested

- Metrics API was unavailable, so `kubectl top` could not be used for live CPU/memory samples.