### PR TITLE
fix(chat): GifPicker — Loader2 + SearchX, match iter-47/48 patterns

### DIFF
--- a/chat/src/components/chat/GifPicker.vue
+++ b/chat/src/components/chat/GifPicker.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
-import { Search, X } from "lucide-vue-next";
+import { Loader2, Search, SearchX, X } from "lucide-vue-next";
 
 const props = defineProps<{
   apiKey: string;
@@ -98,15 +98,29 @@ function selectGif(gif: GiphyGif) {
 
     <!-- Results -->
     <div v-else class="flex-1 overflow-auto p-2">
-      <div v-if="isLoading" class="type-control flex h-24 items-center justify-center text-muted-foreground">
-        <div class="flex items-center justify-center gap-1.5">
-          <span class="typing-dot" />
-          <span class="typing-dot" />
-          <span class="typing-dot" />
-        </div>
+      <!-- Loading state — Loader2 spinner matches the iter-47 channel
+           search loading treatment so every "fetching" surface in the
+           app spins with the same affordance. -->
+      <div v-if="isLoading" class="type-caption flex h-24 items-center justify-center gap-2 text-muted-foreground">
+        <Loader2 class="h-3.5 w-3.5 motion-safe:animate-spin" aria-hidden="true" />
+        <span>Loading…</span>
       </div>
-      <div v-else-if="results.length === 0" class="type-control flex h-24 items-center justify-center rounded-lg text-center text-muted-foreground">
-        {{ query ? "No GIFs found" : "Loading trending GIFs…" }}
+      <!-- Empty search state — SearchX glyph + caption matches the
+           iter-48 EmojiPicker / iter-47 channel-search empty state. -->
+      <div
+        v-else-if="results.length === 0 && query.trim().length > 0"
+        class="flex h-24 flex-col items-center justify-center gap-1.5 rounded-lg text-center"
+      >
+        <SearchX class="h-5 w-5 text-muted-foreground/60" aria-hidden="true" />
+        <span class="type-caption text-muted-foreground">No GIFs found</span>
+      </div>
+      <!-- Idle state — when no query is active but the trending fetch
+           didn't return anything. Rare; keep as a plain caption. -->
+      <div
+        v-else-if="results.length === 0"
+        class="type-caption flex h-24 items-center justify-center rounded-lg text-center text-muted-foreground"
+      >
+        Loading trending GIFs…
       </div>
       <div v-else class="grid grid-cols-3 gap-2">
         <button


### PR DESCRIPTION
## What

GifPicker still used three `typing-dot` spans for the fetching state and a bare-text "No GIFs found" for the empty state. Iter 47 set the Loader2 spinner pattern for loading; iter 48 set the SearchX glyph + caption pattern for empty search results.

Convert GifPicker to match so every loading/empty state across pickers (channel search, emoji picker, GIF picker) speaks one visual language:

| Branch                       | Before                  | After                                  |
|------------------------------|-------------------------|----------------------------------------|
| Loading                      | 3× `.typing-dot`        | `<Loader2 motion-safe:animate-spin />` + "Loading…" |
| Empty with query             | bare "No GIFs found"    | `<SearchX />` stacked above caption    |
| No-query, no-results (idle)  | bare "Loading trending GIFs…" | unchanged (rare; trending fetch still pending or silent fail) |

## Files

- `chat/src/components/chat/GifPicker.vue` — `Loader2` + `SearchX` imports; results-area branch templates updated.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation: open GIF picker, watch loading spinner; search "xxxx" to see SearchX empty state
- [ ] CI green on PR

This PR was created with the assistance of a LLM.