### PR TITLE
fix(chat): mention popover — distinct icons for @everyone vs @here

### DIFF
--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from "vue";
-import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2 } from "lucide-vue-next";
+import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2, Megaphone, Radio } from "lucide-vue-next";
 import type { JSONContent } from "@tiptap/core";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
@@ -725,9 +725,26 @@ watch(
           :class="i === selectedIndex ? 'bg-muted' : ''"
           @mousedown.prevent="insertMention(candidate)"
         >
+          <!-- Broadcast mentions get distinct glyphs so @everyone vs @here
+               reads at a glance without scanning the username text:
+               Megaphone = announce to everyone, Radio = ping the people
+               who are tuned in (online here). Other broadcast values
+               (future-proof) fall back to a generic @ mark. -->
           <span
-            v-if="candidate.kind === 'broadcast'"
-            class="type-caption text-primary"
+            v-if="candidate.kind === 'broadcast' && candidate.username === 'everyone'"
+            class="flex h-5 w-5 items-center justify-center rounded bg-primary/10 text-primary"
+          >
+            <Megaphone class="h-3 w-3" aria-hidden="true" />
+          </span>
+          <span
+            v-else-if="candidate.kind === 'broadcast' && candidate.username === 'here'"
+            class="flex h-5 w-5 items-center justify-center rounded bg-primary/10 text-primary"
+          >
+            <Radio class="h-3 w-3" aria-hidden="true" />
+          </span>
+          <span
+            v-else-if="candidate.kind === 'broadcast'"
+            class="flex h-5 w-5 items-center justify-center rounded bg-primary/10 text-primary type-caption"
           >@</span>
           <img
             v-else-if="candidate.avatar_url"


### PR DESCRIPTION
## What

In the mention popover, both broadcast targets — `@everyone` and `@here` — rendered with the same generic `@` text mark. They're functionally different:

- `@everyone` notifies every member of the room
- `@here` notifies only those currently tuned in

But visually you had to read the username text to tell them apart.

Swap in distinct lucide glyphs in primary-tinted squares so each row reads at a glance:

| Target              | Glyph        | Reading                                    |
|---------------------|--------------|--------------------------------------------|
| `@everyone`         | `Megaphone`  | announce to all                            |
| `@here`             | `Radio`      | concentric arcs — ping the tuned-in        |
| Unknown broadcast   | `@`          | fallback, same square dimensions           |
| Member candidate    | Avatar       | unchanged                                  |

Squares use `h-5 w-5 rounded bg-primary/10 text-primary` — same dimensions as the avatar slot for member candidates — so vertical rhythm in the popover stays uniform regardless of row type.

## Files

- `chat/src/components/chat/MessageComposer.vue` — `Megaphone`, `Radio` imports added; broadcast leading element split into three `v-if` branches keyed on `candidate.username`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: opened mention popover with `@`, observed Megaphone at `@everyone` (top), Radio at `@here` (second), real avatars below for `randax`, `icepuma`, `rawkode`.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.