### PR TITLE
fix(chat): bind stories + communityEvents from controller in ChatReadyShell

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -35,6 +35,8 @@ const {
   channelUnread,
   rosterContacts,
   socialFeed,
+  stories,
+  communityEvents,
   xmppClient,
   activeMessages,
   activeFirstUnseenId,


### PR DESCRIPTION
## Summary

Production fix for the runtime error reported on waddle.chat:

\`\`\`
TypeError: can't access property "activeStories", r.stories is undefined
\`\`\`

The community sidebar templates (HomeDashboard counts, StoriesPane, EventsPane) reference \`stories.activeStories\` and \`communityEvents.events\` as bare template identifiers, but \`ChatReadyShell.vue\`'s \`<script setup>\` destructure of \`props.controller\` only exposed \`socialFeed\`. Vue 3 resolves the missing identifiers against \`_ctx\`, which is undefined at runtime and throws the moment the session lifecycle reactive fires after login.

This PR adds the two missing bindings to the destructure so the templates see the live composables. The controller already returns both (\`chat-app-controller.ts:1651\` for \`stories\`, \`:1652\` for \`communityEvents\`).

## Why local checks didn't catch it

\`bunx astro check\` only validates type-level bindings — the template-to-setup-scope resolution that Vue does for bare identifiers becomes a runtime \`undefined\` access, not a type error.

## Verification

- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [ ] CI rollup green
- [ ] Verify in production after deploy (sign in to waddle.chat → no \`TypeError\` in console; HomeDashboard renders stories-active / upcoming-event counts)

This PR was created with the assistance of a LLM.