### PR TITLE
fix(chat): channel header — surface room description as subtitle

### DIFF
--- a/chat/src/components/chat/ChatHeader.vue
+++ b/chat/src/components/chat/ChatHeader.vue
@@ -159,6 +159,15 @@ const memberButtonCopy = computed(() => {
           <div v-if="dmPeer" class="lg:hidden type-caption text-muted-foreground truncate">
             {{ presenceText(dmPeer.presenceShow) }}
           </div>
+          <!-- Desktop subtitle slot: prefer the channel's own description
+               (its "topic") so rooms with a stated subject get character
+               at the top of the chat instead of an empty title bar.
+               Falls back to the space name (already what mobile shows)
+               when no description is set. Single-line, truncate, muted
+               so it sits behind the H1 title without competing. -->
+          <div v-else-if="channel?.description" class="type-caption text-muted-foreground truncate">
+            {{ channel.description }}
+          </div>
           <div v-else-if="channel && waddle" class="lg:hidden type-caption text-muted-foreground truncate">
             {{ waddle.name }}
           </div>


### PR DESCRIPTION
## What

The desktop channel header was title-only. `ChannelSummary` carries a `description` (the room's "topic" — what this channel is about), but the header never surfaced it: rooms with a clear topic looked identical to rooms with none.

Add a single-line subtitle directly below the H1 channel name:

- **`channel.description` set**: render the description as a muted caption (`type-caption text-muted-foreground truncate`) on BOTH desktop and mobile. Long descriptions clip with ellipsis so the row stays one line.
- **Unset on mobile**: continue to fall back to the space name (the existing mobile-only behaviour — desktop already showed nothing).
- **Unset on desktop**: nothing — clean.

Pure investment: lands the surface so rooms with topics get character at the top of the chat the moment someone sets one. No behavioural change for channels with no description today.

## Files

- `chat/src/components/chat/ChatHeader.vue` — new `v-else-if="channel?.description"` branch placed before the existing mobile-fallback.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: injected a probe description into the active channel via a DOM stub and confirmed the subtitle renders below the H1 (e.g., `CI alerts for waddle-social/waddle — failures route here`).

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP via DOM probe
- [ ] CI green on PR

This PR was created with the assistance of a LLM.