### PR TITLE
fix(chat): drop burst-cluster vertical rail

### DIFF
--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -676,45 +676,6 @@
 .chat-message-grouped {
   min-height: var(--chat-message-first-line-box);
   margin-block-start: calc(-1 * var(--chat-message-row-gap, var(--space-xs)));
-  /* Ensure the cluster rail (::after) is contained by THIS row, not the
-   * nearest positioned ancestor (which on skeleton rows is the viewport). */
-  position: relative;
-}
-
-/* Burst cluster rail — a delicate vertical accent in the avatar gutter
- * that connects grouped follow-up messages back to their burst parent.
- * Replaces the awkward "is this its own message or a continuation?"
- * ambiguity with a clear, soft thread line that reads at a glance:
- * one voice, multiple breaths.
- *
- * Positioned on the grid row's `::after` so it spans the full row
- * height (the avatar-cell child is constrained to the time-gutter's
- * 1.4rem height and can't host a rail that reaches the body). The
- * row's existing `::before` belongs to the hover-background and
- * `--forum / --mention / --thread` accents, so we use `::after`. */
-.chat-message-grouped::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: calc(var(--chat-message-avatar-size) / 2 - 1px);
-  width: 2px;
-  margin-block: 0.125rem;
-  border-radius: 1px;
-  background: color-mix(in oklab, var(--primary) 22%, transparent);
-  pointer-events: none;
-  transition: background-color 0.16s ease;
-}
-
-.chat-message-grouped:hover::after,
-.chat-message-grouped:focus-within::after {
-  background: color-mix(in oklab, var(--primary) 42%, transparent);
-}
-
-/* In a thread panel the burst rail already has the panel's own
- * left-edge accent — soften ours further so they don't compete. */
-.chat-message-grid--thread.chat-message-grouped::after {
-  background: color-mix(in oklab, var(--primary) 14%, transparent);
 }
 
 /* === Swipe-to-reply / swipe-to-thread (touch only) ===


### PR DESCRIPTION
## Summary

Per direct feedback ("Green lines aren't really working. We need a new concept and it shouldn't be broken by media posts."), drop the `.chat-message-grouped::after` vertical rail entirely. Avatar-at-burst-start plus the existing tight row spacing carry the grouping signal — same convention modern chat apps land on, and "no rail" can't be broken by media.

### Why the rail wasn't working

Each row's rail segment had a fixed `margin-block: 0.125rem` and ran `top: 0; bottom: 0`. Two failure modes:

1. **Per-row gaps don't read as continuous when row heights diverge.** A 24px text row + a 200px image row + a 24px text row produces three rail segments whose gaps look stutter-stepped instead of one connected line.
2. **It sat next to image attachments and competed with image edges.** Instead of binding rows together, the bar started fighting the media.

Replacing it with corner brackets or a gutter wash would still be in tension with media — and adds DOM complexity (the wash needs per-cluster wrappers). Dropping cleanly is the right call here.

### What this removes

- `.chat-message-grouped::after` (the rail)
- `.chat-message-grouped:hover::after`, `:focus-within::after` (rail hover)
- `.chat-message-grid--thread.chat-message-grouped::after` (thread-panel softer variant)
- `.chat-message-grouped { position: relative; }` (only existed to contain the rail; the row already has a containing block from its `transform` for swipe)

### What's preserved

- The `chat-message-grouped` class on grouped rows — still drives the `--thread.chat-message-grouped::before` (drop the thread outline on grouped rows) and the hover time-gutter reveal in the avatar column
- Burst spacing (`margin-block-start: calc(-1 * var(--chat-message-row-gap))`) — grouped rows still nestle in tight under their burst parent

## Test plan

- [ ] Visual: thread root with grouped follow-ups — burst still reads as "one author, multiple lines" via avatar-only-at-top + tight spacing, no green bar
- [ ] Visual: burst that contains a media attachment — no broken rail, no fighting image edges
- [ ] Hover on a grouped row — time-gutter still appears
- [ ] Thread-panel view — no rail competing with the panel's own left-edge accent
- [ ] `bun run lint` clean in `chat/`
- [ ] CI green

This PR was created with the assistance of a LLM.