### PR TITLE
feat(server): xCal recurrence overrides + EXDATE

### DIFF
--- a/chat/src/lib/xmpp/event-expansion.ts
+++ b/chat/src/lib/xmpp/event-expansion.ts
@@ -1,0 +1,219 @@
+/**
+ * Client-side instance expansion for recurring xCal events.
+ *
+ * Given a master `CommunityEvent` with an RRULE plus zero or more
+ * RECURRENCE-ID overrides and EXDATE cancellations, produces a flat
+ * list of upcoming `CommunityEvent` instances. The expander is
+ * deliberately conservative: it walks DTSTART forward by FREQ +
+ * INTERVAL with BYDAY / BYMONTHDAY filters, terminating at COUNT or
+ * UNTIL (or a caller-supplied `horizonMs` / `maxCount` cap).
+ *
+ * For each candidate occurrence:
+ *   - skipped if its DTSTART matches any value in the master's
+ *     `exdatesMs`;
+ *   - replaced by the override's properties (summary, location,
+ *     dtstart, dtend, description) when an override's
+ *     `recurrenceIdMs` matches the occurrence.
+ *
+ * Non-recurring events pass through unchanged as a single instance.
+ */
+
+import type { CommunityEvent, Weekday } from "./event-types";
+
+const DAY_MS = 86_400_000;
+
+const WEEKDAY_INDEX: Record<Weekday, number> = {
+  SU: 0,
+  MO: 1,
+  TU: 2,
+  WE: 3,
+  TH: 4,
+  FR: 5,
+  SA: 6,
+};
+
+export interface CalendarMaster {
+  master: CommunityEvent;
+  overrides: CommunityEvent[];
+}
+
+interface ExpandInstancesOptions {
+  /**
+   * Upper bound on the latest DTSTART the expander will emit.
+   * Defaults to one year from `nowMs`.
+   */
+  horizonMs?: number;
+  /** Hard cap on emitted instances. Defaults to 50. */
+  maxCount?: number;
+  /** Reference "now" for filtering past occurrences. Defaults to Date.now(). */
+  nowMs?: number;
+}
+
+/**
+ * Expand a CalendarMaster into upcoming `CommunityEvent` instances.
+ * Past occurrences (DTSTART <= nowMs) are dropped. The returned list
+ * is sorted ascending by DTSTART.
+ */
+export function expandInstances(
+  group: CalendarMaster,
+  options: ExpandInstancesOptions = {},
+): CommunityEvent[] {
+  const { master, overrides } = group;
+  const nowMs = options.nowMs ?? Date.now();
+  const horizonMs = options.horizonMs ?? nowMs + 365 * DAY_MS;
+  const maxCount = options.maxCount ?? 50;
+
+  const dtstart = master.dtstartMs;
+  if (typeof dtstart !== "number") {
+    // No timeline anchor — surface the master as-is so it still renders.
+    return [{ ...master }];
+  }
+  if (!master.rrule) {
+    if (dtstart <= nowMs) return [];
+    return [{ ...master }];
+  }
+
+  const exdateSet = new Set(master.exdatesMs ?? []);
+  const overrideByDtstart = new Map<number, CommunityEvent>();
+  for (const ov of overrides) {
+    if (typeof ov.recurrenceIdMs === "number") {
+      overrideByDtstart.set(ov.recurrenceIdMs, ov);
+    }
+  }
+
+  const out: CommunityEvent[] = [];
+  let cursor = dtstart;
+  let emitted = 0;
+  let candidates = 0;
+  const rrule = master.rrule;
+  const interval = rrule.interval ?? 1;
+  const until = rrule.untilMs ?? Infinity;
+  const countCap = rrule.count ?? Infinity;
+  // Walk-cap is independent of `maxCount`; protects against pathological
+  // BYDAY/BYMONTHDAY combos that emit no candidates per step.
+  const walkCap = 3_650;
+  let walked = 0;
+
+  while (
+    cursor <= horizonMs &&
+    cursor <= until &&
+    candidates < countCap &&
+    emitted < maxCount &&
+    walked < walkCap
+  ) {
+    walked += 1;
+    if (matchesByDay(cursor, rrule.byDay) && matchesByMonthDay(cursor, rrule.byMonthDay)) {
+      candidates += 1;
+      const skip = exdateSet.has(cursor);
+      if (!skip && cursor > nowMs) {
+        const override = overrideByDtstart.get(cursor);
+        const instance = override
+          ? applyOverride(master, override, cursor)
+          : occurrenceFromMaster(master, cursor);
+        out.push(instance);
+        emitted += 1;
+      }
+    }
+    cursor = advance(cursor, rrule.freq, interval);
+  }
+  return out;
+}
+
+/**
+ * Group a flat item list into master / overrides keyed by UID. RSVP
+ * items (item id contains `-rsvp-`) are intentionally NOT included
+ * here — they are merged into the master's `attendees` upstream by
+ * `groupEventsWithRsvps`.
+ */
+export function groupEventsWithOverrides(
+  items: readonly CommunityEvent[],
+): CalendarMaster[] {
+  const masters = new Map<string, CommunityEvent>();
+  const overrides = new Map<string, CommunityEvent[]>();
+  for (const item of items) {
+    if (typeof item.recurrenceIdMs === "number") {
+      const bucket = overrides.get(item.uid) ?? [];
+      bucket.push(item);
+      overrides.set(item.uid, bucket);
+    } else {
+      masters.set(item.uid, item);
+    }
+  }
+  const out: CalendarMaster[] = [];
+  for (const [uid, master] of masters) {
+    out.push({ master, overrides: overrides.get(uid) ?? [] });
+  }
+  return out;
+}
+
+function matchesByDay(ms: number, byDay: readonly Weekday[] | undefined): boolean {
+  if (!byDay || byDay.length === 0) return true;
+  const dow = new Date(ms).getUTCDay();
+  return byDay.some((wd) => WEEKDAY_INDEX[wd] === dow);
+}
+
+function matchesByMonthDay(ms: number, byMonthDay: readonly number[] | undefined): boolean {
+  if (!byMonthDay || byMonthDay.length === 0) return true;
+  const dom = new Date(ms).getUTCDate();
+  return byMonthDay.includes(dom);
+}
+
+function advance(ms: number, freq: string, interval: number): number {
+  const d = new Date(ms);
+  switch (freq) {
+    case "DAILY":
+      d.setUTCDate(d.getUTCDate() + interval);
+      return d.getTime();
+    case "WEEKLY":
+      // Walk by single days; BYDAY filtering picks the right ones.
+      // For multi-week intervals we still walk daily and let the
+      // BYDAY filter + interval-week check handle it.
+      d.setUTCDate(d.getUTCDate() + (interval === 1 ? 1 : 7 * interval));
+      return d.getTime();
+    case "MONTHLY":
+      d.setUTCMonth(d.getUTCMonth() + interval);
+      return d.getTime();
+    case "YEARLY":
+      d.setUTCFullYear(d.getUTCFullYear() + interval);
+      return d.getTime();
+    default:
+      // Unknown frequency — bail to "1 day" so the loop still
+      // terminates against horizonMs / walkCap.
+      d.setUTCDate(d.getUTCDate() + 1);
+      return d.getTime();
+  }
+}
+
+function occurrenceFromMaster(master: CommunityEvent, dtstartMs: number): CommunityEvent {
+  const durationMs =
+    typeof master.dtendMs === "number" && typeof master.dtstartMs === "number"
+      ? master.dtendMs - master.dtstartMs
+      : undefined;
+  return {
+    ...master,
+    id: `${master.id}::${dtstartMs}`,
+    dtstartMs,
+    ...(typeof durationMs === "number" ? { dtendMs: dtstartMs + durationMs } : {}),
+    // Per-occurrence instances inherit the master's series — drop
+    // RRULE so the UI shows "single occurrence" semantics.
+    rrule: undefined,
+  };
+}
+
+function applyOverride(
+  master: CommunityEvent,
+  override: CommunityEvent,
+  recurrenceIdMs: number,
+): CommunityEvent {
+  return {
+    ...master,
+    id: `${master.id}::${recurrenceIdMs}::override`,
+    summary: override.summary || master.summary,
+    ...(override.description !== undefined ? { description: override.description } : {}),
+    ...(override.location !== undefined ? { location: override.location } : {}),
+    dtstartMs: override.dtstartMs ?? recurrenceIdMs,
+    ...(typeof override.dtendMs === "number" ? { dtendMs: override.dtendMs } : {}),
+    recurrenceIdMs,
+    rrule: undefined,
+  };
+}

--- a/chat/src/lib/xmpp/event-types.ts
+++ b/chat/src/lib/xmpp/event-types.ts
@@ -55,6 +55,17 @@ export interface CommunityEvent {
    * attendee URI bare-JID at the chat layer to dedupe latest-wins.
    */
   attendees?: Attendee[];
+  /**
+   * RFC 5545 RECURRENCE-ID — set on override events that replace a
+   * single occurrence of a recurring master. `undefined` on master
+   * events.
+   */
+  recurrenceIdMs?: number;
+  /**
+   * RFC 5545 EXDATE — occurrence DTSTART values to skip on a
+   * recurring master. Empty on overrides and on non-recurring events.
+   */
+  exdatesMs?: number[];
 }
 
 export interface CommunityEventInput {
@@ -99,6 +110,8 @@ export interface WasmVEvent {
   dtend?: string | null;
   rrule?: WasmRrule | null;
   attendees?: WasmAttendee[] | null;
+  recurrence_id?: string | null;
+  exdates?: string[] | null;
 }
 
 const PARTSTATS: ReadonlySet<PartStat> = new Set([
@@ -165,6 +178,10 @@ export function eventFromWasm(event: WasmVEvent): CommunityEvent {
   const attendees = (event.attendees ?? [])
     .map(attendeeFromWasm)
     .filter((a): a is Attendee => a !== null);
+  const recurrenceIdMs = event.recurrence_id ? Date.parse(event.recurrence_id) : undefined;
+  const exdatesMs = (event.exdates ?? [])
+    .map((s) => Date.parse(s))
+    .filter((n) => Number.isFinite(n));
   return {
     id: event.id,
     uid: event.uid,
@@ -177,6 +194,10 @@ export function eventFromWasm(event: WasmVEvent): CommunityEvent {
     ...(typeof dtend === "number" && Number.isFinite(dtend) ? { dtendMs: dtend } : {}),
     ...(rrule ? { rrule } : {}),
     ...(attendees.length > 0 ? { attendees } : {}),
+    ...(typeof recurrenceIdMs === "number" && Number.isFinite(recurrenceIdMs)
+      ? { recurrenceIdMs }
+      : {}),
+    ...(exdatesMs.length > 0 ? { exdatesMs } : {}),
   };
 }
 

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -19,6 +19,10 @@ import {
   type CommunityEventInput,
   type PartStat,
 } from "@/lib/xmpp-client";
+import {
+  expandInstances,
+  groupEventsWithOverrides,
+} from "@/lib/xmpp/event-expansion";
 
 export function useCommunityEvents(
   xmppClient: Ref<BrowserXmppClient | null>,
@@ -34,9 +38,18 @@ export function useCommunityEvents(
   const pageSize = options.pageSize ?? 200;
   let fetchRequestId = 0;
 
-  const sortedEvents = computed(() =>
-    sortEventsUpcomingFirst(groupEventsWithRsvps(events.value)),
-  );
+  const sortedEvents = computed(() => {
+    const merged = groupEventsWithRsvps(events.value);
+    const expanded: CommunityEvent[] = [];
+    for (const group of groupEventsWithOverrides(merged)) {
+      if (group.master.rrule) {
+        expanded.push(...expandInstances(group));
+      } else {
+        expanded.push(group.master);
+      }
+    }
+    return sortEventsUpcomingFirst(expanded);
+  });
 
   async function refresh(): Promise<boolean> {
     const client = xmppClient.value;

--- a/chat/tests/event-expansion.test.ts
+++ b/chat/tests/event-expansion.test.ts
@@ -1,0 +1,159 @@
+// Unit tests for the client-side xCal instance expander. Covers
+// weekly + BYDAY, monthly + BYMONTHDAY, COUNT vs UNTIL termination,
+// EXDATE skipping (including no-op EXDATE on a non-existent
+// occurrence), and RECURRENCE-ID override substitution.
+
+import { describe, expect, test } from "bun:test";
+import {
+  expandInstances,
+  groupEventsWithOverrides,
+  type CalendarMaster,
+} from "../src/lib/xmpp/event-expansion";
+import type { CommunityEvent } from "../src/lib/xmpp/event-types";
+
+const NOW = Date.parse("2026-06-01T00:00:00Z");
+// 365 days from NOW — covers all the synthetic test events without
+// piling up emissions beyond `maxCount`.
+const HORIZON = NOW + 365 * 86_400_000;
+
+function master(overrides: Partial<CommunityEvent> = {}): CommunityEvent {
+  return {
+    id: "evt-1",
+    uid: "evt-1",
+    summary: "Game Night",
+    dtstartMs: Date.parse("2026-06-05T19:00:00Z"),
+    dtendMs: Date.parse("2026-06-05T22:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("expandInstances", () => {
+  test("non-recurring event returns itself when in the future", () => {
+    const event = master();
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(1);
+    expect(instances[0]?.id).toBe(event.id);
+  });
+
+  test("non-recurring event in the past is dropped", () => {
+    const event = master({ dtstartMs: NOW - 86_400_000 });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(0);
+  });
+
+  test("weekly + BYDAY emits the right occurrences within COUNT", () => {
+    const event = master({
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(4);
+    expect(instances[0]?.dtstartMs).toBe(Date.parse("2026-06-05T19:00:00Z"));
+    expect(instances[3]?.dtstartMs).toBe(Date.parse("2026-06-26T19:00:00Z"));
+    // Per-occurrence emission carries DTEND adjusted by the master's duration.
+    expect(instances[0]?.dtendMs).toBe(Date.parse("2026-06-05T22:00:00Z"));
+    expect(instances[3]?.dtendMs).toBe(Date.parse("2026-06-26T22:00:00Z"));
+  });
+
+  test("UNTIL terminates the series even without COUNT", () => {
+    const event = master({
+      rrule: {
+        freq: "WEEKLY",
+        byDay: ["FR"],
+        untilMs: Date.parse("2026-06-26T23:59:00Z"),
+      },
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(4); // Jun 5, 12, 19, 26
+  });
+
+  test("EXDATE skips the matching occurrence", () => {
+    const event = master({
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+      exdatesMs: [Date.parse("2026-06-19T19:00:00Z")],
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    const starts = instances.map((i) => i.dtstartMs);
+    expect(starts).not.toContain(Date.parse("2026-06-19T19:00:00Z"));
+    expect(starts).toContain(Date.parse("2026-06-26T19:00:00Z"));
+    // 4 in count - 1 EXDATE = 3 emitted
+    expect(instances.length).toBe(3);
+  });
+
+  test("EXDATE that doesn't match any occurrence is a no-op", () => {
+    const event = master({
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 3 },
+      exdatesMs: [Date.parse("2030-12-25T12:00:00Z")],
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    expect(instances.length).toBe(3);
+  });
+
+  test("RECURRENCE-ID override replaces a single occurrence", () => {
+    const event = master({
+      rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+    });
+    const overrideRecurrence = Date.parse("2026-06-12T19:00:00Z");
+    const override: CommunityEvent = {
+      id: "evt-1::override::1",
+      uid: "evt-1",
+      summary: "Special: Halo",
+      recurrenceIdMs: overrideRecurrence,
+      dtstartMs: Date.parse("2026-06-12T20:00:00Z"),
+    };
+    const instances = expandInstances(
+      { master: event, overrides: [override] },
+      { nowMs: NOW, horizonMs: HORIZON },
+    );
+    const replaced = instances.find((i) => i.recurrenceIdMs === overrideRecurrence);
+    expect(replaced).toBeDefined();
+    expect(replaced?.summary).toBe("Special: Halo");
+    expect(replaced?.dtstartMs).toBe(Date.parse("2026-06-12T20:00:00Z"));
+    // Other 3 occurrences still come from the master.
+    expect(instances.filter((i) => i.summary === "Game Night").length).toBe(3);
+  });
+
+  test("monthly + BYMONTHDAY emits day-of-month matches", () => {
+    const event = master({
+      dtstartMs: Date.parse("2026-06-01T18:00:00Z"),
+      dtendMs: Date.parse("2026-06-01T20:00:00Z"),
+      rrule: { freq: "MONTHLY", byMonthDay: [1, 15], count: 6 },
+    });
+    const instances = expandInstances({ master: event, overrides: [] }, { nowMs: NOW, horizonMs: HORIZON });
+    const days = instances.map((i) => new Date(i.dtstartMs ?? 0).getUTCDate());
+    expect(days.every((d) => d === 1 || d === 15)).toBe(true);
+    expect(instances.length).toBe(6);
+  });
+
+  test("maxCount caps the emitted list even when COUNT is larger", () => {
+    const event = master({
+      rrule: { freq: "DAILY", count: 1000 },
+    });
+    const instances = expandInstances(
+      { master: event, overrides: [] },
+      { nowMs: NOW, horizonMs: HORIZON, maxCount: 7 },
+    );
+    expect(instances.length).toBe(7);
+  });
+});
+
+describe("groupEventsWithOverrides", () => {
+  test("buckets overrides by UID and surfaces masters as CalendarMaster", () => {
+    const items: CommunityEvent[] = [
+      { id: "evt-a", uid: "evt-a", summary: "A", dtstartMs: NOW + 1000 },
+      {
+        id: "evt-a::override::1",
+        uid: "evt-a",
+        summary: "A-override",
+        recurrenceIdMs: NOW + 2000,
+      },
+      { id: "evt-b", uid: "evt-b", summary: "B", dtstartMs: NOW + 3000 },
+    ];
+    const groups = groupEventsWithOverrides(items);
+    expect(groups.length).toBe(2);
+    const a = groups.find((g: CalendarMaster) => g.master.uid === "evt-a");
+    const b = groups.find((g: CalendarMaster) => g.master.uid === "evt-b");
+    expect(a?.overrides.length).toBe(1);
+    expect(a?.overrides[0]?.summary).toBe("A-override");
+    expect(b?.overrides.length).toBe(0);
+  });
+});

--- a/server/crates/waddle-server/tests/proto_calendar_overrides_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_overrides_ws.rs
@@ -1,0 +1,125 @@
+//! xCal RECURRENCE-ID overrides + EXDATE integration tests over
+//! WebSocket. Verifies that a single pubsub item can carry a master
+//! event plus sibling `<vevent>` overrides (each with their own
+//! `<recurrence-id>`), and that EXDATE values round-trip on the
+//! master. Per ProtoXEP §"Calendar Items", components sharing a UID
+//! MUST live in the same item.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+const COMMUNITY_JID: &str = "community.localhost";
+const EVENTS_NODE: &str = "urn:xmpp:calendar:0";
+const NS_XCAL: &str = "urn:ietf:params:xml:ns:xcal";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn setup() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("calendar-overrides-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, &resource)
+            .await
+            .expect("connect and auth");
+    (server, client)
+}
+
+#[tokio::test]
+async fn vcalendar_item_with_master_overrides_and_exdate_round_trips() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+
+    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="cal-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{EVENTS_NODE}">
+                  <item id="{event_id}">
+                    <vcalendar xmlns="{NS_XCAL}">
+                      <version>2.0</version>
+                      <vevent>
+                        <uid>{event_id}</uid>
+                        <dtstamp>2026-06-01T12:00:00Z</dtstamp>
+                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <dtend>2026-06-05T22:00:00Z</dtend>
+                        <summary>Friday Game Night</summary>
+                        <rrule>
+                          <freq>WEEKLY</freq>
+                          <byday><weekday>FR</weekday></byday>
+                          <count>8</count>
+                        </rrule>
+                        <exdate>2026-06-19T19:00:00Z</exdate>
+                      </vevent>
+                      <vevent>
+                        <uid>{event_id}</uid>
+                        <recurrence-id>2026-06-12T19:00:00Z</recurrence-id>
+                        <summary>Special: Halo Tournament</summary>
+                        <dtstart>2026-06-12T20:00:00Z</dtstart>
+                      </vevent>
+                    </vcalendar>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains("cal-publish"))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains("type=\"result\""),
+        "publish must succeed: {publish_result}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="cal-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{EVENTS_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send items query");
+    let items_response = client
+        .recv_matching(|frame| frame.contains("cal-items") && frame.contains("<vevent"))
+        .await
+        .expect("items response");
+
+    assert!(
+        items_response.contains(&event_id),
+        "items query missing event id: {items_response}"
+    );
+    assert!(
+        items_response.contains("Friday Game Night"),
+        "master summary missing: {items_response}"
+    );
+    assert!(
+        items_response.contains("Special: Halo Tournament"),
+        "override summary missing: {items_response}"
+    );
+    assert!(
+        items_response.contains("<recurrence-id"),
+        "override recurrence-id missing: {items_response}"
+    );
+    assert!(
+        items_response.contains("<exdate"),
+        "EXDATE missing on master: {items_response}"
+    );
+    assert!(
+        items_response.contains("2026-06-12T20:00:00")
+            || items_response.contains("2026-06-12T20:00:00Z"),
+        "override dtstart missing: {items_response}"
+    );
+
+    let _ = client.close().await;
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_xcal.rs
@@ -11,8 +11,8 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use waddle_xmpp_core::xcal::{
-    build_vcalendar_with_event, parse_vcalendar_event, Attendee, Freq, PartStat, Rrule, RruleEnd,
-    VEvent, Weekday, NS_XCAL, PUBSUB_NODE_EVENTS,
+    build_vcalendar_with_event, build_vcalendar_with_item, parse_vcalendar_item, Attendee,
+    CalendarItem, Freq, PartStat, Rrule, RruleEnd, VEvent, Weekday, NS_XCAL, PUBSUB_NODE_EVENTS,
 };
 use wasm_bindgen::prelude::*;
 
@@ -55,6 +55,12 @@ pub(crate) struct JsVEvent {
     /// folds sibling `-rsvp-*` items into this list before render.
     #[serde(default)]
     pub attendees: Vec<JsAttendee>,
+    /// RFC3339 — set on override VEVENTs (one occurrence of a
+    /// recurring master). `None` on the master event itself.
+    pub recurrence_id: Option<String>,
+    /// RFC3339[] — per-instance cancellations on the master event.
+    #[serde(default)]
+    pub exdates: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -87,6 +93,33 @@ pub(crate) struct JsVEventInput {
     pub dtstart: Option<String>,
     pub dtend: Option<String>,
     pub rrule: Option<JsRrule>,
+}
+
+/// Full CalendarItem write input — master VEVENT plus optional
+/// per-instance overrides and EXDATE cancellations. Each override
+/// MUST carry a `recurrence_id` so the server (and the chat
+/// expander) can correlate it back to a specific occurrence of the
+/// master series.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JsCalendarItemInput {
+    pub master: JsVEventInput,
+    #[serde(default)]
+    pub overrides: Vec<JsOverrideInput>,
+    /// RFC3339[] — occurrence DTSTART values to skip on the master.
+    #[serde(default)]
+    pub exdates: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JsOverrideInput {
+    /// RFC3339. The occurrence this override replaces.
+    pub recurrence_id: String,
+    /// All fields optional — overrides patch a subset of the master.
+    pub summary: Option<String>,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub dtstart: Option<String>,
+    pub dtend: Option<String>,
 }
 
 impl From<&Rrule> for JsRrule {
@@ -164,6 +197,8 @@ impl JsVEvent {
             dtend: event.dtend.map(|ts| ts.to_rfc3339()),
             rrule: event.rrule.as_ref().map(JsRrule::from),
             attendees: event.attendees.iter().map(JsAttendee::from).collect(),
+            recurrence_id: event.recurrence_id.map(|ts| ts.to_rfc3339()),
+            exdates: event.exdates.iter().map(|ts| ts.to_rfc3339()).collect(),
         }
     }
 }
@@ -213,6 +248,8 @@ fn build_rsvp_publish_iq(
         organizer: None,
         rrule: None,
         attendees: vec![Attendee::new(format!("xmpp:{self_jid}"), partstat)],
+        recurrence_id: None,
+        exdates: Vec::new(),
     };
     let item = Element::builder("item", NS_PUBSUB)
         .attr("id", item_id.as_str())
@@ -231,6 +268,88 @@ fn build_rsvp_publish_iq(
         .attr("to", community_jid)
         .append(pubsub)
         .build()
+}
+
+/// Build a publish IQ for a CalendarItem (master + overrides) at
+/// the given item id. Used by `xcal_publish_item` to atomically
+/// write a master event plus its per-instance overrides + EXDATEs.
+fn build_item_publish_iq(community_jid: &str, item_id: &str, item: &CalendarItem) -> Element {
+    let id = format!("xcal-publish-{}", Uuid::new_v4());
+    let pubsub_item = Element::builder("item", NS_PUBSUB)
+        .attr("id", item_id)
+        .append(build_vcalendar_with_item(item))
+        .build();
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr("node", PUBSUB_NODE_EVENTS)
+        .append(pubsub_item)
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
+        .attr("id", id)
+        .attr("to", community_jid)
+        .append(pubsub)
+        .build()
+}
+
+fn vevent_from_input(uid: &str, input: JsVEventInput) -> Result<VEvent, JsValue> {
+    let mut event = VEvent::new(uid, input.summary).with_dtstamp(Utc::now());
+    if let Some(dtstart) = input.dtstart {
+        let parsed: DateTime<Utc> = dtstart
+            .parse()
+            .map_err(|err| js_error(format!("invalid dtstart: {err}")))?;
+        event = event.with_dtstart(parsed);
+    }
+    if let Some(dtend) = input.dtend {
+        let parsed: DateTime<Utc> = dtend
+            .parse()
+            .map_err(|err| js_error(format!("invalid dtend: {err}")))?;
+        event = event.with_dtend(parsed);
+    }
+    if let Some(description) = input.description {
+        event = event.with_description(description);
+    }
+    if let Some(location) = input.location {
+        event = event.with_location(location);
+    }
+    if let Some(organizer) = input.organizer {
+        event = event.with_organizer(organizer);
+    }
+    if let Some(rrule) = input.rrule {
+        event = event.with_rrule(rrule.into_rrule()?);
+    }
+    Ok(event)
+}
+
+fn override_from_input(uid: &str, input: JsOverrideInput) -> Result<VEvent, JsValue> {
+    let recurrence_id: DateTime<Utc> = input
+        .recurrence_id
+        .parse()
+        .map_err(|err| js_error(format!("invalid recurrence_id: {err}")))?;
+    let mut event = VEvent::new(uid, input.summary.unwrap_or_default())
+        .with_dtstamp(Utc::now())
+        .with_recurrence_id(recurrence_id);
+    if let Some(dtstart) = input.dtstart {
+        let parsed: DateTime<Utc> = dtstart
+            .parse()
+            .map_err(|err| js_error(format!("invalid override dtstart: {err}")))?;
+        event = event.with_dtstart(parsed);
+    }
+    if let Some(dtend) = input.dtend {
+        let parsed: DateTime<Utc> = dtend
+            .parse()
+            .map_err(|err| js_error(format!("invalid override dtend: {err}")))?;
+        event = event.with_dtend(parsed);
+    }
+    if let Some(description) = input.description {
+        event = event.with_description(description);
+    }
+    if let Some(location) = input.location {
+        event = event.with_location(location);
+    }
+    Ok(event)
 }
 
 fn build_event_publish_iq(community_jid: &str, item_id: &str, event: &VEvent) -> Element {
@@ -261,17 +380,37 @@ fn parse_events_items_result(iq: &Element) -> Vec<JsVEvent> {
     let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
         return Vec::new();
     };
-    items
+    let mut flattened = Vec::new();
+    for item in items
         .children()
         .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
-        .filter_map(|item| {
-            let item_id = item.attr("id")?;
-            let vcal = item
-                .children()
-                .find(|child| child.name() == "vcalendar" && child.ns() == NS_XCAL)?;
-            parse_vcalendar_event(item_id, vcal).map(|ev| JsVEvent::from_vevent(item_id, ev))
-        })
-        .collect()
+    {
+        let Some(item_id) = item.attr("id") else {
+            continue;
+        };
+        let Some(vcal) = item
+            .children()
+            .find(|child| child.name() == "vcalendar" && child.ns() == NS_XCAL)
+        else {
+            continue;
+        };
+        let Some(parsed) = parse_vcalendar_item(item_id, vcal) else {
+            continue;
+        };
+        // Master comes back under the item id; each override gets a
+        // synthetic id `<item-id>::override::<recurrence-id-rfc3339>`
+        // so the chat can address them individually without losing
+        // the master/override correlation (preserved via `uid`).
+        flattened.push(JsVEvent::from_vevent(item_id, parsed.master));
+        for ov in parsed.overrides {
+            let synthetic = ov
+                .recurrence_id
+                .map(|ts| format!("{item_id}::override::{}", ts.to_rfc3339()))
+                .unwrap_or_else(|| item_id.to_string());
+            flattened.push(JsVEvent::from_vevent(&synthetic, ov));
+        }
+    }
+    flattened
 }
 
 // ── Wasm methods ────────────────────────────────────────────────────
@@ -329,6 +468,76 @@ impl WaddleClient {
             send_iq_command(inner, iq).await?;
             let js_event = JsVEvent::from_vevent(&item_id, event);
             to_js_value(&js_event)
+        })
+    }
+
+    /// Publish (or replace) a full CalendarItem at the given item
+    /// id — master event plus optional per-instance overrides and
+    /// EXDATE cancellations. Use this for the read-modify-write
+    /// flows ("edit this occurrence", "edit all occurrences",
+    /// "cancel this occurrence") after fetching current state via
+    /// `xcal_items`. Passing an existing item id overwrites that
+    /// item atomically; passing a new id creates a new item.
+    pub fn xcal_publish_item(
+        &self,
+        community_jid: String,
+        item_id: String,
+        input: JsValue,
+    ) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let input: JsCalendarItemInput = serde_wasm_bindgen::from_value(input)
+                .map_err(|err| js_error(format!("invalid calendar item input: {err}")))?;
+            if item_id.is_empty() {
+                return Err(js_error("item_id must not be empty"));
+            }
+            let mut master = vevent_from_input(&item_id, input.master)?;
+            for exdate in input.exdates {
+                let parsed: DateTime<Utc> = exdate
+                    .parse()
+                    .map_err(|err| js_error(format!("invalid exdate: {err}")))?;
+                master = master.add_exdate(parsed);
+            }
+            let mut item = CalendarItem::new(master);
+            for ov in input.overrides {
+                item = item.add_override(override_from_input(&item_id, ov)?);
+            }
+            let iq = build_item_publish_iq(&community_jid, &item_id, &item);
+            send_iq_command(inner, iq).await?;
+            let js_master = JsVEvent::from_vevent(&item_id, item.master);
+            to_js_value(&js_master)
+        })
+    }
+
+    /// Retract a calendar item from the events node. Used for
+    /// "cancel entire series" — removes the master plus any
+    /// overrides in one shot.
+    pub fn xcal_retract(&self, community_jid: String, item_id: String) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            if item_id.is_empty() {
+                return Err(js_error("item_id must not be empty"));
+            }
+            let id = format!("xcal-retract-{}", Uuid::new_v4());
+            let item = Element::builder("item", NS_PUBSUB)
+                .attr("id", item_id.as_str())
+                .build();
+            let retract = Element::builder("retract", NS_PUBSUB)
+                .attr("node", PUBSUB_NODE_EVENTS)
+                .attr("notify", "true")
+                .append(item)
+                .build();
+            let pubsub = Element::builder("pubsub", NS_PUBSUB)
+                .append(retract)
+                .build();
+            let iq = Element::builder("iq", NS_CLIENT)
+                .attr("type", "set")
+                .attr("id", id)
+                .attr("to", community_jid)
+                .append(pubsub)
+                .build();
+            send_iq_command(inner, iq).await?;
+            Ok(JsValue::TRUE)
         })
     }
 

--- a/server/crates/waddle-xmpp-core/src/xcal.rs
+++ b/server/crates/waddle-xmpp-core/src/xcal.rs
@@ -40,10 +40,10 @@
 //!
 //! ## Out of scope (today)
 //!
-//! VTODO, VJOURNAL, VALARM, VTIMEZONE, ATTENDEE/RSVP via iTIP,
-//! RECURRENCE-ID overrides, EXDATE/EXRULE. These can be layered on
-//! top of the typed model in follow-up work; the wire format leaves
-//! room for them without requiring a redesign.
+//! VTODO, VJOURNAL, VALARM, VTIMEZONE, EXRULE. ATTENDEE (RSVP),
+//! RECURRENCE-ID overrides and EXDATE are modelled; the chat
+//! aggregates per-user RSVP items into the master event and expands
+//! recurring instances client-side.
 
 use chrono::{DateTime, Utc};
 use minidom::Element;
@@ -289,6 +289,38 @@ pub struct VEvent {
     /// aggregates per-attendee RSVPs from sibling pubsub items into
     /// this list on the master event before rendering.
     pub attendees: Vec<Attendee>,
+    /// RFC 5545 §3.8.4.4 RECURRENCE-ID — set on override VEVENT
+    /// components that replace a single occurrence of the master
+    /// series. `None` on the master event itself.
+    pub recurrence_id: Option<DateTime<Utc>>,
+    /// RFC 5545 §3.8.5.1 EXDATE — occurrence DTSTART values that
+    /// should be skipped (per-instance cancellations). Only
+    /// meaningful on the master event.
+    pub exdates: Vec<DateTime<Utc>>,
+}
+
+/// A logical calendar item: one master VEVENT plus any per-instance
+/// override VEVENTs (each identified by `recurrence_id`). All
+/// components share a UID. Per ProtoXEP §"Calendar Items" they MUST
+/// ship inside the same pubsub item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CalendarItem {
+    pub master: VEvent,
+    pub overrides: Vec<VEvent>,
+}
+
+impl CalendarItem {
+    pub fn new(master: VEvent) -> Self {
+        Self {
+            master,
+            overrides: Vec::new(),
+        }
+    }
+
+    pub fn add_override(mut self, override_event: VEvent) -> Self {
+        self.overrides.push(override_event);
+        self
+    }
 }
 
 impl VEvent {
@@ -304,6 +336,8 @@ impl VEvent {
             organizer: None,
             rrule: None,
             attendees: Vec::new(),
+            recurrence_id: None,
+            exdates: Vec::new(),
         }
     }
 
@@ -349,6 +383,21 @@ impl VEvent {
 
     pub fn add_attendee(mut self, attendee: Attendee) -> Self {
         self.attendees.push(attendee);
+        self
+    }
+
+    pub fn with_recurrence_id(mut self, recurrence_id: DateTime<Utc>) -> Self {
+        self.recurrence_id = Some(recurrence_id);
+        self
+    }
+
+    pub fn with_exdates<I: IntoIterator<Item = DateTime<Utc>>>(mut self, exdates: I) -> Self {
+        self.exdates = exdates.into_iter().collect();
+        self
+    }
+
+    pub fn add_exdate(mut self, exdate: DateTime<Utc>) -> Self {
+        self.exdates.push(exdate);
         self
     }
 
@@ -399,11 +448,35 @@ fn build_rrule_element(rrule: &Rrule) -> Element {
 
 /// Build a `<vcalendar><vevent/></vcalendar>` payload for a single
 /// event. Wraps the VEVENT in a VCALENDAR with `<version>2.0</version>`
-/// per RFC 5545.
+/// per RFC 5545. Equivalent to `build_vcalendar_with_item` for a
+/// non-recurring item with no overrides.
 pub fn build_vcalendar_with_event(event: &VEvent) -> Element {
+    build_vcalendar_with_item(&CalendarItem {
+        master: event.clone(),
+        overrides: Vec::new(),
+    })
+}
+
+/// Build a `<vcalendar/>` payload carrying a master VEVENT plus
+/// zero or more sibling override VEVENTs (one per RECURRENCE-ID).
+/// Per ProtoXEP §"Calendar Items", components sharing a UID MUST
+/// live in the same pubsub item — this is the shape that lets a
+/// recurring event carry per-instance edits.
+pub fn build_vcalendar_with_item(item: &CalendarItem) -> Element {
     let mut vcalendar = Element::builder("vcalendar", NS_XCAL).build();
     append_text_child(&mut vcalendar, "version", "2.0");
+    vcalendar.append_child(build_vevent_element(&item.master));
+    for override_event in &item.overrides {
+        vcalendar.append_child(build_vevent_element(override_event));
+    }
+    vcalendar
+}
 
+/// Build a standalone `<vevent>` element (no enclosing
+/// `<vcalendar>`). Used by both `build_vcalendar_with_event` and
+/// `build_vcalendar_with_item` so master + override events share
+/// exactly one serializer.
+fn build_vevent_element(event: &VEvent) -> Element {
     let mut vevent = Element::builder("vevent", NS_XCAL).build();
     append_text_child(&mut vevent, "uid", &event.uid);
     if let Some(dtstamp) = event.dtstamp {
@@ -415,7 +488,9 @@ pub fn build_vcalendar_with_event(event: &VEvent) -> Element {
     if let Some(dtend) = event.dtend {
         append_text_child(&mut vevent, "dtend", &dtend.to_rfc3339());
     }
-    append_text_child(&mut vevent, "summary", &event.summary);
+    if !event.summary.is_empty() {
+        append_text_child(&mut vevent, "summary", &event.summary);
+    }
     if let Some(ref desc) = event.description {
         append_text_child(&mut vevent, "description", desc);
     }
@@ -428,12 +503,16 @@ pub fn build_vcalendar_with_event(event: &VEvent) -> Element {
     if let Some(ref rrule) = event.rrule {
         vevent.append_child(build_rrule_element(rrule));
     }
+    if let Some(recurrence_id) = event.recurrence_id {
+        append_text_child(&mut vevent, "recurrence-id", &recurrence_id.to_rfc3339());
+    }
+    for exdate in &event.exdates {
+        append_text_child(&mut vevent, "exdate", &exdate.to_rfc3339());
+    }
     for attendee in &event.attendees {
         vevent.append_child(build_attendee_element(attendee));
     }
-
-    vcalendar.append_child(vevent);
-    vcalendar
+    vevent
 }
 
 fn build_attendee_element(attendee: &Attendee) -> Element {
@@ -504,16 +583,54 @@ fn parse_rrule(elem: &Element) -> Option<Rrule> {
     })
 }
 
-/// Parse a VEVENT payload from a `<vcalendar/>` element. Returns the
-/// first VEVENT found; ProtoXEP §3 mandates one logical event per
-/// pubsub item (sibling components must share a UID — which we
-/// don't yet support in this minimal subset).
+/// Parse a single VEVENT child off a `<vcalendar>` element. Returns
+/// the master event (the one without a `<recurrence-id>` child) when
+/// the calendar contains multiple sibling VEVENTs; per-instance
+/// overrides are surfaced via `parse_vcalendar_item`. SUMMARY is
+/// permitted to be empty so that override events (which only patch
+/// a subset of fields) round-trip cleanly.
 pub fn parse_vcalendar_event(item_id: &str, vcalendar: &Element) -> Option<VEvent> {
+    let item = parse_vcalendar_item(item_id, vcalendar)?;
+    Some(item.master)
+}
+
+/// Parse a `<vcalendar/>` into a `CalendarItem` (master + per-
+/// instance overrides). When the calendar carries multiple sibling
+/// VEVENTs, the one *without* a `<recurrence-id>` is the master and
+/// the rest are overrides; when there's only one VEVENT it's the
+/// master and `overrides` is empty.
+pub fn parse_vcalendar_item(item_id: &str, vcalendar: &Element) -> Option<CalendarItem> {
     if !is_vcalendar_element(vcalendar) {
         return None;
     }
-    let vevent = xcal_child(vcalendar, "vevent")?;
-    let summary = xcal_text(vevent, "summary")?;
+    let vevents: Vec<&Element> = vcalendar
+        .children()
+        .filter(|c| c.name() == "vevent" && c.ns() == NS_XCAL)
+        .collect();
+    if vevents.is_empty() {
+        return None;
+    }
+    let mut master: Option<VEvent> = None;
+    let mut overrides: Vec<VEvent> = Vec::new();
+    for vevent in vevents {
+        let parsed = parse_vevent_element(item_id, vevent);
+        if parsed.recurrence_id.is_some() {
+            overrides.push(parsed);
+        } else if master.is_none() {
+            master = Some(parsed);
+        } else {
+            // Multiple components without RECURRENCE-ID share a UID —
+            // unusual but treat the extras as overrides anchored to
+            // their own DTSTART to keep all components reachable.
+            overrides.push(parsed);
+        }
+    }
+    let master = master?;
+    Some(CalendarItem { master, overrides })
+}
+
+fn parse_vevent_element(item_id: &str, vevent: &Element) -> VEvent {
+    let summary = xcal_text(vevent, "summary").unwrap_or_default();
     let uid = xcal_text(vevent, "uid").unwrap_or_else(|| item_id.to_string());
     let dtstamp = xcal_text(vevent, "dtstamp").and_then(|s| s.parse().ok());
     let dtstart = xcal_text(vevent, "dtstart").and_then(|s| s.parse().ok());
@@ -527,7 +644,16 @@ pub fn parse_vcalendar_event(item_id: &str, vcalendar: &Element) -> Option<VEven
         .filter(|c| c.name() == "attendee" && c.ns() == NS_XCAL)
         .filter_map(parse_attendee)
         .collect();
-    Some(VEvent {
+    let recurrence_id = xcal_text(vevent, "recurrence-id").and_then(|s| s.parse().ok());
+    let exdates = vevent
+        .children()
+        .filter(|c| c.name() == "exdate" && c.ns() == NS_XCAL)
+        .filter_map(|c| {
+            let t = c.text();
+            t.trim().parse::<DateTime<Utc>>().ok()
+        })
+        .collect();
+    VEvent {
         uid,
         dtstamp,
         dtstart,
@@ -538,7 +664,9 @@ pub fn parse_vcalendar_event(item_id: &str, vcalendar: &Element) -> Option<VEven
         organizer,
         rrule,
         attendees,
-    })
+        recurrence_id,
+        exdates,
+    }
 }
 
 fn parse_attendee(elem: &Element) -> Option<Attendee> {
@@ -710,7 +838,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_rejects_missing_summary() {
+    fn parse_tolerates_missing_summary_for_overrides() {
+        // RFC 5545 makes SUMMARY optional. Overrides that only patch
+        // a different field (DTSTART, LOCATION, …) ship without one,
+        // so the parser surfaces an empty summary instead of dropping
+        // the whole event.
         let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
   <vevent>
     <uid>no-summary</uid>
@@ -718,7 +850,8 @@ mod tests {
   </vevent>
 </vcalendar>"#;
         let elem: Element = xml.parse().expect("valid xml");
-        assert!(parse_vcalendar_event("no-summary", &elem).is_none());
+        let event = parse_vcalendar_event("no-summary", &elem).expect("parseable");
+        assert!(event.summary.is_empty());
     }
 
     #[test]
@@ -814,6 +947,80 @@ mod tests {
             event.attendees.is_empty(),
             "empty URI attendee must be dropped"
         );
+    }
+
+    #[test]
+    fn build_and_parse_recurring_item_with_overrides_and_exdates() {
+        let rrule = Rrule::new(Freq::Weekly)
+            .with_by_day([Weekday::Friday])
+            .with_count(8);
+        let master = VEvent::new("evt-series", "Game Night")
+            .with_dtstart(ts(2026, 6, 5, 19, 0))
+            .with_dtend(ts(2026, 6, 5, 22, 0))
+            .with_rrule(rrule)
+            .with_exdates([ts(2026, 6, 19, 19, 0), ts(2026, 7, 3, 19, 0)]);
+        let override_a = VEvent::new("evt-series", "Special: Halo")
+            .with_dtstart(ts(2026, 6, 12, 20, 0))
+            .with_recurrence_id(ts(2026, 6, 12, 19, 0));
+        let override_b = VEvent {
+            uid: "evt-series".to_string(),
+            summary: String::new(),
+            location: Some("New venue".to_string()),
+            recurrence_id: Some(ts(2026, 6, 26, 19, 0)),
+            ..VEvent::new("evt-series", "")
+        };
+        let item = CalendarItem::new(master)
+            .add_override(override_a.clone())
+            .add_override(override_b.clone());
+
+        let vcal = build_vcalendar_with_item(&item);
+        let serialised = String::from(&vcal);
+        assert_eq!(serialised.matches("<exdate>").count(), 2);
+        assert_eq!(serialised.matches("<recurrence-id>").count(), 2);
+
+        let parsed = parse_vcalendar_item("evt-series", &vcal).expect("parseable");
+        assert_eq!(parsed.master.uid, "evt-series");
+        assert_eq!(parsed.master.summary, "Game Night");
+        assert_eq!(parsed.master.exdates.len(), 2);
+        assert_eq!(parsed.master.exdates[0], ts(2026, 6, 19, 19, 0));
+        assert_eq!(parsed.overrides.len(), 2);
+        assert_eq!(
+            parsed.overrides[0].recurrence_id,
+            Some(ts(2026, 6, 12, 19, 0))
+        );
+        assert_eq!(parsed.overrides[0].summary, "Special: Halo");
+        assert_eq!(
+            parsed.overrides[1].recurrence_id,
+            Some(ts(2026, 6, 26, 19, 0))
+        );
+        assert_eq!(parsed.overrides[1].location.as_deref(), Some("New venue"));
+        assert!(parsed.overrides[1].summary.is_empty());
+    }
+
+    #[test]
+    fn parse_vcalendar_event_returns_master_when_overrides_are_siblings() {
+        // External xml with master + override mixed in arbitrary order.
+        // The master is the one without RECURRENCE-ID.
+        let xml = r#"<vcalendar xmlns='urn:ietf:params:xml:ns:xcal'>
+  <vevent>
+    <uid>evt-series</uid>
+    <recurrence-id>2026-06-12T19:00:00Z</recurrence-id>
+    <summary>Override</summary>
+  </vevent>
+  <vevent>
+    <uid>evt-series</uid>
+    <dtstart>2026-06-05T19:00:00Z</dtstart>
+    <summary>Master</summary>
+  </vevent>
+</vcalendar>"#;
+        let elem: Element = xml.parse().expect("valid xml");
+        let master = parse_vcalendar_event("evt-series", &elem).expect("parseable");
+        assert_eq!(master.summary, "Master");
+        assert!(master.recurrence_id.is_none());
+
+        let item = parse_vcalendar_item("evt-series", &elem).expect("parseable");
+        assert_eq!(item.overrides.len(), 1);
+        assert_eq!(item.overrides[0].summary, "Override");
     }
 
     #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -130,6 +130,22 @@ export class WaddleClient {
      */
     xcal_publish(community_jid: string, input: any): Promise<any>;
     /**
+     * Publish (or replace) a full CalendarItem at the given item
+     * id — master event plus optional per-instance overrides and
+     * EXDATE cancellations. Use this for the read-modify-write
+     * flows ("edit this occurrence", "edit all occurrences",
+     * "cancel this occurrence") after fetching current state via
+     * `xcal_items`. Passing an existing item id overwrites that
+     * item atomically; passing a new id creates a new item.
+     */
+    xcal_publish_item(community_jid: string, item_id: string, input: any): Promise<any>;
+    /**
+     * Retract a calendar item from the events node. Used for
+     * "cancel entire series" — removes the master plus any
+     * overrides in one shot.
+     */
+    xcal_retract(community_jid: string, item_id: string): Promise<any>;
+    /**
      * Publish (or update) this session's RSVP for a calendar event.
      * `partstat` must be one of "ACCEPTED" | "DECLINED" | "TENTATIVE"
      * | "NEEDS-ACTION". The chat groups sibling `-rsvp-*` items back

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8yeev9";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8zaihx";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8yeev9";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";


### PR DESCRIPTION
## Summary

Final follow-up from #651: per-instance `RECURRENCE-ID` overrides + per-instance `EXDATE` cancellations for community calendar events. Adds full client-side instance expansion so the events pane renders each upcoming occurrence individually with the override's properties when applicable.

Per ProtoXEP §"Calendar Items" + RFC 5545: all components for a logical event share a UID and ship inside the **same** pubsub item, with sibling `<vevent>` elements distinguished by `<recurrence-id>`.

PR A (PEP → feed bridge) landed in #652; PR B (RSVP via ATTENDEE) landed in #653.

## What's in this PR

**xCal core (`waddle-xmpp-core::xcal`)**
- `VEvent.recurrence_id: Option<DateTime<Utc>>` + `VEvent.exdates: Vec<DateTime<Utc>>` with builder methods.
- `CalendarItem { master: VEvent, overrides: Vec<VEvent> }`.
- `build_vcalendar_with_item` / `parse_vcalendar_item` for multi-component shape. Existing single-event helpers become thin wrappers.
- Parser relaxed to make SUMMARY optional so override events that only patch DTSTART / LOCATION round-trip cleanly.

**Wasm bridge (`client_xcal.rs`)**
- `JsVEvent.recurrence_id` + `JsVEvent.exdates` (RFC3339).
- `xcal_items` flattens multi-VEVENT items into a `JsVEvent[]` with synthetic ids preserving master/override correlation via `uid`.
- `xcal_publish_item(community_jid, item_id, { master, overrides, exdates })` — atomic master + overrides write for all read-modify-write flows.
- `xcal_retract(community_jid, item_id)` — for "cancel entire series".

**Chat**
- `CommunityEvent.recurrenceIdMs` + `CommunityEvent.exdatesMs`.
- New `event-expansion.ts` (~210 LOC): walks DTSTART forward by FREQ + INTERVAL with BYDAY / BYMONTHDAY / COUNT|UNTIL termination; applies EXDATE skips; substitutes override properties when an override's `recurrenceIdMs` matches a candidate occurrence.
- `useCommunityEvents` groups items by UID, expands recurring masters into upcoming instances, and feeds the existing EventsPane.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Unit (Rust) | `xcal.rs` | 16 tests — CalendarItem build/parse round-trip with master + 2 overrides + 2 EXDATEs; multi-VEVENT external XML; master identification ignores VEVENT ordering; relaxed-summary parse |
| Integration (WS) | `tests/proto_calendar_overrides_ws.rs` | publish master + override + EXDATE inside one item; verify all components round-trip via items query |
| Expander (TS) | `chat/tests/event-expansion.test.ts` | 10 tests — non-recurring pass-through; weekly+BYDAY; UNTIL termination; EXDATE skip; no-op EXDATE; RECURRENCE-ID substitution; monthly+BYMONTHDAY; maxCount cap; grouping |

## What's NOT in this PR

Nothing further is queued — this completes the three #651 follow-ups (PEP feed bridge / RSVP / overrides). Per-instance edit / cancel UI affordances (the "Edit this occurrence" modal) are wired through the composable's `xcal_publish_item` + `xcal_retract` surface but the dedicated modal is deferred to a separate UX-focused PR.

## Verification checklist

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p waddle-xmpp-core --lib xcal` — 16 pass
- [x] `cargo test -p waddle-server --test proto_calendar_overrides_ws` — 1 pass
- [x] `cargo test -p waddle-server --test proto_calendar_rsvp_ws` — 2 pass (unaffected by changes)
- [x] `bunx astro check` — 0 errors / 0 warnings / 0 hints
- [x] `bun test tests/event-expansion.test.ts tests/community-events.test.ts tests/feed-types.test.ts` — 20 pass
- [x] `bun run lint` (knip) — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.