### PR TITLE
feat(chat): move-MUC-between-spaces from channel settings

### DIFF
--- a/chat/src/components/chat/ChatAppModals.vue
+++ b/chat/src/components/chat/ChatAppModals.vue
@@ -23,6 +23,7 @@ const {
   handleCreateChannel,
   handleUpdateChannel,
   handleDeleteChannel,
+  handleMoveChannelToSpace,
   confirmDeleteChannel,
   handleUpdateWaddle,
   handleDeleteWaddle,
@@ -63,9 +64,12 @@ const {
       :channel="waddles.currentChannel.value"
       :form="waddles.editChannelForm.value"
       :is-submitting="waddles.isSubmitting.value"
+      :spaces="waddles.sortedSpaces.value"
+      :can-move-channel="waddles.canManageChannels.value"
       @update:form="waddles.editChannelForm.value = $event"
       @save="handleUpdateChannel"
       @delete="handleDeleteChannel"
+      @move-to-space="handleMoveChannelToSpace"
     />
 
     <MemberManagement

--- a/chat/src/components/modals/EditChannelDialog.vue
+++ b/chat/src/components/modals/EditChannelDialog.vue
@@ -1,22 +1,54 @@
 <script setup lang="ts">
+import { ref, watch } from "vue";
 import { X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
 import type { ChannelEditFormData } from "@/lib/chat-ui";
-import type { ChannelSummary, PinPermission } from "@/lib/chat-types";
+import type { ChannelSummary, PinPermission, SpaceSummary } from "@/lib/chat-types";
 
 const open = defineModel<boolean>("open", { required: true });
 
-defineProps<{
+const props = defineProps<{
   channel: ChannelSummary | null;
   form: ChannelEditFormData;
   isSubmitting: boolean;
+  /** Spaces the user can move the channel into. */
+  spaces: SpaceSummary[];
+  /** Whether the user has permission to move the channel between
+   * spaces. Falls back to the same `canManageChannels` gate as
+   * editing other channel attributes. */
+  canMoveChannel: boolean;
 }>();
 
 const emit = defineEmits<{
   save: [];
   delete: [];
   "update:form": [form: ChannelEditFormData];
+  /** Move the current channel to a different Space. Wired to the
+   * `moveChannelToSpace` waddle action. Distinct from `save` because
+   * the move is a separate XMPP publish (not part of MUC owner
+   * config), and we want the user to see immediate Move feedback
+   * without the rest of the dialog gating on it. */
+  moveToSpace: [targetSpaceId: string];
 }>();
+
+// Pending target Space for the "Move" subsection. Resets to the
+// channel's current Space whenever the dialog is (re)opened, so the
+// user starts each session at "no pending change."
+const pendingTargetSpaceId = ref<string | null>(null);
+watch(
+  () => [open.value, props.channel?.id, props.channel?.spaceId] as const,
+  () => {
+    pendingTargetSpaceId.value = props.channel?.spaceId ?? null;
+  },
+  { immediate: true },
+);
+
+function onMoveClick() {
+  const target = pendingTargetSpaceId.value;
+  if (!target) return;
+  if (target === (props.channel?.spaceId ?? null)) return;
+  emit("moveToSpace", target);
+}
 </script>
 
 <template>
@@ -74,6 +106,59 @@ const emit = defineEmits<{
           <option value="admins-only">Admins only</option>
           <option value="anyone">Anyone</option>
         </select>
+      </div>
+
+      <!-- XEP-0503 Space membership. Distinct from name/description
+           because the server-side change goes through a PubSub
+           publish against the Spaces service (not the MUC owner
+           form), so we surface its own Move button rather than
+           folding it into the dialog-wide Save. The server enforces
+           single-membership per #620: publishing to the target
+           Space retracts the bookmark from any prior Space, so the
+           client just issues the publish. -->
+      <div v-if="canMoveChannel" class="chat-field-stack">
+        <label for="edit-channel-space" class="type-section-label text-muted-foreground">
+          Space
+        </label>
+        <div class="flex items-center gap-2">
+          <select
+            id="edit-channel-space"
+            :value="pendingTargetSpaceId ?? ''"
+            class="chat-field-control type-field flex-1"
+            :disabled="isSubmitting || spaces.length === 0"
+            @change="pendingTargetSpaceId = (($event.target as HTMLSelectElement).value || null)"
+          >
+            <option v-if="spaces.length === 0" value="" disabled>No other spaces</option>
+            <option v-for="space in spaces" :key="space.id" :value="space.id">
+              {{ space.name }}
+            </option>
+          </select>
+          <button
+            class="chat-action-button chat-action-button--secondary type-control"
+            type="button"
+            :disabled="
+              isSubmitting
+                || !pendingTargetSpaceId
+                || pendingTargetSpaceId === (channel?.spaceId ?? null)
+            "
+            @click="onMoveClick"
+          >
+            {{ isSubmitting ? "Moving…" : "Move" }}
+          </button>
+        </div>
+        <p
+          v-if="channel?.spaceId && pendingTargetSpaceId && pendingTargetSpaceId !== channel.spaceId"
+          class="type-meta text-muted-foreground"
+        >
+          The room will move from
+          <span class="type-emphasis">
+            {{ spaces.find((s) => s.id === channel?.spaceId)?.name ?? channel.spaceId }}
+          </span>
+          to
+          <span class="type-emphasis">
+            {{ spaces.find((s) => s.id === pendingTargetSpaceId)?.name ?? pendingTargetSpaceId }}
+          </span>.
+        </p>
       </div>
     </div>
 

--- a/chat/src/lib/xmpp/protocol-helpers.ts
+++ b/chat/src/lib/xmpp/protocol-helpers.ts
@@ -180,6 +180,24 @@ async function publishMucToSpace(client: HybridClient, spacesServiceJid: string,
   );
 }
 
+/**
+ * Move a MUC bookmark to a different XEP-0503 Space.
+ *
+ * Implemented as a publish to the target Space — the server-side
+ * `handle_spaces_publish` enforces XEP-0503 single-membership by
+ * retracting the same `item-id` from every other Space first, so
+ * the client doesn't have to issue a separate retract.
+ */
+export async function moveMucToSpace(
+  client: HybridClient,
+  spacesServiceJid: string,
+  targetSpaceNode: string,
+  mucJid: string,
+  params: PublishMucToSpaceParams,
+): Promise<void> {
+  await publishMucToSpace(client, spacesServiceJid, targetSpaceNode, mucJid, params);
+}
+
 export async function createMucInSpace(client: HybridClient, mucServiceJid: string, spacesServiceJid: string, params: CreateMucInSpaceParams): Promise<{ roomJid: string; spaceNode: string; spacesServiceJid: string }> {
   const { roomJid } = await createMucRoom(client, mucServiceJid, params);
   await publishMucToSpace(client, spacesServiceJid, params.spaceNode, roomJid, { name: params.name, autojoin: true });

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1510,6 +1510,13 @@ export function useChatAppController(giphyApiKey: string) {
     ui.confirmDeleteChannel.value = true;
   }
 
+  async function handleMoveChannelToSpace(targetSpaceId: string) {
+    const channel = waddles.currentChannel.value;
+    if (!channel) return;
+    const ok = await waddles.moveChannelToSpace(channel.id, targetSpaceId);
+    if (ok) ui.showEditChannel.value = false;
+  }
+
   async function confirmDeleteChannel() {
     ui.confirmDeleteChannel.value = false;
     await waddles.deleteChannel();
@@ -1677,6 +1684,7 @@ export function useChatAppController(giphyApiKey: string) {
       handleCreateChannel,
       handleUpdateChannel,
       handleDeleteChannel,
+      handleMoveChannelToSpace,
       confirmDeleteChannel,
       handleUpdateWaddle,
       handleDeleteWaddle,

--- a/chat/src/waddles/directory.ts
+++ b/chat/src/waddles/directory.ts
@@ -10,6 +10,7 @@ import {
   createSpaceNode,
   createMucInSpace,
   createSpaceWithMuc,
+  moveMucToSpace,
 } from "@/lib/xmpp/protocol-helpers";
 import { mucServiceDomain, spacesServiceDomain } from "@/lib/xmpp/discovery";
 
@@ -477,6 +478,61 @@ export function useWaddleDirectory(
     actionError.value = "Channel deletion is not available until the XMPP command exists.";
   }
 
+  /**
+   * Move a channel to a different XEP-0503 Space. Returns `true` on
+   * success.
+   *
+   * Implementation publishes the channel's `<conference>` bookmark
+   * to the target Space; the server (per XEP-0503 single-membership
+   * enforcement) retracts the item from every other Space before
+   * persisting, so no separate retract is required here.
+   *
+   * Re-loads the channel structure after a successful move so the
+   * sidebar groups reflect the new membership.
+   */
+  async function moveChannelToSpace(
+    channelId: string,
+    targetSpaceId: string,
+  ): Promise<boolean> {
+    const channel = channels.value.find((c) => c.id === channelId);
+    if (!channel?.jid) {
+      actionError.value = "Cannot move a channel without a known room JID.";
+      return false;
+    }
+    if (channel.spaceId === targetSpaceId) {
+      // No-op: already in the target Space. Surface as success so
+      // the UI clears its pending state.
+      return true;
+    }
+    const client = xmppClient.value;
+    const sess = session.value;
+    if (!client?.agent || !sess) {
+      actionError.value = "XMPP session is not ready.";
+      return false;
+    }
+    const spacesService = spacesServiceJid.value ?? spacesServiceDomain(sess.jid);
+    isSubmitting.value = true;
+    try {
+      await moveMucToSpace(client.agent, spacesService, targetSpaceId, channel.jid, {
+        name: channel.name,
+        autojoin: true,
+      });
+      // Optimistically update local state so the channel re-groups
+      // in the sidebar before the next structure reload.
+      const idx = channels.value.findIndex((c) => c.id === channelId);
+      if (idx >= 0) {
+        channels.value[idx] = { ...channels.value[idx], spaceId: targetSpaceId };
+      }
+      await loadStructure(channelId);
+      return true;
+    } catch (error) {
+      actionError.value = normalizeError(error);
+      return false;
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
   function clearData() {
     spaceRequestId++;
     structureRequestId++;
@@ -523,6 +579,7 @@ export function useWaddleDirectory(
     createChannel,
     updateChannel,
     deleteChannel,
+    moveChannelToSpace,
     clearData,
     resetForms,
   };


### PR DESCRIPTION
## Summary

User-reported follow-up to the #620 XEP-0503 single-membership fix: once the server stops duplicating room bookmarks across Spaces, the chat UI needed a way for users to actually trigger the move.

Adds a **Space** selector + **Move** button to the existing **EditChannelDialog** — the same channel-settings cog already wired in the channel header. The button is its own action (not the dialog-wide Save) because the underlying XMPP operation is a PubSub publish against the Spaces service rather than a MUC owner form submission, and the user should see immediate Move feedback without the rest of the dialog gating on it.

## Wiring

- `protocol-helpers.moveMucToSpace` — public wrapper around the existing private `publishMucToSpace`. Server enforces XEP-0503 single-membership (#620), so the client just publishes; the server retracts the bookmark from the prior Space.
- `directory.moveChannelToSpace` (waddle method) — publishes via `moveMucToSpace`, optimistically updates `channels[i].spaceId` so the sidebar regroups instantly, then triggers `loadStructure` for the authoritative view. No-ops if the channel is already in the target Space.
- `EditChannelDialog` — new "Space" field (gated on `canManageChannels`). Local `pendingTargetSpaceId` ref resets to current on each open, with a "from … to …" preview before commit.
- `ChatAppModals` + `chat-app-controller.handleMoveChannelToSpace` — emit chain. Closes the dialog on success.

## Out of scope

Drag-and-drop. It lands on top of `moveChannelToSpace` in a follow-up PR.

## Test plan

- [x] `bun run lint` (chat: knip) → no findings
- [x] `bun test` (chat) → 773 passing
- [x] `bunx astro check` → only 3 pre-existing client.ts errors unrelated to this PR (WASM types)

Manual:
- [ ] Open channel settings cog on a room
- [ ] Verify Space dropdown lists other Spaces (current Space pre-selected)
- [ ] Pick another Space → click Move → channel re-groups in sidebar; reload survives

This PR was created with the assistance of a LLM.