### PR TITLE
test(server): XEP-0410 dedicated test suite (audit pass — conformant)

### DIFF
--- a/server/crates/waddle-xmpp/tests/xep0410_muc_self_ping.rs
+++ b/server/crates/waddle-xmpp/tests/xep0410_muc_self_ping.rs
@@ -1,0 +1,264 @@
+//! XEP-0410: MUC Self-Ping (Schrödinger's Chat) — dedicated test suite.
+//!
+//! Spec: https://xmpp.org/extensions/xep-0410.html (v1.1.0, Draft).
+//!
+//! This file is the CLAUDE.md "every implemented XEP MUST have a
+//! dedicated Rust custom test suite" coverage for XEP-0410. The server-
+//! side optimization (the MUC IQ handler that short-circuits a joined
+//! self-ping with `result` and a non-joined sender with `not-acceptable`)
+//! is exercised end-to-end through the websocket integration suite at
+//! `server/crates/waddle-server/tests/xep0054_0049_0191_ws.rs`. This
+//! file pins the **client-facing helper library** under
+//! `waddle_xmpp::xep::xep0410`: the IQ builder, the receive-side
+//! classifier, and the response-interpretation switch the spec
+//! mandates in §2.2.
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0410::{
+    build_self_ping, interpret_self_ping_response, is_self_ping, SelfPingResult,
+    FEATURE_MUC_SELFPING, PING_TIMEOUT_SECS, RECOMMENDED_INTERVAL_SECS,
+};
+use xmpp_parsers::{
+    iq::{Iq, IqType},
+    stanza_error::{DefinedCondition, ErrorType, StanzaError},
+};
+
+const NS_PING: &str = "urn:xmpp:ping";
+
+fn occupant_jid() -> jid::Jid {
+    "room@muc.example.com/mynick"
+        .parse()
+        .expect("valid occupant jid")
+}
+
+fn error_iq(condition: DefinedCondition) -> Iq {
+    Iq {
+        from: Some("room@muc.example.com/mynick".parse().expect("valid")),
+        to: Some("juliet@example.com/client".parse().expect("valid")),
+        id: "sp-err".to_owned(),
+        payload: IqType::Error(StanzaError::new(ErrorType::Cancel, condition, "en", "")),
+    }
+}
+
+// ── Feature advertisement & spec constants ─────────────────────────────
+
+#[test]
+fn xep_0410_feature_string_matches_spec_exactly() {
+    // XEP-0410 §3 + Registrar §7: the disco#info feature on individual
+    // MUC room JIDs that signals server-side optimization support.
+    assert_eq!(
+        FEATURE_MUC_SELFPING,
+        "http://jabber.org/protocol/muc#self-ping-optimization"
+    );
+}
+
+#[test]
+fn xep_0410_recommended_constants_match_spec_intent() {
+    // §2.2 "After an adequate amount of silence from a given MUC (e.g.
+    // 15 minutes), or from all MUCs from a given service domain, a
+    // client should initiate a self-ping." The 60 s default in the
+    // helper library is below that 15-minute threshold; clients that
+    // want longer can override.
+    assert_eq!(RECOMMENDED_INTERVAL_SECS, 60);
+    // The spec doesn't fix a timeout, but every joined-occupant ping
+    // either reflects to a peer or short-circuits via the optimization
+    // — both bounded in single-digit seconds in practice.
+    assert_eq!(PING_TIMEOUT_SECS, 10);
+}
+
+// ── §2.2 client-side builder ──────────────────────────────────────────
+
+#[test]
+fn xep_0410_build_self_ping_emits_canonical_iq_get_shape() {
+    let iq = build_self_ping(None::<jid::Jid>, occupant_jid(), "sp-1");
+    assert_eq!(iq.id, "sp-1");
+    assert_eq!(iq.to, Some(occupant_jid()));
+    // Payload is `<ping xmlns='urn:xmpp:ping'/>` inside an `iq type='get'`,
+    // matching the §2.2 canonical example.
+    let IqType::Get(elem) = &iq.payload else {
+        panic!("self-ping must be type='get'");
+    };
+    assert_eq!(elem.name(), "ping");
+    assert_eq!(elem.ns(), NS_PING);
+    assert!(
+        elem.children().next().is_none(),
+        "the <ping/> element has no children per XEP-0199 §3.1"
+    );
+}
+
+#[test]
+fn xep_0410_build_self_ping_round_trips_explicit_from_jid() {
+    let from: jid::Jid = "juliet@example.com/laptop".parse().unwrap();
+    let iq = build_self_ping(Some(from.clone()), occupant_jid(), "sp-2");
+    assert_eq!(iq.from, Some(from));
+}
+
+// ── §2.2 receive-side classifier (`is_self_ping`) ─────────────────────
+
+#[test]
+fn xep_0410_is_self_ping_accepts_ping_to_full_occupant_jid() {
+    let iq = build_self_ping(None::<jid::Jid>, occupant_jid(), "sp-1");
+    assert!(
+        is_self_ping(&iq),
+        "an IQ-get with <ping/> destined for a full MUC occupant JID is a self-ping"
+    );
+}
+
+#[test]
+fn xep_0410_is_self_ping_rejects_bare_jid_destination() {
+    // A ping to the room's bare JID is a regular server / domain ping,
+    // not a self-ping. Spec scope is occupant-JID destinations only.
+    let bare: jid::Jid = "room@muc.example.com".parse().expect("valid bare jid");
+    let ping_elem = Element::builder("ping", NS_PING).build();
+    let iq = Iq {
+        from: None,
+        to: Some(bare),
+        id: "sp-bare".to_owned(),
+        payload: IqType::Get(ping_elem),
+    };
+    assert!(!is_self_ping(&iq));
+}
+
+#[test]
+fn xep_0410_is_self_ping_rejects_non_ping_payloads() {
+    // A roster-query IQ to a full JID is NOT a self-ping.
+    let other_elem = Element::builder("query", "jabber:iq:roster").build();
+    let iq = Iq {
+        from: None,
+        to: Some(occupant_jid()),
+        id: "rq-1".to_owned(),
+        payload: IqType::Get(other_elem),
+    };
+    assert!(!is_self_ping(&iq));
+}
+
+#[test]
+fn xep_0410_is_self_ping_rejects_ping_in_wrong_namespace() {
+    let elem = Element::builder("ping", "urn:example:not-ping").build();
+    let iq = Iq {
+        from: None,
+        to: Some(occupant_jid()),
+        id: "wrongns".to_owned(),
+        payload: IqType::Get(elem),
+    };
+    assert!(!is_self_ping(&iq));
+}
+
+// ── §2.2 response interpretation (the canonical 5-way switch) ─────────
+//
+// The spec enumerates the responses a client must distinguish:
+//   - Successful IQ response → still joined
+//   - service-unavailable / feature-not-implemented → joined,
+//     but the pinged client doesn't implement XEP-0199 — treat
+//     as Connected (the routing was reflected, so we ARE joined)
+//   - item-not-found → joined, but the occupant nick changed
+//     mid-session — treat as Connected
+//   - remote-server-not-found / remote-server-timeout → no
+//     decision available; treat as Timeout
+//   - Any other error → probably not joined; rejoin
+//   - Timeout (no response) → caller-driven (handled outside this
+//     classifier).
+
+#[test]
+fn xep_0410_iq_result_interpreted_as_connected() {
+    let iq = Iq {
+        from: Some(occupant_jid()),
+        to: None,
+        id: "sp-1".to_owned(),
+        payload: IqType::Result(None),
+    };
+    assert_eq!(interpret_self_ping_response(&iq), SelfPingResult::Connected);
+}
+
+#[test]
+fn xep_0410_not_acceptable_error_interpreted_as_disconnected() {
+    // §2.2 explicitly: "<not-acceptable> — the client is not joined
+    // any more. It should perform a re-join."
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::NotAcceptable)),
+        SelfPingResult::Disconnected
+    );
+}
+
+#[test]
+fn xep_0410_service_unavailable_means_joined_but_peer_lacks_ping() {
+    // §2.2: "<service-unavailable> or <feature-not-implemented> — the
+    // client is joined, but the pinged client does not implement
+    // XEP-0199." Treat as Connected because the routing reached a
+    // co-occupant.
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::ServiceUnavailable)),
+        SelfPingResult::Connected
+    );
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::FeatureNotImplemented)),
+        SelfPingResult::Connected
+    );
+}
+
+#[test]
+fn xep_0410_item_not_found_means_joined_mid_nick_change() {
+    // §2.2: "<item-not-found> — the client is joined, but the
+    // occupant just changed their name (e.g. initiated by a different
+    // client)."
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::ItemNotFound)),
+        SelfPingResult::Connected
+    );
+}
+
+#[test]
+fn xep_0410_remote_server_errors_are_indeterminate_timeouts() {
+    // §2.2: "<remote-server-not-found> or <remote-server-timeout> —
+    // the remote server is unreachable for unspecified reasons; this
+    // can be a temporary network failure or a server outage. No
+    // decision can be made based on this; Treat like a timeout."
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::RemoteServerNotFound)),
+        SelfPingResult::Timeout
+    );
+    assert_eq!(
+        interpret_self_ping_response(&error_iq(DefinedCondition::RemoteServerTimeout)),
+        SelfPingResult::Timeout
+    );
+}
+
+#[test]
+fn xep_0410_unrecognised_errors_fall_to_disconnected_per_spec_guidance() {
+    // §2.2: "Any other error — the client is probably not joined any
+    // more. It should perform a re-join."
+    //
+    // Spec notes that real implementations send `not-acceptable`,
+    // `not-allowed`, or `bad-request` for this case. Confirm all three
+    // are treated as Disconnected.
+    for condition in [
+        DefinedCondition::NotAllowed,
+        DefinedCondition::BadRequest,
+        DefinedCondition::Forbidden,
+    ] {
+        assert_eq!(
+            interpret_self_ping_response(&error_iq(condition.clone())),
+            SelfPingResult::Disconnected,
+            "{condition:?} should trigger a rejoin per spec catch-all",
+        );
+    }
+}
+
+#[test]
+fn xep_0410_self_ping_result_should_rejoin_table() {
+    // The Disconnected and Timeout cases both warrant a rejoin
+    // (Timeout because the connection state is indeterminate and the
+    // safe default is to assume disconnected).
+    assert!(!SelfPingResult::Connected.should_rejoin());
+    assert!(SelfPingResult::Disconnected.should_rejoin());
+    assert!(SelfPingResult::Timeout.should_rejoin());
+}
+
+#[test]
+fn xep_0410_self_ping_result_display_strings() {
+    // Display form is used in logs and telemetry; pin the values so
+    // log-parsing dashboards don't drift.
+    assert_eq!(SelfPingResult::Connected.to_string(), "connected");
+    assert_eq!(SelfPingResult::Disconnected.to_string(), "disconnected");
+    assert_eq!(SelfPingResult::Timeout.to_string(), "timeout");
+}


### PR DESCRIPTION
Audit of XEP-0410 v1.1.0 (MUC Self-Ping / "Schrödinger's Chat", Draft). Net result: **conformant on every spec MUST**. Only the test-suite hard-rule gap remained, which this PR closes.

## Audit checklist

| Spec requirement | Where it lives in Waddle | Conformant? |
|---|---|---|
| §3 feature advertised on individual MUC room JIDs | `muc_room_features` in `waddle-xmpp-core/src/disco/info.rs` | ✓ |
| §3 feature MUST NOT appear on MUC service component | `muc_service_features` omits it; pinned by negative test | ✓ |
| §3 server-side optimization: matched self-ping → `<iq type='result'/>` | `handle_muc_self_ping_iq` → `PingSelfCheck` room-actor message → `Ok(())` arm | ✓ |
| §3 server-side optimization: unmatched / not-joined → `<not-acceptable>` | Same handler, `Err(HandlerError(_))` arm | ✓ |
| §2.2 builder produces `<iq type='get'><ping xmlns='urn:xmpp:ping'/></iq>` | `build_self_ping` | ✓ |
| §2.2 response classification (5-way table) | `interpret_self_ping_response` | ✓ |

The end-to-end WS path for the joined-occupant case is already exercised by `websocket_muc_self_ping_succeeds_for_joined_occupant` (in the bundled `xep0054_0049_0191_ws.rs` file).

## What this PR adds

New `server/crates/waddle-xmpp/tests/xep0410_muc_self_ping.rs` — 16 tests lifting the previously-inline `xep0410::tests` coverage into a dedicated suite with spec-citing test names. Notable additions over the previous inline coverage:

- Spec-feature-string identity check (`http://jabber.org/protocol/muc#self-ping-optimization` exact match).
- `<iq type='get'><ping/></iq>` shape pin including the "ping element has no children" XEP-0199 §3.1 invariant.
- `<not-allowed>` / `<bad-request>` / `<forbidden>` all interpreted as Disconnected per the §2.2 catch-all guidance.
- `RECOMMENDED_INTERVAL_SECS` / `PING_TIMEOUT_SECS` defaults pinned against the §2.2 "15 minutes" silence-window guideline.

## Out of scope (tracked separately)

Cross-occupant pings (Alice pinging Bob's nick in the same room) currently flow through `handle_muc_self_ping_iq` and return `<not-acceptable>` rather than reflecting per XEP-0045 §7.4. **This is not a XEP-0410 conformance gap** — §3's MUSTs apply only to actual self-pings — but it is a XEP-0045 IQ-routing concern that will surface in that audit.

## Verification

- [x] `cargo test -p waddle-xmpp --test xep0410_muc_self_ping` — 16/16 pass
- [x] `cargo test -p waddle-xmpp --lib` — 1,835/1,835 pass
- [x] `cargo clippy -p waddle-xmpp --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [ ] CI green

This PR was created with the assistance of a LLM.