### PR TITLE
fix(chat): retracted tombstone — Trash2 glyph + lift opacity

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -740,12 +740,16 @@ onBeforeUnmount(() => {
     </section>
   </template>
 
-  <!-- Retracted tombstone -->
+  <!-- Retracted tombstone — body is gone but author/time/avatar
+       stay for context. Lift the row opacity from 35 % → 55 % so
+       the avatar reads as a faded-but-readable mark rather than
+       a ghost, and pair the italic copy with a Trash2 glyph so
+       the state has a clear iconographic signal next to the prose. -->
   <div
     v-else-if="message.isRetracted"
     :data-message-id="message.id"
     :data-message-created-at="message.createdAt"
-    class="chat-message-grid opacity-35 animate-message-in"
+    class="chat-message-grid opacity-55 animate-message-in"
     :class="grouped ? 'chat-message-grouped' : ''"
   >
     <div v-if="grouped" class="chat-message-avatar-cell chat-message-time-gutter">
@@ -767,7 +771,10 @@ onBeforeUnmount(() => {
           {{ formatTimelineTimeOfDay(message.createdAt) }}
         </span>
       </div>
-      <p class="type-message-body italic text-muted-foreground">This message was deleted.</p>
+      <p class="type-message-body italic text-muted-foreground inline-flex items-center gap-1.5">
+        <Trash2 class="w-3.5 h-3.5 flex-shrink-0 opacity-70" aria-hidden="true" />
+        <span>This message was deleted.</span>
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
## What

The retracted-message tombstone rendered the full row (avatar + author + time + body `"This message was deleted."`) at `opacity-35`. The fade was heavy enough that the avatar dropped to near-ghostly — heavier than the state needs to communicate *"this body is gone, the author/time context stays."*

Two small changes:

1. **`opacity-35` → `opacity-55`** so the avatar reads as a faded-but-readable mark rather than a wisp. The body still differs from active messages via italic + muted text + the new icon; the opacity drop now serves *"noticeably quieter,"* not *"almost invisible."*
2. **Trash2 glyph inline** next to `"This message was deleted."`. The italic copy alone could read as a chat-prose convention (italic = quoted text); the icon makes the state unambiguous at a glance. `w-3.5 h-3.5 opacity-70` so it sits with the body text without competing.

The body becomes `inline-flex items-center gap-1.5` to align the icon with the text baseline. `Trash2` was already imported (used by the message action sheet) so no new dependency.

## Files

- `chat/src/components/chat/MessageCard.vue` — retracted-tombstone block: opacity bump + body becomes `<p inline-flex>` with `<Trash2 />` + `<span>`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- No deleted message in the current Chrome MCP page window — change is small, single-component, low-risk; lint + tests cover the structure.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation once a retracted message is in view
- [ ] CI green on PR

This PR was created with the assistance of a LLM.