### PR TITLE
fix(chat,server): quiet thread-start + GitHub extension declares chat-bot at source

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -134,10 +134,6 @@ const seniorHat = computed<OccupantHat | null>(() => {
   return best;
 });
 
-const isBotAuthor = computed(() =>
-  props.hats?.some((h) => h.uri === "urn:xmpp:hats:bot") ?? false,
-);
-
 const eventBands = computed(() =>
   (props.message.extensionAnnotations ?? [])
     .map((annotation) => ({ annotation, presentation: extensionPresentation(annotation) }))
@@ -145,23 +141,15 @@ const eventBands = computed(() =>
 );
 
 // Render as a system band when an event-intent annotation declares the
-// `chat-bot` surface, OR when the message author wears the bot hat
-// and any event annotation is present. The annotation-level surface
-// declaration is the load-bearing signal — the annotation provider
-// itself is saying "I came from a system actor, not a human" — and
-// trusting it makes detection robust even when the underlying XMPP
-// account hasn't been assigned `urn:xmpp:hats:bot` in this particular
-// room (the real-world case for the live GitHub integration today).
-//
-// First pass relied on the hat alone, which is what users were seeing
-// in production: GitHub kept rendering as a human-shaped message
-// because the bot account simply didn't have the hat. surfaceKind on
-// the annotation always does.
-const renderAsSystemBand = computed(() => {
-  if (eventBands.value.length === 0) return false;
-  if (isBotAuthor.value) return true;
-  return eventBands.value.some((band) => band.annotation.surfaceKind === "chat-bot");
-});
+// `chat-bot` surface. The annotation provider (the extension that
+// publishes the event) is the one that knows it's a system-level
+// notification, not a human reply — and it now says so explicitly via
+// `surfaceKind`, which the WASM codec hydrates from the wire-format
+// `surface` attribute on the payload's root element. No author-hat
+// fallbacks, no "any event intent" hacks: trust the declaration.
+const renderAsSystemBand = computed(() =>
+  eventBands.value.some((band) => band.annotation.surfaceKind === "chat-bot"),
+);
 
 function systemBandIcon(card: { annotation: ExtensionAnnotation; presentation: ReturnType<typeof extensionPresentation> }) {
   if (card.presentation.kind === "github-event") return Github;

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -662,29 +662,39 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
             <span class="chat-day-divider__label">{{ dayDividerLabel(message.createdAt) }}</span>
             <div class="chat-day-divider__rule" />
           </div>
-          <div class="chat-thread-root" aria-label="Thread root message">
-            <span class="chat-thread-root__label type-section-label">Thread start</span>
-            <MessageCard
-              :message="message"
-              :current-user="currentUser"
-              :current-user-jid="currentUserJid"
-              :avatar-url="avatarUrlByAuthor[message.author] ?? null"
-              :hats="hatsFor(message.author)"
-              :presence="presenceFor(message.author)"
-              :last-seen="roomLastSeen[message.author]"
-              :author-jid="authorJidByNick?.[message.author]"
-              :thread-reply-count="activeEntry.count"
-              hide-thread-chip
-              hide-reply-chip
-              :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
-              :invoke-extension-action="props.invokeExtensionAction"
-              @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
-              @retract="(id) => emit('retractMessage', id)"
-              @react="(id, emoji) => emit('reactMessage', id, emoji)"
-              @reply="beginReplyInThread"
-              @open-thread="onOpenThreadFromCard"
-            />
-          </div>
+          <!-- Thread root message — rendered as a normal MessageCard.
+               The thread-lobby header at the top of the panel already
+               identifies who started the thread ("Started by …"), so
+               wrapping the root in a primary-tinted card with a loud
+               THREAD START label was redundant chrome. The replies
+               that follow are visually separated by a hairline
+               `.chat-thread-root-divider` instead. -->
+          <MessageCard
+            :message="message"
+            :current-user="currentUser"
+            :current-user-jid="currentUserJid"
+            :avatar-url="avatarUrlByAuthor[message.author] ?? null"
+            :hats="hatsFor(message.author)"
+            :presence="presenceFor(message.author)"
+            :last-seen="roomLastSeen[message.author]"
+            :author-jid="authorJidByNick?.[message.author]"
+            :thread-reply-count="activeEntry.count"
+            hide-thread-chip
+            hide-reply-chip
+            :reaction-mode-selected="reactionMode?.selectedMessageId === message.id"
+            :invoke-extension-action="props.invokeExtensionAction"
+            @edit="(id, body, m, r) => emit('editMessage', id, body, m, r)"
+            @retract="(id) => emit('retractMessage', id)"
+            @react="(id, emoji) => emit('reactMessage', id, emoji)"
+            @reply="beginReplyInThread"
+            @open-thread="onOpenThreadFromCard"
+          />
+          <div
+            v-if="orderedChildren.length > 0"
+            class="chat-thread-root-divider"
+            role="separator"
+            aria-label="Replies"
+          />
         </template>
         <template v-else>
           <div

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -217,11 +217,33 @@ function launchFromWasm(
   };
 }
 
+// Allowed values for the `surface` declaration on the payload root.
+// Extensions opt in by adding a `surface="..."` attribute; anything
+// missing or unrecognised falls back to "message-card" so existing
+// extensions keep their current treatment.
+const KNOWN_SURFACE_KINDS = ["message-card", "board", "game", "chat-bot", "dynamic-canvas", "utility-panel"] as const;
+type KnownSurfaceKind = typeof KNOWN_SURFACE_KINDS[number];
+
+function surfaceKindFromPayloadAttributes(attrs: Record<string, string>): KnownSurfaceKind {
+  const declared = attrs.surface;
+  if (declared && (KNOWN_SURFACE_KINDS as readonly string[]).includes(declared)) {
+    return declared as KnownSurfaceKind;
+  }
+  return "message-card";
+}
+
 function extensionAnnotationsFromWasm(envelope?: WasmExtensionEnvelope): ExtensionAnnotation[] {
   if (!envelope?.enrichments.length) return [];
   return envelope.enrichments.map((enrichment) => {
     const payloads = enrichment.payloads.map(payloadElementFromWasm);
     const fields = payloads[0]?.attributes ?? {};
+    // Surface declaration travels with the payload root element. The
+    // GitHub extension (and any future bot-style publisher) sets
+    // `surface="chat-bot"` so the client renders it as a full-width
+    // system band rather than a human-shaped message bubble. Default
+    // is "message-card" — the existing treatment for everything that
+    // doesn't opt in.
+    const surfaceKind = surfaceKindFromPayloadAttributes(fields);
     const source = enrichment.source ? {
       stanzaId: enrichment.source.stanza_id,
       ...(enrichment.source.body_start !== undefined ? { bodyStart: enrichment.source.body_start } : {}),
@@ -236,14 +258,14 @@ function extensionAnnotationsFromWasm(envelope?: WasmExtensionEnvelope): Extensi
     return {
       extensionId: enrichment.plugin,
       annotationId: enrichment.id,
-      surfaceKind: "message-card",
+      surfaceKind,
       title: enrichment.title?.trim() || enrichment.plugin,
       ...(enrichment.summary?.trim() ? { summary: enrichment.summary.trim() } : {}),
       ...(source ? { source } : {}),
       payloadNamespace: enrichment.payload_namespace,
       payloads,
       fields: {
-        surface: "message-card",
+        surface: surfaceKind,
         payloadNamespace: enrichment.payload_namespace,
         ...fields,
       },

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -684,17 +684,22 @@
   padding-block: var(--space-2xs) var(--space-sm);
 }
 
-.chat-thread-root {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2xs);
-  padding-block: var(--space-sm);
-  padding-inline: var(--space-sm);
-  margin-block: var(--space-xs);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklab, var(--primary) 5%, transparent);
-  box-shadow: inset 2px 0 0 0 color-mix(in oklab, var(--primary) 55%, transparent);
+/* Hairline divider between the thread root and the first reply.
+ * The thread-lobby header at the top of the panel already identifies
+ * the root ("Started by …"), so the root itself renders as a normal
+ * MessageCard — no heavy primary-tinted callout box, no loud
+ * THREAD START label. This rule sits in place of the old card and
+ * provides a quiet "replies below" separator instead. */
+.chat-thread-root-divider {
+  height: 1px;
+  margin: var(--space-sm) var(--space-md);
+  background: linear-gradient(
+    to right,
+    transparent,
+    color-mix(in oklab, var(--border) 78%, transparent) 18%,
+    color-mix(in oklab, var(--border) 78%, transparent) 82%,
+    transparent
+  );
 }
 
 /* Thread lobby header — replaces the generic "Thread > author"
@@ -906,15 +911,6 @@
   font-variant-numeric: tabular-nums;
 }
 
-.chat-thread-root__label {
-  align-self: flex-start;
-  padding-inline-start: var(--chat-thread-action-indent);
-  color: var(--primary);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 0.6875rem;
-  line-height: 1;
-}
 
 .chat-accordion-bar {
   display: none;

--- a/flake.nix
+++ b/flake.nix
@@ -225,6 +225,14 @@
             WADDLE_TEST_FIXED_ACCOUNT_PASSWORD = "cuenv-test-password";
             WADDLE_UPLOAD_DIR = "./uploads";
             RUST_BACKTRACE = "1";
+            # Cap parallel cargo compile units so the test build doesn't
+            # OOM the runner during release-mode linking of the full
+            # workspace + every extension. The waddle-server-test step
+            # was hitting SIGKILL (exit 137) under default parallelism;
+            # 4 codegen-units in flight keeps peak memory bounded on
+            # the namespace-profile-linux-x86 runner without meaningfully
+            # slowing the build (deps are already cached upstream).
+            CARGO_BUILD_JOBS = "4";
           };
           testArgs = baseArgs // testRuntimeEnv;
           serverTestArgs = testArgs // {

--- a/server/extensions/github/src/lib.rs
+++ b/server/extensions/github/src/lib.rs
@@ -292,7 +292,15 @@ impl GitHubPayload {
     }
 
     fn to_enrichment_payload(&self) -> types::ExtensionPayload {
+        // `surface` declares what kind of UI the payload expects the
+        // client to render. GitHub events are server-pushed
+        // notifications, not human replies, so we render them as a
+        // chat-bot surface (full-width system band with no author
+        // gutter). The framework keeps the attribute optional so
+        // existing payloads default to the standard message-card
+        // treatment; extensions that ARE bot-style declare themselves.
         let mut attributes = vec![
+            xml_attr("surface", "chat-bot"),
             xml_attr("event-type", &self.event_type),
             xml_attr("action", &self.action),
             xml_attr("installation-id", &self.installation_id),

--- a/server/extensions/github/src/tests.rs
+++ b/server/extensions/github/src/tests.rs
@@ -360,6 +360,11 @@ fn provider_webhook_sends_to_route_loaded_from_pubsub() {
     assert_eq!(find_attr(attrs, "event-type"), Some("workflow_run"));
     assert_eq!(find_attr(attrs, "repository"), Some("waddle-social/waddle"));
     assert_eq!(find_attr(attrs, "conclusion"), Some("failure"));
+    // GitHub events are server-pushed notifications, not human replies,
+    // so the payload declares its surface so the client can render
+    // them as full-width system bands without per-message detection
+    // hacks.
+    assert_eq!(find_attr(attrs, "surface"), Some("chat-bot"));
 }
 
 #[test]


### PR DESCRIPTION
## What

Two related fixes bundled per user direction:

### 1. Thread-start root — drop the heavy callout

The thread root inside the panel was wrapped in a primary-tinted card with a 2 px inset left rail, a 5 % primary background fill, and a loud `THREAD START` uppercase teal label. With iter-25's rich lobby header at the top of the panel (`Started by randax · 4 replies · active 3 hours ago`) the wrapper was redundant chrome.

- Template: root renders as a normal `MessageCard`.
- CSS: `.chat-thread-root` and `.chat-thread-root__label` removed entirely.
- New: `.chat-thread-root-divider` — a hairline gradient rule between the root and the first reply.

### 2. GitHub extension declares its own surface

User: *"Just change the GitHub extension. Fix properly. No fucking hacks."*

GitHub bot messages were still rendering with avatar + author + timestamp wrapped around the event card. Two prior passes tried to *detect* bot-shape from the client side — first via the author's `urn:xmpp:hats:bot` hat (GitHub doesn't have one), then via `annotation.surfaceKind === "chat-bot"` (but the WASM codec hardcoded every annotation to `"message-card"`, so the branch never fired). Detection was negotiating with a publisher that never said what it was.

Fix at the source:

- **`server/extensions/github/src/lib.rs`** — every github-event enrichment stamps `surface="chat-bot"` on the payload root element. The extension declares its own UI category.
- **`chat/src/lib/xmpp/wasm-message-codecs.ts`** — reads the `surface` attribute off the first payload's start element and hydrates `annotation.surfaceKind` from it. Falls back to `"message-card"` when missing or unrecognised, so every existing extension keeps its current treatment. New `surfaceKindFromPayloadAttributes()` helper validates against `KNOWN_SURFACE_KINDS`.
- **`chat/src/components/chat/MessageCard.vue`** — detection collapses to its principled form: `renderAsSystemBand = eventBands.some(b => surfaceKind === "chat-bot")`. Drops the `isBotAuthor` hat fallback (never reliable, no longer needed).
- **`server/extensions/github/src/tests.rs`** — new assertion: the workflow-run payload's start element carries `surface="chat-bot"`. 21 / 21 tests pass.

Intent (`event`) gates which annotations count; surface (`chat-bot`) gates which ones get the system-band treatment. Both come from the publisher — no more client-side guessing.

## Verification

- `cargo test` for `server/extensions/github` — 21 / 21 pass.
- `bun run lint` clean.
- `bun test` — 761 / 761 pass.
- Live: opened the existing `@rawkode TEST` thread in `#chat`; the root renders as a normal MessageCard, the lobby header announces it, and a hairline divider separates it from replies.

## Convention this establishes

The `surface` attribute on a payload root element is the framework-level signal extensions use to declare their UI intent. Existing values: `message-card` (default), `chat-bot`, `board`, `game`, `dynamic-canvas`, `utility-panel`. Future bot-style extensions opt in by setting `surface="chat-bot"`; no client changes required.