### PR TITLE
fix(chat): comfortable row spacing via real design-system tokens

### DIFF
--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -88,7 +88,7 @@
   column-gap: var(--space-sm);
   border-radius: var(--radius-md);
   isolation: isolate;
-  padding: var(--space-xs) 0;
+  padding: var(--chat-message-row-pad) 0;
 }
 
 .chat-message-grid::before {
@@ -381,6 +381,11 @@
   line-height: 1.4;
   gap: var(--space-xs);
   align-items: center;
+  /* Lift the chip away from the message body — the body-stack's base
+   * gap (0.25rem) is too tight for a chip that carries its own avatar
+   * row and recency suffix, especially with the in-gutter rail glyph
+   * sitting on the same horizontal line. */
+  margin-block-start: var(--chat-thread-chip-gap);
 }
 
 .chat-thread-chip__icon {
@@ -413,9 +418,13 @@
  *
  * The chip is the last child of the body stack, so its avatars sit at
  * a predictable y-offset from the row's bottom edge:
- *   row pad-bottom (var(--space-xs)) + chip pad-bottom (0.125rem)
+ *   row pad-bottom (--chat-message-row-pad) + chip pad-bottom (0.125rem)
  *     + half chip avatar (0.5625rem of 1.125rem) − half icon (0.5rem)
- *   = var(--space-xs) + 0.1875rem
+ *   = --chat-message-row-pad + 0.1875rem
+ *
+ * Tracks the row-pad token rather than hardcoding --space-xs so the
+ * glyph stays centred on the chip avatars when the design system tunes
+ * row breathing room.
  *
  * Anchoring the icon by that distance from the bottom makes the
  * icon's vertical centre line up exactly with the chip avatars'
@@ -423,7 +432,7 @@
  * (body)" reads as one horizontal row instead of a drifting pair. */
 .chat-thread-rail-glyph {
   position: absolute;
-  bottom: calc(var(--space-xs) + 0.1875rem);
+  bottom: calc(var(--chat-message-row-pad) + 0.1875rem);
   left: 0;
   width: var(--chat-message-avatar-size);
   height: 1rem;
@@ -681,7 +690,7 @@
  * timestamp gutter so the user can still read the per-message time. */
 .chat-message-grouped {
   min-height: var(--chat-message-first-line-box);
-  margin-block-start: calc(-1 * var(--chat-message-row-gap, var(--space-xs)));
+  margin-block-start: calc(-1 * var(--chat-message-burst-overlap));
 }
 
 /* === Swipe-to-reply / swipe-to-thread (touch only) ===

--- a/chat/src/styles/global/tokens.css
+++ b/chat/src/styles/global/tokens.css
@@ -118,6 +118,23 @@
   --chat-message-body-gap: var(--space-2xs);
   --chat-message-first-line-box: 1.40625rem;
   --chat-message-avatar-size: calc(var(--chat-message-header-height) + var(--chat-message-body-gap) + var(--chat-message-first-line-box));
+  /* Vertical breathing room around every message row. Applied as
+   * symmetric block-padding on .chat-message-grid, so the visible gap
+   * between two non-grouped rows is twice this value. Default of
+   * --space-sm (0.75rem) yields a 1.5rem gap between independent
+   * messages — comfortable, chat-app pace, not Slack-density.
+   *
+   * The chat-message-grouped class for same-author bursts pulls its
+   * row up by --chat-message-burst-overlap so consecutive lines from
+   * one voice stay visually attached without sacrificing the breathing
+   * room between independent voices. */
+  --chat-message-row-pad: var(--space-sm);
+  --chat-message-burst-overlap: 1.1rem;
+  /* Thread-chip lift: the chip is the last child of the body stack and
+   * carries its own avatar row + recency suffix, so it needs more air
+   * above it than the 0.25rem --chat-message-body-gap supplies between
+   * plain inline children. */
+  --chat-thread-chip-gap: var(--space-2xs);
   --chat-attachment-image-width: min(100%, 20rem);
   --chat-attachment-card-width: min(100%, 28rem);
   --chat-composer-block: var(--space-sm);


### PR DESCRIPTION
## Summary

User feedback: _"spacing is important and there's almost none on this sub thread stuff … our design system should set spacing. Chat app should be spacious and comfortable."_ — the cramped area was specifically a thread root (with chip + gutter glyph) butting straight up against the next author row.

Three problems addressed:

### 1. The design system didn't actually own the row gap

`--chat-message-row-gap` was a phantom CSS-var — the only reference site (`.chat-message-grouped`'s negative margin) read it with a `var(--space-xs)` fallback, but it was never defined anywhere. The design system was claiming ownership of a value that lived only as a code-level fallback.

### 2. Base row padding was too tight

`padding: var(--space-xs) 0` = 0.5rem each side → 1rem gap between independent messages. That's Slack-density — fine for transactional notifications, cramped for a chat surface that wants to feel spacious, especially around thread roots that carry both the in-body chip and the in-gutter rail glyph.

### 3. The thread chip kissed the body above it

Body-stack gap was `--chat-message-body-gap` (0.25rem). On rows with attachments + chip + glyph, everything mashed into one visual block.

## Changes

Introduces three real tokens in `tokens.css`:

```css
--chat-message-row-pad: var(--space-sm)         /* 0.75rem each side */
--chat-message-burst-overlap: 1.1rem            /* grouped pull-up */
--chat-thread-chip-gap: var(--space-2xs)        /* chip lift */
```

Effective spacing after this commit:

| Pair | Before | After |
|------|--------|-------|
| Non-grouped row → row | 1rem | **1.5rem** (3× more breathing room than the design intent) |
| Grouped (same-author burst) | 0.5rem | **0.4rem** (still tight; bursts continue to read as one block) |
| Message body → thread chip | 0.25rem | **0.5rem** (chip can breathe before the next row) |

`.chat-message-grouped`'s `margin-block-start` now consumes `--chat-message-burst-overlap` directly (no fallback chain), so the design system genuinely owns the burst-cluster collapse value.

## Follow-up (small)

PR #598's `.chat-thread-rail-glyph { bottom: calc(var(--space-xs) + 0.1875rem); }` is derived from the previous row-pad of 0.5rem. Once this PR lands and the row-pad becomes 0.75rem, the glyph would sit 0.25rem high relative to the chip avatars. Will fix in #598 with a one-line token swap before merging that PR.

## Test plan

- [ ] Visual: independent messages now have ~1.5rem of air between rows — channel feed feels spacious
- [ ] Visual: same-author bursts still cluster tight, no per-message floating
- [ ] Visual: thread root row with chip — the chip lifts off the body, no longer kisses the message above it
- [ ] Visual: thread root + next message — generous separation, no cramped mash
- [ ] `bun run lint` clean in `chat/`
- [ ] CI green

This PR was created with the assistance of a LLM.