### PR TITLE
fix(chat): logo becomes a Home button — route back from any channel

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -31,6 +31,7 @@ const {
   activeExtensionRouteKey,
   activeRightPanel,
   openUserSettings,
+  openHome,
   handleLogout,
   handleRequestNotifications,
   handleToggleNotifications,
@@ -76,9 +77,11 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
             :waddles="[]"
             :active-space-id="null"
             :active-sidebar-mode="ui.sidebarMode.value"
+            :active-page="ui.activePage.value"
             :has-unread-dms="dmConversations.hasUnread.value"
             :session="null"
             horizontal
+            @open-home="openHome"
             @toggle-channels="ui.sidebarMode.value = 'channels'"
             @toggle-dms="ui.sidebarMode.value = 'dms'"
           />

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -74,6 +74,7 @@ const {
   handleRequestNotifications,
   handleToggleNotifications,
   openUserSettings,
+  openHome,
   closeUserSettings,
   handleLogout,
   selectChannel,
@@ -162,6 +163,7 @@ function setPinnedPanelOpen(isOpen: boolean) {
           :waddles="[]"
           :active-space-id="null"
           :active-sidebar-mode="ui.sidebarMode.value"
+          :active-page="ui.activePage.value"
           :has-unread-dms="dmConversations.hasUnread.value"
           :session="connectionStore.session"
           :notification-permission="notifications.permissionState.value"
@@ -170,6 +172,7 @@ function setPinnedPanelOpen(isOpen: boolean) {
           :total-mention-count="channelUnread.totalMentionCount.value"
           :web-commit-sha="version.webCommitSha.value"
           :server-version="version.serverVersion.value"
+          @open-home="openHome"
           @open-settings="openUserSettings"
           @toggle-channels="ui.sidebarMode.value = 'channels'"
           @toggle-dms="ui.sidebarMode.value = 'dms'"

--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -18,12 +18,16 @@ defineProps<{
   horizontal?: boolean;
   webCommitSha?: string;
   serverVersion?: XmppServerVersion | null;
+  /** Current top-level page so the Home/logo button can render an
+   * "active" treatment when we're already on the dashboard. */
+  activePage?: "dashboard" | "chat" | "settings";
 }>();
 
 const emit = defineEmits<{
   toggleChannels: [];
   toggleDms: [];
   openSettings: [];
+  openHome: [];
   logout: [];
   "request-notifications": [];
   "toggle-notifications": [];
@@ -37,15 +41,28 @@ const emit = defineEmits<{
       ? 'chat-rail-horizontal'
       : 'chat-rail-vertical'"
   >
-    <!-- Logo -->
+    <!-- Logo / Home — clicking returns to the dashboard from anywhere.
+         Was a passive img; now a real button so users in a channel have
+         a route back to Home (channel header doesn't currently expose
+         one). Active when `activePage === "dashboard"`. -->
     <div class="chat-rail-logo-slot flex flex-shrink-0 items-center justify-center">
-      <img
-        src="/waddle-logo.svg"
-        alt="Waddle"
-        width="40"
-        height="40"
-        class="chat-rail-logo-mark rounded-lg object-contain"
-      />
+      <button
+        type="button"
+        class="chat-rail-home-button"
+        :class="activePage === 'dashboard' ? 'chat-rail-home-button--active' : ''"
+        :aria-pressed="activePage === 'dashboard'"
+        title="Home"
+        aria-label="Go to home"
+        @click="emit('openHome')"
+      >
+        <img
+          src="/waddle-logo.svg"
+          alt=""
+          width="40"
+          height="40"
+          class="chat-rail-logo-mark rounded-lg object-contain"
+        />
+      </button>
     </div>
 
     <!-- Divider -->

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1170,6 +1170,24 @@ export function useChatAppController(giphyApiKey: string) {
     ui.activePage.value = "settings";
   }
 
+  /**
+   * Navigate back to the Home dashboard from anywhere. Clears any
+   * channel/DM selection, drops thread state, closes the mobile nav
+   * drawer, and resyncs the URL so a refresh returns the user to home
+   * rather than re-entering the last channel.
+   */
+  function openHome() {
+    ui.showMobileNav.value = false;
+    ui.showMobileDetails.value = false;
+    ui.activePage.value = "dashboard";
+    waddles.activeChannelId.value = null;
+    dmConversations.closeDm();
+    activeRightPanel.value = null;
+    activeThreadStack.value = [];
+    activeExtensionRouteKey.value = null;
+    pushChannelRoute(null);
+  }
+
   function closeUserSettings() {
     const state = window.history.state as { waddlePage?: string; origin?: string } | null;
     if (
@@ -1636,6 +1654,7 @@ export function useChatAppController(giphyApiKey: string) {
       handleRequestNotifications,
       handleToggleNotifications,
       openUserSettings,
+      openHome,
       closeUserSettings,
       handleLogout,
       selectChannel,

--- a/chat/src/styles/global/shell.css
+++ b/chat/src/styles/global/shell.css
@@ -36,6 +36,47 @@
   height: var(--chat-rail-logo-size);
 }
 
+/* Logo / Home button in the icon rail — clicking returns to the
+ * dashboard. Idle is a quiet container; hover lifts the logo with the
+ * established Aether glow. Active (you're on dashboard) gets a soft
+ * primary-tinted plate so the user sees "you are here". */
+.chat-rail-home-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--chat-rail-logo-size);
+  height: var(--chat-rail-logo-size);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chat-rail-home-button:hover {
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  transform: scale(1.04);
+}
+
+.chat-rail-home-button:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.chat-rail-home-button:active {
+  transform: scale(0.97);
+}
+
+.chat-rail-home-button--active {
+  background: color-mix(in oklab, var(--primary) 14%, transparent);
+  box-shadow: 0 0 12px -4px var(--glow-strong);
+}
+
+.chat-rail-home-button--active:hover {
+  background: color-mix(in oklab, var(--primary) 18%, transparent);
+}
+
 .chat-startup-logo img,
 .chat-startup-mobile-logo img {
   display: block;


### PR DESCRIPTION
## What

User flagged the regression: *"There's no way for users to show the dashboard when on a channel. We need a route back. Fix."*

Confirmed: the Waddle logo in the icon rail was a passive `<img>`. The only way to get back to the Home dashboard after entering a channel was to log out (which reset `activePage` to `"dashboard"` as a side effect of cleanup). Even in their channel thread today: *"So there is no way to go from the chat view to the dashboard view?"*

## Fix

The logo is now a real button (`<button class="chat-rail-home-button">`). Clicking it fires a new controller action `openHome()` which:

- Closes mobile nav / details drawers
- Drops `waddles.activeChannelId` and the DM selection
- Closes any open right panel (thread / pinned / extension)
- Clears the thread stack
- Sets `ui.activePage` to `"dashboard"`
- Calls `pushChannelRoute(null)` so the URL goes to `/` — a refresh now returns the user to home, not back into the last channel they had open

The button picks up an **active-state plate** when `activePage === "dashboard"` — a subtle primary-tinted background and the established `--glow-strong` shadow, matching the rail's existing Spaces / DMs toggle treatment. So the rail reads *"you are home"* visually.

Mobile drawer's embedded `WaddlesSidebar` (horizontal variant in the hamburger drawer) gets the same wiring, so mobile users have the same Home affordance as desktop.

## Verified live

Local dev at port 4321:
- Started on `/r/chat`, logo was inactive.
- Clicked the logo → URL transitioned to `/`, Home dashboard rendered with the atrium hero ("Late one tonight."), logo gained the primary-tinted active plate.
- Refresh on `/` now stays on Home (no auto-reentry into the last channel).

## Files

- `chat/src/components/chat/WaddlesSidebar.vue` — new `activePage` prop + `openHome` emit; logo `<img>` becomes a button.
- `chat/src/components/chat/ChatReadyShell.vue` — destructures `openHome` from the controller and wires `@open-home` + `:active-page`.
- `chat/src/components/chat/ChatMobileDrawers.vue` — same wiring on the horizontal WaddlesSidebar inside the mobile nav drawer.
- `chat/src/shell/chat-app-controller.ts` — new `openHome()` action; exported alongside `openUserSettings`.
- `chat/src/styles/global/shell.css` — new `.chat-rail-home-button` + `--active` modifier. Hover/focus/active/scale transitions inherit the established rail-button language.