### PR TITLE
fix(chat): connection chip — tone-specific bg tint + glow halo

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -564,31 +564,41 @@ const connectionStatusIcon = computed(() => {
 const connectionStatusClasses = computed(() => {
   switch (connectionNotice.value?.tone) {
     case "offline":
+      // Passive state — user already knows they're disconnected.
+      // Keep the chip quiet: muted bg tint, no glow halo.
       return {
         banner: "bg-muted/35 text-foreground",
         iconWrap: "border-border/70 bg-background/60 text-muted-foreground/80",
-        chip: "border-border/70 bg-transparent text-muted-foreground/80",
+        chip: "border-border/70 bg-muted/25 text-muted-foreground/80",
         body: "text-muted-foreground",
       };
     case "reconnecting":
+      // Active reconnection — warning-tinted bg + warning-glow halo
+      // reach the eye without becoming an alarm. The icon's spinner
+      // carries the "moving" signal.
       return {
         banner: "bg-warning/10 text-foreground",
         iconWrap: "border-warning/15 bg-background/60 text-warning/80",
-        chip: "border-warning/15 bg-transparent text-warning/80",
+        chip: "chat-connection-chip-glow--warning border-warning/35 bg-warning/10 text-warning/90",
         body: "text-foreground/75",
       };
     case "error":
+      // Wants user attention (session expired, etc.). Destructive-
+      // tinted bg + destructive-glow halo distinguish it from the
+      // reconnecting tone without escalating to a banner.
       return {
         banner: "bg-destructive/10 text-foreground",
         iconWrap: "border-destructive/15 bg-background/60 text-destructive/80",
-        chip: "border-destructive/15 bg-transparent text-destructive/80",
+        chip: "chat-connection-chip-glow--destructive border-destructive/35 bg-destructive/10 text-destructive/90",
         body: "text-foreground/80",
       };
     case "reconnected":
+      // Brief celebration. Primary-tinted bg + --glow-strong halo
+      // so the chip reads "we're back" before the banner ages out.
       return {
         banner: "bg-primary/8 text-foreground",
         iconWrap: "border-primary/12 bg-background/60 text-primary/80",
-        chip: "border-primary/12 bg-transparent text-primary/80",
+        chip: "chat-connection-chip-glow--primary border-primary/35 bg-primary/10 text-primary/90",
         body: "text-foreground/75",
       };
     default:

--- a/chat/src/styles/global/surfaces.css
+++ b/chat/src/styles/global/surfaces.css
@@ -100,6 +100,24 @@
   }
 }
 
+/* Connection status chip — header pill that surfaces XMPP connection
+ * state (offline / reconnecting / error / reconnected). The base chip
+ * shape lives inline in ChatHeader.vue; these modifiers add tone-
+ * specific glow halos so an active connection event registers in
+ * peripheral vision without resorting to a banner. Matches the
+ * iter-54 bell badge + iter-56 collapsed-group halo pattern. */
+.chat-connection-chip-glow--warning {
+  box-shadow: 0 0 10px color-mix(in oklab, var(--warning) 30%, transparent);
+}
+
+.chat-connection-chip-glow--destructive {
+  box-shadow: 0 0 10px color-mix(in oklab, var(--destructive) 30%, transparent);
+}
+
+.chat-connection-chip-glow--primary {
+  box-shadow: 0 0 10px var(--glow-strong);
+}
+
 @media (min-width: 40rem) {
   .chat-settings-field-row {
     grid-template-columns: minmax(0, var(--chat-settings-label-width)) 1fr;


### PR DESCRIPTION
## Summary

The header connection-status chip rendered as `bg-transparent` with a 15%-opacity tone-coloured border. When the app actually had something to say — "reconnecting", "needs attention", "back online" — the chip was so quiet it disappeared into the toolbar. The point of a status chip is to surface state at glance distance; the current treatment was effectively decorative.

## Changes

Lift the chip's per-tone treatment so the surface reads cleanly without becoming a banner:

| Tone | Treatment |
|------|-----------|
| `offline` | Muted bg tint, **no glow** — passive state, user already knows |
| `reconnecting` | Warning bg tint + **warning glow halo** — icon spinner carries motion, halo carries presence |
| `error` | Destructive bg tint + **destructive glow halo** — distinct from reconnecting without escalating to a banner |
| `reconnected` | Primary bg tint + **`--glow-strong` halo** — brief celebration before the banner ages out |

Three new glow modifiers (`.chat-connection-chip-glow--warning`, `--destructive`, `--primary`) live in `surfaces.css` alongside the lightbox controls. They match the iter-54 bell badge / iter-56 collapsed-group halo pattern so connection state speaks the same dialect as the rest of the chrome.

Border opacity steps from 15% → 35% and text from `/80` → `/90` so the chip remains legible at glance distance while staying design-quiet.

## Test plan

- [ ] Manual: disable network, watch chip transition offline → reconnecting → reconnected as connection comes back. Each tone halo distinct
- [ ] Visual: in light theme, halos read without overpowering surrounding header controls
- [ ] Visual: in dark theme, same
- [ ] `bun run lint` clean
- [ ] CI green

This PR was created with the assistance of a LLM.