### PR TITLE
fix(chat): scrollbar polish — Firefox parity + color-mix tokens

### DIFF
--- a/chat/src/styles/global/motion.css
+++ b/chat/src/styles/global/motion.css
@@ -13,6 +13,15 @@
 
 /* Scrollbar — ghost-thin, luminous */
 @layer base {
+  /* Firefox / non-WebKit browsers: standardized scrollbar properties.
+   * Without these, Firefox falls back to chunky platform scrollbars
+   * that visually conflict with the ghost-thin treatment Chrome/Safari
+   * users see via the ::-webkit-scrollbar block below. */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--muted-foreground) 28%, transparent) transparent;
+  }
+
   ::-webkit-scrollbar {
     width: 5px;
     height: 5px;
@@ -21,13 +30,12 @@
     background: transparent;
   }
   ::-webkit-scrollbar-thumb {
-    background: var(--muted-foreground);
+    background: color-mix(in oklab, var(--muted-foreground) 28%, transparent);
     border-radius: 99px;
-    opacity: 0.2;
+    transition: background-color 0.18s ease;
   }
   ::-webkit-scrollbar-thumb:hover {
-    background: var(--primary);
-    opacity: 0.4;
+    background: color-mix(in oklab, var(--primary) 55%, transparent);
   }
 }
 


### PR DESCRIPTION
## What

Scrollbars were styled only via `::-webkit-scrollbar`, leaving Firefox to fall back to chunky platform scrollbars that visually conflict with the ghost-thin treatment Chrome / Safari users see. Three small changes:

1. **Firefox parity** via `* { scrollbar-width: thin; scrollbar-color: <thumb> transparent; }` so non-WebKit browsers get the same slim treatment.
2. **`color-mix` thumb** instead of `var(--muted-foreground)` + `opacity: 0.2`. The opacity-on-element approach was unreliable once hover-state overrides changed both `background` and implicitly the layered alpha; mixing the alpha INTO the colour via `color-mix(in oklab, --muted-foreground 28%, transparent)` keeps the token system uniform and applies the same alpha arithmetic in both WebKit and Firefox.
3. **Hover transition** `0.18s ease` on the thumb's `background-color` so the hue shift to primary feels intentional rather than a flicker.

## Files

- `chat/src/styles/global/motion.css` — `* { scrollbar-width / scrollbar-color }` block added; `::-webkit-scrollbar-thumb` switched to `color-mix` for both rest + hover.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Cross-browser visual check (Chrome, Safari, Firefox)
- [ ] CI green on PR

This PR was created with the assistance of a LLM.