### PR TITLE
feat(server): PEP → community feed bridge

### DIFF
--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -1,9 +1,42 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { MessageSquareText, RefreshCw, Send } from "lucide-vue-next";
+import {
+  Briefcase,
+  IdCard,
+  MessageSquareText,
+  Music,
+  RefreshCw,
+  Send,
+  Smile,
+  User,
+} from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import Skeleton from "@/components/ui/Skeleton.vue";
-import type { FeedEntry, FeedPostInput } from "@/lib/xmpp-client";
+import type { FeedEntry, FeedPostInput, FeedSourceKind } from "@/lib/xmpp-client";
+
+const SOURCE_ICONS = {
+  mood: Smile,
+  activity: Briefcase,
+  tune: Music,
+  avatar: User,
+  vcard: IdCard,
+} as const;
+
+const SOURCE_LABELS: Record<FeedSourceKind, string> = {
+  mood: "Mood update",
+  activity: "Activity update",
+  tune: "Now listening",
+  avatar: "Avatar update",
+  vcard: "Profile update",
+};
+
+function iconFor(source: FeedSourceKind | undefined) {
+  return source ? SOURCE_ICONS[source] : null;
+}
+
+function labelFor(source: FeedSourceKind | undefined): string {
+  return source ? SOURCE_LABELS[source] : "";
+}
 
 interface FeedPaneProps {
   entries: readonly FeedEntry[];
@@ -115,7 +148,15 @@ function submit() {
             </div>
           </header>
           <h2 v-if="entry.title" class="type-control font-semibold text-foreground">{{ entry.title }}</h2>
-          <p class="whitespace-pre-wrap break-words text-sm text-foreground">{{ entry.body }}</p>
+          <p class="flex items-start gap-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
+            <component
+              :is="iconFor(entry.source)"
+              v-if="entry.source"
+              class="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+              :aria-label="labelFor(entry.source)"
+            />
+            <span>{{ entry.body }}</span>
+          </p>
           <a
             v-if="entry.link"
             :href="entry.link"

--- a/chat/src/lib/xmpp/feed-types.ts
+++ b/chat/src/lib/xmpp/feed-types.ts
@@ -4,6 +4,13 @@
  * (the snake_case-to-camelCase boundary) and the codec helper.
  */
 
+/**
+ * Discriminator for PEP-bridged feed entries — present only when the
+ * server side `pep_feed_bridge` shadow-published this entry. Manual
+ * posts leave `source` undefined.
+ */
+export type FeedSourceKind = "mood" | "activity" | "tune" | "avatar" | "vcard";
+
 export interface FeedEntry {
   /** Pubsub item id assigned by the publisher (UUID). */
   id: string;
@@ -14,6 +21,8 @@ export interface FeedEntry {
   /** Epoch ms; absent when the publisher omitted `<published/>`. */
   publishedMs?: number;
   link?: string;
+  /** PEP-bridge kind; undefined for manual posts. */
+  source?: FeedSourceKind;
 }
 
 export interface FeedPostInput {
@@ -32,10 +41,30 @@ export interface WasmFeedEntry {
   /** RFC3339 string or null. */
   published?: string | null;
   link?: string | null;
+  /** PEP-bridge source kind, set only on bridged entries. */
+  source?: string | null;
+}
+
+const KNOWN_SOURCE_KINDS: ReadonlySet<FeedSourceKind> = new Set([
+  "mood",
+  "activity",
+  "tune",
+  "avatar",
+  "vcard",
+]);
+
+function coerceSource(raw: string | null | undefined): FeedSourceKind | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  return KNOWN_SOURCE_KINDS.has(raw as FeedSourceKind)
+    ? (raw as FeedSourceKind)
+    : undefined;
 }
 
 export function feedEntryFromWasm(entry: WasmFeedEntry): FeedEntry {
   const publishedMs = entry.published ? Date.parse(entry.published) : undefined;
+  const source = coerceSource(entry.source);
   return {
     id: entry.id,
     body: entry.body,
@@ -43,5 +72,6 @@ export function feedEntryFromWasm(entry: WasmFeedEntry): FeedEntry {
     ...(entry.author ? { author: entry.author } : {}),
     ...(typeof publishedMs === "number" && Number.isFinite(publishedMs) ? { publishedMs } : {}),
     ...(entry.link ? { link: entry.link } : {}),
+    ...(source ? { source } : {}),
   };
 }

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -10,7 +10,7 @@ export {
 } from "./jid";
 export type { OutboundFileAttachment } from "./send-types";
 export type { InboxEntry } from "./inbox-types";
-export type { FeedEntry, FeedPostInput } from "./feed-types";
+export type { FeedEntry, FeedPostInput, FeedSourceKind } from "./feed-types";
 export type { Story, StoryPostInput } from "./story-types";
 export { isStoryActive } from "./story-types";
 export type {

--- a/chat/tests/feed-types.test.ts
+++ b/chat/tests/feed-types.test.ts
@@ -1,0 +1,57 @@
+// Codec round-trip for the wasm → TS feed entry boundary, focused on
+// the PEP-bridge `source` discriminator added in the PEP → community
+// feed bridge. Manual posts must round-trip without a `source` field;
+// bridged entries must carry the kind through; unknown kinds must be
+// silently dropped (forward-compat for new bridge kinds the server
+// may emit before the client knows about them).
+
+import { describe, expect, test } from "bun:test";
+import { feedEntryFromWasm, type WasmFeedEntry } from "@/lib/xmpp/feed-types";
+
+describe("feedEntryFromWasm", () => {
+  test("manual post round-trips without a source field", () => {
+    const wasm: WasmFeedEntry = {
+      id: "post-1",
+      body: "Hello world",
+      author: "alice@localhost",
+      published: "2026-05-16T12:00:00Z",
+    };
+    const entry = feedEntryFromWasm(wasm);
+    expect(entry.id).toBe("post-1");
+    expect(entry.body).toBe("Hello world");
+    expect(entry.author).toBe("alice@localhost");
+    expect(entry.publishedMs).toBe(Date.parse("2026-05-16T12:00:00Z"));
+    expect(entry.source).toBeUndefined();
+  });
+
+  test("bridged entry surfaces the source kind", () => {
+    for (const kind of ["mood", "activity", "tune", "avatar", "vcard"] as const) {
+      const wasm: WasmFeedEntry = {
+        id: `bridged-${kind}`,
+        body: "summary",
+        author: "alice@localhost",
+        source: kind,
+      };
+      expect(feedEntryFromWasm(wasm).source).toBe(kind);
+    }
+  });
+
+  test("unknown source kind is dropped (forward-compat)", () => {
+    const wasm: WasmFeedEntry = {
+      id: "bridged-future",
+      body: "summary",
+      author: "alice@localhost",
+      source: "telemetry",
+    };
+    expect(feedEntryFromWasm(wasm).source).toBeUndefined();
+  });
+
+  test("null source is treated as absent", () => {
+    const wasm: WasmFeedEntry = {
+      id: "post-null",
+      body: "summary",
+      source: null,
+    };
+    expect(feedEntryFromWasm(wasm).source).toBeUndefined();
+  });
+});

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -7,6 +7,7 @@ pub mod inbox;
 pub mod messages;
 pub mod notification_settings_projection;
 pub mod pending_delivery;
+pub mod pep_feed_bridge;
 pub mod permissions;
 pub mod profile;
 pub mod pubsub;

--- a/server/crates/waddle-server/src/pep_feed_bridge.rs
+++ b/server/crates/waddle-server/src/pep_feed_bridge.rs
@@ -1,0 +1,510 @@
+//! PEP → community feed bridge.
+//!
+//! Observes successful PEP publishes (mood / activity / tune /
+//! avatar / vCard4) and shadow-publishes a typed feed entry to
+//! `urn:xmpp:pubsub-social-feed:0` on the community service so the
+//! Feed pane surfaces user activity automatically alongside manual
+//! posts.
+//!
+//! ## Design
+//!
+//! - Bridge entries are published as the community service itself
+//!   (no `publisher` JID on the wire) so the originating user
+//!   doesn't need Publisher affiliation on the community node.
+//!   The entry's `<author>` field carries their bare JID for chat-
+//!   side attribution.
+//! - A `<source xmlns='urn:waddle:feed-source:0' kind='...'/>`
+//!   typed child distinguishes bridged entries from manual posts so
+//!   the chat can render a kind-icon (mood / activity / tune /
+//!   avatar / vcard).
+//! - Per-(user, kind) throttle suppresses high-cadence updates
+//!   (tune in particular). Re-publishes that produce the same
+//!   summary string are also suppressed.
+//! - `WADDLE_PEP_FEED_BRIDGE_ENABLED=0` disables the bridge without
+//!   a redeploy.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use jid::BareJid;
+use minidom::Element;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+use tracing::{debug, warn};
+use uuid::Uuid;
+use waddle_xmpp::pubsub::{PubSubItem, PubSubStorage};
+
+const NS_MOOD: &str = "http://jabber.org/protocol/mood";
+const NS_ACTIVITY: &str = "http://jabber.org/protocol/activity";
+const NS_TUNE: &str = "http://jabber.org/protocol/tune";
+const NS_AVATAR_METADATA: &str = "urn:xmpp:avatar:metadata";
+const NS_VCARD4: &str = "urn:ietf:params:xml:ns:vcard-4.0";
+
+const NS_FEED_SOURCE: &str = "urn:waddle:feed-source:0";
+
+const COOLDOWN_DEFAULT: Duration = Duration::from_secs(5 * 60);
+const COOLDOWN_TUNE: Duration = Duration::from_secs(30 * 60);
+
+const FEATURE_ENV: &str = "WADDLE_PEP_FEED_BRIDGE_ENABLED";
+
+/// Which PEP kind a bridged entry summarises. Matches the
+/// `<source kind=.../>` attribute the chat reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PepKind {
+    Mood,
+    Activity,
+    Tune,
+    Avatar,
+    VCard,
+}
+
+impl PepKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Mood => "mood",
+            Self::Activity => "activity",
+            Self::Tune => "tune",
+            Self::Avatar => "avatar",
+            Self::VCard => "vcard",
+        }
+    }
+
+    fn cooldown(self) -> Duration {
+        match self {
+            Self::Tune => COOLDOWN_TUNE,
+            _ => COOLDOWN_DEFAULT,
+        }
+    }
+
+    /// Map a PEP node namespace to a `PepKind`, or `None` when the
+    /// node is not a PEP we bridge.
+    pub fn from_node(node: &str) -> Option<Self> {
+        match node {
+            NS_MOOD => Some(Self::Mood),
+            NS_ACTIVITY => Some(Self::Activity),
+            NS_TUNE => Some(Self::Tune),
+            NS_AVATAR_METADATA => Some(Self::Avatar),
+            NS_VCARD4 => Some(Self::VCard),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ThrottleSlot {
+    last_at: Instant,
+    last_summary: String,
+}
+
+/// Bridge state shared across all PEP publishes. Holds throttle
+/// state per-(user, kind) so a rapid-fire publisher (e.g. Tune
+/// updating every track) doesn't spam the community feed.
+pub struct PepFeedBridge {
+    enabled: bool,
+    throttle: Mutex<HashMap<(BareJid, PepKind), ThrottleSlot>>,
+}
+
+impl PepFeedBridge {
+    /// Construct a new bridge. Reads `WADDLE_PEP_FEED_BRIDGE_ENABLED`
+    /// for the on/off flag (defaults to enabled).
+    pub fn new() -> Self {
+        let enabled = std::env::var(FEATURE_ENV)
+            .map(|v| !matches!(v.trim(), "0" | "false" | "no" | "off"))
+            .unwrap_or(true);
+        Self {
+            enabled,
+            throttle: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Observe a PEP publish. Returns immediately if the bridge is
+    /// disabled, the node isn't a bridged PEP, or the throttle
+    /// suppresses this update. Otherwise builds and publishes the
+    /// feed entry, returning the published item id on success.
+    ///
+    /// Failures are logged at WARN and swallowed — a PEP publish
+    /// must not fail because the bridge couldn't post.
+    pub async fn observe<S: PubSubStorage + ?Sized>(
+        &self,
+        storage: &Arc<S>,
+        community_jid: &BareJid,
+        author_jid: &BareJid,
+        node: &str,
+        published: &PubSubItem,
+    ) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+        let kind = PepKind::from_node(node)?;
+        let summary = render_summary(kind, published)?;
+        if !self.admit(author_jid.clone(), kind, &summary).await {
+            debug!(
+                author = %author_jid,
+                kind = ?kind,
+                "PEP→feed bridge: suppressed by throttle"
+            );
+            return None;
+        }
+
+        let item_id = format!("pep-{}-{}", kind.as_str(), Uuid::new_v4());
+        let entry = build_bridge_entry(&item_id, kind, author_jid, &summary);
+        let item = PubSubItem {
+            id: Some(item_id.clone()),
+            publisher: None,
+            payload: Some(entry),
+        };
+
+        match storage
+            .publish_item(
+                community_jid,
+                waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED,
+                &item,
+                None,
+                false,
+            )
+            .await
+        {
+            Ok(result) => {
+                debug!(
+                    author = %author_jid,
+                    kind = ?kind,
+                    item_id = %result.item_id,
+                    "PEP→feed bridge: published"
+                );
+                Some(result.item_id)
+            }
+            Err(error) => {
+                warn!(
+                    author = %author_jid,
+                    kind = ?kind,
+                    error = %error,
+                    "PEP→feed bridge: publish failed"
+                );
+                None
+            }
+        }
+    }
+
+    /// Return `true` when this (author, kind, summary) should be
+    /// bridged; `false` to suppress. Records the new state when
+    /// admitting.
+    async fn admit(&self, author: BareJid, kind: PepKind, summary: &str) -> bool {
+        let mut guard = self.throttle.lock().await;
+        let now = Instant::now();
+        let cooldown = kind.cooldown();
+        match guard.get(&(author.clone(), kind)) {
+            Some(slot) if slot.last_summary == summary => {
+                // Identical summary — suppress regardless of cooldown
+                // so back-to-back re-publishes (avatar republish on
+                // login etc.) don't generate duplicate entries.
+                false
+            }
+            Some(slot) if now.duration_since(slot.last_at) < cooldown => false,
+            _ => {
+                guard.insert(
+                    (author, kind),
+                    ThrottleSlot {
+                        last_at: now,
+                        last_summary: summary.to_string(),
+                    },
+                );
+                true
+            }
+        }
+    }
+}
+
+impl Default for PepFeedBridge {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Summary rendering ───────────────────────────────────────────────
+
+fn render_summary(kind: PepKind, item: &PubSubItem) -> Option<String> {
+    let payload = item.payload.as_ref()?;
+    match kind {
+        PepKind::Mood => render_mood(payload),
+        PepKind::Activity => render_activity(payload),
+        PepKind::Tune => render_tune(payload),
+        PepKind::Avatar => render_avatar(payload),
+        PepKind::VCard => render_vcard(payload),
+    }
+}
+
+fn render_mood(payload: &Element) -> Option<String> {
+    let mood = waddle_xmpp::xep::xep0107::parse_mood_element(payload)
+        .ok()
+        .flatten()?;
+    Some(format!("is feeling {}", mood.kind.as_element_name()))
+}
+
+fn render_activity(payload: &Element) -> Option<String> {
+    let activity = waddle_xmpp::xep::xep0108::parse_activity_element(payload)
+        .ok()
+        .flatten()?;
+    let general = activity.general.as_element_name().replace('_', " ");
+    Some(format!("is {general}"))
+}
+
+fn render_tune(payload: &Element) -> Option<String> {
+    let tune = waddle_xmpp::xep::xep0118::parse_tune_element(payload).ok()?;
+    match (tune.title.as_deref(), tune.artist.as_deref()) {
+        (Some(title), Some(artist)) => Some(format!("is listening to {title} by {artist}")),
+        (Some(title), None) => Some(format!("is listening to {title}")),
+        (None, Some(artist)) => Some(format!("is listening to {artist}")),
+        (None, None) => None,
+    }
+}
+
+fn render_avatar(payload: &Element) -> Option<String> {
+    let info = waddle_xmpp::xep::xep0084::parse_avatar_metadata(payload)?;
+    Some(format!(
+        "updated their avatar ({})",
+        &info.id[..8.min(info.id.len())]
+    ))
+}
+
+fn render_vcard(payload: &Element) -> Option<String> {
+    let vcard = waddle_xmpp::xep::xep0292::parse_vcard4(payload);
+    if vcard.full_name.is_none()
+        && vcard.nickname.is_none()
+        && vcard.note.is_none()
+        && vcard.org.is_none()
+        && vcard.title.is_none()
+    {
+        return None;
+    }
+    Some("updated their profile".to_string())
+}
+
+// ── Feed-entry builder ──────────────────────────────────────────────
+
+fn build_bridge_entry(item_id: &str, kind: PepKind, author: &BareJid, body: &str) -> Element {
+    let mut entry = Element::builder("entry", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
+
+    let mut id_el = Element::builder("id", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
+    id_el.append_text_node(item_id);
+    entry.append_child(id_el);
+
+    let mut author_el =
+        Element::builder("author", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
+    author_el.append_text_node(author.to_string());
+    entry.append_child(author_el);
+
+    let mut body_el = Element::builder("body", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
+    body_el.append_text_node(body);
+    entry.append_child(body_el);
+
+    let mut published_el =
+        Element::builder("published", waddle_xmpp_core::xep0472::NS_SOCIAL_FEED).build();
+    published_el.append_text_node(chrono::Utc::now().to_rfc3339());
+    entry.append_child(published_el);
+
+    let source = Element::builder("source", NS_FEED_SOURCE)
+        .attr("kind", kind.as_str())
+        .build();
+    entry.append_child(source);
+
+    entry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use minidom::Element;
+
+    fn bare(s: &str) -> BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn payload(xml: &str) -> PubSubItem {
+        let element: Element = xml.parse().expect("valid xml");
+        PubSubItem {
+            id: Some("test".to_string()),
+            publisher: None,
+            payload: Some(element),
+        }
+    }
+
+    #[test]
+    fn mood_summary_renders_kind_name() {
+        let item = payload("<mood xmlns='http://jabber.org/protocol/mood'><happy/></mood>");
+        let summary = render_summary(PepKind::Mood, &item).expect("renders");
+        assert_eq!(summary, "is feeling happy");
+    }
+
+    #[test]
+    fn activity_summary_uses_general_kind() {
+        let item =
+            payload("<activity xmlns='http://jabber.org/protocol/activity'><working/></activity>");
+        let summary = render_summary(PepKind::Activity, &item).expect("renders");
+        assert_eq!(summary, "is working");
+    }
+
+    #[test]
+    fn activity_summary_humanises_underscored_kinds() {
+        let item = payload(
+            "<activity xmlns='http://jabber.org/protocol/activity'><doing_chores/></activity>",
+        );
+        let summary = render_summary(PepKind::Activity, &item).expect("renders");
+        assert_eq!(summary, "is doing chores");
+    }
+
+    #[test]
+    fn tune_summary_includes_title_and_artist() {
+        let item = payload(
+            "<tune xmlns='http://jabber.org/protocol/tune'>\
+                <title>Africa</title>\
+                <artist>Toto</artist>\
+            </tune>",
+        );
+        let summary = render_summary(PepKind::Tune, &item).expect("renders");
+        assert_eq!(summary, "is listening to Africa by Toto");
+    }
+
+    #[test]
+    fn tune_summary_renders_with_title_only() {
+        let item =
+            payload("<tune xmlns='http://jabber.org/protocol/tune'><title>Africa</title></tune>");
+        let summary = render_summary(PepKind::Tune, &item).expect("renders");
+        assert_eq!(summary, "is listening to Africa");
+    }
+
+    #[test]
+    fn tune_summary_empty_when_no_track_info() {
+        let item =
+            payload("<tune xmlns='http://jabber.org/protocol/tune'><length>180</length></tune>");
+        assert_eq!(render_summary(PepKind::Tune, &item), None);
+    }
+
+    #[test]
+    fn avatar_summary_short_hashes_id() {
+        let item = payload(
+            "<metadata xmlns='urn:xmpp:avatar:metadata'>\
+                <info id='abcdef1234567890' bytes='100' type='image/png'/>\
+            </metadata>",
+        );
+        let summary = render_summary(PepKind::Avatar, &item).expect("renders");
+        assert_eq!(summary, "updated their avatar (abcdef12)");
+    }
+
+    #[test]
+    fn vcard_summary_requires_a_meaningful_field() {
+        let empty = payload("<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'/>");
+        assert_eq!(render_summary(PepKind::VCard, &empty), None);
+
+        let with_name = payload(
+            "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                <fn><text>Alice</text></fn>\
+            </vcard>",
+        );
+        let summary = render_summary(PepKind::VCard, &with_name).expect("renders");
+        assert_eq!(summary, "updated their profile");
+    }
+
+    #[tokio::test]
+    async fn throttle_suppresses_identical_summary_back_to_back() {
+        let bridge = PepFeedBridge {
+            enabled: true,
+            throttle: Mutex::new(HashMap::new()),
+        };
+        let author = bare("alice@example.com");
+        assert!(
+            bridge
+                .admit(author.clone(), PepKind::Mood, "is feeling happy")
+                .await
+        );
+        // Same summary — suppressed even though cooldown hasn't fired.
+        assert!(
+            !bridge
+                .admit(author.clone(), PepKind::Mood, "is feeling happy")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn throttle_admits_different_summary_after_first() {
+        let bridge = PepFeedBridge {
+            enabled: true,
+            throttle: Mutex::new(HashMap::new()),
+        };
+        let author = bare("alice@example.com");
+        assert!(
+            bridge
+                .admit(author.clone(), PepKind::Mood, "is feeling happy")
+                .await
+        );
+        // Different summary within cooldown — still suppressed (cooldown gates per-kind).
+        assert!(
+            !bridge
+                .admit(author.clone(), PepKind::Mood, "is feeling sad")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn throttle_isolates_per_user_and_per_kind() {
+        let bridge = PepFeedBridge {
+            enabled: true,
+            throttle: Mutex::new(HashMap::new()),
+        };
+        let alice = bare("alice@example.com");
+        let bob = bare("bob@example.com");
+        assert!(
+            bridge
+                .admit(alice.clone(), PepKind::Mood, "is feeling happy")
+                .await
+        );
+        // Different user — admitted.
+        assert!(
+            bridge
+                .admit(bob.clone(), PepKind::Mood, "is feeling happy")
+                .await
+        );
+        // Same user, different kind — admitted.
+        assert!(
+            bridge
+                .admit(alice.clone(), PepKind::Tune, "is listening to X")
+                .await
+        );
+    }
+
+    #[test]
+    fn from_node_recognises_all_bridged_namespaces() {
+        assert_eq!(PepKind::from_node(NS_MOOD), Some(PepKind::Mood));
+        assert_eq!(PepKind::from_node(NS_ACTIVITY), Some(PepKind::Activity));
+        assert_eq!(PepKind::from_node(NS_TUNE), Some(PepKind::Tune));
+        assert_eq!(
+            PepKind::from_node(NS_AVATAR_METADATA),
+            Some(PepKind::Avatar)
+        );
+        assert_eq!(PepKind::from_node(NS_VCARD4), Some(PepKind::VCard));
+        assert_eq!(PepKind::from_node("urn:xmpp:avatar:data"), None);
+    }
+
+    #[test]
+    fn bridge_entry_carries_author_body_and_source_kind() {
+        let entry = build_bridge_entry(
+            "pep-1",
+            PepKind::Mood,
+            &bare("alice@example.com"),
+            "is feeling happy",
+        );
+        let xml = String::from(&entry);
+        assert!(
+            xml.contains("<author>alice@example.com</author>"),
+            "author missing: {xml}"
+        );
+        assert!(
+            xml.contains("<body>is feeling happy</body>"),
+            "body missing: {xml}"
+        );
+        assert!(
+            xml.contains("kind=\"mood\"") || xml.contains("kind='mood'"),
+            "source kind missing: {xml}"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -396,6 +396,7 @@ async fn create_websocket_state(
                 caps_resolver,
                 avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                 profile_publish_tracker: tokio_util::task::TaskTracker::new(),
+                pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
             provider_ingress,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -176,6 +176,32 @@ pub(super) async fn handle_pubsub_iq(
                             },
                         )
                         .await;
+                        // PEP → community feed bridge. Shadow-publish
+                        // a typed feed entry on `community.<domain>`
+                        // for mood / activity / tune / avatar /
+                        // vCard4 PEP updates so the Feed pane
+                        // surfaces user activity automatically.
+                        // Throttled per-(user, kind); failure-silent
+                        // (a bridge error MUST NOT fail the user's
+                        // PEP publish).
+                        if is_pep && target_jid == user_jid {
+                            if let Ok(community_jid) =
+                                state.deps.service_domains.community.parse::<BareJid>()
+                            {
+                                let _ = state
+                                    .deps
+                                    .protocol
+                                    .pep_feed_bridge
+                                    .observe(
+                                        &state.deps.protocol.pubsub_storage,
+                                        &community_jid,
+                                        &user_jid,
+                                        &node,
+                                        &item,
+                                    )
+                                    .await;
+                            }
+                        }
                         // Provenance flip — runs while holding the
                         // per-JID lock above so an OIDC reconcile
                         // either sees the new `'user'` flag or hasn't

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -124,6 +124,12 @@ pub struct ProtocolServices {
     /// populated on detach and removed on take/resume (or swept when the
     /// corresponding SM session expires).
     pub resumable_sessions: Arc<dashmap::DashMap<String, Session>>,
+    /// PEP → community feed bridge. Observes successful PEP publishes
+    /// (mood / activity / tune / avatar / vCard4) and shadow-publishes
+    /// a typed feed entry on `community.<domain>` so the community
+    /// Feed pane surfaces user activity automatically. Holds per-
+    /// (user, kind) throttle state.
+    pub pep_feed_bridge: Arc<crate::pep_feed_bridge::PepFeedBridge>,
 }
 
 /// Per-connection mutable state for a single WebSocket XMPP transport.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -150,6 +150,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     ),
                     avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                     profile_publish_tracker: tokio_util::task::TaskTracker::new(),
+                    pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
                 },
                 occupant_id_secret: OccupantIdSecret::new(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),

--- a/server/crates/waddle-server/tests/pep_feed_bridge_ws.rs
+++ b/server/crates/waddle-server/tests/pep_feed_bridge_ws.rs
@@ -1,0 +1,171 @@
+//! PEP → community feed bridge integration tests over WebSocket.
+//!
+//! Publishes a PEP mood update from a regular user and verifies that
+//! a typed feed entry appears on the community feed node, carrying
+//! the author's bare JID and a `<source kind='mood'/>` typed child.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+const COMMUNITY_JID: &str = "community.localhost";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("pep-bridge-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+#[tokio::test]
+async fn pep_mood_publish_emits_typed_feed_entry() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    // User publishes a mood to their PEP service (self-targeted: no
+    // `to` attribute means the server treats it as PEP on the bound
+    // user JID).
+    client
+        .send(
+            r#"<iq type="set" id="pep-mood">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="http://jabber.org/protocol/mood">
+                  <item>
+                    <mood xmlns="http://jabber.org/protocol/mood">
+                      <happy/>
+                    </mood>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#,
+        )
+        .await
+        .expect("send PEP publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains("pep-mood"))
+        .await
+        .expect("PEP publish result");
+    assert!(
+        publish_result.contains("type=\"result\""),
+        "PEP publish must succeed: {publish_result}"
+    );
+
+    // Query the community feed node — the bridge should have
+    // shadow-published an entry with author=admin and source kind=mood.
+    client
+        .send(&format!(
+            r#"<iq type="get" id="feed-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("feed-items") && frame.contains("<entry"))
+        .await
+        .expect("items response");
+
+    assert!(
+        items_response.contains("<author>admin@localhost</author>"),
+        "bridged entry must carry author bare JID: {items_response}"
+    );
+    assert!(
+        items_response.contains("<body>is feeling happy</body>"),
+        "bridged entry must carry the rendered summary: {items_response}"
+    );
+    assert!(
+        items_response.contains("urn:waddle:feed-source:0"),
+        "bridged entry must declare the source namespace: {items_response}"
+    );
+    assert!(
+        items_response.contains("kind=\"mood\"") || items_response.contains("kind='mood'"),
+        "bridged entry must tag the source kind: {items_response}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn pep_mood_publish_is_throttled_on_identical_repeat() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    // First publish — should bridge.
+    client
+        .send(
+            r#"<iq type="set" id="pep-mood-1">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="http://jabber.org/protocol/mood">
+                  <item>
+                    <mood xmlns="http://jabber.org/protocol/mood"><happy/></mood>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#,
+        )
+        .await
+        .expect("send first PEP publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains("pep-mood-1"))
+        .await
+        .expect("first publish result");
+
+    // Identical second publish within the cooldown — should NOT
+    // generate a second feed entry.
+    client
+        .send(
+            r#"<iq type="set" id="pep-mood-2">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="http://jabber.org/protocol/mood">
+                  <item>
+                    <mood xmlns="http://jabber.org/protocol/mood"><happy/></mood>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#,
+        )
+        .await
+        .expect("send second PEP publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains("pep-mood-2"))
+        .await
+        .expect("second publish result");
+
+    // Items query — should see exactly one bridged entry.
+    client
+        .send(&format!(
+            r#"<iq type="get" id="feed-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("feed-items"))
+        .await
+        .expect("items response");
+
+    // Count the bridged entries (items with our source-kind tag).
+    let kind_hits = items_response.matches("kind=\"mood\"").count()
+        + items_response.matches("kind='mood'").count();
+    assert_eq!(
+        kind_hits, 1,
+        "exactly one bridged entry expected — throttle must suppress identical repeats: {items_response}"
+    );
+
+    let _ = client.close().await;
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_social_feed.rs
@@ -20,19 +20,28 @@ use super::{js_error, send_iq_command, to_js_value, WaddleClient};
 use crate::NS_CLIENT;
 
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+/// Waddle-namespaced typed child on bridged feed entries (PEP →
+/// feed). Carries `kind="mood"|"activity"|"tune"|"avatar"|"vcard"`
+/// so the chat can render a kind-icon next to bridged posts.
+const NS_FEED_SOURCE: &str = "urn:waddle:feed-source:0";
 
 /// JS-facing snapshot of a XEP-0472 feed entry. Mirrors `FeedEntry`
 /// but with stringly-typed `published` so it serialises cleanly
-/// across the wasm boundary.
+/// across the wasm boundary, plus a derived `source` field that
+/// captures the PEP-bridge kind (when present) so the chat can
+/// distinguish bridged entries from manual posts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct JsFeedEntry {
     pub id: String,
     pub title: Option<String>,
     pub body: String,
     pub author: Option<String>,
-    /// RFC3339 string (or `None` if absent).
     pub published: Option<String>,
     pub link: Option<String>,
+    /// PEP-bridge source kind from the `<source xmlns='urn:waddle:
+    /// feed-source:0' kind='...'/>` child. Present only on bridged
+    /// entries; manual posts leave this `None`.
+    pub source: Option<String>,
 }
 
 impl From<FeedEntry> for JsFeedEntry {
@@ -44,8 +53,20 @@ impl From<FeedEntry> for JsFeedEntry {
             author: entry.author,
             published: entry.published.map(|ts| ts.to_rfc3339()),
             link: entry.link,
+            source: None,
         }
     }
+}
+
+/// Extract the PEP-bridge source kind from the raw `<entry>` element
+/// (`<source xmlns='urn:waddle:feed-source:0' kind='...'/>`) when
+/// present. Returns `None` for manual posts that omit the child.
+fn extract_source_kind(entry_el: &Element) -> Option<String> {
+    entry_el
+        .children()
+        .find(|c| c.name() == "source" && c.ns() == NS_FEED_SOURCE)
+        .and_then(|c| c.attr("kind"))
+        .map(str::to_string)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -111,7 +132,12 @@ fn parse_feed_items_result(iq: &Element) -> Vec<JsFeedEntry> {
             let entry_el = item
                 .children()
                 .find(|child| child.name() == "entry" && child.ns() == NS_SOCIAL_FEED)?;
-            parse_feed_entry(item_id, entry_el).map(JsFeedEntry::from)
+            let source = extract_source_kind(entry_el);
+            parse_feed_entry(item_id, entry_el).map(|entry| {
+                let mut js = JsFeedEntry::from(entry);
+                js.source = source;
+                js
+            })
         })
         .collect()
 }
@@ -167,6 +193,7 @@ impl WaddleClient {
                 author: feed_entry.author,
                 published: Some(published.to_rfc3339()),
                 link: feed_entry.link,
+                source: None,
             };
             to_js_value(&js_entry)
         })

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8vp0nr";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8vp0nr";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8vp0nr";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8x9nci";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8vp0nr";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";


### PR DESCRIPTION
## Summary

When a user publishes a PEP update for **mood**, **activity**, **tune**, **avatar**, or **vCard4**, the server now shadow-publishes a typed feed entry on `urn:xmpp:pubsub-social-feed:0` hosted by `community.<domain>`. The update surfaces in the community Feed pane alongside manual posts, with a small icon distinguishing bridged entries from human-authored ones.

Closes the first of three follow-ups from #651 ("PEP → feed bridge", "RECURRENCE-ID overrides", "RSVP via ATTENDEE").

## What's in this PR

**Server (`crates/waddle-server/src/pep_feed_bridge.rs`, new)**
- `PepKind` enum (`Mood`/`Activity`/`Tune`/`Avatar`/`VCard`) keyed off PEP namespaces.
- `PepFeedBridge` owns a per-(user, kind) throttle map: Tune 30 min, others 5 min, with identical-summary suppression to deduplicate idempotent re-publishes.
- Bridged entries are built as XEP-0472 `<entry/>` payloads (typed via `minidom::Element`, no string concatenation) and shadow-published as the community service so users don't need Publisher affiliation.
- Typed `<source xmlns='urn:waddle:feed-source:0' kind='mood|activity|tune|avatar|vcard'/>` child distinguishes bridged entries on the wire.
- Gated by `WADDLE_PEP_FEED_BRIDGE_ENABLED` (default on).

**Server hook (`pubsub_dispatch.rs`)** — after a successful PEP publish + fan-out, calls `pep_feed_bridge.observe(...)` against the community service JID.

**Wasm bridge (`client_social_feed.rs`)** — extracts the `<source>` child from the raw entry and surfaces it as `JsFeedEntry.source`.

**Chat**
- `FeedEntry` extended with optional `source?: FeedSourceKind` (`"mood" | "activity" | "tune" | "avatar" | "vcard"`).
- `feedEntryFromWasm` codec parses and validates the kind (unknown kinds dropped for forward-compat).
- `FeedPane.vue` renders a lucide-vue-next icon (Smile/Briefcase/Music/User/IdCard) inline with bridged post bodies.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Unit (Rust) | `pep_feed_bridge.rs` | 13 tests: summary rendering per kind, throttle suppression, per-(user, kind) isolation, entry XML shape |
| Integration (WS) | `tests/pep_feed_bridge_ws.rs` | mood-publish → feed-entry round-trip; identical-repeat throttled to one entry |
| Codec (TS) | `chat/tests/feed-types.test.ts` | known kinds round-trip; unknown kind dropped; null source treated as absent |

## What's NOT in this PR

- RSVP via `ATTENDEE` (PR B in `/Users/rawkode/.claude/plans/greedy-plotting-widget.md`)
- `RECURRENCE-ID` overrides + `EXDATE` (PR C)

## Verification checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p waddle-server --lib pep_feed_bridge` — 13 pass
- [x] `cargo test -p waddle-server --test pep_feed_bridge_ws` — 2 pass
- [x] `bunx astro check` — 0 errors / 0 warnings / 0 hints
- [x] `bun test tests/feed-types.test.ts` — 4 pass
- [x] `bun run lint` (knip) — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.