### PR TITLE
fix(chat): collapsed-group badges — apply iter-54 glow halos

### DIFF
--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -253,15 +253,21 @@ watch(
                   :class="isGroupCollapsed(group.id) ? '-rotate-90' : ''"
                 />
                 <span class="flex-1 truncate">{{ group.name }}</span>
+                <!-- Rolled-up activity badges on a collapsed group —
+                     match the iter-54 .chat-badge-glow halo so they
+                     pull the eye the same way the rail bell badge
+                     and sidebar unread badges do. Activity dot
+                     already had a glow; mention / unread counts now
+                     get one too. -->
                 <template v-if="isGroupCollapsed(group.id)">
                   <span
                     v-if="groupUnreadSummary(group).mentions > 0"
-                    class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
+                    class="chat-badge-glow--mention type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-destructive text-destructive-foreground"
                     aria-hidden="true"
                   >{{ groupUnreadSummary(group).mentions }}</span>
                   <span
                     v-else-if="groupUnreadSummary(group).unread > 0"
-                    class="type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
+                    class="chat-badge-glow--primary type-count-badge inline-flex min-w-[18px] h-[18px] px-1 items-center justify-center rounded-full bg-primary text-primary-foreground"
                     aria-hidden="true"
                   >{{ groupUnreadSummary(group).unread }}</span>
                   <span


### PR DESCRIPTION
## What

When a sidebar group is collapsed, its header rolls up activity into a mention count, an unread count, or an "active" dot. The dot already had a glow; the count badges didn't. Iter 54 lifted `.chat-badge-glow--primary` / `--mention` out of the sidebar-bound naming so other badge surfaces could pick up the brand language — apply them here too.

After this, every primary / destructive count badge in the sidebar speaks one visual language:

| Badge                                  | Glow source       |
|----------------------------------------|-------------------|
| Per-channel unread/mention (iter 39)   | `.chat-list-row--*-badge` |
| Rolled-up collapsed-group (this PR)    | `.chat-badge-glow--*`     |
| Rail bell (iter 54)                    | `.chat-badge-glow--*`     |

## Depends on

PR #583 (iter 54) which adds the `.chat-badge-glow--{primary,mention}` utility classes. This PR lands gracefully if merged before #583 — the unknown class names just have no effect, no visual regression versus current state.

## Files

- `chat/src/components/chat/TopicsPanel.vue` — collapsed-group mention/unread count spans gain `chat-badge-glow--mention` / `chat-badge-glow--primary`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation in a session where a group has unread + is collapsed
- [ ] CI green on PR

This PR was created with the assistance of a LLM.