### PR TITLE
feat(chat): XEP-0501 stories — horizontal stories bar + composer + viewer

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -32,6 +32,7 @@ const {
   channelUnread,
   rosterContacts,
   socialFeed,
+  stories,
   xmppClient,
   activeMessages,
   activeFirstUnseenId,
@@ -133,6 +134,14 @@ const homeDashboardProps = computed(() => buildHomeDashboardProps({
     // owners actually have Publisher affiliation, so non-owner posts
     // surface as a stanza error → composer shows the error inline.
     // Per-deployment role-based posting controls is a follow-up.
+    canPost: !!connectionStore.session,
+    selfJid: connectionStore.session?.jid ?? null,
+  },
+  stories: {
+    stories: stories.activeStories.value,
+    isLoading: stories.isLoading.value,
+    isPosting: stories.isPosting.value,
+    error: stories.error.value,
     canPost: !!connectionStore.session,
     selfJid: connectionStore.session?.jid ?? null,
   },
@@ -239,6 +248,7 @@ function setPinnedPanelOpen(isOpen: boolean) {
         @open-nav="ui.showMobileNav.value = true"
         @refresh-feed="socialFeed.refresh()"
         @post-feed="(input) => socialFeed.post(input)"
+        @post-story="(input) => stories.post(input)"
       />
       <UserSettingsPage
         v-else-if="ui.activePage.value === 'settings' && connectionStore.session"

--- a/chat/src/components/chat/HomeDashboard.vue
+++ b/chat/src/components/chat/HomeDashboard.vue
@@ -6,7 +6,9 @@ import type { RosterContact } from "@/lib/xmpp/types";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import CommunityFeed from "@/components/chat/CommunityFeed.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
-import type { FeedPostInput } from "@/lib/xmpp-client";
+import StoriesBar from "@/components/chat/StoriesBar.vue";
+import StoryViewer from "@/components/chat/StoryViewer.vue";
+import type { FeedPostInput, Story, StoryPostInput } from "@/lib/xmpp-client";
 import { isForumChannel } from "@/lib/channel-types";
 import { groupChannelsBySpace } from "@/lib/channel-grouping";
 import { formatTimelineStamp } from "@/channels/timeline";
@@ -33,7 +35,10 @@ const emit = defineEmits<{
   openNav: [];
   refreshFeed: [];
   postFeed: [input: FeedPostInput];
+  postStory: [input: StoryPostInput];
 }>();
+
+const activeStory = ref<Story | null>(null);
 
 const now = ref<Date>(new Date());
 let heroClockHandle: ReturnType<typeof setInterval> | null = null;
@@ -330,6 +335,18 @@ function onHeroCta() {
         </button>
       </section>
 
+      <StoriesBar
+        v-if="stories"
+        :stories="stories.stories"
+        :is-loading="stories.isLoading"
+        :is-posting="stories.isPosting"
+        :error="stories.error"
+        :can-post="stories.canPost"
+        :self-jid="stories.selfJid"
+        @post="(input) => emit('postStory', input)"
+        @view="(story) => (activeStory = story)"
+      />
+
       <CommunityFeed
         v-if="feed"
         :entries="feed.entries"
@@ -340,6 +357,12 @@ function onHeroCta() {
         :self-jid="feed.selfJid"
         @refresh="emit('refreshFeed')"
         @post="(input) => emit('postFeed', input)"
+      />
+
+      <StoryViewer
+        v-if="activeStory"
+        :story="activeStory"
+        @close="activeStory = null"
       />
 
       <section class="grid gap-3">

--- a/chat/src/components/chat/StoriesBar.vue
+++ b/chat/src/components/chat/StoriesBar.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { Camera, Plus, X } from "lucide-vue-next";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import type { Story, StoryPostInput } from "@/lib/xmpp-client";
+
+interface StoriesBarProps {
+  stories: readonly Story[];
+  isLoading: boolean;
+  isPosting: boolean;
+  error: string | null;
+  canPost: boolean;
+  selfJid: string | null;
+}
+
+const props = defineProps<StoriesBarProps>();
+const emit = defineEmits<{
+  post: [input: StoryPostInput];
+  view: [story: Story];
+}>();
+
+const composerOpen = ref(false);
+const composerBody = ref("");
+const composerMediaUrl = ref("");
+
+function authorLabel(author: string | undefined): string {
+  if (!author) return "Anonymous";
+  return author.split("@")[0] ?? author;
+}
+
+function timeRemaining(story: Story, nowMs: number = Date.now()): string {
+  if (typeof story.expiresMs !== "number") return "";
+  const delta = story.expiresMs - nowMs;
+  if (delta < 0) return "expired";
+  if (delta < 60_000) return "<1m";
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m`;
+  return `${Math.floor(delta / 3_600_000)}h`;
+}
+
+const canSubmit = computed(() => {
+  if (props.isPosting) return false;
+  return composerBody.value.trim().length > 0 || composerMediaUrl.value.trim().length > 0;
+});
+
+function submit() {
+  const body = composerBody.value.trim();
+  const mediaUrl = composerMediaUrl.value.trim();
+  if (!body && !mediaUrl) return;
+  emit("post", {
+    ...(body ? { body } : {}),
+    ...(mediaUrl ? { mediaUrl } : {}),
+    ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
+  });
+  composerBody.value = "";
+  composerMediaUrl.value = "";
+  composerOpen.value = false;
+}
+
+function dismissComposer() {
+  composerOpen.value = false;
+  composerBody.value = "";
+  composerMediaUrl.value = "";
+}
+</script>
+
+<template>
+  <section
+    v-if="canPost || stories.length > 0"
+    class="grid gap-3"
+    aria-label="Stories"
+  >
+    <div class="flex items-center gap-2">
+      <Camera class="h-4 w-4 text-primary" aria-hidden="true" />
+      <h2 class="type-pane-title">Stories</h2>
+      <span class="ml-auto type-caption text-muted-foreground">
+        {{ stories.length }} {{ stories.length === 1 ? "active" : "active" }}
+      </span>
+    </div>
+
+    <div v-if="error" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      Couldn't post: {{ error }}
+    </div>
+
+    <!-- Horizontal scroll strip: composer pill + story bubbles -->
+    <div class="flex gap-3 overflow-x-auto pb-2">
+      <button
+        v-if="canPost"
+        type="button"
+        class="flex w-[5rem] flex-shrink-0 flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-card p-2 text-center text-muted-foreground hover:border-primary/60 hover:text-primary"
+        :disabled="isPosting"
+        :aria-label="composerOpen ? 'Close story composer' : 'Add a story'"
+        @click="composerOpen = !composerOpen"
+      >
+        <span class="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+          <Plus class="h-5 w-5" aria-hidden="true" />
+        </span>
+        <span class="type-caption truncate text-current">
+          {{ composerOpen ? "Close" : "Add" }}
+        </span>
+      </button>
+
+      <button
+        v-for="story in stories"
+        :key="story.id"
+        type="button"
+        class="group flex w-[5rem] flex-shrink-0 flex-col items-center gap-2 rounded-lg p-2 hover:bg-muted/50"
+        :aria-label="`View story by ${authorLabel(story.author)}`"
+        @click="emit('view', story)"
+      >
+        <span class="relative">
+          <AppAvatar :name="authorLabel(story.author)" :src="story.mediaUrl ?? null" size="md" />
+          <span
+            class="pointer-events-none absolute inset-0 rounded-full ring-2 ring-primary/70 ring-offset-1 ring-offset-background"
+            aria-hidden="true"
+          ></span>
+        </span>
+        <span class="min-w-0 type-caption text-foreground">
+          <span class="block truncate">{{ authorLabel(story.author) }}</span>
+          <span class="block text-muted-foreground">{{ timeRemaining(story) }}</span>
+        </span>
+      </button>
+
+      <template v-if="isLoading && stories.length === 0 && !canPost">
+        <div
+          v-for="i in 3"
+          :key="`story-skel-${i}`"
+          class="flex w-[5rem] flex-shrink-0 flex-col items-center gap-2 rounded-lg p-2"
+          aria-hidden="true"
+        >
+          <span class="h-12 w-12 animate-pulse rounded-full bg-muted"></span>
+          <span class="h-3 w-3/4 animate-pulse rounded bg-muted"></span>
+        </div>
+      </template>
+    </div>
+
+    <!-- Composer panel slides under the strip when open -->
+    <form
+      v-if="composerOpen"
+      class="grid gap-2 rounded-lg border border-border bg-card p-3"
+      @submit.prevent="submit"
+    >
+      <textarea
+        v-model="composerBody"
+        class="min-h-[3rem] w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        placeholder="Share a quick update…"
+        :disabled="isPosting"
+        aria-label="Story body"
+      />
+      <input
+        v-model="composerMediaUrl"
+        type="url"
+        class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        placeholder="Optional image / video URL"
+        :disabled="isPosting"
+        aria-label="Story media URL"
+      />
+      <div class="flex items-center justify-between gap-2">
+        <span class="type-caption text-muted-foreground">
+          Expires in 24h
+        </span>
+        <div class="flex items-center gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+            :disabled="isPosting"
+            @click="dismissComposer"
+          >
+            <X class="h-3.5 w-3.5" aria-hidden="true" />
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            :disabled="!canSubmit"
+          >
+            {{ isPosting ? "Posting…" : "Share" }}
+          </button>
+        </div>
+      </div>
+    </form>
+  </section>
+</template>

--- a/chat/src/components/chat/StoryViewer.vue
+++ b/chat/src/components/chat/StoryViewer.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { X } from "lucide-vue-next";
+import AppAvatar from "@/components/ui/AppAvatar.vue";
+import type { Story } from "@/lib/xmpp-client";
+
+interface StoryViewerProps {
+  story: Story;
+}
+
+const props = defineProps<StoryViewerProps>();
+const emit = defineEmits<{ close: [] }>();
+
+function authorLabel(author: string | undefined): string {
+  if (!author) return "Anonymous";
+  return author.split("@")[0] ?? author;
+}
+
+const remaining = computed(() => {
+  if (typeof props.story.expiresMs !== "number") return null;
+  const delta = props.story.expiresMs - Date.now();
+  if (delta < 0) return "expired";
+  if (delta < 60_000) return "<1m left";
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m left`;
+  return `${Math.floor(delta / 3_600_000)}h left`;
+});
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") emit("close");
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="fixed inset-0 z-50 flex items-center justify-center bg-background/85 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="`Story by ${authorLabel(story.author)}`"
+      tabindex="-1"
+      @keydown="onKeydown"
+      @click.self="emit('close')"
+    >
+      <div class="relative grid w-full max-w-md gap-3 rounded-xl border border-border bg-card p-4 shadow-xl">
+        <button
+          type="button"
+          class="absolute right-3 top-3 inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+          aria-label="Close story"
+          @click="emit('close')"
+        >
+          <X class="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        <header class="flex items-center gap-3">
+          <AppAvatar :name="authorLabel(story.author)" :src="null" size="sm" />
+          <div class="min-w-0 flex-1">
+            <p class="type-control truncate text-foreground">{{ authorLabel(story.author) }}</p>
+            <p v-if="remaining" class="type-caption text-muted-foreground">{{ remaining }}</p>
+          </div>
+        </header>
+
+        <img
+          v-if="story.mediaUrl"
+          :src="story.mediaUrl"
+          :alt="`Story media from ${authorLabel(story.author)}`"
+          class="max-h-[60vh] w-full rounded-md object-contain"
+          referrerpolicy="no-referrer"
+        />
+        <p v-if="story.body" class="whitespace-pre-wrap break-words text-sm text-foreground">
+          {{ story.body }}
+        </p>
+      </div>
+    </div>
+  </Teleport>
+</template>

--- a/chat/src/home/dashboard-props.ts
+++ b/chat/src/home/dashboard-props.ts
@@ -1,10 +1,19 @@
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { RosterContact } from "@/lib/xmpp/types";
-import type { DmConversation, FeedEntry } from "@/lib/xmpp-client";
+import type { DmConversation, FeedEntry, Story } from "@/lib/xmpp-client";
 import type { ChannelUnreadMap } from "@/home/activity";
 
 export interface HomeDashboardFeedState {
   entries: readonly FeedEntry[];
+  isLoading: boolean;
+  isPosting: boolean;
+  error: string | null;
+  canPost: boolean;
+  selfJid: string | null;
+}
+
+export interface HomeDashboardStoriesState {
+  stories: readonly Story[];
   isLoading: boolean;
   isPosting: boolean;
   error: string | null;
@@ -21,6 +30,7 @@ export interface HomeDashboardProps {
   activeChannelJids?: Set<string>;
   dmConversations?: DmConversation[];
   feed?: HomeDashboardFeedState;
+  stories?: HomeDashboardStoriesState;
 }
 
 interface HomeDashboardSources extends Omit<HomeDashboardProps, "channelUnreadMap"> {
@@ -42,6 +52,7 @@ export function buildHomeDashboardProps(sources: HomeDashboardSources): HomeDash
     activeChannelJids: sources.activeChannelJids,
     dmConversations: sources.dmConversations,
     ...(sources.feed ? { feed: sources.feed } : {}),
+    ...(sources.stories ? { stories: sources.stories } : {}),
   };
 }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -63,6 +63,12 @@ import {
   type FeedPostInput,
   type WasmFeedEntry,
 } from "./feed-types";
+import {
+  storyFromWasm,
+  type Story,
+  type StoryPostInput,
+  type WasmStory,
+} from "./story-types";
 import type { FetchInboxOptions, InboxEntry, InboxResult } from "./inbox-types";
 import type { ActivityPublication, MoodPublication, TunePublication, UserPepProfile } from "./pep-types";
 import {
@@ -904,6 +910,37 @@ export class BrowserXmppClient {
       throw new Error("feed_publish returned no entry");
     }
     return feedEntryFromWasm(result);
+  }
+
+  /**
+   * Fetch the latest XEP-0501 community stories. The wasm bridge
+   * returns ALL items including expired ones; the chat filters
+   * active vs expired locally so countdowns fade stories out without
+   * a server roundtrip.
+   */
+  async fetchStories(spacesJid: string, maxItems: number | undefined = undefined): Promise<Story[]> {
+    const xmpp = await this.requireConnectedXmpp();
+    const result = await xmpp.stories_items?.(spacesJid, maxItems ?? null) as WasmStory[] | undefined;
+    return (result ?? []).map(storyFromWasm);
+  }
+
+  /**
+   * Publish a XEP-0501 story to the community stories node. At
+   * least one of `body` or `mediaUrl` must be set; the server
+   * rejects empty stories.
+   */
+  async publishStory(spacesJid: string, input: StoryPostInput): Promise<Story> {
+    const xmpp = await this.requireConnectedXmpp();
+    const result = await xmpp.stories_publish?.(spacesJid, {
+      ...(input.body ? { body: input.body } : {}),
+      ...(input.mediaUrl ? { media_url: input.mediaUrl } : {}),
+      ...(input.author ? { author: input.author } : {}),
+      ...(typeof input.expiryHours === "number" ? { expiry_hours: input.expiryHours } : {}),
+    }) as WasmStory | undefined;
+    if (!result) {
+      throw new Error("stories_publish returned no story");
+    }
+    return storyFromWasm(result);
   }
   async publishMood(mood: MoodPublication): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.publish_mood?.({ kind: mood.kind, ...(mood.text ? { text: mood.text } : {}) }); }
   async retractMood(): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.retract_mood?.(); }

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -11,6 +11,8 @@ export {
 export type { OutboundFileAttachment } from "./send-types";
 export type { InboxEntry } from "./inbox-types";
 export type { FeedEntry, FeedPostInput } from "./feed-types";
+export type { Story, StoryPostInput } from "./story-types";
+export { isStoryActive } from "./story-types";
 export type { UserPepProfile } from "./pep-types";
 export type {
   DmChatStateEvent,

--- a/chat/src/lib/xmpp/story-types.ts
+++ b/chat/src/lib/xmpp/story-types.ts
@@ -1,0 +1,61 @@
+/**
+ * XEP-0501 Story shapes mirrored from the wasm bridge.
+ *
+ * Stories are ephemeral pubsub items with an `expires` timestamp;
+ * the chat filters expired entries locally so the UI fades them out
+ * as soon as the countdown hits zero, without waiting for a server
+ * roundtrip.
+ */
+
+export interface Story {
+  /** Pubsub item id assigned by the publisher (UUID). */
+  id: string;
+  body?: string;
+  /** Image / video URL. */
+  mediaUrl?: string;
+  /** Author bare JID. */
+  author?: string;
+  /** Epoch ms when the story was posted. */
+  postedMs?: number;
+  /** Epoch ms when the story expires; absent ⇒ never expires. */
+  expiresMs?: number;
+}
+
+export interface StoryPostInput {
+  body?: string;
+  mediaUrl?: string;
+  author?: string;
+  /** Hours from now until expiry. Defaults to 24 server-side. */
+  expiryHours?: number;
+}
+
+/** Snake-case shape emitted by the wasm bridge. */
+export interface WasmStory {
+  id: string;
+  body?: string | null;
+  media_url?: string | null;
+  author?: string | null;
+  /** RFC3339 string or null. */
+  posted?: string | null;
+  /** RFC3339 string or null. */
+  expires?: string | null;
+}
+
+export function storyFromWasm(story: WasmStory): Story {
+  const postedMs = story.posted ? Date.parse(story.posted) : undefined;
+  const expiresMs = story.expires ? Date.parse(story.expires) : undefined;
+  return {
+    id: story.id,
+    ...(story.body ? { body: story.body } : {}),
+    ...(story.media_url ? { mediaUrl: story.media_url } : {}),
+    ...(story.author ? { author: story.author } : {}),
+    ...(typeof postedMs === "number" && Number.isFinite(postedMs) ? { postedMs } : {}),
+    ...(typeof expiresMs === "number" && Number.isFinite(expiresMs) ? { expiresMs } : {}),
+  };
+}
+
+/** Returns true when the story is still active (no expiry, or expiry in the future). */
+export function isStoryActive(story: Story, nowMs: number = Date.now()): boolean {
+  if (typeof story.expiresMs !== "number") return true;
+  return story.expiresMs > nowMs;
+}

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -1,0 +1,106 @@
+/**
+ * XEP-0501 Stories composable.
+ *
+ * Mirrors `useSocialFeed` for the ephemeral stories pubsub node.
+ * The composable filters expired entries locally — the wasm bridge
+ * returns ALL items, and we re-derive `active` every minute so
+ * stories fade out as their countdowns hit zero without a server
+ * roundtrip.
+ */
+import { computed, onScopeDispose, ref, type Ref } from "vue";
+import { isStoryActive, type BrowserXmppClient, type Story, type StoryPostInput } from "@/lib/xmpp-client";
+
+const TICK_INTERVAL_MS = 60_000;
+
+export function useStories(
+  xmppClient: Ref<BrowserXmppClient | null>,
+  options: {
+    /** Bare JID of the spaces service. */
+    spacesJid: Ref<string | null>;
+    /** Max items to fetch per refresh. */
+    pageSize?: number;
+  },
+) {
+  const stories = ref<Story[]>([]);
+  const isLoading = ref(false);
+  const isPosting = ref(false);
+  const error = ref<string | null>(null);
+  const pageSize = options.pageSize ?? 50;
+  let fetchRequestId = 0;
+  const nowMs = ref(Date.now());
+  const tickHandle = setInterval(() => {
+    nowMs.value = Date.now();
+  }, TICK_INTERVAL_MS);
+  onScopeDispose(() => clearInterval(tickHandle));
+
+  const activeStories = computed(() => {
+    const live = stories.value.filter((s) => isStoryActive(s, nowMs.value));
+    return [...live].sort((a, b) => (b.postedMs ?? 0) - (a.postedMs ?? 0));
+  });
+
+  async function refresh(): Promise<boolean> {
+    const client = xmppClient.value;
+    const spacesJid = options.spacesJid.value;
+    if (!client || !spacesJid) {
+      stories.value = [];
+      return false;
+    }
+    const requestId = ++fetchRequestId;
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const fetched = await client.fetchStories(spacesJid, pageSize);
+      if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
+      stories.value = fetched;
+      return true;
+    } catch (err) {
+      if (requestId === fetchRequestId) {
+        error.value = err instanceof Error ? err.message : String(err);
+      }
+      return false;
+    } finally {
+      if (requestId === fetchRequestId) {
+        isLoading.value = false;
+      }
+    }
+  }
+
+  async function post(input: StoryPostInput): Promise<Story | null> {
+    const client = xmppClient.value;
+    const spacesJid = options.spacesJid.value;
+    if (!client || !spacesJid) return null;
+    if (!(input.body?.trim() || input.mediaUrl?.trim())) return null;
+    isPosting.value = true;
+    error.value = null;
+    try {
+      const story = await client.publishStory(spacesJid, input);
+      stories.value = [story, ...stories.value.filter((s) => s.id !== story.id)];
+      return story;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return null;
+    } finally {
+      isPosting.value = false;
+    }
+  }
+
+  function clear() {
+    fetchRequestId += 1;
+    stories.value = [];
+    error.value = null;
+    isLoading.value = false;
+    isPosting.value = false;
+  }
+
+  return {
+    activeStories,
+    isLoading,
+    isPosting,
+    error,
+    refresh,
+    post,
+    clear,
+    /** Exposed so tests can advance time without waiting for the interval. */
+    nowMs,
+  };
+}

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -11,6 +11,7 @@ import { useServiceWorkerUpdate } from "@/shell/service-worker-update";
 import { usePushNotifications } from "@/shell/notifications";
 import { useChannelInbox } from "@/channels/inbox";
 import { useSocialFeed } from "@/services/social-feed";
+import { useStories } from "@/services/stories";
 import { useChatReadActivity } from "@/shell/read-activity";
 import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
@@ -89,6 +90,7 @@ export function useChatAppController(giphyApiKey: string) {
     return domain ? `spaces.${domain}` : null;
   });
   const socialFeed = useSocialFeed(xmppClient, { spacesJid });
+  const stories = useStories(xmppClient, { spacesJid });
 
   const dmMessaging = useDirectMessages(
     session,
@@ -696,6 +698,7 @@ export function useChatAppController(giphyApiKey: string) {
       void dmConversations.hydrateFromInbox();
       void channelUnread.hydrateFromInbox();
       void socialFeed.refresh();
+      void stories.refresh();
     });
   }, { immediate: true });
 
@@ -1411,6 +1414,7 @@ export function useChatAppController(giphyApiKey: string) {
     void channelUnread.hydrateFromInbox();
     void rosterContacts.loadRosterContacts();
     void socialFeed.refresh();
+    void stories.refresh();
 
     // Register service worker and sync push subscription (best-effort, non-blocking)
     void (async () => {
@@ -1642,6 +1646,7 @@ export function useChatAppController(giphyApiKey: string) {
       channelUnread,
       rosterContacts,
       socialFeed,
+      stories,
       dmMessaging,
       xmppClient,
       activeMessages,

--- a/chat/tests/stories.test.ts
+++ b/chat/tests/stories.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, mock, test } from "bun:test";
+import { effectScope, ref } from "vue";
+import { useStories } from "../src/services/stories";
+import type { BrowserXmppClient, Story } from "../src/lib/xmpp-client";
+
+const SPACES = "spaces.example.com";
+
+type MockClient = BrowserXmppClient & {
+  fetchStories: ReturnType<typeof mock>;
+  publishStory: ReturnType<typeof mock>;
+};
+
+function makeClient(stories: Story[] = []): MockClient {
+  return {
+    fetchStories: mock(() => Promise.resolve(stories)),
+    publishStory: mock((_jid: string, input: { body?: string; mediaUrl?: string; author?: string }) =>
+      Promise.resolve({
+        id: "new-story",
+        ...(input.body ? { body: input.body } : {}),
+        ...(input.mediaUrl ? { mediaUrl: input.mediaUrl } : {}),
+        ...(input.author ? { author: input.author } : {}),
+        postedMs: Date.parse("2026-06-01T12:00:00Z"),
+        expiresMs: Date.parse("2026-06-02T12:00:00Z"),
+      } satisfies Story),
+    ),
+  } as unknown as MockClient;
+}
+
+function withScope<T>(fn: () => T): T {
+  const scope = effectScope();
+  let result!: T;
+  scope.run(() => {
+    result = fn();
+  });
+  return result;
+}
+
+describe("useStories", () => {
+  test("refresh filters expired stories and sorts newest-first", async () => {
+    const now = Date.parse("2026-06-01T12:00:00Z");
+    const future = now + 10 * 60_000;
+    const past = now - 10 * 60_000;
+    const client = makeClient([
+      { id: "expired", body: "old", postedMs: now - 60_000, expiresMs: past },
+      { id: "later", body: "newer", postedMs: now - 30_000, expiresMs: future },
+      { id: "newest", body: "newest", postedMs: now, expiresMs: future },
+    ]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), {
+        spacesJid: ref<string | null>(SPACES),
+      }),
+    );
+    story.nowMs.value = now;
+
+    await story.refresh();
+    expect(story.activeStories.value.map((s) => s.id)).toEqual(["newest", "later"]);
+  });
+
+  test("post appends locally and skips empty input", async () => {
+    const client = makeClient([]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), {
+        spacesJid: ref<string | null>(SPACES),
+      }),
+    );
+    story.nowMs.value = Date.parse("2026-06-01T12:00:00Z");
+
+    const empty = await story.post({ body: "  " });
+    expect(empty).toBe(null);
+    expect(client.publishStory).not.toHaveBeenCalled();
+
+    const posted = await story.post({ body: "hi", author: "alice@example.com" });
+    expect(posted?.id).toBe("new-story");
+    expect(story.activeStories.value.map((s) => s.id)).toContain("new-story");
+  });
+
+  test("post error surfaces and entries stay intact", async () => {
+    const now = Date.parse("2026-06-01T12:00:00Z");
+    const future = now + 60_000;
+    const client = makeClient([
+      { id: "existing", body: "x", postedMs: now, expiresMs: future },
+    ]);
+    client.publishStory = mock(() => Promise.reject(new Error("Forbidden"))) as unknown as MockClient["publishStory"];
+
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), {
+        spacesJid: ref<string | null>(SPACES),
+      }),
+    );
+    story.nowMs.value = now;
+    await story.refresh();
+
+    const failed = await story.post({ body: "no-can-do" });
+    expect(failed).toBe(null);
+    expect(story.error.value).toBe("Forbidden");
+    expect(story.activeStories.value.map((s) => s.id)).toEqual(["existing"]);
+  });
+
+  test("clear resets state and prevents stale refresh from landing", async () => {
+    const now = Date.parse("2026-06-01T12:00:00Z");
+    const client = makeClient([
+      { id: "x", body: "x", postedMs: now, expiresMs: now + 60_000 },
+    ]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), {
+        spacesJid: ref<string | null>(SPACES),
+      }),
+    );
+    story.nowMs.value = now;
+    await story.refresh();
+    expect(story.activeStories.value.length).toBe(1);
+
+    story.clear();
+    expect(story.activeStories.value.length).toBe(0);
+  });
+
+  test("expiry filtering re-evaluates as nowMs advances", async () => {
+    const t0 = Date.parse("2026-06-01T12:00:00Z");
+    const client = makeClient([
+      { id: "soon", body: "soon", postedMs: t0, expiresMs: t0 + 60_000 },
+      { id: "later", body: "later", postedMs: t0, expiresMs: t0 + 3_600_000 },
+    ]);
+    const story = withScope(() =>
+      useStories(ref<BrowserXmppClient | null>(client), {
+        spacesJid: ref<string | null>(SPACES),
+      }),
+    );
+    story.nowMs.value = t0;
+    await story.refresh();
+    expect(story.activeStories.value.length).toBe(2);
+
+    // Advance past "soon" expiry: it should drop out of active list.
+    story.nowMs.value = t0 + 2 * 60_000;
+    expect(story.activeStories.value.map((s) => s.id)).toEqual(["later"]);
+  });
+});

--- a/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_stories.rs
@@ -1,0 +1,180 @@
+//! XEP-0501 Pubsub Stories — wasm bridge surface.
+//!
+//! The server bootstraps a community stories node at
+//! `urn:xmpp:stories:0` on the spaces service. These wasm methods
+//! let the chat read active stories (`stories_items`, filters
+//! expired locally) and publish new stories with an expiry
+//! (`stories_publish`) via standard XEP-0060 pubsub IQs, with the
+//! typed XEP-0501 `<story/>` payload constructed / parsed in Rust
+//! via `waddle_xmpp_core::xep0501`.
+
+use chrono::{DateTime, Duration, Utc};
+use minidom::Element;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use waddle_xmpp_core::xep0501::{
+    build_story_element, parse_story, Story, DEFAULT_EXPIRY_HOURS, NS_STORIES, PUBSUB_NODE_STORIES,
+};
+use wasm_bindgen::prelude::*;
+
+use super::{js_error, send_iq_command, to_js_value, WaddleClient};
+use crate::NS_CLIENT;
+
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+
+/// JS-facing snapshot of a XEP-0501 story. Mirrors `Story` with
+/// RFC3339 strings on the timestamp fields so it serialises cleanly
+/// across the wasm boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsStory {
+    pub id: String,
+    pub body: Option<String>,
+    pub media_url: Option<String>,
+    pub author: Option<String>,
+    /// RFC3339 string (or `None` if absent).
+    pub posted: Option<String>,
+    /// RFC3339 string (or `None` if absent).
+    pub expires: Option<String>,
+}
+
+impl From<Story> for JsStory {
+    fn from(story: Story) -> Self {
+        Self {
+            id: story.id,
+            body: story.body,
+            media_url: story.media_url,
+            author: story.author,
+            posted: story.posted.map(|ts| ts.to_rfc3339()),
+            expires: story.expires.map(|ts| ts.to_rfc3339()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JsStoryInput {
+    pub body: Option<String>,
+    pub media_url: Option<String>,
+    pub author: Option<String>,
+    /// Hours from now until the story expires. Defaults to
+    /// `DEFAULT_EXPIRY_HOURS` (24) when absent.
+    pub expiry_hours: Option<i64>,
+}
+
+fn build_stories_items_iq(spaces_jid: &str, max_items: Option<u32>) -> Element {
+    let id = format!("stories-items-{}", Uuid::new_v4());
+    let mut items_builder = Element::builder("items", NS_PUBSUB).attr("node", PUBSUB_NODE_STORIES);
+    let max_items_value;
+    if let Some(max) = max_items {
+        max_items_value = max.to_string();
+        items_builder = items_builder.attr("max_items", max_items_value.as_str());
+    }
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(items_builder.build())
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("id", id)
+        .attr("to", spaces_jid)
+        .append(pubsub)
+        .build()
+}
+
+fn build_story_publish_iq(spaces_jid: &str, item_id: &str, story: &Story) -> Element {
+    let id = format!("stories-publish-{}", Uuid::new_v4());
+    let item = Element::builder("item", NS_PUBSUB)
+        .attr("id", item_id)
+        .append(build_story_element(story))
+        .build();
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr("node", PUBSUB_NODE_STORIES)
+        .append(item)
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
+        .attr("id", id)
+        .attr("to", spaces_jid)
+        .append(pubsub)
+        .build()
+}
+
+fn parse_stories_items_result(iq: &Element) -> Vec<JsStory> {
+    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
+        return Vec::new();
+    };
+    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
+        return Vec::new();
+    };
+    items
+        .children()
+        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+        .filter_map(|item| {
+            let item_id = item.attr("id")?;
+            let story_el = item
+                .children()
+                .find(|child| child.name() == "story" && child.ns() == NS_STORIES)?;
+            parse_story(item_id, story_el).map(JsStory::from)
+        })
+        .collect()
+}
+
+#[wasm_bindgen]
+impl WaddleClient {
+    /// Fetch the latest items from the community stories node on
+    /// `spaces_jid`. Returns ALL items including expired ones —
+    /// the chat client filters active vs expired locally so it can
+    /// fade out a story right as the countdown hits zero without a
+    /// server round-trip.
+    pub fn stories_items(&self, spaces_jid: String, max_items: Option<u32>) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let iq = build_stories_items_iq(&spaces_jid, max_items);
+            let result = send_iq_command(inner, iq).await?;
+            let stories = parse_stories_items_result(&result);
+            to_js_value(&stories)
+        })
+    }
+
+    /// Publish a new story to the community stories node. Body
+    /// and/or media URL must be provided; the server stamps the
+    /// publisher's JID separately. `expiry_hours` defaults to 24
+    /// (matches XEP-0501 §"Default expiry").
+    pub fn stories_publish(&self, spaces_jid: String, input: JsValue) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let input: JsStoryInput = serde_wasm_bindgen::from_value(input)
+                .map_err(|err| js_error(format!("invalid story input: {err}")))?;
+            if input.body.is_none() && input.media_url.is_none() {
+                return Err(js_error("story must have body or media_url"));
+            }
+            let item_id = format!("story-{}", Uuid::new_v4());
+            let mut story = Story::new(item_id.clone());
+            if let Some(body) = input.body {
+                story = story.with_body(body);
+            }
+            if let Some(url) = input.media_url {
+                story = story.with_media(url);
+            }
+            if let Some(author) = input.author {
+                story = story.with_author(author);
+            }
+            let hours = input.expiry_hours.unwrap_or(DEFAULT_EXPIRY_HOURS).max(1);
+            story = story.with_expiry(Duration::hours(hours));
+            let iq = build_story_publish_iq(&spaces_jid, &item_id, &story);
+            send_iq_command(inner, iq).await?;
+            let posted: DateTime<Utc> = story.posted.unwrap_or_else(Utc::now);
+            let expires: DateTime<Utc> = story.expires.expect("with_expiry always sets expires");
+            let js_story = JsStory {
+                id: item_id,
+                body: story.body,
+                media_url: story.media_url,
+                author: story.author,
+                posted: Some(posted.to_rfc3339()),
+                expires: Some(expires.to_rfc3339()),
+            };
+            to_js_value(&js_story)
+        })
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -57,6 +57,7 @@ mod client_history;
 mod client_messaging;
 mod client_rooms;
 mod client_social_feed;
+mod client_stories;
 mod commands;
 mod conversions;
 mod driver;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -98,6 +98,21 @@ export class WaddleClient {
     set_on_presence(cb: Function): void;
     set_on_session_lifecycle(cb: Function): void;
     set_room_affiliation(room_jid: string, jid: string, affiliation: string): Promise<any>;
+    /**
+     * Fetch the latest items from the community stories node on
+     * `spaces_jid`. Returns ALL items including expired ones —
+     * the chat client filters active vs expired locally so it can
+     * fade out a story right as the countdown hits zero without a
+     * server round-trip.
+     */
+    stories_items(spaces_jid: string, max_items?: number | null): Promise<any>;
+    /**
+     * Publish a new story to the community stories node. Body
+     * and/or media URL must be provided; the server stamps the
+     * publisher's JID separately. `expiry_hours` defaults to 24
+     * (matches XEP-0501 §"Default expiry").
+     */
+    stories_publish(spaces_jid: string, input: any): Promise<any>;
     subscribe_to_presence(peer_jid: string): Promise<any>;
     /**
      * Publish an unpin request (#414). Same authorization rules as

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8qxkmx";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8qxkmx";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8qxkmx";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8sp00n";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8sp00n";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8sp00n";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8qxkmx";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8sp00n";


### PR DESCRIPTION
## Summary

Surfaces the bootstrapped community stories node (server side merged in #647) on the home dashboard. Signed-in users see active stories in a horizontal strip above the Community Feed, tap one to open a full-screen viewer, and post their own stories with optional body + media URL (24h expiry by default).

## Wire shape end-to-end

| Layer | What it gains |
|---|---|
| `waddle-xmpp-client-wasm` | `WaddleClient.stories_items(spaces_jid, max_items)` + `WaddleClient.stories_publish(spaces_jid, input)` |
| Chat `lib/xmpp/story-types.ts` + `client.ts` | Typed `fetchStories` / `publishStory` with camelCase snapshot + `isStoryActive` helper |
| Chat `services/stories.ts` | `useStories` composable with per-minute `nowMs` tick → `activeStories` re-derives so stories fade out as their countdown hits zero, no server roundtrip |
| Chat `components/chat/StoriesBar.vue` | Horizontal scroll strip: composer pill → inline expand (body + media URL), story bubbles with author + time-remaining, ring-styled avatars |
| Chat `components/chat/StoryViewer.vue` | Teleport-to-body modal: large media render, Escape + backdrop-click close |
| `HomeDashboard.vue` | Slots StoriesBar above the Community Feed, renders viewer on demand |
| `chat-app-controller.ts` | Instantiates `useStories`, re-hydrates alongside the feed on every XMPP session-ready (resumed + fresh) |

## Behaviour call-outs

- **Local expiry filtering**: the wasm bridge returns ALL items including expired ones; the composable filters per-tick (`nowMs` updates every 60s) so a story disappears the moment it expires without a server fetch.
- **Optimistic append on post**: same pattern as the feed — no auto-refresh, append the just-published story to local state.
- **Composer guard**: server enforces that at least body OR media URL is set; client mirrors that, blocks the Share button until one is non-empty.
- **Permissions**: composer shown to every signed-in user. Non-publisher posts surface as a stanza error inline (same as feed).

## Test plan

- [x] `cargo build -p waddle-xmpp-client-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `bunx astro check` — 0 errors
- [x] `bun test` — 788 pass (5 new in `tests/stories.test.ts`: expiry filter + sort, optimistic append + empty-input guard, error path, clear, nowMs advancement drops expired)
- [x] `bun run lint` (knip) — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.