### PR TITLE
fix(server): inbox mark-read fans out to all user resources

### DIFF
--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -193,14 +193,27 @@ impl InboxStorage for DatabaseInboxStorage {
         user: &BareJid,
         partner: &BareJid,
         thread_id: Option<&str>,
-    ) -> Result<(), InboxStorageError> {
+    ) -> Result<Option<InboxEntry>, InboxStorageError> {
         let tid = thread_id.unwrap_or("");
-        self.execute(
-            "UPDATE inbox_entries SET unread = 0 WHERE user_jid = ? AND partner_jid = ? AND thread_id = ?",
-            crate::db_params![user.to_string(), partner.to_string(), tid.to_string()],
-        )
-        .await?;
-        Ok(())
+        let sql = format!(
+            "UPDATE inbox_entries SET unread = 0 \
+             WHERE user_jid = ? AND partner_jid = ? AND thread_id = ? \
+             RETURNING {SELECT_COLS}"
+        );
+        let mut rows = self
+            .query(
+                &sql,
+                crate::db_params![user.to_string(), partner.to_string(), tid.to_string()],
+            )
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(decode_row(&row)?))
     }
 
     #[instrument(skip(self), fields(user = %user))]

--- a/server/crates/waddle-server/src/inbox/tests.rs
+++ b/server/crates/waddle-server/src/inbox/tests.rs
@@ -39,11 +39,31 @@ async fn sqlx_inbox_storage_round_trips_entries() {
     assert_eq!(entries[0].partner, jid("room@muc.example.com"));
     assert_eq!(storage.total_unread(&user).await.expect("unread"), 1);
 
-    storage
+    let updated = storage
         .mark_read(&user, &jid("alice@example.com"), None)
         .await
-        .expect("mark read");
+        .expect("mark read")
+        .expect("entry returned for fan-out");
+    assert_eq!(updated.unread, 0);
+    assert_eq!(updated.partner, jid("alice@example.com"));
+    assert!(updated.thread_id.is_none());
     assert_eq!(storage.total_unread(&user).await.expect("unread"), 0);
+}
+
+#[tokio::test]
+async fn sqlx_inbox_storage_mark_read_returns_none_for_missing_row() {
+    let storage = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let user = jid("me@example.com");
+    let result = storage
+        .mark_read(&user, &jid("ghost@example.com"), None)
+        .await
+        .expect("mark read");
+    assert!(
+        result.is_none(),
+        "RETURNING must yield no row when no UPDATE matched so the IQ handler skips fan-out"
+    );
 }
 
 #[tokio::test]
@@ -108,10 +128,13 @@ async fn sqlx_inbox_storage_thread_entries() {
     assert_eq!(updated.thread_title.as_deref(), Some("Discussion"));
 
     // Mark thread read
-    storage
+    let updated = storage
         .mark_read(&user, &room, Some("t1"))
         .await
-        .expect("mark thread read");
+        .expect("mark thread read")
+        .expect("thread entry returned for fan-out");
+    assert_eq!(updated.unread, 0);
+    assert_eq!(updated.thread_id.as_deref(), Some("t1"));
     let threads = storage
         .list_threads(&user, &room)
         .await

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -181,6 +181,7 @@ use route_to_connection::route_to_connection;
 use routing::{deliver_peer_to_full, run_headless_recipient_pass};
 
 pub use deps::{Deps, InterpretOutcome};
+pub(crate) use groupchat_archive::push_inbox_update;
 
 /// Execute the side effects described by `events`.
 ///

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -331,7 +331,13 @@ pub(super) async fn project_groupchat_inbox(
 /// from `WebSocketState` (Copilot review on PR #279) so unit tests
 /// and non-WebSocket callers can drive the projection without
 /// standing up the full route stack.
-pub(super) async fn push_inbox_update(
+///
+/// Used by the new-message archive path (which observes a fresh
+/// inbox row and broadcasts it) *and* the mark-read IQ handler
+/// (which broadcasts the read-state flip so the user's other
+/// devices clear their unread badges in real time — XEP-0430
+/// §"Mark as read" cross-device sync).
+pub(crate) async fn push_inbox_update(
     connection_registry: &waddle_xmpp::registry::ConnectionRegistry,
     user: &BareJid,
     entry: &InboxEntry,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -245,7 +245,7 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                         )];
                     }
                 };
-                if let Err(error) = state
+                let updated = match state
                     .deps
                     .protocol
                     .inbox_storage
@@ -256,13 +256,27 @@ pub(super) async fn handle_archive_inbox_upload_iq(
                     )
                     .await
                 {
-                    warn!(error = %error, jid = %user_jid, partner = %mark_read.partner, "Failed to mark inbox read");
-                    return vec![build_iq_error_xml_typed(
-                        id,
-                        None,
-                        None,
-                        internal_server_error_iq_error("Internal server error."),
-                    )];
+                    Ok(updated) => updated,
+                    Err(error) => {
+                        warn!(error = %error, jid = %user_jid, partner = %mark_read.partner, "Failed to mark inbox read");
+                        return vec![build_iq_error_xml_typed(
+                            id,
+                            None,
+                            None,
+                            internal_server_error_iq_error("Internal server error."),
+                        )];
+                    }
+                };
+                // Cross-device sync: fan the post-update entry out to every
+                // resource bound for this user so other devices clear their
+                // unread badges without waiting for a fresh inbox query.
+                if let Some(entry) = updated {
+                    crate::server::routes::interpret::push_inbox_update(
+                        state.deps.protocol.connection_registry.as_ref(),
+                        &user_jid,
+                        &entry,
+                    )
+                    .await;
                 }
                 return vec![iq_to_xml(build_mark_read_result(request_iq))];
             }

--- a/server/crates/waddle-server/src/server/xmpp_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_state.rs
@@ -428,19 +428,6 @@ impl waddle_xmpp::AppState for XmppAppState {
         .await
     }
 
-    async fn mark_inbox_read(
-        &self,
-        user_jid: &jid::BareJid,
-        partner_jid: &jid::BareJid,
-    ) -> Result<(), XmppError> {
-        super::xmpp_user_storage_state::mark_inbox_read(
-            self.inbox_storage.as_deref(),
-            user_jid,
-            partner_jid,
-        )
-        .await
-    }
-
     async fn inbox_total_unread(&self, user_jid: &jid::BareJid) -> Result<u64, XmppError> {
         super::xmpp_user_storage_state::inbox_total_unread(self.inbox_storage.as_deref(), user_jid)
             .await

--- a/server/crates/waddle-server/src/server/xmpp_user_storage_state.rs
+++ b/server/crates/waddle-server/src/server/xmpp_user_storage_state.rs
@@ -166,26 +166,6 @@ pub(crate) async fn upsert_inbox_entry(
         })
 }
 
-pub(crate) async fn mark_inbox_read(
-    storage: Option<&dyn InboxStorage>,
-    user_jid: &jid::BareJid,
-    partner_jid: &jid::BareJid,
-) -> Result<(), XmppError> {
-    let storage = require_inbox_storage(storage)?;
-    storage
-        .mark_read(user_jid, partner_jid, None)
-        .await
-        .map_err(|error| {
-            warn!(
-                jid = %user_jid,
-                partner = %partner_jid,
-                error = %error,
-                "Failed to mark inbox conversation read"
-            );
-            XmppError::internal(format!("Inbox error: {}", error))
-        })
-}
-
 pub(crate) async fn inbox_total_unread(
     storage: Option<&dyn InboxStorage>,
     user_jid: &jid::BareJid,

--- a/server/crates/waddle-xmpp/src/app_state.rs
+++ b/server/crates/waddle-xmpp/src/app_state.rs
@@ -393,13 +393,6 @@ pub trait AppState: Send + Sync + 'static {
         increment_unread: bool,
     ) -> impl std::future::Future<Output = Result<(), XmppError>> + Send;
 
-    /// Mark a conversation as read in the user's inbox.
-    fn mark_inbox_read(
-        &self,
-        user_jid: &jid::BareJid,
-        partner_jid: &jid::BareJid,
-    ) -> impl std::future::Future<Output = Result<(), XmppError>> + Send;
-
     /// Compute the total unread count across the user's inbox.
     fn inbox_total_unread(
         &self,

--- a/server/crates/waddle-xmpp/src/inbox/mod.rs
+++ b/server/crates/waddle-xmpp/src/inbox/mod.rs
@@ -249,16 +249,18 @@ impl InboxView {
         next
     }
 
-    /// Mark a channel-level conversation as read.
-    pub fn mark_read(&mut self, partner: &BareJid) {
-        self.mark_read_by_key(&InboxKey::channel(partner.clone()));
+    /// Mark a channel-level conversation as read. Returns the entry after the
+    /// update, or `None` when no entry matched.
+    pub fn mark_read(&mut self, partner: &BareJid) -> Option<InboxEntry> {
+        self.mark_read_by_key(&InboxKey::channel(partner.clone()))
     }
 
-    /// Mark a specific conversation (channel or thread) as read.
-    pub fn mark_read_by_key(&mut self, key: &InboxKey) {
-        if let Some(e) = self.entries.get_mut(key) {
-            e.unread = 0;
-        }
+    /// Mark a specific conversation (channel or thread) as read. Returns the
+    /// entry after the update so callers can fan it out to other resources.
+    pub fn mark_read_by_key(&mut self, key: &InboxKey) -> Option<InboxEntry> {
+        let entry = self.entries.get_mut(key)?;
+        entry.unread = 0;
+        Some(entry.clone())
     }
 
     pub fn remove(&mut self, partner: &BareJid) -> Option<InboxEntry> {

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -43,12 +43,16 @@ pub trait InboxStorage: Send + Sync {
 
     /// Mark a conversation as read. When `thread_id` is `Some`, only the
     /// specific thread is marked; otherwise the channel-level entry is.
+    ///
+    /// Returns the post-update entry so the caller can fan it out to the
+    /// user's other resources (cross-device sync); `None` when no row
+    /// matched the `(user, partner, thread_id)` triple.
     async fn mark_read(
         &self,
         user: &BareJid,
         partner: &BareJid,
         thread_id: Option<&str>,
-    ) -> Result<(), InboxStorageError>;
+    ) -> Result<Option<InboxEntry>, InboxStorageError>;
 
     /// Return the total unread count for the user (channel-level only).
     async fn total_unread(&self, user: &BareJid) -> Result<u64, InboxStorageError>;
@@ -111,19 +115,19 @@ impl InboxStorage for InMemoryInboxStorage {
         user: &BareJid,
         partner: &BareJid,
         thread_id: Option<&str>,
-    ) -> Result<(), InboxStorageError> {
+    ) -> Result<Option<InboxEntry>, InboxStorageError> {
         let mut guard = self
             .per_user
             .lock()
             .map_err(|e| InboxStorageError::Other(e.to_string()))?;
-        if let Some(view) = guard.get_mut(user) {
-            let key = match thread_id {
-                Some(tid) => InboxKey::thread(partner.clone(), tid),
-                None => InboxKey::channel(partner.clone()),
-            };
-            view.mark_read_by_key(&key);
-        }
-        Ok(())
+        let Some(view) = guard.get_mut(user) else {
+            return Ok(None);
+        };
+        let key = match thread_id {
+            Some(tid) => InboxKey::thread(partner.clone(), tid),
+            None => InboxKey::channel(partner.clone()),
+        };
+        Ok(view.mark_read_by_key(&key))
     }
 
     async fn total_unread(&self, user: &BareJid) -> Result<u64, InboxStorageError> {
@@ -180,11 +184,28 @@ mod tests {
         assert_eq!(snapshot[0].last_stanza_id, "sid-2");
         assert_eq!(store.total_unread(&user).await.unwrap(), 2);
 
-        store
+        let updated = store
             .mark_read(&user, &jid("alice@example.com"), None)
             .await
-            .unwrap();
+            .unwrap()
+            .expect("mark_read returns the post-update entry for fan-out");
+        assert_eq!(updated.unread, 0);
+        assert_eq!(updated.partner, jid("alice@example.com"));
         assert_eq!(store.total_unread(&user).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_mark_read_returns_none_when_no_row_matches() {
+        let store = InMemoryInboxStorage::new();
+        let user = jid("me@example.com");
+        let result = store
+            .mark_read(&user, &jid("ghost@example.com"), None)
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "mark_read must signal no-op so the IQ handler skips fan-out"
+        );
     }
 
     #[tokio::test]
@@ -226,7 +247,13 @@ mod tests {
         assert_eq!(threads[0].thread_id.as_deref(), Some("t1"));
 
         // Mark thread read
-        store.mark_read(&user, &room, Some("t1")).await.unwrap();
+        let updated = store
+            .mark_read(&user, &room, Some("t1"))
+            .await
+            .unwrap()
+            .expect("thread entry returned for fan-out");
+        assert_eq!(updated.unread, 0);
+        assert_eq!(updated.thread_id.as_deref(), Some("t1"));
         let threads = store.list_threads(&user, &room).await.unwrap();
         assert_eq!(threads[0].unread, 0);
 

--- a/server/crates/waddle-xmpp/src/inbox/tests.rs
+++ b/server/crates/waddle-xmpp/src/inbox/tests.rs
@@ -39,7 +39,10 @@ fn test_mark_read_resets_only_that_partner() {
         entry("b@example.com", ConversationKind::Direct, "s2", 2),
         true,
     );
-    inbox.mark_read(&jid("a@example.com"));
+    let updated = inbox
+        .mark_read(&jid("a@example.com"))
+        .expect("entry present");
+    assert_eq!(updated.unread, 0);
     assert_eq!(inbox.get(&jid("a@example.com")).unwrap().unread, 0);
     assert_eq!(inbox.get(&jid("b@example.com")).unwrap().unread, 1);
     assert_eq!(inbox.total_unread(), 1);
@@ -168,7 +171,9 @@ fn test_mark_read_by_key_for_thread() {
     );
 
     let key = InboxKey::thread(jid(room), "t1");
-    inbox.mark_read_by_key(&key);
+    let updated = inbox.mark_read_by_key(&key).expect("entry present");
+    assert_eq!(updated.unread, 0);
+    assert_eq!(updated.thread_id.as_deref(), Some("t1"));
 
     let t1 = inbox.get_by_key(&key).unwrap();
     assert_eq!(t1.unread, 0);

--- a/server/crates/waddle-xmpp/tests/xep0430_cross_device_mark_read.rs
+++ b/server/crates/waddle-xmpp/tests/xep0430_cross_device_mark_read.rs
@@ -1,0 +1,157 @@
+//! XEP-0430 — cross-device mark-read fan-out tests.
+//!
+//! When a user marks a conversation read on Device A, the server MUST
+//! propagate the unread-state flip to the user's other resources so
+//! Device B can clear its unread badges without waiting for a fresh
+//! inbox query.
+//!
+//! These tests pin the storage-trait contract that makes that
+//! possible: `InboxStorage::mark_read` returns the post-update
+//! `InboxEntry` (suitable for re-broadcasting via `build_inbox_push`)
+//! or `None` when no row matched, so the IQ handler can short-circuit
+//! the fan-out for no-op requests.
+//!
+//! They also pin the wire shape of the resulting headline push so
+//! clients can parse the unread=0 flip with the same `<conversation>`
+//! decoder they already use for `build_inbox_query_result` entries.
+
+use jid::{BareJid, Jid};
+use waddle_xmpp::inbox::storage::{InMemoryInboxStorage, InboxStorage};
+use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+use waddle_xmpp::xep::xep0430::{build_inbox_push, NS_INBOX};
+use xmpp_parsers::message::MessageType;
+
+fn jid(s: &str) -> BareJid {
+    s.parse().expect("bare jid")
+}
+
+#[tokio::test]
+async fn mark_read_returns_post_update_entry_suitable_for_fanout() {
+    let store = InMemoryInboxStorage::new();
+    let me = jid("me@example.com");
+    let alice = jid("alice@example.com");
+
+    store
+        .upsert(
+            &me,
+            InboxEntry::new(alice.clone(), ConversationKind::Direct, "sid-1", 100)
+                .with_preview("hi"),
+            true,
+        )
+        .await
+        .expect("upsert");
+
+    let updated = store
+        .mark_read(&me, &alice, None)
+        .await
+        .expect("mark_read ok")
+        .expect("entry returned so the IQ handler can fan it out");
+
+    assert_eq!(
+        updated.unread, 0,
+        "post-update entry must reflect unread=0 so other devices clear badges"
+    );
+    assert_eq!(
+        updated.partner, alice,
+        "the entry returned must identify the conversation that flipped"
+    );
+    assert!(
+        updated.thread_id.is_none(),
+        "channel-level mark-read returns a channel-level entry"
+    );
+    assert_eq!(
+        updated.preview.as_deref(),
+        Some("hi"),
+        "preview must round-trip so other devices don't lose context on fan-out"
+    );
+}
+
+#[tokio::test]
+async fn mark_read_returns_thread_entry_when_thread_id_specified() {
+    let store = InMemoryInboxStorage::new();
+    let me = jid("me@example.com");
+    let room = jid("room@muc.example.com");
+
+    store
+        .upsert(
+            &me,
+            InboxEntry::new(room.clone(), ConversationKind::MucRoom, "sid-1", 100)
+                .with_thread("t1")
+                .with_thread_title("Lunch plans"),
+            true,
+        )
+        .await
+        .expect("upsert thread");
+
+    let updated = store
+        .mark_read(&me, &room, Some("t1"))
+        .await
+        .expect("mark_read ok")
+        .expect("thread entry returned");
+
+    assert_eq!(updated.unread, 0);
+    assert_eq!(updated.thread_id.as_deref(), Some("t1"));
+    assert_eq!(
+        updated.thread_title.as_deref(),
+        Some("Lunch plans"),
+        "thread metadata must round-trip so the push doesn't clobber it on Device B"
+    );
+}
+
+#[tokio::test]
+async fn mark_read_returns_none_when_no_row_matches() {
+    // The IQ handler relies on this to skip fan-out when the
+    // mark-read is a no-op (typo'd JID, race against retract, etc.) —
+    // emitting a headline push with a synthetic entry would clobber
+    // the receiver's local state with empty fields.
+    let store = InMemoryInboxStorage::new();
+    let me = jid("me@example.com");
+    let ghost = jid("ghost@example.com");
+
+    let result = store
+        .mark_read(&me, &ghost, None)
+        .await
+        .expect("mark_read ok");
+
+    assert!(
+        result.is_none(),
+        "no-op mark-read must NOT return a synthetic entry — fan-out is skipped"
+    );
+}
+
+#[test]
+fn build_inbox_push_emits_headline_with_inbox_namespace_payload() {
+    // The fan-out path is `mark_read` → `Option<InboxEntry>` →
+    // `build_inbox_push` → routed to every resource. This test pins
+    // the resulting Message shape so any change to the push wire
+    // format is caught by a XEP-test, not by a downstream client
+    // regression.
+    let entry = InboxEntry::new(
+        jid("alice@example.com"),
+        ConversationKind::Direct,
+        "sid-1",
+        100,
+    )
+    .with_preview("hi")
+    .with_unread(0);
+
+    let recipient: Jid = "me@example.com/desktop".parse().expect("full jid");
+    let msg = build_inbox_push(recipient, &entry);
+
+    assert_eq!(
+        msg.type_,
+        MessageType::Headline,
+        "XEP-0430 unsolicited inbox updates are headlines so they bypass offline storage"
+    );
+
+    let payload = msg
+        .payloads
+        .iter()
+        .find(|p| p.ns() == NS_INBOX)
+        .expect("inbox-namespaced payload present");
+    assert_eq!(
+        payload.name(),
+        "conversation",
+        "the headline carries a <conversation> element — same shape as query-result rows"
+    );
+}


### PR DESCRIPTION
## Summary

Cross-device unread sync was broken: marking a conversation read on Device A only updated the SQL row, leaving Device B with a stale badge until the next inbox query (reconnect, focus, or app launch). This wires the mark-read flow into the same XEP-0430 push fan-out the new-message path already uses, so other resources clear their unread state in real time.

## Changes

- `InboxStorage::mark_read` now returns `Result<Option<InboxEntry>, _>` so callers get the post-update row without a second roundtrip. SQL impl uses `UPDATE … RETURNING`; in-memory clones the mutated entry.
- `Some(entry)` → IQ handler fans out via `push_inbox_update` to every resource bound for the user. `None` → no-op mark-read, skip the push (e.g. typo'd JID, race against retract) so we don't clobber receivers with a synthetic entry.
- Promoted `groupchat_archive::push_inbox_update` to `pub(crate)` and re-exported from `interpret` so the IQ handler can reach the existing helper.
- Deleted the latent `UserStorageState::mark_inbox_read` trait method, its impl, and the `mark_inbox_read` shim that hard-coded `thread_id = None`. No Rust callers — the wasm client sends the IQ directly.

## XEP-0430 conformance

The headline push is the same `<conversation>` envelope (`urn:waddle:inbox:0`, `MessageType::Headline`) that `build_inbox_query_result` emits per row, so clients reuse their existing decoder. Tests pin the wire shape so any drift is caught by a XEP-test, not a downstream regression.

## Test plan

- [x] `cargo test -p waddle-xmpp --lib` — 1821 pass
- [x] `cargo test -p waddle-server inbox` — incl. updated round-trip + new `mark_read_returns_none_for_missing_row`
- [x] `cargo test -p waddle-xmpp --test xep0430_cross_device_mark_read` — 4 new dedicated tests
- [x] `cargo clippy -p waddle-xmpp -p waddle-server --all-targets -- -D warnings`
- [x] `cargo fmt --all`
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.