### PR TITLE
feat(server): RSVP via xCal ATTENDEE (sibling pubsub items)

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -140,6 +140,18 @@ const contentPaneClass = computed(() => {
   return activeRightPanel.value ? "chat-content-pane--desktop-split" : "";
 });
 
+function onCommunityRsvp(
+  event: { uid: string },
+  partstat: "ACCEPTED" | "DECLINED" | "TENTATIVE" | "NEEDS-ACTION",
+) {
+  const session = connectionStore.session;
+  if (!session) return;
+  const bareJid = session.jid.split("/")[0] ?? session.jid;
+  const localpart = bareJid.split("@")[0];
+  if (!localpart) return;
+  void communityEvents.rsvp(event.uid, localpart, bareJid, partstat);
+}
+
 function selectCurrentChannelExtensionRoute(route: DiscoveredExtensionRoute) {
   const channel = waddles.currentChannel.value;
   if (!channel) return;
@@ -279,6 +291,7 @@ function onSelectChannelFromSidebar(id: string) {
         :self-jid="connectionStore.session?.jid ?? null"
         @refresh="communityEvents.refresh()"
         @post="(input) => communityEvents.post(input)"
+        @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
       />
       <UserSettingsPage
         v-else-if="ui.activePage.value === 'settings' && connectionStore.session"

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -2,7 +2,14 @@
 import { computed, ref } from "vue";
 import { CalendarDays, Plus, RefreshCw, Repeat, X } from "lucide-vue-next";
 import RecurrencePicker from "@/components/community/RecurrencePicker.vue";
-import type { CommunityEvent, CommunityEventInput, Rrule, Weekday } from "@/lib/xmpp-client";
+import type {
+  Attendee,
+  CommunityEvent,
+  CommunityEventInput,
+  PartStat,
+  Rrule,
+  Weekday,
+} from "@/lib/xmpp-client";
 
 interface EventsPaneProps {
   events: readonly CommunityEvent[];
@@ -17,7 +24,41 @@ const props = defineProps<EventsPaneProps>();
 const emit = defineEmits<{
   refresh: [];
   post: [input: CommunityEventInput];
+  rsvp: [event: CommunityEvent, partstat: PartStat];
 }>();
+
+const selfBareJid = computed(() => {
+  const raw = props.selfJid;
+  return raw ? raw.split("/")[0] ?? raw : null;
+});
+
+const selfAttendeeUri = computed(() => {
+  const bare = selfBareJid.value;
+  return bare ? `xmpp:${bare}` : null;
+});
+
+function attendeesByPartstat(event: CommunityEvent): Record<PartStat, Attendee[]> {
+  const buckets: Record<PartStat, Attendee[]> = {
+    "ACCEPTED": [],
+    "DECLINED": [],
+    "TENTATIVE": [],
+    "NEEDS-ACTION": [],
+  };
+  for (const a of event.attendees ?? []) {
+    (buckets[a.partstat] ??= []).push(a);
+  }
+  return buckets;
+}
+
+function myPartstat(event: CommunityEvent): PartStat | null {
+  const uri = selfAttendeeUri.value;
+  if (!uri) return null;
+  return event.attendees?.find((a) => a.uri === uri)?.partstat ?? null;
+}
+
+function onRsvp(event: CommunityEvent, partstat: PartStat) {
+  emit("rsvp", event, partstat);
+}
 
 const composerOpen = ref(false);
 const summary = ref("");
@@ -233,6 +274,37 @@ function resetComposer() {
           <p v-if="event.organizer" class="type-caption text-muted-foreground">
             Organised by {{ authorLabel(event.organizer) }}
           </p>
+          <div v-if="selfBareJid" class="mt-1 flex flex-wrap items-center gap-1.5">
+            <button
+              type="button"
+              class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+              :class="myPartstat(event) === 'ACCEPTED'
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+              @click="onRsvp(event, 'ACCEPTED')"
+            >Going</button>
+            <button
+              type="button"
+              class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+              :class="myPartstat(event) === 'TENTATIVE'
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+              @click="onRsvp(event, 'TENTATIVE')"
+            >Maybe</button>
+            <button
+              type="button"
+              class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium transition-colors"
+              :class="myPartstat(event) === 'DECLINED'
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border bg-background text-muted-foreground hover:bg-muted/50 hover:text-foreground'"
+              @click="onRsvp(event, 'DECLINED')"
+            >Not going</button>
+            <span class="type-caption ml-1 text-muted-foreground">
+              {{ attendeesByPartstat(event)["ACCEPTED"].length }} going ·
+              {{ attendeesByPartstat(event)["TENTATIVE"].length }} maybe ·
+              {{ attendeesByPartstat(event)["DECLINED"].length }} not going
+            </span>
+          </div>
         </article>
         <p
           v-if="upcoming.length === 0 && !isLoading"

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -74,6 +74,7 @@ import {
   rruleToWasm,
   type CommunityEvent,
   type CommunityEventInput,
+  type PartStat,
   type WasmVEvent,
 } from "./event-types";
 import type { FetchInboxOptions, InboxEntry, InboxResult } from "./inbox-types";
@@ -981,6 +982,22 @@ export class BrowserXmppClient {
       throw new Error("xcal_publish returned no event");
     }
     return eventFromWasm(result);
+  }
+
+  /**
+   * Publish (or update) this session's RSVP for a calendar event.
+   * The server bridges the call to a sibling pubsub item; the chat
+   * folds it back into the master event on the next refresh.
+   */
+  async rsvpCommunityEvent(
+    communityJid: string,
+    masterUid: string,
+    selfLocalpart: string,
+    selfBareJid: string,
+    partstat: PartStat,
+  ): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    await xmpp.xcal_rsvp?.(communityJid, masterUid, selfLocalpart, selfBareJid, partstat);
   }
   async publishMood(mood: MoodPublication): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.publish_mood?.({ kind: mood.kind, ...(mood.text ? { text: mood.text } : {}) }); }
   async retractMood(): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.retract_mood?.(); }

--- a/chat/src/lib/xmpp/event-types.ts
+++ b/chat/src/lib/xmpp/event-types.ts
@@ -22,6 +22,17 @@ export interface Rrule {
   untilMs?: number;
 }
 
+/** RFC 5545 §3.2.12 participation status. */
+export type PartStat = "NEEDS-ACTION" | "ACCEPTED" | "DECLINED" | "TENTATIVE";
+
+export interface Attendee {
+  /** Typically `xmpp:user@example.com`. */
+  uri: string;
+  partstat: PartStat;
+  role?: string;
+  rsvp?: boolean;
+}
+
 export interface CommunityEvent {
   /** Pubsub item id (UUID). */
   id: string;
@@ -38,6 +49,12 @@ export interface CommunityEvent {
   /** Epoch ms. */
   dtendMs?: number;
   rrule?: Rrule;
+  /**
+   * RSVPs aggregated from sibling `<master-uid>-rsvp-<localpart>`
+   * pubsub items. Empty for events with no RSVPs yet. Keyed by
+   * attendee URI bare-JID at the chat layer to dedupe latest-wins.
+   */
+  attendees?: Attendee[];
 }
 
 export interface CommunityEventInput {
@@ -63,6 +80,13 @@ export interface WasmRrule {
   until?: string | null;
 }
 
+export interface WasmAttendee {
+  uri: string;
+  partstat: string;
+  role?: string | null;
+  rsvp?: boolean | null;
+}
+
 export interface WasmVEvent {
   id: string;
   uid: string;
@@ -74,6 +98,29 @@ export interface WasmVEvent {
   dtstart?: string | null;
   dtend?: string | null;
   rrule?: WasmRrule | null;
+  attendees?: WasmAttendee[] | null;
+}
+
+const PARTSTATS: ReadonlySet<PartStat> = new Set([
+  "NEEDS-ACTION",
+  "ACCEPTED",
+  "DECLINED",
+  "TENTATIVE",
+]);
+
+function isPartStat(value: string): value is PartStat {
+  return PARTSTATS.has(value as PartStat);
+}
+
+function attendeeFromWasm(wasm: WasmAttendee): Attendee | null {
+  if (!wasm.uri) return null;
+  const partstat: PartStat = isPartStat(wasm.partstat) ? wasm.partstat : "NEEDS-ACTION";
+  return {
+    uri: wasm.uri,
+    partstat,
+    ...(wasm.role ? { role: wasm.role } : {}),
+    ...(typeof wasm.rsvp === "boolean" ? { rsvp: wasm.rsvp } : {}),
+  };
 }
 
 function isFreq(value: string): value is Freq {
@@ -115,6 +162,9 @@ export function eventFromWasm(event: WasmVEvent): CommunityEvent {
   const dtstart = event.dtstart ? Date.parse(event.dtstart) : undefined;
   const dtend = event.dtend ? Date.parse(event.dtend) : undefined;
   const rrule = event.rrule ? rruleFromWasm(event.rrule) ?? undefined : undefined;
+  const attendees = (event.attendees ?? [])
+    .map(attendeeFromWasm)
+    .filter((a): a is Attendee => a !== null);
   return {
     id: event.id,
     uid: event.uid,
@@ -126,7 +176,58 @@ export function eventFromWasm(event: WasmVEvent): CommunityEvent {
     ...(typeof dtstart === "number" && Number.isFinite(dtstart) ? { dtstartMs: dtstart } : {}),
     ...(typeof dtend === "number" && Number.isFinite(dtend) ? { dtendMs: dtend } : {}),
     ...(rrule ? { rrule } : {}),
+    ...(attendees.length > 0 ? { attendees } : {}),
   };
+}
+
+function parseRsvpItemId(itemId: string): { masterUid: string; localpart: string } | null {
+  const idx = itemId.lastIndexOf("-rsvp-");
+  if (idx <= 0) return null;
+  const localpart = itemId.slice(idx + "-rsvp-".length);
+  if (!localpart) return null;
+  return { masterUid: itemId.slice(0, idx), localpart };
+}
+
+/**
+ * Group a flat item list (from `xcal_items`) into master events
+ * with their sibling RSVPs folded into the master's `attendees`.
+ * RSVP items override the master's own attendees on a per-URI basis
+ * (latest-wins by item dtstamp where available, else last seen).
+ */
+export function groupEventsWithRsvps(items: readonly CommunityEvent[]): CommunityEvent[] {
+  const masters = new Map<string, CommunityEvent>();
+  const rsvps = new Map<string, Map<string, Attendee>>();
+
+  for (const item of items) {
+    const parsed = parseRsvpItemId(item.id);
+    if (parsed) {
+      const single = item.attendees?.[0];
+      if (single) {
+        const bucket = rsvps.get(parsed.masterUid) ?? new Map<string, Attendee>();
+        bucket.set(single.uri, single);
+        rsvps.set(parsed.masterUid, bucket);
+      }
+      continue;
+    }
+    masters.set(item.uid, item);
+  }
+
+  const out: CommunityEvent[] = [];
+  for (const master of masters.values()) {
+    const merged = new Map<string, Attendee>();
+    for (const attendee of master.attendees ?? []) {
+      merged.set(attendee.uri, attendee);
+    }
+    for (const [uri, attendee] of rsvps.get(master.uid) ?? new Map()) {
+      merged.set(uri, attendee);
+    }
+    const attendees = [...merged.values()];
+    out.push({
+      ...master,
+      ...(attendees.length > 0 ? { attendees } : {}),
+    });
+  }
+  return out;
 }
 
 /** Sort events by upcoming-first, past events at the end newest-first. */

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -14,13 +14,15 @@ export type { FeedEntry, FeedPostInput, FeedSourceKind } from "./feed-types";
 export type { Story, StoryPostInput } from "./story-types";
 export { isStoryActive } from "./story-types";
 export type {
+  Attendee,
   CommunityEvent,
   CommunityEventInput,
   Freq,
+  PartStat,
   Rrule,
   Weekday,
 } from "./event-types";
-export { sortEventsUpcomingFirst } from "./event-types";
+export { groupEventsWithRsvps, sortEventsUpcomingFirst } from "./event-types";
 export type { UserPepProfile } from "./pep-types";
 export type {
   DmChatStateEvent,

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -12,10 +12,12 @@
  */
 import { computed, ref, type Ref } from "vue";
 import {
+  groupEventsWithRsvps,
   sortEventsUpcomingFirst,
   type BrowserXmppClient,
   type CommunityEvent,
   type CommunityEventInput,
+  type PartStat,
 } from "@/lib/xmpp-client";
 
 export function useCommunityEvents(
@@ -32,7 +34,9 @@ export function useCommunityEvents(
   const pageSize = options.pageSize ?? 200;
   let fetchRequestId = 0;
 
-  const sortedEvents = computed(() => sortEventsUpcomingFirst(events.value));
+  const sortedEvents = computed(() =>
+    sortEventsUpcomingFirst(groupEventsWithRsvps(events.value)),
+  );
 
   async function refresh(): Promise<boolean> {
     const client = xmppClient.value;
@@ -80,6 +84,42 @@ export function useCommunityEvents(
     }
   }
 
+  /**
+   * Publish (or update) this session's RSVP for an event. Server
+   * persists a sibling pubsub item; we optimistically fold the new
+   * attendee into the local master and rely on refresh() for the
+   * authoritative state from peers.
+   */
+  async function rsvp(
+    masterUid: string,
+    selfLocalpart: string,
+    selfBareJid: string,
+    partstat: PartStat,
+  ): Promise<boolean> {
+    const client = xmppClient.value;
+    const jid = options.communityJid.value;
+    if (!client || !jid) return false;
+    if (!masterUid || !selfLocalpart || !selfBareJid) return false;
+    try {
+      await client.rsvpCommunityEvent(jid, masterUid, selfLocalpart, selfBareJid, partstat);
+      const rsvpId = `${masterUid}-rsvp-${selfLocalpart}`;
+      const placeholder: CommunityEvent = {
+        id: rsvpId,
+        uid: masterUid,
+        summary: "",
+        attendees: [{ uri: `xmpp:${selfBareJid}`, partstat }],
+      };
+      events.value = [
+        placeholder,
+        ...events.value.filter((e) => e.id !== rsvpId),
+      ];
+      return true;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
   function clear() {
     fetchRequestId += 1;
     events.value = [];
@@ -95,6 +135,7 @@ export function useCommunityEvents(
     error,
     refresh,
     post,
+    rsvp,
     clear,
   };
 }

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -8,6 +8,7 @@ const COMMUNITY = "community.example.com";
 type MockClient = BrowserXmppClient & {
   fetchCommunityEvents: ReturnType<typeof mock>;
   publishCommunityEvent: ReturnType<typeof mock>;
+  rsvpCommunityEvent: ReturnType<typeof mock>;
 };
 
 function makeClient(events: CommunityEvent[] = []): MockClient {
@@ -26,6 +27,7 @@ function makeClient(events: CommunityEvent[] = []): MockClient {
         ...(input.rrule ? { rrule: input.rrule } : {}),
       } satisfies CommunityEvent),
     ),
+    rsvpCommunityEvent: mock(() => Promise.resolve()),
   } as unknown as MockClient;
 }
 
@@ -69,5 +71,65 @@ describe("useCommunityEvents", () => {
       rrule,
     });
     expect(posted?.rrule).toEqual(rrule);
+  });
+
+  test("refresh groups sibling RSVP items into the master event", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-1", uid: "evt-1", summary: "Game Night", dtstartMs: future },
+      {
+        id: "evt-1-rsvp-alice",
+        uid: "evt-1",
+        summary: "",
+        attendees: [{ uri: "xmpp:alice@example.com", partstat: "ACCEPTED" }],
+      },
+      {
+        id: "evt-1-rsvp-bob",
+        uid: "evt-1",
+        summary: "",
+        attendees: [{ uri: "xmpp:bob@example.com", partstat: "DECLINED" }],
+      },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    // Only the master event survives; sibling RSVPs fold in as attendees.
+    expect(events.events.value.map((e) => e.id)).toEqual(["evt-1"]);
+    const attendees = events.events.value[0]?.attendees ?? [];
+    expect(attendees.length).toBe(2);
+    expect(attendees.find((a) => a.uri === "xmpp:alice@example.com")?.partstat).toBe("ACCEPTED");
+    expect(attendees.find((a) => a.uri === "xmpp:bob@example.com")?.partstat).toBe("DECLINED");
+  });
+
+  test("rsvp publishes via wasm and optimistically folds a self-attendee in", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-2", uid: "evt-2", summary: "Game Night", dtstartMs: future },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const ok = await events.rsvp("evt-2", "alice", "alice@example.com", "ACCEPTED");
+    expect(ok).toBe(true);
+    expect(client.rsvpCommunityEvent).toHaveBeenCalledWith(
+      COMMUNITY,
+      "evt-2",
+      "alice",
+      "alice@example.com",
+      "ACCEPTED",
+    );
+    const evt = events.events.value.find((e) => e.uid === "evt-2");
+    expect(evt?.attendees?.[0]?.uri).toBe("xmpp:alice@example.com");
+    expect(evt?.attendees?.[0]?.partstat).toBe("ACCEPTED");
+  });
+
+  test("rsvp returns false without communityJid / xmpp client", async () => {
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(null), {
+      communityJid: ref<string | null>(null),
+    });
+    const ok = await events.rsvp("evt", "alice", "alice@example.com", "ACCEPTED");
+    expect(ok).toBe(false);
   });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -492,7 +492,169 @@ pub(super) async fn handle_community_publish(
     {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
     }
+    // RSVP carve-out: the events node accepts per-attendee RSVP items
+    // from any authenticated session, bypassing the
+    // server-owner/space-owner gate. Each user owns their own RSVP
+    // item (`<master-uid>-rsvp-<localpart>`) carrying a single
+    // attendee whose URI bare-JID matches the publisher. This keeps
+    // RSVPs scoped to the publishing user and avoids granting
+    // Publisher affiliation on the master events node.
+    if node == waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS && session.is_some() {
+        let user_domain = state.deps.auth_state.xmpp_domain.as_str();
+        if is_well_formed_rsvp_item(session, user_domain, &item) {
+            return handle_community_rsvp_publish(iq, state, community_domain, node, item).await;
+        }
+    }
     handle_community_non_bookmark_publish(iq, state, community_domain, node, item, session).await
+}
+
+/// `true` when `item` is a well-formed RSVP for the publishing
+/// session: item id of the form `<uid>-rsvp-<localpart>` where
+/// `<localpart>` matches the session, payload is a single VEVENT
+/// carrying exactly one `<attendee>` whose URI bare JID matches
+/// `<localpart>@<user_domain>`, and the event contains no
+/// master-event-only fields (no SUMMARY/DTSTART/RRULE).
+fn is_well_formed_rsvp_item(
+    session: Option<&Session>,
+    user_domain: &str,
+    item: &PubSubItem,
+) -> bool {
+    let Some(session) = session else {
+        return false;
+    };
+    let Some(item_id) = &item.id else {
+        return false;
+    };
+    let Some((master_uid, localpart)) = parse_rsvp_item_id(item_id) else {
+        return false;
+    };
+    if !localpart.eq_ignore_ascii_case(&session.xmpp_localpart) {
+        return false;
+    }
+    // Master UID must be non-empty; we don't constrain its shape
+    // further (matches the master item's id).
+    if master_uid.is_empty() {
+        return false;
+    }
+    let Some(payload) = &item.payload else {
+        return false;
+    };
+    if !waddle_xmpp_core::xcal::is_vcalendar_element(payload) {
+        return false;
+    }
+    let ns_xcal = waddle_xmpp_core::xcal::NS_XCAL;
+    let Some(vevent) = payload
+        .children()
+        .find(|c| c.name() == "vevent" && c.ns() == ns_xcal)
+    else {
+        return false;
+    };
+    // Master-event-only fields MUST NOT appear on an RSVP item.
+    let forbidden = [
+        "summary",
+        "dtstart",
+        "dtend",
+        "rrule",
+        "description",
+        "location",
+        "organizer",
+    ];
+    for child in vevent.children() {
+        if child.ns() != ns_xcal {
+            return false;
+        }
+        if forbidden.contains(&child.name()) {
+            return false;
+        }
+    }
+    let attendees: Vec<_> = vevent
+        .children()
+        .filter(|c| c.name() == "attendee" && c.ns() == ns_xcal)
+        .collect();
+    if attendees.len() != 1 {
+        return false;
+    }
+    let uri = attendees[0].text();
+    let uri_trimmed = uri.trim();
+    let attendee_bare = waddle_xmpp_core::xcal::xmpp_uri_to_bare_jid(uri_trimmed);
+    let expected_jid = format!(
+        "{}@{}",
+        localpart.to_ascii_lowercase(),
+        user_domain.to_ascii_lowercase()
+    );
+    attendee_bare.as_deref() == Some(expected_jid.as_str())
+}
+
+/// Split a string like `evt-launch-rsvp-alice` into
+/// `("evt-launch", "alice")`. Returns `None` for inputs without the
+/// `-rsvp-` separator.
+fn parse_rsvp_item_id(item_id: &str) -> Option<(&str, &str)> {
+    let (master_uid, localpart) = item_id.rsplit_once("-rsvp-")?;
+    if localpart.is_empty() {
+        return None;
+    }
+    Some((master_uid, localpart))
+}
+
+async fn handle_community_rsvp_publish(
+    iq: &xmpp_parsers::iq::Iq,
+    state: &WebSocketState,
+    community_domain: &str,
+    node: &str,
+    item: PubSubItem,
+) -> Vec<String> {
+    let Ok(community_jid) = community_domain.parse::<BareJid>() else {
+        return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
+    };
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .get_node(&community_jid, node)
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
+        Err(error) => {
+            warn!(node, error = %error, "Failed to resolve community node for RSVP publish");
+            return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];
+        }
+    }
+    match state
+        .deps
+        .protocol
+        .pubsub_storage
+        .publish_item(&community_jid, node, &item, None, false)
+        .await
+    {
+        Ok(result) => {
+            pubsub_fanout::fan_out_publish(
+                state,
+                pubsub_fanout::FanOutRequest {
+                    owner: &community_jid,
+                    node,
+                    published_item: &item,
+                    item_id: &result.item_id,
+                    publisher: None,
+                    publisher_full: None,
+                    is_pep: false,
+                },
+            )
+            .await;
+            vec![iq_to_xml(build_pubsub_publish_result(
+                iq,
+                node,
+                &result.item_id,
+            ))]
+        }
+        Err(error) => {
+            warn!(node, error = %error, "Failed to publish community RSVP item");
+            vec![iq_to_xml(build_pubsub_error(
+                iq,
+                PubSubError::InternalServerError,
+            ))]
+        }
+    }
 }
 
 pub(super) async fn handle_community_items(

--- a/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
@@ -1,0 +1,254 @@
+//! RSVP via xCal ATTENDEE — sibling pubsub item integration tests.
+//!
+//! Verifies that a non-admin user (no Publisher affiliation on the
+//! events node) can publish a well-formed RSVP item for someone
+//! else's master event, and that malformed RSVP shapes fall through
+//! to the standard admin-only gate and are rejected.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const ADMIN: &str = "admin";
+const COMMUNITY_JID: &str = "community.localhost";
+const EVENTS_NODE: &str = "urn:xmpp:calendar:0";
+const NS_XCAL: &str = "urn:ietf:params:xml:ns:xcal";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+/// Start a server with an extra "bob" account so we can test the RSVP
+/// path from a non-owner. Returns (server, admin client, bob client).
+async fn setup() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let bob_password = "bob-rsvp-pw";
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password)]);
+
+    let admin_pw = server.fixed_account_password().to_string();
+    let admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        ADMIN,
+        &admin_pw,
+        &format!("admin-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("admin connect");
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connect");
+    (server, admin, bob)
+}
+
+#[tokio::test]
+async fn non_owner_can_publish_rsvp_for_master_event() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut admin, mut bob) = setup().await;
+
+    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
+
+    // Admin (server owner) publishes the master event.
+    admin
+        .send(&format!(
+            r#"<iq type="set" id="cal-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{EVENTS_NODE}">
+                  <item id="{event_id}">
+                    <vcalendar xmlns="{NS_XCAL}">
+                      <version>2.0</version>
+                      <vevent>
+                        <uid>{event_id}</uid>
+                        <dtstamp>2026-06-01T12:00:00Z</dtstamp>
+                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <summary>Friday Game Night</summary>
+                        <organizer>xmpp:admin@localhost</organizer>
+                      </vevent>
+                    </vcalendar>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send master publish");
+    let publish_result = admin
+        .recv_matching(|frame| frame.contains("cal-publish"))
+        .await
+        .expect("master publish result");
+    assert!(
+        publish_result.contains("type=\"result\""),
+        "master publish must succeed: {publish_result}"
+    );
+
+    // Bob (a regular user, no Publisher affiliation on the events
+    // node) publishes their RSVP as a sibling item.
+    let rsvp_id = format!("{event_id}-rsvp-bob");
+    bob.send(&format!(
+        r#"<iq type="set" id="rsvp-1" to="{COMMUNITY_JID}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="{EVENTS_NODE}">
+              <item id="{rsvp_id}">
+                <vcalendar xmlns="{NS_XCAL}">
+                  <vevent>
+                    <uid>{event_id}</uid>
+                    <attendee partstat="ACCEPTED">xmpp:bob@localhost</attendee>
+                  </vevent>
+                </vcalendar>
+              </item>
+            </publish>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("send rsvp publish");
+    let rsvp_result = bob
+        .recv_matching(|frame| frame.contains("rsvp-1"))
+        .await
+        .expect("rsvp publish result");
+    assert!(
+        rsvp_result.contains("type=\"result\""),
+        "rsvp publish must succeed for non-owner: {rsvp_result}"
+    );
+
+    // Items query — both the master and the RSVP should appear.
+    admin
+        .send(&format!(
+            r#"<iq type="get" id="cal-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{EVENTS_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = admin
+        .recv_matching(|frame| frame.contains("cal-items") && frame.contains("<vevent"))
+        .await
+        .expect("items response");
+    assert!(
+        items_response.contains(&event_id),
+        "items missing master id: {items_response}"
+    );
+    assert!(
+        items_response.contains(&rsvp_id),
+        "items missing RSVP sibling id: {items_response}"
+    );
+    assert!(
+        items_response.contains("xmpp:bob@localhost"),
+        "items missing attendee URI: {items_response}"
+    );
+    assert!(
+        items_response.contains("partstat=\"ACCEPTED\"")
+            || items_response.contains("partstat='ACCEPTED'"),
+        "items missing ACCEPTED partstat: {items_response}"
+    );
+
+    let _ = admin.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn malformed_rsvp_for_other_user_is_rejected() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut admin, mut bob) = setup().await;
+
+    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
+
+    // Admin publishes a master event.
+    admin
+        .send(&format!(
+            r#"<iq type="set" id="cal-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{EVENTS_NODE}">
+                  <item id="{event_id}">
+                    <vcalendar xmlns="{NS_XCAL}">
+                      <vevent>
+                        <uid>{event_id}</uid>
+                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <summary>Game Night</summary>
+                      </vevent>
+                    </vcalendar>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send master publish");
+    let _ = admin
+        .recv_matching(|frame| frame.contains("cal-publish"))
+        .await
+        .expect("master publish result");
+
+    // Bob tries to RSVP on behalf of admin — attendee URI doesn't
+    // match Bob's session. Must fall through to the admin-only gate
+    // and be rejected with Forbidden.
+    let attack_id = format!("{event_id}-rsvp-admin");
+    bob.send(&format!(
+        r#"<iq type="set" id="rsvp-spoof" to="{COMMUNITY_JID}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="{EVENTS_NODE}">
+              <item id="{attack_id}">
+                <vcalendar xmlns="{NS_XCAL}">
+                  <vevent>
+                    <uid>{event_id}</uid>
+                    <attendee partstat="ACCEPTED">xmpp:admin@localhost</attendee>
+                  </vevent>
+                </vcalendar>
+              </item>
+            </publish>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("send spoofed rsvp");
+    let spoof_result = bob
+        .recv_matching(|frame| frame.contains("rsvp-spoof"))
+        .await
+        .expect("spoof result");
+    assert!(
+        spoof_result.contains("type=\"error\"") || spoof_result.contains("<error"),
+        "spoofed RSVP must be rejected: {spoof_result}"
+    );
+
+    // Bob tries to publish a non-RSVP-shaped item under their own
+    // RSVP id (carries a SUMMARY, which is a master-only field).
+    // Must also fall through to the admin gate and be rejected.
+    let rich_id = format!("{event_id}-rsvp-bob");
+    bob.send(&format!(
+        r#"<iq type="set" id="rsvp-rich" to="{COMMUNITY_JID}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="{EVENTS_NODE}">
+              <item id="{rich_id}">
+                <vcalendar xmlns="{NS_XCAL}">
+                  <vevent>
+                    <uid>{event_id}</uid>
+                    <summary>Hostile takeover</summary>
+                    <attendee partstat="ACCEPTED">xmpp:bob@localhost</attendee>
+                  </vevent>
+                </vcalendar>
+              </item>
+            </publish>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("send rich rsvp");
+    let rich_result = bob
+        .recv_matching(|frame| frame.contains("rsvp-rich"))
+        .await
+        .expect("rich result");
+    assert!(
+        rich_result.contains("type=\"error\"") || rich_result.contains("<error"),
+        "RSVP item with master-event fields must be rejected: {rich_result}"
+    );
+
+    let _ = admin.close().await;
+    let _ = bob.close().await;
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
@@ -11,8 +11,8 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use waddle_xmpp_core::xcal::{
-    build_vcalendar_with_event, parse_vcalendar_event, Freq, Rrule, RruleEnd, VEvent, Weekday,
-    NS_XCAL, PUBSUB_NODE_EVENTS,
+    build_vcalendar_with_event, parse_vcalendar_event, Attendee, Freq, PartStat, Rrule, RruleEnd,
+    VEvent, Weekday, NS_XCAL, PUBSUB_NODE_EVENTS,
 };
 use wasm_bindgen::prelude::*;
 
@@ -51,6 +51,30 @@ pub(crate) struct JsVEvent {
     pub dtstart: Option<String>,
     pub dtend: Option<String>,
     pub rrule: Option<JsRrule>,
+    /// ATTENDEE list — empty for events with no RSVPs yet. The chat
+    /// folds sibling `-rsvp-*` items into this list before render.
+    #[serde(default)]
+    pub attendees: Vec<JsAttendee>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsAttendee {
+    pub uri: String,
+    /// PartStat: "ACCEPTED"|"DECLINED"|"TENTATIVE"|"NEEDS-ACTION".
+    pub partstat: String,
+    pub role: Option<String>,
+    pub rsvp: Option<bool>,
+}
+
+impl From<&Attendee> for JsAttendee {
+    fn from(a: &Attendee) -> Self {
+        Self {
+            uri: a.uri.clone(),
+            partstat: a.partstat.as_str().to_string(),
+            role: a.role.clone(),
+            rsvp: a.rsvp,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -139,6 +163,7 @@ impl JsVEvent {
             dtstart: event.dtstart.map(|ts| ts.to_rfc3339()),
             dtend: event.dtend.map(|ts| ts.to_rfc3339()),
             rrule: event.rrule.as_ref().map(JsRrule::from),
+            attendees: event.attendees.iter().map(JsAttendee::from).collect(),
         }
     }
 }
@@ -158,6 +183,50 @@ fn build_events_items_iq(community_jid: &str, max_items: Option<u32>) -> Element
         .build();
     Element::builder("iq", NS_CLIENT)
         .attr("type", "get")
+        .attr("id", id)
+        .attr("to", community_jid)
+        .append(pubsub)
+        .build()
+}
+
+/// Build an RSVP item payload for a master event: a VEVENT carrying
+/// only the master UID and a single `<attendee/>` with the chosen
+/// PartStat. Item id uses the canonical `<master-uid>-rsvp-<localpart>`
+/// shape so the chat can fold sibling RSVP items back into the master.
+fn build_rsvp_publish_iq(
+    community_jid: &str,
+    master_uid: &str,
+    self_localpart: &str,
+    self_jid: &str,
+    partstat: PartStat,
+) -> Element {
+    let id = format!("xcal-rsvp-{}", Uuid::new_v4());
+    let item_id = format!("{master_uid}-rsvp-{self_localpart}");
+    let rsvp_event = VEvent {
+        uid: master_uid.to_string(),
+        dtstamp: Some(Utc::now()),
+        dtstart: None,
+        dtend: None,
+        summary: String::new(),
+        description: None,
+        location: None,
+        organizer: None,
+        rrule: None,
+        attendees: vec![Attendee::new(format!("xmpp:{self_jid}"), partstat)],
+    };
+    let item = Element::builder("item", NS_PUBSUB)
+        .attr("id", item_id.as_str())
+        .append(build_vcalendar_with_event(&rsvp_event))
+        .build();
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr("node", PUBSUB_NODE_EVENTS)
+        .append(item)
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
         .attr("id", id)
         .attr("to", community_jid)
         .append(pubsub)
@@ -260,6 +329,48 @@ impl WaddleClient {
             send_iq_command(inner, iq).await?;
             let js_event = JsVEvent::from_vevent(&item_id, event);
             to_js_value(&js_event)
+        })
+    }
+
+    /// Publish (or update) this session's RSVP for a calendar event.
+    /// `partstat` must be one of "ACCEPTED" | "DECLINED" | "TENTATIVE"
+    /// | "NEEDS-ACTION". The chat groups sibling `-rsvp-*` items back
+    /// into the master event on the next items fetch.
+    pub fn xcal_rsvp(
+        &self,
+        community_jid: String,
+        master_uid: String,
+        self_localpart: String,
+        self_jid: String,
+        partstat: String,
+    ) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let partstat = PartStat::from_str_value(&partstat)
+                .ok_or_else(|| js_error(format!("invalid partstat: {partstat}")))?;
+            if master_uid.is_empty() {
+                return Err(js_error("master_uid must not be empty"));
+            }
+            if self_localpart.is_empty() {
+                return Err(js_error("self_localpart must not be empty"));
+            }
+            if !self_jid.contains('@') {
+                return Err(js_error("self_jid must be a bare JID"));
+            }
+            let iq = build_rsvp_publish_iq(
+                &community_jid,
+                &master_uid,
+                &self_localpart,
+                &self_jid,
+                partstat,
+            );
+            send_iq_command(inner, iq).await?;
+            to_js_value(&JsAttendee {
+                uri: format!("xmpp:{self_jid}"),
+                partstat: partstat.as_str().to_string(),
+                role: None,
+                rsvp: None,
+            })
         })
     }
 }

--- a/server/crates/waddle-xmpp-core/src/xcal.rs
+++ b/server/crates/waddle-xmpp-core/src/xcal.rs
@@ -197,6 +197,71 @@ impl Rrule {
     }
 }
 
+// ── ATTENDEE / PARTSTAT (RFC 5545 §3.2.12 + §3.8.4.1) ──────────────
+
+/// Participation status of an attendee. RFC 5545 §3.2.12 defines a
+/// small enum; we model the four states the chat UX exposes (Going /
+/// Maybe / Not going + the initial "no answer yet" placeholder).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PartStat {
+    NeedsAction,
+    Accepted,
+    Declined,
+    Tentative,
+}
+
+impl PartStat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NeedsAction => "NEEDS-ACTION",
+            Self::Accepted => "ACCEPTED",
+            Self::Declined => "DECLINED",
+            Self::Tentative => "TENTATIVE",
+        }
+    }
+
+    pub fn from_str_value(s: &str) -> Option<Self> {
+        match s {
+            "NEEDS-ACTION" => Some(Self::NeedsAction),
+            "ACCEPTED" => Some(Self::Accepted),
+            "DECLINED" => Some(Self::Declined),
+            "TENTATIVE" => Some(Self::Tentative),
+            _ => None,
+        }
+    }
+}
+
+/// VEVENT ATTENDEE (RFC 5545 §3.8.4.1) — a single participant and
+/// their RSVP status. URI is typically `xmpp:user@example.com`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Attendee {
+    pub uri: String,
+    pub partstat: PartStat,
+    pub role: Option<String>,
+    pub rsvp: Option<bool>,
+}
+
+impl Attendee {
+    pub fn new(uri: impl Into<String>, partstat: PartStat) -> Self {
+        Self {
+            uri: uri.into(),
+            partstat,
+            role: None,
+            rsvp: None,
+        }
+    }
+
+    pub fn with_role(mut self, role: impl Into<String>) -> Self {
+        self.role = Some(role.into());
+        self
+    }
+
+    pub fn with_rsvp(mut self, rsvp: bool) -> Self {
+        self.rsvp = Some(rsvp);
+        self
+    }
+}
+
 // ── VEVENT ──────────────────────────────────────────────────────────
 
 /// Calendar event modelled as the iCalendar VEVENT component.
@@ -220,6 +285,10 @@ pub struct VEvent {
     pub organizer: Option<String>,
     /// Optional RRULE for recurring events.
     pub rrule: Option<Rrule>,
+    /// ATTENDEE list. Empty for events with no RSVPs yet; the chat
+    /// aggregates per-attendee RSVPs from sibling pubsub items into
+    /// this list on the master event before rendering.
+    pub attendees: Vec<Attendee>,
 }
 
 impl VEvent {
@@ -234,6 +303,7 @@ impl VEvent {
             location: None,
             organizer: None,
             rrule: None,
+            attendees: Vec::new(),
         }
     }
 
@@ -269,6 +339,16 @@ impl VEvent {
 
     pub fn with_rrule(mut self, rrule: Rrule) -> Self {
         self.rrule = Some(rrule);
+        self
+    }
+
+    pub fn with_attendees<I: IntoIterator<Item = Attendee>>(mut self, attendees: I) -> Self {
+        self.attendees = attendees.into_iter().collect();
+        self
+    }
+
+    pub fn add_attendee(mut self, attendee: Attendee) -> Self {
+        self.attendees.push(attendee);
         self
     }
 
@@ -348,9 +428,26 @@ pub fn build_vcalendar_with_event(event: &VEvent) -> Element {
     if let Some(ref rrule) = event.rrule {
         vevent.append_child(build_rrule_element(rrule));
     }
+    for attendee in &event.attendees {
+        vevent.append_child(build_attendee_element(attendee));
+    }
 
     vcalendar.append_child(vevent);
     vcalendar
+}
+
+fn build_attendee_element(attendee: &Attendee) -> Element {
+    let mut builder =
+        Element::builder("attendee", NS_XCAL).attr("partstat", attendee.partstat.as_str());
+    if let Some(ref role) = attendee.role {
+        builder = builder.attr("role", role);
+    }
+    if let Some(rsvp) = attendee.rsvp {
+        builder = builder.attr("rsvp", if rsvp { "TRUE" } else { "FALSE" });
+    }
+    let mut elem = builder.build();
+    elem.append_text_node(attendee.uri.as_str());
+    elem
 }
 
 /// `true` when an element is a `<vcalendar/>` in the xCal namespace.
@@ -425,6 +522,11 @@ pub fn parse_vcalendar_event(item_id: &str, vcalendar: &Element) -> Option<VEven
     let location = xcal_text(vevent, "location");
     let organizer = xcal_text(vevent, "organizer");
     let rrule = xcal_child(vevent, "rrule").and_then(parse_rrule);
+    let attendees = vevent
+        .children()
+        .filter(|c| c.name() == "attendee" && c.ns() == NS_XCAL)
+        .filter_map(parse_attendee)
+        .collect();
     Some(VEvent {
         uid,
         dtstamp,
@@ -435,7 +537,45 @@ pub fn parse_vcalendar_event(item_id: &str, vcalendar: &Element) -> Option<VEven
         location,
         organizer,
         rrule,
+        attendees,
     })
+}
+
+fn parse_attendee(elem: &Element) -> Option<Attendee> {
+    let uri = elem.text();
+    let uri = uri.trim();
+    if uri.is_empty() {
+        return None;
+    }
+    let partstat = elem
+        .attr("partstat")
+        .and_then(PartStat::from_str_value)
+        .unwrap_or(PartStat::NeedsAction);
+    let role = elem.attr("role").map(str::to_string);
+    let rsvp = elem.attr("rsvp").and_then(|v| match v {
+        "TRUE" | "true" => Some(true),
+        "FALSE" | "false" => Some(false),
+        _ => None,
+    });
+    Some(Attendee {
+        uri: uri.to_string(),
+        partstat,
+        role,
+        rsvp,
+    })
+}
+
+/// Bare-JID localpart of an `xmpp:` URI, lower-cased. Returns `None`
+/// for non-XMPP URIs or malformed values. Used by the chat to map
+/// attendee URIs back to JIDs and by the server to authorise RSVP
+/// publishes (an attendee URI must match the publisher's bare JID).
+pub fn xmpp_uri_to_bare_jid(uri: &str) -> Option<String> {
+    let rest = uri.strip_prefix("xmpp:")?;
+    let stripped = rest.split(['?', '/']).next().unwrap_or(rest);
+    if !stripped.contains('@') {
+        return None;
+    }
+    Some(stripped.to_ascii_lowercase())
 }
 
 #[cfg(test)]
@@ -595,5 +735,109 @@ mod tests {
 
         let past = VEvent::new("e", "Past").with_dtstart(ts(2020, 1, 1, 0, 0));
         assert!(!past.is_upcoming());
+    }
+
+    #[test]
+    fn partstat_round_trip_covers_every_state() {
+        for ps in [
+            PartStat::NeedsAction,
+            PartStat::Accepted,
+            PartStat::Declined,
+            PartStat::Tentative,
+        ] {
+            assert_eq!(PartStat::from_str_value(ps.as_str()), Some(ps));
+        }
+        assert_eq!(PartStat::from_str_value("UNKNOWN"), None);
+    }
+
+    #[test]
+    fn build_and_parse_event_with_attendees() {
+        let event = VEvent::new("evt-rsvp", "Game Night")
+            .with_dtstart(ts(2026, 6, 5, 19, 0))
+            .add_attendee(
+                Attendee::new("xmpp:alice@example.com", PartStat::Accepted)
+                    .with_role("REQ-PARTICIPANT")
+                    .with_rsvp(true),
+            )
+            .add_attendee(Attendee::new("xmpp:bob@example.com", PartStat::Declined))
+            .add_attendee(Attendee::new("xmpp:carol@example.com", PartStat::Tentative));
+
+        let vcal = build_vcalendar_with_event(&event);
+        let serialised = String::from(&vcal);
+        assert!(
+            serialised.contains("partstat=\"ACCEPTED\"")
+                || serialised.contains("partstat='ACCEPTED'"),
+            "ACCEPTED partstat must appear: {serialised}"
+        );
+        assert!(
+            serialised.contains("xmpp:bob@example.com"),
+            "attendee URI must appear: {serialised}"
+        );
+
+        let parsed = parse_vcalendar_event("evt-rsvp", &vcal).expect("parseable");
+        assert_eq!(parsed.attendees.len(), 3);
+        assert_eq!(parsed.attendees[0].uri, "xmpp:alice@example.com");
+        assert_eq!(parsed.attendees[0].partstat, PartStat::Accepted);
+        assert_eq!(parsed.attendees[0].role.as_deref(), Some("REQ-PARTICIPANT"));
+        assert_eq!(parsed.attendees[0].rsvp, Some(true));
+        assert_eq!(parsed.attendees[1].partstat, PartStat::Declined);
+        assert_eq!(parsed.attendees[2].partstat, PartStat::Tentative);
+    }
+
+    #[test]
+    fn attendee_without_partstat_defaults_to_needs_action() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+          <vevent>
+            <uid>evt-default</uid>
+            <summary>Default partstat</summary>
+            <attendee>xmpp:alice@example.com</attendee>
+          </vevent>
+        </vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        let event = parse_vcalendar_event("evt-default", &elem).expect("parseable");
+        assert_eq!(event.attendees.len(), 1);
+        assert_eq!(event.attendees[0].partstat, PartStat::NeedsAction);
+    }
+
+    #[test]
+    fn attendee_with_empty_uri_is_dropped() {
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+          <vevent>
+            <uid>evt-empty</uid>
+            <summary>Empty attendee</summary>
+            <attendee partstat='ACCEPTED'></attendee>
+          </vevent>
+        </vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        let event = parse_vcalendar_event("evt-empty", &elem).expect("parseable");
+        assert!(
+            event.attendees.is_empty(),
+            "empty URI attendee must be dropped"
+        );
+    }
+
+    #[test]
+    fn xmpp_uri_to_bare_jid_handles_common_cases() {
+        assert_eq!(
+            xmpp_uri_to_bare_jid("xmpp:alice@example.com").as_deref(),
+            Some("alice@example.com")
+        );
+        // Lowercases — JIDs are case-insensitive at the bare-JID layer.
+        assert_eq!(
+            xmpp_uri_to_bare_jid("xmpp:Alice@Example.COM").as_deref(),
+            Some("alice@example.com")
+        );
+        // Strips resource and query.
+        assert_eq!(
+            xmpp_uri_to_bare_jid("xmpp:alice@example.com/Resource").as_deref(),
+            Some("alice@example.com")
+        );
+        assert_eq!(
+            xmpp_uri_to_bare_jid("xmpp:alice@example.com?message").as_deref(),
+            Some("alice@example.com")
+        );
+        // Rejects non-xmpp URIs and malformed values.
+        assert_eq!(xmpp_uri_to_bare_jid("mailto:alice@example.com"), None);
+        assert_eq!(xmpp_uri_to_bare_jid("xmpp:not-a-jid"), None);
     }
 }

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -129,6 +129,13 @@ export class WaddleClient {
      * required for the event to be useful on a timeline.
      */
     xcal_publish(community_jid: string, input: any): Promise<any>;
+    /**
+     * Publish (or update) this session's RSVP for a calendar event.
+     * `partstat` must be one of "ACCEPTED" | "DECLINED" | "TENTATIVE"
+     * | "NEEDS-ACTION". The chat groups sibling `-rsvp-*` items back
+     * into the master event on the next items fetch.
+     */
+    xcal_rsvp(community_jid: string, master_uid: string, self_localpart: string, self_jid: string, partstat: string): Promise<any>;
 }
 
 export class WaddleConfig {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8x9nci";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8yeev9";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8x9nci";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";


### PR DESCRIPTION
## Summary

Adds Going / Maybe / Not going RSVPs to community calendar events using xCal `<attendee partstat="..."/>` per RFC 5545. RSVPs ship as **sibling pubsub items** (`<master-uid>-rsvp-<localpart>`) rather than mutating the master event — each user owns their RSVP item without requiring Publisher affiliation on the events node.

Second of three #651 follow-ups. PR A (PEP → feed bridge) landed in #652. PR C (RECURRENCE-ID overrides + EXDATE) follows.

## What's in this PR

**xCal core (`waddle-xmpp-core::xcal`)**
- `PartStat` enum: `NEEDS-ACTION | ACCEPTED | DECLINED | TENTATIVE`.
- `Attendee { uri, partstat, role: Option<String>, rsvp: Option<bool> }`.
- `VEvent.attendees: Vec<Attendee>`, builder + parser round-trip.
- `xmpp_uri_to_bare_jid(...)` helper for matching attendees to sessions.

**Server publish gate (`pubsub_helpers::handle_community_publish`)**
- RSVP carve-out: events node accepts an item from any authenticated session when the item id is `<uid>-rsvp-<localpart>`, localpart matches the session, and the payload is a single VEVENT carrying exactly one attendee whose URI bare-JID equals the session's bare JID. No master-event fields (SUMMARY/DTSTART/RRULE/…) permitted.
- Everything else still falls through to the existing admin-only gate.
- Builds typed `minidom::Element` payloads — no string concatenation.

**Wasm bridge (`client_xcal.rs`)**
- `JsAttendee`, `JsVEvent.attendees`.
- `xcal_rsvp(community_jid, master_uid, self_localpart, self_jid, partstat)`.

**Chat**
- `Attendee` / `PartStat` types, `CommunityEvent.attendees`.
- `groupEventsWithRsvps`: folds sibling `-rsvp-*` items back into their master (latest-wins by URI).
- `rsvp(masterUid, selfLocalpart, selfJid, partstat)` composable method with optimistic update.
- `EventsPane.vue`: three pill buttons + aggregate counts, current RSVP highlighted.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Unit (Rust) | `xcal.rs` | 14 tests — PartStat enum, Attendee build/parse round-trip, xmpp URI helper, missing-partstat default, empty-URI dropped |
| Integration (WS) | `tests/proto_calendar_rsvp_ws.rs` | non-owner RSVP succeeds end-to-end with master + RSVP returned together; spoofed attendee URI rejected; RSVP item carrying a SUMMARY rejected |
| Composable (TS) | `chat/tests/community-events.test.ts` | grouping master + 2 RSVP siblings into a single event with 2 attendees; optimistic update flows the new attendee in; no-op without session |

## What's NOT in this PR

- `RECURRENCE-ID` overrides + `EXDATE` (PR C in the same plan).
- PEP → feed bridge (PR A, landed in #652).

## Verification checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p waddle-xmpp-core --lib xcal` — 14 pass
- [x] `cargo test -p waddle-server --test proto_calendar_rsvp_ws` — 2 pass
- [x] `bunx astro check` — 0 errors / 0 warnings / 0 hints
- [x] `bun test tests/community-events.test.ts` — 6 pass
- [x] `bun run lint` (knip) — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.