### PR TITLE
feat(server): add vcard4 PRONOUNS (RFC 6350) — pronouns on user profile

### DIFF
--- a/server/crates/waddle-server/src/pep_feed_bridge.rs
+++ b/server/crates/waddle-server/src/pep_feed_bridge.rs
@@ -452,6 +452,7 @@ fn render_vcard(payload: &Element) -> Option<String> {
         && vcard.note.is_none()
         && vcard.org.is_none()
         && vcard.title.is_none()
+        && vcard.pronouns.is_none()
     {
         return None;
     }
@@ -641,6 +642,21 @@ mod tests {
             </vcard>",
         );
         let summary = render_summary(PepKind::VCard, &with_name).expect("renders");
+        assert_eq!(summary, "updated their profile");
+    }
+
+    #[test]
+    fn vcard_summary_triggers_on_pronouns_only_update() {
+        // A user can publish a vCard4 item carrying only pronouns
+        // (RFC 6350 §6.2.7 / RFC 9554 PRONOUNS) — every other field
+        // can stay untouched. The feed bridge must still treat this
+        // as a meaningful profile update so subscribers see it.
+        let with_pronouns = payload(
+            "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                <pronouns><text>they/them</text></pronouns>\
+            </vcard>",
+        );
+        let summary = render_summary(PepKind::VCard, &with_pronouns).expect("renders");
         assert_eq!(summary, "updated their profile");
     }
 

--- a/server/crates/waddle-xmpp/src/xep/xep0292.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0292.rs
@@ -65,6 +65,12 @@ pub struct VCard4 {
     pub url: Option<String>,
     /// Photo URL or base64 data URI.
     pub photo_uri: Option<String>,
+    /// Pronouns (RFC 6350 §6.2.7 / RFC 9554 PRONOUNS property).
+    ///
+    /// Freeform per RFC 6350; the XEP-0292 XML binding wraps the
+    /// value in a `<text>` grandchild like other text properties
+    /// (e.g. `<pronouns><text>they/them</text></pronouns>`).
+    pub pronouns: Option<String>,
 }
 
 impl VCard4 {
@@ -121,6 +127,12 @@ impl VCard4 {
         self
     }
 
+    /// Set the pronouns.
+    pub fn with_pronouns(mut self, pronouns: impl Into<String>) -> Self {
+        self.pronouns = Some(pronouns.into());
+        self
+    }
+
     /// Returns the best display name (full_name > nickname > None).
     pub fn display_name(&self) -> Option<&str> {
         self.full_name.as_deref().or(self.nickname.as_deref())
@@ -137,6 +149,7 @@ impl VCard4 {
             && self.title.is_none()
             && self.url.is_none()
             && self.photo_uri.is_none()
+            && self.pronouns.is_none()
     }
 }
 
@@ -180,6 +193,7 @@ pub fn parse_vcard4(elem: &Element) -> VCard4 {
         title: text_prop("title"),
         url: uri_prop("url"),
         photo_uri: uri_prop("photo"),
+        pronouns: text_prop("pronouns"),
     }
 }
 
@@ -232,6 +246,9 @@ pub fn build_vcard4_element(vcard: &VCard4) -> Element {
     if let Some(ref v) = vcard.photo_uri {
         append_uri_prop(&mut elem, "photo", v);
     }
+    if let Some(ref v) = vcard.pronouns {
+        append_text_prop(&mut elem, "pronouns", v);
+    }
 
     elem
 }
@@ -260,6 +277,7 @@ mod tests {
                     <title><text>Heir</text></title>\
                     <url><uri>https://romeo.example.com</uri></url>\
                     <photo><uri>https://example.com/romeo.jpg</uri></photo>\
+                    <pronouns><text>he/him</text></pronouns>\
                     </vcard>";
         let elem: Element = xml.parse().expect("valid xml");
         let vcard = parse_vcard4(&elem);
@@ -275,6 +293,7 @@ mod tests {
             vcard.photo_uri.as_deref(),
             Some("https://example.com/romeo.jpg")
         );
+        assert_eq!(vcard.pronouns.as_deref(), Some("he/him"));
         assert!(!vcard.is_empty());
     }
 
@@ -307,7 +326,8 @@ mod tests {
             .with_email("juliet@example.com")
             .with_note("Also star-crossed")
             .with_url("https://juliet.example.com")
-            .with_photo("https://example.com/juliet.jpg");
+            .with_photo("https://example.com/juliet.jpg")
+            .with_pronouns("she/her");
 
         let elem = build_vcard4_element(&vcard);
         assert_eq!(elem.name(), "vcard");
@@ -324,6 +344,7 @@ mod tests {
             parsed.photo_uri.as_deref(),
             Some("https://example.com/juliet.jpg")
         );
+        assert_eq!(parsed.pronouns.as_deref(), Some("she/her"));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
+++ b/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
@@ -298,9 +298,7 @@ fn xep0292_pronouns_omitted_when_unset() {
     let elem = build_vcard4_element(&vcard);
 
     assert!(
-        elem.children()
-            .find(|c| c.name() == "pronouns")
-            .is_none(),
+        elem.children().find(|c| c.name() == "pronouns").is_none(),
         "unset pronouns must not emit a <pronouns/> element"
     );
 

--- a/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
+++ b/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
@@ -183,7 +183,8 @@ fn xep0292_round_trip_preserves_every_supported_property() {
         .with_org("House Montague")
         .with_title("Heir")
         .with_url("https://romeo.example.com")
-        .with_photo("https://example.com/romeo.jpg");
+        .with_photo("https://example.com/romeo.jpg")
+        .with_pronouns("he/him");
 
     let elem = build_vcard4_element(&original);
     let reparsed = parse_vcard4(&elem);
@@ -196,6 +197,7 @@ fn xep0292_round_trip_preserves_every_supported_property() {
     assert_eq!(reparsed.title, original.title);
     assert_eq!(reparsed.url, original.url);
     assert_eq!(reparsed.photo_uri, original.photo_uri);
+    assert_eq!(reparsed.pronouns, original.pronouns);
 }
 
 #[test]
@@ -227,4 +229,102 @@ fn xep0292_parse_tolerates_missing_optional_properties() {
     assert_eq!(parsed.full_name, None);
     assert_eq!(parsed.email, None);
     assert_eq!(parsed.photo_uri, None);
+    assert_eq!(parsed.pronouns, None);
+}
+
+// ── RFC 6350 §6.2.7 / RFC 9554 PRONOUNS round-trip ───────────────────
+
+#[test]
+fn xep0292_parses_pronouns_text_child_per_rfc6350() {
+    // RFC 6350 §6.2 (extended by RFC 9554 §3.1) defines `PRONOUNS` as
+    // a text property. The XEP-0292 XML binding wraps every text
+    // property's value in a `<text>` grandchild — `<pronouns>` is no
+    // different. A conformant client publishes
+    // `<pronouns><text>they/them</text></pronouns>`; the parser must
+    // surface the value as `vcard.pronouns`.
+    let xml = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                  <fn><text>Sam</text></fn>\
+                  <pronouns><text>they/them</text></pronouns>\
+              </vcard>";
+    let elem: Element = xml.parse().expect("valid vCard4 XML");
+    let parsed = parse_vcard4(&elem);
+
+    assert_eq!(parsed.full_name.as_deref(), Some("Sam"));
+    assert_eq!(parsed.pronouns.as_deref(), Some("they/them"));
+}
+
+#[test]
+fn xep0292_pronouns_round_trip_preserves_value() {
+    // Build a vCard4 with only pronouns set, serialize, reparse, and
+    // confirm the value survives. Guards against accidental dropping
+    // of the property by either the builder or the parser.
+    let original = VCard4::new().with_pronouns("xe/xem");
+    let elem = build_vcard4_element(&original);
+    let reparsed = parse_vcard4(&elem);
+
+    assert_eq!(reparsed.pronouns.as_deref(), Some("xe/xem"));
+    assert_eq!(reparsed.full_name, None);
+}
+
+#[test]
+fn xep0292_pronouns_builder_emits_namespaced_text_grandchild() {
+    // Wire-shape contract: the builder MUST emit
+    // `<pronouns xmlns='urn:ietf:params:xml:ns:vcard-4.0'>
+    //    <text xmlns='urn:ietf:params:xml:ns:vcard-4.0'>...</text>
+    //  </pronouns>` — the same shape every other RFC 6350 text
+    // property uses. A peer parser following the spec will look for
+    // exactly this nesting.
+    let vcard = VCard4::new().with_pronouns("she/they");
+    let elem = build_vcard4_element(&vcard);
+
+    let pronouns_child = elem
+        .children()
+        .find(|c| c.name() == "pronouns" && c.ns() == NS_VCARD4)
+        .expect("<pronouns> child present");
+    let pronouns_text = pronouns_child
+        .children()
+        .find(|c| c.name() == "text" && c.ns() == NS_VCARD4)
+        .expect("<pronouns> wraps <text> per RFC 6351 mapping");
+    assert_eq!(pronouns_text.text(), "she/they");
+}
+
+#[test]
+fn xep0292_pronouns_omitted_when_unset() {
+    // Absent pronouns MUST NOT serialize to a ghost
+    // `<pronouns/>` element — an empty element would parse back to
+    // `Some("")` on some implementations and falsely indicate the
+    // user has declared pronouns when they have not.
+    let vcard = VCard4::new().with_full_name("Anonymous");
+    let elem = build_vcard4_element(&vcard);
+
+    assert!(
+        elem.children()
+            .find(|c| c.name() == "pronouns")
+            .is_none(),
+        "unset pronouns must not emit a <pronouns/> element"
+    );
+
+    // And the parser side: an empty `<text/>` under `<pronouns>`
+    // MUST round-trip to `None`, not `Some("")` — the parser already
+    // filters empty text values; this test pins that behaviour for
+    // pronouns specifically.
+    let xml = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                  <fn><text>Anon</text></fn>\
+                  <pronouns><text></text></pronouns>\
+              </vcard>";
+    let parsed = parse_vcard4(&xml.parse::<Element>().expect("valid xml"));
+    assert_eq!(parsed.pronouns, None);
+}
+
+#[test]
+fn xep0292_pronouns_freeform_value_preserved_verbatim() {
+    // RFC 9554 §3.1 explicitly leaves the value freeform — no
+    // enumeration, no normalisation. The parser/builder must not
+    // mangle whitespace, case, or punctuation in the user's chosen
+    // string.
+    let raw = "He/Him  ·  They/Them (formal)";
+    let vcard = VCard4::new().with_pronouns(raw);
+    let elem = build_vcard4_element(&vcard);
+    let parsed = parse_vcard4(&elem);
+    assert_eq!(parsed.pronouns.as_deref(), Some(raw));
 }


### PR DESCRIPTION
## Summary

- Add the RFC 6350 `PRONOUNS` property to Waddle's vcard4 (XEP-0292) support — no new XEP advert, just an extra field on an XEP we already implement.
- Surface pronouns read/write in the chat profile UI.

## Why this shape

There is no XEP for "Pronouns." RFC 6350 (vCard 4.0) defines `PRONOUNS` as a top-level property; XEP-0292 carries vCard 4.0 over XMPP. Adding it to the existing vcard4 struct keeps Waddle on the standard track and avoids a Waddle-namespaced parallel mechanism.

## Plan

1. Add typed `pronouns: Option<String>` to `VCard4` in `server/crates/waddle-xmpp/src/xep/xep0292.rs`.
2. Extend serializer/parser to round-trip `<pronouns><text>they/them</text></pronouns>` per RFC 6350.
3. Extend `server/crates/waddle-xmpp/tests/xep0292_vcard4.rs` with round-trip + omission tests (dedicated test suite per CLAUDE.md hard rule).
4. Update profile RMW (`server/crates/waddle-server/src/profile/vcard_rmw.rs`) if it filters known fields explicitly.
5. Wire pronouns into the chat profile view/edit UI under `chat/src/`.
6. Update `docs/xep-conformance-audit.md` XEP-0292 row.

## Non-goals

- No vcard-temp (XEP-0054) changes — pronouns live in vcard4 only.
- No new disco feature advert.

## Test plan

- [ ] vcard4 round-trip preserves pronouns
- [ ] Empty pronouns omitted from XML (no `<pronouns/>` ghost element)
- [ ] PEP `+notify` carries pronouns updates to subscribers
- [ ] Chat client publishes and renders pronouns
- [ ] `bun test && bun run lint` in `chat/` clean (Knip hard rule)
- [ ] `cargo clippy -D warnings` clean in `server/`

This PR was created with the assistance of a LLM.
