### PR TITLE
fix(chat): center thread rail glyph with chip avatars

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -832,11 +832,13 @@ onBeforeUnmount(() => {
       <AppAvatar :name="message.author" :src="avatarUrl" :presence="presence" :last-seen="lastSeen" size="message" />
     </button>
     <!-- Thread rail glyph — a small "messages-stack" icon centred in the
-         avatar column, under the author avatar. Structural marker that
-         this row anchors a thread; the rich summary (who replied, how
-         many, how recently) lives in the in-body chip. Position-absolute
-         relative to the row's grid; bottom-anchored to align with the
-         chip which is the last body child. -->
+         avatar column, vertically aligned with the in-body chip's
+         avatar row. Structural marker that this row anchors a thread;
+         the rich summary (who replied, how many, how recently) lives
+         in the in-body chip. Position-absolute relative to the row's
+         grid; bottom-anchored so its centre line matches the chip
+         avatars' centre line — see .chat-thread-rail-glyph in
+         messages.css for the offset derivation. -->
     <div
       v-if="showThreadChip"
       class="chat-thread-rail-glyph"

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -406,21 +406,27 @@
 }
 
 /* Thread rail glyph — a single "stacked messages" icon centred in the
- * avatar column right under the main author avatar. Structural rail
- * marker that this row anchors a thread; the rich summary (who
- * replied + how many + how recently) lives in the in-body chip.
+ * avatar column, vertically aligned with the chip's avatar row in the
+ * body. Structural rail marker that this row anchors a thread; the
+ * rich summary (who replied + how many + how recently) lives in the
+ * in-body chip.
  *
- * Anchored RIGHT BELOW the avatar (top = avatar-size + gap) rather
- * than at the row bottom, so the relationship "avatar → thread
- * marker → chip" reads as a tight vertical column regardless of
- * message body length. Bottom-anchoring (the previous treatment)
- * left long messages with a big visual gap between the avatar and
- * the icon. */
+ * The chip is the last child of the body stack, so its avatars sit at
+ * a predictable y-offset from the row's bottom edge:
+ *   row pad-bottom (var(--space-xs)) + chip pad-bottom (0.125rem)
+ *     + half chip avatar (0.5625rem of 1.125rem) − half icon (0.5rem)
+ *   = var(--space-xs) + 0.1875rem
+ *
+ * Anchoring the icon by that distance from the bottom makes the
+ * icon's vertical centre line up exactly with the chip avatars'
+ * centre line, so "thread marker (gutter) ↔ thread participants
+ * (body)" reads as one horizontal row instead of a drifting pair. */
 .chat-thread-rail-glyph {
   position: absolute;
-  top: calc(var(--space-xs) + var(--chat-message-avatar-size) + 0.4rem);
+  bottom: calc(var(--space-xs) + 0.1875rem);
   left: 0;
   width: var(--chat-message-avatar-size);
+  height: 1rem;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary

Iter 66 anchored the gutter `MessagesSquare` glyph under the author avatar (`top: avatar-size + gap`). On any row taller than a one-line message, that left the icon hanging well above the in-body thread chip — the gutter marker and the chip's participant avatars drifted apart instead of reading as one horizontal row.

Per user feedback ("Thread icon should be vertically centered with avatars!"), switch `.chat-thread-rail-glyph` to **bottom-anchored on the chip avatars' centre line** so the gutter glyph and the chip avatars sit on the same horizontal axis regardless of message body length.

### Offset derivation

The chip is the last child of `.chat-message-body-stack`, so its avatar centre sits at a deterministic distance from the row's bottom edge:

```
bottom = row pad-bottom  (var(--space-xs))
       + chip pad-bottom (0.125rem, py-0.5)
       + half chip avatar (0.5625rem of 1.125rem)
       − half icon         (0.5rem of 1rem)
       = var(--space-xs) + 0.1875rem
```

Encoded as `calc(var(--space-xs) + 0.1875rem)` so the value tracks the design-system spacing token if it ever changes.

### Why CSS-only

Both rail glyph and chip are siblings under the message grid — the glyph is absolutely positioned in column 1, the chip lives in column 2. Reaching the chip's coordinate space without a JS measure isn't possible, but the chip's geometry is fixed by the design system (chip padding, chip avatar size, row padding), so a token-based calc gets perfect alignment statically.

Also drops the stale "under the author avatar" wording in the `MessageCard.vue` markup comment.

## Test plan

- [ ] Visual: thread root in `#general` — the gutter `MessagesSquare` icon's vertical centre lines up exactly with the chip's participant avatars
- [ ] Verify in both grouped and ungrouped thread root rows
- [ ] Verify alignment holds for long-body messages (where the previous top-anchor placed the icon far above the chip)
- [ ] `bun run lint` clean in `chat/`
- [ ] CI green

This PR was created with the assistance of a LLM.