### PR TITLE
fix(server): XEP-0428 — support &lt;subject/&gt; + optional for=, dedicated test suite

### DIFF
--- a/server/crates/waddle-xmpp/src/xep/xep0428.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0428.rs
@@ -1,20 +1,35 @@
 //! XEP-0428: Fallback Indication
 //!
-//! Marks text ranges inside a message `<body/>` as fallback content that
-//! reply-aware or other capability-aware clients should strip when rendering
-//! the primary payload (for example, the quoted prefix prepended in front of
-//! an XEP-0461 reply so legacy clients still see readable context).
+//! Marks part or all of a message's `<body/>` and/or `<subject/>` as fallback
+//! content for a specific protocol (XEP-0461 replies, XEP-0424 message
+//! retraction, XEP-0447 stateless file sharing, …). Capability-aware clients
+//! strip the fallback when rendering the primary payload; legacy clients see
+//! it as a regular body and gracefully degrade.
 //!
-//! Wire shape:
+//! Wire shape (XEP-0428 §2, v0.2.1):
 //!
 //! ```xml
-//! <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>
-//!   <body start='0' end='42'/>
-//! </fallback>
+//! <message to='anna@example.com' type='groupchat'>
+//!   <body>&gt; Anna wrote:&#10;&gt; Hi&#10;Great</body>
+//!   <reply to='anna@example.com' id='message-id1' xmlns='urn:xmpp:reply:0' />
+//!   <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>
+//!     <body start='0' end='33' />
+//!   </fallback>
+//! </message>
 //! ```
 //!
-//! A message may carry multiple `<fallback/>` payloads — one per feature
-//! namespace the fallback targets.
+//! Key spec points (XEP-0428 §2.2):
+//!
+//! - The `for` attribute is OPTIONAL. When present, it names the specification
+//!   the fallback substitutes for; when absent, the indication applies to all
+//!   bodies and subjects of the message.
+//! - `<body/>` and `<subject/>` children may carry optional `start`/`end`
+//!   character offsets (XEP-0426 grapheme-aware UTF-16 code-unit positions —
+//!   we treat them as plain UTF-16 code units per the JS string-slice model).
+//! - A `<body/>` or `<subject/>` child with no offsets means the entire
+//!   element is fallback.
+//! - A `<fallback/>` with no children at all is shorthand for "every body and
+//!   every subject in this message is fallback".
 
 use minidom::Element;
 use xmpp_parsers::message::Message;
@@ -22,47 +37,101 @@ use xmpp_parsers::message::Message;
 /// Namespace for XEP-0428 Fallback Indication.
 pub const NS_FALLBACK: &str = "urn:xmpp:fallback:0";
 
-/// A body character range `[start, end)` marked as fallback.
+/// A character range `[start, end)` inside a `<body/>` or `<subject/>` element,
+/// measured in UTF-16 code units (matches XEP-0426's grapheme-position model
+/// closely enough for the JS / browser substring slicing every existing
+/// client uses).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FallbackRange {
-    /// Inclusive UTF-16 code-unit start offset into the body.
     pub start: usize,
-    /// Exclusive UTF-16 code-unit end offset into the body.
     pub end: usize,
+}
+
+/// How a region (body or subject) participates in a fallback indication.
+///
+/// `Whole` corresponds to `<body/>` / `<subject/>` without `start`/`end`
+/// attributes ("the entire element is fallback"). `Ranges` carries one or
+/// more explicit range elements; the spec lets multiple per region appear.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FallbackRegion {
+    /// The entire body or subject element is fallback content.
+    Whole,
+    /// Specific UTF-16 ranges within the body or subject are fallback.
+    Ranges(Vec<FallbackRange>),
+}
+
+impl FallbackRegion {
+    /// Build a region from an iterator of ranges. Empty input canonicalises
+    /// to `Whole` (the same wire shape the spec uses for "no offsets given").
+    pub fn from_ranges(ranges: impl IntoIterator<Item = FallbackRange>) -> Self {
+        let collected: Vec<FallbackRange> = ranges.into_iter().collect();
+        if collected.is_empty() {
+            Self::Whole
+        } else {
+            Self::Ranges(collected)
+        }
+    }
 }
 
 /// A parsed `<fallback/>` payload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FallbackIndication {
-    /// The feature namespace this fallback is for (e.g. `urn:xmpp:reply:0`).
-    pub for_ns: String,
-    /// Optional body ranges; absent means "the entire body is fallback".
-    pub body_ranges: Option<Vec<FallbackRange>>,
+    /// `for=` attribute (XEP-0428 §2.2). Spec-optional; when `None`, the
+    /// indication applies to all bodies and subjects of the message.
+    pub for_ns: Option<String>,
+    /// `<body/>` children, if any.
+    pub body: Option<FallbackRegion>,
+    /// `<subject/>` children, if any.
+    pub subject: Option<FallbackRegion>,
 }
 
 impl FallbackIndication {
-    /// Construct a whole-body fallback for a feature namespace.
+    /// `<fallback xmlns='urn:xmpp:fallback:0' for='X'><body/></fallback>` —
+    /// the whole body is fallback for the named protocol.
     pub fn whole_body(for_ns: impl Into<String>) -> Self {
         Self {
-            for_ns: for_ns.into(),
-            body_ranges: None,
+            for_ns: Some(for_ns.into()),
+            body: Some(FallbackRegion::Whole),
+            subject: None,
         }
     }
 
-    /// Construct a body-range fallback.
+    /// `<fallback for='X'><body start='S' end='E'/></fallback>` — a single
+    /// UTF-16 range inside the body is fallback.
     pub fn for_range(for_ns: impl Into<String>, start: usize, end: usize) -> Self {
         Self::for_ranges(for_ns, [FallbackRange { start, end }])
     }
 
-    /// Construct a fallback with multiple body ranges.
+    /// `<fallback for='X'><body start='…' end='…'/>…</fallback>` — multiple
+    /// UTF-16 ranges. An empty range list collapses to `whole_body`.
     pub fn for_ranges(
         for_ns: impl Into<String>,
         body_ranges: impl IntoIterator<Item = FallbackRange>,
     ) -> Self {
-        let body_ranges: Vec<FallbackRange> = body_ranges.into_iter().collect();
         Self {
-            for_ns: for_ns.into(),
-            body_ranges: (!body_ranges.is_empty()).then_some(body_ranges),
+            for_ns: Some(for_ns.into()),
+            body: Some(FallbackRegion::from_ranges(body_ranges)),
+            subject: None,
+        }
+    }
+
+    /// `<fallback for='X'><subject/></fallback>` — the whole subject is
+    /// fallback for the named protocol.
+    pub fn whole_subject(for_ns: impl Into<String>) -> Self {
+        Self {
+            for_ns: Some(for_ns.into()),
+            body: None,
+            subject: Some(FallbackRegion::Whole),
+        }
+    }
+
+    /// `<fallback/>` — no `for`, no children. Per the spec, this means
+    /// every body and every subject in the carrier message is fallback.
+    pub fn whole_message() -> Self {
+        Self {
+            for_ns: None,
+            body: None,
+            subject: None,
         }
     }
 }
@@ -79,76 +148,125 @@ fn parse_usize_attr(elem: &Element, name: &str) -> Result<Option<usize>, ()> {
     }
 }
 
-fn parse_body_ranges(fallback_elem: &Element) -> Result<Option<Vec<FallbackRange>>, ()> {
-    let body_children: Vec<&Element> = fallback_elem
-        .children()
-        .filter(|child| child.name() == "body" && child.ns() == NS_FALLBACK)
-        .collect();
-    if body_children.is_empty() {
-        if fallback_elem.children().next().is_none() {
-            return Ok(None);
-        }
-        return Err(());
-    }
-
-    let mut ranges = Vec::with_capacity(body_children.len());
-    let mut whole_body = false;
-    for body_elem in body_children {
-        let start = parse_usize_attr(body_elem, "start")?;
-        let end = parse_usize_attr(body_elem, "end")?;
-        match (start, end) {
-            (None, None) => whole_body = true,
-            (Some(start), Some(end)) if end >= start => ranges.push(FallbackRange { start, end }),
-            _ => return Err(()),
-        }
-    }
-
-    if whole_body {
-        if ranges.is_empty() {
-            Ok(None)
-        } else {
-            Err(())
-        }
-    } else {
-        Ok(Some(ranges))
+/// Parse a `<body/>` or `<subject/>` child of `<fallback/>`. Returns the
+/// range, or `Whole` when no offsets are provided. `Err(())` flags a parse
+/// failure (one-sided offsets, end-before-start, non-integer) so the caller
+/// can reject the whole indication.
+fn parse_region_child(elem: &Element) -> Result<FallbackRange, ()> {
+    let start = parse_usize_attr(elem, "start")?;
+    let end = parse_usize_attr(elem, "end")?;
+    match (start, end) {
+        (Some(start), Some(end)) if end >= start => Ok(FallbackRange { start, end }),
+        (None, None) => Err(()), // caller distinguishes via separate path
+        _ => Err(()),
     }
 }
 
+/// Collect every `<body/>` (or `<subject/>`, depending on `child_name`)
+/// child of the `<fallback/>` element into a typed region.
+///
+/// Returns:
+/// - `Ok(None)` if no children of that kind exist (the region is not
+///   targeted by this indication).
+/// - `Ok(Some(Whole))` if there is exactly one child with no offsets — the
+///   spec's "the whole element is fallback" shape.
+/// - `Ok(Some(Ranges([…])))` if all children declared offsets.
+/// - `Err(())` if the element mixed offsets with no-offset children, or
+///   carried malformed offsets — the indication is rejected.
+fn collect_region(fallback_elem: &Element, child_name: &str) -> Result<Option<FallbackRegion>, ()> {
+    let children: Vec<&Element> = fallback_elem
+        .children()
+        .filter(|child| child.name() == child_name && child.ns() == NS_FALLBACK)
+        .collect();
+    if children.is_empty() {
+        return Ok(None);
+    }
+    // A single child with no offsets is the canonical "whole element"
+    // form. Multiple children require every one of them to declare a range.
+    if children.len() == 1 {
+        let only = children[0];
+        let start = parse_usize_attr(only, "start")?;
+        let end = parse_usize_attr(only, "end")?;
+        match (start, end) {
+            (None, None) => return Ok(Some(FallbackRegion::Whole)),
+            (Some(start), Some(end)) if end >= start => {
+                return Ok(Some(FallbackRegion::Ranges(vec![FallbackRange {
+                    start,
+                    end,
+                }])));
+            }
+            _ => return Err(()),
+        }
+    }
+    let mut ranges = Vec::with_capacity(children.len());
+    for child in children {
+        ranges.push(parse_region_child(child)?);
+    }
+    Ok(Some(FallbackRegion::Ranges(ranges)))
+}
+
 /// Parse all `<fallback/>` payloads attached to a message.
+///
+/// Conformant inputs that are silently rejected:
+/// - Malformed offsets (non-integer, end before start, half-supplied).
+/// - Mixed "whole element" + range children in the same region.
+///
+/// `for=` is honoured as optional per the spec: a missing attribute leaves
+/// `for_ns` as `None` and means the indication applies to every body and
+/// subject in the message.
 pub fn parse_fallbacks_from_message(msg: &Message) -> Vec<FallbackIndication> {
     msg.payloads
         .iter()
         .filter(|elem| is_fallback_element(elem))
         .filter_map(|elem| {
-            let for_ns = elem.attr("for").map(str::trim).filter(|v| !v.is_empty())?;
-            let body_ranges = parse_body_ranges(elem).ok()?;
+            let for_ns = elem
+                .attr("for")
+                .map(str::trim)
+                .filter(|v| !v.is_empty())
+                .map(str::to_owned);
+            let body = collect_region(elem, "body").ok()?;
+            let subject = collect_region(elem, "subject").ok()?;
             Some(FallbackIndication {
-                for_ns: for_ns.to_owned(),
-                body_ranges,
+                for_ns,
+                body,
+                subject,
             })
         })
         .collect()
 }
 
-/// Build an XEP-0428 `<fallback/>` element.
-pub fn build_fallback_element(fallback: &FallbackIndication) -> Element {
-    let mut builder =
-        Element::builder("fallback", NS_FALLBACK).attr("for", fallback.for_ns.as_str());
-    match &fallback.body_ranges {
-        None => {
-            builder = builder.append(Element::builder("body", NS_FALLBACK).build());
+fn append_region(parent: &mut Element, region: &FallbackRegion, name: &str) {
+    match region {
+        FallbackRegion::Whole => {
+            parent.append_child(Element::builder(name, NS_FALLBACK).build());
         }
-        Some(ranges) => {
+        FallbackRegion::Ranges(ranges) => {
             for range in ranges {
-                let body = Element::builder("body", NS_FALLBACK)
-                    .attr("start", range.start.to_string())
-                    .attr("end", range.end.to_string())
-                    .build();
-                builder = builder.append(body);
+                parent.append_child(
+                    Element::builder(name, NS_FALLBACK)
+                        .attr("start", range.start.to_string())
+                        .attr("end", range.end.to_string())
+                        .build(),
+                );
             }
         }
     }
-    builder.build()
+}
+
+/// Build an XEP-0428 `<fallback/>` element.
+pub fn build_fallback_element(fallback: &FallbackIndication) -> Element {
+    let mut builder = Element::builder("fallback", NS_FALLBACK);
+    if let Some(for_ns) = fallback.for_ns.as_deref() {
+        builder = builder.attr("for", for_ns);
+    }
+    let mut elem = builder.build();
+    if let Some(subject) = &fallback.subject {
+        append_region(&mut elem, subject, "subject");
+    }
+    if let Some(body) = &fallback.body {
+        append_region(&mut elem, body, "body");
+    }
+    elem
 }
 
 /// Replace all fallback payloads on a message with the given set.
@@ -159,9 +277,9 @@ pub fn set_fallback_payloads(msg: &mut Message, fallbacks: &[FallbackIndication]
     }
 }
 
-/// Strip every fallback range from a body string, returning the caller-visible
-/// text. Offsets are treated as UTF-16 code units per XEP-0428 §2, which
-/// matches how JavaScript/browser clients slice strings; the body is
+/// Strip every fallback range from a body string, returning the
+/// caller-visible text. Offsets are treated as UTF-16 code units per the
+/// XEP-0426 character-position model the spec references; the body is
 /// round-tripped through UTF-16 so emoji and other non-BMP characters are
 /// stripped correctly.
 pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
@@ -184,260 +302,4 @@ pub fn strip_fallback_ranges(body: &str, ranges: &[FallbackRange]) -> String {
         .filter_map(|(u, k)| if *k { Some(*u) } else { None })
         .collect();
     String::from_utf16_lossy(&kept)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_fallback_element() {
-        let elem = Element::builder("fallback", NS_FALLBACK).build();
-        assert!(is_fallback_element(&elem));
-        let wrong = Element::builder("fallback", "other:ns").build();
-        assert!(!is_fallback_element(&wrong));
-    }
-
-    #[test]
-    fn test_parse_whole_body_fallback() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'/>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 1);
-        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
-        assert_eq!(fallbacks[0].body_ranges, None);
-    }
-
-    #[test]
-    fn test_parse_body_range_fallback() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='0' end='42'/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 1);
-        assert_eq!(
-            fallbacks[0].body_ranges,
-            Some(vec![FallbackRange { start: 0, end: 42 }])
-        );
-    }
-
-    #[test]
-    fn test_parse_body_child_without_offsets_means_whole_body() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'>\
-                <body/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 1);
-        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:sfs:0");
-        assert_eq!(fallbacks[0].body_ranges, None);
-    }
-
-    #[test]
-    fn test_parse_multiple_body_ranges() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='0' end='10'/>\
-                <body start='20' end='30'/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 1);
-        assert_eq!(
-            fallbacks[0].body_ranges,
-            Some(vec![
-                FallbackRange { start: 0, end: 10 },
-                FallbackRange { start: 20, end: 30 },
-            ])
-        );
-    }
-
-    #[test]
-    fn test_parse_mixed_whole_body_and_range_is_skipped() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='0' end='10'/>\
-                <body/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        assert!(parse_fallbacks_from_message(&msg).is_empty());
-    }
-
-    #[test]
-    fn test_parse_multiple_fallbacks() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='0' end='10'/>\
-            </fallback>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:example:other'/>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 2);
-        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
-        assert_eq!(fallbacks[1].for_ns, "urn:example:other");
-    }
-
-    #[test]
-    fn test_parse_missing_for_attr_skipped() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0'/>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        assert!(parse_fallbacks_from_message(&msg).is_empty());
-    }
-
-    #[test]
-    fn test_parse_subject_only_fallback_is_skipped() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <subject start='0' end='4'/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        assert!(parse_fallbacks_from_message(&msg).is_empty());
-    }
-
-    #[test]
-    fn test_parse_partial_body_range_is_skipped() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='0'/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        assert!(parse_fallbacks_from_message(&msg).is_empty());
-    }
-
-    #[test]
-    fn test_parse_end_before_start_is_skipped() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
-                <body start='4' end='1'/>\
-            </fallback>\
-        </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-        assert!(parse_fallbacks_from_message(&msg).is_empty());
-    }
-
-    #[test]
-    fn test_build_round_trip() {
-        let original = FallbackIndication::for_range("urn:xmpp:reply:0", 0, 17);
-        let elem = build_fallback_element(&original);
-        assert_eq!(elem.ns(), NS_FALLBACK);
-        assert_eq!(elem.attr("for"), Some("urn:xmpp:reply:0"));
-        let body = elem
-            .children()
-            .find(|c| c.name() == "body")
-            .expect("body child");
-        assert_eq!(body.attr("start"), Some("0"));
-        assert_eq!(body.attr("end"), Some("17"));
-    }
-
-    #[test]
-    fn test_build_whole_body_fallback_emits_body_child_without_offsets() {
-        let elem = build_fallback_element(&FallbackIndication::whole_body("urn:xmpp:sfs:0"));
-        assert_eq!(elem.attr("for"), Some("urn:xmpp:sfs:0"));
-        let body = elem.get_child("body", NS_FALLBACK).expect("body child");
-        assert!(body.attr("start").is_none());
-        assert!(body.attr("end").is_none());
-    }
-
-    #[test]
-    fn test_empty_body_ranges_canonicalize_to_whole_body() {
-        let fallback = FallbackIndication::for_ranges("urn:xmpp:sfs:0", std::iter::empty());
-        assert_eq!(fallback.body_ranges, None);
-        let elem = build_fallback_element(&fallback);
-        assert!(elem.get_child("body", NS_FALLBACK).is_some());
-    }
-
-    #[test]
-    fn test_set_fallback_payloads_replaces_existing() {
-        let xml = "<message xmlns='jabber:client'>\
-            <fallback xmlns='urn:xmpp:fallback:0' for='urn:old'/>\
-        </message>";
-        let mut msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message");
-
-        set_fallback_payloads(
-            &mut msg,
-            &[FallbackIndication::for_range("urn:xmpp:reply:0", 2, 5)],
-        );
-
-        let fallbacks = parse_fallbacks_from_message(&msg);
-        assert_eq!(fallbacks.len(), 1);
-        assert_eq!(fallbacks[0].for_ns, "urn:xmpp:reply:0");
-        assert_eq!(
-            fallbacks[0].body_ranges,
-            Some(vec![FallbackRange { start: 2, end: 5 }])
-        );
-    }
-
-    #[test]
-    fn test_strip_fallback_ranges_basic() {
-        let stripped = strip_fallback_ranges(
-            "> quoted\n\nreply body",
-            &[FallbackRange { start: 0, end: 10 }],
-        );
-        assert_eq!(stripped, "reply body");
-    }
-
-    #[test]
-    fn test_strip_fallback_ranges_multiple_overlapping() {
-        let stripped = strip_fallback_ranges(
-            "abcdefg",
-            &[
-                FallbackRange { start: 0, end: 2 },
-                FallbackRange { start: 4, end: 6 },
-            ],
-        );
-        assert_eq!(stripped, "cdg");
-    }
-
-    #[test]
-    fn test_strip_fallback_ranges_utf16_emoji_prefix() {
-        // "👋 hi\n\n" as a quoted prefix: 👋 is a surrogate pair (2 UTF-16 units),
-        // space is 1, 'h' is 1, 'i' is 1, '\n' is 1, '\n' is 1 — total 7 units.
-        let body = "👋 hi\n\nreply";
-        let prefix_units = "👋 hi\n\n".encode_utf16().count();
-        let stripped = strip_fallback_ranges(
-            body,
-            &[FallbackRange {
-                start: 0,
-                end: prefix_units,
-            }],
-        );
-        assert_eq!(stripped, "reply");
-    }
-
-    #[test]
-    fn test_strip_fallback_ranges_out_of_bounds_saturates() {
-        let stripped = strip_fallback_ranges(
-            "short",
-            &[FallbackRange {
-                start: 2,
-                end: 9999,
-            }],
-        );
-        assert_eq!(stripped, "sh");
-    }
 }

--- a/server/crates/waddle-xmpp/tests/xep0428_fallback_indication.rs
+++ b/server/crates/waddle-xmpp/tests/xep0428_fallback_indication.rs
@@ -1,0 +1,472 @@
+//! XEP-0428: Fallback Indication — dedicated conformance test suite.
+//!
+//! Spec source: https://xmpp.org/extensions/xep-0428.html (v0.2.1, 2024-03-20).
+//!
+//! The audit found three gaps that this suite locks down:
+//!
+//! 1. **`<subject/>` children**. Earlier impl silently ignored fallbacks
+//!    that targeted only the subject; spec §2.2 says subjects are valid
+//!    fallback regions on equal footing with bodies.
+//! 2. **Optional `for=` attribute**. Spec schema marks it optional; a
+//!    bare `<fallback xmlns='urn:xmpp:fallback:0'/>` is shorthand for
+//!    "every body and subject in this message is fallback". Earlier
+//!    impl rejected such elements.
+//! 3. **No dedicated test file**. Per CLAUDE.md "Every implemented XEP
+//!    MUST have a dedicated Rust custom test suite" hard rule.
+//!
+//! The tests below exercise the public API published by
+//! `waddle_xmpp::xep::xep0428` — building, parsing, set/strip
+//! lifecycles — and pin the spec-required shape on the wire.
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0428::{
+    build_fallback_element, is_fallback_element, parse_fallbacks_from_message,
+    set_fallback_payloads, strip_fallback_ranges, FallbackIndication, FallbackRange,
+    FallbackRegion, NS_FALLBACK,
+};
+use xmpp_parsers::message::Message;
+
+fn parse_message(xml: &str) -> Message {
+    Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("parse message")
+}
+
+// ── §1: container shape and namespace pinning ─────────────────────────────
+
+#[test]
+fn xep_0428_namespace_constant_matches_spec() {
+    // The container namespace is mandatory per §2.2.
+    assert_eq!(NS_FALLBACK, "urn:xmpp:fallback:0");
+}
+
+#[test]
+fn xep_0428_is_fallback_element_namespaces_strictly() {
+    let elem = Element::builder("fallback", NS_FALLBACK).build();
+    assert!(is_fallback_element(&elem));
+    let wrong_ns = Element::builder("fallback", "other:ns").build();
+    assert!(!is_fallback_element(&wrong_ns));
+    let wrong_name = Element::builder("fallbacks", NS_FALLBACK).build();
+    assert!(!is_fallback_element(&wrong_name));
+}
+
+// ── §2.2: `for=` attribute (optional) ─────────────────────────────────────
+
+#[test]
+fn xep_0428_for_attribute_present_round_trips() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'/>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].for_ns.as_deref(), Some("urn:xmpp:reply:0"));
+}
+
+#[test]
+fn xep_0428_for_attribute_absent_means_whole_message_per_spec() {
+    // §2.2: "If the <fallback/> element does not have any childs, it is
+    // assumed to apply to every message <body/> and <subject/> present
+    // in the message." The `for=` attribute is OPTIONAL on the wire —
+    // a bare element is a valid spec form and must NOT be dropped.
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0'/>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(
+        fallbacks.len(),
+        1,
+        "spec-conformant bare <fallback/> must parse, not be dropped"
+    );
+    assert!(fallbacks[0].for_ns.is_none());
+    assert!(fallbacks[0].body.is_none());
+    assert!(fallbacks[0].subject.is_none());
+}
+
+#[test]
+fn xep_0428_for_attribute_empty_string_treated_as_absent() {
+    // Defensive: a `for=""` is functionally indistinguishable from
+    // `for=` being absent. Treat as absent rather than retaining an
+    // empty string.
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for=''/>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert!(fallbacks[0].for_ns.is_none());
+}
+
+// ── §2.2: <body/> children (whole + ranges) ───────────────────────────────
+
+#[test]
+fn xep_0428_body_with_offsets_marks_a_range() {
+    // The §2.2 canonical example exactly.
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='33'/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].for_ns.as_deref(), Some("urn:xmpp:reply:0"));
+    assert_eq!(
+        fallbacks[0].body,
+        Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 0,
+            end: 33
+        }]))
+    );
+    assert!(fallbacks[0].subject.is_none());
+}
+
+#[test]
+fn xep_0428_body_without_offsets_marks_the_whole_body() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'>\
+                <body/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].body, Some(FallbackRegion::Whole));
+}
+
+#[test]
+fn xep_0428_multiple_body_ranges_are_all_carried() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+                <body start='20' end='30'/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(
+        fallbacks[0].body,
+        Some(FallbackRegion::Ranges(vec![
+            FallbackRange { start: 0, end: 10 },
+            FallbackRange { start: 20, end: 30 },
+        ]))
+    );
+}
+
+// ── §2.2: <subject/> children ─────────────────────────────────────────────
+//
+// Spec §2.2 is explicit that subject AND body may both be fallback
+// regions: "The <fallback/> element may have one or multiple <body/> or
+// <subject/> child elements". Earlier impl silently dropped subject-only
+// elements.
+
+#[test]
+fn xep_0428_subject_with_offsets_marks_a_range() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <subject start='0' end='4'/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert!(fallbacks[0].body.is_none());
+    assert_eq!(
+        fallbacks[0].subject,
+        Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 0,
+            end: 4
+        }]))
+    );
+}
+
+#[test]
+fn xep_0428_subject_without_offsets_marks_the_whole_subject() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <subject/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].subject, Some(FallbackRegion::Whole));
+}
+
+#[test]
+fn xep_0428_body_and_subject_can_both_be_targeted() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <subject start='0' end='4'/>\
+                <body start='5' end='20'/>\
+            </fallback>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(
+        fallbacks[0].subject,
+        Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 0,
+            end: 4
+        }]))
+    );
+    assert_eq!(
+        fallbacks[0].body,
+        Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 5,
+            end: 20
+        }]))
+    );
+}
+
+// ── Defensive parsing: malformed shapes are rejected ──────────────────────
+
+#[test]
+fn xep_0428_mixed_whole_body_plus_range_is_rejected() {
+    // Mixing `<body/>` (whole) with `<body start=… end=…/>` (range) in
+    // the same fallback indication is ambiguous; reject the whole
+    // indication rather than guess.
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+                <body/>\
+            </fallback>\
+        </message>",
+    );
+    assert!(parse_fallbacks_from_message(&msg).is_empty());
+}
+
+#[test]
+fn xep_0428_half_specified_range_is_rejected() {
+    // `start=` without `end=` is malformed.
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0'/>\
+            </fallback>\
+        </message>",
+    );
+    assert!(parse_fallbacks_from_message(&msg).is_empty());
+}
+
+#[test]
+fn xep_0428_end_before_start_is_rejected() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='10' end='3'/>\
+            </fallback>\
+        </message>",
+    );
+    assert!(parse_fallbacks_from_message(&msg).is_empty());
+}
+
+#[test]
+fn xep_0428_non_integer_offsets_are_rejected() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='abc' end='123'/>\
+            </fallback>\
+        </message>",
+    );
+    assert!(parse_fallbacks_from_message(&msg).is_empty());
+}
+
+// ── Multiple <fallback/> payloads on a single message ─────────────────────
+//
+// Spec doesn't bound the count — every payload is independent.
+
+#[test]
+fn xep_0428_multiple_fallback_payloads_each_parse_independently() {
+    let msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:reply:0'>\
+                <body start='0' end='10'/>\
+            </fallback>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:xmpp:sfs:0'/>\
+        </message>",
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 2);
+    assert_eq!(fallbacks[0].for_ns.as_deref(), Some("urn:xmpp:reply:0"));
+    assert_eq!(fallbacks[1].for_ns.as_deref(), Some("urn:xmpp:sfs:0"));
+}
+
+// ── Builder round-trips and emits canonical shape ─────────────────────────
+
+#[test]
+fn xep_0428_builder_emits_for_attribute_and_body_offsets() {
+    let elem = build_fallback_element(&FallbackIndication::for_range("urn:xmpp:reply:0", 0, 17));
+    assert_eq!(elem.ns(), NS_FALLBACK);
+    assert_eq!(elem.attr("for"), Some("urn:xmpp:reply:0"));
+    let body = elem
+        .children()
+        .find(|c| c.name() == "body")
+        .expect("body child");
+    assert_eq!(body.ns(), NS_FALLBACK);
+    assert_eq!(body.attr("start"), Some("0"));
+    assert_eq!(body.attr("end"), Some("17"));
+}
+
+#[test]
+fn xep_0428_builder_omits_for_when_indication_is_whole_message() {
+    let elem = build_fallback_element(&FallbackIndication::whole_message());
+    assert_eq!(elem.ns(), NS_FALLBACK);
+    assert!(
+        elem.attr("for").is_none(),
+        "whole-message indication has no `for` attribute on the wire"
+    );
+    assert!(
+        elem.children().next().is_none(),
+        "whole-message indication has no children on the wire"
+    );
+}
+
+#[test]
+fn xep_0428_builder_emits_subject_alongside_body() {
+    let indication = FallbackIndication {
+        for_ns: Some("urn:xmpp:reply:0".to_owned()),
+        body: Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 0,
+            end: 10,
+        }])),
+        subject: Some(FallbackRegion::Whole),
+    };
+    let elem = build_fallback_element(&indication);
+    let subject = elem
+        .children()
+        .find(|c| c.name() == "subject")
+        .expect("subject child must be emitted");
+    assert_eq!(subject.ns(), NS_FALLBACK);
+    assert!(subject.attr("start").is_none());
+    assert!(subject.attr("end").is_none());
+    let body = elem
+        .children()
+        .find(|c| c.name() == "body")
+        .expect("body child must be emitted");
+    assert_eq!(body.attr("start"), Some("0"));
+    assert_eq!(body.attr("end"), Some("10"));
+}
+
+#[test]
+fn xep_0428_round_trip_preserves_full_indication_shape() {
+    let original = FallbackIndication {
+        for_ns: Some("urn:xmpp:message-retract:1".to_owned()),
+        body: Some(FallbackRegion::Whole),
+        subject: Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 4,
+            end: 9,
+        }])),
+    };
+    let elem = build_fallback_element(&original);
+    let wrapper_xml = format!(
+        "<message xmlns='jabber:client'>{}</message>",
+        String::from(&elem)
+    );
+    let msg = parse_message(&wrapper_xml);
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0], original);
+}
+
+// ── set_fallback_payloads replaces previous fallback set ──────────────────
+
+#[test]
+fn xep_0428_set_fallback_payloads_replaces_existing_indications() {
+    let mut msg = parse_message(
+        "<message xmlns='jabber:client'>\
+            <fallback xmlns='urn:xmpp:fallback:0' for='urn:old'/>\
+        </message>",
+    );
+    set_fallback_payloads(
+        &mut msg,
+        &[FallbackIndication::for_range("urn:xmpp:reply:0", 2, 5)],
+    );
+    let fallbacks = parse_fallbacks_from_message(&msg);
+    assert_eq!(fallbacks.len(), 1);
+    assert_eq!(fallbacks[0].for_ns.as_deref(), Some("urn:xmpp:reply:0"));
+    assert_eq!(
+        fallbacks[0].body,
+        Some(FallbackRegion::Ranges(vec![FallbackRange {
+            start: 2,
+            end: 5
+        }]))
+    );
+}
+
+// ── strip_fallback_ranges UTF-16 model ────────────────────────────────────
+
+#[test]
+fn xep_0428_strip_fallback_ranges_drops_specified_substrings() {
+    let stripped = strip_fallback_ranges(
+        "> quoted\n\nreply body",
+        &[FallbackRange { start: 0, end: 10 }],
+    );
+    assert_eq!(stripped, "reply body");
+}
+
+#[test]
+fn xep_0428_strip_fallback_ranges_handles_overlapping_and_non_bmp() {
+    // "👋 hi\n\n" is a 7-UTF-16-unit prefix (surrogate pair counts as 2).
+    let body = "👋 hi\n\nreply";
+    let prefix_units = "👋 hi\n\n".encode_utf16().count();
+    let stripped = strip_fallback_ranges(
+        body,
+        &[FallbackRange {
+            start: 0,
+            end: prefix_units,
+        }],
+    );
+    assert_eq!(stripped, "reply");
+}
+
+#[test]
+fn xep_0428_strip_fallback_ranges_saturates_out_of_bounds() {
+    let stripped = strip_fallback_ranges(
+        "short",
+        &[FallbackRange {
+            start: 2,
+            end: 9999,
+        }],
+    );
+    assert_eq!(stripped, "sh");
+}
+
+// ── Convenience constructors ──────────────────────────────────────────────
+
+#[test]
+fn xep_0428_whole_body_constructor_matches_canonical_wire_form() {
+    let elem = build_fallback_element(&FallbackIndication::whole_body("urn:xmpp:sfs:0"));
+    assert_eq!(elem.attr("for"), Some("urn:xmpp:sfs:0"));
+    let body = elem.get_child("body", NS_FALLBACK).expect("body child");
+    assert!(body.attr("start").is_none());
+    assert!(body.attr("end").is_none());
+    assert!(elem.get_child("subject", NS_FALLBACK).is_none());
+}
+
+#[test]
+fn xep_0428_whole_subject_constructor_emits_subject_only() {
+    let elem = build_fallback_element(&FallbackIndication::whole_subject("urn:xmpp:reply:0"));
+    assert_eq!(elem.attr("for"), Some("urn:xmpp:reply:0"));
+    assert!(elem.get_child("subject", NS_FALLBACK).is_some());
+    assert!(elem.get_child("body", NS_FALLBACK).is_none());
+}
+
+#[test]
+fn xep_0428_empty_range_list_canonicalises_to_whole_body() {
+    let indication =
+        FallbackIndication::for_ranges("urn:xmpp:sfs:0", std::iter::empty::<FallbackRange>());
+    assert_eq!(indication.body, Some(FallbackRegion::Whole));
+}


### PR DESCRIPTION
Audit of XEP-0428 (Fallback Indication, v0.2.1 published 2024-03-20). The on-disk `xeps/xep-0428.xml` is the stale v0.1.1 form — `xeps/` is gitignored, so I refreshed it locally and grounded this audit on the current published spec at https://xmpp.org/extensions/xep-0428.html.

## Findings

Three spec gaps in the previous impl plus one hard-rule gap:

| # | Gap | Spec citation |
|---|-----|---------------|
| 1 | `<subject/>` children silently dropped | §2.2: "The `<fallback/>` element may have one or multiple `<body/>` or `<subject/>` child elements" |
| 2 | `for=` attribute treated as required (missing → rejected) | §2.2 schema: `<xs:attribute name="for" type="xs:string" />` — no `use="required"`. §2.2 prose: "If the `<fallback/>` element does not have any childs, it is assumed to apply to every message `<body/>` and `<subject/>` present in the message." |
| 3 | No dedicated test file | CLAUDE.md "XEP custom test-suite hard rule" |

The wire shape Waddle was already emitting (with `for=` and `<body start=/end=/>`) IS correct per v0.2.1 — the impl was tracking the newer spec ahead of the on-disk copy. The bugs were on the receive side: rejecting bare `<fallback/>` and `<fallback><subject/></fallback>` shapes a conformant peer is allowed to send.

## Type model changes

| Before | After |
|--------|-------|
| `for_ns: String` | `for_ns: Option<String>` |
| `body_ranges: Option<Vec<FallbackRange>>` (None = whole body) | `body: Option<FallbackRegion>` where `FallbackRegion::{Whole, Ranges(Vec<FallbackRange>)}` makes the wire distinction explicit |
| — | `subject: Option<FallbackRegion>` (new — mirrors body) |

Convenience constructors `whole_body(for_ns)` / `for_range(for_ns, s, e)` / `for_ranges(for_ns, …)` keep their signatures so `bot.rs` (the only non-test caller of the public API) is untouched. New `whole_subject(for_ns)` and `whole_message()` cover previously-unrepresentable spec forms.

## Test coverage

New dedicated suite `server/crates/waddle-xmpp/tests/xep0428_fallback_indication.rs` — 27 tests covering:

- Namespace pinning and element identification (`urn:xmpp:fallback:0`).
- `for=` present / absent / empty-string — all round-trip per spec.
- `<body/>` ranges, whole-body, multi-range cases — including the §2.2 canonical example exactly.
- `<subject/>` ranges, whole-subject, body+subject combos — the apex gap.
- Defensive rejection of malformed shapes (mixed `Whole` + `Ranges` in one region, half-specified ranges, end-before-start, non-integer offsets).
- Multiple fallback payloads per message.
- Builder round-trip preserving the full indication shape.
- `set_fallback_payloads` replacement semantics.
- UTF-16 strip helper, including non-BMP emoji prefixes.
- Convenience-constructor wire shapes.

## Verification

- [x] `cargo test -p waddle-xmpp --test xep0428_fallback_indication` — 27/27 pass
- [x] `cargo test -p waddle-xmpp --lib` — 1,816/1,816 pass
- [x] `cargo test -p waddle-server --lib` — 603/603 pass
- [x] `cargo clippy -p waddle-xmpp -p waddle-server -p waddle-xmpp-core --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI green

This PR was created with the assistance of a LLM.