### PR TITLE
fix(chat): delivery status — icon prefix per state

### DIFF
--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -2,6 +2,9 @@
 import { useStore } from "@nanostores/vue";
 import { ref, computed, nextTick, onBeforeUnmount, watch } from "vue";
 import {
+  AlertCircle,
+  Clock,
+  Loader2,
   MoreHorizontal,
   Pencil,
   Reply,
@@ -221,6 +224,19 @@ const deliveryStatusClass = computed(() => {
       return "text-destructive/80";
     default:
       return "text-muted-foreground/50";
+  }
+});
+
+const deliveryStatusIcon = computed(() => {
+  switch (props.message.deliveryStatus) {
+    case "queued":
+      return Clock;
+    case "sending":
+      return Loader2;
+    case "failed":
+      return AlertCircle;
+    default:
+      return null;
   }
 });
 
@@ -874,9 +890,16 @@ onBeforeUnmount(() => {
         <span v-if="message.isEdited" class="type-meta text-muted-foreground/50">(edited)</span>
         <span
           v-if="message.isSelf && deliveryStatusLabel"
-          class="type-meta"
+          class="type-meta inline-flex items-center gap-1"
           :class="deliveryStatusClass"
         >
+          <component
+            v-if="deliveryStatusIcon"
+            :is="deliveryStatusIcon"
+            class="w-3 h-3"
+            :class="message.deliveryStatus === 'sending' ? 'motion-safe:animate-spin' : ''"
+            aria-hidden="true"
+          />
           {{ deliveryStatusLabel }}
         </span>
         <span


### PR DESCRIPTION
## Summary

Self-messages displayed delivery state as a single text span ("queued" / "sending…" / "failed") next to the author name. Plain text undersells the most important transitions:

- A "sending" message stays motionless on screen even though it's mid-flight — the user has no visual cue something's happening
- "failed" looks like just another grey caption among the other meta-row spans

## Changes

Add an icon prefix that matches each state's tone:

| State | Icon | Notes |
|-------|------|-------|
| `queued` | `Clock` | Waiting in the offline queue |
| `sending` | `Loader2` | Spinning, respects `prefers-reduced-motion` |
| `failed` | `AlertCircle` | Pairs with the existing destructive text colour |
| `delivered` / `sent` | — | Status was already `null` in this case, no chip |

Implementation:

- New `deliveryStatusIcon` computed picks the icon by `message.deliveryStatus`
- The chip becomes `inline-flex items-center gap-1` so the icon and text track together when the row reflows
- The Loader2 spin uses the existing `motion-safe:animate-spin` utility, so users with `prefers-reduced-motion` see a static glyph

## Test plan

- [ ] Send a message while offline → "queued" chip appears with Clock icon
- [ ] Send a normal message → brief "sending…" chip with spinning Loader2 visible before it confirms
- [ ] Force a send failure → "failed" chip with AlertCircle, destructive text
- [ ] Delivered messages have no chip (status returns null, hidden via v-if)
- [ ] `bun run lint` clean
- [ ] CI green

This PR was created with the assistance of a LLM.