### PR TITLE
fix(chat): encrypted attachment indicator — unify Lock glyph across kinds

### DIFF
--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -385,7 +385,7 @@ watch(
         <div class="type-caption text-muted-foreground">
           {{ file.name ?? "Video" }} · {{ file.mediaType ?? "video" }}
           <span v-if="file.size"> · {{ formatFileSize(file.size) }}</span>
-          <span v-if="file.encrypted"> · Encrypted</span>
+          <span v-if="file.encrypted" class="inline-flex items-baseline gap-1"> · <Lock class="h-3 w-3 self-center text-primary/70" aria-hidden="true" /> Encrypted</span>
         </div>
       </div>
     </div>
@@ -423,7 +423,7 @@ watch(
         <div class="type-caption text-muted-foreground">
           {{ file.name ?? "Audio" }} · {{ file.mediaType ?? "audio" }}
           <span v-if="file.size"> · {{ formatFileSize(file.size) }}</span>
-          <span v-if="file.encrypted"> · Encrypted</span>
+          <span v-if="file.encrypted" class="inline-flex items-baseline gap-1"> · <Lock class="h-3 w-3 self-center text-primary/70" aria-hidden="true" /> Encrypted</span>
         </div>
       </div>
     </div>
@@ -462,7 +462,7 @@ watch(
           <div class="type-caption text-muted-foreground">
             {{ file.name ?? "PDF" }} · {{ file.mediaType ?? "application/pdf" }}
             <span v-if="file.size"> · {{ formatFileSize(file.size) }}</span>
-            <span v-if="file.encrypted"> · Encrypted</span>
+            <span v-if="file.encrypted" class="inline-flex items-baseline gap-1"> · <Lock class="h-3 w-3 self-center text-primary/70" aria-hidden="true" /> Encrypted</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Image attachments showed `🔒 Encrypted` with the Lock icon in a bottom strip. Video / audio / PDF attachments only got an inline `· Encrypted` text suffix with no glyph. Two visual languages for the same state — *"this attachment is end-to-end encrypted"*.

Unify on the Lock-glyph treatment for the inline metadata lines too:

| Before                                  | After                                       |
|-----------------------------------------|---------------------------------------------|
| `Filename · video/mp4 · 9.6 MB · Encrypted` | `Filename · video/mp4 · 9.6 MB · 🔒 Encrypted` |

Implementation: the existing `<span v-if="file.encrypted">` text suffix gains an `inline-flex items-baseline gap-1` layout and a `<Lock h-3 w-3 self-center text-primary/70 />` glyph between the `·` separator and the word. `self-center` keeps the icon aligned to the baseline of the surrounding caption.

One `Edit` with `replace_all` covers the three identical sites (video, audio, PDF metadata). Image attachments already had the Lock glyph in their distinct bottom-strip treatment — unchanged there.

## Files

- `chat/src/components/chat/MessageBody.vue` — three identical `<span v-if="file.encrypted">` runs updated.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation once a non-image encrypted attachment is in view
- [ ] CI green on PR

This PR was created with the assistance of a LLM.