### PR TITLE
feat(server): emit process RSS as OTel gauge

### DIFF
--- a/scripts/state-inventory-grafana-dashboard.json
+++ b/scripts/state-inventory-grafana-dashboard.json
@@ -10,8 +10,8 @@
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
         {
-          "expr": "process_resident_memory_bytes{job=\"waddle-server\"}",
-          "legendFormat": "{{pod}}"
+          "expr": "waddle_process_resident_memory_bytes_By",
+          "legendFormat": "{{service_instance_id}}"
         }
       ],
       "fieldConfig": { "defaults": { "unit": "bytes" } },
@@ -22,11 +22,11 @@
       "title": "Auth state maps (.len())",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_auth_pending_auth", "legendFormat": "pending_auth" },
-        { "expr": "waddle_state_auth_device_auth", "legendFormat": "device_auth" },
-        { "expr": "waddle_state_auth_xmpp_auth_codes", "legendFormat": "xmpp_auth_codes" },
-        { "expr": "waddle_state_auth_dynamic_oidc_clients", "legendFormat": "dynamic_oidc_clients" },
-        { "expr": "waddle_state_auth_dynamic_oidc_client_locks", "legendFormat": "dynamic_oidc_client_locks" }
+        { "expr": "waddle_state_auth_pending_auth_entry", "legendFormat": "pending_auth" },
+        { "expr": "waddle_state_auth_device_auth_entry", "legendFormat": "device_auth" },
+        { "expr": "waddle_state_auth_xmpp_auth_codes_entry", "legendFormat": "xmpp_auth_codes" },
+        { "expr": "waddle_state_auth_dynamic_oidc_clients_entry", "legendFormat": "dynamic_oidc_clients" },
+        { "expr": "waddle_state_auth_dynamic_oidc_client_locks_entry", "legendFormat": "dynamic_oidc_client_locks" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 }
     },
@@ -35,9 +35,9 @@
       "title": "Profile + dispatch in-flight",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_profile_avatar_source_locks", "legendFormat": "avatar_source_locks" },
-        { "expr": "waddle_state_profile_publish_tracker_in_flight", "legendFormat": "profile_publish" },
-        { "expr": "waddle_state_profile_provider_dispatch_in_flight", "legendFormat": "provider_dispatch" }
+        { "expr": "waddle_state_profile_avatar_source_locks_entry", "legendFormat": "avatar_source_locks" },
+        { "expr": "waddle_state_profile_publish_tracker_in_flight_entry", "legendFormat": "profile_publish" },
+        { "expr": "waddle_state_profile_provider_dispatch_in_flight_entry", "legendFormat": "provider_dispatch" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
     },
@@ -46,10 +46,10 @@
       "title": "Sessions + caps",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_sessions_sm_live_sessions", "legendFormat": "sm_live" },
-        { "expr": "waddle_state_sessions_resumable_sessions", "legendFormat": "resumable" },
-        { "expr": "waddle_state_caps_caps_cache", "legendFormat": "caps_cache" },
-        { "expr": "waddle_state_caps_pending_resolutions", "legendFormat": "caps_pending" }
+        { "expr": "waddle_state_sessions_sm_live_sessions_entry", "legendFormat": "sm_live" },
+        { "expr": "waddle_state_sessions_resumable_sessions_entry", "legendFormat": "resumable" },
+        { "expr": "waddle_state_caps_caps_cache_entry", "legendFormat": "caps_cache" },
+        { "expr": "waddle_state_caps_pending_resolutions_entry", "legendFormat": "caps_pending" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 }
     },
@@ -58,10 +58,10 @@
       "title": "Connections + presence",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_connections_full_jid_connections", "legendFormat": "connections" },
-        { "expr": "waddle_state_connections_pending_subscription_stanzas", "legendFormat": "pending_subs" },
-        { "expr": "waddle_state_connections_presence_states", "legendFormat": "presence_states" },
-        { "expr": "waddle_state_connections_last_activity", "legendFormat": "last_activity" }
+        { "expr": "waddle_state_connections_full_jid_connections_entry", "legendFormat": "connections" },
+        { "expr": "waddle_state_connections_pending_subscription_stanzas_entry", "legendFormat": "pending_subs" },
+        { "expr": "waddle_state_connections_presence_states_entry", "legendFormat": "presence_states" },
+        { "expr": "waddle_state_connections_last_activity_entry", "legendFormat": "last_activity" }
       ],
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 }
     },
@@ -70,8 +70,8 @@
       "title": "MUC rooms (total vs dormant — reclaimable headroom)",
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "targets": [
-        { "expr": "waddle_state_rooms_total", "legendFormat": "total" },
-        { "expr": "waddle_state_rooms_dormant", "legendFormat": "dormant (will be evicted)" }
+        { "expr": "waddle_state_rooms_total_entry", "legendFormat": "total" },
+        { "expr": "waddle_state_rooms_dormant_entry", "legendFormat": "dormant (will be evicted)" }
       ],
       "gridPos": { "h": 8, "w": 24, "x": 0, "y": 24 }
     }

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6035,6 +6035,7 @@ dependencies = [
  "jid",
  "jsonwebtoken",
  "kameo",
+ "libc",
  "lru 0.12.5",
  "minidom",
  "object_store",

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -90,6 +90,12 @@ lru = { workspace = true }
 percent-encoding = "2.3"
 urlencoding = "2.1"
 html-escape = "0.2"
+# Used by `state_inventory_metrics::read_process_rss_bytes` to query
+# the running kernel's page size before converting `/proc/self/statm`
+# pages to bytes. Already a transitive dep of tokio/sqlx/etc; declared
+# explicitly here so the call site doesn't depend on a transitive
+# closure being re-exported.
+libc = "0.2"
 jsonwebtoken = { workspace = true }
 prescience = { version = "0.1.0", features = ["tls-rustls"] }
 

--- a/server/crates/waddle-server/src/server/state_inventory_metrics.rs
+++ b/server/crates/waddle-server/src/server/state_inventory_metrics.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use opentelemetry::metrics::Gauge;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::server::routes::websocket::WebSocketState;
 use crate::server::state_inventory::collect_snapshot;
@@ -43,6 +43,51 @@ macro_rules! gauge {
                 .build()
         })
     }};
+}
+
+/// Process resident-set-size gauge, units bytes.
+fn rss_gauge() -> &'static Gauge<i64> {
+    static G: OnceLock<Gauge<i64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .i64_gauge("waddle.process.resident_memory_bytes")
+            .with_description(
+                "Server process resident set size, sampled from /proc/self/statm \
+                 on each state-inventory publisher tick. Plot against \
+                 waddle.state.* to attribute an RSS climb to the map driving it.",
+            )
+            .with_unit("By")
+            .build()
+    })
+}
+
+/// Read RSS in bytes from `/proc/self/statm`. The second whitespace-
+/// separated field is the resident set size in pages; multiply by the
+/// page size on the running kernel. Returns `None` on Linux platforms
+/// where the file is missing/malformed or on non-Linux hosts (the
+/// helper is a no-op there). The publisher logs and skips the sample
+/// in that case rather than failing the whole tick.
+fn read_process_rss_bytes() -> Option<i64> {
+    #[cfg(target_os = "linux")]
+    {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+        // SAFETY: `sysconf(_SC_PAGESIZE)` is signal-safe and always
+        // returns a positive value on a running Linux kernel. We
+        // clamp to a known fallback (4 KiB) if the call returns ≤ 0
+        // for any reason rather than panicking.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        let page_size: u64 = if page_size > 0 {
+            page_size as u64
+        } else {
+            4096
+        };
+        i64::try_from(pages.saturating_mul(page_size)).ok()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
 }
 
 /// Cast a `usize` length to `i64` for OTel without panicking on
@@ -199,11 +244,33 @@ pub(crate) async fn publish_once(websocket_state: &WebSocketState) {
     )
     .record(as_i64(snapshot.rooms.dormant), labels);
 
+    // Process RSS — co-emitted here so the state-inventory dashboard
+    // can correlate map sizes against memory pressure without
+    // depending on a cluster-side cAdvisor / kubelet scrape that
+    // doesn't exist on this deployment today.
+    let mut rss_sampled: Option<i64> = None;
+    match read_process_rss_bytes() {
+        Some(bytes) => {
+            rss_gauge().record(bytes, labels);
+            rss_sampled = Some(bytes);
+        }
+        None => {
+            // Logged at warn so an unexpected platform / malformed
+            // /proc/self/statm shows up in the canary logs rather than
+            // silently leaving the RSS panel empty.
+            warn!(
+                target_os = std::env::consts::OS,
+                "state-inventory publisher: RSS sample unavailable; skipping waddle.process.resident_memory_bytes"
+            );
+        }
+    }
+
     debug!(
         rooms_total = snapshot.rooms.total,
         rooms_dormant = snapshot.rooms.dormant,
         sm_live = ?snapshot.sessions.sm_live_sessions,
         full_jid_conns = snapshot.connections.full_jid_connections,
+        rss_bytes = ?rss_sampled,
         "state-inventory publisher: recorded gauge sample"
     );
 }
@@ -220,6 +287,24 @@ mod tests {
         // map at zero; we just want to confirm the publisher walks
         // them all without panicking.
         publish_once(&state).await;
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_process_rss_bytes_returns_positive_value_on_linux() {
+        // The test process is itself a Linux user-space process, so
+        // /proc/self/statm MUST exist and report a non-zero RSS.
+        let rss = super::read_process_rss_bytes().expect("Linux /proc/self/statm");
+        assert!(rss > 0, "RSS must be positive in a live process");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn read_process_rss_bytes_is_none_off_linux() {
+        // macOS / Windows builders run the test suite too — make
+        // explicit that the helper returns None there rather than
+        // panicking.
+        assert!(super::read_process_rss_bytes().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Context

The state-inventory dashboard from #509's `Process RSS` panel is empty in production — the cluster doesn't scrape kubelet / cAdvisor metrics, so there's no `process_resident_memory_bytes` or `container_memory_*` series in Mimir to chart against. Without an RSS line, the inventory panels showing which map is growing have nothing to correlate against, which defeats the point of the dashboard.

## What this PR does

Read RSS from `/proc/self/statm` (pages × `sysconf(_SC_PAGESIZE)`) on every state-inventory publisher tick and record it as a `waddle.process.resident_memory_bytes` i64 gauge with unit `By`. Flows through the same OTel pipeline as the other `waddle.state.*` gauges — no new infra plumbing or per-pod auth.

- New `read_process_rss_bytes` helper; Linux-only with an explicit `None` fallback on macOS / Windows so dev + CI runs don't panic.
- `publish_once` records the gauge and logs the sample alongside the existing state-snapshot debug line. A failed sample logs at WARN so an unexpected platform / malformed statm shows up in canary logs instead of silently leaving the panel empty.
- Dashboard JSON updated to point at `waddle_process_resident_memory_bytes_By` (the OTel-to-Prom conversion appends the unit suffix). Legend uses `service_instance_id` so per-pod RSS plots cleanly.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test -p waddle-server --lib` → 578 passed (was 577; +1 new test, the off-Linux test compiles to a different body via cfg)
- [ ] CI green on PR
- [ ] After merge: Flux reconciles the new image, the RSS gauge appears in Mimir within ~60 s, and the `Waddle server — long-lived state inventory` dashboard panel populates.

This PR was created with the assistance of a LLM.