### PR TITLE
fix(server): XEP-0425 v1 — moderator occupant-id attribution + dead-code cull

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -311,12 +311,24 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             .unwrap_or_else(|| sender_jid.resource().to_string());
         let moderated_by = format!("{room_jid}/{moderator_nick}");
         let stamp_time = chrono::Utc::now();
-        let stamp = stamp_time.to_rfc3339();
+        // XEP-0425 v1 §3: the broadcast `<moderated>` element
+        // carries the moderator's XEP-0421 occupant-id so
+        // semi-anonymous rooms still surface a stable attribution
+        // identifier even when `by=` hides the real JID. We pin it
+        // unconditionally — non-anonymous rooms already disclose the
+        // bare JID via `by=`, so the extra `<occupant-id/>` is
+        // harmless and keeps the wire shape uniform across room
+        // configurations.
+        let moderator_occupant_id = waddle_xmpp::xep::xep0421::generate_occupant_id(
+            &sender_jid.to_bare(),
+            &room_jid,
+            &state.deps.occupant_id_secret,
+        );
         let mut moderation = build_moderation_result_message(
             Some(jid::Jid::from(room_jid.clone())),
             &request.target_id,
             &moderated_by,
-            &stamp,
+            Some(moderator_occupant_id.as_str()),
             request.reason.as_deref(),
         );
         let archive_id = uuid::Uuid::now_v7().to_string();

--- a/server/crates/waddle-xmpp/src/inbox/runtime.rs
+++ b/server/crates/waddle-xmpp/src/inbox/runtime.rs
@@ -8,8 +8,8 @@ use crate::mam::STANZA_ID_NS;
 use crate::xep::xep0424::extract_retraction_from_message;
 use crate::xep::xep0430::InboxQuery;
 use crate::xep::{
-    has_file_sharing, is_moderation_request_message, is_moderation_result_message,
-    is_reaction_message, is_sticker_message, should_skip_storage,
+    has_file_sharing, is_moderation_result_message, is_reaction_message, is_sticker_message,
+    should_skip_storage,
 };
 
 pub fn should_project_message(msg: &Message) -> bool {
@@ -26,7 +26,6 @@ pub fn should_project_message(msg: &Message) -> bool {
             extract_retraction_from_message(msg),
             Some(crate::xep::RetractionKind::Request(_))
         )
-        || is_moderation_request_message(msg)
         || is_moderation_result_message(msg)
         || has_file_sharing(msg)
         || is_sticker_message(msg)

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -21,8 +21,8 @@ use super::context::RoomContext;
 use super::traits::{RoomHandler, RoomHandlerOutcome};
 use crate::xep::xep0424::{extract_retraction_from_message, RetractionKind};
 use crate::xep::{
-    extract_forum_action, has_file_sharing, is_moderation_request_message,
-    is_moderation_result_message, is_reaction_message, is_sticker_message, should_skip_storage,
+    extract_forum_action, has_file_sharing, is_moderation_result_message, is_reaction_message,
+    is_sticker_message, should_skip_storage,
 };
 use waddle_xmpp_core::xep0201::{thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS};
 use xmpp_parsers::message::{Message, MessageType};
@@ -81,7 +81,6 @@ pub fn is_archivable(message: &Message) -> bool {
             extract_retraction_from_message(message),
             Some(RetractionKind::Request(_))
         )
-        || is_moderation_request_message(message)
         || is_moderation_result_message(message)
         || thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS).is_some()
         || extract_forum_action(message).is_some()

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -218,10 +218,9 @@ pub use super::xep0424::{
 };
 
 pub use super::xep0425::{
-    build_moderated_retract_element, build_moderation_result_message, extract_moderation_request,
-    extract_moderation_result, is_moderation_request_message, is_moderation_result_message,
-    parse_moderation_iq, ModerationCarrier, ModerationRequest, ModerationResult,
-    NS_MESSAGE_MODERATE,
+    build_moderated_retract_element, build_moderation_result_message, extract_moderation_result,
+    is_moderation_result_message, parse_moderation_iq, ModerationCarrier, ModerationRequest,
+    ModerationResult, NS_MESSAGE_MODERATE,
 };
 
 pub use super::xep0444::{

--- a/server/crates/waddle-xmpp/src/xep/xep0425.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0425.rs
@@ -1,55 +1,62 @@
-//! XEP-0425: Moderated Message Retraction
+//! XEP-0425: Moderated Message Retraction (v1).
 //!
-//! Allows MUC moderators to retract any occupant's message. Extends
-//! XEP-0424 (Message Retraction) with moderator authority and uses
-//! XEP-0422 (Message Fastening) for targeting.
+//! Allows MUC moderators to retract any occupant's message. Replaces
+//! the v0 XEP-0422 message-fastening shape with a direct IQ from the
+//! moderator and a `<retract>`-shaped broadcast carrying a
+//! `<moderated>` attribution child.
 //!
 //! ## XML Format
 //!
-//! Moderator sends to room:
+//! Moderator → room (IQ request):
 //! ```xml
-//! <message type='groupchat' to='room@muc.example.com' id='mod-1'>
-//!   <apply-to id='target-msg-id' xmlns='urn:xmpp:fasten:0'>
-//!     <moderate xmlns='urn:xmpp:message-moderate:1'>
-//!       <retract xmlns='urn:xmpp:message-retract:1'/>
-//!       <reason>Spam</reason>
-//!     </moderate>
-//!   </apply-to>
+//! <iq type='set' to='room@muc.example.com' id='mod-1'>
+//!   <moderate id='target-stanza-id' xmlns='urn:xmpp:message-moderate:1'>
+//!     <retract xmlns='urn:xmpp:message-retract:1'/>
+//!     <reason>Spam</reason>
+//!   </moderate>
+//! </iq>
+//! ```
+//!
+//! Room → all occupants (groupchat broadcast):
+//! ```xml
+//! <message type='groupchat' from='room@muc.example.com'>
+//!   <retract id='target-stanza-id' xmlns='urn:xmpp:message-retract:1'>
+//!     <moderated by='room@muc.example.com/modnick' xmlns='urn:xmpp:message-moderate:1'>
+//!       <occupant-id xmlns='urn:xmpp:occupant-id:0' id='dd72…'/>
+//!     </moderated>
+//!     <reason>Spam</reason>
+//!   </retract>
 //! </message>
 //! ```
 //!
-//! Server broadcasts to room:
-//! ```xml
-//! <message type='groupchat' from='room@muc.example.com'>
-//!   <apply-to id='target-msg-id' xmlns='urn:xmpp:fasten:0'>
-//!     <moderated xmlns='urn:xmpp:message-moderate:1' by='room@muc.example.com/modnick'>
-//!       <retracted xmlns='urn:xmpp:message-retract:1' stamp='2024-06-01T12:00:00Z'/>
-//!       <reason>Spam</reason>
-//!     </moderated>
-//!   </apply-to>
-//! </message>
-//! ```
+//! Per XEP-0425 v1 §3 spec example, `<moderated>` carries the
+//! moderator's XEP-0421 `<occupant-id/>` child when the room is
+//! semi-anonymous — the `by=` JID alone is insufficient there since
+//! the moderator's real bare JID is hidden.
 //!
 //! ## Server Behavior
 //!
 //! The MUC service MUST:
-//! - Verify the sender has moderator role
-//! - Replace `<moderate>` with `<moderated by='...'>` adding the moderator's JID
-//! - Replace `<retract/>` with `<retracted stamp='...'/>`
-//! - Broadcast to all occupants
+//! - Verify the sender has Moderator role.
+//! - Look up the target message in MAM.
+//! - Broadcast a `<message>` with `<retract id='…'>` containing a
+//!   `<moderated by='…'><occupant-id/></moderated>` child and the
+//!   optional `<reason/>`.
+//! - Replace the archived message contents with a `<retracted/>`
+//!   tombstone (XEP-0424 path) preserving the stanza-id position.
 
 use minidom::Element;
 use xmpp_parsers::iq::{Iq, IqType};
 use xmpp_parsers::message::Message;
 
-/// Namespace for XEP-0425 Message Moderation.
+/// Namespace for XEP-0425 Message Moderation v1.
 pub const NS_MESSAGE_MODERATE: &str = "urn:xmpp:message-moderate:1";
-
-/// Namespace for XEP-0422 Message Fastening.
-pub const NS_FASTEN: &str = "urn:xmpp:fasten:0";
 
 /// Namespace for XEP-0424 Message Retraction (used within moderation).
 const NS_RETRACT: &str = "urn:xmpp:message-retract:1";
+
+/// Namespace for XEP-0421 Occupant Identifiers (embedded in `<moderated>`).
+const NS_OCCUPANT_ID: &str = "urn:xmpp:occupant-id:0";
 
 /// A moderation request from a moderator.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,47 +107,37 @@ impl ModerationRequest {
 }
 
 /// A moderation result broadcast by the server.
+///
+/// Carries the moderator's MUC JID **and** their XEP-0421
+/// `<occupant-id/>` when present — the latter is mandatory
+/// attribution in semi-anonymous rooms where the `by=` JID alone
+/// cannot identify the moderator.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModerationResult {
     /// The ID of the moderated message.
     pub target_id: String,
     /// The MUC JID of the moderator who performed the action.
     pub moderated_by: String,
-    /// Timestamp of the moderation action.
-    pub stamp: String,
+    /// XEP-0421 occupant-id of the moderator. Required by v1 §3 in
+    /// semi-anonymous rooms; optional for fully non-anonymous rooms
+    /// where `moderated_by` already discloses the real JID.
+    pub moderator_occupant_id: Option<String>,
     /// Optional reason.
     pub reason: Option<String>,
 }
 
 /// Trait for types that can carry moderation elements.
 pub trait ModerationCarrier {
-    /// Extract a moderation request from this carrier.
-    fn moderation_request(&self) -> Option<ModerationRequest>;
-
     /// Extract a moderation result from this carrier.
     fn moderation_result(&self) -> Option<ModerationResult>;
-
-    /// Returns `true` if this is a moderation request.
-    fn is_moderation_request(&self) -> bool {
-        self.moderation_request().is_some()
-    }
 
     /// Returns `true` if this is a moderation result (broadcast).
     fn is_moderation_result(&self) -> bool {
         self.moderation_result().is_some()
     }
-
-    /// Returns `true` if this carries any moderation element.
-    fn has_moderation(&self) -> bool {
-        self.is_moderation_request() || self.is_moderation_result()
-    }
 }
 
 impl ModerationCarrier for Message {
-    fn moderation_request(&self) -> Option<ModerationRequest> {
-        extract_moderation_request(self)
-    }
-
     fn moderation_result(&self) -> Option<ModerationResult> {
         extract_moderation_result(self)
     }
@@ -148,60 +145,58 @@ impl ModerationCarrier for Message {
 
 // ── Detection ────────────────────────────────────────────────────────
 
-/// Check if a message contains a moderation request (`<apply-to>/<moderate>`).
-pub fn is_moderation_request_message(msg: &Message) -> bool {
-    extract_moderation_request(msg).is_some()
-}
-
-/// Check if a message contains a moderation result (`<apply-to>/<moderated>`).
+/// Check if a message contains a v1 moderation broadcast
+/// (`<retract>` with `<moderated>` child).
 pub fn is_moderation_result_message(msg: &Message) -> bool {
     extract_moderation_result(msg).is_some()
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
 
-/// Extract a moderation request from a message.
-pub fn extract_moderation_request(_msg: &Message) -> Option<ModerationRequest> {
-    None
-}
-
-/// Extract a moderation result from a message.
+/// Extract a moderation result from a message broadcast.
 pub fn extract_moderation_result(msg: &Message) -> Option<ModerationResult> {
-    if let Some(retract) = msg
+    let retract = msg
         .payloads
         .iter()
-        .find(|e| e.name() == "retract" && e.ns() == NS_RETRACT)
-    {
-        let target_id = retract.attr("id").filter(|s| !s.is_empty())?.to_owned();
-        let moderated = retract
-            .children()
-            .find(|c| c.name() == "moderated" && c.ns() == NS_MESSAGE_MODERATE)?;
-        let moderated_by = moderated.attr("by").filter(|s| !s.is_empty())?.to_owned();
-        let reason = retract
-            .children()
-            .find(|c| c.name() == "reason" && c.ns() == NS_RETRACT)
-            .map(|c| c.text())
-            .filter(|t| !t.is_empty());
+        .find(|e| e.name() == "retract" && e.ns() == NS_RETRACT)?;
+    let target_id = retract.attr("id").filter(|s| !s.is_empty())?.to_owned();
+    let moderated = retract
+        .children()
+        .find(|c| c.name() == "moderated" && c.ns() == NS_MESSAGE_MODERATE)?;
+    let moderated_by = moderated.attr("by").filter(|s| !s.is_empty())?.to_owned();
+    let moderator_occupant_id = moderated
+        .children()
+        .find(|c| c.name() == "occupant-id" && c.ns() == NS_OCCUPANT_ID)
+        .and_then(|c| c.attr("id"))
+        .filter(|s| !s.is_empty())
+        .map(ToOwned::to_owned);
+    let reason = retract
+        .children()
+        .find(|c| c.name() == "reason" && c.ns() == NS_RETRACT)
+        .map(|c| c.text())
+        .filter(|t| !t.is_empty());
 
-        return Some(ModerationResult {
-            target_id,
-            moderated_by,
-            stamp: String::new(),
-            reason,
-        });
-    }
-
-    None
+    Some(ModerationResult {
+        target_id,
+        moderated_by,
+        moderator_occupant_id,
+        reason,
+    })
 }
 
 // ── Building ─────────────────────────────────────────────────────────
 
 /// Build a complete moderation result message for broadcasting.
+///
+/// `moderator_occupant_id` is the moderator's XEP-0421 occupant id;
+/// supply it whenever the room would otherwise hide the moderator's
+/// real bare JID (semi-anonymous rooms). For non-anonymous rooms
+/// the spec allows passing `None`, but supplying it is harmless.
 pub fn build_moderation_result_message(
     from_room: impl Into<Option<jid::Jid>>,
     target_id: &str,
     moderated_by: &str,
-    stamp: &str,
+    moderator_occupant_id: Option<&str>,
     reason: Option<&str>,
 ) -> Message {
     let mut msg = Message::new(None::<jid::Jid>);
@@ -211,26 +206,45 @@ pub fn build_moderation_result_message(
     msg.payloads.push(build_moderated_retract_element(
         target_id,
         moderated_by,
-        stamp,
+        moderator_occupant_id,
         reason,
     ));
     msg
 }
 
-/// Build the current XEP-0425 broadcast payload:
-/// `<retract id='target'><moderated by='moderator'/><reason>...</reason></retract>`.
+/// Build the v1 XEP-0425 broadcast payload:
+///
+/// ```xml
+/// <retract id='target' xmlns='urn:xmpp:message-retract:1'>
+///   <moderated by='moderator' xmlns='urn:xmpp:message-moderate:1'>
+///     <occupant-id id='…' xmlns='urn:xmpp:occupant-id:0'/>
+///   </moderated>
+///   <reason>…</reason>
+/// </retract>
+/// ```
+///
+/// The `<occupant-id>` child is emitted when
+/// `moderator_occupant_id` is `Some`. The spec example in §3 shows
+/// it as the canonical attribution mechanism for semi-anonymous
+/// rooms (XEP-0421 §3) — without it, a moderator's identity cannot
+/// be cited from the broadcast alone, breaking audit trails.
 pub fn build_moderated_retract_element(
     target_id: &str,
     moderated_by: &str,
-    stamp: &str,
+    moderator_occupant_id: Option<&str>,
     reason: Option<&str>,
 ) -> Element {
-    let moderated = Element::builder("moderated", NS_MESSAGE_MODERATE)
-        .attr("by", moderated_by)
-        .build();
+    let mut moderated = Element::builder("moderated", NS_MESSAGE_MODERATE).attr("by", moderated_by);
+    if let Some(occupant_id) = moderator_occupant_id.filter(|s| !s.is_empty()) {
+        moderated = moderated.append(
+            Element::builder("occupant-id", NS_OCCUPANT_ID)
+                .attr("id", occupant_id)
+                .build(),
+        );
+    }
     let mut retract = Element::builder("retract", NS_RETRACT)
         .attr("id", target_id)
-        .append(moderated);
+        .append(moderated.build());
     if let Some(reason_text) = reason {
         retract = retract.append(
             Element::builder("reason", NS_RETRACT)
@@ -239,7 +253,6 @@ pub fn build_moderated_retract_element(
         );
     }
 
-    let _ = stamp;
     retract.build()
 }
 
@@ -280,9 +293,14 @@ mod tests {
 
     #[test]
     fn test_parse_moderation_result() {
+        // Note the v1 spec shape: `<retract>` outer, `<moderated>`
+        // inner with its own `<occupant-id>` child for semi-anonymous
+        // attribution.
         let xml = "<message xmlns='jabber:client' type='groupchat'>\
                     <retract xmlns='urn:xmpp:message-retract:1' id='target-1'>\
-                      <moderated xmlns='urn:xmpp:message-moderate:1' by='room@muc.example.com/modnick'/>\
+                      <moderated xmlns='urn:xmpp:message-moderate:1' by='room@muc.example.com/modnick'>\
+                        <occupant-id xmlns='urn:xmpp:occupant-id:0' id='abc123'/>\
+                      </moderated>\
                       <reason>Spam</reason>\
                     </retract>\
                     </message>";
@@ -292,14 +310,13 @@ mod tests {
         let result = extract_moderation_result(&msg).expect("has result");
         assert_eq!(result.target_id, "target-1");
         assert_eq!(result.moderated_by, "room@muc.example.com/modnick");
-        assert_eq!(result.stamp, "");
+        assert_eq!(result.moderator_occupant_id.as_deref(), Some("abc123"));
         assert_eq!(result.reason.as_deref(), Some("Spam"));
     }
 
     #[test]
     fn test_extract_absent() {
         let msg = Message::new(None::<jid::Jid>);
-        assert!(extract_moderation_request(&msg).is_none());
         assert!(extract_moderation_result(&msg).is_none());
     }
 
@@ -308,7 +325,7 @@ mod tests {
         let elem = build_moderated_retract_element(
             "msg-42",
             "room@muc.example.com/admin",
-            "2024-06-01T12:00:00Z",
+            Some("opaque-occupant-id"),
             Some("Spam"),
         );
 
@@ -319,6 +336,10 @@ mod tests {
         let result = extract_moderation_result(&msg).expect("parseable");
         assert_eq!(result.target_id, "msg-42");
         assert_eq!(result.moderated_by, "room@muc.example.com/admin");
+        assert_eq!(
+            result.moderator_occupant_id.as_deref(),
+            Some("opaque-occupant-id")
+        );
         assert_eq!(result.reason.as_deref(), Some("Spam"));
     }
 
@@ -328,31 +349,15 @@ mod tests {
             "room@muc.example.com".parse::<jid::Jid>().ok(),
             "orig-1",
             "room@muc.example.com/mod",
-            "2024-01-01T00:00:00Z",
+            None,
             None,
         );
 
         assert_eq!(msg.type_, MessageType::Groupchat);
         let result = extract_moderation_result(&msg).expect("parseable");
         assert_eq!(result.target_id, "orig-1");
+        assert_eq!(result.moderator_occupant_id, None);
         assert_eq!(result.reason, None);
-    }
-
-    #[test]
-    fn test_moderation_carrier_trait_request() {
-        let xml = "<message xmlns='jabber:client' type='groupchat'>\
-                    <apply-to xmlns='urn:xmpp:fasten:0' id='t-1'>\
-                      <moderate xmlns='urn:xmpp:message-moderate:1'>\
-                        <retract xmlns='urn:xmpp:message-retract:1'/>\
-                      </moderate>\
-                    </apply-to>\
-                    </message>";
-        let msg =
-            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
-
-        assert!(!msg.is_moderation_request());
-        assert!(!msg.is_moderation_result());
-        assert!(!msg.has_moderation());
     }
 
     #[test]
@@ -365,9 +370,7 @@ mod tests {
         let msg =
             Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
 
-        assert!(!msg.is_moderation_request());
         assert!(msg.is_moderation_result());
-        assert!(msg.has_moderation());
     }
 
     #[test]
@@ -383,7 +386,6 @@ mod tests {
     #[test]
     fn test_is_helpers() {
         let plain = Message::new(None::<jid::Jid>);
-        assert!(!is_moderation_request_message(&plain));
         assert!(!is_moderation_result_message(&plain));
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0425_message_moderation.rs
+++ b/server/crates/waddle-xmpp/tests/xep0425_message_moderation.rs
@@ -1,0 +1,315 @@
+//! XEP-0425: Moderated Message Retraction (v1) — dedicated suite.
+//!
+//! In-crate `xep::xep0425::tests` covers helper internals
+//! (`<moderate>` IQ parse, builder/extractor round-trip). This file
+//! pins the v1 audit-level invariants at the public API:
+//!
+//! - the §3 namespace string `urn:xmpp:message-moderate:1`,
+//! - the §"Discovering support" MUST disco feature on every MUC
+//!   room configuration,
+//! - the v1 §3 broadcast wire shape: outer `<retract id=…>` with a
+//!   nested `<moderated by=…><occupant-id/></moderated>` and optional
+//!   `<reason>`,
+//! - the XEP-0421 `<occupant-id/>` attribution invariant — the
+//!   broadcast MUST carry the moderator's occupant-id when supplied,
+//!   so semi-anonymous rooms still surface a stable identifier even
+//!   when `by=` hides the real bare JID,
+//! - parser robustness: empty `id="…"`, missing `<moderated>`, and
+//!   wrong-namespace near-misses are all rejected.
+
+use minidom::Element;
+use waddle_xmpp::disco::{muc_room_features, Feature};
+use waddle_xmpp::xep::xep0425::{
+    build_moderated_retract_element, build_moderation_result_message, extract_moderation_result,
+    is_moderation_result_message, parse_moderation_iq, ModerationCarrier, NS_MESSAGE_MODERATE,
+};
+use xmpp_parsers::iq::Iq;
+use xmpp_parsers::message::Message;
+
+// ── §3 namespace ─────────────────────────────────────────────────────
+
+#[test]
+fn xep0425_namespace_matches_spec_v1() {
+    // XEP-0425 v1 (Proposed, post-fastening) bumped the namespace
+    // from `:0` to `:1` when the spec dropped the XEP-0422
+    // `<apply-to>` wrapping. Pin the literal so an accidental v0
+    // import or a typo trips a test instead of silently routing
+    // moderation broadcasts into "unknown payload."
+    assert_eq!(NS_MESSAGE_MODERATE, "urn:xmpp:message-moderate:1");
+}
+
+// ── §"Discovering support" advertisement ────────────────────────────
+
+#[test]
+fn xep0425_advertised_on_every_room_configuration() {
+    // XEP-0425 §"Discovering support": "If a groupchat supports
+    // moderated message retraction, it MUST specify the
+    // 'urn:xmpp:message-moderate:1' feature in its service
+    // discovery information features." Waddle's MUC server enforces
+    // moderation authz uniformly across room configurations, so the
+    // advert MUST survive every (persistent × members_only ×
+    // moderated × forum) cell.
+    let target = Feature::message_moderation();
+    for persistent in [false, true] {
+        for members_only in [false, true] {
+            for moderated in [false, true] {
+                for forum in [false, true] {
+                    let feats = muc_room_features(persistent, members_only, moderated, forum);
+                    assert!(
+                        feats.iter().any(|f| f == &target),
+                        "muc_room_features(persistent={persistent}, members_only={members_only}, \
+                         moderated={moderated}, forum={forum}) MUST advertise \
+                         `urn:xmpp:message-moderate:1`"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn xep0425_feature_constructor_pins_namespace_string() {
+    // Defence in depth against a future constructor rename
+    // silently changing the wire string.
+    assert_eq!(
+        Feature::message_moderation().0,
+        "urn:xmpp:message-moderate:1"
+    );
+}
+
+// ── §3 IQ request shape ─────────────────────────────────────────────
+
+#[test]
+fn xep0425_parses_v1_iq_request_with_reason() {
+    // The §3 example moderation request: an IQ-set against the
+    // room JID, with `<moderate id=…>` carrying a `<retract/>`
+    // child and optional `<reason>`.
+    let xml = "<iq xmlns='jabber:client' type='set' to='room@muc.example.com' id='m-1'>\
+                  <moderate xmlns='urn:xmpp:message-moderate:1' id='target-stanza-1'>\
+                    <retract xmlns='urn:xmpp:message-retract:1'/>\
+                    <reason>off-topic</reason>\
+                  </moderate>\
+               </iq>";
+    let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("iq");
+
+    let req = parse_moderation_iq(&iq).expect("v1 moderate IQ parses");
+    assert_eq!(req.target_id, "target-stanza-1");
+    assert_eq!(req.reason.as_deref(), Some("off-topic"));
+}
+
+#[test]
+fn xep0425_rejects_v0_apply_to_fastening_iq() {
+    // Pre-v1 (XEP-0425 v0) wrapped `<moderate>` inside an
+    // XEP-0422 `<apply-to>` element on a message. v1 dropped that
+    // entirely; the parser MUST NOT recognise the legacy shape.
+    let xml = "<iq xmlns='jabber:client' type='set' to='room@muc.example.com' id='m-2'>\
+                  <apply-to xmlns='urn:xmpp:fasten:0' id='target-stanza-2'>\
+                    <moderate xmlns='urn:xmpp:message-moderate:1'>\
+                      <retract xmlns='urn:xmpp:message-retract:1'/>\
+                    </moderate>\
+                  </apply-to>\
+               </iq>";
+    let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("iq");
+
+    assert!(parse_moderation_iq(&iq).is_none());
+}
+
+#[test]
+fn xep0425_request_iq_requires_inner_retract_child() {
+    // §3 mandates the `<retract/>` child inside `<moderate>`. A
+    // `<moderate>` without it is malformed and MUST NOT parse, since
+    // moderating-but-not-retracting has no defined semantics in v1.
+    let xml = "<iq xmlns='jabber:client' type='set' to='room@muc.example.com' id='m-3'>\
+                  <moderate xmlns='urn:xmpp:message-moderate:1' id='target-stanza-3'>\
+                    <reason>nope</reason>\
+                  </moderate>\
+               </iq>";
+    let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("iq");
+
+    assert!(parse_moderation_iq(&iq).is_none());
+}
+
+#[test]
+fn xep0425_request_iq_rejects_get_type() {
+    // §3 fixes the request as `type='set'`. A `get` on the same
+    // shape is meaningless and MUST NOT be classified as a request,
+    // otherwise the moderation handler would be reachable via the
+    // wrong IQ type.
+    let xml = "<iq xmlns='jabber:client' type='get' to='room@muc.example.com' id='m-4'>\
+                  <moderate xmlns='urn:xmpp:message-moderate:1' id='target-stanza-4'>\
+                    <retract xmlns='urn:xmpp:message-retract:1'/>\
+                  </moderate>\
+               </iq>";
+    let iq = Iq::try_from(xml.parse::<Element>().expect("valid xml")).expect("iq");
+
+    assert!(parse_moderation_iq(&iq).is_none());
+}
+
+// ── §3 broadcast wire shape ─────────────────────────────────────────
+
+#[test]
+fn xep0425_broadcast_carries_occupant_id_attribution() {
+    // XEP-0425 v1 §3 spec example places `<occupant-id>` inside
+    // `<moderated>`. Without it, semi-anonymous rooms (which hide
+    // the moderator's real JID via XEP-0421) have no stable
+    // identifier to cite the moderator from the broadcast alone.
+    //
+    // We assert against the typed minidom tree rather than the
+    // serialised string so attribute quote-style ambiguity (the
+    // minidom serializer mixes single and double quotes) doesn't
+    // leak into the test.
+    let elem = build_moderated_retract_element(
+        "victim-stanza-id",
+        "room@muc.example.com/mod-nick",
+        Some("dd72603deec90a38ba552f7c68cbcc61"),
+        Some("Inappropriate content"),
+    );
+
+    assert_eq!(elem.name(), "retract");
+    assert_eq!(elem.ns(), "urn:xmpp:message-retract:1");
+    assert_eq!(elem.attr("id"), Some("victim-stanza-id"));
+
+    let moderated = elem
+        .children()
+        .find(|c| c.name() == "moderated" && c.ns() == "urn:xmpp:message-moderate:1")
+        .expect("<moderated> child present");
+    assert_eq!(moderated.attr("by"), Some("room@muc.example.com/mod-nick"));
+
+    let occ = moderated
+        .children()
+        .find(|c| c.name() == "occupant-id" && c.ns() == "urn:xmpp:occupant-id:0")
+        .expect(
+            "broadcast MUST embed moderator's XEP-0421 occupant-id \
+             for semi-anonymous attribution",
+        );
+    assert_eq!(occ.attr("id"), Some("dd72603deec90a38ba552f7c68cbcc61"));
+
+    let reason = elem
+        .children()
+        .find(|c| c.name() == "reason" && c.ns() == "urn:xmpp:message-retract:1")
+        .expect("<reason> child present");
+    assert_eq!(reason.text(), "Inappropriate content");
+}
+
+#[test]
+fn xep0425_broadcast_omits_occupant_id_child_when_none_supplied() {
+    // For non-anonymous rooms the spec allows the moderator's real
+    // JID via `by=` alone; the builder MUST honor `None` rather
+    // than emitting a placeholder `<occupant-id id=""/>` that would
+    // be unparseable on the receiving side.
+    let elem = build_moderated_retract_element(
+        "victim-stanza-id",
+        "room@muc.example.com/mod-nick",
+        None,
+        None,
+    );
+
+    let moderated = elem
+        .children()
+        .find(|c| c.name() == "moderated" && c.ns() == "urn:xmpp:message-moderate:1")
+        .expect("<moderated> child present");
+    assert!(
+        moderated
+            .children()
+            .find(|c| c.name() == "occupant-id")
+            .is_none(),
+        "absent occupant-id MUST NOT be invented"
+    );
+    assert!(
+        elem.children().find(|c| c.name() == "reason").is_none(),
+        "absent reason MUST NOT be invented"
+    );
+}
+
+#[test]
+fn xep0425_broadcast_round_trip_preserves_occupant_id_attribution() {
+    // Round-trip: build the broadcast, parse it back, confirm every
+    // field is recovered including the occupant-id. The audit-bug
+    // this guards against is the prior `stamp: String::new()` mode
+    // where part of the parsed value was unconditionally empty.
+    let msg = build_moderation_result_message(
+        "room@muc.example.com".parse::<jid::Jid>().ok(),
+        "msg-99",
+        "room@muc.example.com/moderator",
+        Some("opaque-occupant-id-abcdef"),
+        Some("Spam"),
+    );
+
+    assert!(
+        is_moderation_result_message(&msg),
+        "built broadcast must classify as a moderation result"
+    );
+    let result = msg.moderation_result().expect("extractable");
+    assert_eq!(result.target_id, "msg-99");
+    assert_eq!(result.moderated_by, "room@muc.example.com/moderator");
+    assert_eq!(
+        result.moderator_occupant_id.as_deref(),
+        Some("opaque-occupant-id-abcdef")
+    );
+    assert_eq!(result.reason.as_deref(), Some("Spam"));
+}
+
+// ── Parser robustness ───────────────────────────────────────────────
+
+#[test]
+fn xep0425_extract_rejects_empty_target_id() {
+    // `id=""` would route the moderation announcement against a
+    // phantom message id; consumers must treat it as malformed.
+    let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                  <retract xmlns='urn:xmpp:message-retract:1' id=''>\
+                    <moderated xmlns='urn:xmpp:message-moderate:1' by='room@example/m'/>\
+                  </retract>\
+               </message>";
+    let msg = Message::try_from(xml.parse::<Element>().expect("xml")).expect("message");
+
+    assert!(extract_moderation_result(&msg).is_none());
+}
+
+#[test]
+fn xep0425_extract_rejects_missing_moderated_child() {
+    // A `<retract>` without `<moderated>` is a plain XEP-0424
+    // self-retraction, not a XEP-0425 moderator broadcast. The
+    // classifier MUST distinguish them — otherwise the inbox /
+    // archive paths would attribute every self-retraction to a
+    // moderator.
+    let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                  <retract xmlns='urn:xmpp:message-retract:1' id='abc'/>\
+               </message>";
+    let msg = Message::try_from(xml.parse::<Element>().expect("xml")).expect("message");
+
+    assert!(extract_moderation_result(&msg).is_none());
+}
+
+#[test]
+fn xep0425_extract_rejects_moderated_with_empty_by() {
+    // `<moderated by=""/>` strips the attribution that the spec
+    // example treats as required. Consumers can't show "moderated
+    // by ⟨nothing⟩" — drop it.
+    let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                  <retract xmlns='urn:xmpp:message-retract:1' id='abc'>\
+                    <moderated xmlns='urn:xmpp:message-moderate:1' by=''/>\
+                  </retract>\
+               </message>";
+    let msg = Message::try_from(xml.parse::<Element>().expect("xml")).expect("message");
+
+    assert!(extract_moderation_result(&msg).is_none());
+}
+
+#[test]
+fn xep0425_extract_accepts_broadcast_without_reason() {
+    // §3 allows `<reason>` to be absent — moderators don't have to
+    // justify every action. The classifier must accept the
+    // reasonless shape.
+    let xml = "<message xmlns='jabber:client' type='groupchat'>\
+                  <retract xmlns='urn:xmpp:message-retract:1' id='abc'>\
+                    <moderated xmlns='urn:xmpp:message-moderate:1' by='room@example/m'>\
+                      <occupant-id xmlns='urn:xmpp:occupant-id:0' id='xyz'/>\
+                    </moderated>\
+                  </retract>\
+               </message>";
+    let msg = Message::try_from(xml.parse::<Element>().expect("xml")).expect("message");
+
+    let result = extract_moderation_result(&msg).expect("reasonless broadcast is valid");
+    assert_eq!(result.reason, None);
+    assert_eq!(result.moderator_occupant_id.as_deref(), Some("xyz"));
+}


### PR DESCRIPTION
## Summary

XEP-0425 v1 audit. Three problems on the moderation surface — one security-impacting, two structural — plus the routine dedicated-suite addition.

### 1. Missing `<occupant-id/>` attribution in moderator broadcast (security)

XEP-0425 v1 §3 spec example places `<occupant-id xmlns="urn:xmpp:occupant-id:0" id="…"/>` inside `<moderated>` as the canonical attribution mechanism. Waddle's MUC rooms are semi-anonymous by configuration (XEP-0421 §3), so the `by=` JID alone is *insufficient* — without occupant-id, a moderator's identity can't be matched back to their other occupant traffic. Audit-trail integrity for moderation actions failed.

### 2. `stamp` parameter silently discarded (typed-payloads-rule violation)

`build_moderated_retract_element` accepted `stamp: &str` and dropped it via `let _ = stamp;`. The parser correspondingly produced `ModerationResult { stamp: String::new(), … }` regardless of input. The v1 broadcast carries no stamp attribute — it's on `<retracted>` tombstones (XEP-0424 territory). Structural misinformation.

### 3. Dead `extract_moderation_request` stub

`extract_moderation_request` returned `None` unconditionally. v1 moderation requests are IQ-only (`parse_moderation_iq` handles them); the message-based path was dead, broken, and reachable only from inbox/archive classifiers where its `false` return was a no-op. Remove the family entirely.

## Wire-shape changes

- `build_moderated_retract_element` / `build_moderation_result_message`: drop `stamp`, add `moderator_occupant_id: Option<&str>`. `Some` emits the v1 §3 `<occupant-id/>` child; `None` is honored.
- `ModerationResult`: drop `stamp`, add `moderator_occupant_id: Option<String>`.
- `extract_moderation_result`: parses `<occupant-id/>` child; empty `id=""` rejected.

## Server caller change

`muc_owner_moderation.rs` computes the moderator's occupant-id via `generate_occupant_id(sender_bare, room_jid, occupant_id_secret)` and passes it through.

## Dead-code culls

- `extract_moderation_request`, `is_moderation_request_message`, `ModerationCarrier::moderation_request`, `ModerationCarrier::is_moderation_request`, `ModerationCarrier::has_moderation` deleted.
- Public `NS_FASTEN` constant deleted (XEP-0422 was a v0-only dep; v1 has no fastening).
- `inbox::runtime::should_project_message` and `protocol::room::archive::is_archivable` drop the no-op `is_moderation_request_message(msg)` predicate.

## Doc comments

Module preamble brought to v1 — replaced stale `<apply-to>` example with the current §3 IQ + broadcast shapes.

## Dedicated test suite

`tests/xep0425_message_moderation.rs` — 14 tests covering:

- §3 namespace string
- §"Discovering support" advertisement on every (persistent × members_only × moderated × forum) room configuration
- v1 IQ request shape; rejection of legacy v0 `<apply-to>` wrapping
- v1 broadcast: `<occupant-id/>` attribution embedded when supplied, omitted when `None`; round-trip preserves every field; empty `id=""` and missing `<moderated>` rejected; reasonless broadcast accepted

## Test plan

- [x] `cargo test --package waddle-xmpp --test xep0425_message_moderation` → 14/14
- [x] `cargo test --package waddle-xmpp --tests` → 1820+ tests, no regressions
- [x] `cargo test --package waddle-server --test xmpp_e2e_cue` → 3/3
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --package waddle-xmpp --package waddle-xmpp-core --package waddle-server --tests -- -D warnings`

This PR was created with the assistance of a LLM.