### PR TITLE
fix(chat): Latest button — go all the way to the edge

### DIFF
--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -98,6 +98,38 @@ async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
     align: isTopPinnedScrollDirection(mode) ? "start" : "end",
   });
   await nextTick();
+  // The virtualizer's `scrollToIndex` plans the scroll using the
+  // `estimateSize` heights (112px / 44px); real rows — especially
+  // ones with images, code blocks, or extension cards — measure much
+  // taller. After `scrollToIndex` we're "close to" the edge, but the
+  // measurement reconciliation that follows grows scrollHeight, so we
+  // end up several rows shy of the actual last message.
+  //
+  // Pin scrollTop directly across a short raf loop, bailing once the
+  // scrollHeight stops changing for two consecutive frames. The
+  // browser clamps to (scrollHeight - clientHeight) for us so this
+  // always lands at the true edge once measurements settle. Capped
+  // at 8 frames so a runaway re-render can't spin the loop.
+  const el = scrollElement.value;
+  if (!el) return true;
+  await new Promise<void>((resolve) => {
+    const topPinned = isTopPinnedScrollDirection(mode);
+    let lastHeight = -1;
+    let stable = 0;
+    let frames = 0;
+    function tick() {
+      el!.scrollTop = topPinned ? 0 : el!.scrollHeight;
+      if (el!.scrollHeight === lastHeight) {
+        if (++stable >= 2) return resolve();
+      } else {
+        stable = 0;
+        lastHeight = el!.scrollHeight;
+      }
+      if (++frames >= 8) return resolve();
+      requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+  });
   return true;
 }
 


### PR DESCRIPTION
## Summary

User report: _"the latest button not actually going all the way to the top / bottom / latest message"_.

### Root cause

The "Latest" jump-to-live-edge button called `virtualizer.scrollToIndex(lastIndex, { align: "end" })`. The virtualizer plans that scroll using its `estimateSize` callback — 112px per message row, 44px for sentinels. Real rows are routinely much taller (image attachments, code blocks, GitHub-event extension cards, multi-line wrapped text). The estimate-driven plan lands "close to" the edge, then the measurement pass that follows grows `scrollHeight`, leaving the user several rows shy of the actual newest message. Click "Latest" → still not at latest. Button felt broken.

### Fix

After `scrollToIndex` and the next tick, drive `scrollTop` directly in a short rAF loop, bailing once `scrollHeight` is stable across two consecutive frames (capped at 8 frames so a runaway re-render can't spin the loop forever).

The browser clamps `scrollTop = scrollHeight` to `scrollHeight - clientHeight`, so this always lands at the true edge once the virtualizer's measurement reconciliation settles. Same treatment for top-pinned ("social") mode via `scrollTop = 0`.

```ts
await new Promise<void>((resolve) => {
  const topPinned = isTopPinnedScrollDirection(mode);
  let lastHeight = -1;
  let stable = 0;
  let frames = 0;
  function tick() {
    el!.scrollTop = topPinned ? 0 : el!.scrollHeight;
    if (el!.scrollHeight === lastHeight) {
      if (++stable >= 2) return resolve();
    } else {
      stable = 0;
      lastHeight = el!.scrollHeight;
    }
    if (++frames >= 8) return resolve();
    requestAnimationFrame(tick);
  }
  requestAnimationFrame(tick);
});
```

## Test plan

- [ ] Scroll up in a busy channel (image-heavy), click Latest — lands on the newest message, button disappears
- [ ] Same in social mode (top-pinned) — lands at the top, button disappears
- [ ] Channel with mostly plain text rows — still lands cleanly (no regression for the cheap path)
- [ ] Switching channels while Latest is mid-scroll — no console errors (8-frame cap protects us)
- [ ] `bun run lint` clean
- [ ] CI green

This PR was created with the assistance of a LLM.