### PR TITLE
feat(chat): vcard4 profile editor (pairs with #663 pronouns)

### DIFF
--- a/chat/src/components/chat/UserSettingsPage.vue
+++ b/chat/src/components/chat/UserSettingsPage.vue
@@ -3,6 +3,7 @@ import { computed, reactive, ref } from "vue";
 import { ChevronLeft, MessageCircle, ScanText, UserRound } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import ScrollDirectionSwitcher from "@/components/chat/ScrollDirectionSwitcher.vue";
+import VCardEditor from "@/components/chat/VCardEditor.vue";
 import VersionFooter from "@/components/chat/VersionFooter.vue";
 import type { XmppServerVersion } from "@/shell/version";
 import type { WaddleSession } from "@/lib/server-auth";
@@ -369,6 +370,8 @@ async function clearTuneStatus() {
           </div>
         </div>
       </section>
+
+      <VCardEditor :xmpp-client="xmppClient" :self-jid="session.jid" />
 
       <section class="chat-section-card glass-panel">
         <div class="flex items-start gap-3 pb-4">

--- a/chat/src/components/chat/VCardEditor.vue
+++ b/chat/src/components/chat/VCardEditor.vue
@@ -1,0 +1,280 @@
+<script setup lang="ts">
+import { onMounted, reactive, ref, watch } from "vue";
+import { IdCard } from "lucide-vue-next";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import {
+  draftFromProfile,
+  profileFromDraft,
+  profilesEqual,
+  type VCard4Draft,
+  type VCard4Profile,
+} from "@/lib/xmpp/vcard4-types";
+
+const props = defineProps<{
+  xmppClient?: BrowserXmppClient | null;
+  selfJid: string;
+}>();
+
+type FeedbackTone = "muted" | "success" | "error";
+
+interface VCardFeedback {
+  tone: FeedbackTone;
+  message: string;
+}
+
+const fieldLabelClass = "type-section-label text-muted-foreground/75";
+const fieldClass = "chat-field-control type-field disabled:opacity-50";
+const textareaClass = "chat-field-control chat-textarea-control type-field disabled:opacity-50";
+const primaryButtonClass = "chat-action-button chat-action-button--primary type-control disabled:opacity-40";
+const secondaryButtonClass = "chat-action-button chat-action-button--secondary type-control disabled:opacity-40";
+
+const draft = reactive<VCard4Draft>(draftFromProfile(null));
+const loading = ref(false);
+const saving = ref(false);
+/** Last value seen from the server — the rollback target on save failure. */
+const lastPersisted = ref<VCard4Profile>({});
+const feedback = ref<VCardFeedback>({
+  tone: "muted",
+  message: "Add your name, nickname, pronouns, bio, and a link — publish to share over XMPP.",
+});
+
+function applyDraft(profile: VCard4Profile) {
+  const next = draftFromProfile(profile);
+  draft.fullName = next.fullName;
+  draft.nickname = next.nickname;
+  draft.pronouns = next.pronouns;
+  draft.note = next.note;
+  draft.url = next.url;
+}
+
+async function loadProfile() {
+  if (!props.xmppClient) {
+    feedback.value = {
+      tone: "muted",
+      message: "Reconnect to load your profile.",
+    };
+    return;
+  }
+  loading.value = true;
+  try {
+    const profile = await props.xmppClient.fetchVCard4(props.selfJid);
+    const next = profile ?? {};
+    lastPersisted.value = next;
+    applyDraft(next);
+    feedback.value = profile
+      ? {
+          tone: "muted",
+          message: "Loaded from your vCard4 PEP node. Edit and publish to share an update.",
+        }
+      : {
+          tone: "muted",
+          message: "No profile saved yet — fill in what you want to share.",
+        };
+  } catch (error) {
+    feedback.value = {
+      tone: "error",
+      message: error instanceof Error
+        ? `Couldn't load profile: ${error.message}`
+        : "Couldn't load your profile.",
+    };
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  void loadProfile();
+});
+
+watch(
+  () => props.xmppClient,
+  (client, previous) => {
+    if (client && client !== previous) {
+      void loadProfile();
+    }
+  },
+);
+
+async function saveProfile() {
+  if (!props.xmppClient) {
+    feedback.value = {
+      tone: "error",
+      message: "Reconnect before publishing your profile.",
+    };
+    return;
+  }
+  const next = profileFromDraft(draft);
+  if (profilesEqual(next, lastPersisted.value)) {
+    feedback.value = {
+      tone: "muted",
+      message: "Nothing to publish — your draft matches the saved profile.",
+    };
+    return;
+  }
+  const previous = lastPersisted.value;
+  // Optimistic update — show the new value as persisted before the server
+  // confirms, then roll back to `previous` if the publish fails.
+  lastPersisted.value = next;
+  saving.value = true;
+  try {
+    await props.xmppClient.publishVCard4(next);
+    feedback.value = {
+      tone: "success",
+      message: "Profile published.",
+    };
+  } catch (error) {
+    lastPersisted.value = previous;
+    applyDraft(previous);
+    feedback.value = {
+      tone: "error",
+      message: error instanceof Error
+        ? `Couldn't publish: ${error.message}`
+        : "Couldn't publish your profile. Rolled back to the last saved version.",
+    };
+  } finally {
+    saving.value = false;
+  }
+}
+
+function revertDraft() {
+  applyDraft(lastPersisted.value);
+  feedback.value = {
+    tone: "muted",
+    message: "Reverted to the last saved profile.",
+  };
+}
+
+function feedbackClass(tone: FeedbackTone): string {
+  switch (tone) {
+    case "success":
+      return "text-emerald-700 dark:text-emerald-300";
+    case "error":
+      return "text-destructive";
+    default:
+      return "text-muted-foreground";
+  }
+}
+</script>
+
+<template>
+  <section class="chat-section-card glass-panel">
+    <div class="flex items-start gap-3 pb-4">
+      <div class="flex h-8 w-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+        <IdCard class="h-4 w-4" />
+      </div>
+      <div class="chat-settings-copy max-w-2xl">
+        <p class="type-section-label text-muted-foreground/70">XEP-0292</p>
+        <h2 class="type-pane-title">Profile (vCard4)</h2>
+        <p class="type-caption text-muted-foreground">
+          Public profile published over your <code>urn:xmpp:vcard4</code> PEP node.
+          Visible to anyone who can read your profile.
+        </p>
+      </div>
+    </div>
+
+    <p
+      v-if="!xmppClient"
+      class="type-caption mb-4 rounded-lg border border-border/70 bg-muted/50 px-3 py-2 text-muted-foreground"
+      role="status"
+    >
+      Reconnect before loading or publishing your profile.
+    </p>
+
+    <form class="chat-settings-form" @submit.prevent="saveProfile">
+      <div class="grid gap-3 sm:grid-cols-2">
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Full name</span>
+          <input
+            v-model="draft.fullName"
+            :class="fieldClass"
+            :disabled="loading || saving"
+            data-testid="vcard4-fn"
+            maxlength="160"
+            placeholder="Romeo Montague"
+            type="text"
+          />
+        </label>
+
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Nickname</span>
+          <input
+            v-model="draft.nickname"
+            :class="fieldClass"
+            :disabled="loading || saving"
+            data-testid="vcard4-nickname"
+            maxlength="80"
+            placeholder="Romeo"
+            type="text"
+          />
+        </label>
+
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">Pronouns</span>
+          <input
+            v-model="draft.pronouns"
+            :class="fieldClass"
+            :disabled="loading || saving"
+            data-testid="vcard4-pronouns"
+            maxlength="48"
+            placeholder="he/him, she/her, they/them"
+            type="text"
+          />
+        </label>
+
+        <label class="grid gap-1.5">
+          <span :class="fieldLabelClass">URL</span>
+          <input
+            v-model="draft.url"
+            :class="fieldClass"
+            :disabled="loading || saving"
+            data-testid="vcard4-url"
+            maxlength="240"
+            placeholder="https://romeo.example.com"
+            type="url"
+          />
+        </label>
+
+        <label class="grid gap-1.5 sm:col-span-2">
+          <span :class="fieldLabelClass">Bio</span>
+          <textarea
+            v-model="draft.note"
+            :class="textareaClass"
+            :disabled="loading || saving"
+            data-testid="vcard4-note"
+            maxlength="500"
+            placeholder="A short note about you. Plain text only."
+            rows="3"
+          />
+        </label>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2 pt-3">
+        <button
+          type="submit"
+          :class="primaryButtonClass"
+          :disabled="loading || saving || !xmppClient"
+          data-testid="vcard4-save"
+        >
+          {{ saving ? "Publishing…" : "Save profile" }}
+        </button>
+        <button
+          type="button"
+          :class="secondaryButtonClass"
+          :disabled="loading || saving || !xmppClient"
+          data-testid="vcard4-revert"
+          @click="revertDraft"
+        >
+          Revert
+        </button>
+        <p
+          class="type-caption"
+          :class="feedbackClass(feedback.tone)"
+          aria-live="polite"
+          data-testid="vcard4-feedback"
+        >
+          {{ feedback.message }}
+        </p>
+      </div>
+    </form>
+  </section>
+</template>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -106,7 +106,9 @@ import type {
   WasmRosterContact,
   WasmServerVersion,
   WasmUserSearchResult,
+  WasmVCard4,
 } from "./wasm-types";
+import type { VCard4Profile } from "./vcard4-types";
 
 export { dmMessageFromArchived, roomMessageFromArchived } from "./wasm-message-codecs";
 
@@ -1055,6 +1057,28 @@ export class BrowserXmppClient {
     const xmpp = await this.requireConnectedXmpp();
     const profile = await xmpp.fetch_user_pep_profile?.(jid) as WasmPepProfile | null;
     return { mood: profile?.mood ? { kind: profile.mood.kind as any, ...(profile.mood.text ? { text: profile.mood.text } : {}) } : null, activity: profile?.activity ? { general: profile.activity.general as any, ...(profile.activity.specific ? { specific: profile.activity.specific } : {}), ...(profile.activity.text ? { text: profile.activity.text } : {}) } : null, tune: profile?.tune ? { ...profile.tune } : null };
+  }
+  async fetchVCard4(jid: string): Promise<VCard4Profile | null> {
+    const xmpp = await this.requireConnectedXmpp();
+    const payload = await xmpp.fetch_vcard4?.(jid) as WasmVCard4 | null;
+    if (!payload) return null;
+    const profile: VCard4Profile = {};
+    if (payload.fn) profile.fullName = payload.fn;
+    if (payload.nickname) profile.nickname = payload.nickname;
+    if (payload.pronouns) profile.pronouns = payload.pronouns;
+    if (payload.note) profile.note = payload.note;
+    if (payload.url) profile.url = payload.url;
+    return profile;
+  }
+  async publishVCard4(profile: VCard4Profile): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    const payload: WasmVCard4 = {};
+    if (profile.fullName) payload.fn = profile.fullName;
+    if (profile.nickname) payload.nickname = profile.nickname;
+    if (profile.pronouns) payload.pronouns = profile.pronouns;
+    if (profile.note) payload.note = profile.note;
+    if (profile.url) payload.url = profile.url;
+    await xmpp.publish_vcard4?.(payload);
   }
 
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {

--- a/chat/src/lib/xmpp/vcard4-types.ts
+++ b/chat/src/lib/xmpp/vcard4-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Chat-side typed mirror of the XEP-0292 vCard4 payload exchanged with the wasm
+ * client over the `fetch_vcard4` / `publish_vcard4` JSI boundary. The wasm side
+ * carries a `WaddleVCard4` struct (see `chat/src/lib/xmpp/wasm-types.ts`) and
+ * the typed Rust `VCard4` in `waddle-xmpp-client::xep::xep0292`.
+ *
+ * Every property is optional. Empty strings are treated as "unset" by the
+ * editor and translate to `undefined` on the wire — empty `<fn><text/></fn>`
+ * round-trips would otherwise persist whitespace and shadow a real value.
+ *
+ * `pronouns` corresponds to the XEP-0292 `PRONOUNS` property. The wasm boundary
+ * always carries the field, but older servers may drop it on publish until the
+ * server-side support lands.
+ */
+export interface VCard4Profile {
+  fullName?: string;
+  nickname?: string;
+  pronouns?: string;
+  note?: string;
+  url?: string;
+}
+
+/** Mutable draft used by the editor while the user is typing. */
+export interface VCard4Draft {
+  fullName: string;
+  nickname: string;
+  pronouns: string;
+  note: string;
+  url: string;
+}
+
+/** Returns a fresh draft seeded from `profile`, defaulting absent fields to "". */
+export function draftFromProfile(profile: VCard4Profile | null): VCard4Draft {
+  return {
+    fullName: profile?.fullName ?? "",
+    nickname: profile?.nickname ?? "",
+    pronouns: profile?.pronouns ?? "",
+    note: profile?.note ?? "",
+    url: profile?.url ?? "",
+  };
+}
+
+/** Snapshots a draft as a profile, trimming whitespace and dropping empties. */
+export function profileFromDraft(draft: VCard4Draft): VCard4Profile {
+  const profile: VCard4Profile = {};
+  const apply = (key: keyof VCard4Profile, value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) profile[key] = trimmed;
+  };
+  apply("fullName", draft.fullName);
+  apply("nickname", draft.nickname);
+  apply("pronouns", draft.pronouns);
+  apply("note", draft.note);
+  apply("url", draft.url);
+  return profile;
+}
+
+/** Returns `true` when the two profiles carry identical values across every field. */
+export function profilesEqual(a: VCard4Profile, b: VCard4Profile): boolean {
+  return (
+    (a.fullName ?? "") === (b.fullName ?? "") &&
+    (a.nickname ?? "") === (b.nickname ?? "") &&
+    (a.pronouns ?? "") === (b.pronouns ?? "") &&
+    (a.note ?? "") === (b.note ?? "") &&
+    (a.url ?? "") === (b.url ?? "")
+  );
+}

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -272,6 +272,20 @@ export interface WasmPepProfile {
   } | null;
 }
 
+/**
+ * XEP-0292 vCard4 payload exchanged over the wasm boundary. Mirrors the Rust
+ * `WaddleVCard4` struct: every property is optional, and the `fn` field uses
+ * the XEP-0292 spelling rather than `fullName` so the serde rename on the Rust
+ * side stays a 1:1 wire mapping.
+ */
+export interface WasmVCard4 {
+  fn?: string;
+  nickname?: string;
+  pronouns?: string;
+  note?: string;
+  url?: string;
+}
+
 /** Options for send_groupchat_message / send_chat_message. */
 export interface WasmSendOptions {
   stanza_id?: string;

--- a/chat/tests/vcard4-editor.test.ts
+++ b/chat/tests/vcard4-editor.test.ts
@@ -1,0 +1,239 @@
+// Tests for the XEP-0292 vcard4 profile editor surface.
+//
+// The Vue component itself is not mounted (no @vue/test-utils harness in this
+// repo) — instead we test:
+//   - the vcard4-types helpers that own the boundary shape, and
+//   - a small in-memory model that mirrors `VCardEditor.vue`'s read-on-mount,
+//     publish-on-save, optimistic-update + rollback flow against a stubbed
+//     `BrowserXmppClient.fetchVCard4` / `publishVCard4`.
+//
+// The model under test below is intentionally a tiny copy of the editor's
+// state machine so the same flow can be asserted without Vue reactivity.
+
+import { describe, expect, mock, test } from "bun:test";
+import {
+  draftFromProfile,
+  profileFromDraft,
+  profilesEqual,
+  type VCard4Draft,
+  type VCard4Profile,
+} from "../src/lib/xmpp/vcard4-types";
+
+// ---------------------------------------------------------------------------
+// vcard4-types unit tests
+// ---------------------------------------------------------------------------
+
+describe("vcard4-types helpers", () => {
+  test("draftFromProfile defaults absent fields to empty strings", () => {
+    expect(draftFromProfile(null)).toEqual({
+      fullName: "",
+      nickname: "",
+      pronouns: "",
+      note: "",
+      url: "",
+    });
+  });
+
+  test("draftFromProfile round-trips an existing profile", () => {
+    const profile: VCard4Profile = {
+      fullName: "Romeo Montague",
+      nickname: "Romeo",
+      pronouns: "he/him",
+      note: "Star-crossed",
+      url: "https://romeo.example.com",
+    };
+    expect(draftFromProfile(profile)).toEqual({
+      fullName: "Romeo Montague",
+      nickname: "Romeo",
+      pronouns: "he/him",
+      note: "Star-crossed",
+      url: "https://romeo.example.com",
+    });
+  });
+
+  test("profileFromDraft trims whitespace and drops empty fields", () => {
+    const draft: VCard4Draft = {
+      fullName: "  Juliet  ",
+      nickname: "",
+      pronouns: "she/her",
+      note: "   ",
+      url: " https://juliet.example.com ",
+    };
+    expect(profileFromDraft(draft)).toEqual({
+      fullName: "Juliet",
+      pronouns: "she/her",
+      url: "https://juliet.example.com",
+    });
+  });
+
+  test("profileFromDraft on an empty draft yields {}", () => {
+    const empty: VCard4Draft = {
+      fullName: "",
+      nickname: "",
+      pronouns: "",
+      note: "",
+      url: "",
+    };
+    expect(profileFromDraft(empty)).toEqual({});
+  });
+
+  test("profilesEqual treats undefined fields and empty strings as equal", () => {
+    expect(profilesEqual({}, {})).toBe(true);
+    expect(profilesEqual({ fullName: "" }, {})).toBe(true);
+    expect(profilesEqual({ fullName: "x" }, { fullName: "x" })).toBe(true);
+    expect(profilesEqual({ fullName: "x" }, { fullName: "y" })).toBe(false);
+    expect(
+      profilesEqual({ pronouns: "they/them" }, { pronouns: "she/they" }),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Editor flow — mirrors VCardEditor.vue, no Vue mount required.
+// ---------------------------------------------------------------------------
+
+interface EditorClient {
+  fetchVCard4: (jid: string) => Promise<VCard4Profile | null>;
+  publishVCard4: (profile: VCard4Profile) => Promise<void>;
+}
+
+interface EditorState {
+  draft: VCard4Draft;
+  lastPersisted: VCard4Profile;
+  feedbackTone: "muted" | "success" | "error";
+  feedbackMessage: string;
+}
+
+function createEditor(client: EditorClient, selfJid: string) {
+  const state: EditorState = {
+    draft: draftFromProfile(null),
+    lastPersisted: {},
+    feedbackTone: "muted",
+    feedbackMessage: "",
+  };
+
+  async function load() {
+    const profile = await client.fetchVCard4(selfJid);
+    const next = profile ?? {};
+    state.lastPersisted = next;
+    state.draft = draftFromProfile(next);
+    state.feedbackTone = "muted";
+    state.feedbackMessage = profile ? "loaded" : "empty";
+  }
+
+  async function save() {
+    const next = profileFromDraft(state.draft);
+    if (profilesEqual(next, state.lastPersisted)) {
+      state.feedbackTone = "muted";
+      state.feedbackMessage = "nothing to publish";
+      return;
+    }
+    const previous = state.lastPersisted;
+    // Optimistic update of the persisted snapshot.
+    state.lastPersisted = next;
+    try {
+      await client.publishVCard4(next);
+      state.feedbackTone = "success";
+      state.feedbackMessage = "published";
+    } catch (error) {
+      state.lastPersisted = previous;
+      state.draft = draftFromProfile(previous);
+      state.feedbackTone = "error";
+      state.feedbackMessage = error instanceof Error ? error.message : "failed";
+    }
+  }
+
+  return { state, load, save };
+}
+
+describe("VCardEditor flow", () => {
+  test("empty PEP node hydrates draft with empty fields", async () => {
+    const fetchVCard4 = mock(async () => null);
+    const publishVCard4 = mock(async () => undefined);
+    const editor = createEditor({ fetchVCard4, publishVCard4 }, "alice@example.com");
+
+    await editor.load();
+
+    expect(fetchVCard4).toHaveBeenCalledTimes(1);
+    expect(editor.state.draft).toEqual({
+      fullName: "",
+      nickname: "",
+      pronouns: "",
+      note: "",
+      url: "",
+    });
+    expect(editor.state.lastPersisted).toEqual({});
+    expect(editor.state.feedbackMessage).toBe("empty");
+  });
+
+  test("existing PEP node round-trips through the editor without data loss", async () => {
+    const stored: VCard4Profile = {
+      fullName: "Romeo Montague",
+      nickname: "Romeo",
+      pronouns: "he/him",
+      note: "Star-crossed",
+      url: "https://romeo.example.com",
+    };
+    const fetchVCard4 = mock(async () => stored);
+    const publishVCard4 = mock(async (_profile: VCard4Profile) => undefined);
+    const editor = createEditor({ fetchVCard4, publishVCard4 }, "romeo@example.com");
+
+    await editor.load();
+    // Resave with no changes — should be a no-op.
+    await editor.save();
+    expect(publishVCard4).not.toHaveBeenCalled();
+    expect(editor.state.feedbackMessage).toBe("nothing to publish");
+
+    // Now edit and save.
+    editor.state.draft.note = "Updated bio";
+    await editor.save();
+    expect(publishVCard4).toHaveBeenCalledTimes(1);
+    const publishedArg = (publishVCard4 as unknown as ReturnType<typeof mock>).mock.calls[0]![0];
+    expect(publishedArg).toEqual({
+      fullName: "Romeo Montague",
+      nickname: "Romeo",
+      pronouns: "he/him",
+      note: "Updated bio",
+      url: "https://romeo.example.com",
+    });
+    expect(editor.state.feedbackTone).toBe("success");
+  });
+
+  test("pronouns are forwarded to publishVCard4 (no-op on pre-#663 servers)", async () => {
+    const fetchVCard4 = mock(async () => null);
+    const publishVCard4 = mock(async (_profile: VCard4Profile) => undefined);
+    const editor = createEditor({ fetchVCard4, publishVCard4 }, "alice@example.com");
+
+    await editor.load();
+    editor.state.draft.pronouns = "they/them";
+    editor.state.draft.fullName = "Alice";
+    await editor.save();
+
+    const publishedArg = (publishVCard4 as unknown as ReturnType<typeof mock>).mock.calls[0]![0];
+    expect(publishedArg.pronouns).toBe("they/them");
+    expect(publishedArg.fullName).toBe("Alice");
+  });
+
+  test("save error rolls back draft + persisted state to the previous snapshot", async () => {
+    const stored: VCard4Profile = {
+      fullName: "Mercutio",
+      nickname: "Merc",
+    };
+    const fetchVCard4 = mock(async () => stored);
+    const publishVCard4 = mock(async () => {
+      throw new Error("publish failed");
+    });
+    const editor = createEditor({ fetchVCard4, publishVCard4 }, "mercutio@example.com");
+
+    await editor.load();
+    editor.state.draft.fullName = "Lord Mercutio";
+    await editor.save();
+
+    expect(publishVCard4).toHaveBeenCalledTimes(1);
+    expect(editor.state.feedbackTone).toBe("error");
+    expect(editor.state.feedbackMessage).toBe("publish failed");
+    // Both the persisted snapshot and the draft are reverted.
+    expect(editor.state.lastPersisted).toEqual(stored);
+    expect(editor.state.draft).toEqual(draftFromProfile(stored));
+  });
+});

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -255,6 +255,47 @@ impl WaddleClient {
         })
     }
 
+    pub fn fetch_vcard4(&self, jid: String) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let iq = build_fetch_vcard4_iq(&jid, &request_id);
+            let vcard = match send_iq_command(inner, iq).await {
+                Ok(result) => parse_pep_vcard4(&result),
+                Err(_) => None,
+            };
+            match vcard {
+                Some(vcard) => to_js_value(&WaddleVCard4 {
+                    full_name: vcard.full_name,
+                    nickname: vcard.nickname,
+                    pronouns: vcard.pronouns,
+                    note: vcard.note,
+                    url: vcard.url,
+                }),
+                None => Ok(JsValue::NULL),
+            }
+        })
+    }
+
+    pub fn publish_vcard4(&self, vcard_json: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let payload: WaddleVCard4 = serde_wasm_bindgen::from_value(vcard_json)
+                .map_err(|err| js_error(err.to_string()))?;
+            let vcard = VCard4 {
+                full_name: payload.full_name,
+                nickname: payload.nickname,
+                pronouns: payload.pronouns,
+                note: payload.note,
+                url: payload.url,
+            };
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let iq = build_publish_vcard4_iq(&vcard, &request_id);
+            let _ = send_iq_command(inner, iq).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
     pub fn fetch_user_pep_profile(&self, jid: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -40,6 +40,7 @@ use waddle_xmpp_client::transport::{
 use waddle_xmpp_client::xep::{
     reply::{FallbackRange, ReplyMarker},
     thread::ThreadRef,
+    xep0292::{build_fetch_vcard4_iq, build_publish_vcard4_iq, parse_pep_vcard4, VCard4},
 };
 use waddle_xmpp_client::{
     AccessToken, ArchivedMessage, ClientConfig, ClientError, ClientEvent, ClientRequest,

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -476,6 +476,27 @@ pub struct WaddlePepProfile {
     pub tune: Option<WaddleTuneResult>,
 }
 
+/// Typed vCard4 payload exchanged with JS. Every property is optional and is
+/// dropped from the published payload when `None` / undefined.
+///
+/// `pronouns` is carried through the wasm boundary even if the connected
+/// server has not yet learned to round-trip XEP-0292 `PRONOUNS` — the editor
+/// always offers the field, and the server is responsible for preserving or
+/// dropping it.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct WaddleVCard4 {
+    #[serde(rename = "fn", default, skip_serializing_if = "Option::is_none")]
+    pub full_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nickname: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pronouns: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct WaddleMamPageParam {
     #[serde(rename = "type")]

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -103,3 +103,7 @@ pub use waddle_xmpp_core::{
     mam::{FULLTEXT_MAM_FIELD, WADDLE_MAM_THREAD_FIELD},
     ConnectionConfig,
 };
+pub use xep::xep0292::{
+    build_fetch_vcard4_iq, build_publish_vcard4_iq, build_vcard4_element, parse_pep_vcard4,
+    parse_vcard4_element, VCard4, NS_VCARD4, PEP_NODE_VCARD4,
+};

--- a/server/crates/waddle-xmpp-client/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/mod.rs
@@ -9,3 +9,4 @@ pub mod encrypted_file;
 pub mod fallback;
 pub mod reply;
 pub mod thread;
+pub mod xep0292;

--- a/server/crates/waddle-xmpp-client/src/xep/xep0292.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/xep0292.rs
@@ -1,0 +1,326 @@
+//! XEP-0292: vCard4 over XMPP.
+//!
+//! Typed value, parser, and element builder for the `urn:ietf:params:xml:ns:vcard-4.0`
+//! payload used on the PEP node `urn:xmpp:vcard4`. Also provides IQ builders for the
+//! XEP-0163 fetch (`<items node='urn:xmpp:vcard4'>`) and publish
+//! (`<publish node='urn:xmpp:vcard4'><item id='current'>…</item></publish>`)
+//! round-trip so the wasm-client and chat UI can read/write the user's own profile
+//! without parallel XML construction.
+//!
+//! The struct is intentionally narrower than RFC 6350 — only the fields that the
+//! chat profile editor surfaces are modelled. Adding a new property is additive:
+//! parse + build are property-by-property, so a missing property on the wire is
+//! `None` on the typed value, and a `None` typed value is omitted from the wire.
+
+use minidom::Element;
+
+use crate::pep::NS_PUBSUB;
+
+/// vCard4 XML namespace.
+pub const NS_VCARD4: &str = "urn:ietf:params:xml:ns:vcard-4.0";
+
+/// PEP node for vCard4 publication.
+pub const PEP_NODE_VCARD4: &str = "urn:xmpp:vcard4";
+
+const NS_CLIENT: &str = "jabber:client";
+
+/// Typed vCard4 value. Each field is `None` when the corresponding XEP-0292
+/// property is absent on the wire.
+///
+/// `pronouns` corresponds to the vCard4 `PRONOUNS` property (advertised under
+/// `NS_VCARD4`). Older servers that have not yet learned to round-trip the
+/// property will simply drop it; the wasm boundary still carries the value so
+/// the editor can save it the moment the server supports it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VCard4 {
+    /// `FN` — full formatted name.
+    pub full_name: Option<String>,
+    /// `NICKNAME`.
+    pub nickname: Option<String>,
+    /// `PRONOUNS`. May be ignored by older servers — see module docs.
+    pub pronouns: Option<String>,
+    /// `NOTE` — free-form bio.
+    pub note: Option<String>,
+    /// `URL` — website / social link, transmitted as `<uri>`.
+    pub url: Option<String>,
+}
+
+impl VCard4 {
+    /// Create an empty vCard4.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns `true` if every property is `None`.
+    pub fn is_empty(&self) -> bool {
+        self.full_name.is_none()
+            && self.nickname.is_none()
+            && self.pronouns.is_none()
+            && self.note.is_none()
+            && self.url.is_none()
+    }
+}
+
+// ── Element shape ───────────────────────────────────────────────────────────
+
+fn text_prop(parent: &Element, name: &str) -> Option<String> {
+    parent
+        .children()
+        .find(|c| c.name() == name && c.ns() == NS_VCARD4)
+        .and_then(|c| c.children().find(|t| t.name() == "text"))
+        .map(|t| t.text())
+        .filter(|t| !t.is_empty())
+}
+
+fn uri_or_text_prop(parent: &Element, name: &str) -> Option<String> {
+    parent
+        .children()
+        .find(|c| c.name() == name && c.ns() == NS_VCARD4)
+        .and_then(|c| {
+            c.children()
+                .find(|t| t.name() == "uri" || t.name() == "text")
+        })
+        .map(|t| t.text())
+        .filter(|t| !t.is_empty())
+}
+
+/// Parse a `<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>` element.
+pub fn parse_vcard4_element(elem: &Element) -> VCard4 {
+    VCard4 {
+        full_name: text_prop(elem, "fn"),
+        nickname: text_prop(elem, "nickname"),
+        pronouns: text_prop(elem, "pronouns"),
+        note: text_prop(elem, "note"),
+        url: uri_or_text_prop(elem, "url"),
+    }
+}
+
+fn append_text_prop(parent: &mut Element, name: &str, value: &str) {
+    let mut prop = Element::builder(name, NS_VCARD4).build();
+    let mut text = Element::builder("text", NS_VCARD4).build();
+    text.append_text_node(value);
+    prop.append_child(text);
+    parent.append_child(prop);
+}
+
+fn append_uri_prop(parent: &mut Element, name: &str, value: &str) {
+    let mut prop = Element::builder(name, NS_VCARD4).build();
+    let mut uri = Element::builder("uri", NS_VCARD4).build();
+    uri.append_text_node(value);
+    prop.append_child(uri);
+    parent.append_child(prop);
+}
+
+/// Build a `<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>` element. Empty
+/// properties are omitted entirely.
+pub fn build_vcard4_element(vcard: &VCard4) -> Element {
+    let mut elem = Element::builder("vcard", NS_VCARD4).build();
+    if let Some(ref v) = vcard.full_name {
+        append_text_prop(&mut elem, "fn", v);
+    }
+    if let Some(ref v) = vcard.nickname {
+        append_text_prop(&mut elem, "nickname", v);
+    }
+    if let Some(ref v) = vcard.pronouns {
+        append_text_prop(&mut elem, "pronouns", v);
+    }
+    if let Some(ref v) = vcard.note {
+        append_text_prop(&mut elem, "note", v);
+    }
+    if let Some(ref v) = vcard.url {
+        append_uri_prop(&mut elem, "url", v);
+    }
+    elem
+}
+
+// ── IQ shape ────────────────────────────────────────────────────────────────
+
+/// Build a `get` IQ requesting the latest item from the target's
+/// `urn:xmpp:vcard4` PEP node (XEP-0163).
+pub fn build_fetch_vcard4_iq(target_jid: &str, request_id: &str) -> Element {
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("to", target_jid)
+        .attr("id", request_id)
+        .append(
+            Element::builder("pubsub", NS_PUBSUB)
+                .append(
+                    Element::builder("items", NS_PUBSUB)
+                        .attr("node", PEP_NODE_VCARD4)
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+/// Build a `set` IQ that publishes `vcard` to the user's own
+/// `urn:xmpp:vcard4` PEP node, using the canonical item id `current`.
+pub fn build_publish_vcard4_iq(vcard: &VCard4, request_id: &str) -> Element {
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
+        .attr("id", request_id)
+        .append(
+            Element::builder("pubsub", NS_PUBSUB)
+                .append(
+                    Element::builder("publish", NS_PUBSUB)
+                        .attr("node", PEP_NODE_VCARD4)
+                        .append(
+                            Element::builder("item", NS_PUBSUB)
+                                .attr("id", "current")
+                                .append(build_vcard4_element(vcard))
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+/// Extract the vCard4 payload from a successful XEP-0060 items response.
+/// Returns `None` when the node has no current item or the payload is missing.
+pub fn parse_pep_vcard4(iq: &Element) -> Option<VCard4> {
+    let payload = iq
+        .get_child("pubsub", NS_PUBSUB)?
+        .get_child("items", NS_PUBSUB)
+        .filter(|items| items.attr("node") == Some(PEP_NODE_VCARD4))?
+        .get_child("item", NS_PUBSUB)?
+        .get_child("vcard", NS_VCARD4)?;
+    Some(parse_vcard4_element(payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_payload() {
+        let xml = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                    <fn><text>Romeo Montague</text></fn>\
+                    <nickname><text>Romeo</text></nickname>\
+                    <pronouns><text>he/him</text></pronouns>\
+                    <note><text>Star-crossed lover</text></note>\
+                    <url><uri>https://romeo.example.com</uri></url>\
+                    </vcard>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let vcard = parse_vcard4_element(&elem);
+
+        assert_eq!(vcard.full_name.as_deref(), Some("Romeo Montague"));
+        assert_eq!(vcard.nickname.as_deref(), Some("Romeo"));
+        assert_eq!(vcard.pronouns.as_deref(), Some("he/him"));
+        assert_eq!(vcard.note.as_deref(), Some("Star-crossed lover"));
+        assert_eq!(vcard.url.as_deref(), Some("https://romeo.example.com"));
+        assert!(!vcard.is_empty());
+    }
+
+    #[test]
+    fn empty_element_parses_to_empty_value() {
+        let xml = "<vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'/>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let vcard = parse_vcard4_element(&elem);
+        assert!(vcard.is_empty());
+    }
+
+    #[test]
+    fn round_trip_keeps_every_property() {
+        let original = VCard4 {
+            full_name: Some("Juliet Capulet".into()),
+            nickname: Some("Juliet".into()),
+            pronouns: Some("she/her".into()),
+            note: Some("Also star-crossed".into()),
+            url: Some("https://juliet.example.com".into()),
+        };
+        let elem = build_vcard4_element(&original);
+        let parsed = parse_vcard4_element(&elem);
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn build_omits_none_properties() {
+        let only_fn = VCard4 {
+            full_name: Some("Alice".into()),
+            ..Default::default()
+        };
+        let elem = build_vcard4_element(&only_fn);
+        assert_eq!(elem.children().count(), 1);
+        assert_eq!(elem.children().next().unwrap().name(), "fn");
+    }
+
+    #[test]
+    fn fetch_iq_targets_pep_vcard4_node() {
+        let iq = build_fetch_vcard4_iq("juliet@example.com", "req-1");
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("to"), Some("juliet@example.com"));
+        assert_eq!(iq.attr("id"), Some("req-1"));
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PEP_NODE_VCARD4));
+    }
+
+    #[test]
+    fn publish_iq_uses_current_item_id() {
+        let vcard = VCard4 {
+            full_name: Some("Romeo".into()),
+            ..Default::default()
+        };
+        let iq = build_publish_vcard4_iq(&vcard, "req-pub");
+        assert_eq!(iq.attr("type"), Some("set"));
+        assert_eq!(iq.attr("id"), Some("req-pub"));
+        let item = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("publish", NS_PUBSUB))
+            .and_then(|p| p.get_child("item", NS_PUBSUB))
+            .expect("item element");
+        assert_eq!(item.attr("id"), Some("current"));
+        let payload = item.get_child("vcard", NS_VCARD4).expect("vcard payload");
+        assert_eq!(
+            parse_vcard4_element(payload).full_name.as_deref(),
+            Some("Romeo")
+        );
+    }
+
+    #[test]
+    fn parse_pep_extracts_payload_from_iq() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                    <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+                      <items node='urn:xmpp:vcard4'>\
+                        <item id='current'>\
+                          <vcard xmlns='urn:ietf:params:xml:ns:vcard-4.0'>\
+                            <fn><text>Mercutio</text></fn>\
+                            <pronouns><text>they/them</text></pronouns>\
+                          </vcard>\
+                        </item>\
+                      </items>\
+                    </pubsub>\
+                  </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        let vcard = parse_pep_vcard4(&iq).expect("payload present");
+        assert_eq!(vcard.full_name.as_deref(), Some("Mercutio"));
+        assert_eq!(vcard.pronouns.as_deref(), Some("they/them"));
+    }
+
+    #[test]
+    fn parse_pep_returns_none_when_node_mismatched() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                    <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+                      <items node='http://jabber.org/protocol/mood'/>\
+                    </pubsub>\
+                  </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        assert!(parse_pep_vcard4(&iq).is_none());
+    }
+
+    #[test]
+    fn parse_pep_returns_none_when_item_empty() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                    <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+                      <items node='urn:xmpp:vcard4'/>\
+                    </pubsub>\
+                  </iq>";
+        let iq: Element = xml.parse().expect("valid xml");
+        assert!(parse_pep_vcard4(&iq).is_none());
+    }
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -50,6 +50,7 @@ export class WaddleClient {
      */
     fetch_room_pins(room_jid: string): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
+    fetch_vcard4(jid: string): Promise<any>;
     get_resume_state(): any;
     get_resume_state_handle(): WaddleResumeState | undefined;
     get_server_version(): Promise<any>;
@@ -71,6 +72,7 @@ export class WaddleClient {
     publish_activity(activity_json: any): Promise<any>;
     publish_mood(mood_json: any): Promise<any>;
     publish_tune(tune_json: any): Promise<any>;
+    publish_vcard4(vcard_json: any): Promise<any>;
     request_avatar(jid: string): Promise<any>;
     request_upload_slot(service_jid: string, filename: string, size: bigint, content_type: string): Promise<any>;
     retract_activity(): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9kods7";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9rziw5";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9rziw5";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9rziw5";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9kods7";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9rziw5";


### PR DESCRIPTION
## Summary

Build the **vcard4 profile editor** in the chat client — the chat-side counterpart to PR #663 (server-side vcard4 PRONOUNS). Currently `WasmPepProfile` only covers mood/activity/tune; there is no read/write surface for vcard4. This PR adds it so users can actually set their pronouns (and the rest of their public profile) from the UI.

Depends on #663 to land for PRONOUNS field; the rest of the editor works against today's vcard4 server support.

## Scope

### In

- New wasm bindings on the xmpp-client crate:
  - `fetch_vcard4(jid: &BareJid) -> Result<Option<VCard4>>`
  - `publish_vcard4(vcard: VCard4) -> Result<()>` (publishes to the user's own PEP node `urn:xmpp:vcard4`)
- TypeScript wrapper types in `chat/src/lib/xmpp/` mirroring the wasm `VCard4` shape
- Vue editor component (suggested: `chat/src/components/chat/VCardEditor.vue` or extend `UserSettingsPage.vue` with a Profile section)
- Editable fields (matching what's actually backed in the Rust `VCard4` struct):
  - **FN** (full name)
  - **NICKNAME**
  - **PRONOUNS** (requires #663)
  - **NOTE** (free-form bio)
  - **URL**
- Read-on-mount, save-on-button-click, optimistic UI with rollback on error
- Dedicated UI tests (Vitest) for the editor component

### Out

- Photo upload (separate upload-pipeline work; vcard4 photo is non-trivial)
- TEL / ADR / EMAIL (privacy implications, separate review)
- Field-level validation beyond "non-empty if required" / max-length
- vcard-temp (XEP-0054) compatibility — vcard4 only
- Avatar resync triggers — already exists via XEP-0084 separately

## Plan

1. Read the existing wasm interop pattern from `chat/src/lib/xmpp/wasm-types.ts:261` (`WasmPepProfile`) and `client.ts:1056` (`fetch_user_pep_profile`) and follow it.
2. Read the Rust `VCard4` struct (post-#663) at `server/crates/waddle-xmpp/src/xep/xep0292.rs` to confirm field set.
3. Add `fetch_vcard4` / `publish_vcard4` to the wasm-client crate (`server/crates/waddle-xmpp-client-wasm`). Use existing PEP IQ helpers — don't introduce a parallel transport.
4. Add the editor component. Match existing chat UI styling (Tailwind + Ark-UI per `CLAUDE.md` Active Technologies block). Mount it under `UserSettingsPage.vue` as a "Profile" section.
5. Add tests under `chat/src/components/chat/__tests__/` covering: load existing vcard, edit fields, save flow, error rollback.
6. Verify with `bun test && bun run lint` in `chat/`.

## Hard rules

- Bun only (no npm/yarn/pnpm).
- Knip clean — no unused files/exports/deps.
- **XMPP-native**: vcard4 publish/fetch flows through XEP-0292 PEP — no REST endpoint.
- Single scope per commit: `feat(chat): ...` for UI, `feat(server): ...` only if the wasm crate is treated as server-side (use whichever scope the repo's prior wasm work used).
- Typed wasm boundary — `VCard4` is a typed struct on both sides, not a JSON-blob string.

## Test plan

- [ ] Empty vcard4 (new user) renders with empty fields
- [ ] Existing vcard4 round-trips through editor without data loss
- [ ] Pronouns field saves and re-fetches correctly (requires #663)
- [ ] Save error rolls back UI state
- [ ] `bun test` clean
- [ ] `bun run lint` (knip) clean

## Dependency

⚠️ This PR depends on **#663** (vcard4 PRONOUNS) being merged before the pronouns field is functional. Editor can land before that — the field is gracefully no-op against pre-#663 server builds.

This PR was created with the assistance of a LLM.
