### PR TITLE
fix(chat): avatar fallback — radial gradient gives the letter mark depth

### DIFF
--- a/chat/src/components/ui/AppAvatar.vue
+++ b/chat/src/components/ui/AppAvatar.vue
@@ -39,6 +39,20 @@ const wrapperSizeClass = computed(() => {
 });
 
 const bgColor = computed(() => consistentColor(props.name, 55, 45));
+
+// Subtle radial gradient for the letter-fallback avatar — slight
+// highlight up-and-left, base color in the body, slight shade
+// bottom-right. Mixes in OKLab against the name-derived hue so each
+// avatar keeps its identity while gaining a tiny "lit from above"
+// dimensionality. Flat-solid discs read as wireframes; this reads
+// as a finished mark without straying into skeuomorphic territory.
+const fallbackBackground = computed(() =>
+  `radial-gradient(circle at 32% 26%, ` +
+    `color-mix(in oklab, ${bgColor.value}, white 22%), ` +
+    `${bgColor.value} 58%, ` +
+    `color-mix(in oklab, ${bgColor.value}, black 14%))`,
+);
+
 const showImage = computed(() => !!props.src && !imageFailed.value);
 
 const presenceDotColor = computed(() => {
@@ -116,7 +130,10 @@ watch(
     <div
       v-else
       :class="[sizeClass, 'type-avatar-mark flex items-center justify-center rounded-lg text-white']"
-      :style="{ backgroundColor: bgColor, boxShadow: `0 2px 8px ${bgColor}30` }"
+      :style="{
+        background: fallbackBackground,
+        boxShadow: `inset 0 1px 0 rgba(255,255,255,0.18), 0 2px 8px ${bgColor}30`,
+      }"
     >
       {{ initials }}
     </div>


### PR DESCRIPTION
## What

Letter-fallback avatars (every user without an uploaded image, and every bot using the consistent-color initials disc) rendered as a flat solid color. In a channel like GitHub Actions with multiple bots stacking identical green discs, the feed read as wireframes — finished by tone, not by craft.

Replace the flat `backgroundColor` with a subtle **radial gradient** keyed off the same name-derived hue:

- **Highlight** up-and-left (32% 26%): `color-mix(in oklab, ${bgColor}, white 22%)` — a quiet "lit from above" hotspot.
- **Base** body (58%): the `bgColor` itself.
- **Shade** bottom-right (100%): `color-mix(in oklab, ${bgColor}, black 14%)`.

All mixing happens in OKLab so the gradient stays in the avatar's own hue family — the avatar still reads as "that green" for `github`, "that blue" for some user named Sam — just with a tiny sphere-like quality instead of a flat sticker.

Plus an `inset 0 1px 0 rgba(255,255,255,0.18)` top-edge highlight on the box-shadow so the disc gets a hint of inner-rim catch. The existing outer `0 2px 8px ${bgColor}30` halo is unchanged.

## Files

- `chat/src/components/ui/AppAvatar.vue` — new `fallbackBackground` computed; inline `background` and `boxShadow` swapped in the fallback `<div>`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: bot G-avatars and user fallbacks in the channel feed now show clear dimensionality without straying skeuomorphic.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.