### PR TITLE
fix(chat): new-messages divider — primary tone + pill label

### DIFF
--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -1286,14 +1286,17 @@ function dayDividerLabel(createdAt: string): string {
           </div>
           <div
             v-if="showDividerBefore(msg.id)"
-            class="type-section-label flex items-center gap-3 py-2 text-destructive"
+            class="chat-new-messages-divider type-section-label"
             data-new-messages-divider
             role="separator"
             aria-label="New messages"
           >
-            <div class="flex-1 h-px bg-destructive/40" />
-            <span>New messages</span>
-            <div class="flex-1 h-px bg-destructive/40" />
+            <div class="chat-new-messages-divider__rule" />
+            <span class="chat-new-messages-divider__label">
+              <span class="chat-new-messages-divider__pulse" aria-hidden="true" />
+              New messages
+            </span>
+            <div class="chat-new-messages-divider__rule" />
           </div>
           <MessageCard
             :message="msg"
@@ -1324,14 +1327,17 @@ function dayDividerLabel(createdAt: string): string {
           />
           <div
             v-if="showDividerAfter(msg.id)"
-            class="type-section-label flex items-center gap-3 py-2 text-destructive"
+            class="chat-new-messages-divider type-section-label"
             data-new-messages-divider
             role="separator"
             aria-label="New messages"
           >
-            <div class="flex-1 h-px bg-destructive/40" />
-            <span>New messages</span>
-            <div class="flex-1 h-px bg-destructive/40" />
+            <div class="chat-new-messages-divider__rule" />
+            <span class="chat-new-messages-divider__label">
+              <span class="chat-new-messages-divider__pulse" aria-hidden="true" />
+              New messages
+            </span>
+            <div class="chat-new-messages-divider__rule" />
           </div>
       </template>
     </VirtualTimeline>

--- a/chat/src/styles/global/messages.css
+++ b/chat/src/styles/global/messages.css
@@ -683,6 +683,49 @@
   font-size: 0.6875rem;
 }
 
+/* "New messages" divider — visible between the last read and first
+ * unread message when a channel has activity since the user was
+ * away. Previously typed in text-destructive (red), which read as
+ * "warning / danger" when it should read as "fresh activity from
+ * here on". Switched to --primary to match the language the unread
+ * badges (iter-54/56) already speak. A small pill around the label
+ * gives the divider weight without going full banner. */
+.chat-new-messages-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding-block: var(--space-xs);
+  color: color-mix(in oklab, var(--primary) 85%, var(--foreground));
+}
+
+.chat-new-messages-divider__rule {
+  flex: 1;
+  height: 1px;
+  background: color-mix(in oklab, var(--primary) 35%, transparent);
+}
+
+.chat-new-messages-divider__label {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in oklab, var(--primary) 30%, transparent);
+  background: color-mix(in oklab, var(--primary) 10%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.6875rem;
+}
+
+.chat-new-messages-divider__pulse {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 9999px;
+  background: var(--primary);
+  box-shadow: 0 0 6px var(--glow-strong);
+}
+
 /* Grouped follow-up: same author, < 5 min after the previous rendered
  * message. The avatar column is reserved (visibility: hidden) so the body
  * stays aligned under the burst's first message; the meta row is hidden


### PR DESCRIPTION
## Summary

The "New messages" divider rendered in `text-destructive` with red rule lines — a "warning/danger" treatment for what's actually "fresh activity from here on, look here". The Aether design system already uses `--primary` for unread badges (iter 54/56) and the unread row rail (iter 39); the divider was the lone surface still speaking the red-alert dialect.

## Changes

New `.chat-new-messages-divider` class in `messages.css`:

- Text + rule lines switch to `--primary`
- Label wrapped in a small pill (primary-tinted bg, 30% border) so it reads as a "marker", not just typeset words
- Tiny primary glow dot to the left of the label

Both copies of the inline divider markup in `ContentArea.vue` (showDividerBefore for chat mode, showDividerAfter for social mode) replaced with the shared class — future tuning is a single edit instead of two.

## Test plan

- [ ] In a channel with unread messages: divider renders in primary teal, not red
- [ ] The pill label sits on a quiet tinted bg, the rule lines blend without dominating
- [ ] Glow dot pulses subtly to the left of "New messages"
- [ ] Light + dark themes both look correct (primary token is theme-aware)
- [ ] Social-mode (top-pinned) timeline shows the divider in the same form
- [ ] `bun run lint` clean
- [ ] CI green

This PR was created with the assistance of a LLM.