### PR TITLE
feat(server): bridge RSVPs to feed + carry mood/activity detail + feed styling

### DIFF
--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -2,7 +2,9 @@
 import { computed, ref } from "vue";
 import {
   Briefcase,
+  CalendarCheck,
   IdCard,
+  Inbox,
   Menu,
   MessageSquareText,
   Music,
@@ -21,14 +23,48 @@ const SOURCE_ICONS = {
   tune: Music,
   avatar: User,
   vcard: IdCard,
+  rsvp: CalendarCheck,
 } as const;
 
 const SOURCE_LABELS: Record<FeedSourceKind, string> = {
   mood: "Mood update",
-  activity: "Activity update",
+  activity: "Activity",
   tune: "Now listening",
-  avatar: "Avatar update",
+  avatar: "New avatar",
   vcard: "Profile update",
+  rsvp: "Event RSVP",
+};
+
+/**
+ * Per-kind accent palette. Tailwind utility classes (text + bg) are
+ * paired so the badge and the card's left accent line stay tonally
+ * consistent. Chosen for contrast in both light and dark theme.
+ */
+const SOURCE_ACCENT: Record<FeedSourceKind, { chip: string; rail: string }> = {
+  mood: {
+    chip: "bg-amber-500/15 text-amber-700 dark:text-amber-300 ring-amber-500/20",
+    rail: "bg-amber-500/70",
+  },
+  activity: {
+    chip: "bg-sky-500/15 text-sky-700 dark:text-sky-300 ring-sky-500/20",
+    rail: "bg-sky-500/70",
+  },
+  tune: {
+    chip: "bg-violet-500/15 text-violet-700 dark:text-violet-300 ring-violet-500/20",
+    rail: "bg-violet-500/70",
+  },
+  avatar: {
+    chip: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 ring-emerald-500/20",
+    rail: "bg-emerald-500/70",
+  },
+  vcard: {
+    chip: "bg-rose-500/15 text-rose-700 dark:text-rose-300 ring-rose-500/20",
+    rail: "bg-rose-500/70",
+  },
+  rsvp: {
+    chip: "bg-indigo-500/15 text-indigo-700 dark:text-indigo-300 ring-indigo-500/20",
+    rail: "bg-indigo-500/70",
+  },
 };
 
 function iconFor(source: FeedSourceKind | undefined) {
@@ -37,6 +73,14 @@ function iconFor(source: FeedSourceKind | undefined) {
 
 function labelFor(source: FeedSourceKind | undefined): string {
   return source ? SOURCE_LABELS[source] : "";
+}
+
+function chipClassFor(source: FeedSourceKind | undefined): string {
+  return source ? SOURCE_ACCENT[source].chip : "";
+}
+
+function railClassFor(source: FeedSourceKind | undefined): string {
+  return source ? SOURCE_ACCENT[source].rail : "bg-border";
 }
 
 interface FeedPaneProps {
@@ -56,6 +100,7 @@ const emit = defineEmits<{
 }>();
 
 const composerBody = ref("");
+const COMPOSER_MAX = 500;
 
 function timeAgo(ms: number): string {
   const delta = Date.now() - ms;
@@ -75,9 +120,11 @@ const canSubmit = computed(() => {
   return props.canPost && !props.isPosting && composerBody.value.trim().length > 0;
 });
 
+const composerOver = computed(() => composerBody.value.length > COMPOSER_MAX);
+
 function submit() {
   const body = composerBody.value.trim();
-  if (!body) return;
+  if (!body || composerOver.value) return;
   emit("post", { body, ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}) });
   composerBody.value = "";
 }
@@ -85,7 +132,7 @@ function submit() {
 
 <template>
   <div class="chat-pane-scroll flex-1 min-h-0 bg-background px-[var(--chat-content-inline)] py-6">
-    <div class="mx-auto grid w-full max-w-3xl gap-4">
+    <div class="mx-auto grid w-full max-w-2xl gap-5">
       <header class="flex items-center gap-2">
         <button
           type="button"
@@ -95,38 +142,51 @@ function submit() {
         >
           <Menu class="h-4 w-4" aria-hidden="true" />
         </button>
-        <MessageSquareText class="h-5 w-5 text-primary" aria-hidden="true" />
-        <h1 class="type-pane-title text-foreground">Community Feed</h1>
+        <span class="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <MessageSquareText class="h-4.5 w-4.5" aria-hidden="true" />
+        </span>
+        <div class="min-w-0">
+          <h1 class="type-pane-title text-foreground leading-tight">Community Feed</h1>
+          <p class="type-caption text-muted-foreground">Highlights from across the community</p>
+        </div>
         <button
           type="button"
-          class="ml-auto inline-flex items-center gap-1 rounded-md border border-transparent px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          class="ml-auto inline-flex items-center gap-1.5 rounded-md border border-transparent px-2 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
           :disabled="isLoading"
           :aria-label="isLoading ? 'Refreshing' : 'Refresh feed'"
           @click="emit('refresh')"
         >
           <RefreshCw class="h-3.5 w-3.5" :class="{ 'animate-spin': isLoading }" aria-hidden="true" />
-          Refresh
+          <span class="hidden sm:inline">Refresh</span>
         </button>
       </header>
 
       <form
         v-if="canPost"
-        class="grid gap-2 rounded-lg border border-border bg-card p-3"
+        class="grid gap-3 rounded-xl border border-border bg-card p-4 shadow-sm focus-within:ring-1 focus-within:ring-ring/40"
         @submit.prevent="submit"
       >
-        <textarea
-          v-model="composerBody"
-          class="min-h-[3.5rem] w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          placeholder="Share something with the community…"
-          :disabled="isPosting"
-          aria-label="Feed post body"
-        />
-        <div class="flex items-center justify-between gap-2">
-          <span class="type-caption text-muted-foreground">{{ composerBody.length }} chars</span>
+        <div class="flex items-start gap-3">
+          <AppAvatar :name="authorLabel(selfJid ?? '')" :src="null" size="md" />
+          <textarea
+            v-model="composerBody"
+            class="min-h-[4rem] w-full resize-y rounded-lg border border-input bg-background px-3 py-2.5 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            placeholder="Share something with the community…"
+            :disabled="isPosting"
+            aria-label="Feed post body"
+          />
+        </div>
+        <div class="flex items-center justify-between gap-2 pl-[3.25rem]">
+          <span
+            class="type-caption"
+            :class="composerOver ? 'text-destructive' : 'text-muted-foreground'"
+          >
+            {{ composerBody.length }} / {{ COMPOSER_MAX }}
+          </span>
           <button
             type="submit"
-            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-            :disabled="!canSubmit"
+            class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3.5 py-1.5 text-xs font-medium text-primary-foreground shadow-sm transition-opacity hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            :disabled="!canSubmit || composerOver"
           >
             <Send class="h-3.5 w-3.5" aria-hidden="true" />
             {{ isPosting ? "Posting…" : "Post" }}
@@ -134,71 +194,105 @@ function submit() {
         </div>
       </form>
 
-      <div v-if="error" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+      <div
+        v-if="error"
+        class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+      >
         Couldn't load the feed: {{ error }}
       </div>
 
-      <div class="grid gap-2">
+      <div class="grid gap-3">
         <article
           v-for="entry in entries"
           :key="entry.id"
-          class="grid gap-2 rounded-lg border border-border bg-card px-4 py-3"
+          class="group relative overflow-hidden rounded-xl border border-border bg-card shadow-sm transition-colors hover:bg-card/80"
         >
-          <header class="flex min-w-0 items-center gap-3">
-            <AppAvatar :name="authorLabel(entry.author)" :src="null" size="sm" />
-            <div class="min-w-0 flex-1">
-              <p class="type-control truncate text-foreground">{{ authorLabel(entry.author) }}</p>
-              <p
-                v-if="entry.publishedMs"
-                class="type-caption text-muted-foreground"
-                :title="new Date(entry.publishedMs).toLocaleString()"
-              >
-                {{ timeAgo(entry.publishedMs) }}
-              </p>
-            </div>
-          </header>
-          <h2 v-if="entry.title" class="type-control font-semibold text-foreground">{{ entry.title }}</h2>
-          <p class="flex items-start gap-1.5 whitespace-pre-wrap break-words text-sm text-foreground">
-            <component
-              :is="iconFor(entry.source)"
-              v-if="entry.source"
-              class="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
-              :aria-label="labelFor(entry.source)"
-            />
-            <span>{{ entry.body }}</span>
-          </p>
-          <a
-            v-if="entry.link"
-            :href="entry.link"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="type-caption text-primary underline-offset-2 hover:underline"
-          >{{ entry.link }}</a>
+          <span
+            class="absolute inset-y-0 left-0 w-1"
+            :class="railClassFor(entry.source)"
+            aria-hidden="true"
+          ></span>
+          <div class="grid gap-2 pl-4 pr-4 py-3.5">
+            <header class="flex min-w-0 items-start gap-3">
+              <AppAvatar :name="authorLabel(entry.author)" :src="null" size="md" />
+              <div class="min-w-0 flex-1">
+                <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <p class="type-control truncate font-semibold text-foreground">
+                    {{ authorLabel(entry.author) }}
+                  </p>
+                  <span
+                    v-if="entry.source"
+                    class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.65rem] font-medium uppercase tracking-wide ring-1 ring-inset"
+                    :class="chipClassFor(entry.source)"
+                    :aria-label="labelFor(entry.source)"
+                  >
+                    <component
+                      :is="iconFor(entry.source)"
+                      class="h-3 w-3"
+                      aria-hidden="true"
+                    />
+                    {{ labelFor(entry.source) }}
+                  </span>
+                </div>
+                <p
+                  v-if="entry.publishedMs"
+                  class="type-caption text-muted-foreground"
+                  :title="new Date(entry.publishedMs).toLocaleString()"
+                >
+                  {{ timeAgo(entry.publishedMs) }}
+                </p>
+              </div>
+            </header>
+            <h2
+              v-if="entry.title"
+              class="type-control font-semibold text-foreground"
+            >
+              {{ entry.title }}
+            </h2>
+            <p class="whitespace-pre-wrap break-words text-sm leading-relaxed text-foreground">
+              {{ entry.body }}
+            </p>
+            <a
+              v-if="entry.link"
+              :href="entry.link"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="type-caption inline-flex items-center gap-1 text-primary underline-offset-2 hover:underline"
+            >
+              {{ entry.link }}
+            </a>
+          </div>
         </article>
 
         <template v-if="isLoading && entries.length === 0">
           <div
             v-for="i in 3"
             :key="`feed-skel-${i}`"
-            class="grid gap-2 rounded-lg border border-border bg-card px-4 py-3"
+            class="grid gap-3 rounded-xl border border-border bg-card px-4 py-3.5 shadow-sm"
             aria-hidden="true"
           >
             <div class="flex items-center gap-3">
-              <Skeleton width="2rem" height="2rem" radius="9999px" />
+              <Skeleton width="2.25rem" height="2.25rem" radius="9999px" />
               <div class="flex flex-1 flex-col gap-1.5">
-                <Skeleton width="35%" height="0.7rem" />
-                <Skeleton width="20%" height="0.55rem" />
+                <Skeleton width="35%" height="0.75rem" />
+                <Skeleton width="20%" height="0.6rem" />
               </div>
             </div>
-            <Skeleton width="100%" height="0.75rem" />
-            <Skeleton width="80%" height="0.75rem" />
+            <Skeleton width="100%" height="0.8rem" />
+            <Skeleton width="80%" height="0.8rem" />
           </div>
         </template>
         <div
           v-else-if="entries.length === 0"
-          class="type-caption rounded-lg border border-border px-4 py-6 text-center text-muted-foreground"
+          class="flex flex-col items-center gap-2 rounded-xl border border-dashed border-border bg-card/40 px-6 py-10 text-center"
         >
-          No posts yet. {{ canPost ? "Be the first to share something." : "Check back later." }}
+          <span class="flex h-10 w-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Inbox class="h-5 w-5" aria-hidden="true" />
+          </span>
+          <p class="type-control text-foreground">It's quiet in here</p>
+          <p class="type-caption text-muted-foreground">
+            {{ canPost ? "Share the first update — moods, activities, RSVPs and posts land here." : "Check back later." }}
+          </p>
         </div>
       </div>
     </div>

--- a/chat/src/lib/xmpp/feed-types.ts
+++ b/chat/src/lib/xmpp/feed-types.ts
@@ -9,7 +9,7 @@
  * server side `pep_feed_bridge` shadow-published this entry. Manual
  * posts leave `source` undefined.
  */
-export type FeedSourceKind = "mood" | "activity" | "tune" | "avatar" | "vcard";
+export type FeedSourceKind = "mood" | "activity" | "tune" | "avatar" | "vcard" | "rsvp";
 
 export interface FeedEntry {
   /** Pubsub item id assigned by the publisher (UUID). */
@@ -51,6 +51,7 @@ const KNOWN_SOURCE_KINDS: ReadonlySet<FeedSourceKind> = new Set([
   "tune",
   "avatar",
   "vcard",
+  "rsvp",
 ]);
 
 function coerceSource(raw: string | null | undefined): FeedSourceKind | undefined {

--- a/chat/tests/feed-types.test.ts
+++ b/chat/tests/feed-types.test.ts
@@ -25,7 +25,7 @@ describe("feedEntryFromWasm", () => {
   });
 
   test("bridged entry surfaces the source kind", () => {
-    for (const kind of ["mood", "activity", "tune", "avatar", "vcard"] as const) {
+    for (const kind of ["mood", "activity", "tune", "avatar", "vcard", "rsvp"] as const) {
       const wasm: WasmFeedEntry = {
         id: `bridged-${kind}`,
         body: "summary",

--- a/server/crates/waddle-server/src/pep_feed_bridge.rs
+++ b/server/crates/waddle-server/src/pep_feed_bridge.rs
@@ -1,7 +1,8 @@
-//! PEP → community feed bridge.
+//! Community activity → social feed bridge.
 //!
 //! Observes successful PEP publishes (mood / activity / tune /
-//! avatar / vCard4) and shadow-publishes a typed feed entry to
+//! avatar / vCard4) AND successful RSVP publishes on the calendar
+//! events node, and shadow-publishes a typed feed entry to
 //! `urn:xmpp:pubsub-social-feed:0` on the community service so the
 //! Feed pane surfaces user activity automatically alongside manual
 //! posts.
@@ -48,8 +49,11 @@ const COOLDOWN_TUNE: Duration = Duration::from_secs(30 * 60);
 
 const FEATURE_ENV: &str = "WADDLE_PEP_FEED_BRIDGE_ENABLED";
 
-/// Which PEP kind a bridged entry summarises. Matches the
-/// `<source kind=.../>` attribute the chat reads.
+/// Which kind of activity a bridged feed entry summarises. Matches
+/// the `<source kind=.../>` attribute the chat reads to render the
+/// right kind-icon next to the entry. Despite the type name (kept
+/// stable to avoid a cross-repo rename), this also covers non-PEP
+/// surfaces such as calendar RSVPs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PepKind {
     Mood,
@@ -57,6 +61,7 @@ pub enum PepKind {
     Tune,
     Avatar,
     VCard,
+    Rsvp,
 }
 
 impl PepKind {
@@ -67,6 +72,7 @@ impl PepKind {
             Self::Tune => "tune",
             Self::Avatar => "avatar",
             Self::VCard => "vcard",
+            Self::Rsvp => "rsvp",
         }
     }
 
@@ -78,7 +84,8 @@ impl PepKind {
     }
 
     /// Map a PEP node namespace to a `PepKind`, or `None` when the
-    /// node is not a PEP we bridge.
+    /// node is not a PEP we bridge. RSVPs come in via a separate
+    /// publish path (calendar events node) and aren't covered here.
     pub fn from_node(node: &str) -> Option<Self> {
         match node {
             NS_MOOD => Some(Self::Mood),
@@ -103,6 +110,10 @@ struct ThrottleSlot {
 pub struct PepFeedBridge {
     enabled: bool,
     throttle: Mutex<HashMap<(BareJid, PepKind), ThrottleSlot>>,
+    /// Separate throttle for RSVPs so each (user, event-uid) gets its
+    /// own slot — sharing a single PepKind::Rsvp slot would suppress
+    /// legitimate RSVPs to *different* events within the cooldown.
+    rsvp_throttle: Mutex<HashMap<(BareJid, String), ThrottleSlot>>,
 }
 
 impl PepFeedBridge {
@@ -115,6 +126,7 @@ impl PepFeedBridge {
         Self {
             enabled,
             throttle: Mutex::new(HashMap::new()),
+            rsvp_throttle: Mutex::new(HashMap::new()),
         }
     }
 
@@ -186,6 +198,100 @@ impl PepFeedBridge {
         }
     }
 
+    /// Observe a successful RSVP publish. Looks up the master event
+    /// to grab its SUMMARY, renders a feed entry like "is going to
+    /// Friday Game Night", and shadow-publishes it. Suppressed when
+    /// the bridge is disabled, the master can't be found, or the
+    /// per-(author, master-uid) throttle fires (so toggling Going →
+    /// Maybe → Going within the cooldown only produces one entry
+    /// per change).
+    pub async fn observe_rsvp<S: PubSubStorage + ?Sized>(
+        &self,
+        storage: &Arc<S>,
+        community_jid: &BareJid,
+        author_jid: &BareJid,
+        master_uid: &str,
+        partstat: waddle_xmpp_core::xcal::PartStat,
+    ) -> Option<String> {
+        if !self.enabled {
+            return None;
+        }
+        let master = lookup_master_event(storage, community_jid, master_uid).await?;
+        let event_label = if master.summary.is_empty() {
+            "an event".to_string()
+        } else {
+            master.summary.clone()
+        };
+        let summary = render_rsvp_summary(partstat, &event_label);
+        if !self
+            .admit_rsvp(author_jid.clone(), master_uid.to_string(), &summary)
+            .await
+        {
+            debug!(
+                author = %author_jid,
+                master_uid,
+                "RSVP→feed bridge: suppressed by throttle"
+            );
+            return None;
+        }
+        let item_id = format!("rsvp-{}-{}", short_uid(master_uid), Uuid::new_v4());
+        let entry = build_bridge_entry(&item_id, PepKind::Rsvp, author_jid, &summary);
+        let item = PubSubItem {
+            id: Some(item_id.clone()),
+            publisher: None,
+            payload: Some(entry),
+        };
+        match storage
+            .publish_item(
+                community_jid,
+                waddle_xmpp_core::xep0472::PUBSUB_NODE_FEED,
+                &item,
+                None,
+                false,
+            )
+            .await
+        {
+            Ok(result) => {
+                debug!(
+                    author = %author_jid,
+                    master_uid,
+                    item_id = %result.item_id,
+                    "RSVP→feed bridge: published"
+                );
+                Some(result.item_id)
+            }
+            Err(error) => {
+                warn!(
+                    author = %author_jid,
+                    master_uid,
+                    error = %error,
+                    "RSVP→feed bridge: publish failed"
+                );
+                None
+            }
+        }
+    }
+
+    async fn admit_rsvp(&self, author: BareJid, master_uid: String, summary: &str) -> bool {
+        let mut guard = self.rsvp_throttle.lock().await;
+        let now = Instant::now();
+        let cooldown = COOLDOWN_DEFAULT;
+        match guard.get(&(author.clone(), master_uid.clone())) {
+            Some(slot) if slot.last_summary == summary => false,
+            Some(slot) if now.duration_since(slot.last_at) < cooldown => false,
+            _ => {
+                guard.insert(
+                    (author, master_uid),
+                    ThrottleSlot {
+                        last_at: now,
+                        last_summary: summary.to_string(),
+                    },
+                );
+                true
+            }
+        }
+    }
+
     /// Return `true` when this (author, kind, summary) should be
     /// bridged; `false` to suppress. Records the new state when
     /// admitting.
@@ -231,6 +337,9 @@ fn render_summary(kind: PepKind, item: &PubSubItem) -> Option<String> {
         PepKind::Tune => render_tune(payload),
         PepKind::Avatar => render_avatar(payload),
         PepKind::VCard => render_vcard(payload),
+        // RSVPs render via `render_rsvp_summary` from `observe_rsvp`;
+        // they never flow through PEP `observe`.
+        PepKind::Rsvp => None,
     }
 }
 
@@ -238,7 +347,16 @@ fn render_mood(payload: &Element) -> Option<String> {
     let mood = waddle_xmpp::xep::xep0107::parse_mood_element(payload)
         .ok()
         .flatten()?;
-    Some(format!("is feeling {}", mood.kind.as_element_name()))
+    let kind = mood.kind.as_element_name();
+    let detail = mood
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    Some(match detail {
+        Some(text) => format!("is feeling {kind} — {text}"),
+        None => format!("is feeling {kind}"),
+    })
 }
 
 fn render_activity(payload: &Element) -> Option<String> {
@@ -246,7 +364,23 @@ fn render_activity(payload: &Element) -> Option<String> {
         .ok()
         .flatten()?;
     let general = activity.general.as_element_name().replace('_', " ");
-    Some(format!("is {general}"))
+    let specific = activity
+        .specific
+        .as_ref()
+        .map(|s| s.as_str().replace('_', " "));
+    let detail = activity
+        .text
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let head = match specific.as_deref() {
+        Some(specific) if specific != general => format!("is {general} ({specific})"),
+        _ => format!("is {general}"),
+    };
+    Some(match detail {
+        Some(text) => format!("{head} — {text}"),
+        None => head,
+    })
 }
 
 fn render_tune(payload: &Element) -> Option<String> {
@@ -265,6 +399,50 @@ fn render_avatar(payload: &Element) -> Option<String> {
         "updated their avatar ({})",
         &info.id[..8.min(info.id.len())]
     ))
+}
+
+/// Render a one-line RSVP summary like "is going to Friday Game
+/// Night". `partstat` chooses the verb; `NEEDS-ACTION` is treated
+/// as a passive "is invited to" — the chat shouldn't normally
+/// publish that as an RSVP, but if it ever does we surface it
+/// without exploding.
+fn render_rsvp_summary(partstat: waddle_xmpp_core::xcal::PartStat, event_label: &str) -> String {
+    let verb = match partstat {
+        waddle_xmpp_core::xcal::PartStat::Accepted => "is going to",
+        waddle_xmpp_core::xcal::PartStat::Tentative => "might go to",
+        waddle_xmpp_core::xcal::PartStat::Declined => "won't be at",
+        waddle_xmpp_core::xcal::PartStat::NeedsAction => "is invited to",
+    };
+    format!("{verb} {event_label}")
+}
+
+/// Fetch the master VEVENT for `master_uid` from the community
+/// events node. Returns `None` when the item isn't found or the
+/// payload isn't a valid VCALENDAR (a race window when the event
+/// was retracted between RSVP publish and bridge observation).
+async fn lookup_master_event<S: PubSubStorage + ?Sized>(
+    storage: &Arc<S>,
+    community_jid: &BareJid,
+    master_uid: &str,
+) -> Option<waddle_xmpp_core::xcal::VEvent> {
+    let item_ids = [master_uid.to_string()];
+    let items = storage
+        .get_items(
+            community_jid,
+            waddle_xmpp_core::xcal::PUBSUB_NODE_EVENTS,
+            None,
+            &item_ids,
+        )
+        .await
+        .ok()?;
+    let stored = items.into_iter().next()?;
+    let pubsub_item = stored.to_pubsub_item();
+    let payload = pubsub_item.payload?;
+    waddle_xmpp_core::xcal::parse_vcalendar_event(master_uid, &payload)
+}
+
+fn short_uid(uid: &str) -> &str {
+    &uid[..12.min(uid.len())]
 }
 
 fn render_vcard(payload: &Element) -> Option<String> {
@@ -354,6 +532,67 @@ mod tests {
     }
 
     #[test]
+    fn mood_summary_appends_user_text() {
+        let item = payload(
+            "<mood xmlns='http://jabber.org/protocol/mood'>\
+                <excited/>\
+                <text>Friday tournament tonight!</text>\
+            </mood>",
+        );
+        let summary = render_summary(PepKind::Mood, &item).expect("renders");
+        assert_eq!(summary, "is feeling excited — Friday tournament tonight!");
+    }
+
+    #[test]
+    fn activity_summary_includes_specific_and_text() {
+        let item = payload(
+            "<activity xmlns='http://jabber.org/protocol/activity'>\
+                <working><coding/></working>\
+                <text>migrating the calendar module to xCal</text>\
+            </activity>",
+        );
+        let summary = render_summary(PepKind::Activity, &item).expect("renders");
+        assert_eq!(
+            summary,
+            "is working (coding) — migrating the calendar module to xCal"
+        );
+    }
+
+    #[test]
+    fn rsvp_summary_renders_each_partstat() {
+        use waddle_xmpp_core::xcal::PartStat;
+        assert_eq!(
+            render_rsvp_summary(PartStat::Accepted, "Friday Game Night"),
+            "is going to Friday Game Night"
+        );
+        assert_eq!(
+            render_rsvp_summary(PartStat::Tentative, "Friday Game Night"),
+            "might go to Friday Game Night"
+        );
+        assert_eq!(
+            render_rsvp_summary(PartStat::Declined, "Friday Game Night"),
+            "won't be at Friday Game Night"
+        );
+        assert_eq!(
+            render_rsvp_summary(PartStat::NeedsAction, "Friday Game Night"),
+            "is invited to Friday Game Night"
+        );
+    }
+
+    #[test]
+    fn activity_summary_drops_redundant_specific_equal_to_general() {
+        // Defensive: if a client somehow emits the general name as
+        // the specific (unusual but seen in the wild), don't repeat.
+        let item = payload(
+            "<activity xmlns='http://jabber.org/protocol/activity'>\
+                <working><working/></working>\
+            </activity>",
+        );
+        let summary = render_summary(PepKind::Activity, &item).expect("renders");
+        assert_eq!(summary, "is working");
+    }
+
+    #[test]
     fn tune_summary_includes_title_and_artist() {
         let item = payload(
             "<tune xmlns='http://jabber.org/protocol/tune'>\
@@ -410,6 +649,7 @@ mod tests {
         let bridge = PepFeedBridge {
             enabled: true,
             throttle: Mutex::new(HashMap::new()),
+            rsvp_throttle: Mutex::new(HashMap::new()),
         };
         let author = bare("alice@example.com");
         assert!(
@@ -430,6 +670,7 @@ mod tests {
         let bridge = PepFeedBridge {
             enabled: true,
             throttle: Mutex::new(HashMap::new()),
+            rsvp_throttle: Mutex::new(HashMap::new()),
         };
         let author = bare("alice@example.com");
         assert!(
@@ -450,6 +691,7 @@ mod tests {
         let bridge = PepFeedBridge {
             enabled: true,
             throttle: Mutex::new(HashMap::new()),
+            rsvp_throttle: Mutex::new(HashMap::new()),
         };
         let alice = bare("alice@example.com");
         let bob = bare("bob@example.com");

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -596,6 +596,35 @@ fn parse_rsvp_item_id(item_id: &str) -> Option<(&str, &str)> {
     Some((master_uid, localpart))
 }
 
+/// Extract (author bare-JID, master event UID, partstat) from a
+/// well-formed RSVP pubsub item. The item is already validated by
+/// `is_well_formed_rsvp_item` at this point — we only return `Some`
+/// when every field needed for the feed bridge is intact.
+fn rsvp_bridge_context(
+    item: &PubSubItem,
+) -> Option<(BareJid, String, waddle_xmpp_core::xcal::PartStat)> {
+    let item_id = item.id.as_deref()?;
+    let (master_uid, _localpart) = parse_rsvp_item_id(item_id)?;
+    let payload = item.payload.as_ref()?;
+    if !waddle_xmpp_core::xcal::is_vcalendar_element(payload) {
+        return None;
+    }
+    let ns_xcal = waddle_xmpp_core::xcal::NS_XCAL;
+    let vevent = payload
+        .children()
+        .find(|c| c.name() == "vevent" && c.ns() == ns_xcal)?;
+    let attendee = vevent
+        .children()
+        .find(|c| c.name() == "attendee" && c.ns() == ns_xcal)?;
+    let partstat = attendee
+        .attr("partstat")
+        .and_then(waddle_xmpp_core::xcal::PartStat::from_str_value)?;
+    let uri = attendee.text();
+    let bare = waddle_xmpp_core::xcal::xmpp_uri_to_bare_jid(uri.trim())?;
+    let author_jid = bare.parse::<BareJid>().ok()?;
+    Some((author_jid, master_uid.to_string(), partstat))
+}
+
 async fn handle_community_rsvp_publish(
     iq: &xmpp_parsers::iq::Iq,
     state: &WebSocketState,
@@ -603,6 +632,7 @@ async fn handle_community_rsvp_publish(
     node: &str,
     item: PubSubItem,
 ) -> Vec<String> {
+    let bridge_context = rsvp_bridge_context(&item);
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
@@ -641,6 +671,24 @@ async fn handle_community_rsvp_publish(
                 },
             )
             .await;
+            // Bridge into the social feed so "X is going to <event>"
+            // surfaces alongside manual posts. Best-effort: failures
+            // are logged inside `observe_rsvp` and never block the
+            // RSVP publish itself.
+            if let Some((author_jid, master_uid, partstat)) = bridge_context {
+                let _ = state
+                    .deps
+                    .protocol
+                    .pep_feed_bridge
+                    .observe_rsvp(
+                        &state.deps.protocol.pubsub_storage,
+                        &community_jid,
+                        &author_jid,
+                        &master_uid,
+                        partstat,
+                    )
+                    .await;
+            }
             vec![iq_to_xml(build_pubsub_publish_result(
                 iq,
                 node,

--- a/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
+++ b/server/crates/waddle-server/tests/proto_calendar_rsvp_ws.rs
@@ -14,6 +14,7 @@ const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
 const COMMUNITY_JID: &str = "community.localhost";
 const EVENTS_NODE: &str = "urn:xmpp:calendar:0";
+const FEED_NODE: &str = "urn:xmpp:pubsub-social-feed:0";
 const NS_XCAL: &str = "urn:ietf:params:xml:ns:xcal";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
@@ -247,6 +248,104 @@ async fn malformed_rsvp_for_other_user_is_rejected() {
     assert!(
         rich_result.contains("type=\"error\"") || rich_result.contains("<error"),
         "RSVP item with master-event fields must be rejected: {rich_result}"
+    );
+
+    let _ = admin.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn rsvp_publish_bridges_to_social_feed() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut admin, mut bob) = setup().await;
+
+    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
+
+    // Admin publishes the master event with a recognisable summary.
+    admin
+        .send(&format!(
+            r#"<iq type="set" id="cal-publish" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <publish node="{EVENTS_NODE}">
+                  <item id="{event_id}">
+                    <vcalendar xmlns="{NS_XCAL}">
+                      <version>2.0</version>
+                      <vevent>
+                        <uid>{event_id}</uid>
+                        <dtstart>2026-06-05T19:00:00Z</dtstart>
+                        <summary>Friday Game Night</summary>
+                      </vevent>
+                    </vcalendar>
+                  </item>
+                </publish>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send master publish");
+    let _ = admin
+        .recv_matching(|frame| frame.contains("cal-publish"))
+        .await
+        .expect("master publish result");
+
+    // Bob RSVPs ACCEPTED.
+    let rsvp_id = format!("{event_id}-rsvp-bob");
+    bob.send(&format!(
+        r#"<iq type="set" id="rsvp-1" to="{COMMUNITY_JID}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="{EVENTS_NODE}">
+              <item id="{rsvp_id}">
+                <vcalendar xmlns="{NS_XCAL}">
+                  <vevent>
+                    <uid>{event_id}</uid>
+                    <attendee partstat="ACCEPTED">xmpp:bob@localhost</attendee>
+                  </vevent>
+                </vcalendar>
+              </item>
+            </publish>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("send rsvp");
+    let rsvp_result = bob
+        .recv_matching(|frame| frame.contains("rsvp-1"))
+        .await
+        .expect("rsvp publish result");
+    assert!(
+        rsvp_result.contains("type=\"result\""),
+        "rsvp publish must succeed: {rsvp_result}"
+    );
+
+    // Query the social feed — the bridge should have shadow-published
+    // a "bob is going to Friday Game Night" entry tagged with the
+    // RSVP source kind.
+    admin
+        .send(&format!(
+            r#"<iq type="get" id="feed-items" to="{COMMUNITY_JID}">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{FEED_NODE}"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send feed query");
+    let feed_response = admin
+        .recv_matching(|frame| frame.contains("feed-items") && frame.contains("<entry"))
+        .await
+        .expect("feed response");
+
+    assert!(
+        feed_response.contains("<author>bob@localhost</author>"),
+        "feed entry must carry bob's bare JID: {feed_response}"
+    );
+    assert!(
+        feed_response.contains("is going to Friday Game Night"),
+        "feed entry must carry the RSVP summary: {feed_response}"
+    );
+    assert!(
+        feed_response.contains("kind=\"rsvp\"") || feed_response.contains("kind='rsvp'"),
+        "feed entry must tag the RSVP source kind: {feed_response}"
     );
 
     let _ = admin.close().await;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp8zaihx";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9jd9v8";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp8zaihx";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";


### PR DESCRIPTION
## Summary

Three changes shipping together because they all touch the community feed.

### 1. Mood + activity feed entries lost their detail

The PEP→feed bridge dropped the human-supplied colour from mood ("why I'm in the mood") and activity ("what specifically I'm working on") updates, so the feed showed bare \`is feeling happy\` / \`is working\` with no context. Renderers now stitch:
- Mood: \`is feeling {kind}\` + optional \` — {text}\`.
- Activity: \`is {general}\` + optional \` ({specific})\` + optional \` — {text}\`.
- Tune / avatar / vcard unchanged.

### 2. RSVPs weren't on the feed at all

Calendar RSVPs were a private write against the events node and never surfaced as feed activity. Added \`observe_rsvp(community_jid, author, master_uid, partstat)\` on the bridge, called from the RSVP publish path. The bridge looks up the master event for its SUMMARY and emits typed feed entries like \`is going to Friday Game Night\`, tagged with \`<source kind='rsvp'/>\` so the chat renders the calendar icon. PartStat verbs:

| PartStat | Verb |
| --- | --- |
| ACCEPTED | is going to |
| TENTATIVE | might go to |
| DECLINED | won't be at |
| NEEDS-ACTION | is invited to |

RSVPs get their own \`(author, master_uid)\`-keyed throttle alongside the existing per-(user, kind) PEP throttle, so RSVPing to two different events in the same cooldown window doesn't drop the second one.

### 3. Feed styling pass

Each kind now has a paired accent palette (chip + left-rail). Entries gain a labelled source chip ("Mood update", "Now listening", "Event RSVP" etc.), the composer wraps the author's avatar, the empty state uses an icon + headline, and skeleton rows match the new card shape.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Unit (Rust) | \`pep_feed_bridge.rs\` | +3 cases: mood text appended, activity specific+text formatted, RSVP renderer covers every partstat (kept previous 16 tests) |
| Integration (WS) | \`tests/proto_calendar_rsvp_ws.rs\` | new \`rsvp_publish_bridges_to_social_feed\` — publish master + RSVP, assert feed entry carries bob's bare JID, "is going to Friday Game Night" body, and \`kind="rsvp"\` source |
| Codec (TS) | \`chat/tests/feed-types.test.ts\` | round-trip rsvp kind alongside the existing five |

## Verification

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`cargo test -p waddle-server --lib pep_feed_bridge\` — 19 pass
- [x] \`cargo test -p waddle-server --test proto_calendar_rsvp_ws\` — 3 pass
- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [x] \`bun test tests/feed-types.test.ts tests/community-events.test.ts\` — 10 pass
- [x] \`bun run lint\` (knip) — clean
- [ ] CI rollup green before manual merge

This PR was created with the assistance of a LLM.