### PR TITLE
fix(chat): wire community surface taps in mobile drawer TopicsPanel

### DIFF
--- a/chat/src/components/chat/ChatMobileDrawers.vue
+++ b/chat/src/components/chat/ChatMobileDrawers.vue
@@ -41,7 +41,15 @@ const {
   selectExtensionRoute,
   openCreateChannelDialog,
   openChannelEdit,
+  stories,
+  communityEvents,
 } = props.controller;
+
+function selectCommunitySurface(surface: "feed" | "stories" | "events") {
+  ui.activePage.value = "chat";
+  ui.activeCommunitySurface.value = surface;
+  ui.showMobileNav.value = false;
+}
 
 const drawerExtensionRoutes = computed(() =>
   extensionRouteRailItems(
@@ -101,9 +109,13 @@ function openExtensionRoute(route: DiscoveredExtensionRoute) {
           :collapsed-group-ids="ui.collapsedSpaceGroupIds.value"
           :channel-unread-map="computedChannelUnreadMap"
           :thread-entries-fn="(roomJid: string) => channelUnread.threadEntries(roomJid)"
+          :active-community-surface="ui.activeCommunitySurface.value"
+          :stories-active-count="stories.activeStories.value.length"
+          :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
           class="!w-full !border-r-0 !flex-1"
-          @select-channel="selectChannel"
+          @select-channel="(id: string) => { ui.activeCommunitySurface.value = null; selectChannel(id); }"
           @select-thread="onSelectThread"
+          @select-community-surface="selectCommunitySurface"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"


### PR DESCRIPTION
## Summary

On mobile, tapping Feed / Stories / Events in the sidebar did nothing. The desktop \`ChatReadyShell\` listens for \`@select-community-surface\` on its \`TopicsPanel\` and toggles \`ui.activeCommunitySurface\`, but the mobile drawer (\`ChatMobileDrawers.vue\`) reuses the same \`TopicsPanel\` without binding the listener — so taps fired the emit and went nowhere. Active state, stories count, and upcoming event count were also missing on the mobile instance, leaving the active chip + badge counters dark.

## Fix

In \`ChatMobileDrawers.vue\`:
- Destructure \`stories\` and \`communityEvents\` from the controller (already exported there; same pattern as the #655 fix to \`ChatReadyShell\`).
- Bind the missing props: \`:active-community-surface\`, \`:stories-active-count\`, \`:upcoming-event-count\`.
- Add a \`selectCommunitySurface\` handler that mirrors the desktop one and also closes the mobile drawer so the user lands directly on the pane.
- Wrap \`@select-channel\` to clear \`activeCommunitySurface\` first, matching the desktop \`onSelectChannelFromSidebar\` behaviour.

## Verification

- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [ ] CI rollup green
- [ ] Verify on mobile after deploy: tap Feed / Stories / Events from the nav drawer → drawer closes, pane renders, active chip highlights

This PR was created with the assistance of a LLM.