### PR TITLE
fix(chat): grouped-row timestamp now occludes the burst rail cleanly

### DIFF
--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -740,6 +740,26 @@
 .chat-message-grouped:hover .chat-message-time-gutter,
 .chat-message-grouped:focus-within .chat-message-time-gutter {
   opacity: 1;
+  /* The iter-19 burst cluster rail runs through the middle of the
+   * avatar gutter. When the row reveals its timestamp on hover the two
+   * elements end up fighting for the same pixels — the rail bisects
+   * the "23:10" text. Give the visible timestamp a solid background
+   * that matches the hover row's composite colour
+   * (`--muted` 36 % over `--background`) so it occludes the rail
+   * cleanly while still reading as part of the row. */
+  background: color-mix(in oklab, var(--muted) 36%, var(--background));
+  border-radius: var(--radius-sm);
+  padding: 0 0.25rem;
+  position: relative;
+  z-index: 1;
+}
+
+/* Thread-mode rows hover with a different background tint (muted 38%
+ * over a primary-tinted base) — match that here too so the time-gutter
+ * blends with whichever row state it's in. */
+.chat-message-grid--thread.chat-message-grouped:hover .chat-message-time-gutter,
+.chat-message-grid--thread.chat-message-grouped:focus-within .chat-message-time-gutter {
+  background: color-mix(in oklab, var(--muted) 38%, var(--background));
 }
 
 @media (pointer: coarse) {


### PR DESCRIPTION
## What

User screenshot: when a grouped follow-up row was hovered/selected, the revealed \"23:10\" timestamp text sat right on top of the iter-19 burst cluster rail and the two visually fought for the same column. The rail bisected the digits — \`23 | 10\`.

## Fix

The visible \`.chat-message-time-gutter\` gains:

- A small solid background sized to the row's hover-tint composite — \`color-mix(in oklab, var(--muted) 36%, var(--background))\` — so the eye sees one coherent surface, not a rail poking through.
- A rounded radius and a tiny horizontal pad so the bubble has breathing room around the digits.
- \`position: relative; z-index: 1\` to stack the gutter above the rail's \`::after\` pseudo-element. The rail remains visible above and below the text; only the digits' direct footprint is occluded.

Thread-mode rows hover with a slightly different composite (\`muted 38%\` over a primary-tinted base), so they get a matching variant of the same rule.

## Verification

- \`bun run lint\` clean.
- \`bun test\` — 761/761 pass.
- Live: hovered a grouped reply in #chat; the \`23:10\` timestamp now reads as a single coherent unit instead of being bisected by the cluster rail.