### PR TITLE
fix(chat): github cards — drop dupe repo, positional chips, quiet wash, gutters

### DIFF
--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -203,6 +203,7 @@ watch(
         card.presentation.tone === 'success' ? 'chat-system-band--tone-success' : '',
         card.presentation.tone === 'danger'  ? 'chat-system-band--tone-danger'  : '',
         card.presentation.tone === 'warning' ? 'chat-system-band--tone-warning' : '',
+        card.presentation.kind ? `chat-system-band--kind-${card.presentation.kind}` : '',
       ]"
     >
       <div class="chat-system-band__header">
@@ -243,7 +244,7 @@ watch(
           <span class="chat-system-band__meta-label">{{ detail.label }}</span>
           <span
             class="chat-system-band__meta-value"
-            :class="detail.label === 'Commit' ? 'chat-system-band__meta-value--mono' : ''"
+            :class="(detail.label === 'Commit' || detail.label === 'Branch') ? 'chat-system-band__meta-value--mono' : ''"
             :title="detail.value"
           >{{ detail.value }}</span>
         </span>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -165,6 +165,22 @@ function systemBandToneClass(tone: string): string {
   return "";
 }
 
+// Per-kind modifier so the stylesheet can tune layout for specific
+// payload shapes — github-event cards hide their meta-item labels and
+// render as a positional chip strip (branch · commit · event) instead
+// of a labeled K/V grid.
+function systemBandKindClass(kind: string): string {
+  return kind ? `chat-system-band--kind-${kind}` : "";
+}
+
+// Branch values look like code (slashes, identifier-style suffixes)
+// and deserve the same tabular-mono treatment commit SHAs get.
+function systemBandMetaValueClass(label: string): string {
+  return label === "Commit" || label === "Branch"
+    ? "chat-system-band__meta-value--mono"
+    : "";
+}
+
 // Reuse the same action-state machine MessageBody uses so loading /
 // success / error feedback is consistent across all extension surfaces.
 const allExtensionAnnotations = computed(() => props.message.extensionAnnotations ?? []);
@@ -656,7 +672,10 @@ onBeforeUnmount(() => {
       :data-message-id="message.id"
       :data-message-created-at="message.createdAt"
       class="chat-system-band animate-message-in"
-      :class="systemBandToneClass(card.presentation.tone)"
+      :class="[
+        systemBandToneClass(card.presentation.tone),
+        systemBandKindClass(card.presentation.kind),
+      ]"
     >
       <div class="chat-system-band__header">
         <span class="chat-system-band__source">
@@ -697,7 +716,7 @@ onBeforeUnmount(() => {
           <span class="chat-system-band__meta-label">{{ detail.label }}</span>
           <span
             class="chat-system-band__meta-value"
-            :class="detail.label === 'Commit' ? 'chat-system-band__meta-value--mono' : ''"
+            :class="systemBandMetaValueClass(detail.label)"
             :title="detail.value"
           >{{ detail.value }}</span>
         </span>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -12,6 +12,7 @@ import {
   Github,
   LayoutDashboard,
   MessageSquare,
+  MessagesSquare,
   Pin,
   PinOff,
 } from "lucide-vue-next";
@@ -231,7 +232,7 @@ function openThreadFromChip() {
   emit("openThread", props.message.id);
 }
 
-const MAX_CHIP_PARTICIPANTS = 2;
+const MAX_CHIP_PARTICIPANTS = 3;
 const visibleThreadParticipants = computed(() =>
   (props.threadParticipants ?? []).slice(0, MAX_CHIP_PARTICIPANTS),
 );
@@ -247,14 +248,14 @@ function formatThreadRecency(iso: string | undefined): string {
   const seconds = Math.floor(ms / 1000);
   if (seconds < 45) return "just now";
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 2) return "1 min";
-  if (minutes < 60) return `${minutes} min`;
+  if (minutes < 2) return "1 min ago";
+  if (minutes < 60) return `${minutes} min ago`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 2) return "1 hour";
-  if (hours < 24) return `${hours} hours`;
+  if (hours < 2) return "1 hour ago";
+  if (hours < 24) return `${hours} hours ago`;
   const days = Math.floor(hours / 24);
-  if (days < 2) return "1 day";
-  if (days < 7) return `${days} days`;
+  if (days < 2) return "1 day ago";
+  if (days < 7) return `${days} days ago`;
   return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
@@ -799,33 +800,18 @@ onBeforeUnmount(() => {
     >
       <AppAvatar :name="message.author" :src="avatarUrl" :presence="presence" :last-seen="lastSeen" size="message" />
     </button>
-    <!-- Thread participant stack — pulled out of the inline thread chip
-         into the avatar gutter so it sits visually under the main
-         author avatar, sharing the column with the burst rail and the
-         time gutter. Position-absolute relative to the row's grid;
-         centred horizontally in the avatar column, bottom-anchored so
-         it aligns with the chip which is the last body child. -->
+    <!-- Thread rail glyph — a small "messages-stack" icon centred in the
+         avatar column, under the author avatar. Structural marker that
+         this row anchors a thread; the rich summary (who replied, how
+         many, how recently) lives in the in-body chip. Position-absolute
+         relative to the row's grid; bottom-anchored to align with the
+         chip which is the last body child. -->
     <div
-      v-if="showThreadChip && visibleThreadParticipants.length > 0"
-      class="chat-thread-chip-gutter"
+      v-if="showThreadChip"
+      class="chat-thread-rail-glyph"
       aria-hidden="true"
     >
-      <span
-        v-for="participant in visibleThreadParticipants"
-        :key="`thread-gutter-avatar:${message.id}:${participant.nick}`"
-        class="chat-thread-chip-gutter__avatar-wrap"
-      >
-        <AppAvatar
-          :name="participant.nick"
-          :src="participant.avatarUrl ?? null"
-          :presence="participant.presence"
-          size="xs"
-        />
-      </span>
-      <span
-        v-if="threadParticipantOverflow > 0"
-        class="chat-thread-chip-gutter__overflow"
-      >+{{ threadParticipantOverflow }}</span>
+      <MessagesSquare class="chat-thread-rail-glyph__icon" />
     </div>
     <div class="chat-message-body-stack">
       <div v-if="!grouped" class="chat-message-meta-row">
@@ -946,10 +932,12 @@ onBeforeUnmount(() => {
 
     <!-- Thread replies affordance. Visible in the main channel feed on roots
          that have replies; the thread panel hides it via hideThreadChip since
-         the panel already shows children. Carries a tiny avatar stack of
-         participants (current user excluded by the caller) and a relative-
-         time suffix so the eye can triage threads at a glance — who's been
-         talking, how recently — without opening the panel. -->
+         the panel already shows children. The chip carries a row of
+         participant avatars (current user excluded by the caller) + reply
+         count, with the recency timestamp right-aligned so the eye can
+         triage threads at a glance — who's been talking, how many turns,
+         how recently — without opening the panel. The structural "this is
+         a thread" marker lives in the avatar gutter as the rail glyph. -->
     <button
       v-if="showThreadChip"
       type="button"
@@ -957,7 +945,28 @@ onBeforeUnmount(() => {
       :title="`Open thread (${threadReplyCount} ${threadReplyCount === 1 ? 'reply' : 'replies'})`"
       @click="openThreadFromChip"
     >
-      <MessageSquare class="chat-thread-chip__icon w-3 h-3 flex-shrink-0" />
+      <span
+        v-if="visibleThreadParticipants.length > 0"
+        class="chat-thread-chip__avatars"
+        aria-hidden="true"
+      >
+        <span
+          v-for="participant in visibleThreadParticipants"
+          :key="`thread-chip-avatar:${message.id}:${participant.nick}`"
+          class="chat-thread-chip__avatar-wrap"
+        >
+          <AppAvatar
+            :name="participant.nick"
+            :src="participant.avatarUrl ?? null"
+            :presence="participant.presence"
+            size="xs"
+          />
+        </span>
+        <span
+          v-if="threadParticipantOverflow > 0"
+          class="chat-thread-chip__overflow"
+        >+{{ threadParticipantOverflow }}</span>
+      </span>
       <span class="chat-thread-chip__count min-w-0 truncate">{{ threadReplyCount }} {{ threadReplyCount === 1 ? "reply" : "replies" }}</span>
       <span v-if="threadChipRecency" class="chat-thread-chip__recency">{{ threadChipRecency }}</span>
     </button>

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -519,7 +519,12 @@ function githubEventPresentation(
     title: name,
     summary,
     primaryValue: conclusion && conclusion !== "unknown" ? humanizeExtensionKey(conclusion) : humanizeExtensionKey(action),
-    secondaryValue: repository,
+    // `secondaryValue` previously echoed the repository as a prominent
+    // un-labeled meta-item — a duplicate of the Repository detail below.
+    // GitHub-event cards now use a positional chip strip (labels hidden
+    // via CSS for kind=github-event) so the repo appears exactly once,
+    // alongside branch / commit / event. Dropping the dupe gets the
+    // card from ~6 lines to ~3 on the same payload.
     ...(primaryUrl ? { primaryUrl } : {}),
     options: [],
     details,

--- a/chat/src/styles/global/extension-cards.css
+++ b/chat/src/styles/global/extension-cards.css
@@ -31,20 +31,19 @@
   flex-direction: column;
   gap: 0.3rem;
   width: 100%;
-  padding: 0.65rem var(--space-md) 0.65rem calc(var(--space-md) + 0.5rem);
-  background: linear-gradient(
-    90deg,
-    color-mix(in oklab, var(--rail-color) 6%, transparent),
-    transparent 55%
-  );
-  border-top: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
-  border-bottom: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+  padding: 0.7rem var(--space-md) 0.7rem calc(var(--space-md) + 0.5rem);
+  /* Rail-only treatment — full-card tonal wash dropped. A stack of
+   * five failing CI cards previously painted the whole feed red; the
+   * 3 px left rail (::before) carries tone alone, leaving the body
+   * neutral so the feed reads like a list of distinct events. */
+  background: transparent;
+  /* Explicit breathing room between consecutive bands. The message
+   * list's --space-2xs row gap is too tight for the visual weight of
+   * a full-width card; --space-sm gives each event its own block. */
+  margin-block-end: var(--space-sm);
+  border-top: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+  border-bottom: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
   transition: background-color 0.16s ease;
-}
-
-.chat-system-band + .chat-system-band {
-  border-top: 0;
-  margin-top: -1px;
 }
 
 .chat-system-band::before {
@@ -59,9 +58,12 @@
 }
 
 .chat-system-band:hover {
+  /* Hover gives a quiet hue-tinted lift on the BODY only — well below
+   * the at-rest wash that used to live here, and only while the user
+   * is actually pointing at the card. Standing CI feed stays neutral. */
   background: linear-gradient(
     90deg,
-    color-mix(in oklab, var(--rail-color) 10%, transparent),
+    color-mix(in oklab, var(--rail-color) 5%, transparent),
     transparent 55%
   );
 }
@@ -77,9 +79,10 @@
 .chat-system-band--inline {
   border: 1px solid color-mix(in oklab, var(--border) 88%, transparent);
   border-radius: var(--radius-md);
-  background:
-    linear-gradient(90deg, color-mix(in oklab, var(--rail-color) 5%, transparent), transparent 55%),
-    color-mix(in oklab, var(--card) 55%, transparent);
+  /* Inline variant keeps its quiet --card surface; the rail-color
+   * wash that used to layer on top is dropped (same quietening pass
+   * as the full-width band). The rail still carries tone. */
+  background: color-mix(in oklab, var(--card) 55%, transparent);
 }
 
 .chat-system-band--inline::before {
@@ -198,6 +201,20 @@
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
+}
+
+/* GitHub-event kind — positional chip strip. The labels (REPOSITORY,
+ * BRANCH, COMMIT, EVENT) carry zero new information per card (every
+ * github event publishes the same four keys), so they're hidden and
+ * the values render as a single flowing strip:
+ *
+ *   waddle-social/waddle · main · dbcbc16 · Workflow Run
+ *
+ * Position is the label — repo first, branch second, commit third,
+ * event last. The "·" between items comes from the `+ ::before`
+ * separator that's already in the base style. */
+.chat-system-band--kind-github-event .chat-system-band__meta-label {
+  display: none;
 }
 
 /* ============================================================

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -376,48 +376,64 @@
   flex-shrink: 0;
 }
 
-/* Participant stack lives in the message's avatar gutter, anchored to
- * the bottom of the avatar column so it sits visually under the main
- * author avatar (or the time gutter on grouped rows). Uses absolute
- * positioning relative to the row's grid; the message-card grid is
- * already `position: relative`. */
-.chat-thread-chip-gutter {
+/* Thread rail glyph — a single "stacked messages" icon centred in the
+ * avatar column under the main author avatar. Structural rail marker
+ * that this row anchors a thread; the rich summary (who replied + how
+ * many + how recently) lives in the in-body chip. Absolute-positioned
+ * relative to the row's grid (the message-card grid is already
+ * `position: relative`), bottom-anchored to align with the chip which
+ * is the last body child. */
+.chat-thread-rail-glyph {
   position: absolute;
-  bottom: 0.35rem;
+  bottom: 0.4rem;
   left: 0;
   width: var(--chat-message-avatar-size);
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  isolation: isolate;
   pointer-events: none;
+  color: color-mix(in oklab, var(--primary) 55%, var(--muted-foreground));
+  opacity: 0.7;
 }
 
-.chat-thread-chip-gutter__avatar-wrap {
+.chat-thread-rail-glyph__icon {
+  width: 0.95rem;
+  height: 0.95rem;
+}
+
+/* Participant stack lives inside the thread chip body, ahead of the
+ * reply count, so the eye reads "[who's here] [how many turns] …
+ * [how recently]" left-to-right. Avatars shrink to 1.125 rem so they
+ * sit comfortably on the 0.6875 rem chip text baseline and remain
+ * legible without overpowering the count. The gutter holds only the
+ * structural rail glyph; this stack carries the richness. */
+.chat-thread-chip__avatars {
+  display: inline-flex;
+  align-items: center;
+  isolation: isolate;
+  flex-shrink: 0;
+}
+
+.chat-thread-chip__avatar-wrap {
   display: inline-flex;
   margin-left: -0.35rem;
   border-radius: 9999px;
   outline: 1.5px solid var(--background);
 }
 
-.chat-thread-chip-gutter__avatar-wrap:first-child {
+.chat-thread-chip__avatar-wrap:first-child {
   margin-left: 0;
 }
 
-/* The xs AppAvatar preset is 1.5 rem; the avatar column is
- * `--chat-message-avatar-size` (≈ 2.78 rem) wide, so two visible
- * avatars plus a "+N" chip need to fit. Shrink to 1.125 rem so they
- * fit centred in the column without crowding the time-gutter
- * timestamp when both reveal on hover. */
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar,
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar > .type-avatar-mark,
-.chat-thread-chip-gutter__avatar-wrap > .app-avatar > img {
+.chat-thread-chip__avatar-wrap > .app-avatar,
+.chat-thread-chip__avatar-wrap > .app-avatar > .type-avatar-mark,
+.chat-thread-chip__avatar-wrap > .app-avatar > img {
   width: 1.125rem;
   height: 1.125rem;
   font-size: 0.55rem;
 }
 
-.chat-thread-chip-gutter__overflow {
+.chat-thread-chip__overflow {
   display: inline-flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## What

User feedback on the GitHub Actions channel: stacked CI cards read as one wall of pink noise. This PR ships proposals **A + B + D** from the prior discussion, plus explicit between-card spacing.

### A. Drop the duplicate repo line

`githubEventPresentation` no longer emits `secondaryValue: repository`. The repository still appears once via the `details` array; the dup at the top is gone. Each card drops ~1 line.

### B. Positional chip strip for github-event kind

New `.chat-system-band--kind-github-event` modifier hides `.chat-system-band__meta-label` for github cards only. The `·` separator pseudo between adjacent meta-items is already in the base style, so the row reads:

```
waddle-social/waddle · main · dbcbc16 · Workflow Run
```

Position is the label — repo first, branch second, commit third, event last. Generic / non-github cards keep their labeled grid (other extensions may have varying keys per card; their labels still carry meaning).

Branch values now monospace alongside Commit (`systemBandMetaValueClass(label)` accepts both) since branch names are code-shaped (`claude/test-error-messages-saUDm`).

### D. Rail-only failure treatment

The at-rest linear-gradient wash on `.chat-system-band` is **dropped**. The 3 px left rail (`::before`) carries tone alone. Hover still gives a quiet 5% wash on the body (vs 10% before, and at-rest is now 0%), so pointing at a failing card lifts it without painting the whole feed red. Same quietening applied to `.chat-system-band--inline`.

### + Card gutters

`.chat-system-band` gains `margin-block-end: var(--space-sm)`, so consecutive cards no longer abut. The unused `.chat-system-band + .chat-system-band` collapse rule (negative `-1px` margin between siblings — which never matched in practice because each band lives inside its own MessageCard wrapper) is removed.

## Server-side note

The GitHub extension already publishes all the right attributes (repository, branch, revision, event-type, conclusion, url, `surface="chat-bot"`) via `to_enrichment_payload` after iter 30. This PR is client-side only — the card *content* is published by the extension; the card *layout* is the chat's responsibility.

## Files

- `chat/src/lib/chat-ui.ts` — drop `secondaryValue: repository` from github presentation.
- `chat/src/components/chat/MessageCard.vue` — new `systemBandKindClass`, `systemBandMetaValueClass` helpers; emit `chat-system-band--kind-github-event` on the band root; monospace Branch like Commit.
- `chat/src/components/chat/MessageBody.vue` — same kind class on the inline band; same branch-mono extension.
- `chat/src/styles/global/extension-cards.css` — at-rest wash → 0%; hover wash 10% → 5%; bottom margin between bands; new `--kind-github-event` rule that hides meta labels.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Note: my local Chrome MCP session can't trigger the system-band render — the messages in the live channel pre-date iter 30's server deploy, so they don't carry the `chat-bot` surface annotation yet. The user's earlier screenshot shows the same payload rendering as a system band, so the new CSS/template will be visible once the page picks up this PR.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation in user's session once page reloads
- [ ] CI green on PR

This PR was created with the assistance of a LLM.