### PR TITLE
fix(chat): text selection — primary-tinted brand colour

### DIFF
--- a/chat/src/styles/global/motion.css
+++ b/chat/src/styles/global/motion.css
@@ -11,6 +11,18 @@
   }
 }
 
+/* Text selection — primary-tinted so highlighted text speaks the
+ * brand instead of the OS default (system blue on macOS, varies
+ * elsewhere). Mixes 30% of --primary against the page so the
+ * selection is clearly visible without being jarring, and the
+ * inherited foreground keeps long passages legible. */
+@layer base {
+  ::selection {
+    background: color-mix(in oklab, var(--primary) 30%, transparent);
+    color: var(--foreground);
+  }
+}
+
 /* Scrollbar — ghost-thin, luminous */
 @layer base {
   ::-webkit-scrollbar {


### PR DESCRIPTION
## What

Selecting text anywhere in the app used the browser/OS default selection colour (typically system blue on macOS, varies elsewhere). Override with a primary-tinted color-mix so highlighted text speaks the brand instead of the OS — same dialect as the iter-32 / 39 / 42 primary rails.

```css
::selection {
  background: color-mix(in oklab, var(--primary) 30%, transparent);
  color: var(--foreground);
}
```

The 30 % primary mix is visible enough to read at a glance without being jarring against long passages of body copy. Foreground stays on `--foreground` so multi-paragraph selections stay legible regardless of theme.

Rule placed inside `@layer base` so component-level styles can still override per-surface if a future iteration needs custom selection on a particular element.

## Files

- `chat/src/styles/global/motion.css` — new `@layer base { ::selection { ... } }` block above the existing scrollbar block.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.

## Test plan

- [x] knip / unit tests green
- [ ] Visual confirmation: drag-select any text in the app, see teal selection instead of system blue
- [ ] CI green on PR

This PR was created with the assistance of a LLM.