### PR TITLE
fix(chat): persist decrypted URL for encrypted video (and audio/PDF) attachments

### DIFF
--- a/chat/src/channels/message-attachments.ts
+++ b/chat/src/channels/message-attachments.ts
@@ -220,7 +220,7 @@ export function useMessageAttachments(message: ReadonlyRef<TimelineMessage>) {
         return null;
       }
       if (!persist) return objectUrl;
-      const stillVisible = imageAttachments.value.some((attachment) => attachmentKey(attachment) === key);
+      const stillVisible = previewableAttachments.value.some((attachment) => attachmentKey(attachment) === key);
       if (!stillVisible) {
         URL.revokeObjectURL(objectUrl);
         return null;

--- a/chat/tests/message-attachments-lightbox.test.ts
+++ b/chat/tests/message-attachments-lightbox.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { nextTick, ref } from "vue";
 import { useMessageAttachments } from "@/channels/message-attachments";
 import type { TimelineMessage, TimelineSharedFile } from "@/lib/chat-ui";
+import { prepareEncryptedAttachmentUpload } from "@/lib/xmpp/encrypted-attachments";
 
 type MessageRef = Parameters<typeof useMessageAttachments>[0];
 
@@ -244,5 +245,57 @@ describe("useMessageAttachments lightbox state", () => {
 
     expect(attachments.lightboxOpen.value).toBe(false);
     expect(attachments.lightboxIndex.value).toBe(0);
+  });
+});
+
+describe("useMessageAttachments encrypted video decryption", () => {
+  const savedFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = savedFetch;
+  });
+
+  it("persists the decrypted URL for an encrypted video so it renders instead of staying at 'Preparing video…'", async () => {
+    const savedWindow = (globalThis as Record<string, unknown>).window;
+    const savedCreateObjectURL = URL.createObjectURL;
+    const savedRevokeObjectURL = URL.revokeObjectURL;
+
+    try {
+      // Simulate a browser context so ensureAttachmentReady proceeds past its
+      // early-return guard (`typeof window === "undefined"`).
+      (globalThis as Record<string, unknown>).window = globalThis;
+
+      const revokedUrls: string[] = [];
+      URL.createObjectURL = mock(() => "blob:fake-decrypted-video") as typeof URL.createObjectURL;
+      URL.revokeObjectURL = mock((url: string) => { revokedUrls.push(url); }) as typeof URL.revokeObjectURL;
+
+      const original = new File(["video content"], "clip.mp4", { type: "video/mp4" });
+      const prepared = await prepareEncryptedAttachmentUpload(original);
+      const encryptedUrl = "https://files.example.com/clip.mp4.enc";
+      const ciphertext = await prepared.uploadFile.arrayBuffer();
+
+      globalThis.fetch = mock(async () => new Response(ciphertext, { status: 200 })) as typeof fetch;
+
+      const file: TimelineSharedFile = {
+        url: encryptedUrl,
+        name: "clip.mp4",
+        mediaType: "video/mp4",
+        disposition: "inline",
+        encrypted: { ...prepared.encrypted, sources: [encryptedUrl] },
+      };
+
+      const attachments = messageAttachments(ref(messageWithFiles([file])));
+
+      // Give the watcher-triggered async decryption time to complete.
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      await nextTick();
+
+      expect(attachments.resolvedAttachmentUrl(file)).toBe("blob:fake-decrypted-video");
+      expect(revokedUrls).not.toContain("blob:fake-decrypted-video");
+    } finally {
+      URL.createObjectURL = savedCreateObjectURL;
+      URL.revokeObjectURL = savedRevokeObjectURL;
+      (globalThis as Record<string, unknown>).window = savedWindow;
+    }
   });
 });


### PR DESCRIPTION
ensureAttachmentReady checked imageAttachments to decide whether the
attachment was still visible before storing the decrypted blob URL. For
video, audio, and PDF attachments this check always returned false,
causing the fresh object URL to be immediately revoked and the
decryptedAttachmentUrls map to never be updated. resolvedAttachmentUrl
therefore kept returning null, leaving the recipient stuck at
"Preparing video…" indefinitely.

Fix: check previewableAttachments (the union of images, videos, audio,
and PDFs) instead of imageAttachments.

Adds a test that drives the full encrypt→upload→decrypt cycle for an
encrypted video and asserts that the resolved URL is stored (not
revoked) after decryption.

https://claude.ai/code/session_01B1veGg7kswqkLYGDWCQXUn