### PR TITLE
fix(chat): rail bell badge — glow halo matches sidebar treatment

### DIFF
--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -132,14 +132,18 @@ onUnmounted(() => {
     >
       <BellOff v-if="notificationPermission === 'denied' || (notificationPermission === 'granted' && !notificationsEnabled)" class="h-3.5 w-3.5" />
       <Bell v-else class="h-3.5 w-3.5" />
+      <!-- Bell-corner count badges pick up the same glow halo the
+           sidebar unread/mention badges use (iter 39 brand
+           language). The bell is the global unread/mention indicator
+           — it should pull the eye at least as much as a single row. -->
       <span
         v-if="(totalMentionCount ?? 0) > 0"
-        class="type-count-badge absolute -right-0.5 -top-0.5 inline-flex min-w-[14px] h-[14px] px-0.5 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+        class="chat-badge-glow--mention type-count-badge absolute -right-0.5 -top-0.5 inline-flex min-w-[14px] h-[14px] px-0.5 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
         aria-hidden="true"
       >{{ totalMentionCount }}</span>
       <span
         v-else-if="(totalUnreadCount ?? 0) > 0"
-        class="type-count-badge absolute -right-0.5 -top-0.5 inline-flex min-w-[14px] h-[14px] px-0.5 items-center justify-center rounded-full bg-primary text-primary-foreground"
+        class="chat-badge-glow--primary type-count-badge absolute -right-0.5 -top-0.5 inline-flex min-w-[14px] h-[14px] px-0.5 items-center justify-center rounded-full bg-primary text-primary-foreground"
         aria-hidden="true"
       >{{ totalUnreadCount }}</span>
     </button>

--- a/chat/src/styles/global/controls.css
+++ b/chat/src/styles/global/controls.css
@@ -210,13 +210,27 @@
   box-shadow: 0 0 10px color-mix(in oklab, var(--destructive) 38%, transparent);
 }
 
+/* Generic count-badge glow halos — same alphas the sidebar
+ * list-row badges use, but lifted to a non-sidebar-bound class so
+ * other badge surfaces (the rail notification bell) can pull the
+ * eye with the same brand language. */
+.chat-badge-glow--primary {
+  box-shadow: 0 0 10px color-mix(in oklab, var(--primary) 35%, transparent);
+}
+
+.chat-badge-glow--mention {
+  box-shadow: 0 0 10px color-mix(in oklab, var(--destructive) 38%, transparent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .chat-list-row--unread::before,
   .chat-list-row--mention::before {
     box-shadow: none;
   }
   .chat-list-row--unread-badge,
-  .chat-list-row--mention-badge {
+  .chat-list-row--mention-badge,
+  .chat-badge-glow--primary,
+  .chat-badge-glow--mention {
     box-shadow: none;
   }
 }


### PR DESCRIPTION
## What

The notification bell in the left rail shows count + colour (primary for unread, destructive for mention) but its badge had no glow halo. Sidebar list-row badges have a glow halo via `.chat-list-row--unread-badge` / `.chat-list-row--mention-badge`. The bell is the **global** unread/mention indicator — it should pull the eye at least as much as a single row, not less.

Two changes:

1. **Extract** generic `.chat-badge-glow--primary` and `.chat-badge-glow--mention` rules in `controls.css`. Same alphas as the existing list-row glow classes (35 % primary / 38 % destructive) but lifted out of the sidebar-bound naming so other badge surfaces can pick up the same brand language.
2. **Apply** the new classes to the bell-corner badge spans in `ProfilePanel.vue`.

Reduced-motion block extended to include both new classes so users who opt out of motion don't get the glow halos.

## Files

- `chat/src/styles/global/controls.css` — new `.chat-badge-glow--{primary,mention}` rules + reduced-motion entries.
- `chat/src/components/chat/ProfilePanel.vue` — bell mention/unread badges add the matching glow class.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: bell badge with count "3" now shows a primary-teal halo around the badge, matching the sidebar unread badge treatment.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.