### PR TITLE
fix(chat): lightbox controls — keyboard hints, focus rings, hover lift

### DIFF
--- a/chat/src/components/ui/ImageLightbox.vue
+++ b/chat/src/components/ui/ImageLightbox.vue
@@ -74,16 +74,18 @@ onBeforeUnmount(() => {
           :download="current.name ?? ''"
           target="_blank"
           rel="noopener noreferrer"
-          class="h-9 w-9 flex items-center justify-center rounded-full bg-card/80 backdrop-blur border border-border text-foreground hover:bg-card transition-colors"
-          title="Open original"
+          class="chat-lightbox-control h-9 w-9"
+          title="Download"
+          aria-label="Download original"
           @click.stop
         >
           <Download class="w-4 h-4" />
         </a>
         <button
-          class="h-9 w-9 flex items-center justify-center rounded-full bg-card/80 backdrop-blur border border-border text-foreground hover:bg-card transition-colors"
+          class="chat-lightbox-control h-9 w-9"
           type="button"
-          title="Close"
+          title="Close (Esc)"
+          aria-label="Close lightbox"
           @click="close"
         >
           <X class="w-4 h-4" />
@@ -92,18 +94,20 @@ onBeforeUnmount(() => {
 
       <button
         v-if="hasPrev"
-        class="z-sticky absolute left-3 top-1/2 -translate-y-1/2 h-10 w-10 flex items-center justify-center rounded-full bg-card/80 backdrop-blur border border-border text-foreground hover:bg-card transition-colors"
+        class="chat-lightbox-control z-sticky absolute left-3 top-1/2 -translate-y-1/2 h-10 w-10"
         type="button"
-        title="Previous"
+        title="Previous (←)"
+        aria-label="Previous image"
         @click.stop="prev"
       >
         <ChevronLeft class="w-5 h-5" />
       </button>
       <button
         v-if="hasNext"
-        class="z-sticky absolute right-3 top-1/2 -translate-y-1/2 h-10 w-10 flex items-center justify-center rounded-full bg-card/80 backdrop-blur border border-border text-foreground hover:bg-card transition-colors"
+        class="chat-lightbox-control z-sticky absolute right-3 top-1/2 -translate-y-1/2 h-10 w-10"
         type="button"
-        title="Next"
+        title="Next (→)"
+        aria-label="Next image"
         @click.stop="next"
       >
         <ChevronRight class="w-5 h-5" />

--- a/chat/src/styles/global/surfaces.css
+++ b/chat/src/styles/global/surfaces.css
@@ -55,6 +55,51 @@
   max-width: var(--chat-lightbox-caption-width);
 }
 
+/* Lightbox control buttons — close, download, prev, next.
+ * Shared treatment so all four chrome controls speak one language:
+ * frosted-card background, soft hover lift, primary-tinted focus ring
+ * for keyboard nav. Position/size come from the component's own
+ * inline classes; only the visual chrome lives here. */
+.chat-lightbox-control {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--border) 90%, transparent);
+  background: color-mix(in oklab, var(--card) 80%, transparent);
+  color: var(--foreground);
+  backdrop-filter: blur(8px);
+  transition:
+    background-color 0.15s ease,
+    transform 0.18s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow 0.18s ease;
+}
+
+.chat-lightbox-control:hover {
+  background: var(--card);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px color-mix(in oklab, oklch(0.12 0.012 248) 22%, transparent);
+}
+
+.chat-lightbox-control:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.chat-lightbox-control:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--primary) 55%, transparent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-lightbox-control {
+    transition: background-color 0.15s ease;
+  }
+  .chat-lightbox-control:hover {
+    transform: none;
+  }
+}
+
 @media (min-width: 40rem) {
   .chat-settings-field-row {
     grid-template-columns: minmax(0, var(--chat-settings-label-width)) 1fr;


### PR DESCRIPTION
## Summary

The image lightbox's four chrome controls (download, close, prev, next) had three real polish gaps:

1. **No focus-visible outlines.** Tabbing into the lightbox showed no visible focus state — the controls were invisible to keyboard-only users.
2. **No advertised keyboard shortcuts.** `onKeydown` already implements Esc / ← / → but nothing told the user about them.
3. **Icon ↔ label disagreement.** The download anchor showed a Download icon but its tooltip said "Open original" — visual and tooltip telling different stories.

## Changes

Extract a shared `.chat-lightbox-control` class to `surfaces.css` (alongside the existing `.chat-lightbox-*` rules) so all four chrome controls speak one language:

- Frosted card background (`color-mix(in oklab, var(--card) 80%, transparent)` + `backdrop-filter: blur(8px)`)
- Hover lift (`translateY(-1px)` + soft shadow)
- Active settle (transform back to 0)
- Primary-tinted `focus-visible` ring at `--primary 55%` for keyboard nav
- `prefers-reduced-motion` variant drops the lift but keeps the colour fade

Component-side label fixes:

| Control | Old title | New title | New aria-label |
|---------|-----------|-----------|----------------|
| Download | "Open original" | "Download" | "Download original" |
| Close | "Close" | "Close (Esc)" | "Close lightbox" |
| Prev | "Previous" | "Previous (←)" | "Previous image" |
| Next | "Next" | "Next (→)" | "Next image" |

The icon-only buttons now have accessible names; the existing keyboard handlers are surfaced where users will discover them.

## Why surfaces.css and not messages.css

Keeps this change clear of the in-flight row-spacing PR (#600), which touches `messages.css`. `.chat-lightbox-*` rules already live in `surfaces.css`, so the new control class joins them where it semantically belongs.

## Test plan

- [ ] Click an image → lightbox opens → Tab through controls — focus ring visible on each
- [ ] Hover any control — frosted lift, no jitter
- [ ] Hover with `prefers-reduced-motion: reduce` — colour fade only, no transform
- [ ] Press Esc / ← / → — works (existing behaviour, now also discoverable via tooltips)
- [ ] Screen reader reads each control's aria-label
- [ ] `bun run lint` clean
- [ ] CI green

This PR was created with the assistance of a LLM.