### PR TITLE
feat(chat): mention highlight from warning-border to warm spotlight

### DIFF
--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -122,10 +122,37 @@
   background: color-mix(in oklab, var(--card) 72%, transparent);
 }
 
+/* Mention treatment — when the current user is @-mentioned, the row
+ * reads as "this one's for you", not as a warning. Replaces the prior
+ * full warning-yellow border + flat 5% bg (which felt like a danger
+ * outline) with:
+ *
+ *   - A 3 px solid left-edge bar in `--warning` (the "spotlight from
+ *     the side" signal — directional, like a highlighted bookmark)
+ *   - A horizontal gradient sweep that fades the warmth out to the
+ *     right (so the message body stays legible, not tinted)
+ *
+ * Same colour family the user already trains on for amber/warning
+ * states; very different semantics. */
 .chat-message-grid--mention::before {
   opacity: 1;
-  border: 1px solid color-mix(in oklab, var(--warning) 25%, transparent);
-  background: color-mix(in oklab, var(--warning) 5%, transparent);
+  border: 0;
+  box-shadow: inset 3px 0 0 0 color-mix(in oklab, var(--warning) 80%, transparent);
+  background: linear-gradient(
+    to right,
+    color-mix(in oklab, var(--warning) 14%, transparent),
+    color-mix(in oklab, var(--warning) 6%, transparent) 12rem,
+    transparent 28rem
+  );
+}
+
+.chat-message-grid--mention:hover::before {
+  background: linear-gradient(
+    to right,
+    color-mix(in oklab, var(--warning) 18%, transparent),
+    color-mix(in oklab, var(--warning) 8%, transparent) 12rem,
+    color-mix(in oklab, var(--muted) 24%, transparent) 32rem
+  );
 }
 
 .chat-message-grid--thread::before {


### PR DESCRIPTION
## What

When the current user is @-mentioned, the message row used to wrap in a 1 px warning-yellow border + flat 5 % bg tint. The semantic colour (\`--warning\`) is correct but the geometry of a full border reads as a *caution outline* — the same visual shape we use for error states, alert chips, etc. Mentions aren't warnings. They're *"this one is for you"*.

Reshapes the treatment using the same colour family:

- **3 px solid left-edge bar** in \`--warning\` (80 % saturation) via \`inset 3px 0 0 0\` box-shadow on the row's \`::before\`. Reads as a spotlight from the side / highlighted bookmark spine — the eye catches it scanning down a busy channel.
- **Horizontal gradient sweep** that fades the warm tint out by ~28 rem in. The message body stays legible (not tinted); only the left-side margin where the eye lands carries the colour.
- Drops the full border entirely.
- Hover composite still respects the rest of the design system (muted blend layered over the warm tint).

Same \`--warning\` token; very different visual semantics.

## Verified live

`@rawkode` message in `#chat`: the row now renders with a solid amber left bar + warm gradient that fades to the right, leaving the body type fully legible. Reads as "spotlight" not "warning."

## Files

- `chat/src/styles/global/messages.css` — `.chat-message-grid--mention::before` rewritten + hover variant.