### PR TITLE
fix(chat): search result rows — author avatar for visual triage

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -28,6 +28,7 @@ import { formatTimelineStamp, formatTimelineDayDivider, isSameTimelineDay } from
 import { useExtensionLauncher } from "@/channels/extension-launcher";
 import { useJumpToLiveEdge } from "@/ui/use-jump-to-live-edge";
 import { ArrowDown, ArrowUp } from "lucide-vue-next";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ChatHeader, { type ChannelHeaderMember } from "@/components/chat/ChatHeader.vue";
 import ExtensionPalette from "@/components/chat/ExtensionPalette.vue";
 import MessageCard from "@/components/chat/MessageCard.vue";
@@ -958,18 +959,32 @@ function dayDividerLabel(createdAt: string): string {
           No matching messages.
         </div>
         <div v-else class="divide-y divide-border">
+          <!-- Each search result row gets the author's avatar on the
+               left so the eye can triage results by who-said-it at a
+               glance — the same recognition cue the timeline uses.
+               Avatar (xs) + content stack (name + time on row one,
+               truncated body on row two) lets the row read as a
+               compact preview of the matching message. -->
           <button
             v-for="result in searchResults"
             :key="result.id"
-            class="w-full px-[var(--chat-content-inline)] py-3 text-left hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25"
+            class="flex w-full items-start gap-3 px-[var(--chat-content-inline)] py-3 text-left hover:bg-muted/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/25"
             type="button"
             @click="openSearchResult(result)"
           >
-            <div class="flex items-baseline gap-2">
-              <span class="type-control">{{ result.nick }}</span>
-              <span class="type-meta type-numeric text-muted-foreground">{{ formatTimelineStamp(result.createdAt) }}</span>
+            <AppAvatar
+              :name="result.nick"
+              :src="avatarUrlByAuthor[result.nick] ?? null"
+              :presence="roomPresence[result.nick] ?? 'offline'"
+              size="xs"
+            />
+            <div class="min-w-0 flex-1">
+              <div class="flex items-baseline gap-2">
+                <span class="type-control">{{ result.nick }}</span>
+                <span class="type-meta type-numeric text-muted-foreground">{{ formatTimelineStamp(result.createdAt) }}</span>
+              </div>
+              <p class="type-caption truncate text-muted-foreground">{{ result.body }}</p>
             </div>
-            <p class="type-caption truncate text-muted-foreground">{{ result.body }}</p>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## What

Each search result row showed `nick + time + truncated body` but no avatar. With multiple matches you couldn't triage by who said what without reading the nick text each time. Adding the author's `AppAvatar` (xs) on the left gives the eye the same recognition cue the timeline uses.

The row is restructured to a flex layout: avatar on the left, content stack on the right (name + time on row one, truncated body on row two), so the avatar reads as the row's leading mark.

Also adds the missing `AppAvatar` script-setup import. The file uses AppAvatar elsewhere (typing indicator) without an explicit import, which appears to have resolved incidentally; this PR makes the dependency explicit so the new search-row usage definitely resolves.

## Files

- `chat/src/components/chat/ContentArea.vue` — `AppAvatar` import added; search-result `<button>` becomes a flex row with avatar + content stack.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation pending — local search panel didn't surface in the MCP session, but the change is small (template + one import) and well-covered by lint/types.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation in a session that exposes the search results panel
- [ ] CI green on PR

This PR was created with the assistance of a LLM.