### PR TITLE
fix(chat): sidebar active-channel rail — match unread's rail language

### DIFF
--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -303,7 +303,7 @@ watch(
                 class="chat-list-row w-full min-h-10 flex items-center gap-2.5 px-3 py-2 text-left group"
                 :class="[
                   isActiveChannelPage(channel)
-                    ? 'bg-sidebar-accent text-sidebar-foreground'
+                    ? 'chat-list-row--active bg-sidebar-accent text-sidebar-foreground'
                     : 'text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground',
                   !isActiveChannelPage(channel) && unread.mentions > 0
                     ? 'chat-list-row--unread chat-list-row--mention'

--- a/chat/src/styles/global/controls.css
+++ b/chat/src/styles/global/controls.css
@@ -178,12 +178,37 @@
     border-color 0.18s ease;
 }
 
-/* Unread / mention emphasis for sidebar channel rows. A 2px accent rail
- * pinned to the inside-left edge picks up the same --primary / --destructive
- * language used by the composer armed glow, hover toolbar, and reaction
- * chips — so unread channels read as part of the same brand system instead
- * of a one-off "bold + dot" treatment. The rail anchors to the row's
- * rounded corner so it doesn't clip on small radius. */
+/* Unread / mention / active emphasis for sidebar channel rows. A
+ * left-edge accent rail picks up the same --primary / --destructive
+ * language used by the composer armed glow, hover toolbar, and
+ * reaction chips — so the sidebar reads as part of the same brand
+ * system instead of a one-off "bold + dot" treatment. Three
+ * intensities tell the user three states at a glance:
+ *
+ *   - **Active** (the channel currently being viewed): 3 px rail,
+ *     full height, strong glow — paired with the existing
+ *     bg-sidebar-accent fill so the row has BOTH a rail and a
+ *     surface signal ("you are here").
+ *   - **Unread** (has unread messages but not active): 2 px rail
+ *     with a quieter glow.
+ *   - **Mention** (unread + you were @-mentioned): 2 px rail but
+ *     in --destructive instead of --primary.
+ *
+ * The rail anchors to the row's rounded corner so it doesn't clip
+ * on small radius. */
+.chat-list-row--active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12%;
+  bottom: 12%;
+  width: 3px;
+  border-radius: 0 1.5px 1.5px 0;
+  background: var(--primary);
+  box-shadow: 0 0 12px var(--glow-strong);
+  pointer-events: none;
+}
+
 .chat-list-row--unread::before {
   content: "";
   position: absolute;
@@ -211,6 +236,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .chat-list-row--active::before,
   .chat-list-row--unread::before,
   .chat-list-row--mention::before {
     box-shadow: none;


### PR DESCRIPTION
## What

The sidebar used two competing visual idioms for row emphasis:

- **Active channel** (currently being viewed): full `bg-sidebar-accent` fill, no rail.
- **Unread channel** (has activity but not viewed): 2 px primary left-rail with glow, no fill.

"You are here" and "you have unread here" looked like different species. The rail language is what the composer armed glow, the hover toolbar, the reaction chips speak — the brand system — and the active state was reaching for a generic surface fill instead.

Unifies on the rail. A new `chat-list-row--active` modifier adds a **3 px primary left-rail** on the active row (full-height, with the stronger `--glow-strong` halo), paired with the existing `bg-sidebar-accent` fill. Three intensities now tell three states at a glance:

| State    | Rail              | Fill       |
|----------|-------------------|------------|
| Active   | 3 px `--primary`  | bg-accent  |
| Unread   | 2 px `--primary`  | (hover)    |
| Mention  | 2 px `--destructive` | (hover) |
| Default  | none              | (hover)    |

`prefers-reduced-motion: reduce` silences the glow on all three rails consistently.

## Files

- `chat/src/styles/global/controls.css` — new `.chat-list-row--active::before` rule; extended reduced-motion block.
- `chat/src/components/chat/TopicsPanel.vue` — wire `chat-list-row--active` into the active class-binding.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: active "GitHub Actions" row shows a primary-teal rail on the left edge alongside its existing bg fill.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.