### PR TITLE
fix(chat): rendered reply chip — match iter-42 composer chip language

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -890,20 +890,23 @@ onBeforeUnmount(() => {
     <!-- Reply preview chip. Clicking scrolls to the parent message; if the
          preview is available we also expand it inline so users still see the
          full quoted text even when the parent has scrolled off-screen or
-         hasn't loaded from history yet. -->
+         hasn't loaded from history yet.
+         Visual language matches iter-42's composer reply chip: a 3 px
+         primary-tinted left rail + italic preview text so "you are
+         replying" and "this is a reply" speak one dialect. -->
     <div v-if="message.replyTo && !hideReplyChip" class="chat-message-fill">
       <button
         type="button"
-        class="type-caption flex min-h-7 max-w-full items-center gap-1.5 rounded-lg bg-muted/35 px-2 text-left text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+        class="type-caption flex min-h-7 max-w-full items-center gap-1.5 rounded-lg border-l-[3px] border-l-primary/55 bg-muted/35 px-2 text-left text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
         :aria-expanded="replyChipExpanded"
         :title="message.replyTo.preview ? 'Show full quoted message and jump to it' : 'Jump to replied message'"
         @click="onReplyChipClick"
       >
-        <CornerDownRight class="w-3 h-3 flex-shrink-0" />
+        <CornerDownRight class="w-3 h-3 flex-shrink-0 text-primary/70" />
         <span class="type-emphasis text-primary/80">@{{ replyAuthorName }}</span>
         <span
           v-if="message.replyTo.preview"
-          :class="['flex-1 min-w-0 opacity-70', replyChipExpanded ? 'whitespace-pre-wrap break-words' : 'truncate']"
+          :class="['flex-1 min-w-0 italic opacity-75', replyChipExpanded ? 'whitespace-pre-wrap break-words' : 'truncate']"
         >{{ message.replyTo.preview }}</span>
         <span v-else class="type-mono opacity-60">{{ message.replyTo.id.slice(0, 8) }}</span>
       </button>


### PR DESCRIPTION
## What

When a message replies to another, MessageCard renders an inline chip above the body — `↪ @user · preview` — but with a different visual language than iter-42's composer reply chip:

| Surface             | Bg          | Rail          | Icon         | Preview      |
|---------------------|-------------|---------------|--------------|--------------|
| Composer chip (iter 42) | `bg-muted/70` | 3 px `--primary` | primary-teal CornerDownLeft | italic |
| Rendered chip (before)  | `bg-muted/35` | none | plain CornerDownRight | prose |

Two surfaces saying "this is a reply" in two different voices. Unify on the iter-42 language so the brand system reads consistently across compose vs. consume.

Three small drop-in changes to MessageCard's reply chip:

1. **3 px primary left rail** via `border-l-[3px] border-l-primary/55` — same accent as the composer chip, the iter-39 sidebar active row, and the iter-32 mention bar.
2. **Primary-tinted icon**: `text-primary/70` on the CornerDownRight so the leading glyph matches the rail it sits next to.
3. **Italic preview**: the quoted message text gets `italic`, so `↪ @randax / *We need to fix that*` reads as a distinct fragment rather than as more chrome.

No layout change — same children, same hover behaviour, same click handler (scrolls to parent + inline-expands when preview is present).

## Files

- `chat/src/components/chat/MessageCard.vue` — reply preview chip button class extended; icon span gains `text-primary/70`; preview span gains `italic`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: scrolled to a reply, zoomed on the chip — clearly shows primary-teal rail + ↪ + @randax + italic *"We need to fix that"*.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.