### PR TITLE
fix(chat): EmojiPicker — SearchX glyph for "No emoji found" empty state

### DIFF
--- a/chat/src/components/chat/EmojiPicker.vue
+++ b/chat/src/components/chat/EmojiPicker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch, type CSSProperties } from "vue";
-import { Search, X } from "lucide-vue-next";
+import { Search, SearchX, X } from "lucide-vue-next";
 import { searchEmoji } from "@/lib/emoji";
 
 const props = withDefaults(
@@ -237,7 +237,14 @@ onBeforeUnmount(detachWindowListeners);
           </div>
         </template>
         <template v-else-if="query.trim().length >= 2">
-          <div class="type-caption flex h-24 items-center justify-center rounded-lg text-muted-foreground">No emoji found</div>
+          <!-- Empty search state — SearchX glyph stacked above the
+               caption matches the iter-47 channel-search empty state
+               so every "your query had no hits" surface in the app
+               speaks one visual language. -->
+          <div class="flex h-24 flex-col items-center justify-center gap-1.5 rounded-lg text-center">
+            <SearchX class="h-5 w-5 text-muted-foreground/60" aria-hidden="true" />
+            <span class="type-caption text-muted-foreground">No emoji found</span>
+          </div>
         </template>
         <template v-else>
           <template v-if="recents.length > 0">


### PR DESCRIPTION
## What

The EmojiPicker's "search query had no hits" branch rendered as a single muted line `No emoji found`. Iter 47 just established the SearchX-glyph + caption empty-state pattern for the in-channel search panel; apply it here too so every "your query had no results" surface across the app reads in one visual language.

The empty state now stacks the `SearchX` icon above the caption in a centred flex column. Same `h-5 w-5 text-muted-foreground/60` icon weight and `type-caption text-muted-foreground` text as the channel-search empty state.

## Files

- `chat/src/components/chat/EmojiPicker.vue` — `SearchX` lucide import; empty-state template extended to a centred column with glyph + caption.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation once an emoji picker no-match state is in view
- [ ] CI green on PR

This PR was created with the assistance of a LLM.