### PR TITLE
fix(chat): soft-glass sticky day marker — drop bordered/shadowed pill

### DIFF
--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -543,7 +543,13 @@
   align-items: center;
   gap: var(--space-sm);
   justify-content: center;
-  background: color-mix(in oklab, var(--background) 82%, transparent);
+  /* Light frosted band — backdrop-blur so messages scrolling under the
+   * sticky marker softly fade rather than punching through. Less
+   * opaque than before so the rules and pill carry the structure
+   * visually; the blur is what guarantees legibility. */
+  background: color-mix(in oklab, var(--background) 62%, transparent);
+  backdrop-filter: blur(8px) saturate(135%);
+  -webkit-backdrop-filter: blur(8px) saturate(135%);
   padding-block: 0 0.375rem;
 }
 
@@ -572,16 +578,24 @@
   );
 }
 
+/* Sticky day marker pill — soft glass. The previous bordered + shadowed
+ * treatment read like a dropped toast notification, especially in dark
+ * mode where var(--background) collapsed against the lane backdrop and
+ * the hard border was the only thing separating them. Trade the border
+ * and shadow for a translucent --card surface with backdrop-blur so the
+ * pill sits OVER the rules (and any content that scrolls under) as a
+ * gentle frosted-glass anchor instead of a hard-outlined chip. */
 .chat-current-day-marker__label {
-  border: 1px solid color-mix(in oklab, var(--border) 76%, transparent);
   border-radius: 999px;
-  background: color-mix(in oklab, var(--background) 76%, transparent);
-  box-shadow: 0 1px 2px color-mix(in oklab, var(--foreground) 8%, transparent);
-  padding: 0.25rem 0.625rem;
+  background: color-mix(in oklab, var(--card) 72%, transparent);
+  backdrop-filter: blur(6px) saturate(140%);
+  -webkit-backdrop-filter: blur(6px) saturate(140%);
+  padding: 0.25rem 0.75rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
   font-size: 0.6875rem;
   line-height: 1;
+  color: color-mix(in oklab, var(--muted-foreground) 88%, var(--foreground));
 }
 
 .chat-day-divider {


### PR DESCRIPTION
## What

The sticky **YESTERDAY / TODAY** marker at the top of the message list was a hard-edged bordered pill with a drop shadow and a near-opaque `var(--background)` backdrop. In dark mode it collapsed against the lane backdrop and read like a dropped toast notification rather than a temporal anchor.

Two small CSS changes (one file: `chat/src/styles/global/messages.css`):

1. **Lane band** — backdrop-blur(8px) saturate(135%) with a softer 62% `var(--background)` tint (was 82%, no blur). The lane is what guarantees legibility when content scrolls under the sticky marker; the blur replaces brute opacity so messages fade gracefully into the band instead of being clipped by a flat rectangle.
2. **Label pill** — drop the 1px border, drop the box-shadow, swap the `var(--background)` tint for a translucent `var(--card)` surface, add the same backdrop-blur + saturate. Letter-spacing widened `0.04em → 0.08em` and padding `0.625rem → 0.75rem` for breathing room. Foreground tinted `88% --muted-foreground / 12% --foreground` so the text reads as a quiet anchor rather than a colourless ghost.

Result: the marker now feels like a frosted-glass lozenge floating on a barely-there band — the kind of marker iOS and Telegram use — instead of a bordered chip parked on top of the content.

## Files

- `chat/src/styles/global/messages.css` (lines 541–585) — `.chat-current-day-marker__lane` + `.chat-current-day-marker__label`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: the YESTERDAY marker reads as a soft frosted pill, the hairline rules fade in cleanly from either side, and messages scrolling underneath fade smoothly into the band rather than punching through.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.