### PR TITLE
fix(server): vcard4 PEP node defaults to Open access (XEP-0292 §6.1)

### DIFF
--- a/docs/xep-conformance-audit.md
+++ b/docs/xep-conformance-audit.md
@@ -76,7 +76,7 @@ or advertises. One row per XEP. Each gap becomes an isolated PR.
 | 0249 | Direct MUC Invitations                               | jabber:x:conference                |  -  |  Y   |   -   | unaudited  | |
 | 0277 | Microblogging over XMPP                              | urn:xmpp:microblog:0               |  -  |  ?   |   Y   | unaudited  | Test exists, impl path unclear |
 | 0280 | Message Carbons                                      | urn:xmpp:carbons:2 + rules:0       |  Y  |  Y   |   Y   | unaudited  | |
-| 0292 | vCard4 over XMPP                                     | urn:xmpp:vcard4 + +notify          |  Y  |  Y   |   -   | unaudited  | |
+| 0292 | vCard4 over XMPP                                     | urn:xmpp:vcard4 + +notify          |  Y  |  Y   |   Y   | gap (partial) | §6.1 canonical `access_model=open` wired through `NodeConfig::pep_for_node(PEP_NODE_VCARD4)` + reconcile-on-publish for legacy `presence`-access nodes in **PR #669**. Dedicated suite: `crates/waddle-xmpp/tests/xep0292_vcard4.rs` + `crates/waddle-server/tests/xep0292_vcard4_ws.rs`. |
 | 0297 | Stanza Forwarding                                    | urn:xmpp:forward:0                 |  -  |  Y   |   -   | unaudited  | Used by carbons / MAM |
 | 0300 | Use of Cryptographic Hash Functions in XMPP          | urn:xmpp:hashes:2                  |  -  |  Y   |   -   | unaudited  | |
 | 0308 | Last Message Correction                              | urn:xmpp:message-correct:0         |  Y  |  Y   |   Y   | unaudited  | |

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs
@@ -1,4 +1,5 @@
 use super::pubsub_admin::handle_pubsub_admin_request;
+use super::pubsub_helpers;
 use super::*;
 use crate::server::routes::websocket::handlers::pubsub_fanout;
 
@@ -160,6 +161,16 @@ pub(super) async fn handle_pubsub_iq(
                     if let Err(error) = validate_xep0402_bookmark_publish_request(&item) {
                         return vec![iq_to_xml(build_pubsub_error(iq, error))];
                     }
+                }
+
+                // Pre-publish reconcile for well-known PEP nodes whose
+                // canonical XEP-defined config is stricter than the
+                // generic `pep_default()`. Only the owner's own PEP
+                // service is affected — peer fetches go through the
+                // Items arm, not Publish.
+                if is_pep && target_jid == user_jid {
+                    pubsub_helpers::reconcile_well_known_pep_node_config(state, &user_jid, &node)
+                        .await;
                 }
 
                 let result = state

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs
@@ -16,6 +16,59 @@ pub(super) fn is_pep_self_or_to(
     is_pep_request_to(iq, target_jid) || is_pep_request(iq, user_jid)
 }
 
+/// Bring a well-known PEP node's stored config into line with the
+/// current `NodeConfig::pep_for_node` defaults BEFORE a publish lands
+/// its item.
+///
+/// Use case: an earlier version of Waddle auto-created the
+/// `urn:xmpp:vcard4` node with `AccessModel::Presence` (the bare
+/// `pep_default()`). After XEP-0292 §6.1 was wired through
+/// `pep_for_node` the canonical access model is `Open`, but the
+/// already-created node stays on the old config until something
+/// explicitly reconfigures it. A user retrying their first vCard4
+/// publish after upgrading would otherwise still be invisible to
+/// non-roster peers. We reconcile the config in-place so the next
+/// publish lands on a spec-conformant node.
+///
+/// Scope is deliberately narrow: only nodes whose well-known defaults
+/// are stricter than ad-hoc PEP defaults (currently `urn:xmpp:vcard4`)
+/// — we don't bulk-rewrite arbitrary user node configs here.
+pub(super) async fn reconcile_well_known_pep_node_config(
+    state: &WebSocketState,
+    owner: &BareJid,
+    node: &str,
+) {
+    if node != waddle_xmpp_core::pubsub::PEP_NODE_VCARD4 {
+        return;
+    }
+    let storage = &state.deps.protocol.pubsub_storage;
+    let existing = match storage.get_node(owner, node).await {
+        Ok(Some(node)) => node,
+        Ok(None) => return,
+        Err(error) => {
+            warn!(
+                node,
+                error = %error,
+                "Failed to read PEP node config for reconcile-on-publish; \
+                 letting publish proceed against whatever config is stored"
+            );
+            return;
+        }
+    };
+    let canonical = waddle_xmpp_core::pubsub::NodeConfig::pep_for_node(node);
+    if existing.config == canonical {
+        return;
+    }
+    if let Err(error) = storage.update_node_config(owner, node, &canonical).await {
+        warn!(
+            node,
+            error = %error,
+            "Failed to reconcile PEP node config to XEP-defaults on publish; \
+             publish will proceed against the divergent config"
+        );
+    }
+}
+
 pub(super) fn spaces_service_bare_jid(spaces_domain: &str) -> Result<BareJid, String> {
     spaces_domain
         .parse::<BareJid>()

--- a/server/crates/waddle-server/tests/xep0292_vcard4_ws.rs
+++ b/server/crates/waddle-server/tests/xep0292_vcard4_ws.rs
@@ -1,0 +1,304 @@
+//! XEP-0292 vCard4 wire-conformance integration tests over WebSocket.
+//!
+//! Pins the §6.1 canonical access model — `open` — for the
+//! `urn:xmpp:vcard4` PEP node:
+//!
+//! 1. Auto-create on the FIRST chat-editor-shaped publish (a bare
+//!    `<publish>` with no `<publish-options>`) MUST land an
+//!    `open`-access node, so non-roster peers can fetch the vCard
+//!    immediately.
+//! 2. A node that pre-exists with the wrong (`presence`) access model
+//!    MUST be reconciled in-place on the owner's next publish — this
+//!    covers users who first published before XEP-0292 §6.1 was wired
+//!    through `NodeConfig::pep_for_node`.
+//! 3. A second user with no roster relationship to the publisher MUST
+//!    be able to fetch the items via `<items>` on the owner's PEP
+//!    service.
+//!
+//! These tests sit alongside `xep0060_pubsub_ws.rs` and exercise the
+//! same WebSocket binding the wasm chat client uses.
+
+mod ws_common;
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
+const NS_VCARD4: &str = "urn:ietf:params:xml:ns:vcard-4.0";
+const PEP_NODE_VCARD4: &str = "urn:xmpp:vcard4";
+
+async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
+    let password = server.fixed_account_password().to_string();
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, resource)
+        .await
+        .expect("admin connect")
+}
+
+async fn iq_set_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq set");
+    client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("iq set response")
+}
+
+async fn iq_get_to(client: &mut WsXmppClient, id: &str, to: &str, body: &str) -> String {
+    client
+        .send(&format!(
+            r#"<iq type="get" id="{id}" to="{to}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq get");
+    client
+        .recv_matching(|frame| frame.contains(&format!(r#"id="{id}""#)) && frame.contains("<iq"))
+        .await
+        .expect("iq get response")
+}
+
+/// XEP-0292 §3 spec-shape minimal vCard4 publish body — the same
+/// shape the chat editor (`waddle-xmpp-client::xep::xep0292`) builds
+/// via `build_publish_vcard4_iq`, with no `<publish-options>` (which
+/// is what forces the server to apply auto-create defaults).
+fn vcard4_publish_body(full_name: &str, note: &str) -> String {
+    format!(
+        r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{PEP_NODE_VCARD4}"><item id="current"><vcard xmlns="{NS_VCARD4}"><fn><text>{full_name}</text></fn><note><text>{note}</text></note></vcard></item></publish></pubsub>"#
+    )
+}
+
+/// Build a vCard4 fetch IQ targeting the owner's PEP `urn:xmpp:vcard4`
+/// node — the canonical XEP-0292 §4 fetch shape.
+fn vcard4_items_body() -> String {
+    format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{PEP_NODE_VCARD4}"/></pubsub>"#)
+}
+
+#[tokio::test]
+async fn xep0292_first_publish_auto_creates_open_access_node() {
+    // §6.1 canonical default: a fresh publish to `urn:xmpp:vcard4`
+    // MUST land an `open`-access node so any peer can read the vCard
+    // via PEP fetch. This is the path the wasm chat editor takes:
+    // a plain `<publish>` with no `<publish-options>` precondition.
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "xep0292-create-1").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "vc-pub-1",
+        &admin_bare,
+        &vcard4_publish_body("Admin Adminson", "Bio line"),
+    )
+    .await;
+    assert!(
+        pub_resp.contains(r#"type="result""#),
+        "auto-create + publish to vcard4 should succeed: {pub_resp}"
+    );
+
+    // Read the node config back from the owner's PEP service — the
+    // §6.1 contract is `pubsub#access_model=open`.
+    let cfg_resp = iq_get_to(
+        &mut admin,
+        "vc-cfg-1",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{PEP_NODE_VCARD4}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        cfg_resp.contains(r#"var="pubsub#access_model""#)
+            || cfg_resp.contains(r#"var='pubsub#access_model'"#),
+        "configure response must surface access_model field: {cfg_resp}"
+    );
+    assert!(
+        cfg_resp.contains("<value>open</value>") || cfg_resp.contains("<value>open</value>"),
+        "vcard4 PEP node MUST default to access_model=open per XEP-0292 §6.1: {cfg_resp}"
+    );
+
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn xep0292_non_roster_peer_can_fetch_published_vcard4() {
+    // The user-visible bug this PR fixes: user A publishes vcard4
+    // via the chat editor; user B (no roster relationship) opens
+    // A's profile and gets back fields. Requires §6.1 open access
+    // on the auto-created node.
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "xep0292-fetch-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+
+    // Admin publishes their vcard4 — auto-create path.
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "vc-fetch-pub",
+        &admin_bare,
+        &vcard4_publish_body("Admin Adminson", "Star-crossed sysop"),
+    )
+    .await;
+    assert!(
+        pub_resp.contains(r#"type="result""#),
+        "admin vcard4 publish: {pub_resp}"
+    );
+
+    // Bob — no roster relationship — fetches admin's vcard4. With
+    // §6.1 open access this MUST succeed.
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "xep0292-fetch-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    let items_resp = iq_get_to(
+        &mut bob,
+        "vc-fetch-items",
+        &admin_bare,
+        &vcard4_items_body(),
+    )
+    .await;
+    assert!(
+        items_resp.contains(r#"type="result""#),
+        "cross-user vcard4 fetch MUST succeed on an open node (XEP-0292 §6.1): {items_resp}"
+    );
+    assert!(
+        items_resp.contains("Admin Adminson"),
+        "fetched item MUST carry the published <fn> text: {items_resp}"
+    );
+    assert!(
+        items_resp.contains("Star-crossed sysop"),
+        "fetched item MUST carry the published <note> text: {items_resp}"
+    );
+
+    let _ = bob.close().await;
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn xep0292_publish_reconciles_legacy_presence_access_node() {
+    // Migration case: an earlier Waddle version auto-created the
+    // vcard4 PEP node with `presence` access (the bare
+    // `pep_default()`). After §6.1 was wired through
+    // `pep_for_node` the canonical access model is `open`, but
+    // the already-created node sticks with the old config until
+    // something reconfigures it. The publish dispatcher reconciles
+    // the config in-place on the next owner publish so the next
+    // peer fetch sees the spec-conformant node.
+    let _serial = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut admin = admin_client(&server, "xep0292-migrate-admin").await;
+    let admin_bare = format!("{USERNAME}@{DOMAIN}");
+
+    // Step 1: seed a vcard4 node, then EXPLICITLY downgrade its
+    // access to `presence` — simulating what a pre-fix Waddle would
+    // have done on first publish.
+    let pub_resp = iq_set_to(
+        &mut admin,
+        "vc-mig-seed",
+        &admin_bare,
+        &vcard4_publish_body("Pre Migration", "old"),
+    )
+    .await;
+    assert!(
+        pub_resp.contains(r#"type="result""#),
+        "seed publish: {pub_resp}"
+    );
+
+    let downgrade = iq_set_to(
+        &mut admin,
+        "vc-mig-downgrade",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{PEP_NODE_VCARD4}"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>presence</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        downgrade.contains(r#"type="result""#),
+        "downgrade to presence: {downgrade}"
+    );
+
+    // Confirm bob (no roster) currently CANNOT fetch — the
+    // `presence` access model gates this.
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "xep0292-migrate-bob",
+    )
+    .await
+    .expect("bob connect");
+
+    let denied_resp = iq_get_to(&mut bob, "vc-mig-denied", &admin_bare, &vcard4_items_body()).await;
+    assert!(
+        denied_resp.contains(r#"type="error""#),
+        "pre-migration fetch from non-roster peer MUST be denied on presence access: {denied_resp}"
+    );
+
+    // Step 2: admin republishes. This is the reconcile point —
+    // the publish handler MUST notice the well-known node config
+    // diverges from the §6.1 canonical and rewrite it to open
+    // before the new item lands.
+    let republish = iq_set_to(
+        &mut admin,
+        "vc-mig-republish",
+        &admin_bare,
+        &vcard4_publish_body("Post Migration", "new"),
+    )
+    .await;
+    assert!(
+        republish.contains(r#"type="result""#),
+        "republish should succeed and trigger reconcile: {republish}"
+    );
+
+    // Give the server a beat to process the reconcile + publish.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Step 3: now bob's fetch MUST succeed and surface the new
+    // payload — the reconcile flipped the node to open.
+    let ok_resp = iq_get_to(&mut bob, "vc-mig-ok", &admin_bare, &vcard4_items_body()).await;
+    assert!(
+        ok_resp.contains(r#"type="result""#),
+        "post-reconcile fetch MUST succeed (open access per §6.1): {ok_resp}"
+    );
+    assert!(
+        ok_resp.contains("Post Migration"),
+        "fetched item MUST be the post-migration payload: {ok_resp}"
+    );
+
+    // And the owner-readable config now reports `open`.
+    let cfg_resp = iq_get_to(
+        &mut admin,
+        "vc-mig-cfg",
+        &admin_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{PEP_NODE_VCARD4}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        cfg_resp.contains("<value>open</value>"),
+        "reconcile MUST set access_model=open on the existing node: {cfg_resp}"
+    );
+
+    let _ = bob.close().await;
+    let _ = admin.close().await;
+}

--- a/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/mod.rs
@@ -13,6 +13,7 @@ pub use node::{
 pub use pep::{
     build_pep_identity, is_pep_request, is_pep_request_to, pep_features, PepHandler,
     PEP_NODE_AVATAR_DATA, PEP_NODE_AVATAR_METADATA, PEP_NODE_BOOKMARKS, PEP_NODE_MDS_DISPLAYED,
+    PEP_NODE_VCARD4,
 };
 pub use stanzas::{
     build_pubsub_affiliations_result, build_pubsub_configure_form_result, build_pubsub_error,

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -197,8 +197,26 @@ impl NodeConfig {
             config = config.normalize_xep0402_bookmarks();
         } else if node == super::pep::PEP_NODE_MDS_DISPLAYED {
             config = Self::mds_displayed();
+        } else if node == super::pep::PEP_NODE_VCARD4 {
+            config = Self::vcard4_defaults();
         }
         config
+    }
+
+    /// XEP-0292 §6.1 vCard4 PEP node defaults.
+    ///
+    /// XEP-0292 §6.1 pins `open` as the canonical access model for the
+    /// `urn:xmpp:vcard4` node so any peer (roster relationship or not)
+    /// can resolve a user's published vCard4. `max_items = 1` keeps the
+    /// node single-slot so each publish replaces the prior one rather
+    /// than growing an unbounded item history — matching the
+    /// OIDC-managed publisher in `waddle-server::profile::publish`.
+    pub fn vcard4_defaults() -> Self {
+        Self {
+            access_model: AccessModel::Open,
+            max_items: 1,
+            ..Self::pep_default()
+        }
     }
 
     /// XEP-0490 §3 Message Displayed Synchronization node defaults.
@@ -357,6 +375,31 @@ mod tests {
         assert_eq!(private.max_items, u32::MAX);
         assert!(private.persist_items);
         assert!(private.notify_retract);
+    }
+
+    #[test]
+    fn vcard4_pep_config_is_open_with_single_item_retention() {
+        // XEP-0292 §6.1 canonical access model: `open`. The auto-create
+        // path on a publish to `urn:xmpp:vcard4` MUST land Open, not
+        // Presence — otherwise non-roster peers can't read the vCard
+        // even though the XEP says the node is publicly readable.
+        let config = NodeConfig::pep_for_node(super::super::pep::PEP_NODE_VCARD4);
+        assert_eq!(config.access_model, AccessModel::Open);
+        assert_eq!(config.publish_model, PublishModel::Publishers);
+        assert_eq!(config.max_items, 1);
+        assert!(config.persist_items);
+    }
+
+    #[test]
+    fn vcard4_defaults_helper_matches_pep_for_node() {
+        // Defence-in-depth: `vcard4_defaults()` is the single source of
+        // truth that the publish-handler reconcile path will compare
+        // existing-node configs against, so `pep_for_node` MUST return
+        // the same value.
+        assert_eq!(
+            NodeConfig::pep_for_node(super::super::pep::PEP_NODE_VCARD4),
+            NodeConfig::vcard4_defaults()
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
@@ -17,6 +17,15 @@ pub const PEP_NODE_AVATAR_METADATA: &str = "urn:xmpp:avatar:metadata";
 /// matches the wire shape in the XEP-0490 examples.
 pub const PEP_NODE_MDS_DISPLAYED: &str = "urn:xmpp:mds:displayed:0";
 
+/// XEP-0292 §3 vCard4 PEP node.
+///
+/// Mirrored as `waddle_xmpp::xep::xep0292::PEP_NODE_VCARD4` for use at
+/// the wire-handling layer; defined here so the well-known-node
+/// configuration table in `NodeConfig::pep_for_node` can reference it
+/// without pulling `waddle-xmpp` into `waddle-xmpp-core`. The two
+/// constants are pinned equal by a `waddle-xmpp` test.
+pub const PEP_NODE_VCARD4: &str = "urn:xmpp:vcard4";
+
 /// Check if an IQ is a PEP request for the current user.
 pub fn is_pep_request(iq: &Iq, user_jid: &BareJid) -> bool {
     if !is_pubsub_iq(iq) {
@@ -51,6 +60,7 @@ impl PepHandler {
             || node == PEP_NODE_AVATAR_DATA
             || node == PEP_NODE_AVATAR_METADATA
             || node == PEP_NODE_MDS_DISPLAYED
+            || node == PEP_NODE_VCARD4
             || node == "http://jabber.org/protocol/nick"
             || node == "http://jabber.org/protocol/mood"
             || node == "http://jabber.org/protocol/activity"
@@ -63,6 +73,11 @@ impl PepHandler {
     pub fn default_access_model_for_node(node: &str) -> AccessModel {
         if node == PEP_NODE_BOOKMARKS || node == PEP_NODE_MDS_DISPLAYED {
             return AccessModel::Whitelist;
+        }
+        if node == PEP_NODE_VCARD4 {
+            // XEP-0292 §6.1: vCard4 is publicly readable; the canonical
+            // PEP node access model is `open`.
+            return AccessModel::Open;
         }
 
         AccessModel::Presence

--- a/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
+++ b/server/crates/waddle-xmpp/tests/xep0292_vcard4.rs
@@ -39,6 +39,21 @@ fn xep0292_pep_node_matches_spec() {
     assert_eq!(PEP_NODE_VCARD4, "urn:xmpp:vcard4");
 }
 
+#[test]
+fn xep0292_pep_node_constant_mirrors_waddle_xmpp_core() {
+    // `waddle-xmpp-core` keeps an independent `PEP_NODE_VCARD4`
+    // constant so the `NodeConfig::pep_for_node` well-known-node
+    // table can reference it without depending on `waddle-xmpp`. The
+    // two MUST stay equal — otherwise a publish would route through
+    // one identifier and the auto-create config table would key off
+    // the other, and the user's vCard4 node could land with the
+    // wrong access model.
+    assert_eq!(
+        PEP_NODE_VCARD4,
+        waddle_xmpp_core::pubsub::pep::PEP_NODE_VCARD4
+    );
+}
+
 // ── §8 MUST disco advertisement ──────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

vcard4 PEP nodes published via the chat editor (#667) ended up with `AccessModel::Presence` — so only roster contacts could read another user's vcard4. XEP-0292 §6.1 pins the canonical default at `Open`. This PR wires the canonical access model through the well-known-node configuration table so the editor's `<publish>` auto-create produces a publicly-readable vCard, matching what the OIDC-managed publisher already does, and reconciles already-created `Presence`-access nodes on the next publish.

## Root cause

Two paths publish to `urn:xmpp:vcard4`:

1. **OIDC reconcile** (`server/crates/waddle-server/src/profile/publish.rs:61` `oidc_pep_node_config()`) — explicitly sets `AccessModel::Open` via `ensure_node_with_oidc_config`. Correct.
2. **Chat editor** (`waddle-xmpp-client::xep::xep0292::build_publish_vcard4_iq`, called from the wasm `publish_vcard4`) — sends a plain `<publish>` IQ with no `<publish-options>`. The server auto-created the node using `NodeConfig::pep_for_node(node)`, which fell through to `pep_default()` = `AccessModel::Presence`.

`pep_for_node` already had well-known overrides for `PEP_NODE_BOOKMARKS` (XEP-0402 normalization) and `PEP_NODE_MDS_DISPLAYED` (XEP-0490 whitelist). vcard4 gets the same treatment here.

## Changes

### Server

1. **`waddle-xmpp-core/src/pubsub/pep.rs`** — define `PEP_NODE_VCARD4 = "urn:xmpp:vcard4"` (mirrored from `waddle-xmpp::xep::xep0292::PEP_NODE_VCARD4`, with a `waddle-xmpp` test pinning the two constants equal so the configuration table can reference it without a circular `waddle-xmpp-core` → `waddle-xmpp` dep). Add it to `is_well_known_node` and update `default_access_model_for_node`.
2. **`waddle-xmpp-core/src/pubsub/node.rs`** — add `NodeConfig::vcard4_defaults()` returning `access_model = Open`, `max_items = 1`, rest from `pep_default()`. Extend `NodeConfig::pep_for_node` with the `PEP_NODE_VCARD4` branch.
3. **`waddle-server/src/server/routes/websocket/handlers/iq/pubsub_helpers.rs`** — `reconcile_well_known_pep_node_config(state, owner, node)`: when the stored config diverges from `pep_for_node(node)` for the small set of well-known nodes stricter than `pep_default()` (currently only vcard4), rewrite it via `update_node_config` before the publish lands its item. Scope is deliberately narrow — no bulk rewrite of arbitrary user node configs.
4. **`waddle-server/src/server/routes/websocket/handlers/iq/pubsub_dispatch.rs`** — call the reconcile helper at the publish boundary for owner self-PEP publishes, before `publish_item`.

### Tests

- **`waddle-xmpp-core/src/pubsub/node.rs`** — unit tests pinning `pep_for_node(PEP_NODE_VCARD4)` to Open + `max_items=1` and the `vcard4_defaults` helper.
- **`waddle-xmpp/tests/xep0292_vcard4.rs`** — pin `PEP_NODE_VCARD4` equal across the two crates.
- **`waddle-server/tests/xep0292_vcard4_ws.rs`** (new dedicated suite, per CLAUDE.md XEP test-suite hard rule):
  - `xep0292_first_publish_auto_creates_open_access_node` — auto-create + read `<configure/>` shows `access_model=open`.
  - `xep0292_non_roster_peer_can_fetch_published_vcard4` — Bob (no roster relationship) fetches admin's vcard4 successfully.
  - `xep0292_publish_reconciles_legacy_presence_access_node` — seed a `presence`-access node, confirm Bob is denied, owner republishes, confirm reconcile flipped to Open and Bob's fetch now succeeds.

### Audit doc

- Update XEP-0292 row to note the canonical access model is wired through `pep_for_node` and reference this PR + the new test suites.

## Test plan

- [x] `cargo test --workspace` green (including the new node-default + cross-user fetch cases)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: log in as user A, set bio + pronouns; log in as user B (no roster relationship); open A's profile drawer → vcard fields render

## Non-goals

- No wire-protocol changes (no `<publish-options>` added to the chat publish IQ — the server enforces canonical defaults, which matches how MDS works in #665).
- No client changes — pure server fix.

This PR was created with the assistance of a LLM.