### PR TITLE
fix(chat): composer popovers — distinguish keyboard-selected from hover

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -721,8 +721,10 @@ watch(
           v-for="(candidate, i) in mentionResults"
           :key="candidate.kind === 'broadcast' ? `broadcast:${candidate.username}` : candidate.jid ?? candidate.username"
           type="button"
-          class="type-control w-full h-9 px-3 py-0 text-left hover:bg-muted transition-colors flex items-center gap-2 rounded-lg"
-          :class="i === selectedIndex ? 'bg-muted' : ''"
+          class="type-control w-full h-9 px-3 py-0 text-left transition-colors flex items-center gap-2 rounded-lg"
+          :class="i === selectedIndex
+            ? 'bg-primary/15 hover:bg-primary/20'
+            : 'hover:bg-muted'"
           @mousedown.prevent="insertMention(candidate)"
         >
           <span
@@ -756,8 +758,10 @@ watch(
           v-for="(entry, i) in emojiResults"
           :key="entry.name"
           type="button"
-          class="type-control w-full h-9 px-3 py-0 text-left hover:bg-muted transition-colors flex items-center gap-2 rounded-lg"
-          :class="i === selectedIndex ? 'bg-muted' : ''"
+          class="type-control w-full h-9 px-3 py-0 text-left transition-colors flex items-center gap-2 rounded-lg"
+          :class="i === selectedIndex
+            ? 'bg-primary/15 hover:bg-primary/20'
+            : 'hover:bg-muted'"
           @mousedown.prevent="insertEmoji(entry.emoji)"
         >
           <span>{{ entry.emoji }}</span>

--- a/chat/src/components/chat/SlashCommandPopover.vue
+++ b/chat/src/components/chat/SlashCommandPopover.vue
@@ -29,8 +29,10 @@ const emit = defineEmits<{
         v-for="(command, i) in candidates"
         :key="command.node"
         type="button"
-        class="type-control w-full h-9 px-3 py-0 text-left hover:bg-muted transition-colors flex items-center gap-2 rounded-lg"
-        :class="i === selectedIndex ? 'bg-muted' : ''"
+        class="type-control w-full h-9 px-3 py-0 text-left transition-colors flex items-center gap-2 rounded-lg"
+        :class="i === selectedIndex
+          ? 'bg-primary/15 hover:bg-primary/20'
+          : 'hover:bg-muted'"
         @mousedown.prevent="emit('pick', command)"
       >
         <Slash class="h-4 w-4 text-primary" aria-hidden="true" />


### PR DESCRIPTION
## What

Mention picker, emoji picker, and slash command popover all used `bg-muted` for BOTH the keyboard-selected row AND the hovered row. When arrow-keying through suggestions you couldn't tell which row you were on vs which row your cursor happened to be over — both read as the same muted grey.

Switch keyboard-selected to a primary-tinted bg so the two signals separate cleanly. Applied identically across all three popovers so mention / emoji / slash speak one selection language:

| State        | Class                                  | Reading                       |
|--------------|----------------------------------------|-------------------------------|
| Selected     | `bg-primary/15 hover:bg-primary/20`    | teal tint, brighter on hover  |
| Not selected | `hover:bg-muted`                       | grey on hover only            |

Now if the user arrow-down-selects "randax" and then mouses over "rawkode", they see two distinct visual states at once: the teal tint on the keyboard position and the grey on the cursor position. Clear feedback about both inputs.

## Files

- `chat/src/components/chat/MessageComposer.vue` — mention picker button + emoji picker button.
- `chat/src/components/chat/SlashCommandPopover.vue` — slash command list button.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: typed `@r` to open mention popover, observed "everyone" primary-tinted at position 0; pressed `Down Down`, observed tint move to "randax" at position 2.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.