### PR TITLE
feat(chat): typing indicator polish — avatar + bubble + wave

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1058,17 +1058,35 @@ function dayDividerLabel(createdAt: string): string {
     <!-- Typing indicator (social / top-pinned mode) -->
     <div
       v-if="typingUsers.length > 0 && isTopPinned"
-      class="type-caption px-[var(--chat-content-inline)] py-2 text-muted-foreground flex-shrink-0 border-b border-border"
+      class="chat-typing-indicator chat-typing-indicator--social flex-shrink-0 border-b border-border"
     >
-      <div class="chat-message-lane flex items-center gap-2">
-        <span class="flex gap-0.5">
-          <span class="typing-dot" />
-          <span class="typing-dot" />
-          <span class="typing-dot" />
+      <div class="chat-message-lane chat-typing-indicator__lane">
+        <span class="chat-typing-indicator__avatars" aria-hidden="true">
+          <span
+            v-for="nick in typingUsers.slice(0, 3)"
+            :key="`typing-avatar:${nick}`"
+            class="chat-typing-indicator__avatar-wrap"
+          >
+            <AppAvatar
+              :name="nick"
+              :src="avatarUrlByAuthor[nick] ?? null"
+              :presence="roomPresence[nick] ?? 'offline'"
+              size="xs"
+            />
+          </span>
         </span>
-        <span v-if="typingUsers.length === 1">{{ typingUsers[0] }} is typing</span>
-        <span v-else-if="typingUsers.length === 2">{{ typingUsers[0] }} and {{ typingUsers[1] }} are typing</span>
-        <span v-else>{{ typingUsers[0] }} and {{ typingUsers.length - 1 }} others are typing</span>
+        <span class="chat-typing-indicator__bubble">
+          <span class="chat-typing-indicator__wave" aria-hidden="true">
+            <span class="chat-typing-indicator__wave-dot" />
+            <span class="chat-typing-indicator__wave-dot" />
+            <span class="chat-typing-indicator__wave-dot" />
+          </span>
+          <span class="chat-typing-indicator__text">
+            <template v-if="typingUsers.length === 1">{{ typingUsers[0] }} is typing</template>
+            <template v-else-if="typingUsers.length === 2">{{ typingUsers[0] }} and {{ typingUsers[1] }} are typing</template>
+            <template v-else>{{ typingUsers[0] }} and {{ typingUsers.length - 1 }} others are typing</template>
+          </span>
+        </span>
       </div>
     </div>
 
@@ -1279,20 +1297,38 @@ function dayDividerLabel(createdAt: string): string {
     </button>
     </div>
 
-    <!-- Typing indicator -->
+    <!-- Typing indicator (chat / bottom-pinned mode) -->
     <div
       v-if="typingUsers.length > 0 && !isTopPinned"
-      class="type-caption px-[var(--chat-content-inline)] py-2 text-muted-foreground flex-shrink-0"
+      class="chat-typing-indicator chat-typing-indicator--chat flex-shrink-0"
     >
-      <div class="chat-message-lane flex items-center gap-2">
-        <span class="flex gap-0.5">
-          <span class="typing-dot" />
-          <span class="typing-dot" />
-          <span class="typing-dot" />
+      <div class="chat-message-lane chat-typing-indicator__lane">
+        <span class="chat-typing-indicator__avatars" aria-hidden="true">
+          <span
+            v-for="nick in typingUsers.slice(0, 3)"
+            :key="`typing-avatar-bottom:${nick}`"
+            class="chat-typing-indicator__avatar-wrap"
+          >
+            <AppAvatar
+              :name="nick"
+              :src="avatarUrlByAuthor[nick] ?? null"
+              :presence="roomPresence[nick] ?? 'offline'"
+              size="xs"
+            />
+          </span>
         </span>
-        <span v-if="typingUsers.length === 1">{{ typingUsers[0] }} is typing</span>
-        <span v-else-if="typingUsers.length === 2">{{ typingUsers[0] }} and {{ typingUsers[1] }} are typing</span>
-        <span v-else>{{ typingUsers[0] }} and {{ typingUsers.length - 1 }} others are typing</span>
+        <span class="chat-typing-indicator__bubble">
+          <span class="chat-typing-indicator__wave" aria-hidden="true">
+            <span class="chat-typing-indicator__wave-dot" />
+            <span class="chat-typing-indicator__wave-dot" />
+            <span class="chat-typing-indicator__wave-dot" />
+          </span>
+          <span class="chat-typing-indicator__text">
+            <template v-if="typingUsers.length === 1">{{ typingUsers[0] }} is typing</template>
+            <template v-else-if="typingUsers.length === 2">{{ typingUsers[0] }} and {{ typingUsers[1] }} are typing</template>
+            <template v-else>{{ typingUsers[0] }} and {{ typingUsers.length - 1 }} others are typing</template>
+          </span>
+        </span>
       </div>
     </div>
 

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -383,6 +383,104 @@
   white-space: nowrap;
 }
 
+/* Typing indicator — gets a tiny avatar of who's typing (with the
+ * iter-17 presence ring) next to a pill-shaped bubble that contains
+ * the animated wave and the "X is typing" copy. Replaces the prior
+ * three-loose-dots + plain-text rendering with something that feels
+ * like a live presence in the conversation. */
+.chat-typing-indicator {
+  padding: 0.45rem var(--chat-content-inline);
+  color: var(--muted-foreground);
+}
+
+.chat-typing-indicator--social {
+  border-bottom: 1px solid var(--border);
+}
+
+.chat-typing-indicator__lane {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
+.chat-typing-indicator__avatars {
+  display: inline-flex;
+  align-items: center;
+  isolation: isolate;
+  flex-shrink: 0;
+}
+
+.chat-typing-indicator__avatar-wrap {
+  display: inline-flex;
+  margin-left: -0.4rem;
+  border-radius: 9999px;
+  outline: 1.5px solid var(--background);
+}
+
+.chat-typing-indicator__avatar-wrap:first-child {
+  margin-left: 0;
+}
+
+.chat-typing-indicator__avatar-wrap > .app-avatar,
+.chat-typing-indicator__avatar-wrap > .app-avatar > .type-avatar-mark,
+.chat-typing-indicator__avatar-wrap > .app-avatar > img {
+  width: 1.25rem;
+  height: 1.25rem;
+  font-size: 0.55rem;
+}
+
+.chat-typing-indicator__bubble {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 1.5rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklab, var(--primary) 8%, var(--muted));
+  border: 1px solid color-mix(in oklab, var(--primary) 16%, transparent);
+  color: color-mix(in oklab, var(--foreground) 75%, transparent);
+  font-size: var(--text-meta);
+  line-height: 1;
+  box-shadow: 0 0 0 0 var(--glow);
+}
+
+.chat-typing-indicator__wave {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  flex-shrink: 0;
+}
+
+.chat-typing-indicator__wave-dot {
+  display: inline-block;
+  width: 0.32rem;
+  height: 0.32rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  opacity: 0.55;
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chat-typing-indicator__wave-dot {
+    animation: chat-typing-wave 1.25s ease-in-out infinite;
+  }
+  .chat-typing-indicator__wave-dot:nth-child(2) { animation-delay: 0.15s; }
+  .chat-typing-indicator__wave-dot:nth-child(3) { animation-delay: 0.3s; }
+}
+
+@keyframes chat-typing-wave {
+  0%, 100% { opacity: 0.35; transform: scale(0.85); }
+  50%      { opacity: 1;    transform: scale(1.15); }
+}
+
+.chat-typing-indicator__text {
+  min-width: 0;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+
 .chat-current-day-marker {
   flex-shrink: 0;
   padding: var(--space-xs) var(--chat-content-inline) 0;


### PR DESCRIPTION
## What

The typing indicator was three CSS-bouncy dots + plain "X is typing" text. Functional but mechanical — felt out of place next to all the surrounding Aether language (presence rings, glow tokens, soft pill chrome). Polished.

| Before | After |
|---|---|
| `· · ·  alice is typing` (bare dots, plain text) | `[avatar] ( · · ·  alice is typing )` — avatar with presence ring, primary-tinted pill bubble, smooth scale-fade wave |

## Details

- **Avatar** (1.25 rem) of who's typing on the left, carrying the iter-17 presence ring so the eye knows it's a live person, not a placeholder.
- **Pill bubble** with primary 8 % background + 16 % primary border — tinted enough to read as "active", soft enough not to steal attention from the timeline.
- **Wave** — three dots that scale + fade instead of bouncing translateY. Smoother breathing rhythm, much less "metronomic". Reduced-motion gated.
- **Stack** when multiple people are typing: up to 3 overlapping avatars (same pattern as the iter-24 channel-header presence stack), and the text still resolves to "X and Y are typing" or "X and N others are typing".

Two render sites in `ContentArea` (social/top-pinned + chat/bottom-pinned scroll modes) both get the new structure. The legacy `.typing-dot` rule stays because `GifPicker` and the `AppLayout` startup splash still use it.

## Files

- `chat/src/components/chat/ContentArea.vue` — both typing-indicator blocks replaced with the new `.chat-typing-indicator` structure.
- `chat/src/styles/global/messages.css` — new `.chat-typing-indicator` family (`__lane`, `__avatars`, `__avatar-wrap`, `__bubble`, `__wave`, `__wave-dot`, `__text`) + `chat-typing-wave` keyframe.

## Verification

- `bun run lint` clean.
- `bun test` — 761/761 pass.