### PR TITLE
fix(chat): composer card lift — at-rest border + primary-tinted focus border

### DIFF
--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -4,9 +4,36 @@
   box-shadow: var(--shadow-pane);
 }
 
+/* The composer input-shell is where the user writes — the most
+ * emotionally-loaded interaction surface in the app. Previously it
+ * relied on bg-muted + a focus ring for definition, which left the
+ * at-rest state edgeless: the shell blended into the composer pane
+ * backdrop with nothing saying "this is where you type." Two small
+ * additions:
+ *
+ *   - A subtle border at rest so the shell reads as a card, not a
+ *     muted band. ~30% --border in alpha so it sits behind the type
+ *     without competing.
+ *   - Primary-tinted border on focus-within so the surface "wakes"
+ *     when the user lands the caret. The tailwind ring-2 + glow on
+ *     :focus inside the shell still applies; the border colour swap
+ *     gives the lift a clear edge in addition to the ambient halo.
+ *
+ * Transitions are short (180 ms) so the focus state feels responsive,
+ * not floaty. */
 .chat-composer-input-shell {
   min-height: var(--chat-composer-inner-height);
   border-radius: var(--chat-composer-input-radius);
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  transition: border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.chat-composer-input-shell:hover {
+  border-color: color-mix(in oklab, var(--border) 92%, transparent);
+}
+
+.chat-composer-input-shell:has(:focus) {
+  border-color: color-mix(in oklab, var(--primary) 52%, transparent);
 }
 
 .chat-composer-input-action {


### PR DESCRIPTION
## What

The composer input-shell relied on `bg-muted` + a tailwind focus ring for definition. That left the at-rest state edgeless — the shell blended into the composer pane backdrop with nothing distinguishing *"this is where you type"* from the chrome around it. The user writes in this surface every interaction; it should feel like a card, not a band.

Two small additions to `.chat-composer-input-shell` in `composer-pane.css`:

1. **At-rest border** — `1 px solid color-mix(in oklab, var(--border) 70%, transparent)`. Visible enough to define the card, light enough to sit behind the type.
2. **Hover lift** — same border at 92 % alpha. A quiet "you can interact with me" signal on pointer-over without committing to a focus state.
3. **Focus-within border** — switches to 52 % `var(--primary)` so the surface "wakes" when the caret lands inside the ProseMirror editor. The existing tailwind `ring-2` + `shadow-[0_0_22px_var(--glow-strong)]` on `:focus` still apply; the border swap gives the lift a clear edge in addition to the ambient halo.

Transition is 180 ms on `border-color` and `background-color`, so the focus state feels responsive, not floaty. Uses `:has(:focus)` to match focus inside the ProseMirror editor since the shell itself isn't focusable.

## Files

- `chat/src/styles/global/composer-pane.css` — `.chat-composer-input-shell` gains `border`, `transition`, `:hover`, `:has(:focus)` rules.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Visual confirmation in Chrome MCP at `localhost:4321`:
  - At rest: composer reads as a defined card with quiet edge.
  - On focus: full primary-teal border around the shell + caret in the editor.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.