### PR TITLE
feat(chat): edit + cancel community events (organiser-only)

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -295,6 +295,8 @@ function onSelectChannelFromSidebar(id: string) {
         :self-jid="connectionStore.session?.jid ?? null"
         @refresh="communityEvents.refresh()"
         @post="(input) => communityEvents.post(input)"
+        @edit="(id, input) => communityEvents.edit(id, input)"
+        @cancel-event="(event) => communityEvents.cancel(event.id)"
         @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
         @open-nav="ui.showMobileNav.value = true"
       />

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -6,9 +6,11 @@ import {
   ChevronRight,
   List,
   Menu,
+  Pencil,
   Plus,
   RefreshCw,
   Repeat,
+  Trash2,
   X,
 } from "lucide-vue-next";
 import RecurrencePicker from "@/components/community/RecurrencePicker.vue";
@@ -34,9 +36,28 @@ const props = defineProps<EventsPaneProps>();
 const emit = defineEmits<{
   refresh: [];
   post: [input: CommunityEventInput];
+  edit: [itemId: string, input: CommunityEventInput];
+  cancelEvent: [event: CommunityEvent];
   rsvp: [event: CommunityEvent, partstat: PartStat];
   openNav: [];
 }>();
+
+/**
+ * Strip `xmpp:` URI prefix and trim any resource so attendee /
+ * organiser URIs compare cleanly against a session's bare JID.
+ */
+function bareFromUri(uri: string | undefined | null): string | null {
+  if (!uri) return null;
+  const stripped = uri.startsWith("xmpp:") ? uri.slice(5) : uri;
+  return stripped.split("/")[0] ?? stripped;
+}
+
+function isOrganiser(event: CommunityEvent): boolean {
+  const self = selfBareJid.value;
+  if (!self) return false;
+  const eventOrganiser = bareFromUri(event.organizer);
+  return !!eventOrganiser && eventOrganiser === self;
+}
 
 // ─── Identity ────────────────────────────────────────────────────────────────
 
@@ -250,6 +271,7 @@ function authorLabel(jid: string | undefined): string {
 // ─── Composer ─────────────────────────────────────────────────────────────────
 
 const composerOpen = ref(false);
+const editingId = ref<string | null>(null);
 const summary = ref("");
 const description = ref("");
 const location = ref("");
@@ -260,6 +282,31 @@ const rrule = ref<Rrule | null>(null);
 const canSubmit = computed(
   () => props.canPost && !props.isPosting && summary.value.trim().length > 0,
 );
+
+/** Format an epoch-ms timestamp for the `<input type="datetime-local">` widget. */
+function toDatetimeLocal(ms: number | undefined): string {
+  if (typeof ms !== "number") return "";
+  const d = new Date(ms);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function startEdit(event: CommunityEvent) {
+  editingId.value = event.id;
+  summary.value = event.summary;
+  description.value = event.description ?? "";
+  location.value = event.location ?? "";
+  dtstart.value = toDatetimeLocal(event.dtstartMs);
+  dtend.value = toDatetimeLocal(event.dtendMs);
+  rrule.value = event.rrule ?? null;
+  composerOpen.value = true;
+}
+
+function onCancelEvent(event: CommunityEvent) {
+  const ok = window.confirm(`Cancel "${event.summary}"? This removes the event for everyone.`);
+  if (!ok) return;
+  emit("cancelEvent", event);
+}
 
 function submit() {
   const summaryValue = summary.value.trim();
@@ -275,12 +322,17 @@ function submit() {
     ...(dtend.value ? { dtendMs: Date.parse(dtend.value) } : {}),
     ...(rrule.value ? { rrule: rrule.value } : {}),
   };
-  emit("post", input);
+  if (editingId.value) {
+    emit("edit", editingId.value, input);
+  } else {
+    emit("post", input);
+  }
   resetComposer();
 }
 
 function resetComposer() {
   composerOpen.value = false;
+  editingId.value = null;
   summary.value = "";
   description.value = "";
   location.value = "";
@@ -354,10 +406,10 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           v-if="canPost"
           type="button"
           class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90"
-          @click="composerOpen = !composerOpen"
+          @click="composerOpen ? resetComposer() : (composerOpen = true)"
         >
           <Plus class="h-3.5 w-3.5" aria-hidden="true" />
-          {{ composerOpen ? "Close" : "New event" }}
+          {{ composerOpen ? (editingId ? "Cancel edit" : "Close") : "New event" }}
         </button>
         <button
           v-else
@@ -440,7 +492,7 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
             class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
             :disabled="!canSubmit"
           >
-            {{ isPosting ? "Publishing…" : "Publish event" }}
+            {{ isPosting ? (editingId ? "Saving…" : "Publishing…") : (editingId ? "Save changes" : "Publish event") }}
           </button>
         </div>
       </form>
@@ -461,9 +513,29 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
             >
               <header class="flex items-baseline justify-between gap-3">
                 <h3 class="type-control font-semibold text-foreground">{{ event.summary }}</h3>
-                <span class="type-caption shrink-0 text-muted-foreground">
-                  {{ formatTime(event) }}
-                </span>
+                <div class="flex shrink-0 items-center gap-1">
+                  <span class="type-caption text-muted-foreground">
+                    {{ formatTime(event) }}
+                  </span>
+                  <template v-if="isOrganiser(event)">
+                    <button
+                      type="button"
+                      class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                      aria-label="Edit event"
+                      @click="startEdit(event)"
+                    >
+                      <Pencil class="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                      aria-label="Cancel event"
+                      @click="onCancelEvent(event)"
+                    >
+                      <Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  </template>
+                </div>
               </header>
               <p v-if="event.location" class="type-caption text-muted-foreground">
                 📍 {{ event.location }}
@@ -627,7 +699,27 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
           >
             <header class="flex items-baseline justify-between gap-3">
               <h3 class="type-control font-semibold text-foreground">{{ event.summary }}</h3>
-              <span class="type-caption shrink-0 text-muted-foreground">{{ formatStart(event) }}</span>
+              <div class="flex shrink-0 items-center gap-1">
+                <span class="type-caption text-muted-foreground">{{ formatStart(event) }}</span>
+                <template v-if="isOrganiser(event)">
+                  <button
+                    type="button"
+                    class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                    aria-label="Edit event"
+                    @click="startEdit(event)"
+                  >
+                    <Pencil class="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    aria-label="Cancel event"
+                    @click="onCancelEvent(event)"
+                  >
+                    <Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
+                  </button>
+                </template>
+              </div>
             </header>
             <p v-if="event.location" class="type-caption text-muted-foreground">
               📍 {{ event.location }}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -985,6 +985,51 @@ export class BrowserXmppClient {
   }
 
   /**
+   * Replace an existing community event item with new master values.
+   * Uses `xcal_publish_item` which atomically overwrites the item at
+   * `itemId`, preserving any sibling RSVPs (those live on their own
+   * `-rsvp-*` item ids).
+   */
+  async updateCommunityEvent(
+    communityJid: string,
+    itemId: string,
+    input: CommunityEventInput,
+  ): Promise<CommunityEvent> {
+    const xmpp = await this.requireConnectedXmpp();
+    const result = await xmpp.xcal_publish_item?.(communityJid, itemId, {
+      master: {
+        summary: input.summary,
+        ...(input.description ? { description: input.description } : {}),
+        ...(input.location ? { location: input.location } : {}),
+        ...(input.organizer ? { organizer: input.organizer } : {}),
+        ...(typeof input.dtstartMs === "number"
+          ? { dtstart: new Date(input.dtstartMs).toISOString() }
+          : {}),
+        ...(typeof input.dtendMs === "number"
+          ? { dtend: new Date(input.dtendMs).toISOString() }
+          : {}),
+        ...(input.rrule ? { rrule: rruleToWasm(input.rrule) } : {}),
+      },
+      overrides: [],
+      exdates: [],
+    }) as WasmVEvent | undefined;
+    if (!result) {
+      throw new Error("xcal_publish_item returned no event");
+    }
+    return eventFromWasm(result);
+  }
+
+  /**
+   * Retract (delete) a community event item. Removes the master plus
+   * any per-instance overrides in one shot; sibling RSVP items live
+   * under their own ids and stay behind until separately retracted.
+   */
+  async retractCommunityEvent(communityJid: string, itemId: string): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    await xmpp.xcal_retract?.(communityJid, itemId);
+  }
+
+  /**
    * Publish (or update) this session's RSVP for a calendar event.
    * The server bridges the call to a sibling pubsub item; the chat
    * folds it back into the master event on the next refresh.

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -98,6 +98,52 @@ export function useCommunityEvents(
   }
 
   /**
+   * Replace an existing event in place. The pubsub item id is
+   * preserved so sibling RSVPs (`<itemId>-rsvp-*`) stay grouped
+   * under the same master after the next refresh.
+   */
+  async function edit(
+    itemId: string,
+    input: CommunityEventInput,
+  ): Promise<CommunityEvent | null> {
+    const client = xmppClient.value;
+    const jid = options.communityJid.value;
+    if (!client || !jid) return null;
+    if (!input.summary.trim()) return null;
+    isPosting.value = true;
+    error.value = null;
+    try {
+      const event = await client.updateCommunityEvent(jid, itemId, input);
+      events.value = events.value.map((e) => (e.id === itemId ? event : e));
+      return event;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return null;
+    } finally {
+      isPosting.value = false;
+    }
+  }
+
+  /**
+   * Cancel (retract) an event series entirely. Optimistically drops
+   * the master from local state so the UI updates instantly; the
+   * next refresh confirms.
+   */
+  async function cancel(itemId: string): Promise<boolean> {
+    const client = xmppClient.value;
+    const jid = options.communityJid.value;
+    if (!client || !jid || !itemId) return false;
+    try {
+      await client.retractCommunityEvent(jid, itemId);
+      events.value = events.value.filter((e) => e.id !== itemId);
+      return true;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return false;
+    }
+  }
+
+  /**
    * Publish (or update) this session's RSVP for an event. Server
    * persists a sibling pubsub item; we optimistically fold the new
    * attendee into the local master and rely on refresh() for the
@@ -148,6 +194,8 @@ export function useCommunityEvents(
     error,
     refresh,
     post,
+    edit,
+    cancel,
     rsvp,
     clear,
   };

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -8,6 +8,8 @@ const COMMUNITY = "community.example.com";
 type MockClient = BrowserXmppClient & {
   fetchCommunityEvents: ReturnType<typeof mock>;
   publishCommunityEvent: ReturnType<typeof mock>;
+  updateCommunityEvent: ReturnType<typeof mock>;
+  retractCommunityEvent: ReturnType<typeof mock>;
   rsvpCommunityEvent: ReturnType<typeof mock>;
 };
 
@@ -27,6 +29,20 @@ function makeClient(events: CommunityEvent[] = []): MockClient {
         ...(input.rrule ? { rrule: input.rrule } : {}),
       } satisfies CommunityEvent),
     ),
+    updateCommunityEvent: mock((_jid: string, itemId: string, input: CommunityEventInput) =>
+      Promise.resolve({
+        id: itemId,
+        uid: itemId,
+        summary: input.summary,
+        ...(input.description ? { description: input.description } : {}),
+        ...(input.location ? { location: input.location } : {}),
+        ...(input.organizer ? { organizer: input.organizer } : {}),
+        ...(typeof input.dtstartMs === "number" ? { dtstartMs: input.dtstartMs } : {}),
+        ...(typeof input.dtendMs === "number" ? { dtendMs: input.dtendMs } : {}),
+        ...(input.rrule ? { rrule: input.rrule } : {}),
+      } satisfies CommunityEvent),
+    ),
+    retractCommunityEvent: mock(() => Promise.resolve()),
     rsvpCommunityEvent: mock(() => Promise.resolve()),
   } as unknown as MockClient;
 }
@@ -131,5 +147,55 @@ describe("useCommunityEvents", () => {
     });
     const ok = await events.rsvp("evt", "alice", "alice@example.com", "ACCEPTED");
     expect(ok).toBe(false);
+  });
+
+  test("edit replaces the existing event by id and keeps it sorted", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-a", uid: "evt-a", summary: "Original", dtstartMs: future },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const updated = await events.edit("evt-a", {
+      summary: "Renamed",
+      dtstartMs: future,
+    });
+    expect(updated?.summary).toBe("Renamed");
+    expect(client.updateCommunityEvent).toHaveBeenCalledWith(
+      COMMUNITY,
+      "evt-a",
+      expect.objectContaining({ summary: "Renamed" }),
+    );
+    expect(events.events.value.find((e) => e.id === "evt-a")?.summary).toBe("Renamed");
+  });
+
+  test("edit rejects empty summary", async () => {
+    const client = makeClient([
+      { id: "evt-a", uid: "evt-a", summary: "Original", dtstartMs: Date.now() + 1000 },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    const result = await events.edit("evt-a", { summary: "   " });
+    expect(result).toBe(null);
+    expect(client.updateCommunityEvent).not.toHaveBeenCalled();
+  });
+
+  test("cancel retracts and removes the event optimistically", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-a", uid: "evt-a", summary: "Going away", dtstartMs: future },
+      { id: "evt-b", uid: "evt-b", summary: "Stays", dtstartMs: future + 1000 },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const ok = await events.cancel("evt-a");
+    expect(ok).toBe(true);
+    expect(client.retractCommunityEvent).toHaveBeenCalledWith(COMMUNITY, "evt-a");
+    expect(events.events.value.map((e) => e.id)).toEqual(["evt-b"]);
   });
 });


### PR DESCRIPTION
## Summary

PR #654 shipped the wasm-bridge primitives for atomic event replace (\`xcal_publish_item\`) and series retract (\`xcal_retract\`), but never wired them through the chat — so once an event was published there was no way to fix a typo, move the time, or cancel it. \`EventsPane\` only exposed RSVP pills.

This PR closes the loop:

- New \`updateCommunityEvent\` / \`retractCommunityEvent\` client wrappers around the wasm methods.
- New \`edit(itemId, input)\` and \`cancel(itemId)\` methods on the \`useCommunityEvents\` composable with optimistic local-state updates.
- Small Pencil / Trash icon pair on every event card in both the 7-day and month views, visible only when the session user's bare JID matches the event's organiser URI.
- Edit pre-fills the composer with the event's current values (summary, description, location, dtstart, dtend, rrule) and routes submit through \`emit('edit', ...)\` instead of the new-event path. Composer button toggles to \"Cancel edit\" / \"Save changes\" labels when editing.
- Delete is gated behind \`window.confirm\` since retracting a series is destructive and removes the event for everyone.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Composable (TS) | \`chat/tests/community-events.test.ts\` | +3 new tests — edit replaces in place, edit rejects empty summary, cancel retracts + drops from local state (plus 6 existing tests still pass) |

## Verification

- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [x] \`bun test tests/community-events.test.ts\` — 9 pass
- [x] \`bun run lint\` (knip) — clean
- [ ] CI rollup green
- [ ] Verify in production: create event, edit it (organiser sees pencil/trash, non-organiser doesn't), delete it (confirm dialog appears, event vanishes from list)

This PR was created with the assistance of a LLM.