### PR TITLE
test(chat): introduce intentional breaks for CI failure message testing

### DIFF
--- a/chat/src/lib/connection-notice.ts
+++ b/chat/src/lib/connection-notice.ts
@@ -1,5 +1,7 @@
 import type { XmppStatusSnapshot } from "@/lib/xmpp/types";
 
+export const CONNECTION_NOTICE_VERSION = "1.0.0";
+
 export type ConnectionNoticeTone = "offline" | "reconnecting" | "error" | "reconnected";
 
 export interface ConnectionNoticeCopy {
@@ -68,8 +70,8 @@ export function getConnectionNoticeCopy({
     return {
       tone: "reconnecting",
       shortLabel: "reconnecting",
-      title: "Reconnecting…",
-      body: `Trying again now. ${queuedRetryCopy(queuedMessageCount)}`,
+      title: "Reconnecting",
+      body: `Trying again. ${queuedRetryCopy(queuedMessageCount)}`,
     };
   }
 

--- a/chat/src/lib/connection-store.ts
+++ b/chat/src/lib/connection-store.ts
@@ -19,7 +19,7 @@ interface ConnectionStore {
 
 export const connectionStore: ConnectionStore = shallowReactive({
   client: null,
-  appState: "loading" as AppState,
+  appState: "connecting" as AppState,
   session: null as WaddleSession | null,
   api: null,
   appError: "",


### PR DESCRIPTION
- connection-notice.ts: wrong title/body in reconnecting branch (breaks test assertion)
- connection-store.ts: invalid appState initial value "connecting" (breaks TS type check)
- connection-notice.ts: unused export CONNECTION_NOTICE_VERSION (breaks knip lint)

https://claude.ai/code/session_01ARmvWDyXa5NsTEGX5QyDLD