### PR TITLE
revert: restore all deleted XEP helper modules (#639/#640/#641/#642)

### DIFF
--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -143,6 +143,11 @@ pub use super::xep0317::{
     set_hats, strip_hats, Hat, HatCarrier, HatSet, NS_HATS,
 };
 
+pub use super::xep0319::{
+    add_idle, build_idle_element, extract_idle_from_presence, has_idle, is_idle_element,
+    parse_idle_element, strip_idle, IdleCarrier, IdleError, IdleInfo, NS_IDLE,
+};
+
 pub use super::xep0333::{
     add_markable, build_displayed_element, build_displayed_message, build_markable_element,
     extract_marker_from_message, extract_marker_id, has_markable, has_marker, is_marker_element,

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -43,6 +43,11 @@ pub use super::xep0115::{
     CapsCache, NS_CAPS, WADDLE_CAPS_NODE,
 };
 
+pub use super::xep0249::{
+    build_direct_invite, build_invite_message, is_direct_invite, message_has_direct_invite,
+    parse_direct_invite, parse_direct_invite_from_message, DirectInvite, NS_CONFERENCE,
+};
+
 pub use super::xep0363::{
     build_upload_error, build_upload_slot_response, effective_content_type, is_upload_request,
     parse_upload_request, sanitize_filename, UploadError, UploadRequest, UploadSlot,
@@ -306,6 +311,11 @@ pub use super::xep0452::{
     MentionNotificationCarrier, NS_MENTION_NOTIFICATION,
 };
 
+pub use super::xep0471::{
+    build_event_element, is_event_element, parse_event, CalendarEvent, Rsvp, RsvpStatus,
+    NS_CALENDAR, PUBSUB_NODE_EVENTS,
+};
+
 pub use super::xep0470::{
     build_attachments_element, is_attachments_element, parse_attachment_target, Attachment,
     AttachmentPayload, AttachmentTarget, NS_PUBSUB_ATTACHMENTS,
@@ -316,6 +326,11 @@ pub use super::xep_waddle_pin::{
     build_unpinned_element as build_unpinned_message_element, extract_pin_intent_from_message,
     parse_pinned_element as parse_pinned_message_element,
     parse_unpinned_element as parse_unpinned_message_element, PinIntent, NS_WADDLE_PIN_V0,
+};
+
+pub use super::xep0472::{
+    build_feed_entry_element, is_feed_entry, parse_feed_entry, FeedEntry, NS_SOCIAL_FEED,
+    PUBSUB_NODE_FEED,
 };
 
 pub use super::xep0492::{
@@ -332,6 +347,11 @@ pub use super::xep0469::{
     NS_BOOKMARKS_PINNING,
 };
 
+pub use super::xep0501::{
+    build_story_element, filter_active, is_story_element, parse_story, Story, DEFAULT_EXPIRY_HOURS,
+    NS_STORIES, PUBSUB_NODE_STORIES,
+};
+
 pub use super::xep0502::{
     build_activity_notification, build_subscribe_element,
     is_activity_element as is_muc_activity_element, parse_activity_notifications, ActivityTracker,
@@ -344,6 +364,14 @@ pub use super::xep0500::{
 };
 
 pub use super::xep0486::{extract_avatar_hash_from_presence, MucAvatar, MucAvatarCache};
+
+pub use super::xep0488::{
+    build_invite_message_element, build_invite_request, build_invite_response,
+    build_invite_share_message, extract_invite_from_iq, extract_invite_from_message,
+    has_invite_in_message, is_invite_element, is_invite_request, set_invite_on_message,
+    strip_invite_from_message, InviteToken, InviteTokenCarrier, InviteTokenError,
+    NS_MUC_TOKEN_INVITE,
+};
 
 pub use super::xep0513::{
     build_mention_element, build_mentions_elements, extract_explicit_mentions,

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -166,6 +166,11 @@ pub use super::xep0377::{
     ReportStore, NS_REPORTING,
 };
 
+pub use super::xep0393::{
+    blocks_to_html, blocks_to_plain, parse_blocks, parse_spans, spans_to_html, spans_to_plain,
+    Block, Span, StyledBody,
+};
+
 pub use waddle_xmpp_core::xep0359::{
     add_origin_id, add_stanza_id as add_stanza_id_xep0359, build_origin_id_element,
     build_stanza_id_element, extract_origin_id as extract_origin_id_xep0359, extract_origin_id_str,

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -171,6 +171,11 @@ pub use super::xep0377::{
     ReportStore, NS_REPORTING,
 };
 
+pub use super::xep0392::{
+    apply_cvd_correction, compute_hue, generate_color, generate_color_with_params, ConsistentColor,
+    CvdCorrection, HslColor, DEFAULT_LIGHTNESS, DEFAULT_SATURATION,
+};
+
 pub use super::xep0393::{
     blocks_to_html, blocks_to_plain, parse_blocks, parse_spans, spans_to_html, spans_to_plain,
     Block, Span, StyledBody,

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -41,6 +41,8 @@
 //!   via `<reference/>` elements with type, position, and URI.
 //! - **XEP-0377**: Spam Reporting - Abuse/spam reports with reasons
 //!   attached to blocking actions, with server-side report storage.
+//! - **XEP-0393**: Message Styling - Inline text formatting parser for
+//!   bold, italic, strikethrough, code, code blocks, and block quotes.
 //! - **XEP-0359**: Unique and Stable Stanza IDs - Server-assigned `<stanza-id/>`
 //!   and client-assigned `<origin-id/>` for stable message referencing.
 //! - **XEP-0334**: Message Processing Hints
@@ -150,6 +152,7 @@ pub mod xep0357;
 pub mod xep0363;
 pub mod xep0372;
 pub mod xep0377;
+pub mod xep0393;
 pub mod xep0401;
 pub mod xep0402;
 pub mod xep0410;

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -43,6 +43,8 @@
 //!   via `<reference/>` elements with type, position, and URI.
 //! - **XEP-0377**: Spam Reporting - Abuse/spam reports with reasons
 //!   attached to blocking actions, with server-side report storage.
+//! - **XEP-0392**: Consistent Color Generation - Deterministic HSL colors
+//!   from input strings via SHA-1 hue mapping with CVD correction.
 //! - **XEP-0393**: Message Styling - Inline text formatting parser for
 //!   bold, italic, strikethrough, code, code blocks, and block quotes.
 //! - **XEP-0359**: Unique and Stable Stanza IDs - Server-assigned `<stanza-id/>`
@@ -155,6 +157,7 @@ pub mod xep0357;
 pub mod xep0363;
 pub mod xep0372;
 pub mod xep0377;
+pub mod xep0392;
 pub mod xep0393;
 pub mod xep0401;
 pub mod xep0402;

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -35,6 +35,8 @@
 //!   via `<replace/>` element referencing the original message id.
 //! - **XEP-0317**: Hats - Role badges (Admin, Moderator, Bot, Owner) for
 //!   MUC occupants via `<hats/>` in presence, with well-known URIs.
+//! - **XEP-0319**: Last User Interaction in Presence - Idle detection
+//!   via `<idle since='...'/>` in presence stanzas.
 //! - **XEP-0333**: Displayed Markers - `<markable/>` requests and
 //!   `<displayed/>` updates for messages that have been shown.
 //! - **XEP-0372**: References - Structured @mentions and data references
@@ -146,6 +148,7 @@ pub mod xep0297;
 pub mod xep0300;
 pub mod xep0308;
 pub mod xep0317;
+pub mod xep0319;
 pub mod xep0333;
 pub mod xep0334;
 pub mod xep0357;

--- a/server/crates/waddle-xmpp/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp/src/xep/mod.rs
@@ -63,16 +63,24 @@
 //!   pack references, built on XEP-0446/0447 file sharing.
 //! - **XEP-0452**: MUC Mention Notifications - @mention alerts with
 //!   notification elements and per-room unread mention counter.
+//! - **XEP-0471**: Calendar Events - Community events with scheduling,
+//!   RSVP tracking (going/interested/not-going), and PubSub storage.
 //! - **XEP-0470**: Pubsub Attachments - Reactions/comments on PubSub items
 //!   with attachment target and typed payloads.
+//! - **XEP-0472**: Pubsub Social Feed - Social posts and activity feeds
+//!   via PubSub with title, body, author, and publication metadata.
 //! - **XEP-0492**: Chat Notification Settings - Per-chat notification settings
 //!   via `<notify/>` children (`<always/>`, `<on-mention/>`, `<never/>`).
 //! - **XEP-0469**: Bookmark Pinning - Pin favorite channels via `<pinned/>`
 //!   extension on XEP-0402 bookmark elements, with sort helper.
+//! - **XEP-0501**: Pubsub Stories - Ephemeral posts with auto-expiry
+//!   (default 24h), media support, and active/expired filtering.
 //! - **XEP-0502**: MUC Activity Indicator - Lightweight room activity tracking
 //!   with subscribe/notify pattern and per-room activity state.
 //! - **XEP-0500**: MUC Slow Mode - Per-room rate limiting with configurable
 //!   cooldown interval, moderator exemption, and per-occupant tracking.
+//! - **XEP-0488**: MUC Token Invite - Shareable invite tokens for MUC rooms
+//!   with URI generation and IQ-based token request/response.
 //! - **XEP-0447**: Stateless File Sharing - Structured file sharing with
 //!   metadata and download sources, building on XEP-0446 and XEP-0363.
 //! - **XEP-0446**: File Metadata Element - Structured file info (name, size,
@@ -93,6 +101,8 @@
 //!   blocklists and silently dropping messages from blocked JIDs.
 //! - **XEP-0199**: XMPP Ping - Simple ping/pong for connection liveness.
 //! - **XEP-0223**: Persistent Storage Best Practices - Profile of PubSub.
+//! - **XEP-0249**: Direct MUC Invitations - Simple message-based invitations
+//!   for inviting users directly to MUC rooms.
 //! - **XEP-0363**: HTTP File Upload - Server-side support for HTTP-based
 //!   file uploads, returning PUT and GET URLs for file transfer.
 //! - **XEP-0402**: PEP Native Bookmarks - MUC room bookmarks stored via PEP.
@@ -100,7 +110,7 @@
 //! - **XEP-0513**: Explicit Mentions - @everyone, @here, @role, @user
 //!   mentions with notification decision logic.
 //! - Private Waddle MUC thread metadata, used until XEP-0508 is implemented
-//!   through PubSub forum nodes.
+//!   through PubSub/XEP-0472 forum nodes.
 //! - **XEP-0503**: Server-side Spaces - Community discovery via pubsub.
 
 pub mod xep0004;
@@ -128,6 +138,7 @@ pub mod xep0199;
 pub mod xep0202;
 pub mod xep0203;
 pub mod xep0223;
+pub mod xep0249;
 pub mod xep0292;
 pub mod xep0297;
 pub mod xep0300;
@@ -160,9 +171,13 @@ pub mod xep0452;
 pub mod xep0461;
 pub mod xep0469;
 pub mod xep0470;
+pub mod xep0471;
+pub mod xep0472;
 pub mod xep0486;
+pub mod xep0488;
 pub mod xep0492;
 pub mod xep0500;
+pub mod xep0501;
 pub mod xep0502;
 pub mod xep0503;
 pub mod xep0508;
@@ -175,3 +190,7 @@ mod exports;
 mod xep_waddle_mam_stanza_id_tests;
 
 pub use exports::*;
+
+pub mod prelude {
+    pub use super::xep0249::message_has_direct_invite;
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0249.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0249.rs
@@ -1,0 +1,459 @@
+//! XEP-0249: Direct MUC Invitations
+//!
+//! Provides support for inviting users directly to MUC rooms using a simple
+//! message-based invitation mechanism. This is an alternative to the mediated
+//! invitations defined in XEP-0045.
+//!
+//! ## Overview
+//!
+//! Direct MUC invitations allow a user to invite another user to a MUC room
+//! by sending them a message with a special `<x>` element containing:
+//! - The JID of the room to join (required)
+//! - An optional reason for the invitation
+//! - An optional password if the room is password-protected
+//!
+//! ## XML Format
+//!
+//! ```xml
+//! <message from='crone1@shakespeare.lit/desktop'
+//!          to='hecate@shakespeare.lit'>
+//!   <x xmlns='jabber:x:conference'
+//!      jid='darkcave@macbeth.shakespeare.lit'
+//!      reason='Hey Hecate, this is the place for all good witches!'
+//!      password='cauldronburn'/>
+//! </message>
+//! ```
+
+use jid::BareJid;
+use minidom::Element;
+use tracing::debug;
+
+/// Namespace for XEP-0249 Direct MUC Invitations.
+pub const NS_CONFERENCE: &str = "jabber:x:conference";
+
+/// A direct MUC invitation parsed from a message stanza.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirectInvite {
+    /// The JID of the MUC room to join (required).
+    pub jid: BareJid,
+    /// Optional reason/message for the invitation.
+    pub reason: Option<String>,
+    /// Optional password for password-protected rooms.
+    pub password: Option<String>,
+}
+
+impl DirectInvite {
+    /// Create a new direct invite with just a room JID.
+    pub fn new(jid: BareJid) -> Self {
+        Self {
+            jid,
+            reason: None,
+            password: None,
+        }
+    }
+
+    /// Create a new direct invite with a room JID and reason.
+    pub fn with_reason(jid: BareJid, reason: impl Into<String>) -> Self {
+        Self {
+            jid,
+            reason: Some(reason.into()),
+            password: None,
+        }
+    }
+
+    /// Create a new direct invite with all fields.
+    pub fn with_password(
+        jid: BareJid,
+        reason: Option<String>,
+        password: impl Into<String>,
+    ) -> Self {
+        Self {
+            jid,
+            reason,
+            password: Some(password.into()),
+        }
+    }
+
+    /// Set the reason for the invitation.
+    pub fn set_reason(&mut self, reason: impl Into<String>) {
+        self.reason = Some(reason.into());
+    }
+
+    /// Set the password for the invitation.
+    pub fn set_password(&mut self, password: impl Into<String>) {
+        self.password = Some(password.into());
+    }
+}
+
+/// Check if a message element contains a direct MUC invitation (XEP-0249).
+///
+/// Returns true if the message contains an `<x xmlns='jabber:x:conference'>` child element.
+pub fn is_direct_invite(element: &Element) -> bool {
+    element.get_child("x", NS_CONFERENCE).is_some()
+}
+
+/// Check if a parsed Message contains a direct MUC invitation.
+pub fn message_has_direct_invite(msg: &xmpp_parsers::message::Message) -> bool {
+    msg.payloads
+        .iter()
+        .any(|p| p.name() == "x" && p.ns() == NS_CONFERENCE)
+}
+
+/// Parse a direct MUC invitation from a message element.
+///
+/// Returns `Some(DirectInvite)` if the message contains a valid invitation,
+/// or `None` if no invitation is found or the invitation is malformed.
+pub fn parse_direct_invite(element: &Element) -> Option<DirectInvite> {
+    let x_elem = element.get_child("x", NS_CONFERENCE)?;
+    parse_invite_element(x_elem)
+}
+
+/// Parse a direct MUC invitation from a Message.
+pub fn parse_direct_invite_from_message(
+    msg: &xmpp_parsers::message::Message,
+) -> Option<DirectInvite> {
+    for payload in &msg.payloads {
+        if payload.name() == "x" && payload.ns() == NS_CONFERENCE {
+            return parse_invite_element(payload);
+        }
+    }
+    None
+}
+
+/// Parse the `<x>` element into a DirectInvite.
+fn parse_invite_element(x_elem: &Element) -> Option<DirectInvite> {
+    // The jid attribute is required
+    let jid_str = x_elem.attr("jid")?;
+    let jid: BareJid = jid_str.parse().ok()?;
+
+    // Reason and password are optional
+    let reason = x_elem
+        .attr("reason")
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let password = x_elem
+        .attr("password")
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    debug!(
+        room = %jid,
+        has_reason = reason.is_some(),
+        has_password = password.is_some(),
+        "Parsed direct MUC invitation"
+    );
+
+    Some(DirectInvite {
+        jid,
+        reason,
+        password,
+    })
+}
+
+/// Build a direct invite `<x>` element from a DirectInvite struct.
+///
+/// The resulting element can be added to a message stanza.
+pub fn build_direct_invite(invite: &DirectInvite) -> Element {
+    let mut builder = Element::builder("x", NS_CONFERENCE).attr("jid", invite.jid.to_string());
+
+    if let Some(ref reason) = invite.reason {
+        builder = builder.attr("reason", reason.as_str());
+    }
+
+    if let Some(ref password) = invite.password {
+        builder = builder.attr("password", password.as_str());
+    }
+
+    builder.build()
+}
+
+/// Build a complete message stanza containing a direct MUC invitation.
+///
+/// # Arguments
+///
+/// * `from` - The JID of the user sending the invitation
+/// * `to` - The JID of the user being invited
+/// * `invite` - The invitation details
+/// * `body` - Optional message body (some clients display this)
+///
+/// # Returns
+///
+/// An XML string representing the complete message stanza.
+pub fn build_invite_message(
+    from: &jid::Jid,
+    to: &jid::Jid,
+    invite: &DirectInvite,
+    body: Option<&str>,
+) -> String {
+    let invite_elem = build_direct_invite(invite);
+    let invite_xml = String::from(&invite_elem);
+
+    let body_xml = body
+        .map(|b| format!("<body>{}</body>", escape_xml(b)))
+        .unwrap_or_default();
+
+    format!(
+        "<message from='{}' to='{}'>{}{}</message>",
+        escape_xml(&from.to_string()),
+        escape_xml(&to.to_string()),
+        body_xml,
+        invite_xml
+    )
+}
+
+/// Escape XML special characters.
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_direct_invite() {
+        // Valid direct invite
+        let xml = r#"<message xmlns='jabber:client' from='user@example.com' to='friend@example.com'>
+            <x xmlns='jabber:x:conference' jid='room@conference.example.com'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+        assert!(is_direct_invite(&element));
+
+        // Message without invite
+        let xml = r#"<message xmlns='jabber:client' from='user@example.com' to='friend@example.com'>
+            <body>Hello!</body>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+        assert!(!is_direct_invite(&element));
+
+        // Wrong namespace
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='wrong:namespace' jid='room@conference.example.com'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+        assert!(!is_direct_invite(&element));
+    }
+
+    #[test]
+    fn test_parse_direct_invite_minimal() {
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference' jid='darkcave@macbeth.shakespeare.lit'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+
+        let invite = parse_direct_invite(&element).unwrap();
+        assert_eq!(invite.jid.to_string(), "darkcave@macbeth.shakespeare.lit");
+        assert!(invite.reason.is_none());
+        assert!(invite.password.is_none());
+    }
+
+    #[test]
+    fn test_parse_direct_invite_with_reason() {
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference'
+               jid='darkcave@macbeth.shakespeare.lit'
+               reason='Hey Hecate, this is the place for all good witches!'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+
+        let invite = parse_direct_invite(&element).unwrap();
+        assert_eq!(invite.jid.to_string(), "darkcave@macbeth.shakespeare.lit");
+        assert_eq!(
+            invite.reason.as_deref(),
+            Some("Hey Hecate, this is the place for all good witches!")
+        );
+        assert!(invite.password.is_none());
+    }
+
+    #[test]
+    fn test_parse_direct_invite_full() {
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference'
+               jid='darkcave@macbeth.shakespeare.lit'
+               reason='Hey Hecate, this is the place for all good witches!'
+               password='cauldronburn'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+
+        let invite = parse_direct_invite(&element).unwrap();
+        assert_eq!(invite.jid.to_string(), "darkcave@macbeth.shakespeare.lit");
+        assert_eq!(
+            invite.reason.as_deref(),
+            Some("Hey Hecate, this is the place for all good witches!")
+        );
+        assert_eq!(invite.password.as_deref(), Some("cauldronburn"));
+    }
+
+    #[test]
+    fn test_parse_direct_invite_missing_jid() {
+        // Missing required jid attribute
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference' reason='Join us!'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+
+        assert!(parse_direct_invite(&element).is_none());
+    }
+
+    #[test]
+    fn test_parse_direct_invite_invalid_jid() {
+        // Empty JID should fail
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference' jid=''/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+        assert!(parse_direct_invite(&element).is_none());
+
+        // JID with only @ sign should fail
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference' jid='@'/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+        assert!(parse_direct_invite(&element).is_none());
+    }
+
+    #[test]
+    fn test_parse_direct_invite_empty_reason() {
+        // Empty reason should be treated as None
+        let xml = r#"<message xmlns='jabber:client'>
+            <x xmlns='jabber:x:conference' jid='room@conference.example.com' reason=''/>
+        </message>"#;
+        let element: Element = xml.parse().unwrap();
+
+        let invite = parse_direct_invite(&element).unwrap();
+        assert!(invite.reason.is_none());
+    }
+
+    #[test]
+    fn test_build_direct_invite_minimal() {
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let invite = DirectInvite::new(jid);
+
+        let elem = build_direct_invite(&invite);
+
+        assert_eq!(elem.name(), "x");
+        assert_eq!(elem.ns(), NS_CONFERENCE);
+        assert_eq!(elem.attr("jid"), Some("room@conference.example.com"));
+        assert!(elem.attr("reason").is_none());
+        assert!(elem.attr("password").is_none());
+    }
+
+    #[test]
+    fn test_build_direct_invite_with_reason() {
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let invite = DirectInvite::with_reason(jid, "Join our chat!");
+
+        let elem = build_direct_invite(&invite);
+
+        assert_eq!(elem.attr("jid"), Some("room@conference.example.com"));
+        assert_eq!(elem.attr("reason"), Some("Join our chat!"));
+        assert!(elem.attr("password").is_none());
+    }
+
+    #[test]
+    fn test_build_direct_invite_full() {
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let password = format!("test-{}", uuid::Uuid::new_v4());
+        let invite = DirectInvite::with_password(jid, Some("Join us!".to_string()), &password);
+
+        let elem = build_direct_invite(&invite);
+
+        assert_eq!(elem.attr("jid"), Some("room@conference.example.com"));
+        assert_eq!(elem.attr("reason"), Some("Join us!"));
+        assert_eq!(elem.attr("password"), Some(password.as_str()));
+    }
+
+    #[test]
+    fn test_build_invite_message() {
+        let from: jid::Jid = "crone1@shakespeare.lit/desktop".parse().unwrap();
+        let to: jid::Jid = "hecate@shakespeare.lit".parse().unwrap();
+        let jid: BareJid = "darkcave@macbeth.shakespeare.lit".parse().unwrap();
+        let invite = DirectInvite::with_reason(jid, "Join us!");
+
+        let msg = build_invite_message(&from, &to, &invite, None);
+
+        // Check the message wrapper has proper from/to attributes
+        assert!(msg.contains("from='crone1@shakespeare.lit/desktop'"));
+        assert!(msg.contains("to='hecate@shakespeare.lit'"));
+        // Check the invite element is present with correct namespace and attributes
+        assert!(msg.contains("jabber:x:conference"));
+        assert!(msg.contains("darkcave@macbeth.shakespeare.lit"));
+        assert!(msg.contains("Join us!"));
+    }
+
+    #[test]
+    fn test_build_invite_message_with_body() {
+        let from: jid::Jid = "user@example.com".parse().unwrap();
+        let to: jid::Jid = "friend@example.com".parse().unwrap();
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let invite = DirectInvite::new(jid);
+
+        let msg = build_invite_message(
+            &from,
+            &to,
+            &invite,
+            Some("You've been invited to join a room!"),
+        );
+
+        assert!(msg.contains("<body>You&apos;ve been invited to join a room!</body>"));
+        assert!(msg.contains("xmlns='jabber:x:conference'"));
+    }
+
+    #[test]
+    fn test_direct_invite_setters() {
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let mut invite = DirectInvite::new(jid);
+
+        assert!(invite.reason.is_none());
+        assert!(invite.password.is_none());
+
+        invite.set_reason("Come join!");
+        assert_eq!(invite.reason.as_deref(), Some("Come join!"));
+
+        let password = format!("test-{}", uuid::Uuid::new_v4());
+        invite.set_password(&password);
+        assert!(invite.password.is_some());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let original = DirectInvite::with_password(
+            jid,
+            Some("Test roundtrip".to_string()),
+            format!("test-{}", uuid::Uuid::new_v4()),
+        );
+
+        // Build the element
+        let elem = build_direct_invite(&original);
+
+        // Wrap in a message for parsing
+        let msg = Element::builder("message", "jabber:client")
+            .append(elem)
+            .build();
+
+        // Parse it back
+        let parsed = parse_direct_invite(&msg).unwrap();
+
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_escape_special_characters() {
+        let from: jid::Jid = "user@example.com".parse().unwrap();
+        let to: jid::Jid = "friend@example.com".parse().unwrap();
+        let jid: BareJid = "room@conference.example.com".parse().unwrap();
+        let mut invite = DirectInvite::new(jid);
+        invite.set_reason("Join <us> & have fun!");
+
+        let msg = build_invite_message(&from, &to, &invite, Some("Check this <out>!"));
+
+        // Verify special characters are escaped in body
+        assert!(msg.contains("Check this &lt;out&gt;!"));
+        // Note: The element builder handles attribute escaping, so reason may appear differently
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0319.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0319.rs
@@ -1,0 +1,306 @@
+//! XEP-0319: Last User Interaction in Presence
+//!
+//! Provides helpers for detecting, parsing, and building idle indicators
+//! in presence stanzas. Shows when the user last interacted with their
+//! device, enabling "idle" or "away since" display in chat UIs.
+//!
+//! ## XML Format
+//!
+//! ```xml
+//! <presence from='romeo@example.com/mobile'>
+//!   <show>away</show>
+//!   <idle xmlns='urn:xmpp:idle:1' since='2024-06-01T12:00:00Z'/>
+//! </presence>
+//! ```
+//!
+//! ## Use Cases
+//!
+//! - Show "idle for 5 minutes" or "last active 2 hours ago" in user lists
+//! - Distinguish between "away" (manual) and "idle" (automatic)
+//! - Help users decide whether to expect a timely response
+//!
+//! ## Server Behavior
+//!
+//! The server transparently routes presence stanzas containing idle info.
+//! It may also track the last interaction time internally for XEP-0012.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use thiserror::Error;
+use xmpp_parsers::presence::Presence;
+
+/// Namespace for XEP-0319 Last User Interaction.
+pub const NS_IDLE: &str = "urn:xmpp:idle:1";
+
+/// Errors that can occur when parsing idle elements.
+#[derive(Debug, Error)]
+pub enum IdleError {
+    /// The `since` attribute is missing or invalid.
+    #[error("idle element has invalid or missing since: {0}")]
+    InvalidSince(String),
+}
+
+/// Idle state information.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdleInfo {
+    /// The timestamp when the user last interacted.
+    pub since: DateTime<Utc>,
+}
+
+impl IdleInfo {
+    /// Create a new idle info.
+    pub fn new(since: DateTime<Utc>) -> Self {
+        Self { since }
+    }
+
+    /// Create idle info for "idle since now".
+    pub fn now() -> Self {
+        Self { since: Utc::now() }
+    }
+
+    /// How long the user has been idle (from now).
+    pub fn idle_duration(&self) -> chrono::Duration {
+        Utc::now().signed_duration_since(self.since)
+    }
+
+    /// Human-readable idle duration string.
+    pub fn human_idle(&self) -> String {
+        let dur = self.idle_duration();
+        let secs = dur.num_seconds();
+        if secs < 60 {
+            "just now".to_owned()
+        } else if secs < 3600 {
+            format!("{}m ago", secs / 60)
+        } else if secs < 86400 {
+            format!("{}h ago", secs / 3600)
+        } else {
+            format!("{}d ago", secs / 86400)
+        }
+    }
+}
+
+/// Trait for types that can carry idle information.
+pub trait IdleCarrier {
+    /// Extract idle info from this carrier, if present.
+    fn idle_info(&self) -> Option<IdleInfo>;
+
+    /// Returns `true` if this carrier has idle information.
+    fn is_idle(&self) -> bool {
+        self.idle_info().is_some()
+    }
+
+    /// Returns the idle-since timestamp if present.
+    fn idle_since(&self) -> Option<DateTime<Utc>> {
+        self.idle_info().map(|i| i.since)
+    }
+}
+
+impl IdleCarrier for Presence {
+    fn idle_info(&self) -> Option<IdleInfo> {
+        extract_idle_from_presence(self)
+    }
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an element is an `<idle/>` element.
+pub fn is_idle_element(elem: &Element) -> bool {
+    elem.ns() == NS_IDLE && elem.name() == "idle"
+}
+
+/// Check if a presence has idle information.
+pub fn has_idle(presence: &Presence) -> bool {
+    presence.payloads.iter().any(is_idle_element)
+}
+
+// ── Extraction ───────────────────────────────────────────────────────
+
+/// Extract idle info from a presence stanza.
+pub fn extract_idle_from_presence(presence: &Presence) -> Option<IdleInfo> {
+    let elem = presence.payloads.iter().find(|e| is_idle_element(e))?;
+    parse_idle_element(elem).ok()
+}
+
+/// Parse an `<idle/>` element.
+pub fn parse_idle_element(elem: &Element) -> Result<IdleInfo, IdleError> {
+    let since_str = elem
+        .attr("since")
+        .ok_or_else(|| IdleError::InvalidSince("missing since attribute".into()))?;
+    let since = since_str
+        .parse::<DateTime<Utc>>()
+        .map_err(|e| IdleError::InvalidSince(e.to_string()))?;
+    Ok(IdleInfo::new(since))
+}
+
+// ── Building ─────────────────────────────────────────────────────────
+
+/// Build an `<idle xmlns='urn:xmpp:idle:1' since='...'/>` element.
+pub fn build_idle_element(since: DateTime<Utc>) -> Element {
+    Element::builder("idle", NS_IDLE)
+        .attr("since", since.to_rfc3339())
+        .build()
+}
+
+// ── Mutation ─────────────────────────────────────────────────────────
+
+/// Add idle information to a presence stanza.
+pub fn add_idle(presence: &mut Presence, since: DateTime<Utc>) {
+    presence.payloads.retain(|e| e.ns() != NS_IDLE);
+    presence.payloads.push(build_idle_element(since));
+}
+
+/// Remove idle information from a presence stanza.
+pub fn strip_idle(presence: &mut Presence) {
+    presence.payloads.retain(|e| e.ns() != NS_IDLE);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn test_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
+            .single()
+            .expect("valid test date")
+    }
+
+    #[test]
+    fn test_is_idle_element() {
+        let elem = Element::builder("idle", NS_IDLE)
+            .attr("since", "2024-06-01T12:00:00Z")
+            .build();
+        assert!(is_idle_element(&elem));
+
+        let wrong = Element::builder("idle", "jabber:client").build();
+        assert!(!is_idle_element(&wrong));
+    }
+
+    #[test]
+    fn test_extract_idle_from_presence() {
+        let xml = "<presence xmlns='jabber:client'>\
+                    <show>away</show>\
+                    <idle xmlns='urn:xmpp:idle:1' since='2024-06-01T12:00:00Z'/>\
+                    </presence>";
+        let presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+
+        let idle = extract_idle_from_presence(&presence).expect("has idle");
+        assert_eq!(idle.since, test_time());
+    }
+
+    #[test]
+    fn test_extract_idle_absent() {
+        let xml = "<presence xmlns='jabber:client'/>";
+        let presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+        assert!(extract_idle_from_presence(&presence).is_none());
+    }
+
+    #[test]
+    fn test_parse_idle_invalid_since() {
+        let elem = Element::builder("idle", NS_IDLE)
+            .attr("since", "not-a-date")
+            .build();
+        let err = parse_idle_element(&elem).expect_err("should fail");
+        assert!(err.to_string().contains("invalid"));
+    }
+
+    #[test]
+    fn test_parse_idle_missing_since() {
+        let elem = Element::builder("idle", NS_IDLE).build();
+        let err = parse_idle_element(&elem).expect_err("should fail");
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[test]
+    fn test_build_idle_element() {
+        let elem = build_idle_element(test_time());
+        assert_eq!(elem.name(), "idle");
+        assert_eq!(elem.ns(), NS_IDLE);
+        assert!(elem.attr("since").is_some());
+    }
+
+    #[test]
+    fn test_add_idle() {
+        let xml = "<presence xmlns='jabber:client'/>";
+        let mut presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+
+        add_idle(&mut presence, test_time());
+        assert!(has_idle(&presence));
+
+        // Replace
+        let new_time = Utc
+            .with_ymd_and_hms(2024, 7, 1, 0, 0, 0)
+            .single()
+            .expect("valid test date");
+        add_idle(&mut presence, new_time);
+        let idle = extract_idle_from_presence(&presence).expect("has idle");
+        assert_eq!(idle.since, new_time);
+        assert_eq!(
+            presence
+                .payloads
+                .iter()
+                .filter(|e| e.ns() == NS_IDLE)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_strip_idle() {
+        let xml = "<presence xmlns='jabber:client'>\
+                    <idle xmlns='urn:xmpp:idle:1' since='2024-06-01T12:00:00Z'/>\
+                    </presence>";
+        let mut presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+
+        strip_idle(&mut presence);
+        assert!(!has_idle(&presence));
+    }
+
+    #[test]
+    fn test_idle_carrier_trait() {
+        let xml = "<presence xmlns='jabber:client'>\
+                    <idle xmlns='urn:xmpp:idle:1' since='2024-06-01T12:00:00Z'/>\
+                    </presence>";
+        let presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+
+        assert!(presence.is_idle());
+        assert_eq!(presence.idle_since(), Some(test_time()));
+    }
+
+    #[test]
+    fn test_idle_info_now() {
+        let info = IdleInfo::now();
+        assert!(info.idle_duration().num_seconds() < 2);
+    }
+
+    #[test]
+    fn test_idle_info_human() {
+        let recent = IdleInfo::new(Utc::now() - chrono::Duration::seconds(30));
+        assert_eq!(recent.human_idle(), "just now");
+
+        let minutes = IdleInfo::new(Utc::now() - chrono::Duration::minutes(15));
+        assert!(minutes.human_idle().contains("m ago"));
+
+        let hours = IdleInfo::new(Utc::now() - chrono::Duration::hours(3));
+        assert!(hours.human_idle().contains("h ago"));
+
+        let days = IdleInfo::new(Utc::now() - chrono::Duration::days(2));
+        assert!(days.human_idle().contains("d ago"));
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let xml = "<presence xmlns='jabber:client'>\
+                    <idle xmlns='urn:xmpp:idle:1' since='2024-06-01T12:00:00Z'/>\
+                    </presence>";
+        let presence =
+            Presence::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid presence");
+        let idle = extract_idle_from_presence(&presence).expect("has idle");
+        assert_eq!(idle.since, test_time());
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0392.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0392.rs
@@ -1,0 +1,351 @@
+//! XEP-0392: Consistent Color Generation
+//!
+//! Generates deterministic colors from input strings (JIDs, nicknames)
+//! so that each user gets a unique, consistent color across clients.
+//!
+//! ## Algorithm
+//!
+//! 1. Compute SHA-1 hash of the input string (UTF-8 encoded).
+//! 2. Take the first two bytes of the hash as a big-endian u16.
+//! 3. Map to a hue angle: `hue = (value / 65536) * 360`.
+//! 4. Combine with configurable saturation and lightness to produce HSL.
+//!
+//! ## Color Vision Deficiency Correction
+//!
+//! The spec defines optional corrections for red-green and blue-yellow
+//! deficiencies by remapping the hue range. This module supports both.
+
+use sha1::{Digest, Sha1};
+
+/// Default saturation percentage for generated colors.
+pub const DEFAULT_SATURATION: f64 = 100.0;
+
+/// Default lightness percentage for generated colors.
+pub const DEFAULT_LIGHTNESS: f64 = 50.0;
+
+/// Color vision deficiency correction mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CvdCorrection {
+    /// No correction (full 360° hue range).
+    None,
+    /// Red-green deficiency (deuteranopia/protanopia).
+    /// Maps hue to two safe ranges: blue and yellow.
+    RedGreen,
+    /// Blue-yellow deficiency (tritanopia).
+    /// Maps hue to two safe ranges: red and cyan.
+    BlueYellow,
+}
+
+/// An HSL color value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HslColor {
+    /// Hue angle in degrees (0.0–360.0).
+    pub hue: f64,
+    /// Saturation percentage (0.0–100.0).
+    pub saturation: f64,
+    /// Lightness percentage (0.0–100.0).
+    pub lightness: f64,
+}
+
+impl HslColor {
+    /// Create a new HSL color.
+    pub fn new(hue: f64, saturation: f64, lightness: f64) -> Self {
+        Self {
+            hue,
+            saturation,
+            lightness,
+        }
+    }
+
+    /// Convert to a CSS `hsl()` string.
+    pub fn to_css(&self) -> String {
+        format!(
+            "hsl({:.0}, {:.0}%, {:.0}%)",
+            self.hue, self.saturation, self.lightness
+        )
+    }
+
+    /// Convert to an RGB hex string (e.g., `#ff8040`).
+    pub fn to_hex(&self) -> String {
+        let (r, g, b) = hsl_to_rgb(self.hue, self.saturation / 100.0, self.lightness / 100.0);
+        format!("#{:02x}{:02x}{:02x}", r, g, b)
+    }
+
+    /// Convert to RGB tuple (0–255 each).
+    pub fn to_rgb(&self) -> (u8, u8, u8) {
+        hsl_to_rgb(self.hue, self.saturation / 100.0, self.lightness / 100.0)
+    }
+}
+
+/// Compute the consistent hue angle for an input string.
+///
+/// This is the core XEP-0392 algorithm:
+/// 1. SHA-1 hash the input
+/// 2. Take first 2 bytes as big-endian u16
+/// 3. Map to 0.0–360.0 hue range
+pub fn compute_hue(input: &str) -> f64 {
+    let hash = Sha1::digest(input.as_bytes());
+    let value = u16::from_be_bytes([hash[0], hash[1]]);
+    (value as f64 / 65536.0) * 360.0
+}
+
+/// Apply color vision deficiency correction to a hue angle.
+pub fn apply_cvd_correction(hue: f64, correction: CvdCorrection) -> f64 {
+    match correction {
+        CvdCorrection::None => hue,
+        CvdCorrection::RedGreen => {
+            // Map full range to blue (180°–300°) region
+            180.0 + (hue / 360.0) * 120.0
+        }
+        CvdCorrection::BlueYellow => {
+            // Map full range to red-green (0°–180°) region
+            (hue / 360.0) * 180.0
+        }
+    }
+}
+
+/// Generate a consistent color for an input string.
+///
+/// Uses the default saturation (100%) and lightness (50%).
+pub fn generate_color(input: &str) -> HslColor {
+    generate_color_with_params(
+        input,
+        DEFAULT_SATURATION,
+        DEFAULT_LIGHTNESS,
+        CvdCorrection::None,
+    )
+}
+
+/// Generate a consistent color with custom parameters.
+pub fn generate_color_with_params(
+    input: &str,
+    saturation: f64,
+    lightness: f64,
+    cvd: CvdCorrection,
+) -> HslColor {
+    let hue = apply_cvd_correction(compute_hue(input), cvd);
+    HslColor::new(hue, saturation, lightness)
+}
+
+/// Trait for types that can generate a consistent color.
+pub trait ConsistentColor {
+    /// The string to use as input for color generation.
+    fn color_input(&self) -> &str;
+
+    /// Generate the consistent color for this entity.
+    fn consistent_color(&self) -> HslColor {
+        generate_color(self.color_input())
+    }
+
+    /// Generate the consistent color with custom parameters.
+    fn consistent_color_with(
+        &self,
+        saturation: f64,
+        lightness: f64,
+        cvd: CvdCorrection,
+    ) -> HslColor {
+        generate_color_with_params(self.color_input(), saturation, lightness, cvd)
+    }
+}
+
+impl ConsistentColor for str {
+    fn color_input(&self) -> &str {
+        self
+    }
+}
+
+impl ConsistentColor for String {
+    fn color_input(&self) -> &str {
+        self
+    }
+}
+
+// ── HSL to RGB conversion ────────────────────────────────────────────
+
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    if s == 0.0 {
+        let v = (l * 255.0).round() as u8;
+        return (v, v, v);
+    }
+
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+
+    let r = hue_to_rgb(p, q, h / 360.0 + 1.0 / 3.0);
+    let g = hue_to_rgb(p, q, h / 360.0);
+    let b = hue_to_rgb(p, q, h / 360.0 - 1.0 / 3.0);
+
+    (
+        (r * 255.0).round() as u8,
+        (g * 255.0).round() as u8,
+        (b * 255.0).round() as u8,
+    )
+}
+
+fn hue_to_rgb(p: f64, q: f64, mut t: f64) -> f64 {
+    if t < 0.0 {
+        t += 1.0;
+    }
+    if t > 1.0 {
+        t -= 1.0;
+    }
+    if t < 1.0 / 6.0 {
+        return p + (q - p) * 6.0 * t;
+    }
+    if t < 1.0 / 2.0 {
+        return q;
+    }
+    if t < 2.0 / 3.0 {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
+    p
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_hue_deterministic() {
+        let hue1 = compute_hue("alice@example.com");
+        let hue2 = compute_hue("alice@example.com");
+        assert_eq!(hue1, hue2);
+    }
+
+    #[test]
+    fn test_compute_hue_different_inputs() {
+        let hue_alice = compute_hue("alice@example.com");
+        let hue_bob = compute_hue("bob@example.com");
+        assert_ne!(hue_alice, hue_bob);
+    }
+
+    #[test]
+    fn test_compute_hue_range() {
+        for input in ["alice", "bob", "charlie", "dave", "eve", "frank", ""] {
+            let hue = compute_hue(input);
+            assert!(
+                (0.0..360.0).contains(&hue),
+                "hue {hue} out of range for input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_color_defaults() {
+        let color = generate_color("alice@example.com");
+        assert_eq!(color.saturation, DEFAULT_SATURATION);
+        assert_eq!(color.lightness, DEFAULT_LIGHTNESS);
+        assert!((0.0..360.0).contains(&color.hue));
+    }
+
+    #[test]
+    fn test_generate_color_custom_params() {
+        let color = generate_color_with_params("alice", 80.0, 40.0, CvdCorrection::None);
+        assert_eq!(color.saturation, 80.0);
+        assert_eq!(color.lightness, 40.0);
+    }
+
+    #[test]
+    fn test_cvd_red_green() {
+        let normal = generate_color("test");
+        let corrected = generate_color_with_params(
+            "test",
+            DEFAULT_SATURATION,
+            DEFAULT_LIGHTNESS,
+            CvdCorrection::RedGreen,
+        );
+        // Red-green maps to 180°–300° range
+        assert!(corrected.hue >= 180.0 && corrected.hue <= 300.0);
+        // Should differ from uncorrected (usually)
+        assert_ne!(normal.hue, corrected.hue);
+    }
+
+    #[test]
+    fn test_cvd_blue_yellow() {
+        let corrected = generate_color_with_params(
+            "test",
+            DEFAULT_SATURATION,
+            DEFAULT_LIGHTNESS,
+            CvdCorrection::BlueYellow,
+        );
+        // Blue-yellow maps to 0°–180° range
+        assert!(corrected.hue >= 0.0 && corrected.hue <= 180.0);
+    }
+
+    #[test]
+    fn test_hsl_to_css() {
+        let color = HslColor::new(120.0, 100.0, 50.0);
+        assert_eq!(color.to_css(), "hsl(120, 100%, 50%)");
+    }
+
+    #[test]
+    fn test_hsl_to_hex() {
+        // Pure red
+        let red = HslColor::new(0.0, 100.0, 50.0);
+        assert_eq!(red.to_hex(), "#ff0000");
+
+        // Pure green
+        let green = HslColor::new(120.0, 100.0, 50.0);
+        assert_eq!(green.to_hex(), "#00ff00");
+
+        // Pure blue
+        let blue = HslColor::new(240.0, 100.0, 50.0);
+        assert_eq!(blue.to_hex(), "#0000ff");
+    }
+
+    #[test]
+    fn test_hsl_to_rgb() {
+        let white = HslColor::new(0.0, 0.0, 100.0);
+        assert_eq!(white.to_rgb(), (255, 255, 255));
+
+        let black = HslColor::new(0.0, 0.0, 0.0);
+        assert_eq!(black.to_rgb(), (0, 0, 0));
+
+        let gray = HslColor::new(0.0, 0.0, 50.0);
+        assert_eq!(gray.to_rgb(), (128, 128, 128));
+    }
+
+    #[test]
+    fn test_consistent_color_trait() {
+        let color = "alice@example.com".consistent_color();
+        assert!((0.0..360.0).contains(&color.hue));
+
+        let s = String::from("bob@example.com");
+        let color2 = s.consistent_color();
+        assert!((0.0..360.0).contains(&color2.hue));
+    }
+
+    #[test]
+    fn test_consistent_color_with_params() {
+        let color = "alice".consistent_color_with(75.0, 60.0, CvdCorrection::None);
+        assert_eq!(color.saturation, 75.0);
+        assert_eq!(color.lightness, 60.0);
+    }
+
+    // XEP-0392 spec test vector: "Romeo" should produce a known hue
+    #[test]
+    fn test_spec_vector_romeo() {
+        let hue = compute_hue("Romeo");
+        // SHA-1("Romeo") = sha1 hash, first 2 bytes → hue
+        // Just verify it's deterministic and in range
+        assert!((0.0..360.0).contains(&hue));
+        // Re-compute to verify determinism
+        assert_eq!(hue, compute_hue("Romeo"));
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let color = generate_color("");
+        assert!((0.0..360.0).contains(&color.hue));
+    }
+
+    #[test]
+    fn test_unicode_input() {
+        let color = generate_color("日本語ユーザー");
+        assert!((0.0..360.0).contains(&color.hue));
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0393.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0393.rs
@@ -1,0 +1,314 @@
+//! XEP-0393: Message Styling
+//!
+//! Parses inline text styling directives from XMPP message bodies.
+//! This is a body-level formatting spec (not XML element payloads).
+//!
+//! ## Supported Styles
+//!
+//! - `*bold*` → Bold
+//! - `_italic_` → Italic
+//! - `~strikethrough~` → Strikethrough
+//! - `` `monospace` `` → Inline code (no nesting)
+//! - ```` ```\ncode block\n``` ```` → Preformatted block (no nesting)
+//! - `> quote` at line start → Block quote
+//!
+//! ## Rules
+//!
+//! - Styling directives must start at a word boundary (start of line,
+//!   or preceded by whitespace/punctuation).
+//! - Closing directive must end at a word boundary.
+//! - Inline code and preformatted blocks suppress all other formatting.
+//! - Spans cannot cross line boundaries (except preformatted blocks).
+
+/// A parsed span of styled text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Span {
+    /// Plain unstyled text.
+    Plain(String),
+    /// `*bold*`
+    Bold(Vec<Span>),
+    /// `_italic_`
+    Italic(Vec<Span>),
+    /// `~strikethrough~`
+    Strikethrough(Vec<Span>),
+    /// `` `monospace` `` — no nesting allowed.
+    InlineCode(String),
+}
+
+/// A parsed block of styled content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Block {
+    /// A paragraph of inline spans.
+    Paragraph(Vec<Span>),
+    /// A preformatted code block (``` fenced).
+    CodeBlock(String),
+    /// A block quote (`> ` prefixed lines).
+    BlockQuote(Vec<Block>),
+}
+
+/// Trait for types whose body text can be parsed for styling.
+pub trait StyledBody {
+    /// Parse the message body into styled blocks.
+    fn styled_blocks(&self) -> Vec<Block>;
+
+    /// Strip all formatting and return plain text.
+    fn plain_text(&self) -> String {
+        blocks_to_plain(&self.styled_blocks())
+    }
+}
+
+impl StyledBody for str {
+    fn styled_blocks(&self) -> Vec<Block> {
+        parse_blocks(self)
+    }
+}
+
+impl StyledBody for String {
+    fn styled_blocks(&self) -> Vec<Block> {
+        parse_blocks(self)
+    }
+}
+
+// ── Block-level parsing ──────────────────────────────────────────────
+
+/// Parse a message body into blocks.
+pub fn parse_blocks(input: &str) -> Vec<Block> {
+    let mut blocks = Vec::new();
+    let mut lines = input.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        // Preformatted block
+        if line.starts_with("```") {
+            let mut code = String::new();
+            for inner in lines.by_ref() {
+                if inner.starts_with("```") {
+                    break;
+                }
+                if !code.is_empty() {
+                    code.push('\n');
+                }
+                code.push_str(inner);
+            }
+            blocks.push(Block::CodeBlock(code));
+            continue;
+        }
+
+        // Block quote
+        if line.starts_with("> ") || line == ">" {
+            let mut quote_lines = Vec::new();
+            let stripped = if line == ">" { "" } else { &line[2..] };
+            quote_lines.push(stripped.to_owned());
+
+            while let Some(next) = lines.peek() {
+                if next.starts_with("> ") || *next == ">" {
+                    let s = if *next == ">" {
+                        "".to_owned()
+                    } else {
+                        next[2..].to_owned()
+                    };
+                    quote_lines.push(s);
+                    lines.next();
+                } else {
+                    break;
+                }
+            }
+
+            let inner_text = quote_lines.join("\n");
+            let inner_blocks = parse_blocks(&inner_text);
+            blocks.push(Block::BlockQuote(inner_blocks));
+            continue;
+        }
+
+        // Skip empty lines between blocks
+        if line.is_empty() {
+            continue;
+        }
+
+        // Regular paragraph
+        let spans = parse_spans(line);
+        blocks.push(Block::Paragraph(spans));
+    }
+
+    blocks
+}
+
+// ── Inline span parsing ─────────────────────────────────────────────
+
+/// Parse inline styling spans from a single line of text.
+pub fn parse_spans(input: &str) -> Vec<Span> {
+    let mut spans = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut pos = 0;
+    let mut plain = String::new();
+
+    while pos < chars.len() {
+        let ch = chars[pos];
+
+        // Inline code: ` ... `
+        if ch == '`' {
+            if let Some(end) = find_closing_char(&chars, pos + 1, '`') {
+                flush_plain(&mut plain, &mut spans);
+                let code: String = chars[pos + 1..end].iter().collect();
+                spans.push(Span::InlineCode(code));
+                pos = end + 1;
+                continue;
+            }
+        }
+
+        // Styled spans: * _ ~
+        if matches!(ch, '*' | '_' | '~') && is_span_start(&chars, pos) {
+            if let Some(end) = find_closing_char(&chars, pos + 1, ch) {
+                if is_span_end(&chars, end) {
+                    flush_plain(&mut plain, &mut spans);
+                    let inner: String = chars[pos + 1..end].iter().collect();
+                    let inner_spans = parse_spans(&inner);
+                    let styled = match ch {
+                        '*' => Span::Bold(inner_spans),
+                        '_' => Span::Italic(inner_spans),
+                        '~' => Span::Strikethrough(inner_spans),
+                        _ => unreachable!(),
+                    };
+                    spans.push(styled);
+                    pos = end + 1;
+                    continue;
+                }
+            }
+        }
+
+        plain.push(ch);
+        pos += 1;
+    }
+
+    flush_plain(&mut plain, &mut spans);
+    spans
+}
+
+fn flush_plain(plain: &mut String, spans: &mut Vec<Span>) {
+    if !plain.is_empty() {
+        spans.push(Span::Plain(std::mem::take(plain)));
+    }
+}
+
+fn find_closing_char(chars: &[char], start: usize, closing: char) -> Option<usize> {
+    (start..chars.len()).find(|&i| chars[i] == closing)
+}
+
+fn is_span_start(chars: &[char], pos: usize) -> bool {
+    if pos == 0 {
+        return true;
+    }
+    let prev = chars[pos - 1];
+    prev.is_whitespace() || is_punctuation(prev)
+}
+
+fn is_span_end(chars: &[char], pos: usize) -> bool {
+    if pos + 1 >= chars.len() {
+        return true;
+    }
+    let next = chars[pos + 1];
+    next.is_whitespace() || is_punctuation(next)
+}
+
+fn is_punctuation(ch: char) -> bool {
+    matches!(
+        ch,
+        '.' | ',' | ';' | ':' | '!' | '?' | '"' | '\'' | '(' | ')' | '[' | ']' | '{' | '}'
+    )
+}
+
+// ── Plain text extraction ────────────────────────────────────────────
+
+/// Convert styled blocks back to plain text (strip formatting).
+pub fn blocks_to_plain(blocks: &[Block]) -> String {
+    let mut out = String::new();
+    for (i, block) in blocks.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        match block {
+            Block::Paragraph(spans) => out.push_str(&spans_to_plain(spans)),
+            Block::CodeBlock(code) => out.push_str(code),
+            Block::BlockQuote(inner) => out.push_str(&blocks_to_plain(inner)),
+        }
+    }
+    out
+}
+
+/// Convert inline spans to plain text.
+pub fn spans_to_plain(spans: &[Span]) -> String {
+    let mut out = String::new();
+    for span in spans {
+        match span {
+            Span::Plain(text) | Span::InlineCode(text) => out.push_str(text),
+            Span::Bold(inner) | Span::Italic(inner) | Span::Strikethrough(inner) => {
+                out.push_str(&spans_to_plain(inner));
+            }
+        }
+    }
+    out
+}
+
+// ── HTML rendering ───────────────────────────────────────────────────
+
+/// Render styled blocks to HTML.
+pub fn blocks_to_html(blocks: &[Block]) -> String {
+    let mut out = String::new();
+    for block in blocks {
+        match block {
+            Block::Paragraph(spans) => {
+                out.push_str("<p>");
+                out.push_str(&spans_to_html(spans));
+                out.push_str("</p>");
+            }
+            Block::CodeBlock(code) => {
+                out.push_str("<pre><code>");
+                out.push_str(&html_escape(code));
+                out.push_str("</code></pre>");
+            }
+            Block::BlockQuote(inner) => {
+                out.push_str("<blockquote>");
+                out.push_str(&blocks_to_html(inner));
+                out.push_str("</blockquote>");
+            }
+        }
+    }
+    out
+}
+
+/// Render inline spans to HTML.
+pub fn spans_to_html(spans: &[Span]) -> String {
+    let mut out = String::new();
+    for span in spans {
+        match span {
+            Span::Plain(text) => out.push_str(&html_escape(text)),
+            Span::Bold(inner) => {
+                out.push_str("<strong>");
+                out.push_str(&spans_to_html(inner));
+                out.push_str("</strong>");
+            }
+            Span::Italic(inner) => {
+                out.push_str("<em>");
+                out.push_str(&spans_to_html(inner));
+                out.push_str("</em>");
+            }
+            Span::Strikethrough(inner) => {
+                out.push_str("<del>");
+                out.push_str(&spans_to_html(inner));
+                out.push_str("</del>");
+            }
+            Span::InlineCode(text) => {
+                out.push_str("<code>");
+                out.push_str(&html_escape(text));
+                out.push_str("</code>");
+            }
+        }
+    }
+    out
+}
+
+fn html_escape(s: &str) -> String {
+    html_escape::encode_text(s).into_owned()
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/crates/waddle-xmpp/src/xep/xep0393/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0393/tests.rs
@@ -1,0 +1,216 @@
+use super::*;
+
+// ── Inline span tests ────────────────────────────────────
+
+#[test]
+fn test_plain_text() {
+    let spans = parse_spans("Hello world");
+    assert_eq!(spans, vec![Span::Plain("Hello world".into())]);
+}
+
+#[test]
+fn test_bold() {
+    let spans = parse_spans("Hello *world*");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Plain("Hello ".into()),
+            Span::Bold(vec![Span::Plain("world".into())]),
+        ]
+    );
+}
+
+#[test]
+fn test_italic() {
+    let spans = parse_spans("Hello _world_");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Plain("Hello ".into()),
+            Span::Italic(vec![Span::Plain("world".into())]),
+        ]
+    );
+}
+
+#[test]
+fn test_strikethrough() {
+    let spans = parse_spans("Hello ~world~");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Plain("Hello ".into()),
+            Span::Strikethrough(vec![Span::Plain("world".into())]),
+        ]
+    );
+}
+
+#[test]
+fn test_inline_code() {
+    let spans = parse_spans("Use `println!` here");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Plain("Use ".into()),
+            Span::InlineCode("println!".into()),
+            Span::Plain(" here".into()),
+        ]
+    );
+}
+
+#[test]
+fn test_nested_bold_italic() {
+    let spans = parse_spans("*bold _and italic_*");
+    assert_eq!(
+        spans,
+        vec![Span::Bold(vec![
+            Span::Plain("bold ".into()),
+            Span::Italic(vec![Span::Plain("and italic".into())]),
+        ])]
+    );
+}
+
+#[test]
+fn test_no_styling_mid_word() {
+    // * mid-word should not trigger styling
+    let spans = parse_spans("foo*bar*baz");
+    assert_eq!(spans, vec![Span::Plain("foo*bar*baz".into())]);
+}
+
+#[test]
+fn test_styling_at_start_of_line() {
+    let spans = parse_spans("*bold* text");
+    assert_eq!(
+        spans,
+        vec![
+            Span::Bold(vec![Span::Plain("bold".into())]),
+            Span::Plain(" text".into()),
+        ]
+    );
+}
+
+#[test]
+fn test_unclosed_directive_is_plain() {
+    let spans = parse_spans("Hello *world");
+    assert_eq!(spans, vec![Span::Plain("Hello *world".into())]);
+}
+
+// ── Block-level tests ────────────────────────────────────
+
+#[test]
+fn test_code_block() {
+    let input = "```\nfn main() {\n    println!(\"hello\");\n}\n```";
+    let blocks = parse_blocks(input);
+    assert_eq!(
+        blocks,
+        vec![Block::CodeBlock(
+            "fn main() {\n    println!(\"hello\");\n}".into()
+        )]
+    );
+}
+
+#[test]
+fn test_block_quote() {
+    let input = "> This is quoted\n> Second line";
+    let blocks = parse_blocks(input);
+    assert_eq!(
+        blocks,
+        vec![Block::BlockQuote(vec![
+            Block::Paragraph(vec![Span::Plain("This is quoted".into())]),
+            Block::Paragraph(vec![Span::Plain("Second line".into())]),
+        ])]
+    );
+}
+
+#[test]
+fn test_mixed_blocks() {
+    let input = "Hello *world*\n\n> A quote\n\n```\ncode\n```";
+    let blocks = parse_blocks(input);
+    assert_eq!(blocks.len(), 3);
+    assert!(matches!(&blocks[0], Block::Paragraph(_)));
+    assert!(matches!(&blocks[1], Block::BlockQuote(_)));
+    assert!(matches!(&blocks[2], Block::CodeBlock(_)));
+}
+
+#[test]
+fn test_empty_input() {
+    let blocks = parse_blocks("");
+    assert!(blocks.is_empty());
+}
+
+// ── Plain text extraction ────────────────────────────────
+
+#[test]
+fn test_plain_text_extraction() {
+    let blocks = parse_blocks("Hello *bold* and `code`");
+    assert_eq!(blocks_to_plain(&blocks), "Hello bold and code");
+}
+
+#[test]
+fn test_styled_body_trait() {
+    let text = "*hello* _world_";
+    assert_eq!(text.plain_text(), "hello world");
+}
+
+// ── HTML rendering ───────────────────────────────────────
+
+#[test]
+fn test_html_paragraph() {
+    let blocks = parse_blocks("Hello *bold*");
+    assert_eq!(
+        blocks_to_html(&blocks),
+        "<p>Hello <strong>bold</strong></p>"
+    );
+}
+
+#[test]
+fn test_html_code_block() {
+    let blocks = parse_blocks("```\n<script>alert(1)</script>\n```");
+    assert_eq!(
+        blocks_to_html(&blocks),
+        "<pre><code>&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>"
+    );
+}
+
+#[test]
+fn test_html_inline_code() {
+    let blocks = parse_blocks("Use `<div>` here");
+    assert_eq!(
+        blocks_to_html(&blocks),
+        "<p>Use <code>&lt;div&gt;</code> here</p>"
+    );
+}
+
+#[test]
+fn test_html_blockquote() {
+    let blocks = parse_blocks("> Quoted *text*");
+    assert_eq!(
+        blocks_to_html(&blocks),
+        "<blockquote><p>Quoted <strong>text</strong></p></blockquote>"
+    );
+}
+
+#[test]
+fn test_html_all_styles() {
+    let blocks = parse_blocks("*bold* _italic_ ~strike~ `code`");
+    assert_eq!(
+        blocks_to_html(&blocks),
+        "<p><strong>bold</strong> <em>italic</em> <del>strike</del> <code>code</code></p>"
+    );
+}
+
+#[test]
+fn test_html_escaping() {
+    let blocks = parse_blocks("a < b & c > d");
+    assert_eq!(blocks_to_html(&blocks), "<p>a &lt; b &amp; c &gt; d</p>");
+}
+
+#[test]
+fn test_empty_quote_line() {
+    let blocks = parse_blocks(">\n> text");
+    assert_eq!(
+        blocks,
+        vec![Block::BlockQuote(vec![Block::Paragraph(vec![
+            Span::Plain("text".into())
+        ])])]
+    );
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0471.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0471.rs
@@ -1,0 +1,364 @@
+//! XEP-0471: Calendar Events
+//!
+//! Community events scheduling via PubSub. Allows creating, sharing,
+//! and RSVPing to events within XMPP communities.
+//!
+//! ## XML Format
+//!
+//! Event published to a PubSub node:
+//! ```xml
+//! <item id='event-123' xmlns='http://jabber.org/protocol/pubsub'>
+//!   <event xmlns='urn:xmpp:calendar:0'>
+//!     <title>Community Game Night</title>
+//!     <description>Weekly gaming session</description>
+//!     <start>2024-06-15T19:00:00Z</start>
+//!     <end>2024-06-15T22:00:00Z</end>
+//!     <location>Voice Channel #gaming</location>
+//!   </event>
+//! </item>
+//! ```
+//!
+//! ## Use Cases
+//!
+//! - Schedule community meetups and events
+//! - Show upcoming events in channels
+//! - RSVP tracking (going, interested, not going)
+//! - Recurring events
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+
+/// Namespace for XEP-0471 Calendar Events.
+pub const NS_CALENDAR: &str = "urn:xmpp:calendar:0";
+
+/// PEP/PubSub node for calendar events.
+pub const PUBSUB_NODE_EVENTS: &str = "urn:xmpp:calendar:0";
+
+/// RSVP status for an event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RsvpStatus {
+    /// Attending the event.
+    Going,
+    /// Interested but not confirmed.
+    Interested,
+    /// Not attending.
+    NotGoing,
+}
+
+impl RsvpStatus {
+    /// Parse from string.
+    pub fn from_str_attr(s: &str) -> Option<Self> {
+        match s {
+            "going" => Some(Self::Going),
+            "interested" => Some(Self::Interested),
+            "not-going" => Some(Self::NotGoing),
+            _ => None,
+        }
+    }
+
+    /// Convert to string.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Going => "going",
+            Self::Interested => "interested",
+            Self::NotGoing => "not-going",
+        }
+    }
+}
+
+impl std::fmt::Display for RsvpStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A calendar event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalendarEvent {
+    /// Unique event ID.
+    pub id: String,
+    /// Event title.
+    pub title: String,
+    /// Event description.
+    pub description: Option<String>,
+    /// Start time.
+    pub start: Option<DateTime<Utc>>,
+    /// End time.
+    pub end: Option<DateTime<Utc>>,
+    /// Location (room, address, URL).
+    pub location: Option<String>,
+    /// Event organizer JID.
+    pub organizer: Option<String>,
+}
+
+impl CalendarEvent {
+    /// Create a new event.
+    pub fn new(id: impl Into<String>, title: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: title.into(),
+            description: None,
+            start: None,
+            end: None,
+            location: None,
+            organizer: None,
+        }
+    }
+
+    /// Set the description.
+    pub fn with_description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Set start and end times.
+    pub fn with_times(mut self, start: DateTime<Utc>, end: DateTime<Utc>) -> Self {
+        self.start = Some(start);
+        self.end = Some(end);
+        self
+    }
+
+    /// Set the location.
+    pub fn with_location(mut self, loc: impl Into<String>) -> Self {
+        self.location = Some(loc.into());
+        self
+    }
+
+    /// Set the organizer.
+    pub fn with_organizer(mut self, org: impl Into<String>) -> Self {
+        self.organizer = Some(org.into());
+        self
+    }
+
+    /// Returns `true` if the event is in the future.
+    pub fn is_upcoming(&self) -> bool {
+        self.start.is_some_and(|s| s > Utc::now())
+    }
+
+    /// Returns `true` if the event is currently happening.
+    pub fn is_ongoing(&self) -> bool {
+        let now = Utc::now();
+        self.start.is_some_and(|s| s <= now) && self.end.is_some_and(|e| e > now)
+    }
+}
+
+/// An RSVP entry for an event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Rsvp {
+    /// The user JID.
+    pub jid: String,
+    /// Their RSVP status.
+    pub status: RsvpStatus,
+}
+
+impl Rsvp {
+    /// Create a new RSVP.
+    pub fn new(jid: impl Into<String>, status: RsvpStatus) -> Self {
+        Self {
+            jid: jid.into(),
+            status,
+        }
+    }
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an element is a calendar event element.
+pub fn is_event_element(elem: &Element) -> bool {
+    elem.ns() == NS_CALENDAR && elem.name() == "event"
+}
+
+// ── Extraction ───────────────────────────────────────────────────────
+
+/// Parse a calendar event from an `<event/>` element.
+pub fn parse_event(item_id: &str, elem: &Element) -> Option<CalendarEvent> {
+    if !is_event_element(elem) {
+        return None;
+    }
+
+    let text_child = |name: &str| -> Option<String> {
+        elem.children()
+            .find(|c| c.name() == name && c.ns() == NS_CALENDAR)
+            .map(|c| c.text())
+            .filter(|t| !t.is_empty())
+    };
+
+    let dt_child =
+        |name: &str| -> Option<DateTime<Utc>> { text_child(name).and_then(|t| t.parse().ok()) };
+
+    let title = text_child("title")?;
+
+    Some(CalendarEvent {
+        id: item_id.to_owned(),
+        title,
+        description: text_child("description"),
+        start: dt_child("start"),
+        end: dt_child("end"),
+        location: text_child("location"),
+        organizer: text_child("organizer"),
+    })
+}
+
+// ── Building ─────────────────────────────────────────────────────────
+
+/// Build an `<event/>` element.
+pub fn build_event_element(event: &CalendarEvent) -> Element {
+    let mut elem = Element::builder("event", NS_CALENDAR).build();
+
+    let append_text = |parent: &mut Element, name: &str, value: &str| {
+        let mut child = Element::builder(name, NS_CALENDAR).build();
+        child.append_text_node(value);
+        parent.append_child(child);
+    };
+
+    append_text(&mut elem, "title", &event.title);
+
+    if let Some(ref desc) = event.description {
+        append_text(&mut elem, "description", desc);
+    }
+    if let Some(start) = event.start {
+        append_text(&mut elem, "start", &start.to_rfc3339());
+    }
+    if let Some(end) = event.end {
+        append_text(&mut elem, "end", &end.to_rfc3339());
+    }
+    if let Some(ref loc) = event.location {
+        append_text(&mut elem, "location", loc);
+    }
+    if let Some(ref org) = event.organizer {
+        append_text(&mut elem, "organizer", org);
+    }
+
+    elem
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn test_start() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 15, 19, 0, 0)
+            .single()
+            .expect("valid date")
+    }
+
+    fn test_end() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 15, 22, 0, 0)
+            .single()
+            .expect("valid date")
+    }
+
+    #[test]
+    fn test_is_event_element() {
+        let elem = Element::builder("event", NS_CALENDAR).build();
+        assert!(is_event_element(&elem));
+
+        let wrong = Element::builder("event", "jabber:client").build();
+        assert!(!is_event_element(&wrong));
+    }
+
+    #[test]
+    fn test_build_and_parse() {
+        let event = CalendarEvent::new("evt-1", "Game Night")
+            .with_description("Weekly gaming")
+            .with_times(test_start(), test_end())
+            .with_location("Voice #gaming")
+            .with_organizer("alice@example.com");
+
+        let elem = build_event_element(&event);
+        assert_eq!(elem.name(), "event");
+        assert_eq!(elem.ns(), NS_CALENDAR);
+
+        let parsed = parse_event("evt-1", &elem).expect("parseable");
+        assert_eq!(parsed.id, "evt-1");
+        assert_eq!(parsed.title, "Game Night");
+        assert_eq!(parsed.description.as_deref(), Some("Weekly gaming"));
+        assert_eq!(parsed.start, Some(test_start()));
+        assert_eq!(parsed.end, Some(test_end()));
+        assert_eq!(parsed.location.as_deref(), Some("Voice #gaming"));
+        assert_eq!(parsed.organizer.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn test_parse_minimal() {
+        let xml = "<event xmlns='urn:xmpp:calendar:0'>\
+                    <title>Quick Meetup</title>\
+                    </event>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let event = parse_event("e-1", &elem).expect("parseable");
+        assert_eq!(event.title, "Quick Meetup");
+        assert_eq!(event.description, None);
+        assert_eq!(event.start, None);
+    }
+
+    #[test]
+    fn test_parse_missing_title() {
+        let xml = "<event xmlns='urn:xmpp:calendar:0'>\
+                    <description>No title</description>\
+                    </event>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(parse_event("e-1", &elem).is_none());
+    }
+
+    #[test]
+    fn test_is_upcoming() {
+        let future = CalendarEvent::new("e", "Future").with_times(test_start(), test_end());
+        assert!(future.is_upcoming());
+
+        let past = CalendarEvent::new("e", "Past").with_times(
+            Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+                .single()
+                .expect("valid"),
+            Utc.with_ymd_and_hms(2020, 1, 1, 1, 0, 0)
+                .single()
+                .expect("valid"),
+        );
+        assert!(!past.is_upcoming());
+    }
+
+    #[test]
+    fn test_rsvp_status() {
+        assert_eq!(RsvpStatus::from_str_attr("going"), Some(RsvpStatus::Going));
+        assert_eq!(
+            RsvpStatus::from_str_attr("interested"),
+            Some(RsvpStatus::Interested)
+        );
+        assert_eq!(
+            RsvpStatus::from_str_attr("not-going"),
+            Some(RsvpStatus::NotGoing)
+        );
+        assert_eq!(RsvpStatus::from_str_attr("maybe"), None);
+    }
+
+    #[test]
+    fn test_rsvp_display() {
+        assert_eq!(RsvpStatus::Going.to_string(), "going");
+        assert_eq!(RsvpStatus::Interested.to_string(), "interested");
+        assert_eq!(RsvpStatus::NotGoing.to_string(), "not-going");
+    }
+
+    #[test]
+    fn test_rsvp_new() {
+        let rsvp = Rsvp::new("alice@example.com", RsvpStatus::Going);
+        assert_eq!(rsvp.jid, "alice@example.com");
+        assert_eq!(rsvp.status, RsvpStatus::Going);
+    }
+
+    #[test]
+    fn test_event_builder() {
+        let e = CalendarEvent::new("id", "Title")
+            .with_description("Desc")
+            .with_location("Loc")
+            .with_organizer("Org");
+        assert_eq!(e.title, "Title");
+        assert_eq!(e.description.as_deref(), Some("Desc"));
+        assert_eq!(e.location.as_deref(), Some("Loc"));
+        assert_eq!(e.organizer.as_deref(), Some("Org"));
+    }
+
+    #[test]
+    fn test_pubsub_node() {
+        assert_eq!(PUBSUB_NODE_EVENTS, "urn:xmpp:calendar:0");
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0472.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0472.rs
@@ -1,0 +1,263 @@
+//! XEP-0472: Pubsub Social Feed
+//!
+//! Social feed posts via PubSub. Enables community announcements,
+//! microblogging, and activity feeds within XMPP.
+//!
+//! ## XML Format
+//!
+//! A social post published to PubSub:
+//! ```xml
+//! <item id='post-123' xmlns='http://jabber.org/protocol/pubsub'>
+//!   <entry xmlns='urn:xmpp:pubsub-social-feed:0'>
+//!     <title>Announcement</title>
+//!     <body>We're launching a new feature!</body>
+//!     <author>alice@example.com</author>
+//!     <published>2024-06-01T12:00:00Z</published>
+//!   </entry>
+//! </item>
+//! ```
+//!
+//! ## Use Cases
+//!
+//! - Community announcements and news
+//! - Microblogging / status updates
+//! - Activity feed aggregation across spaces
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+
+/// Namespace for XEP-0472 Social Feed.
+pub const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+
+/// PubSub node for social feed posts.
+pub const PUBSUB_NODE_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+
+/// A social feed post/entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeedEntry {
+    /// Post ID.
+    pub id: String,
+    /// Optional title.
+    pub title: Option<String>,
+    /// Post body/content.
+    pub body: String,
+    /// Author JID or display name.
+    pub author: Option<String>,
+    /// Publication timestamp.
+    pub published: Option<DateTime<Utc>>,
+    /// Optional link/URL.
+    pub link: Option<String>,
+}
+
+impl FeedEntry {
+    /// Create a new feed entry.
+    pub fn new(id: impl Into<String>, body: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            title: None,
+            body: body.into(),
+            author: None,
+            published: None,
+            link: None,
+        }
+    }
+
+    /// Set the title.
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Set the author.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = Some(author.into());
+        self
+    }
+
+    /// Set publication time to now.
+    pub fn with_published_now(mut self) -> Self {
+        self.published = Some(Utc::now());
+        self
+    }
+
+    /// Set a specific publication time.
+    pub fn with_published(mut self, ts: DateTime<Utc>) -> Self {
+        self.published = Some(ts);
+        self
+    }
+
+    /// Set a link.
+    pub fn with_link(mut self, link: impl Into<String>) -> Self {
+        self.link = Some(link.into());
+        self
+    }
+
+    /// A short preview of the body (first N chars).
+    pub fn preview(&self, max_len: usize) -> &str {
+        if self.body.len() <= max_len {
+            &self.body
+        } else {
+            let end = self
+                .body
+                .char_indices()
+                .nth(max_len)
+                .map(|(i, _)| i)
+                .unwrap_or(self.body.len());
+            &self.body[..end]
+        }
+    }
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an element is a feed entry element.
+pub fn is_feed_entry(elem: &Element) -> bool {
+    elem.ns() == NS_SOCIAL_FEED && elem.name() == "entry"
+}
+
+// ── Extraction ───────────────────────────────────────────────────────
+
+/// Parse a feed entry from an `<entry/>` element.
+pub fn parse_feed_entry(item_id: &str, elem: &Element) -> Option<FeedEntry> {
+    if !is_feed_entry(elem) {
+        return None;
+    }
+
+    let text = |name: &str| -> Option<String> {
+        elem.children()
+            .find(|c| c.name() == name && c.ns() == NS_SOCIAL_FEED)
+            .map(|c| c.text())
+            .filter(|t| !t.is_empty())
+    };
+
+    let body = text("body")?;
+
+    Some(FeedEntry {
+        id: item_id.to_owned(),
+        title: text("title"),
+        body,
+        author: text("author"),
+        published: text("published").and_then(|t| t.parse().ok()),
+        link: text("link"),
+    })
+}
+
+// ── Building ─────────────────────────────────────────────────────────
+
+/// Build an `<entry/>` element for PubSub publication.
+pub fn build_feed_entry_element(entry: &FeedEntry) -> Element {
+    let mut elem = Element::builder("entry", NS_SOCIAL_FEED).build();
+
+    let add = |parent: &mut Element, name: &str, value: &str| {
+        let mut child = Element::builder(name, NS_SOCIAL_FEED).build();
+        child.append_text_node(value);
+        parent.append_child(child);
+    };
+
+    if let Some(ref title) = entry.title {
+        add(&mut elem, "title", title);
+    }
+    add(&mut elem, "body", &entry.body);
+    if let Some(ref author) = entry.author {
+        add(&mut elem, "author", author);
+    }
+    if let Some(ts) = entry.published {
+        add(&mut elem, "published", &ts.to_rfc3339());
+    }
+    if let Some(ref link) = entry.link {
+        add(&mut elem, "link", link);
+    }
+
+    elem
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn test_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2024, 6, 1, 12, 0, 0)
+            .single()
+            .expect("valid")
+    }
+
+    #[test]
+    fn test_is_feed_entry() {
+        let elem = Element::builder("entry", NS_SOCIAL_FEED).build();
+        assert!(is_feed_entry(&elem));
+
+        let wrong = Element::builder("entry", "jabber:client").build();
+        assert!(!is_feed_entry(&wrong));
+    }
+
+    #[test]
+    fn test_build_and_parse() {
+        let entry = FeedEntry::new("p-1", "Hello community!")
+            .with_title("Announcement")
+            .with_author("alice@example.com")
+            .with_published(test_time())
+            .with_link("https://example.com/post/1");
+
+        let elem = build_feed_entry_element(&entry);
+        assert_eq!(elem.name(), "entry");
+
+        let parsed = parse_feed_entry("p-1", &elem).expect("parseable");
+        assert_eq!(parsed.id, "p-1");
+        assert_eq!(parsed.body, "Hello community!");
+        assert_eq!(parsed.title.as_deref(), Some("Announcement"));
+        assert_eq!(parsed.author.as_deref(), Some("alice@example.com"));
+        assert_eq!(parsed.published, Some(test_time()));
+        assert_eq!(parsed.link.as_deref(), Some("https://example.com/post/1"));
+    }
+
+    #[test]
+    fn test_parse_minimal() {
+        let xml = "<entry xmlns='urn:xmpp:pubsub-social-feed:0'>\
+                    <body>Just a quick update</body>\
+                    </entry>";
+        let elem: Element = xml.parse().expect("valid");
+        let entry = parse_feed_entry("p-2", &elem).expect("parseable");
+        assert_eq!(entry.body, "Just a quick update");
+        assert_eq!(entry.title, None);
+        assert_eq!(entry.author, None);
+    }
+
+    #[test]
+    fn test_parse_missing_body() {
+        let xml = "<entry xmlns='urn:xmpp:pubsub-social-feed:0'>\
+                    <title>No body</title>\
+                    </entry>";
+        let elem: Element = xml.parse().expect("valid");
+        assert!(parse_feed_entry("p-3", &elem).is_none());
+    }
+
+    #[test]
+    fn test_preview() {
+        let entry = FeedEntry::new("p", "Hello world, this is a longer message");
+        assert_eq!(entry.preview(5), "Hello");
+        assert_eq!(entry.preview(100), "Hello world, this is a longer message");
+    }
+
+    #[test]
+    fn test_entry_builder() {
+        let e = FeedEntry::new("id", "body")
+            .with_title("T")
+            .with_author("A")
+            .with_link("L");
+        assert_eq!(e.title.as_deref(), Some("T"));
+        assert_eq!(e.author.as_deref(), Some("A"));
+        assert_eq!(e.link.as_deref(), Some("L"));
+    }
+
+    #[test]
+    fn test_with_published_now() {
+        let e = FeedEntry::new("id", "body").with_published_now();
+        assert!(e.published.is_some());
+    }
+
+    #[test]
+    fn test_pubsub_node() {
+        assert_eq!(PUBSUB_NODE_FEED, "urn:xmpp:pubsub-social-feed:0");
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0488.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0488.rs
@@ -1,0 +1,370 @@
+//! XEP-0488: MUC Token Invite
+//!
+//! Provides invite tokens for MUC rooms, enabling easy room onboarding
+//! via shareable links. Tokens can be single-use or multi-use.
+//!
+//! ## XML Format
+//!
+//! Request an invite token:
+//! ```xml
+//! <iq type='set' to='room@muc.example.com' id='inv-1'>
+//!   <request xmlns='urn:xmpp:muc-token-invite:0'/>
+//! </iq>
+//! ```
+//!
+//! Server responds with token:
+//! ```xml
+//! <iq type='result' from='room@muc.example.com' id='inv-1'>
+//!   <invite xmlns='urn:xmpp:muc-token-invite:0' token='abc123def456'/>
+//! </iq>
+//! ```
+//!
+//! Share invite via message:
+//! ```xml
+//! <message to='friend@example.com'>
+//!   <body>Join our room: xmpp:room@muc.example.com?join;password=abc123def456</body>
+//!   <invite xmlns='urn:xmpp:muc-token-invite:0'
+//!           token='abc123def456'
+//!           jid='room@muc.example.com'/>
+//! </message>
+//! ```
+//!
+//! ## Use Cases
+//!
+//! - Generate shareable invite links for private rooms
+//! - One-click room join without knowing the JID
+//! - Token expiry and usage limits for security
+
+use minidom::Element;
+use thiserror::Error;
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::message::Message;
+
+/// Namespace for XEP-0488 MUC Token Invite.
+pub const NS_MUC_TOKEN_INVITE: &str = "urn:xmpp:muc-token-invite:0";
+
+/// Errors that can occur with invite tokens.
+#[derive(Debug, Error)]
+pub enum InviteTokenError {
+    /// Token generation failed.
+    #[error("failed to generate invite token: {0}")]
+    GenerationFailed(String),
+    /// Token is invalid or expired.
+    #[error("invalid or expired invite token")]
+    InvalidToken,
+}
+
+/// An invite token for a MUC room.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InviteToken {
+    /// The opaque invite token string.
+    pub token: String,
+    /// The room JID this token is for.
+    pub room_jid: Option<String>,
+}
+
+impl InviteToken {
+    /// Create a new invite token.
+    pub fn new(token: impl Into<String>) -> Self {
+        Self {
+            token: token.into(),
+            room_jid: None,
+        }
+    }
+
+    /// Set the room JID.
+    pub fn with_room(mut self, jid: impl Into<String>) -> Self {
+        self.room_jid = Some(jid.into());
+        self
+    }
+
+    /// Generate an XMPP invite URI.
+    ///
+    /// Format: `xmpp:room@muc.example.com?join;password=TOKEN`
+    pub fn to_uri(&self) -> Option<String> {
+        self.room_jid
+            .as_ref()
+            .map(|jid| format!("xmpp:{}?join;password={}", jid, self.token))
+    }
+}
+
+impl std::fmt::Display for InviteToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.token)
+    }
+}
+
+/// Trait for types that can carry invite token elements.
+pub trait InviteTokenCarrier {
+    /// Extract an invite token from this carrier.
+    fn invite_token(&self) -> Option<InviteToken>;
+
+    /// Returns `true` if this carrier has an invite token.
+    fn has_invite_token(&self) -> bool {
+        self.invite_token().is_some()
+    }
+}
+
+impl InviteTokenCarrier for Message {
+    fn invite_token(&self) -> Option<InviteToken> {
+        extract_invite_from_message(self)
+    }
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an element is an invite token element.
+pub fn is_invite_element(elem: &Element) -> bool {
+    elem.ns() == NS_MUC_TOKEN_INVITE && matches!(elem.name(), "invite" | "request")
+}
+
+/// Check if an IQ is an invite token request.
+pub fn is_invite_request(iq: &Iq) -> bool {
+    matches!(&iq.payload, IqType::Set(elem)
+        if elem.name() == "request" && elem.ns() == NS_MUC_TOKEN_INVITE)
+}
+
+/// Check if a message contains an invite token.
+pub fn has_invite_in_message(msg: &Message) -> bool {
+    msg.payloads
+        .iter()
+        .any(|e| e.ns() == NS_MUC_TOKEN_INVITE && e.name() == "invite")
+}
+
+// ── Extraction ───────────────────────────────────────────────────────
+
+/// Extract an invite token from an IQ result.
+pub fn extract_invite_from_iq(iq: &Iq) -> Option<InviteToken> {
+    let elem = match &iq.payload {
+        IqType::Result(Some(elem))
+            if elem.name() == "invite" && elem.ns() == NS_MUC_TOKEN_INVITE =>
+        {
+            elem
+        }
+        _ => return None,
+    };
+
+    let token = elem.attr("token").filter(|t| !t.is_empty())?.to_owned();
+    let room_jid = iq.from.as_ref().map(|j| j.to_string());
+
+    Some(InviteToken { token, room_jid })
+}
+
+/// Extract an invite token from a message.
+pub fn extract_invite_from_message(msg: &Message) -> Option<InviteToken> {
+    let elem = msg
+        .payloads
+        .iter()
+        .find(|e| e.ns() == NS_MUC_TOKEN_INVITE && e.name() == "invite")?;
+
+    let token = elem.attr("token").filter(|t| !t.is_empty())?.to_owned();
+    let room_jid = elem
+        .attr("jid")
+        .filter(|j| !j.is_empty())
+        .map(|j| j.to_owned());
+
+    Some(InviteToken { token, room_jid })
+}
+
+// ── Building ─────────────────────────────────────────────────────────
+
+/// Build an invite token request IQ.
+pub fn build_invite_request(to_room: jid::Jid, id: &str) -> Iq {
+    let request_elem = Element::builder("request", NS_MUC_TOKEN_INVITE).build();
+    Iq {
+        from: None,
+        to: Some(to_room),
+        id: id.to_owned(),
+        payload: IqType::Set(request_elem),
+    }
+}
+
+/// Build an invite token response IQ.
+pub fn build_invite_response(original_iq: &Iq, token: &str) -> Iq {
+    let invite_elem = Element::builder("invite", NS_MUC_TOKEN_INVITE)
+        .attr("token", token)
+        .build();
+    Iq {
+        from: original_iq.to.clone(),
+        to: original_iq.from.clone(),
+        id: original_iq.id.clone(),
+        payload: IqType::Result(Some(invite_elem)),
+    }
+}
+
+/// Build an invite element for inclusion in a message.
+pub fn build_invite_message_element(token: &str, room_jid: &str) -> Element {
+    Element::builder("invite", NS_MUC_TOKEN_INVITE)
+        .attr("token", token)
+        .attr("jid", room_jid)
+        .build()
+}
+
+/// Build a complete invite message to share with another user.
+pub fn build_invite_share_message(
+    to: jid::Jid,
+    from: impl Into<Option<jid::Jid>>,
+    token: &InviteToken,
+) -> Option<Message> {
+    let room_jid = token.room_jid.as_ref()?;
+    let uri = token.to_uri()?;
+
+    let mut msg = Message::new(Some(to));
+    msg.from = from.into();
+    msg.type_ = xmpp_parsers::message::MessageType::Chat;
+    msg.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body(format!("You've been invited to join: {uri}")),
+    );
+    msg.payloads
+        .push(build_invite_message_element(&token.token, room_jid));
+    Some(msg)
+}
+
+// ── Mutation ─────────────────────────────────────────────────────────
+
+/// Add an invite token to a message.
+pub fn set_invite_on_message(msg: &mut Message, token: &str, room_jid: &str) {
+    msg.payloads.retain(|e| e.ns() != NS_MUC_TOKEN_INVITE);
+    msg.payloads
+        .push(build_invite_message_element(token, room_jid));
+}
+
+/// Remove invite token from a message.
+pub fn strip_invite_from_message(msg: &mut Message) {
+    msg.payloads.retain(|e| e.ns() != NS_MUC_TOKEN_INVITE);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::message::MessageType;
+
+    #[test]
+    fn test_is_invite_request() {
+        let room: jid::Jid = "room@muc.example.com".parse().expect("valid jid");
+        let iq = build_invite_request(room, "inv-1");
+        assert!(is_invite_request(&iq));
+    }
+
+    #[test]
+    fn test_is_invite_request_false() {
+        let elem = Element::builder("query", "jabber:iq:roster").build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "inv-2".to_owned(),
+            payload: IqType::Set(elem),
+        };
+        assert!(!is_invite_request(&iq));
+    }
+
+    #[test]
+    fn test_build_and_extract_iq() {
+        let room: jid::Jid = "room@muc.example.com".parse().expect("valid jid");
+        let request = build_invite_request(room, "inv-1");
+        let response = build_invite_response(&request, "abc123");
+
+        let token = extract_invite_from_iq(&response).expect("has token");
+        assert_eq!(token.token, "abc123");
+        assert_eq!(token.room_jid.as_deref(), Some("room@muc.example.com"));
+    }
+
+    #[test]
+    fn test_extract_invite_from_message() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <body>Join us!</body>\
+                    <invite xmlns='urn:xmpp:muc-token-invite:0' token='xyz789' jid='room@muc.example.com'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        let token = extract_invite_from_message(&msg).expect("has token");
+        assert_eq!(token.token, "xyz789");
+        assert_eq!(token.room_jid.as_deref(), Some("room@muc.example.com"));
+    }
+
+    #[test]
+    fn test_extract_absent() {
+        let msg = Message::new(None::<jid::Jid>);
+        assert!(extract_invite_from_message(&msg).is_none());
+    }
+
+    #[test]
+    fn test_invite_token_to_uri() {
+        let token = InviteToken::new("abc123").with_room("room@muc.example.com");
+        assert_eq!(
+            token.to_uri(),
+            Some("xmpp:room@muc.example.com?join;password=abc123".to_owned())
+        );
+
+        let no_room = InviteToken::new("abc123");
+        assert_eq!(no_room.to_uri(), None);
+    }
+
+    #[test]
+    fn test_build_invite_share_message() {
+        let to: jid::Jid = "friend@example.com".parse().expect("valid jid");
+        let token = InviteToken::new("tok123").with_room("room@muc.example.com");
+        let msg =
+            build_invite_share_message(to.clone(), None::<jid::Jid>, &token).expect("has room jid");
+
+        assert_eq!(msg.to, Some(to));
+        assert_eq!(msg.type_, MessageType::Chat);
+        assert!(msg.bodies.values().next().is_some());
+        assert!(has_invite_in_message(&msg));
+    }
+
+    #[test]
+    fn test_set_invite_on_message() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        set_invite_on_message(&mut msg, "tok1", "room@muc.example.com");
+        assert!(has_invite_in_message(&msg));
+
+        // Replace
+        set_invite_on_message(&mut msg, "tok2", "room@muc.example.com");
+        let token = extract_invite_from_message(&msg).expect("has token");
+        assert_eq!(token.token, "tok2");
+        assert_eq!(
+            msg.payloads
+                .iter()
+                .filter(|e| e.ns() == NS_MUC_TOKEN_INVITE)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_strip_invite() {
+        let mut msg = Message::new(None::<jid::Jid>);
+        set_invite_on_message(&mut msg, "tok1", "room@muc.example.com");
+        strip_invite_from_message(&mut msg);
+        assert!(!has_invite_in_message(&msg));
+    }
+
+    #[test]
+    fn test_invite_token_carrier_trait() {
+        let xml = "<message xmlns='jabber:client' type='chat'>\
+                    <invite xmlns='urn:xmpp:muc-token-invite:0' token='trait-test' jid='room@muc'/>\
+                    </message>";
+        let msg =
+            Message::try_from(xml.parse::<Element>().expect("valid xml")).expect("valid message");
+
+        assert!(msg.has_invite_token());
+        let token = msg.invite_token().expect("has token");
+        assert_eq!(token.token, "trait-test");
+    }
+
+    #[test]
+    fn test_invite_token_display() {
+        let token = InviteToken::new("display-test");
+        assert_eq!(token.to_string(), "display-test");
+    }
+
+    #[test]
+    fn test_invite_token_builder() {
+        let token = InviteToken::new("abc").with_room("room@muc.example.com");
+        assert_eq!(token.token, "abc");
+        assert_eq!(token.room_jid.as_deref(), Some("room@muc.example.com"));
+    }
+}

--- a/server/crates/waddle-xmpp/src/xep/xep0501.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0501.rs
@@ -1,0 +1,329 @@
+//! XEP-0501: Pubsub Stories
+//!
+//! Ephemeral stories that auto-expire after a configurable duration
+//! (default 24 hours). Like Instagram/Snapchat stories for communities.
+//!
+//! ## XML Format
+//!
+//! ```xml
+//! <item id='story-123' xmlns='http://jabber.org/protocol/pubsub'>
+//!   <story xmlns='urn:xmpp:stories:0'
+//!          expires='2024-06-02T12:00:00Z'>
+//!     <body>Check out what we're building!</body>
+//!     <media-url>https://example.com/photo.jpg</media-url>
+//!   </story>
+//! </item>
+//! ```
+//!
+//! ## Use Cases
+//!
+//! - Share temporary updates/photos
+//! - Community "what's happening now" feed
+//! - Auto-cleanup of old content
+
+use chrono::{DateTime, Duration, Utc};
+use minidom::Element;
+
+/// Namespace for XEP-0501 Stories.
+pub const NS_STORIES: &str = "urn:xmpp:stories:0";
+
+/// PubSub node for stories.
+pub const PUBSUB_NODE_STORIES: &str = "urn:xmpp:stories:0";
+
+/// Default story expiry: 24 hours.
+pub const DEFAULT_EXPIRY_HOURS: i64 = 24;
+
+/// A story entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Story {
+    /// Story ID.
+    pub id: String,
+    /// Text content.
+    pub body: Option<String>,
+    /// Media URL (image/video).
+    pub media_url: Option<String>,
+    /// Author JID.
+    pub author: Option<String>,
+    /// When the story was posted.
+    pub posted: Option<DateTime<Utc>>,
+    /// When the story expires.
+    pub expires: Option<DateTime<Utc>>,
+}
+
+impl Story {
+    /// Create a new story.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            body: None,
+            media_url: None,
+            author: None,
+            posted: Some(Utc::now()),
+            expires: Some(Utc::now() + Duration::hours(DEFAULT_EXPIRY_HOURS)),
+        }
+    }
+
+    /// Set the text body.
+    pub fn with_body(mut self, body: impl Into<String>) -> Self {
+        self.body = Some(body.into());
+        self
+    }
+
+    /// Set a media URL.
+    pub fn with_media(mut self, url: impl Into<String>) -> Self {
+        self.media_url = Some(url.into());
+        self
+    }
+
+    /// Set the author.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = Some(author.into());
+        self
+    }
+
+    /// Set custom expiry duration from now.
+    pub fn with_expiry(mut self, duration: Duration) -> Self {
+        self.expires = Some(Utc::now() + duration);
+        self
+    }
+
+    /// Set a specific expiry time.
+    pub fn with_expires_at(mut self, at: DateTime<Utc>) -> Self {
+        self.expires = Some(at);
+        self
+    }
+
+    /// Returns `true` if the story has expired.
+    pub fn is_expired(&self) -> bool {
+        self.expires.is_some_and(|e| e < Utc::now())
+    }
+
+    /// Returns `true` if the story is still active.
+    pub fn is_active(&self) -> bool {
+        !self.is_expired()
+    }
+
+    /// Remaining time until expiry, if not yet expired.
+    pub fn time_remaining(&self) -> Option<Duration> {
+        self.expires
+            .filter(|e| *e > Utc::now())
+            .map(|e| e.signed_duration_since(Utc::now()))
+    }
+}
+
+// ── Detection ────────────────────────────────────────────────────────
+
+/// Check if an element is a story element.
+pub fn is_story_element(elem: &Element) -> bool {
+    elem.ns() == NS_STORIES && elem.name() == "story"
+}
+
+// ── Extraction ───────────────────────────────────────────────────────
+
+/// Parse a story from a `<story/>` element.
+pub fn parse_story(item_id: &str, elem: &Element) -> Option<Story> {
+    if !is_story_element(elem) {
+        return None;
+    }
+
+    let text = |name: &str| -> Option<String> {
+        elem.children()
+            .find(|c| c.name() == name && c.ns() == NS_STORIES)
+            .map(|c| c.text())
+            .filter(|t| !t.is_empty())
+    };
+
+    let expires = elem
+        .attr("expires")
+        .and_then(|s| s.parse::<DateTime<Utc>>().ok());
+
+    Some(Story {
+        id: item_id.to_owned(),
+        body: text("body"),
+        media_url: text("media-url"),
+        author: text("author"),
+        posted: text("posted").and_then(|t| t.parse().ok()),
+        expires,
+    })
+}
+
+// ── Building ─────────────────────────────────────────────────────────
+
+/// Build a `<story/>` element.
+pub fn build_story_element(story: &Story) -> Element {
+    let mut builder = Element::builder("story", NS_STORIES);
+
+    if let Some(expires) = story.expires {
+        builder = builder.attr("expires", expires.to_rfc3339());
+    }
+
+    let mut elem = builder.build();
+
+    let add = |parent: &mut Element, name: &str, value: &str| {
+        let mut child = Element::builder(name, NS_STORIES).build();
+        child.append_text_node(value);
+        parent.append_child(child);
+    };
+
+    if let Some(ref body) = story.body {
+        add(&mut elem, "body", body);
+    }
+    if let Some(ref url) = story.media_url {
+        add(&mut elem, "media-url", url);
+    }
+    if let Some(ref author) = story.author {
+        add(&mut elem, "author", author);
+    }
+    if let Some(posted) = story.posted {
+        add(&mut elem, "posted", &posted.to_rfc3339());
+    }
+
+    elem
+}
+
+/// Filter a list of stories to only active (non-expired) ones.
+pub fn filter_active(stories: &[Story]) -> Vec<&Story> {
+    stories.iter().filter(|s| s.is_active()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn future_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2030, 1, 1, 0, 0, 0)
+            .single()
+            .expect("valid")
+    }
+
+    fn past_time() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+            .single()
+            .expect("valid")
+    }
+
+    #[test]
+    fn test_is_story_element() {
+        let elem = Element::builder("story", NS_STORIES).build();
+        assert!(is_story_element(&elem));
+
+        let wrong = Element::builder("story", "jabber:client").build();
+        assert!(!is_story_element(&wrong));
+    }
+
+    #[test]
+    fn test_build_and_parse() {
+        let story = Story::new("s-1")
+            .with_body("Hello!")
+            .with_media("https://example.com/photo.jpg")
+            .with_author("alice@example.com")
+            .with_expires_at(future_time());
+
+        let elem = build_story_element(&story);
+        assert_eq!(elem.name(), "story");
+        assert!(elem.attr("expires").is_some());
+
+        let parsed = parse_story("s-1", &elem).expect("parseable");
+        assert_eq!(parsed.id, "s-1");
+        assert_eq!(parsed.body.as_deref(), Some("Hello!"));
+        assert_eq!(
+            parsed.media_url.as_deref(),
+            Some("https://example.com/photo.jpg")
+        );
+        assert_eq!(parsed.author.as_deref(), Some("alice@example.com"));
+        assert_eq!(parsed.expires, Some(future_time()));
+    }
+
+    #[test]
+    fn test_parse_minimal() {
+        let xml = "<story xmlns='urn:xmpp:stories:0'>\
+                    <body>Quick update</body>\
+                    </story>";
+        let elem: Element = xml.parse().expect("valid");
+        let story = parse_story("s-2", &elem).expect("parseable");
+        assert_eq!(story.body.as_deref(), Some("Quick update"));
+        assert_eq!(story.media_url, None);
+    }
+
+    #[test]
+    fn test_is_expired() {
+        let expired = Story::new("s").with_expires_at(past_time());
+        assert!(expired.is_expired());
+        assert!(!expired.is_active());
+
+        let active = Story::new("s").with_expires_at(future_time());
+        assert!(!active.is_expired());
+        assert!(active.is_active());
+    }
+
+    #[test]
+    fn test_time_remaining() {
+        let active = Story::new("s").with_expires_at(future_time());
+        assert!(active.time_remaining().is_some());
+
+        let expired = Story::new("s").with_expires_at(past_time());
+        assert!(expired.time_remaining().is_none());
+    }
+
+    #[test]
+    fn test_filter_active() {
+        let active = Story::new("a").with_expires_at(future_time());
+        let expired = Story::new("e").with_expires_at(past_time());
+        let stories = vec![active, expired];
+
+        let filtered = filter_active(&stories);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "a");
+    }
+
+    #[test]
+    fn test_story_new_defaults() {
+        let story = Story::new("s-1");
+        assert!(story.posted.is_some());
+        assert!(story.expires.is_some());
+        assert!(story.is_active());
+    }
+
+    #[test]
+    fn test_pubsub_node() {
+        assert_eq!(PUBSUB_NODE_STORIES, "urn:xmpp:stories:0");
+    }
+
+    #[test]
+    fn test_is_story_element_negative() {
+        let wrong = Element::builder("other", NS_STORIES).build();
+        assert!(!is_story_element(&wrong));
+        let wrong_ns = Element::builder("story", "wrong:ns").build();
+        assert!(!is_story_element(&wrong_ns));
+    }
+
+    #[test]
+    fn test_default_expiry_hours() {
+        assert_eq!(DEFAULT_EXPIRY_HOURS, 24);
+    }
+
+    #[test]
+    fn test_story_builder_chain() {
+        let s = Story::new("id")
+            .with_body("hello")
+            .with_media("https://example.com/img.jpg")
+            .with_author("alice@example.com");
+        assert_eq!(s.body.as_deref(), Some("hello"));
+        assert_eq!(s.media_url.as_deref(), Some("https://example.com/img.jpg"));
+        assert_eq!(s.author.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn test_filter_active_all_expired() {
+        let e1 = Story::new("a").with_expires_at(past_time());
+        let e2 = Story::new("b").with_expires_at(past_time());
+        assert!(filter_active(&[e1, e2]).is_empty());
+    }
+
+    #[test]
+    fn test_filter_active_empty() {
+        let empty: Vec<Story> = vec![];
+        assert!(filter_active(&empty).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Reverts #639, #640, #641, and #642 — restoring all the XEP-helper modules I deleted today. The deletions were wrong-headed: each module was working, spec-conformant, and waiting to be wired to a feature path. Treating "no callers yet" as "dead code" was a category error in a product under active development.

Restored:

- **XEP-0319 Idle** — "Alice idle since 5m" presence indicator helpers
- **XEP-0392 Consistent Color** — SHA-1-based avatar color generator (the *correct* impl; chat currently runs a non-conformant DJB2 placeholder)
- **XEP-0393 Message Styling** — inline-formatting parser for interop with clients like Conversations
- **XEP-0249 Direct MUC Invitations** — `<x xmlns='jabber:x:conference'/>` invite handler primitives
- **XEP-0471 Calendar Events** — community-event scheduling helpers
- **XEP-0472 Pubsub Social Feed** — social-post feed entry helpers
- **XEP-0488 MUC Token Invite** — shareable invite-token primitives
- **XEP-0501 Pubsub Stories** — ephemeral-post helpers

## What comes next

Wiring each of these to the chat client (UI + behavior) is now the work. The audit will be conformance + dedicated tests + frontend integration — not deletion.

## Test plan

- [x] `cargo build -p waddle-xmpp -p waddle-server` — clean after all four reverts
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.