### PR TITLE
fix(server): bound avatar locks, sweep expired auth state, add /debug/state-inventory

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -24,6 +24,11 @@ local.toml
 # Logs
 *.log
 
+# dhat-rs heap profile artifacts (produced by the
+# waddle-extensions `profile_all_extensions` example)
+dhat-heap*.json
+profile_extensions.log
+
 # Database
 *.db
 *.db-shm

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -4,11 +4,20 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -171,7 +180,7 @@ dependencies = [
  "memchr",
  "proc-macro2",
  "quote",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
  "syn",
@@ -497,6 +506,21 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -1049,13 +1073,13 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -1394,6 +1418,22 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn",
+]
+
+[[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
 ]
 
 [[package]]
@@ -1862,7 +1902,7 @@ checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags",
  "debugid",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1940,6 +1980,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -2891,6 +2937,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +2976,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -3071,6 +3133,15 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3805,7 +3876,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -3825,7 +3896,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4010,7 +4081,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.17.0",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -4158,6 +4229,12 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5109,6 +5186,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
+
+[[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5906,9 +5989,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "chrono",
+ "dhat",
  "futures",
  "hex",
  "hmac",
+ "memory-stats",
  "minidom",
  "oci-client",
  "regex",
@@ -6375,7 +6460,7 @@ version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efb1ed5899dde98357cfdcf647a4614498798719793898245b4b34e663addabf"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags",
  "bumpalo",
@@ -6384,13 +6469,13 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
+ "gimli 0.33.0",
  "ittapi",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.38.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -6433,11 +6518,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "log",
- "object",
+ "object 0.38.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -6518,10 +6603,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.38.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -6555,7 +6640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c2e05b345f1773e59c20e6ad7298fd6857cdea245023d88bb659c96d8f0ea72"
 dependencies = [
  "cc",
- "object",
+ "object 0.38.1",
  "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -6581,7 +6666,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.38.1",
  "wasmtime-environ",
 ]
 
@@ -6603,9 +6688,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f599b79545e3bba0b7913406055ebede5bb0dabee9ba2015ef25a9f4c9f47807"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "log",
- "object",
+ "object 0.38.1",
  "target-lexicon",
  "wasmparser 0.245.1",
  "wasmtime-environ",
@@ -6842,7 +6927,7 @@ checksum = "52dbb0cf07b0dfe7b7a1ca8efb8f94ba98bd0fb144c411ea1665c78f0449e958"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "regalloc2",
  "smallvec",
  "target-lexicon",

--- a/server/crates/waddle-extensions/Cargo.toml
+++ b/server/crates/waddle-extensions/Cargo.toml
@@ -31,3 +31,9 @@ xmpp-parsers = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+dhat = "0.3"
+memory-stats = "1"
+
+[[example]]
+name = "profile_all_extensions"
+path = "examples/profile_all_extensions.rs"

--- a/server/crates/waddle-extensions/examples/profile_all_extensions.rs
+++ b/server/crates/waddle-extensions/examples/profile_all_extensions.rs
@@ -1,0 +1,348 @@
+//! Heap profile for the full extension runtime with all 5 extensions
+//! loaded. Drives N invocations of each extension's primary hot path:
+//!
+//! - ai-chatbot / link-board / github-enricher → message-enrich hook
+//! - github → provider-webhook
+//!
+//! Run:
+//!   cargo run --release --example profile_all_extensions \
+//!       -p waddle-extensions -- [ITERS_PER_STAGE]
+//!
+//! Outputs:
+//!   ./dhat-heap.json         (open in https://nnethercote.github.io/dh_view/dh_view.html)
+//!   ./profile_extensions.log (per-stage RSS + dhat totals)
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use serde_json::json;
+use waddle_extensions::{
+    ExtensionCapability, ExtensionConfig, ExtensionManager, ExtensionModuleConfig, ProviderField,
+    ProviderFieldText, ProviderFieldValue, ProviderPayload, ProviderWebhook,
+};
+use xmpp_parsers::jid::Jid;
+use xmpp_parsers::message::{Body, Message, MessageType};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[derive(Debug, Clone)]
+struct ExtSpec {
+    name: &'static str,
+    namespace: &'static str,
+    wasm_filename: &'static str,
+    grants: &'static [ExtensionCapability],
+    provider_room_grants: &'static [&'static str],
+    allowed_http_origins: &'static [&'static str],
+    config: fn() -> serde_json::Value,
+}
+
+fn ai_chatbot_config() -> serde_json::Value {
+    json!({
+        "endpoint": "https://openrouter.ai/api/v1/chat/completions",
+        "api_key": "sk-profiling-dummy",
+        "model": "anthropic/claude-opus-4-7"
+    })
+}
+
+fn empty_config() -> serde_json::Value {
+    json!({})
+}
+
+const EXTENSIONS: &[ExtSpec] = &[
+    ExtSpec {
+        name: "ai-chatbot",
+        namespace: "urn:waddle:ai-chatbot:1",
+        wasm_filename: "ai_chatbot.wasm",
+        grants: &[
+            ExtensionCapability::MessageEnrich,
+            ExtensionCapability::HostMamRead,
+            ExtensionCapability::HostMembersRead,
+            ExtensionCapability::HostPresenceRead,
+            ExtensionCapability::HostRosterRead,
+            ExtensionCapability::HostChannelsRead,
+            ExtensionCapability::HostSpacesRead,
+            ExtensionCapability::HostMessageSend,
+            ExtensionCapability::OutboundHttpRequest,
+            ExtensionCapability::Commands,
+        ],
+        provider_room_grants: &[],
+        allowed_http_origins: &["https://openrouter.ai"],
+        config: ai_chatbot_config,
+    },
+    ExtSpec {
+        name: "link-board",
+        namespace: "urn:waddle:link-board:1",
+        wasm_filename: "link_board.wasm",
+        grants: &[
+            ExtensionCapability::MessageEnrich,
+            ExtensionCapability::Launch,
+            ExtensionCapability::PubSubPublish,
+            ExtensionCapability::UiDeclarative,
+        ],
+        provider_room_grants: &[],
+        allowed_http_origins: &[],
+        config: empty_config,
+    },
+    // NOTE: github-enricher has no source in this workspace; the
+    // .wasm in target/ is an orphaned artifact. Omitting it.
+    ExtSpec {
+        name: "github",
+        namespace: "urn:waddle:web-integration:1",
+        wasm_filename: "github.wasm",
+        grants: &[
+            ExtensionCapability::MessageEnrich,
+            ExtensionCapability::HostMessageSend,
+            ExtensionCapability::Commands,
+            ExtensionCapability::PubSubPublish,
+        ],
+        provider_room_grants: &["general@muc.waddle.social"],
+        allowed_http_origins: &[],
+        config: empty_config,
+    },
+    ExtSpec {
+        name: "decision-polls",
+        namespace: "urn:waddle:decision-polls:1",
+        wasm_filename: "decision_polls.wasm",
+        grants: &[
+            ExtensionCapability::MessageEnrich,
+            ExtensionCapability::Commands,
+            ExtensionCapability::Launch,
+            ExtensionCapability::PubSubPublish,
+            ExtensionCapability::HostMessageSend,
+            ExtensionCapability::UiDeclarative,
+        ],
+        provider_room_grants: &[],
+        allowed_http_origins: &[],
+        config: empty_config,
+    },
+];
+
+fn wasm_root() -> PathBuf {
+    let server_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crate is two levels below server root")
+        .to_path_buf();
+    server_dir.join("target/wasm32-wasip2/release")
+}
+
+fn build_module(spec: &ExtSpec, root: &std::path::Path) -> ExtensionModuleConfig {
+    let path = root.join(spec.wasm_filename);
+    if !path.exists() {
+        panic!(
+            "missing built wasm at {}; run `just build-extensions` or `cargo build --target wasm32-wasip2 --release` for the extension crate",
+            path.display(),
+        );
+    }
+    ExtensionModuleConfig {
+        name: spec.name.to_string(),
+        registry: String::new(),
+        digest: None,
+        tag: None,
+        namespace: spec.namespace.to_string(),
+        config: (spec.config)(),
+        capability_grants: spec.grants.to_vec(),
+        allowed_http_origins: spec
+            .allowed_http_origins
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        provider_room_grants: spec
+            .provider_room_grants
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        config_secret_files: Default::default(),
+        local_path: Some(path.to_string_lossy().into_owned()),
+    }
+}
+
+fn rss_bytes() -> usize {
+    memory_stats::memory_stats()
+        .map(|s| s.physical_mem)
+        .unwrap_or(0)
+}
+
+fn fmt_mb(b: usize) -> String {
+    format!("{:.1} MB", b as f64 / (1024.0 * 1024.0))
+}
+
+fn build_message(idx: usize) -> Message {
+    let to: Jid = "general@muc.waddle.social/test".parse().unwrap();
+    let from: Jid = format!("user{}@waddle.social/r1", idx % 50)
+        .parse()
+        .unwrap();
+    let body = format!(
+        "msg {} https://github.com/waddle-social/waddle/pull/{} check this out: https://example.com/a/{}",
+        idx, idx, idx
+    );
+    let mut msg = Message::new(Some(to));
+    msg.from = Some(from);
+    msg.type_ = MessageType::Groupchat;
+    msg.bodies.insert(String::new(), Body(body));
+    msg.id = Some(format!("origin-{idx}"));
+    msg
+}
+
+fn build_provider_webhook(idx: usize) -> ProviderWebhook {
+    use waddle_extensions::{
+        ProviderDeliveryId, ProviderEventType, ProviderFieldName, ProviderId, WaddleId,
+    };
+    ProviderWebhook {
+        waddle_id: WaddleId::new("local").unwrap(),
+        provider: ProviderId::new("github").unwrap(),
+        event_type: ProviderEventType::new("issues").unwrap(),
+        delivery_id: ProviderDeliveryId::new(format!("delivery-{idx}")).unwrap(),
+        payload: ProviderPayload {
+            fields: vec![
+                ProviderField {
+                    path: vec![ProviderFieldName::new("action").unwrap()],
+                    value: ProviderFieldValue::Text(ProviderFieldText::new("opened").unwrap()),
+                },
+                ProviderField {
+                    path: vec![
+                        ProviderFieldName::new("issue").unwrap(),
+                        ProviderFieldName::new("title").unwrap(),
+                    ],
+                    value: ProviderFieldValue::Text(
+                        ProviderFieldText::new(format!("issue #{idx}: something")).unwrap(),
+                    ),
+                },
+                ProviderField {
+                    path: vec![
+                        ProviderFieldName::new("issue").unwrap(),
+                        ProviderFieldName::new("html_url").unwrap(),
+                    ],
+                    value: ProviderFieldValue::Text(
+                        ProviderFieldText::new(format!(
+                            "https://github.com/waddle-social/waddle/issues/{idx}"
+                        ))
+                        .unwrap(),
+                    ),
+                },
+            ],
+        },
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let iters: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(500);
+
+    let _profiler = dhat::Profiler::builder()
+        .file_name("dhat-heap.json")
+        .build();
+
+    let rss_start = rss_bytes();
+    eprintln!("[start] rss={}", fmt_mb(rss_start));
+
+    let root = wasm_root();
+    eprintln!("[load ] wasm root: {}", root.display());
+
+    let cfg = ExtensionConfig {
+        enabled: true,
+        cache_dir: "/tmp/waddle-ext-cache-profile".to_string(),
+        modules: EXTENSIONS.iter().map(|s| build_module(s, &root)).collect(),
+    };
+    let t0 = Instant::now();
+    let manager = Arc::new(ExtensionManager::from_config(cfg).await?);
+    let rss_after_load = rss_bytes();
+    eprintln!(
+        "[load ] {} extensions loaded in {:.2}s rss={} (Δ {})",
+        EXTENSIONS.len(),
+        t0.elapsed().as_secs_f64(),
+        fmt_mb(rss_after_load),
+        fmt_mb(rss_after_load.saturating_sub(rss_start)),
+    );
+
+    let waddle_id = waddle_extensions::WaddleId::new("local").unwrap();
+    let requester: Option<xmpp_parsers::jid::BareJid> =
+        Some("alice@waddle.social".parse().unwrap());
+
+    // Stage 1: message-enrich hot path (the most-called code path in production)
+    let t1 = Instant::now();
+    for i in 0..iters {
+        let mut msg = build_message(i);
+        let _ = manager
+            .process_message_for_waddle_with_requester(
+                &mut msg,
+                waddle_id.clone(),
+                requester.clone(),
+            )
+            .await;
+        if i > 0 && i % 100 == 0 {
+            eprintln!(
+                "  enrich  i={i:>5}/{iters} rss={} t={:.1}s",
+                fmt_mb(rss_bytes()),
+                t1.elapsed().as_secs_f64()
+            );
+        }
+    }
+    let rss_after_enrich = rss_bytes();
+    eprintln!(
+        "[stage] enrich  x{iters} done in {:.2}s rss={} (Δ {} since load)",
+        t1.elapsed().as_secs_f64(),
+        fmt_mb(rss_after_enrich),
+        fmt_mb(rss_after_enrich.saturating_sub(rss_after_load)),
+    );
+
+    // Stage 2: provider webhook (github extension)
+    let t2 = Instant::now();
+    for i in 0..iters {
+        let event = build_provider_webhook(i);
+        let _ = manager.invoke_provider_webhook("github", event).await;
+        if i > 0 && i % 100 == 0 {
+            eprintln!(
+                "  webhook i={i:>5}/{iters} rss={} t={:.1}s",
+                fmt_mb(rss_bytes()),
+                t2.elapsed().as_secs_f64()
+            );
+        }
+    }
+    let rss_after_webhook = rss_bytes();
+    eprintln!(
+        "[stage] webhook x{iters} done in {:.2}s rss={} (Δ {} since enrich)",
+        t2.elapsed().as_secs_f64(),
+        fmt_mb(rss_after_webhook),
+        fmt_mb(rss_after_webhook.saturating_sub(rss_after_enrich)),
+    );
+
+    drop(manager);
+    let rss_after_drop = rss_bytes();
+    eprintln!(
+        "[final] after drop(manager) rss={} (Δ {} since webhook)",
+        fmt_mb(rss_after_drop),
+        fmt_mb(rss_after_drop.saturating_sub(rss_after_webhook)),
+    );
+
+    let summary = json!({
+        "iters_per_stage": iters,
+        "rss_bytes": {
+            "start": rss_start,
+            "after_load": rss_after_load,
+            "after_enrich": rss_after_enrich,
+            "after_webhook": rss_after_webhook,
+            "after_drop": rss_after_drop,
+        },
+        "rss_growth_bytes": {
+            "load_step": rss_after_load.saturating_sub(rss_start),
+            "enrich_total": rss_after_enrich.saturating_sub(rss_after_load),
+            "enrich_per_call": (rss_after_enrich.saturating_sub(rss_after_load)) / iters.max(1),
+            "webhook_total": rss_after_webhook.saturating_sub(rss_after_enrich),
+            "webhook_per_call": (rss_after_webhook.saturating_sub(rss_after_enrich)) / iters.max(1),
+            "freed_on_drop": rss_after_webhook.saturating_sub(rss_after_drop),
+        }
+    });
+    std::fs::write(
+        "profile_extensions.log",
+        serde_json::to_string_pretty(&summary).unwrap(),
+    )?;
+    eprintln!("wrote profile_extensions.log and dhat-heap.json");
+
+    Ok(())
+}

--- a/server/crates/waddle-server/src/profile/avatar_source.rs
+++ b/server/crates/waddle-server/src/profile/avatar_source.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use dashmap::DashMap;
 use jid::BareJid;
 use kameo::actor::ActorRef;
 use thiserror::Error;
@@ -115,6 +116,93 @@ async fn upsert_source(
     Ok(())
 }
 
+/// Per-`BareJid` mutex set guarding the `user_avatar_source`
+/// read-then-publish critical section. Both the OIDC publish chain
+/// and the wire avatar-publish hook acquire the same mutex by
+/// `BareJid` so they cannot race.
+///
+/// Entries are inserted on first acquire and **removed when the last
+/// in-flight guard for that JID drops**, so the map stays bounded by
+/// the number of *currently-contended* JIDs rather than growing to
+/// the lifetime set of users ever seen. See [`AvatarLockGuard::drop`]
+/// for the eviction protocol.
+#[derive(Debug, Default)]
+pub struct AvatarLockMap {
+    inner: DashMap<BareJid, Arc<Mutex<()>>>,
+}
+
+impl AvatarLockMap {
+    pub fn new() -> Self {
+        Self {
+            inner: DashMap::new(),
+        }
+    }
+
+    /// Number of JIDs currently holding or waiting on an entry.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Acquire the per-(`BareJid`) avatar-source mutex against `self`,
+    /// returning an [`AvatarLockGuard`] that evicts the map entry on
+    /// drop when no other acquirer is in flight. Public so call sites
+    /// holding an `Arc<AvatarLockMap>` directly (e.g. tests) can use
+    /// the same eviction-aware path as
+    /// [`acquire_per_jid_lock`].
+    pub async fn acquire(self: &Arc<Self>, jid: &BareJid) -> AvatarLockGuard {
+        let mutex = self
+            .inner
+            .entry(jid.clone())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let guard = mutex.lock_owned().await;
+        AvatarLockGuard {
+            guard: Some(guard),
+            map: Arc::clone(self),
+            jid: jid.clone(),
+        }
+    }
+}
+
+/// Owned guard returned by [`acquire_per_jid_lock`]. On drop, releases
+/// the per-JID mutex AND evicts the map entry iff no other acquirer
+/// is currently holding or waiting on it (detected via
+/// `Arc::strong_count == 1`, i.e. the map's own reference).
+pub struct AvatarLockGuard {
+    // Field order matters: `guard` drops before `map`/`jid`, so the
+    // mutex is released and the per-acquirer `Arc<Mutex<()>>` clone is
+    // dropped *before* we attempt the strong-count check in our own
+    // Drop impl below.
+    guard: Option<OwnedMutexGuard<()>>,
+    map: Arc<AvatarLockMap>,
+    jid: BareJid,
+}
+
+impl Drop for AvatarLockGuard {
+    fn drop(&mut self) {
+        // Release the mutex + the acquirer's `Arc<Mutex<()>>` clone first.
+        self.guard.take();
+
+        // `remove_if` holds the shard write lock for `self.jid` during
+        // the callback, so no concurrent `acquire` can observe / clone
+        // the Arc between our strong-count read and the removal. While
+        // we hold that lock:
+        //
+        // - `strong_count == 1` → only the map holds the Arc; nobody
+        //   else is acquiring or waiting → safe to evict.
+        // - `strong_count > 1`  → at least one other acquirer cloned
+        //   the Arc out of the map; keep the entry so they continue to
+        //   serialize through the same mutex.
+        self.map
+            .inner
+            .remove_if(&self.jid, |_, mutex| Arc::strong_count(mutex) == 1);
+    }
+}
+
 /// Acquire the per-(`BareJid`) avatar-source mutex. Both the OIDC
 /// publish chain and the wire avatar-publish hook take this lock;
 /// holding it across read+write closes the TOCTOU race where OIDC
@@ -122,17 +210,11 @@ async fn upsert_source(
 /// downstream `record_self_published` flip and then wipe the
 /// just-set avatar.
 ///
-/// Returns an `OwnedMutexGuard` so the caller can hold it across
-/// further async operations without lifetime gymnastics.
-pub async fn acquire_per_jid_lock(state: &WebSocketState, jid: &BareJid) -> OwnedMutexGuard<()> {
-    let mutex = state
-        .deps
-        .protocol
-        .avatar_source_locks
-        .entry(jid.clone())
-        .or_insert_with(|| Arc::new(Mutex::new(())))
-        .clone();
-    mutex.lock_owned().await
+/// Returns an [`AvatarLockGuard`] so the caller can hold it across
+/// further async operations without lifetime gymnastics. The guard's
+/// `Drop` evicts the map entry when no other acquirer is in flight.
+pub async fn acquire_per_jid_lock(state: &WebSocketState, jid: &BareJid) -> AvatarLockGuard {
+    state.deps.protocol.avatar_source_locks.acquire(jid).await
 }
 
 /// Mark `jid`'s avatar as user-self-published. Idempotent — repeated
@@ -168,5 +250,81 @@ pub async fn record_oidc_managed(db_actor: &ActorRef<DbActor>, jid: &BareJid) {
             error = %error,
             "Failed to mark avatar_source='oidc'; provenance state may be stale"
         );
+    }
+}
+
+#[cfg(test)]
+mod lock_map_tests {
+    use super::*;
+
+    fn jid(local: &str) -> BareJid {
+        format!("{local}@waddle.test").parse().expect("valid jid")
+    }
+
+    #[tokio::test]
+    async fn entry_is_evicted_after_solo_guard_drops() {
+        let map = Arc::new(AvatarLockMap::new());
+        let alice = jid("alice");
+        {
+            let _guard = map.acquire(&alice).await;
+            assert_eq!(map.len(), 1, "entry exists while guard is held");
+        }
+        assert_eq!(
+            map.len(),
+            0,
+            "entry MUST be evicted once the last guard drops"
+        );
+    }
+
+    #[tokio::test]
+    async fn entry_survives_while_a_second_acquirer_is_waiting() {
+        let map = Arc::new(AvatarLockMap::new());
+        let alice = jid("alice");
+
+        let first = map.acquire(&alice).await;
+        assert_eq!(map.len(), 1);
+
+        // Second acquire blocks on the held mutex, but the map entry must
+        // remain because two acquirers are now sharing the same Arc.
+        let map_for_task = Arc::clone(&map);
+        let alice_for_task = alice.clone();
+        let task = tokio::spawn(async move { map_for_task.acquire(&alice_for_task).await });
+
+        // Give the task a chance to clone the Arc out of the map and
+        // start waiting on the mutex.
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        drop(first);
+        // First-guard drop must NOT evict — the spawned task is still
+        // waiting on the same mutex.
+        let second = task.await.expect("spawned acquire panicked");
+        assert_eq!(
+            map.len(),
+            1,
+            "entry MUST survive while a follower is still holding the guard"
+        );
+        drop(second);
+        assert_eq!(
+            map.len(),
+            0,
+            "entry MUST be evicted once the last follower drops"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_jids_do_not_share_eviction() {
+        let map = Arc::new(AvatarLockMap::new());
+        let alice = jid("alice");
+        let bob = jid("bob");
+
+        let alice_guard = map.acquire(&alice).await;
+        let bob_guard = map.acquire(&bob).await;
+        assert_eq!(map.len(), 2);
+
+        drop(alice_guard);
+        assert_eq!(map.len(), 1, "dropping alice MUST NOT evict bob");
+        drop(bob_guard);
+        assert_eq!(map.len(), 0);
     }
 }

--- a/server/crates/waddle-server/src/profile/mod.rs
+++ b/server/crates/waddle-server/src/profile/mod.rs
@@ -35,7 +35,7 @@ mod vcard_rmw;
 
 pub use avatar_source::{
     acquire_per_jid_lock, read_avatar_source, record_oidc_managed, record_self_published,
-    AvatarSource, AvatarSourceStorageError,
+    AvatarLockGuard, AvatarLockMap, AvatarSource, AvatarSourceStorageError,
 };
 pub use backfill::{run_startup_backfill, BackfillError, BackfillReport};
 pub use fetch::{fetch_avatar_bytes, AvatarBytes, FetchError, FetchPolicy};

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -12,7 +12,8 @@ use crate::server::routes::websocket::{
     ProtocolServices, WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 use crate::server::session_janitors::{
-    spawn_graceful_shutdown_drain, spawn_pending_delivery_claim_janitor, spawn_sm_expiry_janitor,
+    spawn_auth_state_janitor, spawn_graceful_shutdown_drain, spawn_pending_delivery_claim_janitor,
+    spawn_sm_expiry_janitor,
 };
 use crate::server::topology::bootstrap_fresh_xmpp_topology;
 use crate::server::trace::make_request_span;
@@ -185,6 +186,7 @@ pub(crate) async fn create_router(
 
     spawn_sm_expiry_janitor(&websocket_state);
     spawn_pending_delivery_claim_janitor(&websocket_state);
+    spawn_auth_state_janitor(&websocket_state);
     spawn_graceful_shutdown_drain(
         Arc::clone(&websocket_state),
         shutdown_stop_token,

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -248,6 +248,19 @@ pub(crate) async fn create_router(
         ));
     }
 
+    // Debug state-inventory route. Mounted only when
+    // `WADDLE_DEBUG_STATE_TOKEN` is set; production canary opts in by
+    // setting the env var. Returns per-map `.len()` counts so a
+    // Prometheus scrape can correlate the offending structure with
+    // process RSS.
+    if let Some(auth) = crate::server::state_inventory_route::debug_state_auth_from_env() {
+        info!("Mounting /debug/state-inventory (WADDLE_DEBUG_STATE_TOKEN set)");
+        router = router.merge(crate::server::state_inventory_route::router(
+            websocket_state.clone(),
+            auth,
+        ));
+    }
+
     // Always merge common routes required by XMPP, auth, upload, and operations.
     let router = router
         // Merge XMPP over WebSocket endpoint

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -363,7 +363,7 @@ async fn create_websocket_state(
                 sm_session_registry,
                 resumable_sessions,
                 caps_resolver,
-                avatar_source_locks: Arc::new(dashmap::DashMap::new()),
+                avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                 profile_publish_tracker: tokio_util::task::TaskTracker::new(),
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -10,6 +10,7 @@ mod http;
 pub(crate) mod profile_publish_route;
 mod session_janitors;
 mod state;
+pub(crate) mod state_inventory_route;
 mod topology;
 mod trace;
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -96,7 +96,11 @@ pub struct ProtocolServices {
     /// `BareJid`, closing the TOCTOU race where OIDC could read
     /// `'oidc'` between the user's wire publish and the user's
     /// provenance flip and then wipe the just-set avatar.
-    pub avatar_source_locks: Arc<dashmap::DashMap<jid::BareJid, Arc<tokio::sync::Mutex<()>>>>,
+    ///
+    /// Entries are evicted by `AvatarLockGuard::drop` when no
+    /// acquirer is in flight, so the map stays bounded by current
+    /// contention rather than growing to the lifetime user set.
+    pub avatar_source_locks: Arc<crate::profile::AvatarLockMap>,
     /// Tracker for the OIDC → PEP profile-publish background tasks.
     /// The auth callback registers each `tokio::spawn` here so the
     /// graceful-shutdown drain can `wait()` on in-flight publishes

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -136,7 +136,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     caps_resolver: Arc::new(
                         crate::server::caps_resolution::CapsResolver::default(),
                     ),
-                    avatar_source_locks: Arc::new(dashmap::DashMap::new()),
+                    avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                     profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                 },
                 occupant_id_secret: OccupantIdSecret::new(

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1,7 +1,11 @@
 use crate::server::routes;
 use crate::server::routes::websocket::WebSocketState;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, error, info, warn};
+
+/// Default interval for the auth-state TTL janitor.
+const AUTH_JANITOR_INTERVAL: Duration = Duration::from_secs(60);
 
 fn pending_delivery_max_age_days_from_env() -> u32 {
     const DEFAULT_DAYS: u32 = 30;
@@ -580,4 +584,209 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         dispatch_tracker.wait().await;
         info!("Graceful shutdown: provider webhook dispatch drain complete");
     });
+}
+
+/// Per-sweep counts returned by [`sweep_auth_state_once`]. Exposed for
+/// the unit tests that exercise the sweep without the live tokio
+/// ticker.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct AuthSweepCounts {
+    pub pending_pruned: usize,
+    pub device_pruned: usize,
+    pub xmpp_pruned: usize,
+    pub pending_remaining: usize,
+    pub device_remaining: usize,
+    pub xmpp_remaining: usize,
+}
+
+/// Walk the three auth-state DashMaps and remove every entry whose
+/// `is_expired()` reports `true`. Pure helper so the long-running
+/// janitor in [`spawn_auth_state_janitor`] and the unit tests share
+/// the same eviction logic.
+pub(crate) fn sweep_auth_state_once(
+    pending_auth: &dashmap::DashMap<String, crate::server::routes::auth::PendingAuthorization>,
+    device_auth: &dashmap::DashMap<String, crate::server::routes::auth::DeviceAuthorization>,
+    xmpp_auth_codes: &dashmap::DashMap<String, crate::server::routes::auth::XmppAuthCode>,
+) -> AuthSweepCounts {
+    let mut counts = AuthSweepCounts::default();
+    pending_auth.retain(|_, entry| {
+        if entry.is_expired() {
+            counts.pending_pruned += 1;
+            false
+        } else {
+            true
+        }
+    });
+    device_auth.retain(|_, entry| {
+        if entry.is_expired() {
+            counts.device_pruned += 1;
+            false
+        } else {
+            true
+        }
+    });
+    xmpp_auth_codes.retain(|_, entry| {
+        if entry.is_expired() {
+            counts.xmpp_pruned += 1;
+            false
+        } else {
+            true
+        }
+    });
+    counts.pending_remaining = pending_auth.len();
+    counts.device_remaining = device_auth.len();
+    counts.xmpp_remaining = xmpp_auth_codes.len();
+    counts
+}
+
+/// Sweep expired entries from the auth-state DashMaps (`pending_auth`,
+/// `device_auth`, `xmpp_auth_codes`).
+///
+/// These maps grow on every started OAuth / device / XMPP-OAuth flow
+/// and are removed only on the success path. Abandoned flows (network
+/// flake, tab close, user typo) leave entries behind. Each carries an
+/// `is_expired()` and the OAuth specs already bound the validity
+/// window (10 minutes for `PendingAuthorization` / `XmppAuthCode`,
+/// `device_auth.expires_at` for `DeviceAuthorization`), so the
+/// janitor just consults that and removes anything past its window.
+///
+/// Runs on a 60 s ticker. Skips the first immediate tick so a fresh
+/// process doesn't sweep before any auth flow has started.
+pub(crate) fn spawn_auth_state_janitor(websocket_state: &Arc<WebSocketState>) {
+    let weak_state = Arc::downgrade(websocket_state);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(AUTH_JANITOR_INTERVAL);
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let Some(state) = weak_state.upgrade() else {
+                break;
+            };
+            let auth = &state.deps.auth_state;
+            let counts =
+                sweep_auth_state_once(&auth.pending_auth, &auth.device_auth, &auth.xmpp_auth_codes);
+            let total = counts.pending_pruned + counts.device_pruned + counts.xmpp_pruned;
+            if total > 0 {
+                info!(
+                    pending_auth_pruned = counts.pending_pruned,
+                    device_auth_pruned = counts.device_pruned,
+                    xmpp_auth_codes_pruned = counts.xmpp_pruned,
+                    pending_auth_remaining = counts.pending_remaining,
+                    device_auth_remaining = counts.device_remaining,
+                    xmpp_auth_codes_remaining = counts.xmpp_remaining,
+                    "auth janitor: pruned expired entries"
+                );
+            } else {
+                debug!(
+                    pending_auth_remaining = counts.pending_remaining,
+                    device_auth_remaining = counts.device_remaining,
+                    xmpp_auth_codes_remaining = counts.xmpp_remaining,
+                    "auth janitor: no expired entries"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod auth_janitor_tests {
+    use super::sweep_auth_state_once;
+    use crate::auth::providers::AuthProviderTokenEndpointAuthMethod;
+    use crate::server::routes::auth::{
+        BrowserSessionTransport, DeviceAuthStatus, DeviceAuthorization, PendingAuthorization,
+        PendingFlow, XmppAuthCode,
+    };
+    use chrono::{Duration, Utc};
+    use dashmap::DashMap;
+
+    fn make_pending(state: &str, created_minutes_ago: i64) -> PendingAuthorization {
+        PendingAuthorization {
+            state: state.to_string(),
+            provider_id: "p".to_string(),
+            nonce: "n".to_string(),
+            code_verifier: "cv".to_string(),
+            redirect_uri: "https://example.test/cb".to_string(),
+            client_id: "cid".to_string(),
+            client_secret: String::new(),
+            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::NoAuthentication,
+            require_dpop: false,
+            flow: PendingFlow::Browser {
+                next: None,
+                session_transport: BrowserSessionTransport::Cookie,
+            },
+            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
+        }
+    }
+
+    fn make_device(code: &str, expires_minutes_from_now: i64) -> DeviceAuthorization {
+        DeviceAuthorization {
+            device_code: code.to_string(),
+            user_code: "user".to_string(),
+            provider_id: "p".to_string(),
+            expires_at: Utc::now() + Duration::minutes(expires_minutes_from_now),
+            status: DeviceAuthStatus::Pending,
+            session_id: None,
+        }
+    }
+
+    fn make_xmpp_code(session_id: &str, created_minutes_ago: i64) -> XmppAuthCode {
+        XmppAuthCode {
+            session_id: session_id.to_string(),
+            redirect_uri: "xmpp://example.test/cb".to_string(),
+            code_challenge: None,
+            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
+        }
+    }
+
+    #[test]
+    fn sweep_removes_only_expired_entries() {
+        let pending: DashMap<String, PendingAuthorization> = DashMap::new();
+        // PendingAuthorization expires 10 minutes after creation.
+        pending.insert("fresh".to_string(), make_pending("fresh", 1));
+        pending.insert("stale".to_string(), make_pending("stale", 30));
+
+        let device: DashMap<String, DeviceAuthorization> = DashMap::new();
+        device.insert("live".to_string(), make_device("live", 5));
+        device.insert("dead".to_string(), make_device("dead", -1));
+
+        let xmpp: DashMap<String, XmppAuthCode> = DashMap::new();
+        // XmppAuthCode expires 10 minutes after creation.
+        xmpp.insert("fresh".to_string(), make_xmpp_code("fresh", 2));
+        xmpp.insert("stale".to_string(), make_xmpp_code("stale", 20));
+
+        let counts = sweep_auth_state_once(&pending, &device, &xmpp);
+
+        assert_eq!(counts.pending_pruned, 1);
+        assert_eq!(counts.device_pruned, 1);
+        assert_eq!(counts.xmpp_pruned, 1);
+        assert_eq!(counts.pending_remaining, 1);
+        assert_eq!(counts.device_remaining, 1);
+        assert_eq!(counts.xmpp_remaining, 1);
+
+        assert!(pending.contains_key("fresh"));
+        assert!(!pending.contains_key("stale"));
+        assert!(device.contains_key("live"));
+        assert!(!device.contains_key("dead"));
+        assert!(xmpp.contains_key("fresh"));
+        assert!(!xmpp.contains_key("stale"));
+    }
+
+    #[test]
+    fn sweep_is_noop_when_all_entries_are_fresh() {
+        let pending: DashMap<String, PendingAuthorization> = DashMap::new();
+        pending.insert("a".to_string(), make_pending("a", 0));
+        let device: DashMap<String, DeviceAuthorization> = DashMap::new();
+        device.insert("b".to_string(), make_device("b", 30));
+        let xmpp: DashMap<String, XmppAuthCode> = DashMap::new();
+        xmpp.insert("c".to_string(), make_xmpp_code("c", 0));
+
+        let counts = sweep_auth_state_once(&pending, &device, &xmpp);
+
+        assert_eq!(counts.pending_pruned, 0);
+        assert_eq!(counts.device_pruned, 0);
+        assert_eq!(counts.xmpp_pruned, 0);
+        assert_eq!(counts.pending_remaining, 1);
+        assert_eq!(counts.device_remaining, 1);
+        assert_eq!(counts.xmpp_remaining, 1);
+    }
 }

--- a/server/crates/waddle-server/src/server/state_inventory_route.rs
+++ b/server/crates/waddle-server/src/server/state_inventory_route.rs
@@ -1,0 +1,226 @@
+//! `/debug/state-inventory` — JSON snapshot of every long-lived
+//! in-memory map's `.len()`.
+//!
+//! Purpose: the server's process RSS has grown faster than the
+//! observable workload would explain, and the existing `/metrics`
+//! Prometheus surface tracks rates / cumulative counters but not the
+//! instantaneous size of the long-lived maps that are the most
+//! likely culprits (room actors, avatar locks, auth flows, SM
+//! sessions, caps cache, etc.). With this endpoint scraped at
+//! 30 s and charted against RSS, the structure responsible for the
+//! climb falls out of the data within minutes.
+//!
+//! Hardening:
+//!
+//! 1. Mounted only when a non-empty `WADDLE_DEBUG_STATE_TOKEN` env
+//!    var is set at HTTP bootstrap. If unset, the route does not
+//!    exist (404).
+//! 2. Every request MUST carry `X-Waddle-Debug-Token` matching that
+//!    token. Missing or wrong → 401.
+//! 3. The response only reports map sizes — never keys, values, or
+//!    user-identifying data. Safe to log.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Serialize;
+
+use crate::server::routes::websocket::WebSocketState;
+
+const AUTH_HEADER: &str = "x-waddle-debug-token";
+const TOKEN_ENV: &str = "WADDLE_DEBUG_STATE_TOKEN";
+
+#[derive(Debug, Clone)]
+pub struct DebugStateAuth {
+    pub token: String,
+}
+
+/// Read the debug token from the environment at HTTP bootstrap. Returns
+/// `None` when the env var is missing or blank, in which case the
+/// caller MUST NOT mount the route.
+pub fn debug_state_auth_from_env() -> Option<DebugStateAuth> {
+    std::env::var(TOKEN_ENV)
+        .ok()
+        .map(|raw| raw.trim().to_string())
+        .filter(|raw| !raw.is_empty())
+        .map(|token| DebugStateAuth { token })
+}
+
+#[derive(Clone)]
+struct RouteState {
+    websocket: Arc<WebSocketState>,
+    auth: Arc<DebugStateAuth>,
+}
+
+#[derive(Debug, Serialize)]
+struct InventoryResponse {
+    auth: AuthInventory,
+    profile: ProfileInventory,
+    sessions: SessionInventory,
+    caps: CapsInventory,
+    connections: ConnectionInventory,
+}
+
+#[derive(Debug, Serialize)]
+struct AuthInventory {
+    pending_auth: usize,
+    device_auth: usize,
+    xmpp_auth_codes: usize,
+    dynamic_oidc_clients: usize,
+    dynamic_oidc_client_locks: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileInventory {
+    avatar_source_locks: usize,
+    profile_publish_tracker_in_flight: usize,
+    provider_dispatch_tasks_in_flight: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SessionInventory {
+    sm_live_sessions: Option<usize>,
+    resumable_sessions: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct CapsInventory {
+    caps_cache: usize,
+    pending_resolutions: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct ConnectionInventory {
+    full_jid_connections: usize,
+    pending_subscription_stanzas: usize,
+    presence_states: usize,
+    last_activity: usize,
+}
+
+pub fn router(websocket: Arc<WebSocketState>, auth: DebugStateAuth) -> Router {
+    Router::new()
+        .route("/debug/state-inventory", get(handler))
+        .with_state(RouteState {
+            websocket,
+            auth: Arc::new(auth),
+        })
+}
+
+async fn handler(
+    State(state): State<RouteState>,
+    headers: HeaderMap,
+) -> Result<Json<InventoryResponse>, StatusCode> {
+    let Some(provided) = headers
+        .get(AUTH_HEADER)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+    if !constant_time_eq(provided.as_bytes(), state.auth.token.as_bytes()) {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let ws = &state.websocket;
+    let deps = &ws.deps;
+    let auth_state = &deps.auth_state;
+    let protocol = &deps.protocol;
+
+    let sm_live_sessions = protocol
+        .sm_session_registry
+        .live_session_ids()
+        .map(|ids| ids.len());
+
+    let response = InventoryResponse {
+        auth: AuthInventory {
+            pending_auth: auth_state.pending_auth.len(),
+            device_auth: auth_state.device_auth.len(),
+            xmpp_auth_codes: auth_state.xmpp_auth_codes.len(),
+            dynamic_oidc_clients: auth_state.dynamic_oidc_clients.len(),
+            dynamic_oidc_client_locks: auth_state.dynamic_oidc_client_locks.len(),
+        },
+        profile: ProfileInventory {
+            avatar_source_locks: protocol.avatar_source_locks.len(),
+            profile_publish_tracker_in_flight: protocol.profile_publish_tracker.len(),
+            provider_dispatch_tasks_in_flight: deps.provider_dispatch_tasks.len(),
+        },
+        sessions: SessionInventory {
+            sm_live_sessions,
+            resumable_sessions: protocol.resumable_sessions.len(),
+        },
+        caps: CapsInventory {
+            caps_cache: protocol.caps_resolver.cache().len(),
+            pending_resolutions: protocol.caps_resolver.pending_len(),
+        },
+        connections: ConnectionInventory {
+            full_jid_connections: protocol.connection_registry.connection_count(),
+            pending_subscription_stanzas: protocol.connection_registry.pending_subscription_count(),
+            presence_states: protocol.connection_registry.presence_state_count(),
+            last_activity: protocol.connection_registry.last_activity_count(),
+        },
+    };
+    Ok(Json(response))
+}
+
+/// Constant-time byte slice comparison so the auth check cannot leak
+/// the token via timing.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (lhs, rhs) in a.iter().zip(b.iter()) {
+        diff |= lhs ^ rhs;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_state_auth_from_env_returns_none_when_unset() {
+        // Use a known-untouched name so we don't disturb live env in
+        // case another test runs in the same process.
+        let prev = std::env::var(TOKEN_ENV).ok();
+        std::env::remove_var(TOKEN_ENV);
+        assert!(debug_state_auth_from_env().is_none());
+        if let Some(prev) = prev {
+            std::env::set_var(TOKEN_ENV, prev);
+        }
+    }
+
+    #[test]
+    fn debug_state_auth_from_env_returns_none_when_blank() {
+        let prev = std::env::var(TOKEN_ENV).ok();
+        std::env::set_var(TOKEN_ENV, "   ");
+        assert!(debug_state_auth_from_env().is_none());
+        match prev {
+            Some(prev) => std::env::set_var(TOKEN_ENV, prev),
+            None => std::env::remove_var(TOKEN_ENV),
+        }
+    }
+
+    #[test]
+    fn debug_state_auth_from_env_returns_some_when_set() {
+        let prev = std::env::var(TOKEN_ENV).ok();
+        std::env::set_var(TOKEN_ENV, "  shhh-secret  ");
+        let auth = debug_state_auth_from_env().expect("non-blank value parses");
+        assert_eq!(auth.token, "shhh-secret");
+        match prev {
+            Some(prev) => std::env::set_var(TOKEN_ENV, prev),
+            None => std::env::remove_var(TOKEN_ENV),
+        }
+    }
+
+    #[test]
+    fn constant_time_eq_matches_only_identical_byte_strings() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"abcd", b"abc"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -55,6 +55,25 @@ impl ConnectionRegistry {
             started_at: Instant::now(),
         }
     }
+
+    /// Number of bare JIDs holding queued subscription stanzas for
+    /// offline peers. Used by the server's `/debug/state-inventory`
+    /// endpoint.
+    pub fn pending_subscription_count(&self) -> usize {
+        self.pending_subscription_stanzas.len()
+    }
+
+    /// Number of bare JIDs with tracked presence state. Used by the
+    /// server's `/debug/state-inventory` endpoint.
+    pub fn presence_state_count(&self) -> usize {
+        self.presence_states.len()
+    }
+
+    /// Number of bare JIDs with recorded last-activity timestamps.
+    /// Used by the server's `/debug/state-inventory` endpoint.
+    pub fn last_activity_count(&self) -> usize {
+        self.last_activity.len()
+    }
 }
 
 impl Default for ConnectionRegistry {


### PR DESCRIPTION
## Context

Server RSS climbed from ~500 MB → 1 GB → 4 GB over a short window; #503 had to bump the Kubernetes memory limit to keep the latest rollout from OOM-killing. This PR addresses the structural causes.

## Diagnosis

I ran a focused heap profile of the WASM extension runtime (`examples/profile_all_extensions.rs`, dhat heap profiler, 10,000 invocations across ai-chatbot, link-board, github, decision-polls — github-enricher has no source in-tree, just an orphaned artifact) to rule it out as the source. Result:

| metric | value |
| --- | --- |
| dhat retained at exit (`t-end`) | **165 KB / 413 blocks** |
| RSS growth across 10k invocations | **~0.8 MB** |
| One-time load cost (Cranelift JIT for 4 extensions) | ~50 MB |
| Per-invocation alloc churn | ~150 KB allocated + freed (Store-per-call by design) |

The extensions are not the leak. The actual sources are unbounded in-memory state in `waddle-server`:

| # | Suspect | File:Line | Evidence | Action in this PR |
|---|---------|-----------|----------|---|
| 1 | `avatar_source_locks` | `routes/websocket/state.rs:99` | `or_insert_with` per `BareJid`; no removal site in tree | **Fixed** |
| 2 | `pending_auth` / `device_auth` / `xmpp_auth_codes` | `routes/auth.rs:48-138` | Each has `is_expired()`, but `session_janitors.rs` only sweeps SM + pending-delivery | **Fixed** |
| 3 | `MucRoom` actors | `muc/room_registry_actor.rs` | `rooms` HashMap only shrinks via explicit `RemoveRoom` | Deferred — see below |
| 4 | SM detached-session unacked queues | `stream_management/session_registry.rs:28` | 10k × 1k × ~1 KB worst case | Already capped; rely on instrumentation |

## What's in this PR

### 1. `fix(server): evict avatar_source_locks entries when no acquirer is in flight`

Replace the raw `DashMap<BareJid, Arc<Mutex<()>>>` with a typed `AvatarLockMap` + RAII `AvatarLockGuard`. The guard's `Drop` releases the per-JID mutex first, then calls `DashMap::remove_if` with a predicate that evicts iff `Arc::strong_count(mutex) == 1` (only the map itself holds a reference). The shard write lock that `remove_if` acquires during the predicate prevents a concurrent `acquire` from cloning the Arc between the count read and the removal, so the eviction is race-free.

Net effect: the map's size now tracks current contention rather than the lifetime user set. Backed by three unit tests covering solo release, contended release, and per-JID isolation.

### 2. `fix(server): sweep expired pending_auth, device_auth, xmpp_auth_codes`

Add `spawn_auth_state_janitor`, wired alongside the existing SM-expiry and pending-delivery janitors at HTTP bootstrap. Ticks every 60 s and removes any entry reporting `is_expired() == true` (PendingAuthorization / XmppAuthCode: 10-minute window; DeviceAuthorization: explicit `expires_at`). Skips the immediate first tick and only logs at info level when something was pruned. Backed by two unit tests in `auth_janitor_tests`.

### 3. `feat(server): /debug/state-inventory for live in-memory map sizes`

New admin-gated JSON endpoint at `/debug/state-inventory`. Mounted only when `WADDLE_DEBUG_STATE_TOKEN` is set; every request must carry a matching `X-Waddle-Debug-Token` header, compared in constant time. Returns the instantaneous `.len()` of every long-lived map suspected of unbounded growth (auth maps, avatar locks, profile/dispatch trackers, SM sessions + resumable, caps cache + pending, connections + presence + last activity). Set the token on the canary, scrape every 30 s, chart against RSS — the offending structure falls out of the data without more code changes.

### 4. `test(server): add profile_all_extensions heap profile harness`

Reproducible dhat heap profile + RSS sampler over all in-tree extensions. Run with `cargo run --release --example profile_all_extensions -p waddle-extensions -- [ITERS]`. Artifacts (`dhat-heap.json`, `profile_extensions.log`) are gitignored.

## What's NOT in this PR

**Room-actor auto-evict** (suspect #3). MUC semantics around occupant-zero / persistent rooms need a separate design pass — destroying a non-persistent room as soon as its last occupant leaves is generally correct, but several recent PRs (#498, #499, #492, #499) touch this surface and I want the new `/debug/state-inventory` data first to confirm whether room growth is actually what's dominating before changing room lifecycle.

**SM-session worst-case bound** (suspect #4). Already capped at 10k × 1k. If state-inventory shows `sm_live_sessions` near the cap on the canary, we'll revisit.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p waddle-server --lib` (568 passed)
- [x] `cargo test -p waddle-xmpp --features test-utils --lib` (1826 passed)
- [x] `cargo test -p waddle-extensions --lib` (50 passed)
- [x] Profiler harness builds + runs at 5,000 iters per stage
- [ ] CI green on PR
- [ ] After merge, set `WADDLE_DEBUG_STATE_TOKEN` on canary and chart `state-inventory.*` series against RSS to identify the residual leak source (room actors are the leading candidate)

This PR was created with the assistance of a LLM.