### PR TITLE
feat(chat): jump-to-live-edge button + Home overflow hotfix

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -26,6 +26,8 @@ import { useScrollDirectionPreference } from "@/preferences/scroll-direction";
 import type { MessageThreadIndex } from "@/channels/threads";
 import { formatTimelineStamp, formatTimelineDayDivider, isSameTimelineDay } from "@/channels/timeline";
 import { useExtensionLauncher } from "@/channels/extension-launcher";
+import { useJumpToLiveEdge } from "@/ui/use-jump-to-live-edge";
+import { ArrowDown, ArrowUp } from "lucide-vue-next";
 import ChatHeader, { type ChannelHeaderMember } from "@/components/chat/ChatHeader.vue";
 import ExtensionPalette from "@/components/chat/ExtensionPalette.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
@@ -320,7 +322,10 @@ type VirtualTimelineHandle = ComponentPublicInstance & {
 const virtualTimelineRef = ref<VirtualTimelineHandle | null>(null);
 const setMessagesContainer = (el: HTMLDivElement | null) => {
   messagesContainer.value = el;
-  void nextTick(updateCurrentDayMarker);
+  void nextTick(() => {
+    updateCurrentDayMarker();
+    jumpToLive.updateDistance();
+  });
 };
 const setVirtualTimelineRef = (
   instance: VirtualTimelineHandle | null,
@@ -328,6 +333,21 @@ const setVirtualTimelineRef = (
   virtualTimelineRef.value = instance;
   setMessagesContainer(instance?.scrollElement ?? null);
 };
+
+// "Jump to latest" floating button — shown when the user has scrolled
+// away from the live edge. The live-edge anchor flips with the user's
+// scroll-direction preference (social = top, chat = bottom), so the
+// same button reads "↑ Latest" or "↓ Latest" accordingly.
+const jumpToLive = useJumpToLiveEdge({
+  scrollElement: computed(() => virtualTimelineRef.value?.scrollElement ?? null),
+  mode: scrollDirection,
+  scrollToEdge: (mode) => virtualTimelineRef.value?.scrollToPinnedEdge(mode) ?? false,
+});
+
+function onMessagesScroll() {
+  updateCurrentDayMarker();
+  jumpToLive.updateDistance();
+}
 const currentDayMarkerLabel = ref("");
 const composerRef = ref<MessageComposerHandle | null>(null);
 const setComposerRef = (instance: MessageComposerHandle | null) => {
@@ -1170,15 +1190,15 @@ function dayDividerLabel(createdAt: string): string {
 
     </div>
 
+    <div v-else class="chat-message-pane">
     <VirtualTimeline
-      v-else
       :ref="setVirtualTimelineRef"
       :items="orderedFeedMessages"
       :has-older="hasOlderMessages"
       :loading-older="isLoadingOlderMessages"
       :sentinel-position="olderSentinelPosition"
       aria-label="Messages"
-      @scroll="updateCurrentDayMarker"
+      @scroll="onMessagesScroll"
       @load-older="emit('loadOlder')"
     >
       <template #item="{ item: msg }">
@@ -1244,6 +1264,20 @@ function dayDividerLabel(createdAt: string): string {
           </div>
       </template>
     </VirtualTimeline>
+    <button
+      v-if="jumpToLive.shouldShow.value"
+      type="button"
+      class="chat-jump-to-live"
+      :class="isTopPinned ? 'chat-jump-to-live--top' : 'chat-jump-to-live--bottom'"
+      :aria-label="isTopPinned ? 'Jump to latest message' : 'Jump to latest message'"
+      title="Jump to latest"
+      @click="jumpToLive.jump"
+    >
+      <ArrowUp v-if="isTopPinned" class="w-3.5 h-3.5" aria-hidden="true" />
+      <ArrowDown v-else class="w-3.5 h-3.5" aria-hidden="true" />
+      <span>Latest</span>
+    </button>
+    </div>
 
     <!-- Typing indicator -->
     <div

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -335,7 +335,7 @@ function onHeroCta() {
           <button
             v-for="space in spaces"
             :key="space.id"
-            class="chat-list-row flex min-h-16 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
+            class="chat-list-row flex min-w-0 min-h-16 items-center gap-3 overflow-hidden rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
             :class="[
               spaceHasChannels(space.id) ? '' : 'cursor-default hover:bg-card',
               groupActivity(`space:${space.id}`).mentions > 0
@@ -412,14 +412,14 @@ function onHeroCta() {
           <div
             v-for="group in visibleChannelGroups"
             :key="group.id"
-            class="rounded-lg border border-border bg-card p-3"
+            class="min-w-0 overflow-hidden rounded-lg border border-border bg-card p-3"
           >
             <h3 class="type-section-label px-1 pb-2 text-muted-foreground">{{ group.name }}</h3>
             <div class="grid gap-1">
               <button
                 v-for="channel in group.channels"
                 :key="channel.id"
-                class="chat-list-row flex min-h-14 items-center gap-2 rounded-md px-3 py-2 text-left text-muted-foreground hover:bg-muted hover:text-foreground"
+                class="chat-list-row flex min-w-0 min-h-14 items-center gap-2 overflow-hidden rounded-md px-3 py-2 text-left text-muted-foreground hover:bg-muted hover:text-foreground"
                 :class="channelActivity(channel).mentions > 0
                   ? 'chat-list-row--unread chat-list-row--mention'
                   : unreadBadgeCount(channelActivity(channel)) > 0
@@ -475,7 +475,7 @@ function onHeroCta() {
             <div
               v-for="i in 2"
               :key="`channel-group-skel-${i}`"
-              class="rounded-lg border border-border bg-card p-3"
+              class="min-w-0 overflow-hidden rounded-lg border border-border bg-card p-3"
               aria-hidden="true"
             >
               <Skeleton width="35%" height="0.65rem" />
@@ -509,7 +509,7 @@ function onHeroCta() {
           <button
             v-for="conversation in directMessages"
             :key="conversation.peerJid"
-            class="chat-list-row flex min-h-14 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
+            class="chat-list-row flex min-w-0 min-h-14 items-center gap-3 overflow-hidden rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
             :class="conversation.unreadCount > 0 ? 'chat-list-row--unread' : ''"
             type="button"
             :aria-label="dmHomeLabel(conversation, conversation.lastMessageAt ? formatTimelineStamp(conversation.lastMessageAt) : '')"
@@ -570,7 +570,7 @@ function onHeroCta() {
           <button
             v-for="contact in contacts"
             :key="contact.jid"
-            class="chat-list-row flex min-h-12 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
+            class="chat-list-row flex min-w-0 min-h-12 items-center gap-3 overflow-hidden rounded-lg border border-border bg-card px-4 py-3 text-left hover:bg-muted/60"
             type="button"
             @click="emit('selectContact', contact.jid)"
           >

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance, type Ref } from "vue";
-import { X, CornerDownRight, ChevronRight, ChevronLeft } from "lucide-vue-next";
+import { ArrowDown, ArrowUp, X, CornerDownRight, ChevronRight, ChevronLeft } from "lucide-vue-next";
+import { useJumpToLiveEdge } from "@/ui/use-jump-to-live-edge";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
 import MessageComposer from "@/components/chat/MessageComposer.vue";
@@ -179,6 +180,25 @@ type VirtualTimelineHandle = ComponentPublicInstance & {
   scrollToMessageId: (messageId: string, align?: "start" | "center" | "end") => Promise<boolean>;
 };
 const virtualTimelineRef = ref<VirtualTimelineHandle | null>(null);
+
+// "Jump to latest" floating button — same composable as ContentArea
+// so the affordance is consistent between channel and thread surfaces.
+// Live edge flips with scroll-direction preference (top in social,
+// bottom in chat). The pinned-edge scroller already knows the mode,
+// so the scrollToEdge callback just delegates.
+const jumpToLive = useJumpToLiveEdge({
+  scrollElement: computed(() => virtualTimelineRef.value?.scrollElement ?? null),
+  mode: scrollDirectionMode,
+  scrollToEdge: () => {
+    void scrollToPinnedEdge();
+    return true;
+  },
+});
+
+function onThreadScroll() {
+  updateCurrentDayMarker();
+  jumpToLive.updateDistance();
+}
 
 function setComposerRef(el: ComposerHandle | null) {
   composerRef.value = el;
@@ -637,8 +657,8 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
       Thread root isn't in the loaded history. Scroll the main channel or reload to backfill.
     </div>
 
+    <div v-if="activeEntry" class="chat-message-pane">
     <VirtualTimeline
-      v-if="activeEntry"
       :ref="setVirtualTimelineRef"
       :items="orderedThreadMessages"
       :has-older="hasOlderReplies ?? false"
@@ -646,7 +666,7 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
       :sentinel-position="olderSentinelPosition"
       aria-label="Thread messages"
       content-class="chat-panel-stack"
-      @scroll="updateCurrentDayMarker"
+      @scroll="onThreadScroll"
       @load-older="activeThreadId && emit('loadOlder', activeThreadId)"
     >
       <template #item="{ item: message }">
@@ -734,6 +754,20 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         </template>
       </template>
     </VirtualTimeline>
+    <button
+      v-if="jumpToLive.shouldShow.value"
+      type="button"
+      class="chat-jump-to-live"
+      :class="isTopPinned ? 'chat-jump-to-live--top' : 'chat-jump-to-live--bottom'"
+      title="Jump to latest"
+      aria-label="Jump to latest message"
+      @click="jumpToLive.jump"
+    >
+      <ArrowUp v-if="isTopPinned" class="w-3.5 h-3.5" aria-hidden="true" />
+      <ArrowDown v-else class="w-3.5 h-3.5" aria-hidden="true" />
+      <span>Latest</span>
+    </button>
+    </div>
 
     <div
       v-else

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -5,6 +5,80 @@
   gap: var(--space-2xs);
 }
 
+/* Wrapping container for the VirtualTimeline that also hosts the
+ * floating "jump to latest" affordance. Position-relative so the
+ * button can anchor to the live-edge side of the pane. Inherits the
+ * flex-fill behaviour the bare timeline previously had so the surface
+ * layout doesn't shift. */
+.chat-message-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-height: 0;
+}
+
+/* "Jump to latest" floating pill — appears when the user has scrolled
+ * away from the live edge of the message list. Anchors at the
+ * appropriate edge based on scroll-direction preference (top in
+ * social mode, bottom in chat mode). Soft glass surface with the
+ * established --glow-strong shadow so it reads as native to the
+ * design system, not a bolted-on tooltip. */
+.chat-jump-to-live {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--border) 80%, transparent);
+  background: color-mix(in oklab, var(--card) 90%, transparent);
+  color: var(--foreground);
+  font-size: var(--text-meta);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  z-index: var(--z-floating);
+  backdrop-filter: blur(10px);
+  box-shadow:
+    0 8px 24px -8px var(--glow-strong),
+    0 2px 6px color-mix(in oklab, oklch(0.12 0.012 248) 18%, transparent);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+.chat-jump-to-live--top    { top: var(--space-md); }
+.chat-jump-to-live--bottom { bottom: var(--space-md); }
+
+.chat-jump-to-live:hover {
+  background: var(--card);
+  transform: translateX(-50%) translateY(-1px);
+  box-shadow:
+    0 12px 30px -8px var(--glow-strong),
+    0 4px 10px color-mix(in oklab, oklch(0.12 0.012 248) 22%, transparent);
+}
+
+.chat-jump-to-live:active {
+  transform: translateX(-50%) translateY(0);
+}
+
+.chat-jump-to-live:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 55%, transparent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chat-jump-to-live {
+    animation: chat-jump-to-live-in 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+}
+
+@keyframes chat-jump-to-live-in {
+  from { opacity: 0; transform: translateX(-50%) translateY(0.5rem); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
 .chat-message-grid {
   display: grid;
   width: 100%;

--- a/chat/src/ui/use-jump-to-live-edge.ts
+++ b/chat/src/ui/use-jump-to-live-edge.ts
@@ -1,0 +1,71 @@
+import { ref, type ComputedRef, type Ref } from "vue";
+import type { ScrollDirectionMode } from "@/lib/scroll-direction";
+
+/**
+ * Tracks whether a message scroll container has been scrolled away from
+ * its "live edge" (the position where the newest message sits, which
+ * depends on the user's scroll-direction preference):
+ *
+ *   - "social" / top-pinned mode → live edge is the TOP of the container.
+ *     The user is away when scrollTop drifts past the threshold.
+ *   - "chat" / bottom-pinned mode → live edge is the BOTTOM.
+ *     The user is away when (scrollHeight − scrollTop − clientHeight)
+ *     exceeds the threshold.
+ *
+ * When that happens the host component is expected to render a floating
+ * "jump to latest" button. Click invokes `jump()` which delegates back
+ * to the virtual-timeline-provided `scrollToEdge` callback.
+ *
+ * The composable doesn't own the scroll listener — the host wires its
+ * existing `@scroll` handler to also call `updateDistance`. This keeps
+ * the single-scroll-pass invariant the timeline already relies on.
+ */
+interface JumpToLiveEdgeHandle {
+  /** Reactive: true when the user is "far enough" from the live edge. */
+  shouldShow: Ref<boolean>;
+  /** Call from the scroll handler to recompute on each scroll tick. */
+  updateDistance: () => void;
+  /** Click handler — scrolls back to the live edge. */
+  jump: () => Promise<void>;
+}
+
+interface UseJumpToLiveEdgeInput {
+  /** The scrolling element (the same one tracked by VirtualTimeline). */
+  scrollElement: Ref<HTMLElement | null> | ComputedRef<HTMLElement | null>;
+  /** Reactive scroll direction so the live-edge anchor flips when the
+   * user toggles their preference mid-conversation. */
+  mode: Ref<ScrollDirectionMode> | ComputedRef<ScrollDirectionMode>;
+  /** Imperative scroll-to-edge handler — called by `jump()`. */
+  scrollToEdge: (mode: ScrollDirectionMode) => Promise<boolean> | boolean;
+  /** Pixels of drift from the live edge before the button appears.
+   * Defaults to ~1 screen so casual scrolling for context doesn't
+   * surface the button on every wheel tick. */
+  threshold?: number;
+}
+
+export function useJumpToLiveEdge(input: UseJumpToLiveEdgeInput): JumpToLiveEdgeHandle {
+  const threshold = input.threshold ?? 320;
+  const shouldShow = ref(false);
+
+  function updateDistance() {
+    const el = input.scrollElement.value;
+    if (!el) {
+      shouldShow.value = false;
+      return;
+    }
+    if (input.mode.value === "social") {
+      shouldShow.value = el.scrollTop > threshold;
+    } else {
+      const bottomGap = el.scrollHeight - el.scrollTop - el.clientHeight;
+      shouldShow.value = bottomGap > threshold;
+    }
+  }
+
+  async function jump() {
+    const result = input.scrollToEdge(input.mode.value);
+    if (result instanceof Promise) await result;
+    shouldShow.value = false;
+  }
+
+  return { shouldShow, updateDistance, jump };
+}


### PR DESCRIPTION
## What

Bundled per user direction: ship the scroll-to-edge affordance and the home-row horizontal-overflow hotfix together.

### 1. Scroll-to-live-edge button

User request: *"When scrolling main chat, or a thread, show a return to top or bottom button (depending on that or social preferences)."*

When the user has scrolled away from the live edge of a channel or thread, a floating `↑ Latest` / `↓ Latest` pill appears anchored to the live-edge side. Clicking it scrolls back. The arrow direction and pill position **flip with the scroll-direction preference** (social → top, chat → bottom), so the affordance points correctly no matter which orientation the user prefers.

Shared `useJumpToLiveEdge` composable owns the distance-from-edge tracking and the click handler; `ContentArea` and `ThreadPanel` each tap into their existing scroll handlers so no new scroll listener is added. Default threshold ≈ 320 px so casual scrolling for context doesn't surface the button on every wheel tick. Glass surface with the established `--glow-strong` shadow + a 220 ms `prefers-reduced-motion: no-preference` entrance.

### 2. Home dashboard overflow hotfix

User screenshot showed the Spaces *General* card running off the right edge of the viewport: the per-row detail line (`4 channels · Opens Chat · > Cheers Didn't buy any and we can't…`) was wider than the column track. CSS Grid items inherit `min-width: auto` and grow to fit content unless explicitly told otherwise — `truncate` on the inner span never engaged because the parent had already expanded past the viewport.

Adds `min-w-0 overflow-hidden` to every list-row button in `HomeDashboard.vue` (Spaces, channel rows, DMs) plus the wrapping channel-group card. Existing `truncate` now applies as intended; the row clips at the card edge.

## Verified live

Mobile (420 × 900): Home dashboard's General row now reads `4 channels · Opens Chat · > Cheers Didn't buy a…` — ellipsis at the card edge, no horizontal scroll on the page.

Desktop (1280 × 900): scrolled up in #chat, `↓ Latest` pill rendered bottom-centre over the timeline; clicking returned to the live edge.

## Files

- `chat/src/ui/use-jump-to-live-edge.ts` — new shared composable.
- `chat/src/components/chat/ContentArea.vue` — wraps VirtualTimeline in a `.chat-message-pane`, threads `onMessagesScroll` through the composable, renders the button.
- `chat/src/components/chat/ThreadPanel.vue` — same wiring, reuses the panel's existing `scrollToPinnedEdge`.
- `chat/src/components/chat/HomeDashboard.vue` — `min-w-0 overflow-hidden` on Spaces / channels / DMs row buttons and the channel-group wrapper.
- `chat/src/styles/global/messages.css` — `.chat-message-pane`, `.chat-jump-to-live` (+ `--top` / `--bottom`), entrance keyframe.