### PR TITLE
fix(chat): search panel — spinner for loading, glyph for empty

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch, type ComponentPublicInstance } from "vue";
 import { useStore } from "@nanostores/vue";
-import { AlertCircle, CheckCircle2, Hash, MessageCircle, MessagesSquare, RefreshCw, Search, Upload, WifiOff, X } from "lucide-vue-next";
+import { AlertCircle, CheckCircle2, Hash, Loader2, MessageCircle, MessagesSquare, RefreshCw, Search, SearchX, Upload, WifiOff, X } from "lucide-vue-next";
 import { $pinnedStanzaIds } from "@/stores/pinned-messages";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import { getConnectionNoticeCopy } from "@/lib/connection-notice";
@@ -951,11 +951,24 @@ function dayDividerLabel(createdAt: string): string {
     <!-- Search results -->
     <div v-if="showSearch && (searchSubmitted || isSearching)" class="border-b border-border glass-surface max-h-56 overflow-auto flex-shrink-0">
       <div class="chat-message-lane">
-        <div v-if="isSearching" class="type-caption px-[var(--chat-content-inline)] py-3 text-muted-foreground">
-          Searching…
+        <!-- Loading state — Loader2 spinner alongside the copy so the
+             user sees the request is in flight, not just frozen. -->
+        <div
+          v-if="isSearching"
+          class="type-caption flex items-center justify-center gap-2 px-[var(--chat-content-inline)] py-5 text-muted-foreground"
+        >
+          <Loader2 class="h-3.5 w-3.5 motion-safe:animate-spin" aria-hidden="true" />
+          <span>Searching…</span>
         </div>
-        <div v-else-if="searchResults.length === 0" class="type-caption px-[var(--chat-content-inline)] py-3 text-muted-foreground">
-          No matching messages.
+        <!-- Empty state — SearchX glyph stacked above the copy so the
+             "no matches" outcome reads as an authored state, not a
+             one-line ghost. -->
+        <div
+          v-else-if="searchResults.length === 0"
+          class="flex flex-col items-center justify-center gap-1.5 px-[var(--chat-content-inline)] py-6 text-center"
+        >
+          <SearchX class="h-5 w-5 text-muted-foreground/60" aria-hidden="true" />
+          <span class="type-caption text-muted-foreground">No matching messages</span>
         </div>
         <div v-else class="divide-y divide-border">
           <button


### PR DESCRIPTION
## What

The in-channel search panel rendered both transient states as a single line of muted text:

| State    | Before                      |
|----------|-----------------------------|
| Loading  | `Searching…`                |
| Empty    | `No matching messages.`     |

Each state read like a placeholder string. Two small additions match the iter-37 "authored states" pattern:

1. **Loading state** gets a `Loader2` spinner (motion-safe-gated) next to the copy. The user sees the request is in flight, not just frozen.
2. **Empty state** stacks a `SearchX` glyph above the "No matching messages" caption in a centred flex column. The "missing" outcome reads as authored rather than a one-line ghost. Trailing period dropped — centred glyph + copy reads as a complete sentence.

Both states bump from `py-3` to `py-5/6` for breathing room.

## Files

- `chat/src/components/chat/ContentArea.vue` — `Loader2` and `SearchX` lucide imports; the two search-result transient-state divs updated.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: typed `xxnomatchxx`, observed SearchX glyph + "No matching messages" centred in the search panel.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.