### PR TITLE
fix(chat): author name clickable — opens profile like avatar

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -762,7 +762,12 @@ onBeforeUnmount(() => {
     />
     <div class="chat-message-body-stack">
       <div v-if="!grouped" class="chat-message-meta-row">
-        <span class="type-message-author">{{ message.author }}</span>
+        <button
+          type="button"
+          class="type-message-author chat-message-author-button"
+          :aria-label="`Open profile for ${message.author}`"
+          @click.stop="emitAvatarClick"
+        >{{ message.author }}</button>
         <span class="type-meta type-numeric text-muted-foreground">
           {{ formatTimelineTimeOfDay(message.createdAt) }}
         </span>
@@ -834,7 +839,12 @@ onBeforeUnmount(() => {
     </div>
     <div class="chat-message-body-stack">
       <div v-if="!grouped" class="chat-message-meta-row">
-        <span class="type-message-author">{{ message.author }}</span>
+        <button
+          type="button"
+          class="type-message-author chat-message-author-button"
+          :aria-label="`Open profile for ${message.author}`"
+          @click.stop="emitAvatarClick"
+        >{{ message.author }}</button>
         <span
           v-if="seniorHat"
           class="chat-hat-tag"

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -315,6 +315,35 @@
   white-space: nowrap;
 }
 
+/* Author name as a button — opens the same profile drawer the
+ * avatar opens. Strip the default button chrome (bg, border,
+ * padding) so the name reads as plain typography at rest; on hover
+ * the underline + slight colour lift signals the affordance the
+ * same way iter-52 polished body links. */
+.chat-message-author-button {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-decoration: underline transparent;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  transition: text-decoration-color 0.18s ease, color 0.18s ease;
+}
+
+.chat-message-author-button:hover {
+  text-decoration-color: currentColor;
+}
+
+.chat-message-author-button:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 55%, transparent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .chat-message-meta-row > .type-badge,
 .chat-message-meta-row > .type-meta {
   flex-shrink: 0;


### PR DESCRIPTION
## What

The message author name was a plain `<span>`. Clicking the avatar already opens the user's profile drawer, but the most natural target — the name itself — did nothing.

Make the name match the avatar's behaviour:

- `<span>` → `<button type="button">` wired to `emitAvatarClick` (same handler the avatar uses).
- `aria-label="Open profile for {author}"` for keyboard / screen-reader users.
- New `.chat-message-author-button` CSS strips the default button chrome (bg / border / padding) so the name reads as plain typography at rest.
- Hover gets the same transparent-underline fade-in treatment as iter-52 body links — same brand language for "this opens something".
- `:focus-visible` outline ring in `--primary` so keyboard nav has a clear target.
- `@click.stop` so the click doesn't bubble to row-level handlers (matches the avatar's treatment).

Applied to both author-name renders in MessageCard: the normal message header and the retracted-tombstone header.

## Files

- `chat/src/components/chat/MessageCard.vue` — two `<span class="type-message-author">` → `<button>` with `emitAvatarClick`.
- `chat/src/styles/global/messages.css` — `.chat-message-author-button` rule next to the existing `.type-message-author` styles.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation of hover underline + click opening profile
- [ ] CI green on PR

This PR was created with the assistance of a LLM.