### PR TITLE
fix(chat): edit/cancel target master; recurring cancel offers scope

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -293,10 +293,12 @@ function onSelectChannelFromSidebar(id: string) {
         :error="communityEvents.error.value"
         :can-post="!!connectionStore.session"
         :self-jid="connectionStore.session?.jid ?? null"
+        :find-master="communityEvents.findMaster"
         @refresh="communityEvents.refresh()"
         @post="(input) => communityEvents.post(input)"
         @edit="(id, input) => communityEvents.edit(id, input)"
-        @cancel-event="(event) => communityEvents.cancel(event.id)"
+        @cancel-series="(id) => communityEvents.cancel(id)"
+        @cancel-instance="(uid, dtstartMs) => communityEvents.cancelInstance(uid, dtstartMs)"
         @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
         @open-nav="ui.showMobileNav.value = true"
       />

--- a/chat/src/components/community/EventsPane.vue
+++ b/chat/src/components/community/EventsPane.vue
@@ -30,6 +30,12 @@ interface EventsPaneProps {
   error: string | null;
   canPost: boolean;
   selfJid: string | null;
+  /**
+   * Resolver from a UID back to the unexpanded master event so the
+   * pane can edit / cancel the actual pubsub item rather than the
+   * synthetic per-instance id produced by client-side expansion.
+   */
+  findMaster: (uid: string) => CommunityEvent | null;
 }
 
 const props = defineProps<EventsPaneProps>();
@@ -37,7 +43,8 @@ const emit = defineEmits<{
   refresh: [];
   post: [input: CommunityEventInput];
   edit: [itemId: string, input: CommunityEventInput];
-  cancelEvent: [event: CommunityEvent];
+  cancelSeries: [masterId: string];
+  cancelInstance: [masterUid: string, instanceDtstartMs: number];
   rsvp: [event: CommunityEvent, partstat: PartStat];
   openNav: [];
 }>();
@@ -291,21 +298,60 @@ function toDatetimeLocal(ms: number | undefined): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+/**
+ * Edits always target the unexpanded master so the RRULE / EXDATEs
+ * are preserved and the resulting publish lands at the real pubsub
+ * item id. An expanded instance has a synthetic id (`<master>::<ts>`)
+ * which doesn't exist on the server.
+ */
 function startEdit(event: CommunityEvent) {
-  editingId.value = event.id;
-  summary.value = event.summary;
-  description.value = event.description ?? "";
-  location.value = event.location ?? "";
-  dtstart.value = toDatetimeLocal(event.dtstartMs);
-  dtend.value = toDatetimeLocal(event.dtendMs);
-  rrule.value = event.rrule ?? null;
+  const master = props.findMaster(event.uid) ?? event;
+  editingId.value = master.id;
+  summary.value = master.summary;
+  description.value = master.description ?? "";
+  location.value = master.location ?? "";
+  dtstart.value = toDatetimeLocal(master.dtstartMs);
+  dtend.value = toDatetimeLocal(master.dtendMs);
+  rrule.value = master.rrule ?? null;
   composerOpen.value = true;
 }
 
+// ── Cancel action sheet ──────────────────────────────────────────────────────
+// Tracks which event the user just clicked Trash on. For recurring
+// events we pop a small action sheet to choose just-this vs entire-
+// series; for one-off events a plain confirm() is enough.
+const cancelTarget = ref<CommunityEvent | null>(null);
+
 function onCancelEvent(event: CommunityEvent) {
-  const ok = window.confirm(`Cancel "${event.summary}"? This removes the event for everyone.`);
+  const master = props.findMaster(event.uid);
+  if (master?.rrule) {
+    cancelTarget.value = event;
+    return;
+  }
+  const ok = window.confirm(
+    `Cancel "${event.summary}"? This removes the event for everyone.`,
+  );
   if (!ok) return;
-  emit("cancelEvent", event);
+  emit("cancelSeries", (master ?? event).id);
+}
+
+function confirmCancelInstance() {
+  const event = cancelTarget.value;
+  if (!event || typeof event.dtstartMs !== "number") return;
+  emit("cancelInstance", event.uid, event.dtstartMs);
+  cancelTarget.value = null;
+}
+
+function confirmCancelSeries() {
+  const event = cancelTarget.value;
+  if (!event) return;
+  const master = props.findMaster(event.uid) ?? event;
+  emit("cancelSeries", master.id);
+  cancelTarget.value = null;
+}
+
+function dismissCancelSheet() {
+  cancelTarget.value = null;
 }
 
 function submit() {
@@ -776,6 +822,53 @@ const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
         </p>
       </template>
 
+    </div>
+
+    <!-- Cancel action sheet (recurring events only) -->
+    <div
+      v-if="cancelTarget"
+      class="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      @click.self="dismissCancelSheet"
+    >
+      <div class="w-full max-w-sm rounded-lg border border-border bg-card p-4 shadow-lg">
+        <h2 class="type-pane-title text-foreground">
+          Cancel "{{ cancelTarget.summary }}"
+        </h2>
+        <p class="type-caption mt-1 text-muted-foreground">
+          This event repeats. Choose what to cancel:
+        </p>
+        <div class="mt-3 grid gap-2">
+          <button
+            type="button"
+            class="inline-flex items-center justify-between rounded-md border border-input px-3 py-2 text-sm text-foreground hover:bg-muted/50"
+            @click="confirmCancelInstance"
+          >
+            <span>Just this occurrence</span>
+            <span class="type-caption text-muted-foreground">
+              {{ cancelTarget.dtstartMs ? new Date(cancelTarget.dtstartMs).toLocaleString(undefined, { weekday: 'short', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' }) : '' }}
+            </span>
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center justify-between rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
+            @click="confirmCancelSeries"
+          >
+            <span>The entire series</span>
+            <span class="type-caption">All future occurrences</span>
+          </button>
+        </div>
+        <div class="mt-3 flex justify-end">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+            @click="dismissCancelSheet"
+          >
+            Keep event
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -996,6 +996,7 @@ export class BrowserXmppClient {
     input: CommunityEventInput,
   ): Promise<CommunityEvent> {
     const xmpp = await this.requireConnectedXmpp();
+    const exdates = (input.exdatesMs ?? []).map((ms) => new Date(ms).toISOString());
     const result = await xmpp.xcal_publish_item?.(communityJid, itemId, {
       master: {
         summary: input.summary,
@@ -1011,7 +1012,7 @@ export class BrowserXmppClient {
         ...(input.rrule ? { rrule: rruleToWasm(input.rrule) } : {}),
       },
       overrides: [],
-      exdates: [],
+      exdates,
     }) as WasmVEvent | undefined;
     if (!result) {
       throw new Error("xcal_publish_item returned no event");

--- a/chat/src/lib/xmpp/event-types.ts
+++ b/chat/src/lib/xmpp/event-types.ts
@@ -78,6 +78,12 @@ export interface CommunityEventInput {
   /** Epoch ms. */
   dtendMs?: number;
   rrule?: Rrule;
+  /**
+   * EXDATE list (epoch ms) — occurrence DTSTARTs to skip on a
+   * recurring master. Only meaningful when `rrule` is set. Empty /
+   * absent means no occurrences are excluded.
+   */
+  exdatesMs?: number[];
 }
 
 // ── Wasm boundary ───────────────────────────────────────────────────

--- a/chat/src/services/community-events.ts
+++ b/chat/src/services/community-events.ts
@@ -51,6 +51,23 @@ export function useCommunityEvents(
     return sortEventsUpcomingFirst(expanded);
   });
 
+  /**
+   * Look up the unexpanded master event behind an expanded instance
+   * (or a non-recurring event). Returns `null` when the uid isn't
+   * a known master — happens for transient state during a refresh.
+   *
+   * Callers use this to recover the real pubsub item id (so edit /
+   * cancel target the master rather than a synthetic instance id)
+   * and to read the master's RRULE / EXDATEs.
+   */
+  function findMaster(uid: string): CommunityEvent | null {
+    const merged = groupEventsWithRsvps(events.value);
+    for (const group of groupEventsWithOverrides(merged)) {
+      if (group.master.uid === uid) return group.master;
+    }
+    return null;
+  }
+
   async function refresh(): Promise<boolean> {
     const client = xmppClient.value;
     const jid = options.communityJid.value;
@@ -144,6 +161,50 @@ export function useCommunityEvents(
   }
 
   /**
+   * Cancel a single occurrence of a recurring event by appending the
+   * occurrence's DTSTART to the master's EXDATEs and re-publishing
+   * the master in place. Falls back to a full series retract when
+   * the master isn't recurring.
+   */
+  async function cancelInstance(
+    masterUid: string,
+    instanceDtstartMs: number,
+  ): Promise<boolean> {
+    const master = findMaster(masterUid);
+    if (!master) return false;
+    if (!master.rrule) {
+      return cancel(master.id);
+    }
+    const client = xmppClient.value;
+    const jid = options.communityJid.value;
+    if (!client || !jid) return false;
+    const existing = new Set(master.exdatesMs ?? []);
+    existing.add(instanceDtstartMs);
+    const nextExdatesMs = [...existing].sort((a, b) => a - b);
+    isPosting.value = true;
+    error.value = null;
+    try {
+      const updated = await client.updateCommunityEvent(jid, master.id, {
+        summary: master.summary,
+        ...(master.description ? { description: master.description } : {}),
+        ...(master.location ? { location: master.location } : {}),
+        ...(master.organizer ? { organizer: master.organizer } : {}),
+        ...(typeof master.dtstartMs === "number" ? { dtstartMs: master.dtstartMs } : {}),
+        ...(typeof master.dtendMs === "number" ? { dtendMs: master.dtendMs } : {}),
+        ...(master.rrule ? { rrule: master.rrule } : {}),
+        exdatesMs: nextExdatesMs,
+      });
+      events.value = events.value.map((e) => (e.id === master.id ? updated : e));
+      return true;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : String(err);
+      return false;
+    } finally {
+      isPosting.value = false;
+    }
+  }
+
+  /**
    * Publish (or update) this session's RSVP for an event. Server
    * persists a sibling pubsub item; we optimistically fold the new
    * attendee into the local master and rely on refresh() for the
@@ -196,6 +257,8 @@ export function useCommunityEvents(
     post,
     edit,
     cancel,
+    cancelInstance,
+    findMaster,
     rsvp,
     clear,
   };

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -198,4 +198,69 @@ describe("useCommunityEvents", () => {
     expect(client.retractCommunityEvent).toHaveBeenCalledWith(COMMUNITY, "evt-a");
     expect(events.events.value.map((e) => e.id)).toEqual(["evt-b"]);
   });
+
+  test("cancelInstance appends EXDATE on recurring master and republishes", async () => {
+    const dtstart = Date.parse("2026-06-05T19:00:00Z");
+    const skipInstance = Date.parse("2026-06-12T19:00:00Z");
+    const client = makeClient([
+      {
+        id: "evt-series",
+        uid: "evt-series",
+        summary: "Friday Game Night",
+        dtstartMs: dtstart,
+        rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+      },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const ok = await events.cancelInstance("evt-series", skipInstance);
+    expect(ok).toBe(true);
+    expect(client.updateCommunityEvent).toHaveBeenCalledTimes(1);
+    const updateCall = client.updateCommunityEvent.mock.calls[0];
+    expect(updateCall?.[0]).toBe(COMMUNITY);
+    expect(updateCall?.[1]).toBe("evt-series");
+    expect(updateCall?.[2]?.exdatesMs).toEqual([skipInstance]);
+    expect(client.retractCommunityEvent).not.toHaveBeenCalled();
+  });
+
+  test("cancelInstance falls back to retract for non-recurring events", async () => {
+    const future = Date.now() + 86_400_000;
+    const client = makeClient([
+      { id: "evt-once", uid: "evt-once", summary: "One-off", dtstartMs: future },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    const ok = await events.cancelInstance("evt-once", future);
+    expect(ok).toBe(true);
+    expect(client.retractCommunityEvent).toHaveBeenCalledWith(COMMUNITY, "evt-once");
+  });
+
+  test("findMaster recovers the unexpanded master by uid", async () => {
+    const dtstart = Date.parse("2026-06-05T19:00:00Z");
+    const client = makeClient([
+      {
+        id: "evt-series",
+        uid: "evt-series",
+        summary: "Friday Game Night",
+        dtstartMs: dtstart,
+        rrule: { freq: "WEEKLY", byDay: ["FR"], count: 4 },
+      },
+    ]);
+    const events = useCommunityEvents(ref<BrowserXmppClient | null>(client), {
+      communityJid: ref<string | null>(COMMUNITY),
+    });
+    await events.refresh();
+    // Sorted view contains synthetic-id instances.
+    const instance = events.events.value[0]!;
+    expect(instance.id).not.toBe(instance.uid);
+    expect(instance.rrule).toBeUndefined();
+    // findMaster routes back to the real pubsub item with RRULE intact.
+    const master = events.findMaster(instance.uid);
+    expect(master?.id).toBe("evt-series");
+    expect(master?.rrule?.freq).toBe("WEEKLY");
+  });
 });

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -722,6 +722,12 @@ pub(super) async fn handle_community_items(
     let Ok(community_jid) = community_domain.parse::<BareJid>() else {
         return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::InvalidJid))];
     };
+    // Community nodes (feed/stories/events) are server-managed: the
+    // topology bootstrap creates them on every startup. If a read
+    // hits before that bootstrap has run (or pre-dates the node's
+    // introduction in an older prod DB), surface an empty result
+    // rather than `item-not-found` so the chat lands on its empty
+    // state instead of an error banner.
     match state
         .deps
         .protocol
@@ -730,7 +736,7 @@ pub(super) async fn handle_community_items(
         .await
     {
         Ok(Some(_)) => {}
-        Ok(None) => return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))],
+        Ok(None) => return vec![iq_to_xml(build_pubsub_items_result(iq, node, &[]))],
         Err(error) => {
             warn!(node, error = %error, "Failed to retrieve community node");
             return vec![iq_to_xml(build_pubsub_error(iq, PubSubError::NodeNotFound))];

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9jd9v8";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9kods7";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9jd9v8";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";


### PR DESCRIPTION
## Summary

Three regressions surfaced after #660 wired edit/cancel on event cards:

1. **Edit on a recurring event lost the RRULE.** The pane sees expanded instances (synthetic ids, RRULE stripped by the expander), so pre-filling from the clicked card erased recurrence. Editing then republished as a single non-recurring event.
2. **Edit also raised \`item-not-found\`** for any clicked instance because the synthetic id (\`<master>::<dtstart-ms>\`) isn't a real pubsub item.
3. **Delete had no way to cancel only one occurrence** — the trash icon always retracted the entire series.

Plus the unrelated **"Couldn't load events: item-not-found"** banner users were seeing when fetching from a fresh community service.

## Fixes

**Edit + cancel always target the unexpanded master.**
- New \`findMaster(uid)\` on \`useCommunityEvents\` returns the raw master event (with intact RRULE / EXDATEs).
- \`EventsPane\` takes \`findMaster\` as a prop and uses it both to seed the edit composer (preserving RRULE) and to make cancel-scope decisions.
- \`startEdit\` now prefills from the master and submits to the master's real item id.

**Recurring cancel offers scope.**
- \`CommunityEventInput\` gains \`exdatesMs?: number[]\` and the client wrapper forwards it through \`xcal_publish_item\`.
- New composable method \`cancelInstance(masterUid, dtstartMs)\` appends the occurrence to EXDATEs and re-publishes the master. Falls back to a full retract for non-recurring events.
- The trash icon opens a small action sheet on recurring events ("Just this occurrence" / "The entire series" / "Keep event"). Non-recurring events still use a plain \`confirm\`.

**Items query no longer 404s on an empty calendar.**
- The community items handler now returns an empty list instead of \`item-not-found\` when a known community node (feed / stories / events) hasn't been bootstrapped yet. Covers fresh prod DBs and any race between server startup and the first chat fetch. The pane lands on its empty state instead of an error banner.

## Tests

| Layer | File | Coverage |
| --- | --- | --- |
| Composable (TS) | \`chat/tests/community-events.test.ts\` | +3 — cancelInstance on recurring master adds to exdates + re-publishes; cancelInstance on non-recurring falls back to retract; findMaster recovers master from synthetic instance id (plus 9 existing tests still pass) |

## Verification

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\`
- [x] \`bunx astro check\` — 0 errors / 0 warnings / 0 hints
- [x] \`bun test tests/community-events.test.ts\` — 12 pass
- [x] \`bun run lint\` (knip) — clean
- [ ] CI rollup green
- [ ] Verify in prod: edit a recurring event, RRULE survives. Delete a recurring event — action sheet shows. "Just this occurrence" removes one date; "Entire series" removes all.

This PR was created with the assistance of a LLM.