### PR TITLE
fix(chat): hydrate inbox on every XMPP session-ready, not just resume

### DIFF
--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -670,12 +670,18 @@ export function useChatAppController(giphyApiKey: string) {
     client.setSessionLifecycleHandler((event) => {
       messaging.onSessionLifecycle(event);
       dmMessaging.onSessionLifecycle(event);
-      // Only re-hydrate inbox on resumptions (reconnect after brief disconnect).
-      // Fresh connections are handled by onConnectionReady() after appState -> "ready".
-      if (event.type === "resumed") {
-        void dmConversations.hydrateFromInbox();
-        void channelUnread.hydrateFromInbox();
-      }
+      // Re-hydrate inbox on every XMPP session-ready, both resumed and
+      // fresh. Stream resume catches up on stanzas the client missed
+      // while disconnected, but a *fresh* reconnection (resume failed
+      // — too much time elapsed, server restart, network blip past the
+      // resume window) means we lost the push stream entirely and the
+      // local unread map is stale. `onConnectionReady` only hydrates
+      // on the first sign-in (one-shot `hasBootstrapped` guard), so
+      // subsequent fresh reconnections would otherwise never refresh.
+      // `hydrateFromInbox` is request-id deduped, so the redundant
+      // call on the very first connection is harmless.
+      void dmConversations.hydrateFromInbox();
+      void channelUnread.hydrateFromInbox();
     });
   }, { immediate: true });
 

--- a/chat/tests/channel-unread.test.ts
+++ b/chat/tests/channel-unread.test.ts
@@ -213,6 +213,42 @@ describe("useChannelInbox", () => {
     expect(client.markInboxRead).toHaveBeenCalledWith("chat@muc.waddle.social");
   });
 
+  test("hydrate replaces stale local unread state with server-authoritative state", async () => {
+    // Captures the "wrong after reconnect" / "unread counts stay stale"
+    // symptom: device went offline (push stream interrupted), another
+    // device marked-read while disconnected, the fresh reconnection
+    // missed the headline push. On hydrate, the local state must be
+    // overwritten by the server's view — not merged.
+    const liveServerState: InboxEntry[] = [
+      {
+        partner: "space_channel@conference.example.com",
+        kind: "muc",
+        lastStanzaId: "sid-10",
+        lastUpdated: 500,
+        unread: 0,
+      },
+    ];
+    const client = makeClient(liveServerState);
+    const composable = useChannelInbox(ref<BrowserXmppClient | null>(client));
+
+    // Local cache reflects the pre-disconnect state.
+    composable.onInboxPush({
+      partner: "space_channel@conference.example.com",
+      kind: "muc",
+      lastStanzaId: "sid-5",
+      lastUpdated: 100,
+      unread: 7,
+      preview: "old preview",
+    });
+    expect(composable.totalChannelUnreadCount.value).toBe(7);
+
+    // Fresh reconnection triggers hydrate — must replace the stale row.
+    await composable.hydrateFromInbox();
+
+    expect(composable.totalChannelUnreadCount.value).toBe(0);
+    expect(composable.unreadForRoomJid("space_channel@conference.example.com")).toBe(0);
+  });
+
   test("clears stale unread state without a client", async () => {
     const client = ref<BrowserXmppClient | null>(makeClient());
     const composable = useChannelInbox(client);


### PR DESCRIPTION
## Summary

Reported symptoms: "unread counts stay stale" and "wrong after reconnect." Root cause: the chat client only re-hydrates the inbox when XEP-0198 stream resume succeeds. A *fresh* reconnection (resume window expired, server restart, long disconnect) loses the headline-push stream entirely, and the local unread map keeps whatever it had at disconnect time.

`onConnectionReady` hydrates exactly once (one-shot `hasBootstrapped` guard) — so subsequent fresh reconnections never refresh.

## Change

In `chat-app-controller.ts`, the session-lifecycle handler now calls `hydrateFromInbox` on both `resumed` *and* `fresh` events. `hydrateFromInbox` is request-id deduped, so the redundant call on the very first connection is harmless.

## Test plan

- [x] `bun test tests/channel-unread.test.ts` — new test pins that hydrate replaces a stale local unread row with the server's authoritative state
- [x] `bun test` — 774 pass
- [x] `bun run lint` (knip) — clean
- [ ] CI rollup green before manual merge

Pairs with the server-side fan-out fix in #637: server now pushes mark-read flips to every resource; chat now also reconciles on every reconnect, covering the case where pushes were missed.

This PR was created with the assistance of a LLM.