### PR TITLE
fix(chat): two post-merge fixes — system-band detection + mobile presence stack

### DIFF
--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -213,13 +213,16 @@ const memberButtonCopy = computed(() => {
         >
           <Settings class="w-3.5 h-3.5" />
         </button>
-        <!-- Live presence stack: at-a-glance "who's here right now" instead
-             of a static "N members" count. Replaces the eye's first read
-             of "this is a room labeled #x" with "this is a room with
-             these specific people present right now." -->
+        <!-- Live presence stack — desktop only. The mobile header is
+             already crowded with hamburger + channel chip + search/pin/
+             settings + the user's own profile avatar at the very right;
+             dropping more avatars into that lane reads as "the app
+             changed my profile picture" rather than "these other
+             people are here." Mobile gets the compact count button
+             instead. -->
         <button
           v-if="channel"
-          class="chat-presence-stack"
+          class="chat-presence-stack hidden lg:inline-flex"
           type="button"
           :title="memberButtonCopy.title"
           :aria-label="`${memberButtonCopy.aria}. ${onlineCount} online.`"
@@ -257,6 +260,19 @@ const memberButtonCopy = computed(() => {
             <Users class="w-3.5 h-3.5" />
             <span class="type-control">{{ memberButtonCopy.primary }}</span>
           </span>
+        </button>
+        <!-- Mobile members button — same data, no avatars. Keeps the
+             tap-target obvious and prevents the corner avatar from
+             reading as the user's own profile picture. -->
+        <button
+          v-if="channel"
+          class="chat-icon-button chat-icon-button--md lg:hidden text-muted-foreground hover:bg-muted hover:text-foreground"
+          type="button"
+          :title="memberButtonCopy.title"
+          :aria-label="memberButtonCopy.aria"
+          @click="emit('openDetails')"
+        >
+          <Users class="w-4 h-4" />
         </button>
       </div>
     </div>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -137,12 +137,24 @@ const eventBands = computed(() =>
     .filter((card) => card.presentation.intent === "event"),
 );
 
-// Render as a system band when the author wears the bot hat and the
-// message carries at least one event-intent annotation. The standard
-// avatar+meta+body grid is replaced by a full-width flat notification;
-// the bot's literal body text (often a redundant "GitHub …" sentence)
-// is suppressed because the structured payload already says it better.
-const renderAsSystemBand = computed(() => isBotAuthor.value && eventBands.value.length > 0);
+// Render as a system band when an event-intent annotation declares the
+// `chat-bot` surface, OR when the message author wears the bot hat
+// and any event annotation is present. The annotation-level surface
+// declaration is the load-bearing signal — the annotation provider
+// itself is saying "I came from a system actor, not a human" — and
+// trusting it makes detection robust even when the underlying XMPP
+// account hasn't been assigned `urn:xmpp:hats:bot` in this particular
+// room (the real-world case for the live GitHub integration today).
+//
+// First pass relied on the hat alone, which is what users were seeing
+// in production: GitHub kept rendering as a human-shaped message
+// because the bot account simply didn't have the hat. surfaceKind on
+// the annotation always does.
+const renderAsSystemBand = computed(() => {
+  if (eventBands.value.length === 0) return false;
+  if (isBotAuthor.value) return true;
+  return eventBands.value.some((band) => band.annotation.surfaceKind === "chat-bot");
+});
 
 function systemBandIcon(card: { annotation: ExtensionAnnotation; presentation: ReturnType<typeof extensionPresentation> }) {
   if (card.presentation.kind === "github-event") return Github;


### PR DESCRIPTION
## What

Two small fixes for issues the user flagged after PRs #546 and #547 merged.

### 1. System-band detection (originally for PR #546)

User feedback: *"Still looks like a human message. Don't need the avatar and shit."*

The first pass gated system-band rendering on `isBotAuthor` checking the `urn:xmpp:hats:bot` hat. In production the GitHub integration's XMPP account doesn't carry that hat in the rooms it posts to, so detection fell back to the standard MessageCard grid and GitHub kept rendering with avatar gutter + author name + the structured event card nested inside a human-shaped bubble.

**Fix:** trust the annotation's `surfaceKind === "chat-bot"` declaration. That signal travels with the payload and doesn't depend on per-room hat assignment. Detection now passes when *either* surfaceKind says chat-bot *or* the hat is present.

### 2. Drop presence stack on mobile (originally for PR #547)

User feedback: *"the online avatars at the top right was a cool idea but it just feels like my logged account is using the wrong picture"* — followed by: *"Online avatars just will never work on mobile."*

The mobile header is already loaded (hamburger + channel + search/pin/settings + the user's own profile avatar in the corner). Dropping more avatars in that lane reads as "the app changed my profile picture", not "these are other people in this room."

**Fix:** presence stack picks up `hidden lg:inline-flex` (only renders ≥1024 px). Mobile gets a compact icon-only Users button instead. Same data, same emit, no avatars in the mobile header.

## Verification

- `bun run lint` clean.
- Both commits cherry-picked from the original PR branches where they were pushed *after* the parent PRs got merged — so they're known-good against current main.