### PR TITLE
fix(chat): thread chip — participants move to gutter, recency right-aligns

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -231,7 +231,7 @@ function openThreadFromChip() {
   emit("openThread", props.message.id);
 }
 
-const MAX_CHIP_PARTICIPANTS = 3;
+const MAX_CHIP_PARTICIPANTS = 2;
 const visibleThreadParticipants = computed(() =>
   (props.threadParticipants ?? []).slice(0, MAX_CHIP_PARTICIPANTS),
 );
@@ -799,6 +799,34 @@ onBeforeUnmount(() => {
     >
       <AppAvatar :name="message.author" :src="avatarUrl" :presence="presence" :last-seen="lastSeen" size="message" />
     </button>
+    <!-- Thread participant stack — pulled out of the inline thread chip
+         into the avatar gutter so it sits visually under the main
+         author avatar, sharing the column with the burst rail and the
+         time gutter. Position-absolute relative to the row's grid;
+         centred horizontally in the avatar column, bottom-anchored so
+         it aligns with the chip which is the last body child. -->
+    <div
+      v-if="showThreadChip && visibleThreadParticipants.length > 0"
+      class="chat-thread-chip-gutter"
+      aria-hidden="true"
+    >
+      <span
+        v-for="participant in visibleThreadParticipants"
+        :key="`thread-gutter-avatar:${message.id}:${participant.nick}`"
+        class="chat-thread-chip-gutter__avatar-wrap"
+      >
+        <AppAvatar
+          :name="participant.nick"
+          :src="participant.avatarUrl ?? null"
+          :presence="participant.presence"
+          size="xs"
+        />
+      </span>
+      <span
+        v-if="threadParticipantOverflow > 0"
+        class="chat-thread-chip-gutter__overflow"
+      >+{{ threadParticipantOverflow }}</span>
+    </div>
     <div class="chat-message-body-stack">
       <div v-if="!grouped" class="chat-message-meta-row">
         <span class="type-message-author">{{ message.author }}</span>
@@ -925,35 +953,13 @@ onBeforeUnmount(() => {
     <button
       v-if="showThreadChip"
       type="button"
-      class="chat-thread-chip type-caption inline-flex rounded-md py-0.5 text-primary/85 transition-colors hover:text-primary"
+      class="chat-thread-chip type-caption flex w-full items-center rounded-md py-0.5 text-primary/85 transition-colors hover:text-primary"
       :title="`Open thread (${threadReplyCount} ${threadReplyCount === 1 ? 'reply' : 'replies'})`"
       @click="openThreadFromChip"
     >
-      <MessageSquare class="w-3 h-3 flex-shrink-0" />
-      <span class="min-w-0 truncate">{{ threadReplyCount }} {{ threadReplyCount === 1 ? "reply" : "replies" }}</span>
-      <span
-        v-if="visibleThreadParticipants.length > 0"
-        class="chat-thread-chip__avatars"
-        aria-hidden="true"
-      >
-        <span
-          v-for="participant in visibleThreadParticipants"
-          :key="`thread-chip-avatar:${message.id}:${participant.nick}`"
-          class="chat-thread-chip__avatar-wrap"
-        >
-          <AppAvatar
-            :name="participant.nick"
-            :src="participant.avatarUrl ?? null"
-            :presence="participant.presence"
-            size="xs"
-          />
-        </span>
-        <span
-          v-if="threadParticipantOverflow > 0"
-          class="chat-thread-chip__overflow"
-        >+{{ threadParticipantOverflow }}</span>
-      </span>
-      <span v-if="threadChipRecency" class="chat-thread-chip__recency">· {{ threadChipRecency }}</span>
+      <MessageSquare class="chat-thread-chip__icon w-3 h-3 flex-shrink-0" />
+      <span class="chat-thread-chip__count min-w-0 truncate">{{ threadReplyCount }} {{ threadReplyCount === 1 ? "reply" : "replies" }}</span>
+      <span v-if="threadChipRecency" class="chat-thread-chip__recency">{{ threadChipRecency }}</span>
     </button>
 
     <!-- Existing reactions (inline, always visible when present) -->

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -354,47 +354,77 @@
   align-items: center;
 }
 
-.chat-thread-chip > svg {
+.chat-thread-chip__icon {
   opacity: 0.85;
 }
 
-.chat-thread-chip__avatars {
-  display: inline-flex;
-  align-items: center;
-  isolation: isolate;
+.chat-thread-chip__count {
+  /* count text sits on the left right after the icon */
+  flex-shrink: 0;
 }
 
-.chat-thread-chip__avatar-wrap {
+/* Recency suffix is pushed to the right edge of the message body —
+ * matches the visual rhythm of "icon + label on the left, timestamp
+ * on the right" the user explicitly asked for. The "·" bullet that
+ * used to live in the markup is dropped now that there's real
+ * space-between alignment doing the job of a separator. */
+.chat-thread-chip__recency {
+  margin-left: auto;
+  color: color-mix(in oklab, var(--muted-foreground) 92%, transparent);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Participant stack lives in the message's avatar gutter, anchored to
+ * the bottom of the avatar column so it sits visually under the main
+ * author avatar (or the time gutter on grouped rows). Uses absolute
+ * positioning relative to the row's grid; the message-card grid is
+ * already `position: relative`. */
+.chat-thread-chip-gutter {
+  position: absolute;
+  bottom: 0.35rem;
+  left: 0;
+  width: var(--chat-message-avatar-size);
   display: inline-flex;
-  margin-left: -0.3rem;
+  justify-content: center;
+  align-items: center;
+  isolation: isolate;
+  pointer-events: none;
+}
+
+.chat-thread-chip-gutter__avatar-wrap {
+  display: inline-flex;
+  margin-left: -0.35rem;
   border-radius: 9999px;
   outline: 1.5px solid var(--background);
 }
 
-.chat-thread-chip__avatar-wrap:first-child {
+.chat-thread-chip-gutter__avatar-wrap:first-child {
   margin-left: 0;
 }
 
-/* Shrink the AppAvatar instance inside the chip — its xs preset is
- * 1.5 rem which dwarfs the 0.6875 rem chip text. Drop to 1.125 rem
- * for visual harmony with the surrounding type and to give the
- * outline ring room to breathe between adjacent avatars. */
-.chat-thread-chip__avatar-wrap > .app-avatar,
-.chat-thread-chip__avatar-wrap > .app-avatar > .type-avatar-mark,
-.chat-thread-chip__avatar-wrap > .app-avatar > img {
+/* The xs AppAvatar preset is 1.5 rem; the avatar column is
+ * `--chat-message-avatar-size` (≈ 2.78 rem) wide, so two visible
+ * avatars plus a "+N" chip need to fit. Shrink to 1.125 rem so they
+ * fit centred in the column without crowding the time-gutter
+ * timestamp when both reveal on hover. */
+.chat-thread-chip-gutter__avatar-wrap > .app-avatar,
+.chat-thread-chip-gutter__avatar-wrap > .app-avatar > .type-avatar-mark,
+.chat-thread-chip-gutter__avatar-wrap > .app-avatar > img {
   width: 1.125rem;
   height: 1.125rem;
   font-size: 0.55rem;
 }
 
-.chat-thread-chip__overflow {
+.chat-thread-chip-gutter__overflow {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 1.125rem;
+  min-width: 1.05rem;
   height: 1.125rem;
   padding: 0 0.3rem;
-  margin-left: -0.2rem;
+  margin-left: -0.25rem;
   border-radius: 9999px;
   background: color-mix(in oklab, var(--muted) 65%, transparent);
   font-size: 0.55rem;
@@ -402,12 +432,6 @@
   color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   outline: 1.5px solid var(--background);
-}
-
-.chat-thread-chip__recency {
-  color: color-mix(in oklab, var(--muted-foreground) 92%, transparent);
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
 }
 
 /* Typing indicator — gets a tiny avatar of who's typing (with the


### PR DESCRIPTION
## What

User directive (with screenshot): *"Thread avatars should be in the gutter / rail under main avatars. Time should be aligned right. Clean this up."*

The inline thread chip had three concerns squashed onto one row — icon, count text, participant avatar stack, and recency timestamp — and on multi-reply threads the recency drifted into the middle of the body. Splitting the concerns by column:

1. **Avatar gutter (column 1).** New `.chat-thread-chip-gutter` block renders the participant stack absolutely-positioned at the bottom of the avatar column, centred horizontally, so it sits visually under the main author avatar. Shares the column with the iter-19 burst rail and the grouped-row time gutter.
2. **Body chip (column 2).** Stripped down to `[icon] [N replies]  …  [recency]`. Flex row with `margin-left: auto` on the recency span pushes the timestamp to the right edge of the message body. The `·` bullet separator is dropped — space-between is doing the separator's job.
3. **Avatar cap dropped 3 → 2** to fit the narrower ~2.78 rem avatar column without crowding adjacent rows.

## Files

- `chat/src/components/chat/MessageCard.vue` — new `.chat-thread-chip-gutter` sibling of the avatar cell; chip simplified to count + recency; `MAX_CHIP_PARTICIPANTS` dropped to 2.
- `chat/src/styles/global/messages.css` — renamed inline-avatar rules to gutter rules; added `__icon`, `__count`, `__recency` selectors with explicit spacing tokens; recency uses `margin-left: auto`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Verified in Chrome MCP at `localhost:4321` — multiple thread chips render correctly: `💬 1 reply / 8 hours`, `💬 10 replies / 7 hours`, `💬 2 replies / 6 hours`, all with right-aligned recency and participant avatars stacked beneath the main author avatar in the gutter.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP at `localhost:4321`
- [ ] CI green on PR

This PR was created with the assistance of a LLM.