### PR TITLE
fix(chat): extension route rail — primary ring + glow on active state

### DIFF
--- a/chat/src/styles/global/shell.css
+++ b/chat/src/styles/global/shell.css
@@ -249,8 +249,21 @@
   color: var(--primary);
 }
 
+/* Active rail button — armed treatment: bumped ring alpha (18% → 40%)
+ * plus a primary-tinted glow halo so the active state speaks the
+ * same brand-armed language as the iter-61 header toggle and
+ * iter-54 bell badge. Distinguishes "this panel is currently open"
+ * from "the cursor is hovering this button". */
 .extension-route-rail__button--active {
-  box-shadow: 0 0 0 1px color-mix(in oklab, var(--primary) 18%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--primary) 40%, transparent),
+    0 0 10px color-mix(in oklab, var(--primary) 35%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .extension-route-rail__button--active {
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--primary) 40%, transparent);
+  }
 }
 
 .chat-rail {


### PR DESCRIPTION
## What

The right-rail extension route buttons (Saved Links, Tasks, etc.) shared `bg-rail-hover` between hover and active states. The only distinguishing signal was a faint 18 % primary ring on active — barely visible against the rail background.

Bump the active state to the same brand-armed language used by the iter-61 channel-header toggles and iter-54 bell badge:

| Active signal | Before                       | After                                                |
|---------------|------------------------------|------------------------------------------------------|
| Ring alpha    | 18 %                         | 40 %                                                 |
| Glow halo     | (none)                       | `0 0 10px color-mix(--primary 35%, transparent)`     |

`prefers-reduced-motion: reduce` keeps the ring but drops the glow so motion-averse users still get the active signal without the ambient halo.

## Files

- `chat/src/styles/global/shell.css` — `.extension-route-rail__button--active` rule updated; reduced-motion block added.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: active Saved Links rail button shows a clear teal ring + glow halo, distinct from the inactive Tasks button below.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.