### PR TITLE
fix(chat): extension route empty state — halo glyph + headline + hint

### DIFF
--- a/chat/src/components/chat/ExtensionRouteView.vue
+++ b/chat/src/components/chat/ExtensionRouteView.vue
@@ -36,6 +36,16 @@ const routeKey = computed(() =>
 );
 
 const surfaceIcon = computed(() => props.route?.surface === "gallery" ? Grid3X3 : List);
+
+// Derives "No saved links yet" / "No pins yet" / etc. from the route's
+// label. Falls back to a generic "Nothing here yet" when no route is
+// resolved (loading / error / missing-route states render different
+// branches; this is purely for the empty `items` happy path).
+const emptyHeadline = computed(() => {
+  const label = props.route?.label?.trim();
+  if (!label) return "Nothing here yet";
+  return `No ${label.toLowerCase()} yet`;
+});
 let refreshRequestId = 0;
 
 async function refreshItems() {
@@ -156,8 +166,22 @@ onMounted(focusPanel);
         <WifiOff class="h-4 w-4 shrink-0" />
         <span class="type-control">{{ actionError }}</span>
       </div>
-      <div v-else-if="items.length === 0" class="type-caption flex h-full items-center justify-center text-muted-foreground">
-        Nothing saved yet.
+      <!-- Empty state — replaces the prior bare "Nothing saved yet."
+           with the iter-20 halo+glyph pattern so the panel feels
+           authored, not empty. Headline derives from the route's
+           label ("No saved links yet", "No pins yet") so any extension
+           route gets a meaningful empty state without per-route copy. -->
+      <div v-else-if="items.length === 0" class="chat-route-empty">
+        <div class="chat-empty-state__halo">
+          <div class="chat-empty-state__halo-glow chat-empty-state__halo-glow--primary"></div>
+          <div class="chat-empty-state__halo-ring chat-empty-state__halo-ring--primary">
+            <component :is="surfaceIcon" class="h-4 w-4 text-primary" aria-hidden="true" />
+          </div>
+        </div>
+        <div class="type-card-title text-foreground">{{ emptyHeadline }}</div>
+        <div class="type-caption text-muted-foreground max-w-[18rem]">
+          Items added through {{ route?.label ?? "this extension" }} will appear here.
+        </div>
       </div>
       <div
         v-else

--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -196,6 +196,22 @@
   text-align: center;
 }
 
+/* Side-rail panel empty state (Saved Links, Pins, etc.) — same halo
+ * pattern as `.chat-empty-state` but scaled for the narrower side
+ * panel: fills the parent's height (the `.chat-pane-scroll` ancestor
+ * isn't a flex container, so we use min-height: 100% instead of
+ * flex-1 to claim the available space), tighter gap, content
+ * stacked and centered both axes. */
+.chat-route-empty {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  text-align: center;
+}
+
 .chat-empty-state__halo {
   position: relative;
   isolation: isolate;


### PR DESCRIPTION
## What

The right-rail extension route panels (Saved Links, Pins, Tasks, …) rendered `Nothing saved yet.` as bare centred text. The rest of the app uses the iter-20 halo+glyph empty-state pattern, so the side-panel empty state stuck out as unauthored.

Replace the plain text with the same three-element pattern, scaled for the narrower side panel:

1. **Halo glyph** — the route's surface icon (Grid3X3 for gallery, List for list) inside the primary-tinted halo ring, matching the iter-20 mascot empty channels.
2. **Headline** — `No {route.label.toLowerCase()} yet`. Derives a natural headline from the route's own label so any extension route gets a meaningful title without per-route copy. Falls back to "Nothing here yet" when no route is resolved.
3. **Hint** — one line: `Items added through {route.label} will appear here.` Tells the user how items end up in this panel without prescribing the specific UI motion (which differs per extension).

## CSS

New `.chat-route-empty` rule mirrors `.chat-empty-state` (flex column, centred, gap) but uses `min-height: 100%` instead of `flex: 1` — `.chat-pane-scroll` isn't a flex container, so `flex: 1` wouldn't claim the panel height. `min-height: 100%` gets us the same "fill the panel" behaviour through the parent's own height resolution, with content centred both axes.

## Files

- `chat/src/components/chat/ExtensionRouteView.vue` — `emptyHeadline` computed; new empty-state markup wrapping `surfaceIcon` in the halo pattern.
- `chat/src/styles/global/composer-pane.css` — new `.chat-route-empty` rule placed next to `.chat-empty-state`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: open Saved Links panel in a channel with no saved items — empty state shows halo + "No saved links yet" + the hint, centred in the panel.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.