### PR TITLE
fix(chat): left rail Spaces/DMs toggles — primary ring + glow armed

### DIFF
--- a/chat/src/components/chat/WaddlesSidebar.vue
+++ b/chat/src/components/chat/WaddlesSidebar.vue
@@ -78,10 +78,15 @@ const emit = defineEmits<{
 
     <!-- Bottom actions -->
     <div class="chat-rail-actions" :class="horizontal ? 'chat-rail-actions-horizontal' : 'chat-rail-actions-vertical'">
+      <!-- Spaces / DMs rail toggles — active state picks up the same
+           brand-armed treatment as the iter-61 channel-header toggles,
+           iter-54 bell badge, and iter-64 extension-route rail:
+           primary ring + glow halo so "you are currently in this
+           mode" reads distinct from "you are hovering this button". -->
       <button
         class="relative w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-200 hover:scale-105"
         :class="activeSidebarMode === 'channels'
-          ? 'bg-rail-hover text-primary'
+          ? 'bg-rail-hover text-primary ring-1 ring-primary/40 shadow-[0_0_10px_var(--glow)]'
           : 'text-rail-foreground hover:bg-rail-hover hover:text-primary'"
         title="Spaces"
         aria-label="Spaces"
@@ -94,7 +99,7 @@ const emit = defineEmits<{
       <button
         class="relative w-10 h-10 flex items-center justify-center rounded-lg transition-all duration-200 hover:scale-105"
         :class="activeSidebarMode === 'dms'
-          ? 'bg-rail-hover text-primary'
+          ? 'bg-rail-hover text-primary ring-1 ring-primary/40 shadow-[0_0_10px_var(--glow)]'
           : 'text-rail-foreground hover:bg-rail-hover hover:text-primary'"
         title="Direct messages"
         aria-label="Direct messages"


### PR DESCRIPTION
## What

The Spaces (Layers) and DMs (MessageCircle) buttons at the bottom of the left rail shared `bg-rail-hover text-primary` between hover and active. Same problem the iter-61 channel-header toggles and iter-64 extension-route rail had — active reads as hover.

Apply the same brand-armed treatment as the rest of the app:

- `ring-1 ring-primary/40` — visible teal outline on the active button
- `shadow-[0_0_10px_var(--glow)]` — primary-tinted glow halo

`hover:scale-105` stays as-is on both states.

Every armed toggle in the app now speaks the same dialect:

| Toggle                  | Iter |
|-------------------------|------|
| Channel header search   | 61   |
| Channel header pin      | 61   |
| Extension-route rail    | 64   |
| Left-rail Spaces        | 65   |
| Left-rail DMs           | 65   |

All carry the same primary ring + glow when "you are in this mode".

## Files

- `chat/src/components/chat/WaddlesSidebar.vue` — Spaces and DMs button `:class` extended for active state.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: active Spaces button shows clear teal ring + glow vs inactive DMs button.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.