### PR TITLE
fix(chat): MemberManagement Searching — Loader2 instead of typing-dots

### DIFF
--- a/chat/src/components/modals/MemberManagement.vue
+++ b/chat/src/components/modals/MemberManagement.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { X, Search } from "lucide-vue-next";
+import { Loader2, X, Search } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import type { MemberSummary, UserSearchResult } from "@/lib/chat-types";
@@ -96,10 +96,12 @@ const roles: EditableRole[] = ["member", "admin", "owner", "outcast"];
         </button>
       </div>
 
+      <!-- Searching indicator — converges with iter-47/48/57 on
+           Loader2 so every "fetching" surface across the app
+           (channel search, emoji picker, GIF picker, member search)
+           speaks one visual language. -->
       <div v-if="isSearching" class="type-caption text-muted-foreground flex items-center gap-1.5">
-        <span class="typing-dot" />
-        <span class="typing-dot" />
-        <span class="typing-dot" />
+        <Loader2 class="h-3.5 w-3.5 motion-safe:animate-spin" aria-hidden="true" />
         <span>Searching…</span>
       </div>
     </div>


### PR DESCRIPTION
## What

MemberManagement's "Searching…" affordance (while adding a member) used three `.typing-dot` spans. Iter 47 / 48 / 57 converged the channel-search panel, EmojiPicker, and GifPicker on a `Loader2` spinner for "fetching" — converge MemberManagement too so every loading affordance across the app speaks one visual language.

Replace the three-dot row with a single `Loader2` glyph (`motion-safe:animate-spin`, `h-3.5 w-3.5`) next to the "Searching…" caption. Same flex layout, same caption colour, same gap.

## Files

- `chat/src/components/modals/MemberManagement.vue` — `Loader2` import added; three `<span class="typing-dot" />` → one `<Loader2 />`.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation once a Members search is in flight
- [ ] CI green on PR

This PR was created with the assistance of a LLM.