### PR TITLE
fix(chat): add mobile open-nav trigger to community panes

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -271,6 +271,7 @@ function onSelectChannelFromSidebar(id: string) {
         :self-jid="connectionStore.session?.jid ?? null"
         @refresh="socialFeed.refresh()"
         @post="(input) => socialFeed.post(input)"
+        @open-nav="ui.showMobileNav.value = true"
       />
       <StoriesPane
         v-else-if="ui.activeCommunitySurface.value === 'stories'"
@@ -282,6 +283,7 @@ function onSelectChannelFromSidebar(id: string) {
         :self-jid="connectionStore.session?.jid ?? null"
         @refresh="stories.refresh()"
         @post="(input) => stories.post(input)"
+        @open-nav="ui.showMobileNav.value = true"
       />
       <EventsPane
         v-else-if="ui.activeCommunitySurface.value === 'events'"
@@ -294,6 +296,7 @@ function onSelectChannelFromSidebar(id: string) {
         @refresh="communityEvents.refresh()"
         @post="(input) => communityEvents.post(input)"
         @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
+        @open-nav="ui.showMobileNav.value = true"
       />
       <UserSettingsPage
         v-else-if="ui.activePage.value === 'settings' && connectionStore.session"

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { CalendarDays, Plus, RefreshCw, Repeat, X } from "lucide-vue-next";
+import { CalendarDays, Menu, Plus, RefreshCw, Repeat, X } from "lucide-vue-next";
 import RecurrencePicker from "@/components/community/RecurrencePicker.vue";
 import type {
   Attendee,
@@ -25,6 +25,7 @@ const emit = defineEmits<{
   refresh: [];
   post: [input: CommunityEventInput];
   rsvp: [event: CommunityEvent, partstat: PartStat];
+  openNav: [];
 }>();
 
 const selfBareJid = computed(() => {
@@ -160,6 +161,14 @@ function resetComposer() {
   <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
     <div class="mx-auto grid w-full max-w-3xl gap-4">
       <header class="flex items-center gap-2">
+        <button
+          type="button"
+          class="md:hidden inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          aria-label="Open navigation"
+          @click="emit('openNav')"
+        >
+          <Menu class="h-4 w-4" aria-hidden="true" />
+        </button>
         <CalendarDays class="h-5 w-5 text-primary" aria-hidden="true" />
         <h1 class="type-pane-title text-foreground">Community Events</h1>
         <button

--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -3,6 +3,7 @@ import { computed, ref } from "vue";
 import {
   Briefcase,
   IdCard,
+  Menu,
   MessageSquareText,
   Music,
   RefreshCw,
@@ -51,6 +52,7 @@ const props = defineProps<FeedPaneProps>();
 const emit = defineEmits<{
   refresh: [];
   post: [input: FeedPostInput];
+  openNav: [];
 }>();
 
 const composerBody = ref("");
@@ -85,6 +87,14 @@ function submit() {
   <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
     <div class="mx-auto grid w-full max-w-3xl gap-4">
       <header class="flex items-center gap-2">
+        <button
+          type="button"
+          class="md:hidden inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          aria-label="Open navigation"
+          @click="emit('openNav')"
+        >
+          <Menu class="h-4 w-4" aria-hidden="true" />
+        </button>
         <MessageSquareText class="h-5 w-5 text-primary" aria-hidden="true" />
         <h1 class="type-pane-title text-foreground">Community Feed</h1>
         <button

--- a/chat/src/components/community/StoriesPane.vue
+++ b/chat/src/components/community/StoriesPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { Camera, ChevronLeft, ChevronRight, Plus, RefreshCw, X } from "lucide-vue-next";
+import { Camera, ChevronLeft, ChevronRight, Menu, Plus, RefreshCw, X } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import type { Story, StoryPostInput } from "@/lib/xmpp-client";
 
@@ -17,6 +17,7 @@ const props = defineProps<StoriesPaneProps>();
 const emit = defineEmits<{
   refresh: [];
   post: [input: StoryPostInput];
+  openNav: [];
 }>();
 
 const composerOpen = ref(false);
@@ -101,6 +102,14 @@ function dismissComposer() {
   <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
     <div class="mx-auto grid w-full max-w-4xl gap-4">
       <header class="flex items-center gap-2">
+        <button
+          type="button"
+          class="md:hidden inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          aria-label="Open navigation"
+          @click="emit('openNav')"
+        >
+          <Menu class="h-4 w-4" aria-hidden="true" />
+        </button>
         <Camera class="h-5 w-5 text-primary" aria-hidden="true" />
         <h1 class="type-pane-title text-foreground">Stories</h1>
         <span class="type-caption text-muted-foreground">{{ stories.length }} active</span>


### PR DESCRIPTION
## Summary

On mobile, once you tap into Feed / Stories / Events there's no way back to the sidebar — the panes render full-screen with no menu trigger. (Desktop is unaffected because the sidebar is always visible.)

This PR adds a hamburger button to each pane header that emits \`openNav\`, with ChatReadyShell wiring the listener to \`ui.showMobileNav\`. Matches the existing pattern used by HomeDashboard / ChatHeader / SettingsMobileHeader.

## Verification

- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [ ] CI rollup green
- [ ] Verify on mobile: open Feed/Stories/Events → tap top-left hamburger → nav drawer opens

This PR was created with the assistance of a LLM.