### PR TITLE
fix(chat): thread chip — include OP in participants + tighter gutter

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -782,20 +782,22 @@ interface ThreadChipParticipant {
 }
 
 // Distinct participants for a thread chip: walk newest→oldest, dedup,
-// exclude the current user (the chip answers "who else has been talking
-// here?"). Capped at THREAD_CHIP_MAX_PARTICIPANTS — MessageCard renders
-// only the first N visibly and shows a "+N" overflow chip.
+// keep EVERYONE who replied — including the thread author themselves
+// and the current user. Previously the current user was excluded
+// (logic: "the chip answers who *else* has been talking"), but that
+// made the chip read inconsistently: a stranger's reply showed an
+// avatar, my own reply showed nothing. Capped at
+// THREAD_CHIP_MAX_PARTICIPANTS — MessageCard renders only the first
+// N visibly and shows a "+N" overflow chip.
 function threadChipParticipants(messageId: string): ThreadChipParticipant[] {
   const entry = props.threadIndex.get(messageId);
   if (!entry) return [];
   const seen = new Set<string>();
   const ordered: ThreadChipParticipant[] = [];
-  const me = props.currentUser;
   const children = entry.directChildren;
   for (let i = children.length - 1; i >= 0; i--) {
     const c = children[i];
     if (!c) continue;
-    if (me && c.author === me) continue;
     if (seen.has(c.author)) continue;
     seen.add(c.author);
     ordered.push({

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -413,14 +413,14 @@ const threadParticipants = computed<ThreadParticipant[]>(() => {
   if (!entry) return [];
   const seen = new Set<string>();
   const ordered: ThreadParticipant[] = [];
-  const me = props.currentUser;
-  // Walk newest → oldest to bias the visible avatars toward recent
-  // participants.
+  // Include every participant — the thread author themselves and the
+  // current user — so the avatar stack is consistent regardless of
+  // who replies. Walk newest → oldest to bias the visible avatars
+  // toward recent participants.
   const children = entry.directChildren;
   for (let i = children.length - 1; i >= 0; i--) {
     const c = children[i];
     if (!c) continue;
-    if (me && c.author === me) continue;
     if (seen.has(c.author)) continue;
     seen.add(c.author);
     ordered.push({
@@ -430,7 +430,7 @@ const threadParticipants = computed<ThreadParticipant[]>(() => {
     });
   }
   const root = entry.root;
-  if (root && !seen.has(root.author) && (!me || root.author !== me)) {
+  if (root && !seen.has(root.author)) {
     ordered.push({
       nick: root.author,
       avatarUrl: props.avatarUrlByAuthor[root.author] ?? null,

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -406,28 +406,32 @@
 }
 
 /* Thread rail glyph — a single "stacked messages" icon centred in the
- * avatar column under the main author avatar. Structural rail marker
- * that this row anchors a thread; the rich summary (who replied + how
- * many + how recently) lives in the in-body chip. Absolute-positioned
- * relative to the row's grid (the message-card grid is already
- * `position: relative`), bottom-anchored to align with the chip which
- * is the last body child. */
+ * avatar column right under the main author avatar. Structural rail
+ * marker that this row anchors a thread; the rich summary (who
+ * replied + how many + how recently) lives in the in-body chip.
+ *
+ * Anchored RIGHT BELOW the avatar (top = avatar-size + gap) rather
+ * than at the row bottom, so the relationship "avatar → thread
+ * marker → chip" reads as a tight vertical column regardless of
+ * message body length. Bottom-anchoring (the previous treatment)
+ * left long messages with a big visual gap between the avatar and
+ * the icon. */
 .chat-thread-rail-glyph {
   position: absolute;
-  bottom: 0.4rem;
+  top: calc(var(--space-xs) + var(--chat-message-avatar-size) + 0.4rem);
   left: 0;
   width: var(--chat-message-avatar-size);
-  display: inline-flex;
+  display: flex;
   justify-content: center;
   align-items: center;
   pointer-events: none;
   color: color-mix(in oklab, var(--primary) 55%, var(--muted-foreground));
-  opacity: 0.7;
+  opacity: 0.75;
 }
 
 .chat-thread-rail-glyph__icon {
-  width: 0.95rem;
-  height: 0.95rem;
+  width: 1rem;
+  height: 1rem;
 }
 
 /* Participant stack lives inside the thread chip body, ahead of the


### PR DESCRIPTION
## What

User feedback on the iter-33-revise thread chip:

> Alignments and centering is wrong for thread icon. I think in general this can all be positioned better. Also, if someone else replies they get an avatar added. Should do the same for thread author if they reply. So it's consistent and not awkward.

Two fixes:

### 1. Include every replier (including the OP)

`threadChipParticipants` (ContentArea) and `threadParticipants` (ThreadPanel) excluded the current user with logic *"the chip answers who else has been talking"*. That made the chip read inconsistently — a stranger's reply showed an avatar, the OP's own reply showed nothing. Drop both `me` exclusions so every reply contributes an avatar.

### 2. Anchor rail glyph below the avatar, not at row bottom

The glyph was `position: absolute; bottom: 0.4rem` — pinned to the bottom of the grid row. For long messages that left a big visual gap between the author avatar and the thread marker, and the glyph's vertical position varied with body length.

Switch to `top: calc(--space-xs + --chat-message-avatar-size + 0.4rem)` so the icon sits tight under the avatar regardless of body length. The relationship `avatar → thread marker → chip` now reads as a clean vertical column in the gutter.

Plus minor tuning:
- Icon size `0.95rem` → `1rem`
- Opacity `0.7` → `0.75`
- `display: inline-flex` → `display: flex`

## Files

- `chat/src/components/chat/ContentArea.vue` — drop `me` exclusion in `threadChipParticipants`.
- `chat/src/components/chat/ThreadPanel.vue` — drop `me` exclusion in `threadParticipants` (both children and root branches).
- `chat/src/styles/global/messages.css` — `.chat-thread-rail-glyph` positioning + sizing.

## Verification

- `bun run lint` clean (knip).
- `bun test` 762/762 green.
- Visual confirmation in Chrome MCP at `localhost:4321`: rawkode's "Morning / Everyone reply in this thread, please." now shows rawkode's own avatar in the chip's participant stack ("2 replies"), and the gutter glyph sits directly under the author avatar in a tight vertical column.

## Test plan

- [x] knip / unit tests green
- [x] Visual confirmation in Chrome MCP
- [ ] CI green on PR

This PR was created with the assistance of a LLM.