### PR TITLE
fix(chat): thread chip spacing — use design-system tokens, not gap-1.5

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -937,7 +937,7 @@ onBeforeUnmount(() => {
     <button
       v-if="showThreadChip"
       type="button"
-      class="chat-thread-chip type-caption inline-flex items-center gap-1.5 rounded-md py-0.5 text-primary/85 transition-colors hover:text-primary"
+      class="chat-thread-chip type-caption inline-flex rounded-md py-0.5 text-primary/85 transition-colors hover:text-primary"
       :title="`Open thread (${threadReplyCount} ${threadReplyCount === 1 ? 'reply' : 'replies'})`"
       @click="openThreadFromChip"
     >

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -236,10 +236,21 @@
 /* Thread "N replies" chip — quieter inline link, not a button.
  * Carries a tiny avatar stack of participants + a relative-time
  * suffix so the eye can triage threads from the channel feed
- * without opening the panel. */
+ * without opening the panel.
+ *
+ * Spacing system: the chip mixes four element kinds (svg icon, text
+ * count, avatar stack, text recency) at three different visual
+ * heights. A uniform Tailwind `gap-1.5` (0.375 rem) is too tight for
+ * that variety — text and avatars end up visually touching even
+ * though their boxes are notionally apart. Override with explicit
+ * design-system spacing (`--space-xs` = 0.5 rem) between every
+ * group, and shrink the inline avatar from xs (1.5 rem) to
+ * 1.125 rem so its scale matches the 0.6875 rem chip text. */
 .chat-thread-chip {
   font-size: 0.6875rem;
   line-height: 1.4;
+  gap: var(--space-xs);
+  align-items: center;
 }
 
 .chat-thread-chip > svg {
@@ -254,7 +265,7 @@
 
 .chat-thread-chip__avatar-wrap {
   display: inline-flex;
-  margin-left: -0.4rem;
+  margin-left: -0.3rem;
   border-radius: 9999px;
   outline: 1.5px solid var(--background);
 }
@@ -263,14 +274,26 @@
   margin-left: 0;
 }
 
+/* Shrink the AppAvatar instance inside the chip — its xs preset is
+ * 1.5 rem which dwarfs the 0.6875 rem chip text. Drop to 1.125 rem
+ * for visual harmony with the surrounding type and to give the
+ * outline ring room to breathe between adjacent avatars. */
+.chat-thread-chip__avatar-wrap > .app-avatar,
+.chat-thread-chip__avatar-wrap > .app-avatar > .type-avatar-mark,
+.chat-thread-chip__avatar-wrap > .app-avatar > img {
+  width: 1.125rem;
+  height: 1.125rem;
+  font-size: 0.55rem;
+}
+
 .chat-thread-chip__overflow {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 1.1rem;
-  height: 1.1rem;
+  min-width: 1.125rem;
+  height: 1.125rem;
   padding: 0 0.3rem;
-  margin-left: -0.25rem;
+  margin-left: -0.2rem;
   border-radius: 9999px;
   background: color-mix(in oklab, var(--muted) 65%, transparent);
   font-size: 0.55rem;


### PR DESCRIPTION
## What

Follow-up to #550 (iter-26 enriched thread chip). User flagged the deployed result:

> *"We're supposed to be building and improving a design system here and yet we shipped this with zero spacing? Work smarter."*

The chip got new content (count + participant avatar stack + recency) but kept a single Tailwind `gap-1.5` (0.375 rem) covering four heterogenous children: SVG icon, count text, avatar stack, recency text. On mobile the avatar pressed directly against \"3 replies\" and \"· just now\" pressed directly against the avatar. Zero breathing room.

## Fixes

- `.chat-thread-chip` now sets `gap: var(--space-xs)` (0.5 rem) on the CSS class. The chip mixes four element kinds at three visual heights — each transition needs a real spacing step, not a uniform 0.375 rem squeeze. Removed the inline `gap-1.5` utility from the template so the token wins the cascade.
- Avatar size inside the chip drops from `xs` (1.5 rem) to **1.125 rem** via a scoped override on `.chat-thread-chip__avatar-wrap > .app-avatar`. `xs` dwarfed the 0.6875 rem chip text — the smaller size scales with the type and gives the outline ring room between adjacent avatars.
- Avatar overlap eased from -0.4 rem → -0.3 rem to match the smaller diameter.
- `.chat-thread-chip__overflow` rescaled (1.125 rem diameter, tighter overlap).

## Verified live

Reloaded the dev session against the real `#chat` room: `💬 4 replies [avatar] · 3 hours` now reads with proper breathing room between every element. Same data, no zero-spacing.