### PR TITLE
fix(chat): link hover — animated underline + subtle brighten

### DIFF
--- a/chat/src/styles/global/rich-text.css
+++ b/chat/src/styles/global/rich-text.css
@@ -100,13 +100,22 @@
 :where(.styled-body, .chat-editor .ProseMirror) li > p {
   margin: 0;
 }
+/* Links in message bodies + editor — the at-rest treatment is no
+ * underline (just the --rich-link colour), with the underline
+ * fading in on hover. Previously the underline appeared abruptly
+ * via `text-decoration: none` → `underline`; using a transparent
+ * text-decoration-color at rest lets the browser animate the
+ * underline colour to current on hover for a smoother reveal. */
 :where(.styled-body, .chat-editor .ProseMirror) a {
   color: var(--rich-link);
-  text-decoration: none;
+  text-decoration: underline transparent;
+  text-decoration-thickness: 1px;
   text-underline-offset: 2px;
+  transition: text-decoration-color 0.18s ease, color 0.18s ease;
 }
 :where(.styled-body, .chat-editor .ProseMirror) a:hover {
-  text-decoration: underline;
+  color: color-mix(in oklab, var(--rich-link), white 14%);
+  text-decoration-color: currentColor;
 }
 .rich-mention {
   color: var(--primary);


### PR DESCRIPTION
## What

Links in message bodies and the editor showed `text-decoration: none` at rest and `text-decoration: underline` on hover. The underline appeared abruptly because `text-decoration` shorthand isn't animatable.

Three small changes to the message-body / editor link rules:

1. **`text-decoration: underline transparent`** at rest with `text-decoration-thickness: 1px`. The underline is *always* present in the box model; only its colour starts transparent. Browsers can animate `text-decoration-color` smoothly, so the underline now **fades in** on hover instead of popping.
2. **Hover colour brighten** — `color-mix(in oklab, var(--rich-link), white 14%)` so the link itself lifts a touch when pointed at, giving the user a second feedback channel beyond the underline.
3. **`transition: 0.18s ease`** on both `text-decoration-color` and `color` so the two cues land together.

## Files

- `chat/src/styles/global/rich-text.css` — `:where(.styled-body, .chat-editor .ProseMirror) a` + `a:hover` rules.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] CI green on PR

This PR was created with the assistance of a LLM.