### PR TITLE
feat(server): XEP-0472 social feed — bootstrap community feed node + publish path

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -284,6 +284,14 @@ pub(super) async fn handle_spaces_publish(
     item: PubSubItem,
     session: Option<&Session>,
 ) -> Vec<String> {
+    // XEP-0472 community feed lives on the spaces service alongside
+    // the space-bookmark nodes but its items are <entry/> payloads,
+    // not channel bookmarks. Route through the feed-specific path so
+    // we don't try to parse entries as bookmarks.
+    if node == waddle_xmpp::xep::xep0472::PUBSUB_NODE_FEED {
+        return handle_social_feed_publish(iq, state, spaces_domain, node, item, session).await;
+    }
+
     match spaces_node_mutation_allowed(state, session, node).await {
         Ok(true) => {}
         Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
@@ -463,6 +471,85 @@ pub(super) async fn handle_spaces_publish(
         }
         Err(error) => {
             warn!(item_id, node, error = %error, "Failed to publish Spaces item");
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
+        }
+    }
+}
+
+/// XEP-0472 publish to the community Social Feed node on the spaces
+/// service. Same auth gate as space-node mutations (server owners or
+/// space owners), but the item payload is a `<entry xmlns="urn:xmpp:
+/// pubsub-social-feed:0"/>` rather than a XEP-0402 bookmark, so the
+/// space-bookmark validation and channel-parent-tuple wiring are
+/// skipped. Fans the published event out to subscribers via the
+/// standard pubsub fan-out so other devices and resources see the
+/// new post in real time.
+async fn handle_social_feed_publish(
+    iq: &xmpp_parsers::iq::Iq,
+    state: &WebSocketState,
+    spaces_domain: &str,
+    node: &str,
+    item: PubSubItem,
+    session: Option<&Session>,
+) -> Vec<String> {
+    match spaces_node_mutation_allowed(state, session, node).await {
+        Ok(true) => {}
+        Ok(false) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))],
+        Err(error) => {
+            warn!(node, error = %error, "Failed to authorize social-feed publish");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::Forbidden))];
+        }
+    }
+    let Ok(spaces_jid) = spaces_service_bare_jid(spaces_domain) else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_node(&spaces_jid, node)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
+        Err(error) => {
+            warn!(node, error = %error, "Failed to resolve social-feed node for publish");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+        }
+    }
+
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(&spaces_jid, node, &item, None, false)
+        .await
+    {
+        Ok(result) => {
+            pubsub_fanout::fan_out_publish(
+                state,
+                pubsub_fanout::FanOutRequest {
+                    owner: &spaces_jid,
+                    node,
+                    published_item: &item,
+                    item_id: &result.item_id,
+                    publisher: None,
+                    publisher_full: None,
+                    is_pep: false,
+                },
+            )
+            .await;
+            vec![iq_to_xml(build_pubsub_publish_result(
+                iq,
+                node,
+                &result.item_id,
+            ))]
+        }
+        Err(error) => {
+            warn!(node, error = %error, "Failed to publish social-feed item");
             vec![iq_to_xml(build_pubsub_error(
                 iq,
                 PubSubError::InternalServerError,

--- a/server/crates/waddle-server/src/server/topology.rs
+++ b/server/crates/waddle-server/src/server/topology.rs
@@ -122,6 +122,26 @@ async fn seed_initial_xmpp_topology(
         .await
         .map_err(|error| anyhow::anyhow!("failed to configure General space node: {error}"))?;
 
+    // XEP-0472 Social Feed — community-wide pubsub feed for announcements
+    // and microblog-style posts. Hosted on the spaces service alongside
+    // the channel-bookmark nodes; access model is `spaces_public()` so
+    // anyone can subscribe and read, only entities with Publisher or
+    // Owner affiliation may publish. `seed_spaces_admin_affiliations`
+    // runs after this and gives server owners Publisher access via the
+    // existing seed-all-nodes path.
+    pubsub_storage
+        .get_or_create_node(spaces_jid, waddle_xmpp::xep::xep0472::PUBSUB_NODE_FEED)
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to create social feed node: {error}"))?;
+    pubsub_storage
+        .update_node_config(
+            spaces_jid,
+            waddle_xmpp::xep::xep0472::PUBSUB_NODE_FEED,
+            &NodeConfig::spaces_public(),
+        )
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to configure social feed node: {error}"))?;
+
     for channel in INITIAL_MANAGED_CHANNELS {
         let channel_record = get_xmpp_channel(actor.clone(), channel.id)
             .await

--- a/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
+++ b/server/crates/waddle-server/tests/xep0472_social_feed_ws.rs
@@ -1,0 +1,125 @@
+//! XEP-0472 Pubsub Social Feed integration tests over WebSocket.
+//!
+//! Verifies the server-side bootstrap: the spaces service hosts the
+//! global `urn:xmpp:pubsub-social-feed:0` node, advertises the
+//! namespace on disco#info, and accepts publish + items-query for
+//! `<entry/>` payloads built per XEP-0472 §3.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+const SPACES_JID: &str = "spaces.localhost";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
+const NS_SOCIAL_FEED: &str = "urn:xmpp:pubsub-social-feed:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0472-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+#[tokio::test]
+async fn spaces_disco_info_advertises_social_feed_namespace() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="disco-feed" to="{SPACES_JID}"><query xmlns="http://jabber.org/protocol/disco#info"/></iq>"#
+        ))
+        .await
+        .expect("send disco#info");
+    let frame = client
+        .recv_matching(|frame| frame.contains("disco-feed") && frame.contains("<feature"))
+        .await
+        .expect("disco#info response");
+    assert!(
+        frame.contains(&format!("var=\"{NS_SOCIAL_FEED}\""))
+            || frame.contains(&format!("var='{NS_SOCIAL_FEED}'")),
+        "spaces disco#info missing social-feed namespace: {frame}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn social_feed_publish_and_items_round_trip() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    // Publish a feed entry to the bootstrapped community feed node.
+    // The bootstrap creates the node + sets `spaces_public` config
+    // (Open access, Publisher publish-model) at server startup, and
+    // `seed_spaces_admin_affiliations` gives admin Owner affiliation
+    // across all spaces nodes so admin can publish.
+    let post_id = format!("post-{}", uuid::Uuid::new_v4());
+    client
+        .send(&format!(
+            r#"<iq type="set" id="feed-publish" to="{SPACES_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{FEED_NODE}">
+                  <item id="{post_id}">
+                    <entry xmlns="{NS_SOCIAL_FEED}">
+                      <title>Launch day</title>
+                      <body>The community feed is live!</body>
+                      <author>admin@localhost</author>
+                      <published>2026-05-16T12:00:00Z</published>
+                    </entry>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains("feed-publish"))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains("type=\"result\""),
+        "publish must succeed against the bootstrapped feed node: {publish_result}"
+    );
+
+    // Items query — the published entry should round-trip with the
+    // typed `<entry/>` payload intact.
+    client
+        .send(&format!(
+            r#"<iq type="get" id="feed-items" to="{SPACES_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("feed-items") && frame.contains("<entry"))
+        .await
+        .expect("items response");
+    assert!(
+        items_response.contains(&post_id),
+        "items query missing published id: {items_response}"
+    );
+    assert!(
+        items_response.contains("Launch day"),
+        "items query lost title: {items_response}"
+    );
+    assert!(
+        items_response.contains("The community feed is live!"),
+        "items query lost body: {items_response}"
+    );
+
+    let _ = client.close().await;
+}

--- a/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
+++ b/server/crates/waddle-server/tests/xmpp_e2e_cue.rs
@@ -29,8 +29,8 @@ const SUPPORTED_XEPS: &[&str] = &[
     "XEP-0198", "XEP-0199", "XEP-0201", "XEP-0202", "XEP-0203", "XEP-0237", "XEP-0280", "XEP-0292",
     "XEP-0297", "XEP-0308", "XEP-0313", "XEP-0317", "XEP-0333", "XEP-0334", "XEP-0357", "XEP-0359",
     "XEP-0363", "XEP-0372", "XEP-0402", "XEP-0410", "XEP-0421", "XEP-0424", "XEP-0425", "XEP-0428",
-    "XEP-0431", "XEP-0433", "XEP-0444", "XEP-0446", "XEP-0447", "XEP-0461", "XEP-0492", "XEP-0503",
-    "XEP-0511", "XEP-0513",
+    "XEP-0431", "XEP-0433", "XEP-0444", "XEP-0446", "XEP-0447", "XEP-0461", "XEP-0472", "XEP-0492",
+    "XEP-0503", "XEP-0511", "XEP-0513",
 ];
 
 const ADVERTISED_FEATURE_XEPS: &[(&str, &str)] = &[
@@ -123,6 +123,7 @@ const ADVERTISED_FEATURE_XEPS: &[(&str, &str)] = &[
     ("urn:xmpp:mentions:0", "XEP-0513"),
     ("urn:xmpp:mentions:0#channel", "XEP-0513"),
     ("jabber:iq:search", "XEP-0055"),
+    ("urn:xmpp:pubsub-social-feed:0", "XEP-0472"),
 ];
 
 const ADVERTISED_FEATURE_EXEMPTIONS: &[&str] = &[

--- a/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
+++ b/server/crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0472_social_feed.cue
@@ -1,0 +1,125 @@
+package xmpp_e2e_scenarios
+
+scenario: #Scenario & {
+	name: "xep-0472-social-feed"
+	xeps: ["XEP-0060", "XEP-0472"]
+	users: admin: devices: phone: #Actor & {
+		user:     "admin"
+		device:   "phone"
+		username: "admin"
+		resource: "phone"
+		domain:   scenario.domain
+	}
+
+	let adminPhone = users.admin.devices.phone
+
+	steps: [
+		// 1. disco#info on the spaces service MUST advertise the
+		//    XEP-0472 social feed namespace so clients can discover
+		//    support before subscribing or publishing.
+		#SendIq & {
+			actor: adminPhone
+			type:  "get"
+			id:    "cue-feed-disco"
+			to:    "spaces.\(scenario.domain)"
+			payload: #XmlElement & {
+				name: "query"
+				ns:   "http://jabber.org/protocol/disco#info"
+			}
+		},
+		#ExpectIq & {
+			target: adminPhone
+			id:     "cue-feed-disco"
+			type:   "result"
+			contains: [
+				"var=\"urn:xmpp:pubsub-social-feed:0\"",
+			]
+		},
+		// 2. Publish a feed entry to the bootstrapped community feed
+		//    node. The server bootstraps this node at startup with
+		//    spaces_public() access; server-owner affiliation seed
+		//    grants admin Publisher access.
+		#SendIq & {
+			actor: adminPhone
+			type:  "set"
+			id:    "cue-feed-publish"
+			to:    "spaces.\(scenario.domain)"
+			payload: #XmlElement & {
+				name: "pubsub"
+				ns:   "http://jabber.org/protocol/pubsub"
+				children: [
+					#XmlElement & {
+						name:  "publish"
+						ns:    "http://jabber.org/protocol/pubsub"
+						attrs: node: "urn:xmpp:pubsub-social-feed:0"
+						children: [
+							#XmlElement & {
+								name:  "item"
+								ns:    "http://jabber.org/protocol/pubsub"
+								attrs: id: "cue-post-1"
+								children: [
+									#XmlElement & {
+										name: "entry"
+										ns:   "urn:xmpp:pubsub-social-feed:0"
+										children: [
+											#XmlElement & {
+												name: "title"
+												ns:   "urn:xmpp:pubsub-social-feed:0"
+												text: "First post"
+											},
+											#XmlElement & {
+												name: "body"
+												ns:   "urn:xmpp:pubsub-social-feed:0"
+												text: "Hello community feed!"
+											},
+											#XmlElement & {
+												name: "author"
+												ns:   "urn:xmpp:pubsub-social-feed:0"
+												text: "admin@\(scenario.domain)"
+											},
+										]
+									},
+								]
+							},
+						]
+					},
+				]
+			}
+		},
+		#ExpectIq & {
+			target: adminPhone
+			id:     "cue-feed-publish"
+			type:   "result"
+		},
+		// 3. Items query MUST return the published entry with the
+		//    typed <entry/> payload intact (id, title, body, author).
+		#SendIq & {
+			actor: adminPhone
+			type:  "get"
+			id:    "cue-feed-items"
+			to:    "spaces.\(scenario.domain)"
+			payload: #XmlElement & {
+				name: "pubsub"
+				ns:   "http://jabber.org/protocol/pubsub"
+				children: [
+					#XmlElement & {
+						name:  "items"
+						ns:    "http://jabber.org/protocol/pubsub"
+						attrs: node: "urn:xmpp:pubsub-social-feed:0"
+					},
+				]
+			}
+		},
+		#ExpectIq & {
+			target: adminPhone
+			id:     "cue-feed-items"
+			type:   "result"
+			contains: [
+				"id=\"cue-post-1\"",
+				"urn:xmpp:pubsub-social-feed:0",
+				"First post",
+				"Hello community feed!",
+			]
+		},
+	]
+}

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -402,6 +402,9 @@ pub fn spaces_service_features() -> Vec<Feature> {
         Feature::new("http://jabber.org/protocol/pubsub#retract-items"),
         Feature::new("http://jabber.org/protocol/pubsub#multi-items"),
         Feature::new("http://jabber.org/protocol/pubsub#item-ids"),
+        // XEP-0472 Pubsub Social Feed — the spaces service hosts the
+        // community-wide feed node `urn:xmpp:pubsub-social-feed:0`.
+        Feature::social_feed(),
     ]
 }
 

--- a/server/crates/waddle-xmpp-core/src/disco/info/features.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/features.rs
@@ -190,6 +190,11 @@ impl Feature {
         Self::new("urn:xmpp:bookmarks:1")
     }
 
+    /// XEP-0472 Pubsub Social Feed.
+    pub fn social_feed() -> Self {
+        Self::new("urn:xmpp:pubsub-social-feed:0")
+    }
+
     pub fn bookmarks_compat() -> Self {
         Self::new("urn:xmpp:bookmarks:1#compat")
     }

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -141,4 +141,7 @@ fn test_spaces_service_features_include_only_supported_pubsub_features() {
     assert!(!features.contains(&Feature::new(
         "http://jabber.org/protocol/pubsub#manage-subscriptions"
     )));
+    // XEP-0472 Pubsub Social Feed — the spaces service hosts the
+    // community-wide feed node, so disco must advertise the namespace.
+    assert!(features.contains(&Feature::social_feed()));
 }


### PR DESCRIPTION
## Summary

First half of the Social Feed wire-up. The spaces service now hosts a global community feed at `urn:xmpp:pubsub-social-feed:0`, created and configured at server startup so the existing server-owner affiliation seed grants Publisher access out of the box. Chat-side surface (feed sidebar tab, composer, items query + subscribe via wasm bridge) follows in a separate PR.

## Wire shape

- **Node**: `urn:xmpp:pubsub-social-feed:0` (XEP-0472's conventional node name) on the spaces service JID
- **Access model**: `spaces_public()` — Open subscribe, Publisher publish-model, persistent items, `OnSub` last-published delivery
- **Publishers**: server owners by default (`seed_spaces_admin_affiliations` already gives them Owner across all spaces nodes, which includes the feed)
- **Item payload**: `<entry xmlns='urn:xmpp:pubsub-social-feed:0'>` with `<title>`, `<body>`, `<author>`, `<published>`, `<link>` per XEP-0472 §3

## Changes

- `topology.rs`: bootstrap the feed PubSub node with `NodeConfig::spaces_public()` right after the General space node
- `disco/info.rs::spaces_service_features()`: advertise `urn:xmpp:pubsub-social-feed:0`
- `Feature::social_feed()` constant
- `handle_spaces_publish` branches on the feed node name and delegates to a new `handle_social_feed_publish` helper that skips the XEP-0402 bookmark parser + channel-parent-tuple plumbing (those gates are for space-bookmark items, not feed entries) and does a generic publish + fan-out
- Integration test pinning disco advertisement + publish/items round-trip with typed `<entry/>` payload

## What's intentionally not in this PR

- Chat client UI (sidebar tab, composer, feed view)
- Wasm bridge helpers for publish/subscribe (likely doable with the existing generic PubSub publishers already in the wasm crate)
- Permission tuning beyond "server owners can post" (per-community feeds, member-write configs)
- Retract / edit for individual posts (XEP-0472 §5 builds on standard PubSub retract; works today via the generic retract path, just needs UI)

## Test plan

- [x] `cargo build -p waddle-xmpp-core -p waddle-xmpp -p waddle-server` — clean
- [x] `cargo test -p waddle-xmpp-core --lib disco` — 15 pass (incl. updated spaces-feature test)
- [x] `cargo test -p waddle-server --test xep0472_social_feed_ws` — 2 pass (disco advertisement + publish/items round-trip)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.