### PR TITLE
fix(chat): thread chip — icon to gutter, avatars+count to chip, "ago" suffix

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -12,6 +12,7 @@ import {
   Github,
   LayoutDashboard,
   MessageSquare,
+  MessagesSquare,
   Pin,
   PinOff,
 } from "lucide-vue-next";
@@ -231,7 +232,7 @@ function openThreadFromChip() {
   emit("openThread", props.message.id);
 }
 
-const MAX_CHIP_PARTICIPANTS = 2;
+const MAX_CHIP_PARTICIPANTS = 3;
 const visibleThreadParticipants = computed(() =>
   (props.threadParticipants ?? []).slice(0, MAX_CHIP_PARTICIPANTS),
 );
@@ -247,14 +248,14 @@ function formatThreadRecency(iso: string | undefined): string {
   const seconds = Math.floor(ms / 1000);
   if (seconds < 45) return "just now";
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 2) return "1 min";
-  if (minutes < 60) return `${minutes} min`;
+  if (minutes < 2) return "1 min ago";
+  if (minutes < 60) return `${minutes} min ago`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 2) return "1 hour";
-  if (hours < 24) return `${hours} hours`;
+  if (hours < 2) return "1 hour ago";
+  if (hours < 24) return `${hours} hours ago`;
   const days = Math.floor(hours / 24);
-  if (days < 2) return "1 day";
-  if (days < 7) return `${days} days`;
+  if (days < 2) return "1 day ago";
+  if (days < 7) return `${days} days ago`;
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
@@ -799,33 +800,18 @@ onBeforeUnmount(() => {
     >
       <AppAvatar :name="message.author" :src="avatarUrl" :presence="presence" :last-seen="lastSeen" size="message" />
     </button>
-    <!-- Thread participant stack — pulled out of the inline thread chip
-         into the avatar gutter so it sits visually under the main
-         author avatar, sharing the column with the burst rail and the
-         time gutter. Position-absolute relative to the row's grid;
-         centred horizontally in the avatar column, bottom-anchored so
-         it aligns with the chip which is the last body child. -->
+    <!-- Thread rail glyph — a small "messages-stack" icon centred in the
+         avatar column, under the author avatar. Structural marker that
+         this row anchors a thread; the rich summary (who replied, how
+         many, how recently) lives in the in-body chip. Position-absolute
+         relative to the row's grid; bottom-anchored to align with the
+         chip which is the last body child. -->
     <div
-      v-if="showThreadChip && visibleThreadParticipants.length > 0"
-      class="chat-thread-chip-gutter"
+      v-if="showThreadChip"
+      class="chat-thread-rail-glyph"
       aria-hidden="true"
     >
-      <span
-        v-for="participant in visibleThreadParticipants"
-        :key="`thread-gutter-avatar:${message.id}:${participant.nick}`"
-        class="chat-thread-chip-gutter__avatar-wrap"
-      >
-        <AppAvatar
-          :name="participant.nick"
-          :src="participant.avatarUrl ?? null"
-          :presence="participant.presence"
-          size="xs"
-        />
-      </span>
-      <span
-        v-if="threadParticipantOverflow > 0"
-        class="chat-thread-chip-gutter__overflow"
-      >+{{ threadParticipantOverflow }}</span>
+      <MessagesSquare class="chat-thread-rail-glyph__icon" />
     </div>
     <div class="chat-message-body-stack">
       <div v-if="!grouped" class="chat-message-meta-row">
@@ -946,10 +932,12 @@ onBeforeUnmount(() => {
 
     <!-- Thread replies affordance. Visible in the main channel feed on roots
          that have replies; the thread panel hides it via hideThreadChip since
-         the panel already shows children. Carries a tiny avatar stack of
-         participants (current user excluded by the caller) and a relative-
-         time suffix so the eye can triage threads at a glance — who's been
-         talking, how recently — without opening the panel. -->
+         the panel already shows children. The chip carries a row of
+         participant avatars (current user excluded by the caller) + reply
+         count, with the recency timestamp right-aligned so the eye can
+         triage threads at a glance — who's been talking, how many turns,
+         how recently — without opening the panel. The structural "this is
+         a thread" marker lives in the avatar gutter as the rail glyph. -->
     <button
       v-if="showThreadChip"
       type="button"
@@ -957,7 +945,28 @@ onBeforeUnmount(() => {
       :title="`Open thread (${threadReplyCount} ${threadReplyCount === 1 ? 'reply' : 'replies'})`"
       @click="openThreadFromChip"
     >
-      <MessageSquare class="chat-thread-chip__icon w-3 h-3 flex-shrink-0" />
+      <span
+        v-if="visibleThreadParticipants.length > 0"
+        class="chat-thread-chip__avatars"
+        aria-hidden="true"
+      >
+        <span
+          v-for="participant in visibleThreadParticipants"
+          :key="`thread-chip-avatar:${message.id}:${participant.nick}`"
+          class="chat-thread-chip__avatar-wrap"
+        >
+          <AppAvatar
+            :name="participant.nick"
+            :src="participant.avatarUrl ?? null"
+            :presence="participant.presence"
+            size="xs"
+          />
+        </span>
+        <span
+          v-if="threadParticipantOverflow > 0"
+          class="chat-thread-chip__overflow"
+        >+{{ threadParticipantOverflow }}</span>
+      </span>
       <span class="chat-thread-chip__count min-w-0 truncate">{{ threadReplyCount }} {{ threadReplyCount === 1 ? "reply" : "replies" }}</span>
       <span v-if="threadChipRecency" class="chat-thread-chip__recency">{{ threadChipRecency }}</span>
     </button>

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -376,48 +376,64 @@
   flex-shrink: 0;
 }
 
-/* Participant stack lives in the message's avatar gutter, anchored to
- * the bottom of the avatar column so it sits visually under the main
- * author avatar (or the time gutter on grouped rows). Uses absolute
- * positioning relative to the row's grid; the message-card grid is
- * already `position: relative`. */
-.chat-thread-chip-gutter {
+/* Thread rail glyph — a single "stacked messages" icon centred in the
+ * avatar column under the main author avatar. Structural rail marker
+ * that this row anchors a thread; the rich summary (who replied + how
+ * many + how recently) lives in the in-body chip. Absolute-positioned
+ * relative to the row's grid (the message-card grid is already
+ * `position: relative`), bottom-anchored to align with the chip which
+ * is the last body child. */
+.chat-thread-rail-glyph {
   position: absolute;
-  bottom: 0.35rem;
+  bottom: 0.4rem;
   left: 0;
   width: var(--chat-message-avatar-size);
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  isolation: isolate;
   pointer-events: none;
+  color: color-mix(in oklab, var(--primary) 55%, var(--muted-foreground));
+  opacity: 0.7;
 }
 
-.chat-thread-chip-gutter__avatar-wrap {
+.chat-thread-rail-glyph__icon {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+/* Participant stack lives inside the thread chip body, ahead of the
+ * reply count, so the eye reads "[who's here] [how many turns] …
+ * [how recently]" left-to-right. Avatars shrink to 1.125 rem so they
+ * sit comfortably on the 0.6875 rem chip text baseline and remain
+ * legible without overpowering the count. The gutter holds only the
+ * structural rail glyph; this stack carries the richness. */
+.chat-thread-chip__avatars {
+  display: inline-flex;
+  align-items: center;
+  isolation: isolate;
+  flex-shrink: 0;
+}
+
+.chat-thread-chip__avatar-wrap {
   display: inline-flex;
   margin-left: -0.35rem;
   border-radius: 9999px;
   outline: 1.5px solid var(--background);
 }
 
-.chat-thread-chip-gutter__avatar-wrap:first-child {
+.chat-thread-chip__avatar-wrap:first-child {
   margin-left: 0;
 }
 
-/* The xs AppAvatar preset is 1.5 rem; the avatar column is
- * `--chat-message-avatar-size` (≈ 2.78 rem) wide, so two visible
- * avatars plus a "+N" chip need to fit. Shrink to 1.125 rem so they
- * fit centred in the column without crowding the time-gutter
- * timestamp when both reveal on hover. */
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar,
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar > .type-avatar-mark,
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar > img {
+.chat-thread-chip__avatar-wrap > .app-avatar,
+.chat-thread-chip__avatar-wrap > .app-avatar > .type-avatar-mark,
+.chat-thread-chip__avatar-wrap > .app-avatar > img {
   width: 1.125rem;
   height: 1.125rem;
   font-size: 0.55rem;
 }
 
-.chat-thread-chip-gutter__overflow {
+.chat-thread-chip__overflow {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## What

User feedback on the iter-33 layout: the avatars belong inside the chip alongside the reply count, not in the gutter. The gutter should carry a single structural thread **icon** — the "this row anchors a thread" rail glyph. And the recency timestamp should read "1 hour ago", not just "1 hour".

Inverts iter 33:

- **Gutter** — new `.chat-thread-rail-glyph` block holding a single `MessagesSquare` icon (the stacked-bubbles lucide glyph), centred in the avatar column under the main author avatar. Tinted with `color-mix(--primary 55%, --muted-foreground)` at 0.7 opacity so it reads as a quiet structural marker, not a hot CTA.
- **Chip body** — participant avatar row reinstated *inside* the chip, ahead of the reply count, using the same overlapping stack with 1.125 rem avatars and 1.5 px `--background` outline. Layout now reads left-to-right: `[👤👤👤+N] [3 replies] … [1 hour ago]` with the recency right-aligned via `margin-left: auto`.
- **Recency** — `formatThreadRecency` now appends `" ago"` to every relative case (`"1 hour ago"`, `"23 min ago"`, `"2 days ago"`). `"just now"` and the absolute date fallback are unchanged (they already read as complete English).
- **MAX_CHIP_PARTICIPANTS** restored 2 → 3 since the chip body has more width than the ~2.78 rem avatar column had.

## Why this is the right shape

The **gutter** is the row's structural rail: main author avatar at the top, burst-cluster pseudo-rail on grouped follow-ups, and now the thread icon at the bottom when a thread anchors here. The **chip** is the interactive summary — who's been talking, how many turns, how recently. Putting avatars + count + recency together is what lets the eye triage threads at a glance; putting them in the gutter hid the richness behind a narrow column.

## Files

- `chat/src/components/chat/MessageCard.vue` — new `MessagesSquare` import; `.chat-thread-rail-glyph` block replaces avatar stack in gutter; chip body restores `.chat-thread-chip__avatars` row; `formatThreadRecency` appends " ago"; `MAX_CHIP_PARTICIPANTS = 3`.
- `chat/src/styles/global/messages.css` — rename `.chat-thread-chip-gutter*` rules to `.chat-thread-rail-glyph` + `.chat-thread-chip__avatars`/`__avatar-wrap`/`__overflow`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: chip renders as `[🗨 gutter icon] [👤 randax] 3 replies ............ 1 hour ago`. Multiple chips render consistently (`3 replies / 1 hour ago`, `4 replies / 23 min ago`).

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.