### PR TITLE
fix(chat): sidebar empty-group Create button — primary-tinted

### DIFF
--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -283,6 +283,14 @@ watch(
               </button>
             </div>
             <template v-if="!isGroupCollapsed(group.id)">
+              <!-- Empty group row — when a channel group has no
+                   channels, the "Create" button is the row's only
+                   point of action. Tint it primary so it reads as
+                   "this is the next step here" instead of as a
+                   generic outlined chip lost against the muted
+                   sidebar. Matches the same brand language used by
+                   the composer armed glow / unread rails / mention
+                   spotlight (iter 32/39). -->
               <div
                 v-if="group.channels.length === 0"
                 class="type-caption flex items-center justify-between gap-2 px-6 py-2 text-sidebar-muted"
@@ -290,12 +298,13 @@ watch(
                 <span>No channels yet.</span>
                 <button
                   v-if="canManageChannels"
-                  class="type-control rounded-md border border-border px-2 py-1 text-sidebar-foreground hover:bg-sidebar-accent"
+                  class="type-control inline-flex items-center gap-1 rounded-md border border-primary/25 bg-primary/10 px-2 py-1 text-primary transition-colors hover:bg-primary/20 hover:border-primary/40"
                   type="button"
                   :aria-label="group.space ? `Create channel in ${group.name}` : 'Create standalone channel'"
                   @click="emit('createChannelInSpace', group.space?.id ?? null)"
                 >
-                  Create
+                  <Plus class="h-3 w-3" aria-hidden="true" />
+                  <span>Create</span>
                 </button>
               </div>
               <template v-for="{ channel, unread } in group.channels" :key="channel.id">


### PR DESCRIPTION
## What

When a channel group has no channels, the row reads `No channels yet. [Create]`. The Create button was a plain `border-border` outlined chip in muted text — visually inert against the sidebar's hue palette, and easy to miss as the row's only call-to-action.

Tint it primary so it reads as "this is the next step here":

| Property      | Before                          | After                                      |
|---------------|---------------------------------|--------------------------------------------|
| Background    | none                            | `bg-primary/10` (subtle teal fill)         |
| Border        | `border-border`                 | `border-primary/25`                        |
| Text          | `text-sidebar-foreground`       | `text-primary`                             |
| Hover         | `hover:bg-sidebar-accent`       | `hover:bg-primary/20 hover:border-primary/40` |
| Leading glyph | (none)                          | `<Plus h-3 w-3 />`                         |

Matches the brand language already used by the composer armed glow, the unread rails (iter 39), and the mention spotlight (iter 32) — the empty group now speaks the same dialect instead of being an outlined chip lost against the sidebar.

## Files

- `chat/src/components/chat/TopicsPanel.vue` — Create button class swap + `<Plus />` icon prepended; `Plus` was already imported (used in the section header `+` button).

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: ALERTS section's "No channels yet." row now shows a teal `+ Create` chip with primary-tinted fill, border, and text.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.