### PR TITLE
feat(server): emit state-inventory map sizes as OTel gauges

### DIFF
--- a/scripts/state-inventory-grafana-dashboard.json
+++ b/scripts/state-inventory-grafana-dashboard.json
@@ -1,6 +1,6 @@
 {
   "annotations": { "list": [] },
-  "description": "Waddle server long-lived in-memory maps. Charts the /debug/state-inventory snapshot against process RSS so the offending structure for an RSS climb falls out of the data within minutes. State-inventory values come from a sidecar scraper that converts the JSON into Prometheus gauges (e.g. via prom-aggregation-gateway) — sample queries below use the gauge names emitted by scripts/state-inventory-scrape.sh once it's wrapped in such a sidecar. The Grafana dashboard is intentionally hand-buildable from this JSON template, not a Grafana-export of a private dashboard, so it survives Grafana upgrades and is reviewable in PRs.",
+  "description": "Waddle server long-lived in-memory maps, sampled every 15 s by `state_inventory_metrics::spawn_state_inventory_publisher` and exported through the standard OTel meter provider into Grafana Cloud Mimir via the in-cluster grafana-alloy collector. Each panel charts a logical group of maps against `process_resident_memory_bytes` so an RSS climb correlates directly to whichever .len() is growing. Hand-buildable on purpose so it survives Grafana upgrades and is reviewable in PRs.",
   "editable": true,
   "graphTooltip": 1,
   "panels": [
@@ -22,10 +22,11 @@
       "title": "Auth state maps (.len())",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_inventory_pending_auth", "legendFormat": "pending_auth" },
-        { "expr": "waddle_state_inventory_device_auth", "legendFormat": "device_auth" },
-        { "expr": "waddle_state_inventory_xmpp_auth_codes", "legendFormat": "xmpp_auth_codes" },
-        { "expr": "waddle_state_inventory_dynamic_oidc_clients", "legendFormat": "dynamic_oidc_clients" }
+        { "expr": "waddle_state_auth_pending_auth", "legendFormat": "pending_auth" },
+        { "expr": "waddle_state_auth_device_auth", "legendFormat": "device_auth" },
+        { "expr": "waddle_state_auth_xmpp_auth_codes", "legendFormat": "xmpp_auth_codes" },
+        { "expr": "waddle_state_auth_dynamic_oidc_clients", "legendFormat": "dynamic_oidc_clients" },
+        { "expr": "waddle_state_auth_dynamic_oidc_client_locks", "legendFormat": "dynamic_oidc_client_locks" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
@@ -34,9 +35,9 @@
       "title": "Profile + dispatch in-flight",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_inventory_avatar_source_locks", "legendFormat": "avatar_source_locks" },
-        { "expr": "waddle_state_inventory_profile_publish_in_flight", "legendFormat": "profile_publish" },
-        { "expr": "waddle_state_inventory_provider_dispatch_in_flight", "legendFormat": "provider_dispatch" }
+        { "expr": "waddle_state_profile_avatar_source_locks", "legendFormat": "avatar_source_locks" },
+        { "expr": "waddle_state_profile_publish_tracker_in_flight", "legendFormat": "profile_publish" },
+        { "expr": "waddle_state_profile_provider_dispatch_in_flight", "legendFormat": "provider_dispatch" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
@@ -45,10 +46,10 @@
       "title": "Sessions + caps",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_inventory_sm_live_sessions", "legendFormat": "sm_live" },
-        { "expr": "waddle_state_inventory_resumable_sessions", "legendFormat": "resumable" },
-        { "expr": "waddle_state_inventory_caps_cache", "legendFormat": "caps_cache" },
-        { "expr": "waddle_state_inventory_caps_pending", "legendFormat": "caps_pending" }
+        { "expr": "waddle_state_sessions_sm_live_sessions", "legendFormat": "sm_live" },
+        { "expr": "waddle_state_sessions_resumable_sessions", "legendFormat": "resumable" },
+        { "expr": "waddle_state_caps_caps_cache", "legendFormat": "caps_cache" },
+        { "expr": "waddle_state_caps_pending_resolutions", "legendFormat": "caps_pending" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
     },
@@ -57,10 +58,10 @@
       "title": "Connections + presence",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_inventory_full_jid_conns", "legendFormat": "connections" },
-        { "expr": "waddle_state_inventory_pending_subs", "legendFormat": "pending_subs" },
-        { "expr": "waddle_state_inventory_presence_states", "legendFormat": "presence_states" },
-        { "expr": "waddle_state_inventory_last_activity", "legendFormat": "last_activity" }
+        { "expr": "waddle_state_connections_full_jid_connections", "legendFormat": "connections" },
+        { "expr": "waddle_state_connections_pending_subscription_stanzas", "legendFormat": "pending_subs" },
+        { "expr": "waddle_state_connections_presence_states", "legendFormat": "presence_states" },
+        { "expr": "waddle_state_connections_last_activity", "legendFormat": "last_activity" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
     },
@@ -69,8 +70,8 @@
       "title": "MUC rooms (total vs dormant — reclaimable headroom)",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_inventory_rooms_total", "legendFormat": "total" },
-        { "expr": "waddle_state_inventory_rooms_dormant", "legendFormat": "dormant (will be evicted)" }
+        { "expr": "waddle_state_rooms_total", "legendFormat": "total" },
+        { "expr": "waddle_state_rooms_dormant", "legendFormat": "dormant (will be evicted)" }
       ],
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
     }
@@ -90,5 +91,5 @@
   "time": { "from": "now-6h", "to": "now" },
   "title": "Waddle server — long-lived state inventory",
   "uid": "waddle-state-inventory",
-  "version": 1
+  "version": 2
 }

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -188,6 +188,7 @@ pub(crate) async fn create_router(
     spawn_pending_delivery_claim_janitor(&websocket_state);
     spawn_auth_state_janitor(&websocket_state);
     spawn_room_dormancy_janitor(&websocket_state);
+    crate::server::state_inventory_metrics::spawn_state_inventory_publisher(&websocket_state);
     spawn_graceful_shutdown_drain(
         Arc::clone(&websocket_state),
         shutdown_stop_token,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -10,6 +10,8 @@ mod http;
 pub(crate) mod profile_publish_route;
 mod session_janitors;
 mod state;
+pub(crate) mod state_inventory;
+pub(crate) mod state_inventory_metrics;
 pub(crate) mod state_inventory_route;
 mod topology;
 mod trace;

--- a/server/crates/waddle-server/src/server/state_inventory.rs
+++ b/server/crates/waddle-server/src/server/state_inventory.rs
@@ -1,0 +1,154 @@
+//! Shared collection of the server's long-lived in-memory map sizes.
+//!
+//! The same data feeds two surfaces:
+//!
+//! - [`crate::server::state_inventory_route`] — the operator-side
+//!   `/debug/state-inventory` JSON endpoint, gated on a token. Useful
+//!   when Grafana isn't reachable from where the operator is sitting.
+//! - [`crate::server::state_inventory_metrics`] — a periodic
+//!   publisher that records each field as an OTel gauge. This is the
+//!   primary surface in production: the values flow through Alloy
+//!   into Grafana Cloud and chart against `process_resident_memory_bytes`
+//!   without any port-forward or per-pod auth dance.
+
+use serde::Serialize;
+
+use crate::server::routes::websocket::WebSocketState;
+
+/// Typed snapshot of every long-lived map's `.len()`. Field grouping
+/// mirrors the layers of the server (auth → profile → sessions →
+/// caps → connections → rooms) so the Grafana panels can be read in
+/// order from "is this a login storm?" to "is this an MUC growth
+/// problem?".
+#[derive(Debug, Clone, Serialize)]
+pub struct StateInventorySnapshot {
+    pub auth: AuthInventory,
+    pub profile: ProfileInventory,
+    pub sessions: SessionInventory,
+    pub caps: CapsInventory,
+    pub connections: ConnectionInventory,
+    pub rooms: RoomInventory,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthInventory {
+    pub pending_auth: usize,
+    pub device_auth: usize,
+    pub xmpp_auth_codes: usize,
+    pub dynamic_oidc_clients: usize,
+    pub dynamic_oidc_client_locks: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProfileInventory {
+    pub avatar_source_locks: usize,
+    pub profile_publish_tracker_in_flight: usize,
+    pub provider_dispatch_tasks_in_flight: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionInventory {
+    /// `None` only when the SM-session registry's internal locks are
+    /// poisoned — observed as a gap in the Grafana series. We keep
+    /// it nullable here rather than collapsing to `0` so the gap is
+    /// visually distinct from "zero sessions live".
+    pub sm_live_sessions: Option<usize>,
+    pub resumable_sessions: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapsInventory {
+    pub caps_cache: usize,
+    pub pending_resolutions: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ConnectionInventory {
+    pub full_jid_connections: usize,
+    pub pending_subscription_stanzas: usize,
+    pub presence_states: usize,
+    pub last_activity: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RoomInventory {
+    /// Total `RoomActor` instances tracked by `RoomRegistryActor`.
+    pub total: usize,
+    /// Rooms that report `is_dormant() == true` — zero occupants AND
+    /// no subject AND no pinned entries AND no in-memory affiliations.
+    /// Reclaimable by the room dormancy janitor on its next pass.
+    pub dormant: usize,
+}
+
+/// Collect a snapshot of every state-inventory field. Best-effort:
+/// any individual actor `ask` that fails falls through as 0 (or
+/// `None` for `sm_live_sessions`) so the publisher / endpoint never
+/// fail hard on a single hung actor.
+pub async fn collect_snapshot(ws: &WebSocketState) -> StateInventorySnapshot {
+    use waddle_xmpp::muc::room_actor::IsDormant;
+    use waddle_xmpp::muc::room_registry_actor::{GetRoom, ListRooms, RoomCount};
+
+    let deps = &ws.deps;
+    let auth_state = &deps.auth_state;
+    let protocol = &deps.protocol;
+
+    let sm_live_sessions = protocol
+        .sm_session_registry
+        .live_session_ids()
+        .map(|ids| ids.len());
+
+    let rooms_total: usize = protocol.room_registry.ask(RoomCount).await.unwrap_or(0);
+    let room_list = protocol
+        .room_registry
+        .ask(ListRooms)
+        .await
+        .unwrap_or_default();
+    let mut rooms_dormant = 0usize;
+    for room_jid in room_list {
+        let Ok(Some(actor)) = protocol
+            .room_registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+        else {
+            continue;
+        };
+        if matches!(actor.ask(IsDormant).await, Ok(true)) {
+            rooms_dormant += 1;
+        }
+    }
+
+    StateInventorySnapshot {
+        auth: AuthInventory {
+            pending_auth: auth_state.pending_auth.len(),
+            device_auth: auth_state.device_auth.len(),
+            xmpp_auth_codes: auth_state.xmpp_auth_codes.len(),
+            dynamic_oidc_clients: auth_state.dynamic_oidc_clients.len(),
+            dynamic_oidc_client_locks: auth_state.dynamic_oidc_client_locks.len(),
+        },
+        profile: ProfileInventory {
+            avatar_source_locks: protocol.avatar_source_locks.len(),
+            profile_publish_tracker_in_flight: protocol.profile_publish_tracker.len(),
+            provider_dispatch_tasks_in_flight: deps.provider_dispatch_tasks.len(),
+        },
+        sessions: SessionInventory {
+            sm_live_sessions,
+            resumable_sessions: protocol.resumable_sessions.len(),
+        },
+        caps: CapsInventory {
+            caps_cache: protocol.caps_resolver.cache().len(),
+            pending_resolutions: protocol.caps_resolver.pending_len(),
+        },
+        connections: ConnectionInventory {
+            full_jid_connections: protocol.connection_registry.connection_count(),
+            pending_subscription_stanzas: protocol.connection_registry.pending_subscription_count(),
+            presence_states: protocol.connection_registry.presence_state_count(),
+            last_activity: protocol.connection_registry.last_activity_count(),
+        },
+        rooms: RoomInventory {
+            total: rooms_total,
+            dormant: rooms_dormant,
+        },
+    }
+}

--- a/server/crates/waddle-server/src/server/state_inventory_metrics.rs
+++ b/server/crates/waddle-server/src/server/state_inventory_metrics.rs
@@ -1,0 +1,231 @@
+//! OTel publisher for the long-lived in-memory map sizes.
+//!
+//! Spawns a single tokio task that polls
+//! [`crate::server::state_inventory::collect_snapshot`] every
+//! [`STATE_INVENTORY_PUBLISH_INTERVAL`] and records each field as an
+//! i64 gauge under `waddle.state.*`. The values flow through the
+//! global OTel meter provider — wired to Alloy in
+//! `crate::telemetry::init` — and land in Grafana Cloud Mimir
+//! without any per-pod auth or port-forward.
+//!
+//! All gauges carry zero labels: the structure of interest is
+//! "which map", not "which user/room/etc". Bounded cardinality
+//! means OTel SDK aggregation is a no-op and there's no risk of a
+//! per-JID cardinality blowup.
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use opentelemetry::metrics::Gauge;
+use tracing::debug;
+
+use crate::server::routes::websocket::WebSocketState;
+use crate::server::state_inventory::collect_snapshot;
+
+/// How often the publisher polls and records. Chosen well under the
+/// OTel periodic-reader default (60 s) so each export contains a
+/// fresh value rather than a stale one.
+pub const STATE_INVENTORY_PUBLISH_INTERVAL: Duration = Duration::from_secs(15);
+
+fn meter() -> &'static opentelemetry::metrics::Meter {
+    static METER: OnceLock<opentelemetry::metrics::Meter> = OnceLock::new();
+    METER.get_or_init(|| opentelemetry::global::meter("waddle-server"))
+}
+
+macro_rules! gauge {
+    ($name:literal, $description:literal) => {{
+        static G: OnceLock<Gauge<i64>> = OnceLock::new();
+        G.get_or_init(|| {
+            meter()
+                .i64_gauge($name)
+                .with_description($description)
+                .with_unit("entry")
+                .build()
+        })
+    }};
+}
+
+/// Cast a `usize` length to `i64` for OTel without panicking on
+/// (effectively impossible) overflow. Saturates at `i64::MAX` —
+/// in production any `.len()` near that value is already a fatal bug
+/// long before the metric matters.
+fn as_i64(n: usize) -> i64 {
+    i64::try_from(n).unwrap_or(i64::MAX)
+}
+
+/// Spawn the periodic publisher. Wired alongside the existing
+/// janitors at HTTP bootstrap.
+pub(crate) fn spawn_state_inventory_publisher(websocket_state: &Arc<WebSocketState>) {
+    let weak_state = Arc::downgrade(websocket_state);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(STATE_INVENTORY_PUBLISH_INTERVAL);
+        // Skip the first immediate tick — a fresh process shouldn't
+        // emit before any traffic has touched the maps.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let Some(state) = weak_state.upgrade() else {
+                break;
+            };
+            publish_once(&state).await;
+        }
+    });
+}
+
+/// Take a snapshot and record every field as an OTel gauge sample.
+/// Pure helper so unit tests can drive a single publish without the
+/// long-running ticker.
+pub(crate) async fn publish_once(websocket_state: &WebSocketState) {
+    let snapshot = collect_snapshot(websocket_state).await;
+    let labels: &[opentelemetry::KeyValue] = &[];
+
+    // Auth state — the three DashMaps swept by spawn_auth_state_janitor,
+    // plus the OIDC dynamic-client cache they share state with.
+    gauge!(
+        "waddle.state.auth.pending_auth",
+        "Live PendingAuthorization entries awaiting OAuth callback."
+    )
+    .record(as_i64(snapshot.auth.pending_auth), labels);
+    gauge!(
+        "waddle.state.auth.device_auth",
+        "Live DeviceAuthorization entries awaiting device-flow approval."
+    )
+    .record(as_i64(snapshot.auth.device_auth), labels);
+    gauge!(
+        "waddle.state.auth.xmpp_auth_codes",
+        "Live XmppAuthCode entries awaiting XMPP OAuth token exchange."
+    )
+    .record(as_i64(snapshot.auth.xmpp_auth_codes), labels);
+    gauge!(
+        "waddle.state.auth.dynamic_oidc_clients",
+        "Cached dynamic OIDC client registrations."
+    )
+    .record(as_i64(snapshot.auth.dynamic_oidc_clients), labels);
+    gauge!(
+        "waddle.state.auth.dynamic_oidc_client_locks",
+        "Locks guarding dynamic OIDC client registration races."
+    )
+    .record(as_i64(snapshot.auth.dynamic_oidc_client_locks), labels);
+
+    // Profile / publish trackers — the avatar-source lock map and the
+    // two TaskTrackers for OIDC profile publishes and provider webhook
+    // dispatches.
+    gauge!(
+        "waddle.state.profile.avatar_source_locks",
+        "Per-BareJid avatar-publish mutexes currently held or waiting."
+    )
+    .record(as_i64(snapshot.profile.avatar_source_locks), labels);
+    gauge!(
+        "waddle.state.profile.publish_tracker_in_flight",
+        "OIDC profile-publish background tasks currently in flight."
+    )
+    .record(
+        as_i64(snapshot.profile.profile_publish_tracker_in_flight),
+        labels,
+    );
+    gauge!(
+        "waddle.state.profile.provider_dispatch_in_flight",
+        "Provider webhook dispatch tasks currently in flight."
+    )
+    .record(
+        as_i64(snapshot.profile.provider_dispatch_tasks_in_flight),
+        labels,
+    );
+
+    // Stream management — detached XEP-0198 sessions and their
+    // sidecar resumable-session map.
+    gauge!(
+        "waddle.state.sessions.sm_live_sessions",
+        "Detached XEP-0198 sessions in the SM session registry."
+    )
+    .record(
+        as_i64(snapshot.sessions.sm_live_sessions.unwrap_or(0)),
+        labels,
+    );
+    gauge!(
+        "waddle.state.sessions.resumable_sessions",
+        "Sidecar resumable_sessions entries awaiting take or expiry."
+    )
+    .record(as_i64(snapshot.sessions.resumable_sessions), labels);
+
+    // XEP-0115 entity capabilities — the LRU cache and the in-flight
+    // pending-resolution table.
+    gauge!(
+        "waddle.state.caps.caps_cache",
+        "Cached XEP-0115 disco#info bodies (LRU-bounded)."
+    )
+    .record(as_i64(snapshot.caps.caps_cache), labels);
+    gauge!(
+        "waddle.state.caps.pending_resolutions",
+        "Outstanding XEP-0115 disco#info resolutions awaiting client reply."
+    )
+    .record(as_i64(snapshot.caps.pending_resolutions), labels);
+
+    // Connection registry — the four DashMaps inside ConnectionRegistry.
+    gauge!(
+        "waddle.state.connections.full_jid_connections",
+        "Live full-JID WebSocket connections registered with the server."
+    )
+    .record(as_i64(snapshot.connections.full_jid_connections), labels);
+    gauge!(
+        "waddle.state.connections.pending_subscription_stanzas",
+        "Bare JIDs holding queued XEP-0162 subscription stanzas for offline peers."
+    )
+    .record(
+        as_i64(snapshot.connections.pending_subscription_stanzas),
+        labels,
+    );
+    gauge!(
+        "waddle.state.connections.presence_states",
+        "Bare JIDs with tracked presence state."
+    )
+    .record(as_i64(snapshot.connections.presence_states), labels);
+    gauge!(
+        "waddle.state.connections.last_activity",
+        "Bare JIDs with recorded XEP-0012 last-activity timestamps."
+    )
+    .record(as_i64(snapshot.connections.last_activity), labels);
+
+    // MUC rooms — total and the sub-count that the dormancy janitor
+    // will reclaim on its next pass.
+    gauge!(
+        "waddle.state.rooms.total",
+        "Total RoomActor instances tracked by RoomRegistryActor."
+    )
+    .record(as_i64(snapshot.rooms.total), labels);
+    gauge!(
+        "waddle.state.rooms.dormant",
+        "Rooms reported by IsDormant — reclaimable on the next dormancy janitor tick."
+    )
+    .record(as_i64(snapshot.rooms.dormant), labels);
+
+    debug!(
+        rooms_total = snapshot.rooms.total,
+        rooms_dormant = snapshot.rooms.dormant,
+        sm_live = ?snapshot.sessions.sm_live_sessions,
+        full_jid_conns = snapshot.connections.full_jid_connections,
+        "state-inventory publisher: recorded gauge sample"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::websocket::tests::create_test_websocket_state;
+
+    #[tokio::test]
+    async fn publish_once_does_not_panic_on_fresh_state() {
+        let state = create_test_websocket_state().await;
+        // Smoke test — the test harness's WebSocketState has every
+        // map at zero; we just want to confirm the publisher walks
+        // them all without panicking.
+        publish_once(&state).await;
+    }
+
+    #[test]
+    fn as_i64_saturates_at_max() {
+        assert_eq!(super::as_i64(0), 0);
+        assert_eq!(super::as_i64(42), 42);
+        assert_eq!(super::as_i64(usize::MAX), i64::MAX);
+    }
+}

--- a/server/crates/waddle-server/src/server/state_inventory_route.rs
+++ b/server/crates/waddle-server/src/server/state_inventory_route.rs
@@ -1,14 +1,13 @@
 //! `/debug/state-inventory` — JSON snapshot of every long-lived
 //! in-memory map's `.len()`.
 //!
-//! Purpose: the server's process RSS has grown faster than the
-//! observable workload would explain, and the existing `/metrics`
-//! Prometheus surface tracks rates / cumulative counters but not the
-//! instantaneous size of the long-lived maps that are the most
-//! likely culprits (room actors, avatar locks, auth flows, SM
-//! sessions, caps cache, etc.). With this endpoint scraped at
-//! 30 s and charted against RSS, the structure responsible for the
-//! climb falls out of the data within minutes.
+//! In production, the primary surface for these values is the OTel
+//! gauge stream published by
+//! [`crate::server::state_inventory_metrics`] — those values flow
+//! through Alloy into Grafana Cloud without any port-forward or
+//! per-pod auth. This route is the operator backstop: a single
+//! `curl` from inside the cluster (or via port-forward) returns the
+//! same shape as the gauges, useful when Grafana isn't reachable.
 //!
 //! Hardening:
 //!
@@ -26,9 +25,9 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::routing::get;
 use axum::{Json, Router};
-use serde::Serialize;
 
 use crate::server::routes::websocket::WebSocketState;
+use crate::server::state_inventory::{collect_snapshot, StateInventorySnapshot};
 
 const AUTH_HEADER: &str = "x-waddle-debug-token";
 const TOKEN_ENV: &str = "WADDLE_DEBUG_STATE_TOKEN";
@@ -55,65 +54,6 @@ struct RouteState {
     auth: Arc<DebugStateAuth>,
 }
 
-#[derive(Debug, Serialize)]
-struct InventoryResponse {
-    auth: AuthInventory,
-    profile: ProfileInventory,
-    sessions: SessionInventory,
-    caps: CapsInventory,
-    connections: ConnectionInventory,
-    rooms: RoomInventory,
-}
-
-#[derive(Debug, Serialize)]
-struct RoomInventory {
-    /// Total `RoomActor` instances tracked by `RoomRegistryActor`.
-    /// Errors fall through as 0 to keep the endpoint best-effort.
-    total: usize,
-    /// Rooms that report `is_dormant() == true` — zero occupants AND
-    /// no subject AND no pinned entries AND no in-memory affiliations.
-    /// Reclaimable by the room dormancy janitor on its next pass; a
-    /// growing value here is the canary signal that the janitor
-    /// interval should be tightened.
-    dormant: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct AuthInventory {
-    pending_auth: usize,
-    device_auth: usize,
-    xmpp_auth_codes: usize,
-    dynamic_oidc_clients: usize,
-    dynamic_oidc_client_locks: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct ProfileInventory {
-    avatar_source_locks: usize,
-    profile_publish_tracker_in_flight: usize,
-    provider_dispatch_tasks_in_flight: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct SessionInventory {
-    sm_live_sessions: Option<usize>,
-    resumable_sessions: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct CapsInventory {
-    caps_cache: usize,
-    pending_resolutions: usize,
-}
-
-#[derive(Debug, Serialize)]
-struct ConnectionInventory {
-    full_jid_connections: usize,
-    pending_subscription_stanzas: usize,
-    presence_states: usize,
-    last_activity: usize,
-}
-
 pub fn router(websocket: Arc<WebSocketState>, auth: DebugStateAuth) -> Router {
     Router::new()
         .route("/debug/state-inventory", get(handler))
@@ -126,7 +66,7 @@ pub fn router(websocket: Arc<WebSocketState>, auth: DebugStateAuth) -> Router {
 async fn handler(
     State(state): State<RouteState>,
     headers: HeaderMap,
-) -> Result<Json<InventoryResponse>, StatusCode> {
+) -> Result<Json<StateInventorySnapshot>, StatusCode> {
     let Some(provided) = headers
         .get(AUTH_HEADER)
         .and_then(|value| value.to_str().ok())
@@ -137,87 +77,7 @@ async fn handler(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    let ws = &state.websocket;
-    let deps = &ws.deps;
-    let auth_state = &deps.auth_state;
-    let protocol = &deps.protocol;
-
-    let sm_live_sessions = protocol
-        .sm_session_registry
-        .live_session_ids()
-        .map(|ids| ids.len());
-
-    let rooms = collect_room_inventory(ws).await;
-
-    let response = InventoryResponse {
-        auth: AuthInventory {
-            pending_auth: auth_state.pending_auth.len(),
-            device_auth: auth_state.device_auth.len(),
-            xmpp_auth_codes: auth_state.xmpp_auth_codes.len(),
-            dynamic_oidc_clients: auth_state.dynamic_oidc_clients.len(),
-            dynamic_oidc_client_locks: auth_state.dynamic_oidc_client_locks.len(),
-        },
-        profile: ProfileInventory {
-            avatar_source_locks: protocol.avatar_source_locks.len(),
-            profile_publish_tracker_in_flight: protocol.profile_publish_tracker.len(),
-            provider_dispatch_tasks_in_flight: deps.provider_dispatch_tasks.len(),
-        },
-        sessions: SessionInventory {
-            sm_live_sessions,
-            resumable_sessions: protocol.resumable_sessions.len(),
-        },
-        caps: CapsInventory {
-            caps_cache: protocol.caps_resolver.cache().len(),
-            pending_resolutions: protocol.caps_resolver.pending_len(),
-        },
-        connections: ConnectionInventory {
-            full_jid_connections: protocol.connection_registry.connection_count(),
-            pending_subscription_stanzas: protocol.connection_registry.pending_subscription_count(),
-            presence_states: protocol.connection_registry.presence_state_count(),
-            last_activity: protocol.connection_registry.last_activity_count(),
-        },
-        rooms,
-    };
-    Ok(Json(response))
-}
-
-/// Best-effort population of `RoomInventory`. Errors fall through as
-/// zeros so the inventory endpoint stays operational even when the
-/// room registry or a per-room actor is overloaded.
-async fn collect_room_inventory(ws: &WebSocketState) -> RoomInventory {
-    use waddle_xmpp::muc::room_actor::IsDormant;
-    use waddle_xmpp::muc::room_registry_actor::{GetRoom, ListRooms, RoomCount};
-    let total: usize = ws
-        .deps
-        .protocol
-        .room_registry
-        .ask(RoomCount)
-        .await
-        .unwrap_or(0);
-    let room_list = match ws.deps.protocol.room_registry.ask(ListRooms).await {
-        Ok(list) => list,
-        Err(_) => {
-            return RoomInventory { total, dormant: 0 };
-        }
-    };
-    let mut dormant = 0usize;
-    for room_jid in room_list {
-        let Ok(Some(actor)) = ws
-            .deps
-            .protocol
-            .room_registry
-            .ask(GetRoom {
-                room_jid: room_jid.clone(),
-            })
-            .await
-        else {
-            continue;
-        };
-        if matches!(actor.ask(IsDormant).await, Ok(true)) {
-            dormant += 1;
-        }
-    }
-    RoomInventory { total, dormant }
+    Ok(Json(collect_snapshot(&state.websocket).await))
 }
 
 /// Constant-time byte slice comparison so the auth check cannot leak
@@ -236,11 +96,19 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialise the env-var tests against each other so parallel
+    /// `cargo test` execution can't race them on a single
+    /// process-global env slot.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     #[test]
     fn debug_state_auth_from_env_returns_none_when_unset() {
-        // Use a known-untouched name so we don't disturb live env in
-        // case another test runs in the same process.
+        let _guard = env_lock().lock().expect("lock should not be poisoned");
         let prev = std::env::var(TOKEN_ENV).ok();
         std::env::remove_var(TOKEN_ENV);
         assert!(debug_state_auth_from_env().is_none());
@@ -251,6 +119,7 @@ mod tests {
 
     #[test]
     fn debug_state_auth_from_env_returns_none_when_blank() {
+        let _guard = env_lock().lock().expect("lock should not be poisoned");
         let prev = std::env::var(TOKEN_ENV).ok();
         std::env::set_var(TOKEN_ENV, "   ");
         assert!(debug_state_auth_from_env().is_none());
@@ -262,6 +131,7 @@ mod tests {
 
     #[test]
     fn debug_state_auth_from_env_returns_some_when_set() {
+        let _guard = env_lock().lock().expect("lock should not be poisoned");
         let prev = std::env::var(TOKEN_ENV).ok();
         std::env::set_var(TOKEN_ENV, "  shhh-secret  ");
         let auth = debug_state_auth_from_env().expect("non-blank value parses");


### PR DESCRIPTION
## Context

The `/debug/state-inventory` route shipped in #505 was a backstop for the memory-leak hunt — it works via `kubectl port-forward` + token + `scripts/state-inventory-scrape.sh`. The cluster already has `grafana-alloy` at `otlpEndpoint`, so the right surface is OTel gauges flowing through the existing pipeline into Grafana Cloud Mimir without any per-pod auth or manual scrape.

## What this PR does

- **`server::state_inventory`** owns the typed `StateInventorySnapshot` + `collect_snapshot` helper. Single source of truth shared by the route handler and the new metrics publisher — no risk of the two surfaces drifting.
- **`server::state_inventory_metrics::spawn_state_inventory_publisher`** ticks every 15 s, collects a snapshot, and records each field as an *unlabeled* i64 gauge under `waddle.state.*`. 18 gauges total, all bounded cardinality.
- **`state_inventory_route`** is now a thin axum wrapper around `collect_snapshot` (operator backstop when Grafana isn't reachable; Grafana is the primary surface).
- **`scripts/state-inventory-grafana-dashboard.json`** updated to point at the new metric names.

### Metrics emitted

| Metric | Description |
| --- | --- |
| `waddle.state.auth.{pending_auth,device_auth,xmpp_auth_codes,dynamic_oidc_clients,dynamic_oidc_client_locks}` | Live entries in each auth-flow DashMap. |
| `waddle.state.profile.{avatar_source_locks,publish_tracker_in_flight,provider_dispatch_in_flight}` | Avatar-publish mutexes and the two `TaskTracker` sizes. |
| `waddle.state.sessions.{sm_live_sessions,resumable_sessions}` | Detached XEP-0198 sessions and their sidecar map. |
| `waddle.state.caps.{caps_cache,pending_resolutions}` | XEP-0115 LRU + in-flight resolution table. |
| `waddle.state.connections.{full_jid_connections,pending_subscription_stanzas,presence_states,last_activity}` | The four DashMaps inside `ConnectionRegistry`. |
| `waddle.state.rooms.{total,dormant}` | MUC room actors + the dormancy-janitor-reclaimable subset. |

All zero-cardinality — no risk of a per-JID label blowup.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p waddle-server --lib` → 577 passed (was 575; +2 in this PR)
- [x] `cargo test -p waddle-xmpp --features test-utils --lib` → 1832 passed (unchanged)
- [ ] CI green on PR
- [ ] After merge: resume Flux on the cluster (`flux resume helmrelease waddle-server -n waddle`), let the next rollout pick up the new image, then open the `Waddle server — long-lived state inventory` dashboard. Series will populate within ~30 s of pod start.

This PR was created with the assistance of a LLM.