### PR TITLE
fix(chat): composer — extensions to right, GIF mark on left, autofocus search

### DIFF
--- a/chat/src/components/chat/GifPicker.vue
+++ b/chat/src/components/chat/GifPicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { Search, X } from "lucide-vue-next";
 
 const props = defineProps<{
@@ -11,6 +11,11 @@ const emit = defineEmits<{
   select: [url: string];
   close: [];
 }>();
+
+const searchInput = ref<HTMLInputElement | null>(null);
+onMounted(() => {
+  searchInput.value?.focus();
+});
 
 interface GiphyGif {
   id: string;
@@ -68,6 +73,7 @@ function selectGif(gif: GiphyGif) {
           aria-hidden="true"
         />
         <input
+          ref="searchInput"
           v-model="query"
           type="text"
           placeholder="Search GIFs…"

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from "vue";
-import { Send, Image, Paperclip, FileText, Music4, Puzzle, X, Loader2 } from "lucide-vue-next";
+import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2 } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
@@ -787,6 +787,10 @@ watch(
         class="hidden"
         @change="onFileInputChange"
       />
+      <!-- LEFT cluster: content-add actions (attach, GIF). The picker
+           launched by the second button is GIPHY-only — not a generic
+           photo browser — so the affordance is a typographic GIF mark
+           rather than a photo icon. -->
       <button
         type="button"
         class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
@@ -798,16 +802,16 @@ watch(
         <Paperclip class="w-4 h-4" aria-hidden="true" />
       </button>
       <button
-        :ref="setExtensionButtonRef"
         type="button"
-        class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
-        title="Extensions"
-        aria-label="Extensions"
-        :aria-expanded="extensionsOpen"
+        class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 active:scale-[0.94] disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
+        :class="showGifPicker ? 'bg-background/80 text-primary' : 'text-muted-foreground hover:bg-background/70 hover:text-primary'"
+        title="Search GIFs"
+        aria-label="Search GIFs"
+        :aria-expanded="showGifPicker"
         :disabled="disabled"
-        @click="emit('openExtensions')"
+        @click="showGifPicker = !showGifPicker"
       >
-        <Puzzle class="w-4 h-4" aria-hidden="true" />
+        <span class="chat-composer-gif-badge" aria-hidden="true">GIF</span>
       </button>
       <ChatEditor
         :ref="setEditorRef"
@@ -821,17 +825,21 @@ watch(
         @cancel="onEditorCancel"
         @paste="onEditorPaste"
       />
+      <!-- RIGHT cluster: dispatch actions (extensions menu, send).
+           Extensions live next to send so the right edge is consistently
+           "fire an action"; the left edge is consistently "add to the
+           message draft". -->
       <button
+        :ref="setExtensionButtonRef"
         type="button"
-        class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 active:scale-[0.94] disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
-        :class="showGifPicker ? 'bg-background/80 text-primary' : 'text-muted-foreground hover:bg-background/70 hover:text-primary'"
-        title="Open GIF picker"
-        aria-label="Open GIF picker"
-        :aria-expanded="showGifPicker"
+        class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 text-muted-foreground hover:bg-background/70 hover:text-primary active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
+        title="Extensions"
+        aria-label="Extensions"
+        :aria-expanded="extensionsOpen"
         :disabled="disabled"
-        @click="showGifPicker = !showGifPicker"
+        @click="emit('openExtensions')"
       >
-        <Image class="w-4 h-4" aria-hidden="true" />
+        <Puzzle class="w-4 h-4" aria-hidden="true" />
       </button>
       <button
         type="button"

--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -40,6 +40,24 @@
   border-radius: var(--chat-composer-input-control-radius);
 }
 
+/* Typographic "GIF" mark — used in place of a photo-style icon for
+ * the GIF search button. The picker is GIPHY-only, so calling it
+ * out with a 3-letter badge avoids the "is this for any image?"
+ * confusion the Image icon caused. Inherits color from the button so
+ * the hover/active states light it up via `text-primary`. */
+.chat-composer-gif-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.1rem 0.28rem;
+  border-radius: 0.3rem;
+  border: 1.25px solid currentColor;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
 .chat-composer-popover {
   left: var(--chat-content-inline);
   right: var(--chat-content-inline);


### PR DESCRIPTION
## What

User feedback on the iter-36 composer screenshot:

> Extensions on the right, photos and attachments on the left. When we click on the photo icon, the gif search above should have focus by default. Also swap the photos icon for a gif icon. This isn't for generic photos.

Three changes:

### 1. Layout swap

Extensions (Puzzle) moves from the left cluster → right cluster, sitting next to Send. The left edge is now consistently "add content to the draft" (📎 attach, GIF) and the right edge is consistently "fire an action on the draft" (Extensions, Send).

### 2. GIF mark replaces the Image icon

The picker behind that button is GIPHY-only — not a generic photo browser — so the affordance becomes a typographic **GIF** badge: 3-letter mark in `currentColor` with a 1.25 px rounded border. Inherits color from its parent button so the hover/active `text-primary` states light it up. The `Image` import is removed from lucide.

### 3. GIF picker autofocuses its search input

`GifPicker.vue` captures a `searchInput` ref and calls `.focus()` in `onMounted` so the moment the picker appears the caret is already in the search field. Previously you had to click into the search box after opening.

## Files

- `chat/src/components/chat/MessageComposer.vue` — button order swap; `Image` import removed; GIF button uses `<span class="chat-composer-gif-badge">GIF</span>` instead of an icon.
- `chat/src/components/chat/GifPicker.vue` — `searchInput` ref + `onMounted` autofocus.
- `chat/src/styles/global/composer-pane.css` — new `.chat-composer-gif-badge` rule.

## Verification

- `bun run lint` clean (knip).
- `bun test` 761/761 green.
- Visual confirmation in Chrome MCP at `localhost:4321`:
  - Layout: `[📎] [GIF] … [🧩] [▶]`
  - Click GIF → picker opens, search field has caret.
  - Typing "penguin" without clicking the search box lands in the input — autofocus confirmed.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.