### PR TITLE
feat: global Threads view (urn:waddle:threads:0)

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import HomeDashboard from "@/components/chat/HomeDashboard.vue";
+import ThreadsView from "@/components/chat/ThreadsView.vue";
 import FeedPane from "@/components/community/FeedPane.vue";
 import StoriesPane from "@/components/community/StoriesPane.vue";
 import EventsPane from "@/components/community/EventsPane.vue";
@@ -345,6 +346,9 @@ onUnmounted(() => window.removeEventListener("popstate", refreshAdminPanelFromUr
         @cancel-instance="(uid, dtstartMs) => communityEvents.cancelInstance(uid, dtstartMs)"
         @rsvp="(event, partstat) => onCommunityRsvp(event, partstat)"
         @open-nav="ui.showMobileNav.value = true"
+      />
+      <ThreadsView
+        v-else-if="ui.activePage.value === 'threads'"
       />
       <UserSettingsPage
         v-else-if="ui.activePage.value === 'settings' && connectionStore.session"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -85,6 +85,7 @@ const {
   handleToggleNotifications,
   openUserSettings,
   openHome,
+  openThreads,
   closeUserSettings,
   handleLogout,
   selectChannel,
@@ -280,9 +281,11 @@ onUnmounted(() => window.removeEventListener("popstate", refreshAdminPanelFromUr
           :active-community-surface="ui.activeCommunitySurface.value"
           :stories-active-count="stories.activeStories.value.length"
           :upcoming-event-count="communityEvents.events.value.filter((e: { dtstartMs?: number }) => typeof e.dtstartMs === 'number' && e.dtstartMs > Date.now()).length"
+          :is-threads-active="ui.activePage.value === 'threads'"
           @select-channel="onSelectChannelFromSidebar"
           @select-thread="onSelectThread"
           @select-community-surface="onSelectCommunitySurface"
+          @select-threads-view="openThreads"
           @create-channel="openCreateChannelDialog()"
           @create-channel-in-space="openCreateChannelDialog"
           @open-settings="ui.showWaddleSettings.value = true"

--- a/chat/src/components/chat/ThreadsListPanel.vue
+++ b/chat/src/components/chat/ThreadsListPanel.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { WasmThreadEntry, WasmThreadsPage } from "@/lib/xmpp/wasm-types";
+import ThreadsListRow from "@/components/chat/ThreadsListRow.vue";
+
+const props = defineProps<{
+  xmppClient: BrowserXmppClient | null;
+}>();
+
+const emit = defineEmits<{
+  openThread: [entry: WasmThreadEntry];
+}>();
+
+const loading = ref(true);
+const page = ref<WasmThreadsPage | null>(null);
+const error = ref<string | null>(null);
+
+const unread = computed(
+  () => page.value?.entries.filter((entry) => entry.has_unread) ?? [],
+);
+const following = computed(
+  () => page.value?.entries.filter((entry) => !entry.has_unread) ?? [],
+);
+
+onMounted(async () => {
+  if (!props.xmppClient) {
+    loading.value = false;
+    return;
+  }
+  try {
+    page.value = await props.xmppClient.fetchThreads({ pageSize: 50 });
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="chat-panel-stack p-4">
+    <h2 class="type-pane-title">Threads</h2>
+
+    <div v-if="loading" class="type-caption text-muted-foreground" aria-busy="true">
+      Loading threads…
+    </div>
+
+    <div v-else-if="error" class="type-caption text-destructive">
+      Couldn't load threads: {{ error }}
+    </div>
+
+    <template v-else-if="page">
+      <section v-if="unread.length > 0" class="chat-panel-stack">
+        <div class="type-section-label text-muted-foreground/75">
+          Unread · {{ unread.length }}
+        </div>
+        <ThreadsListRow
+          v-for="entry in unread"
+          :key="`${entry.channel}|${entry.thread_id}`"
+          :entry="entry"
+          @open="emit('openThread', $event)"
+        />
+      </section>
+
+      <section v-if="following.length > 0" class="chat-panel-stack">
+        <div class="type-section-label text-muted-foreground/75">
+          Following · {{ following.length }}
+        </div>
+        <ThreadsListRow
+          v-for="entry in following"
+          :key="`${entry.channel}|${entry.thread_id}`"
+          :entry="entry"
+          @open="emit('openThread', $event)"
+        />
+      </section>
+
+      <div
+        v-if="unread.length === 0 && following.length === 0"
+        class="type-caption text-muted-foreground"
+      >
+        No threads yet. Threads you reply to or get mentioned in will show up here.
+      </div>
+    </template>
+  </div>
+</template>

--- a/chat/src/components/chat/ThreadsListRow.vue
+++ b/chat/src/components/chat/ThreadsListRow.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+
+const props = defineProps<{
+  entry: WasmThreadEntry;
+}>();
+
+const emit = defineEmits<{
+  open: [entry: WasmThreadEntry];
+}>();
+
+const recencyLabel = computed(() => {
+  const ts = Date.parse(props.entry.last_activity);
+  if (Number.isNaN(ts)) return "";
+  const deltaSec = Math.floor((Date.now() - ts) / 1000);
+  if (deltaSec < 60) return "just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86_400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  return `${Math.floor(deltaSec / 86_400)}d ago`;
+});
+
+const channelLabel = computed(() => {
+  const local = props.entry.channel.split("@")[0] ?? props.entry.channel;
+  return `#${local}`;
+});
+
+const title = computed(
+  () =>
+    props.entry.thread_title ??
+    props.entry.preview ??
+    "Thread",
+);
+</script>
+
+<template>
+  <button
+    type="button"
+    class="chat-thread-row glass-panel w-full rounded-md px-3 py-2 text-left hover:bg-sidebar-accent/35"
+    @click="emit('open', entry)"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <div class="min-w-0 flex-1">
+        <div class="type-card-title truncate">{{ title }}</div>
+        <div class="type-caption text-muted-foreground truncate">
+          {{ channelLabel }} · {{ recencyLabel }}
+          <span v-if="entry.reply_count > 0"> · {{ entry.reply_count }} replies</span>
+        </div>
+      </div>
+      <span
+        v-if="entry.has_unread"
+        class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+        :aria-label="`${entry.unread} unread`"
+      >
+        {{ entry.unread }}
+      </span>
+    </div>
+  </button>
+</template>

--- a/chat/src/components/chat/ThreadsView.vue
+++ b/chat/src/components/chat/ThreadsView.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { connectionStore } from "@/lib/connection-store";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+import ThreadsListPanel from "@/components/chat/ThreadsListPanel.vue";
+
+const xmppClient = computed(() => connectionStore.client);
+
+function openThread(entry: WasmThreadEntry) {
+  // Navigate to the channel that hosts the thread. The channel page
+  // currently picks the active thread off the URL hash; we land on
+  // the room and the user re-opens the thread by clicking the reply
+  // chip until the live thread-delta hook is in place.
+  const channel = entry.channel.split("@")[0] ?? entry.channel;
+  if (!channel) return;
+  const target = `/r/${channel}#thread=${encodeURIComponent(entry.thread_id)}`;
+  window.location.assign(target);
+}
+</script>
+
+<template>
+  <div class="chat-content-pane">
+    <ThreadsListPanel :xmpp-client="xmppClient" @open-thread="openThread" />
+  </div>
+</template>

--- a/chat/src/components/chat/TopicsPanel.vue
+++ b/chat/src/components/chat/TopicsPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { CalendarDays, Camera, Hash, MessageSquareText, MessagesSquare, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle } from "lucide-vue-next";
+import { CalendarDays, Camera, Hash, ListTree, MessageSquareText, MessagesSquare, Plus, Settings, Users, ChevronDown, ChevronRight, MessageCircle } from "lucide-vue-next";
 import { isForumChannel as detectForumChannel } from "@/lib/channel-types";
 import type { ChannelSummary, SpaceSummary } from "@/lib/chat-types";
 import type { ChannelThreadInboxEntry } from "@/channels/inbox";
@@ -31,6 +31,10 @@ const props = defineProps<{
   feedNewCount?: number;
   storiesActiveCount?: number;
   upcomingEventCount?: number;
+  /** True when the global Threads view is currently active. */
+  isThreadsActive?: boolean;
+  /** Unread-thread count for the global Threads view badge. */
+  threadsUnreadCount?: number;
 }>();
 
 function hasActivity(channelId: string): boolean {
@@ -141,6 +145,7 @@ const emit = defineEmits<{
   selectChannel: [id: string];
   selectThread: [channelId: string, threadId: string];
   selectCommunitySurface: [surface: "feed" | "stories" | "events"];
+  selectThreadsView: [];
   createChannel: [];
   createChannelInSpace: [spaceId: string | null];
   openSettings: [];
@@ -253,6 +258,20 @@ watch(
                are NOT real channels. Selecting one swaps the
                content area for that surface's content pane. -->
           <section class="grid gap-1" aria-label="Community surfaces">
+            <button
+              type="button"
+              class="chat-list-row flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-sidebar-accent/35"
+              :class="isThreadsActive ? 'bg-sidebar-accent/60 text-sidebar-foreground' : 'text-sidebar-foreground/85'"
+              @click="emit('selectThreadsView')"
+            >
+              <ListTree class="h-3.5 w-3.5 flex-shrink-0 text-primary" aria-hidden="true" />
+              <span class="flex-1 truncate type-control">Threads</span>
+              <span
+                v-if="(threadsUnreadCount ?? 0) > 0"
+                class="type-count-badge inline-flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-primary px-1 text-primary-foreground"
+                aria-hidden="true"
+              >{{ threadsUnreadCount }}</span>
+            </button>
             <button
               type="button"
               class="chat-list-row flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-sidebar-accent/35"

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -97,6 +97,7 @@ import {
 import type {
   WasmArchivedMessage,
   WasmAvatar,
+  WasmFetchThreadsOptions,
   WasmInboxResult,
   WasmMamPage,
   WasmMdsDisplayedEntry,
@@ -106,6 +107,7 @@ import type {
   WasmRoomMember,
   WasmRosterContact,
   WasmServerVersion,
+  WasmThreadsPage,
   WasmUserSearchResult,
   WasmVCard4,
 } from "./wasm-types";
@@ -983,6 +985,21 @@ export class BrowserXmppClient {
 
   async markInboxRead(partnerJid: string, threadId?: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.mark_inbox_read?.(barePeerJid(partnerJid), threadId ?? null); }
   async fetchThreadInbox(roomJid: string): Promise<InboxResult> { return this.fetchInbox({ room: roomJid, threads: true }); }
+
+  /**
+   * Fetch the global cross-channel threads view (`urn:waddle:threads:0`).
+   * Returns an empty page when the wasm client lacks the method or the
+   * server doesn't respond — callers can render the empty state.
+   */
+  async fetchThreads(opts: { pageSize?: number; afterCursor?: string } = {}): Promise<WasmThreadsPage> {
+    const xmpp = await this.requireConnectedXmpp();
+    const payload: WasmFetchThreadsOptions = {
+      ...(typeof opts.pageSize === "number" ? { page_size: opts.pageSize } : {}),
+      ...(opts.afterCursor ? { after_cursor: opts.afterCursor } : {}),
+    };
+    const raw = await xmpp.fetch_threads?.(payload) as WasmThreadsPage | undefined;
+    return raw ?? { total: 0, unread_threads: 0, entries: [] };
+  }
 
   /**
    * Fetch the latest XEP-0472 social feed entries from the community

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -286,6 +286,35 @@ export interface WasmVCard4 {
   url?: string;
 }
 
+/** One entry in a urn:waddle:threads:0 response. */
+export interface WasmThreadEntry {
+  channel: string;
+  thread_id: string;
+  last_stanza_id: string;
+  /** RFC 3339 timestamp. */
+  last_activity: string;
+  unread: number;
+  reply_count: number;
+  has_unread: boolean;
+  root_author?: string;
+  preview?: string;
+  thread_title?: string;
+}
+
+/** Paged response to a urn:waddle:threads:0 query. */
+export interface WasmThreadsPage {
+  total: number;
+  unread_threads: number;
+  entries: WasmThreadEntry[];
+  next_cursor?: string;
+}
+
+/** Options bag for fetchThreads. */
+export interface WasmFetchThreadsOptions {
+  page_size?: number;
+  after_cursor?: string;
+}
+
 /** XEP-0490 §3 displayed entry surfaced from the wasm boundary. */
 export interface WasmMdsDisplayedEntry {
   chat_id: string;

--- a/chat/src/pages/threads.astro
+++ b/chat/src/pages/threads.astro
@@ -1,0 +1,5 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+---
+
+<AppLayout />

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -16,7 +16,7 @@ import { useCommunityEvents } from "@/services/community-events";
 import { useChatReadActivity } from "@/shell/read-activity";
 import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
-import { buildDirectMessagePath, buildChannelExtensionPath, buildChannelPath, buildChatSettingsPath, parseChatLocation, pushDirectMessageRoute, pushChannelExtensionRoute, pushChannelRoute, pushChatSettingsRoute, resolveChannelBySlug, shouldLoadWaddleStructureForRoute } from "@/shell/navigation";
+import { buildDirectMessagePath, buildChannelExtensionPath, buildChannelPath, buildChatSettingsPath, parseChatLocation, pushDirectMessageRoute, pushChannelExtensionRoute, pushChannelRoute, pushChatSettingsRoute, pushThreadsRoute, resolveChannelBySlug, shouldLoadWaddleStructureForRoute } from "@/shell/navigation";
 import { barePeerJid, jidDomain, parseManagedRoomBareJid } from "@/lib/xmpp-client";
 import { mdsChatKey, setLastSeen } from "@/lib/last-seen-store";
 import { roomJidForChannelId as resolveRoomJidForChannelId } from "@/lib/channel-room";
@@ -1215,6 +1215,23 @@ export function useChatAppController(giphyApiKey: string) {
   }
 
   /**
+   * Navigate to the global Threads view. Clears any channel/DM
+   * selection, drops local thread-panel state, syncs the URL so a
+   * page refresh lands back on /threads.
+   */
+  function openThreads() {
+    ui.showMobileNav.value = false;
+    ui.showMobileDetails.value = false;
+    ui.activePage.value = "threads";
+    waddles.activeChannelId.value = null;
+    dmConversations.closeDm();
+    activeRightPanel.value = null;
+    activeThreadStack.value = [];
+    activeExtensionRouteKey.value = null;
+    pushThreadsRoute();
+  }
+
+  /**
    * Navigate back to the Home dashboard from anywhere. Clears any
    * channel/DM selection, drops thread state, closes the mobile nav
    * drawer, and resyncs the URL so a refresh returns the user to home
@@ -1274,7 +1291,7 @@ export function useChatAppController(giphyApiKey: string) {
       activeExtensionRouteKey.value = null;
       return;
     }
-    if (route.page === "settings") {
+    if (route.page === "settings" || route.page === "threads") {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
       return;
@@ -1311,7 +1328,7 @@ export function useChatAppController(giphyApiKey: string) {
       activeExtensionRouteKey.value = null;
       return;
     }
-    if (route.page === "settings") {
+    if (route.page === "settings" || route.page === "threads") {
       activeThreadTargetMessageId.value = null;
       activeThreadStack.value = [];
       return;
@@ -1726,6 +1743,7 @@ export function useChatAppController(giphyApiKey: string) {
       handleToggleNotifications,
       openUserSettings,
       openHome,
+      openThreads,
       closeUserSettings,
       handleLogout,
       selectChannel,

--- a/chat/src/shell/navigation.ts
+++ b/chat/src/shell/navigation.ts
@@ -1,7 +1,7 @@
 import type { ChannelSummary } from "@/lib/chat-types";
 
 interface RouteState {
-  page: "dashboard" | "chat" | "settings" | "extension" | "admin";
+  page: "dashboard" | "chat" | "settings" | "extension" | "admin" | "threads";
   channelSlug: string | null;
   dmUsername: string | null;
   extensionPluginId: string | null;
@@ -25,6 +25,7 @@ export type AdminPanel = "users" | "spaces" | "audit" | "push-health" | "setting
 const SETTINGS_PATH = "/settings";
 const ADMIN_PATH_PREFIX = "/admin";
 const DEFAULT_ADMIN_PANEL: AdminPanel = "users";
+const THREADS_PATH = "/threads";
 
 function parseAdminPanel(slug: string | undefined): AdminPanel | null {
   switch (slug) {
@@ -123,6 +124,17 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       adminPanel: panel,
     };
   }
+  if (pathname === THREADS_PATH) {
+    return {
+      page: "threads",
+      channelSlug: null,
+      dmUsername: null,
+      extensionPluginId: null,
+      extensionRouteId: null,
+      threadStack: [],
+      pinnedPanelOpen: false,
+    };
+  }
   if (segments[0] === "r") {
     if (segments[2] === "x" && segments[3] && segments[4]) {
       return {
@@ -214,6 +226,13 @@ export function buildChatSettingsPath(): string {
 
 export function buildAdminPath(panel: AdminPanel = DEFAULT_ADMIN_PANEL): string {
   return `${ADMIN_PATH_PREFIX}/${panel}`;
+}
+
+export function pushThreadsRoute() {
+  const current = window.location.pathname + window.location.search;
+  if (current !== THREADS_PATH) {
+    window.history.pushState({ waddlePage: "threads" }, "", THREADS_PATH);
+  }
 }
 
 export function pushChannelRoute(

--- a/chat/src/shell/navigation.ts
+++ b/chat/src/shell/navigation.ts
@@ -133,6 +133,7 @@ export function parseChatLocation(pathname: string, search?: string): RouteState
       extensionRouteId: null,
       threadStack: [],
       pinnedPanelOpen: false,
+      adminPanel: null,
     };
   }
   if (segments[0] === "r") {

--- a/chat/src/shell/state.ts
+++ b/chat/src/shell/state.ts
@@ -7,7 +7,7 @@ import type { AdminTab } from "@/lib/chat-ui";
 export type CommunitySurface = "feed" | "stories" | "events";
 
 export function useChatShellState() {
-  const activePage = ref<"dashboard" | "chat" | "settings" | "admin">("dashboard");
+  const activePage = ref<"dashboard" | "chat" | "settings" | "admin" | "threads">("dashboard");
   const adminTab = ref<AdminTab>("rooms");
   const sidebarMode = ref<"channels" | "dms">("channels");
   /** Which community pseudo-channel is currently active (if any).

--- a/chat/tests/extension-route-rail-ui.test.ts
+++ b/chat/tests/extension-route-rail-ui.test.ts
@@ -67,7 +67,7 @@ describe("extension route rail UI contract", () => {
     const controller = readFileSync(new URL("../src/shell/chat-app-controller.ts", import.meta.url), "utf8");
     const state = readFileSync(new URL("../src/shell/state.ts", import.meta.url), "utf8");
 
-    expect(state).toContain('ref<"dashboard" | "chat" | "settings" | "admin">');
+    expect(state).toContain('ref<"dashboard" | "chat" | "settings" | "admin" | "threads">');
     expect(readyShell).toContain("<ExtensionRouteRail");
     expect(readyShell).toContain("@close=\"closeExtensionRoutePanel\"");
     expect(readyShell).toContain("@update:pinned-panel-open=\"setPinnedPanelOpen\"");

--- a/chat/tests/threads-list-panel.test.ts
+++ b/chat/tests/threads-list-panel.test.ts
@@ -1,0 +1,167 @@
+// Tests for `ThreadsListPanel.vue` — the global Threads view.
+//
+// Mirrors the test pattern used by `user-profile-drawer.test.ts`:
+// a small in-memory model that captures the same fetch + partition
+// decisions the component makes, exercised against a stubbed
+// `BrowserXmppClient.fetchThreads`.
+
+import { describe, expect, mock, test } from "bun:test";
+import type { WasmThreadEntry, WasmThreadsPage } from "../src/lib/xmpp/wasm-types";
+
+interface PanelClient {
+  fetchThreads: (opts: { pageSize?: number }) => Promise<WasmThreadsPage>;
+}
+
+interface PanelState {
+  loading: boolean;
+  page: WasmThreadsPage | null;
+  error: string | null;
+}
+
+interface PanelView {
+  unread: WasmThreadEntry[];
+  following: WasmThreadEntry[];
+  isEmpty: boolean;
+  errorText: string | null;
+}
+
+/**
+ * Mirrors `ThreadsListPanel.vue`'s on-mount flow: call fetchThreads,
+ * record the result, then partition into Unread (has_unread) and
+ * Following (!has_unread).
+ */
+function createPanel(client: PanelClient | null) {
+  const state: PanelState = {
+    loading: true,
+    page: null,
+    error: null,
+  };
+
+  async function mount() {
+    if (!client) {
+      state.loading = false;
+      return;
+    }
+    try {
+      state.page = await client.fetchThreads({ pageSize: 50 });
+    } catch (err) {
+      state.error = err instanceof Error ? err.message : String(err);
+    } finally {
+      state.loading = false;
+    }
+  }
+
+  function view(): PanelView {
+    const entries = state.page?.entries ?? [];
+    const unread = entries.filter((entry) => entry.has_unread);
+    const following = entries.filter((entry) => !entry.has_unread);
+    return {
+      unread,
+      following,
+      isEmpty: !state.loading && !state.error && unread.length === 0 && following.length === 0,
+      errorText: state.error,
+    };
+  }
+
+  function openThreadEvents() {
+    const captured: Array<{ entry: WasmThreadEntry }> = [];
+    function emit(entry: WasmThreadEntry) {
+      captured.push({ entry });
+    }
+    return { emit, captured };
+  }
+
+  return { state, mount, view, openThreadEvents };
+}
+
+function makeEntry(overrides: Partial<WasmThreadEntry> = {}): WasmThreadEntry {
+  return {
+    channel: "room@x",
+    thread_id: "t",
+    last_stanza_id: "S",
+    last_activity: new Date().toISOString(),
+    unread: 0,
+    reply_count: 0,
+    has_unread: false,
+    ...overrides,
+  };
+}
+
+describe("ThreadsListPanel", () => {
+  test("renders empty state when no entries", async () => {
+    const client: PanelClient = {
+      fetchThreads: mock(async () => ({
+        total: 0,
+        unread_threads: 0,
+        entries: [],
+      })),
+    };
+    const panel = createPanel(client);
+    await panel.mount();
+    const view = panel.view();
+    expect(view.isEmpty).toBe(true);
+    expect(view.unread).toHaveLength(0);
+    expect(view.following).toHaveLength(0);
+  });
+
+  test("splits unread and following sections", async () => {
+    const client: PanelClient = {
+      fetchThreads: mock(async () => ({
+        total: 3,
+        unread_threads: 2,
+        entries: [
+          makeEntry({ thread_id: "t1", has_unread: true, unread: 2 }),
+          makeEntry({ thread_id: "t2", has_unread: false }),
+          makeEntry({ thread_id: "t3", has_unread: true, unread: 1 }),
+        ],
+      })),
+    };
+    const panel = createPanel(client);
+    await panel.mount();
+    const view = panel.view();
+    expect(view.unread.map((e) => e.thread_id)).toEqual(["t1", "t3"]);
+    expect(view.following.map((e) => e.thread_id)).toEqual(["t2"]);
+    expect(view.isEmpty).toBe(false);
+  });
+
+  test("openThread captures click target", async () => {
+    const entry = makeEntry({ thread_id: "click-me", has_unread: true, unread: 1 });
+    const client: PanelClient = {
+      fetchThreads: mock(async () => ({
+        total: 1,
+        unread_threads: 1,
+        entries: [entry],
+      })),
+    };
+    const panel = createPanel(client);
+    await panel.mount();
+    const events = panel.openThreadEvents();
+    // Simulate a click on the first unread row.
+    const target = panel.view().unread[0];
+    expect(target).toBeDefined();
+    if (target) events.emit(target);
+    expect(events.captured).toHaveLength(1);
+    expect(events.captured[0]?.entry.thread_id).toBe("click-me");
+  });
+
+  test("surfaces fetch errors", async () => {
+    const client: PanelClient = {
+      fetchThreads: mock(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const panel = createPanel(client);
+    await panel.mount();
+    const view = panel.view();
+    expect(view.errorText).toBe("boom");
+    expect(view.isEmpty).toBe(false);
+  });
+
+  test("no client renders empty without fetching", async () => {
+    const panel = createPanel(null);
+    await panel.mount();
+    expect(panel.state.loading).toBe(false);
+    expect(panel.state.page).toBeNull();
+    expect(panel.view().isEmpty).toBe(true);
+  });
+});

--- a/docs/superpowers/plans/2026-05-17-threads-implementation.md
+++ b/docs/superpowers/plans/2026-05-17-threads-implementation.md
@@ -1,0 +1,1712 @@
+# Threads view implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a global "Threads" view in the Waddle chat client, backed by a new `urn:waddle:threads:0` IQ query, so users can see at-a-glance which threads have unread messages and which have recent activity.
+
+**Architecture:** Server reads the existing `inbox_entries` table (already keyed `(user, partner, thread_id)`) and exposes a paginated thread list via a new IQ shape on the user's bare JID. The chat client adds a top-level sidebar entry + a panel that partitions the result client-side into two sections (Unread on top, Following below). No new DB schema. No new advert beyond the disco feature for the namespace.
+
+**Tech Stack:**
+- Rust (server crates: `waddle-server`, `waddle-xmpp-client`, `waddle-xmpp-client-wasm`)
+- TypeScript / Astro / Vue 3 / Tailwind 4 (`chat/`)
+- Bun (chat tooling)
+- `minidom::Element` for all XML construction (CLAUDE.md hard rule — never `format!` for XML)
+- `cargo fmt`, `cargo clippy -D warnings`, `bun run lint` (knip) — must all be clean before push
+
+Spec: `docs/superpowers/specs/2026-05-17-threads-design.md` (same branch, first commit).
+
+PR: #671 (draft) at `feat/server-waddle-threads-query`.
+
+---
+
+## Pre-work for the agent
+
+Before starting Task 1, read these files end-to-end to internalize the patterns this plan mirrors:
+
+1. `server/crates/waddle-xmpp/src/xep/xep0430.rs` — the existing Waddle inbox IQ shape. The threads query is a sibling Waddle-namespaced query with similar response semantics.
+2. `server/crates/waddle-server/src/inbox.rs` — DB read patterns, `InboxStorage` trait, query helpers.
+3. `server/crates/waddle-server/src/inbox/codec.rs` — DB-row → typed-value decode (`decode_row` and `SELECT_COLS`).
+4. The most recent merged PR that added a new IQ query — likely #664 (push enforcement) or #669 (vcard4 access). Skim how the IQ handler hooks into the WebSocket router.
+
+CLAUDE.md project rules that apply to every task:
+- `cargo fmt` before every commit (server/CLAUDE.md hard rule — what tripped #663/#664/#665 in CI).
+- No `unwrap` in new code.
+- No clippy allows.
+- No `format!` for XML — use `minidom::Element` builders.
+- Typed payloads everywhere; no string-blob protocol data.
+- Conventional Commits, single scope per commit.
+
+---
+
+## Task 1: Server types + module scaffold
+
+**Files:**
+- Create: `server/crates/waddle-server/src/threads/mod.rs`
+- Create: `server/crates/waddle-server/src/threads/query.rs`
+- Modify: `server/crates/waddle-server/src/lib.rs` (add `pub mod threads;` alongside existing `pub mod inbox;`)
+
+- [ ] **Step 1: Add module declaration**
+
+In `server/crates/waddle-server/src/lib.rs`, find the line `pub mod inbox;` and add directly after it:
+
+```rust
+pub mod threads;
+```
+
+- [ ] **Step 2: Create the module entry file**
+
+Create `server/crates/waddle-server/src/threads/mod.rs`:
+
+```rust
+//! Waddle threads — per-thread cross-channel aggregation view.
+//!
+//! This module carries the IQ-level protocol for the global threads view:
+//! a single query that returns an ordered list of threads the user has
+//! participated in or has unread in, across every channel.
+//!
+//! Wire shape: `urn:waddle:threads:0`. See
+//! `docs/superpowers/specs/2026-05-17-threads-design.md` for the contract.
+//!
+//! Data source: the existing `inbox_entries` table (rows with non-empty
+//! `thread_id`). No new schema.
+
+pub mod query;
+pub mod storage;
+pub mod wire;
+```
+
+- [ ] **Step 3: Create the typed query types**
+
+Create `server/crates/waddle-server/src/threads/query.rs`:
+
+```rust
+//! Typed request and response values for the threads query.
+
+use jid::BareJid;
+
+/// `urn:waddle:threads:0` namespace.
+pub const NS_THREADS: &str = "urn:waddle:threads:0";
+
+/// Maximum entries the server will return on a single page when the
+/// client omits `<set><max>`. Mirrors the existing inbox cap.
+pub const DEFAULT_PAGE_SIZE: u32 = 50;
+
+/// Hard cap on `<set><max>` requested by clients. Same cap as inbox.
+pub const MAX_PAGE_SIZE: u32 = 200;
+
+/// A `<query xmlns='urn:waddle:threads:0'/>` request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsQuery {
+    /// RSM `<max>` — clamped to `MAX_PAGE_SIZE` at parse time.
+    pub page_size: Option<u32>,
+    /// RSM `<after>` cursor — opaque string the server emitted previously.
+    pub after_cursor: Option<String>,
+}
+
+/// One row in a `<threads>` response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadEntry {
+    pub channel: BareJid,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    /// Unix seconds since epoch.
+    pub last_activity_secs: i64,
+    pub unread: u32,
+    pub reply_count: u32,
+    pub root_author: Option<BareJid>,
+    pub preview: Option<String>,
+    pub thread_title: Option<String>,
+}
+
+impl ThreadEntry {
+    pub fn has_unread(&self) -> bool {
+        self.unread > 0
+    }
+}
+
+/// Full response payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsPage {
+    pub entries: Vec<ThreadEntry>,
+    pub total: u64,
+    pub unread_threads: u64,
+    /// `<first>` cursor from RSM, opaque to clients.
+    pub first_cursor: Option<String>,
+    /// `<last>` cursor from RSM.
+    pub last_cursor: Option<String>,
+}
+
+/// Errors returned by threads stanza parsing.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ThreadsError {
+    #[error("expected <{0}/> in '{NS_THREADS}'")]
+    ExpectedElement(&'static str),
+    #[error("invalid integer '{0}'")]
+    InvalidInteger(String),
+    #[error("payload is not the expected IQ type")]
+    WrongIqType,
+}
+```
+
+- [ ] **Step 4: Verify compiles**
+
+Run from the worktree root:
+```bash
+cargo check -p waddle-server
+```
+Expected: PASS (warnings about unused `storage`/`wire` modules are OK; we'll fill them next).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/crates/waddle-server/src/lib.rs server/crates/waddle-server/src/threads/
+cargo fmt
+git add -u server/crates/waddle-server/src/threads/
+git commit -m "feat(server): scaffold urn:waddle:threads:0 module with typed query/response
+
+Adds the empty module tree and typed request/response values for the
+new global threads view. Subsequent commits add the wire builders,
+storage read, IQ handler, and tests.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 2: Wire builders + parser
+
+**Files:**
+- Create: `server/crates/waddle-server/src/threads/wire.rs`
+- Test inside the same file as `#[cfg(test)] mod tests`
+
+- [ ] **Step 1: Write the wire builder skeleton**
+
+Create `server/crates/waddle-server/src/threads/wire.rs`:
+
+```rust
+//! XML wire shape for `urn:waddle:threads:0`. Built via `minidom::Element`
+//! so no XML is ever concatenated as strings (CLAUDE.md hard rule).
+
+use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
+
+use super::query::{ThreadEntry, ThreadsError, ThreadsPage, ThreadsQuery, NS_THREADS};
+
+/// XEP-0059 Result Set Management namespace.
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+
+/// Parse a `<query xmlns='urn:waddle:threads:0'/>` IQ payload into a
+/// `ThreadsQuery`. The IQ MUST be a `get` for this to succeed.
+pub fn parse_threads_query(iq: &Iq) -> Result<ThreadsQuery, ThreadsError> {
+    let payload = match &iq.payload {
+        IqType::Get(el) => el,
+        _ => return Err(ThreadsError::WrongIqType),
+    };
+    if !payload.is("query", NS_THREADS) {
+        return Err(ThreadsError::ExpectedElement("query"));
+    }
+
+    let mut q = ThreadsQuery::default();
+    if let Some(rsm) = payload.get_child("set", NS_RSM) {
+        if let Some(max_el) = rsm.get_child("max", NS_RSM) {
+            let text = max_el.text();
+            let parsed: u32 = text
+                .trim()
+                .parse()
+                .map_err(|_| ThreadsError::InvalidInteger(text.clone()))?;
+            q.page_size = Some(parsed);
+        }
+        if let Some(after_el) = rsm.get_child("after", NS_RSM) {
+            let text = after_el.text();
+            if !text.is_empty() {
+                q.after_cursor = Some(text);
+            }
+        }
+    }
+    Ok(q)
+}
+
+/// Build the `<threads>` response element for `page`.
+pub fn build_threads_response(page: &ThreadsPage) -> Element {
+    let mut threads = Element::builder("threads", NS_THREADS)
+        .attr("total", page.total.to_string())
+        .attr("unread-threads", page.unread_threads.to_string())
+        .build();
+
+    for entry in &page.entries {
+        threads.append_child(build_thread_entry(entry));
+    }
+
+    let mut set = Element::builder("set", NS_RSM).build();
+    if let Some(ref first) = page.first_cursor {
+        let mut first_el = Element::builder("first", NS_RSM).build();
+        first_el.append_text_node(first);
+        set.append_child(first_el);
+    }
+    if let Some(ref last) = page.last_cursor {
+        let mut last_el = Element::builder("last", NS_RSM).build();
+        last_el.append_text_node(last);
+        set.append_child(last_el);
+    }
+    let mut count_el = Element::builder("count", NS_RSM).build();
+    count_el.append_text_node(page.total.to_string());
+    set.append_child(count_el);
+    threads.append_child(set);
+
+    threads
+}
+
+fn build_thread_entry(entry: &ThreadEntry) -> Element {
+    let last_activity_iso = chrono::DateTime::<chrono::Utc>::from_timestamp(
+        entry.last_activity_secs,
+        0,
+    )
+    .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+    .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+    let mut t = Element::builder("thread", NS_THREADS)
+        .attr("channel", entry.channel.to_string())
+        .attr("thread-id", entry.thread_id.clone())
+        .attr("last-stanza-id", entry.last_stanza_id.clone())
+        .attr("last-activity", last_activity_iso)
+        .attr("unread", entry.unread.to_string())
+        .attr("reply-count", entry.reply_count.to_string())
+        .attr("has-unread", if entry.has_unread() { "true" } else { "false" })
+        .build();
+
+    if let Some(ref author) = entry.root_author {
+        let mut author_el = Element::builder("root-author", NS_THREADS).build();
+        author_el.append_text_node(author.to_string());
+        t.append_child(author_el);
+    }
+    if let Some(ref preview) = entry.preview {
+        let mut preview_el = Element::builder("preview", NS_THREADS).build();
+        preview_el.append_text_node(preview);
+        t.append_child(preview_el);
+    }
+    if let Some(ref title) = entry.thread_title {
+        let mut title_el = Element::builder("thread-title", NS_THREADS).build();
+        title_el.append_text_node(title);
+        t.append_child(title_el);
+    }
+    t
+}
+```
+
+- [ ] **Step 2: Verify compiles**
+
+```bash
+cargo check -p waddle-server
+```
+
+Expected: PASS. If `chrono` isn't already a dep of `waddle-server`, the compile will fail. In that case, look at the workspace `Cargo.toml` and existing usage: `grep -rn 'chrono' server/crates/waddle-server/Cargo.toml` — if missing, add `chrono = { workspace = true }` to `[dependencies]`. Re-run `cargo check`.
+
+- [ ] **Step 3: Write the parser round-trip test**
+
+Append this `#[cfg(test)]` module to the bottom of `server/crates/waddle-server/src/threads/wire.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jid::Jid;
+    use xmpp_parsers::iq::Iq;
+
+    fn make_get_iq(payload: Element) -> Iq {
+        Iq {
+            from: None,
+            to: None,
+            id: "test".into(),
+            payload: IqType::Get(payload),
+        }
+    }
+
+    #[test]
+    fn parse_empty_query() {
+        let payload = Element::builder("query", NS_THREADS).build();
+        let iq = make_get_iq(payload);
+        let q = parse_threads_query(&iq).expect("parses");
+        assert_eq!(q.page_size, None);
+        assert_eq!(q.after_cursor, None);
+    }
+
+    #[test]
+    fn parse_query_with_rsm() {
+        let xml = "<query xmlns='urn:waddle:threads:0'>\
+                     <set xmlns='http://jabber.org/protocol/rsm'>\
+                       <max>25</max>\
+                       <after>CURSOR-1</after>\
+                     </set>\
+                   </query>";
+        let payload: Element = xml.parse().unwrap();
+        let iq = make_get_iq(payload);
+        let q = parse_threads_query(&iq).expect("parses");
+        assert_eq!(q.page_size, Some(25));
+        assert_eq!(q.after_cursor.as_deref(), Some("CURSOR-1"));
+    }
+
+    #[test]
+    fn parse_rejects_non_get_iq() {
+        let payload = Element::builder("query", NS_THREADS).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "x".into(),
+            payload: IqType::Set(payload),
+        };
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::WrongIqType)
+        ));
+    }
+
+    #[test]
+    fn build_empty_page() {
+        let page = ThreadsPage::default();
+        let elem = build_threads_response(&page);
+        assert_eq!(elem.name(), "threads");
+        assert_eq!(elem.ns(), NS_THREADS);
+        assert_eq!(elem.attr("total"), Some("0"));
+        assert_eq!(elem.attr("unread-threads"), Some("0"));
+        assert!(elem.children().any(|c| c.name() == "set" && c.ns() == NS_RSM));
+    }
+
+    #[test]
+    fn build_single_entry_round_trip() {
+        let entry = ThreadEntry {
+            channel: "room@conference.example".parse().unwrap(),
+            thread_id: "t-1".into(),
+            last_stanza_id: "S-1".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 2,
+            reply_count: 5,
+            root_author: Some("juliet@example.com".parse().unwrap()),
+            preview: Some("Anyone reviewed the doc?".into()),
+            thread_title: Some("Q3 planning".into()),
+        };
+        let page = ThreadsPage {
+            entries: vec![entry.clone()],
+            total: 1,
+            unread_threads: 1,
+            first_cursor: Some("F".into()),
+            last_cursor: Some("L".into()),
+        };
+        let elem = build_threads_response(&page);
+
+        let thread_el = elem
+            .children()
+            .find(|c| c.name() == "thread")
+            .expect("has thread");
+        assert_eq!(thread_el.attr("channel"), Some("room@conference.example"));
+        assert_eq!(thread_el.attr("thread-id"), Some("t-1"));
+        assert_eq!(thread_el.attr("unread"), Some("2"));
+        assert_eq!(thread_el.attr("has-unread"), Some("true"));
+        assert_eq!(
+            thread_el
+                .get_child("root-author", NS_THREADS)
+                .map(|e| e.text()),
+            Some("juliet@example.com".into())
+        );
+    }
+
+    #[test]
+    fn has_unread_flag_is_false_when_unread_is_zero() {
+        let entry = ThreadEntry {
+            channel: "room@conference.example".parse().unwrap(),
+            thread_id: "t-1".into(),
+            last_stanza_id: "S-1".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 0,
+            reply_count: 1,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+        };
+        let page = ThreadsPage {
+            entries: vec![entry],
+            total: 1,
+            unread_threads: 0,
+            first_cursor: None,
+            last_cursor: None,
+        };
+        let elem = build_threads_response(&page);
+        let thread_el = elem.children().find(|c| c.name() == "thread").unwrap();
+        assert_eq!(thread_el.attr("has-unread"), Some("false"));
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p waddle-server --lib threads::wire
+```
+Expected: 5 tests pass, 0 fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add -u
+git commit -m "feat(server): wire shape builders + parser for urn:waddle:threads:0
+
+Implements parse_threads_query and build_threads_response with XEP-0059
+RSM pagination. Includes a 5-test suite covering the empty query, RSM
+parameters, IQ-type rejection, empty-response shape, and a single-entry
+round-trip with all optional fields populated.
+
+XML is built exclusively via minidom::Element builders — no format! for
+wire shape.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 3: Storage — DB read against `inbox_entries`
+
+**Files:**
+- Create: `server/crates/waddle-server/src/threads/storage.rs`
+
+- [ ] **Step 1: Read the existing inbox storage**
+
+```bash
+sed -n '1,200p' server/crates/waddle-server/src/inbox.rs
+```
+
+Identify:
+- The `InboxStorage` trait shape
+- The DB pool / connection type the inbox uses
+- The exact SELECT pattern used for thread-level entries (it's the existing query at line ~109: `SELECT {SELECT_COLS} FROM inbox_entries WHERE user_jid = ? AND partner_jid = ? AND thread_id != '' ORDER BY last_updated DESC`)
+
+You'll model the threads SELECT on this, but without the `partner_jid` filter so it spans channels.
+
+- [ ] **Step 2: Write the storage trait + impl skeleton**
+
+Create `server/crates/waddle-server/src/threads/storage.rs`:
+
+```rust
+//! Storage read for the global threads view. Pulls per-thread rows from
+//! the existing `inbox_entries` table — no schema changes.
+
+use jid::BareJid;
+
+use super::query::{ThreadEntry, ThreadsPage};
+use crate::inbox::{InboxStorageError, SELECT_COLS};
+
+/// Read trait for the threads view. Implementations read from
+/// `inbox_entries` (or a fixture for tests).
+#[async_trait::async_trait]
+pub trait ThreadsStorage: Send + Sync {
+    async fn page(
+        &self,
+        user_jid: &BareJid,
+        page_size: u32,
+        after_cursor: Option<&str>,
+    ) -> Result<ThreadsPage, InboxStorageError>;
+}
+```
+
+Note: `SELECT_COLS` is currently `pub(super)` on the inbox module. You'll need to re-export it as `pub` from `crate::inbox` so the threads module can read it. Do that as a small edit to `server/crates/waddle-server/src/inbox/codec.rs`: change `pub(super) const SELECT_COLS` to `pub const SELECT_COLS` and add `pub use codec::SELECT_COLS;` to `server/crates/waddle-server/src/inbox.rs` (find the existing `pub use codec::*` or similar; add the line near the top of the module).
+
+Run `cargo check -p waddle-server`.
+
+- [ ] **Step 3: Write the failing storage test**
+
+Append to the bottom of `server/crates/waddle-server/src/threads/storage.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inbox::{ConversationKind, InboxEntry, InboxStorage};
+
+    // Reuse the existing inbox test harness — find the in-memory
+    // InboxStorage impl that the inbox tests use (search for
+    // `InboxStorage` in `server/crates/waddle-server/src/inbox/tests.rs`)
+    // and the same fixture pattern (DB pool + temp file) the inbox
+    // integration tests use.
+
+    // [The agent: open `inbox/tests.rs` and use the same test-DB
+    // bootstrap function it already uses. Mirror the pattern; do
+    // not re-invent.]
+
+    #[tokio::test]
+    async fn page_returns_only_thread_rows() {
+        // Seed three rows:
+        //   - (alice, room1, "")         — no thread, should NOT appear
+        //   - (alice, room1, "t1")       — thread
+        //   - (alice, room2, "t2")       — thread, different room
+        // Expect: page() returns 2 entries.
+        // [Implementation depends on the existing test bootstrap pattern;
+        //  see comment above.]
+    }
+
+    #[tokio::test]
+    async fn page_orders_by_last_updated_desc() {
+        // Seed two thread rows with different last_updated; assert order.
+    }
+
+    #[tokio::test]
+    async fn page_paginates_with_cursor() {
+        // Seed 3 thread rows; request page_size=2; assert first page
+        // returns 2 entries with last_cursor set, next page returns 1.
+    }
+}
+```
+
+The test bodies are intentionally pseudocode — the agent must read `inbox/tests.rs` to find the existing test-DB bootstrap (likely `crate::inbox::tests::make_storage()` or similar) and fill them in. Do NOT invent a new test infrastructure; reuse what's there.
+
+- [ ] **Step 4: Implement `page()` for the SQL backend**
+
+The shape mirrors the existing inbox `list_threads_in_room` function (around line 105 in `inbox.rs`). Implement on whatever struct already implements `InboxStorage` for the SQL backend.
+
+Pseudocode SQL:
+
+```sql
+SELECT partner_jid, thread_id, kind, last_stanza_id, last_updated,
+       unread, preview, thread_title, reply_count, author
+FROM inbox_entries
+WHERE user_jid = ?
+  AND thread_id != ''
+  AND (after_cursor IS NULL OR (last_updated, partner_jid, thread_id) < (?, ?, ?))
+ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC
+LIMIT ?
+```
+
+Cursor format: encode `(last_updated, partner_jid, thread_id)` as a base64-of-JSON or pipe-separated string. Pick whichever the inbox uses if there's a precedent; else `last_updated|partner_jid|thread_id` with `|` escaped via URL-percent-encoding.
+
+Also produce `total` (count of all thread rows for the user) and `unread_threads` (count where `unread > 0`) via a second small query — or a `COUNT(*) FILTER (WHERE ...)` in one SQL round if the DB supports it.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cargo test -p waddle-server --lib threads::storage
+```
+Expected: 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add -u
+git commit -m "feat(server): threads storage reads inbox_entries WHERE thread_id != ''
+
+Adds the ThreadsStorage trait and SQL-backed implementation that paginates
+over per-thread inbox rows. RSM cursor is (last_updated, partner_jid,
+thread_id) tuple — seek-based so pagination is stable under concurrent
+inserts. Includes tests for thread-only filtering, recency ordering, and
+two-page cursor round-trip.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 4: IQ handler + ACL
+
+**Files:**
+- Create: `server/crates/waddle-server/src/threads/handler.rs`
+- Modify: wherever IQ handlers are registered (`grep -rn 'parse_inbox_query\|is_inbox_iq' server/crates/waddle-server/src/server/routes/websocket/handlers/iq/` to locate the dispatch table, mirror that pattern)
+
+- [ ] **Step 1: Read the inbox IQ handler**
+
+```bash
+grep -rn 'parse_inbox_query\|build_inbox_query_result' server/crates/waddle-server/src/server/routes/websocket/handlers/iq/
+```
+
+Read the file(s) returned. The threads handler is structurally identical: parse the IQ → ACL-check the sender → call storage → build response → return IQ.
+
+- [ ] **Step 2: Write the handler**
+
+Create `server/crates/waddle-server/src/threads/handler.rs` with a `handle_threads_iq` function that:
+
+1. Parses the IQ via `wire::parse_threads_query`.
+2. Confirms the requesting full JID's bare matches the IQ's `to` (or, if no `to`, the connection owner). Reject with `<forbidden/>` via the existing `make_forbidden_iq` helper (find it in the inbox handler).
+3. Calls `ThreadsStorage::page(...)` with the parsed query.
+4. Wraps the result in an IQ via `wire::build_threads_response`.
+
+Function signature mirrors the inbox handler's — match parameter names and ordering.
+
+- [ ] **Step 3: Wire the handler into the IQ dispatcher**
+
+Find the place where the inbox handler is dispatched (likely an `if is_inbox_iq(iq) { ... }` chain). Add a parallel branch:
+
+```rust
+} else if iq_payload_is_query_in_ns(iq, NS_THREADS) {
+    let response = crate::threads::handler::handle_threads_iq(state, iq).await;
+    /* push response */
+}
+```
+
+Mirror the exact dispatch pattern in use (the agent: copy-adapt from the inbox branch immediately preceding).
+
+- [ ] **Step 4: Run cargo check + clippy**
+
+```bash
+cargo check -p waddle-server
+cargo clippy -p waddle-server --all-targets -- -D warnings
+```
+
+Expected: PASS, no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add -u
+git commit -m "feat(server): IQ handler + dispatch for urn:waddle:threads:0
+
+Routes <iq type='get'><query xmlns='urn:waddle:threads:0'/></iq> through
+ThreadsStorage and returns the paginated <threads> response. ACL refuses
+with <forbidden/> when the requesting JID's bare doesn't match the
+addressed user.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 5: WebSocket integration test
+
+**Files:**
+- Create: `server/crates/waddle-server/tests/waddle_threads_query_ws.rs`
+
+This is the dedicated XEP test suite required by the audit hard rule.
+
+- [ ] **Step 1: Read an existing WS integration test for pattern**
+
+```bash
+ls server/crates/waddle-server/tests/xep04*.rs
+```
+
+Pick one of the recently added: `xep0490_mds_ws.rs` or `xep0292_vcard4_ws.rs` (both landed in the last 24h). Read top-to-bottom. Note the bootstrap helpers (probably in `server/crates/waddle-server/tests/common/` or inline).
+
+- [ ] **Step 2: Write the test cases**
+
+Create `server/crates/waddle-server/tests/waddle_threads_query_ws.rs`:
+
+```rust
+//! Integration tests for the urn:waddle:threads:0 IQ.
+//!
+//! Spec: docs/superpowers/specs/2026-05-17-threads-design.md
+
+mod common;
+// or whatever import path the existing tests use — mirror that.
+
+// Cases (each is its own #[tokio::test]):
+//
+// 1. fresh_account_returns_empty_page
+//      - Connect alice@host with no inbox state.
+//      - Send <iq type='get'><query xmlns='urn:waddle:threads:0'/></iq>.
+//      - Expect <iq type='result'> with <threads total='0' unread-threads='0'>
+//        containing only an RSM <set><count>0</count></set>.
+//
+// 2. returns_threads_alice_has_participated_in
+//      - Seed two inbox rows for alice across two rooms, each with a
+//        distinct thread_id.
+//      - Query.
+//      - Expect 2 <thread> entries, sorted by last_updated DESC.
+//
+// 3. only_thread_rows_appear
+//      - Seed one thread row + one non-thread row for the same user.
+//      - Query.
+//      - Expect 1 <thread> entry (the thread row).
+//
+// 4. pagination_round_trips
+//      - Seed 3 thread rows.
+//      - First IQ: <set><max>2</max>.
+//      - Expect 2 entries + non-empty <last> cursor.
+//      - Second IQ: <set><max>2</max><after>{cursor}</after>.
+//      - Expect 1 entry + RSM with count=3.
+//
+// 5. acl_refuses_cross_user_query
+//      - alice connects, asks for bob's threads via to='bob@host'.
+//      - Expect <iq type='error'> with <forbidden/>.
+//
+// 6. unread_threads_count_matches_filter
+//      - Seed 3 thread rows: 2 with unread>0, 1 caught up.
+//      - Query.
+//      - Expect <threads ... unread-threads='2'>.
+//      - Confirm each <thread> has the right has-unread attribute.
+
+// Each test body uses the existing test bootstrap (see step 1) — do NOT
+// reinvent the WS connection setup.
+```
+
+The agent fills in the test bodies once they've read the existing pattern. The case list above is non-negotiable — these are the tests the spec calls for.
+
+- [ ] **Step 3: Run the integration tests**
+
+```bash
+cargo test -p waddle-server --test waddle_threads_query_ws
+```
+Expected: 6 passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt
+git add server/crates/waddle-server/tests/waddle_threads_query_ws.rs
+git commit -m "test(server): waddle_threads_query_ws — end-to-end IQ matrix
+
+Six cases: empty result, multi-channel listing, thread-row filtering,
+RSM pagination cursor round-trip, ACL forbidden for cross-user query,
+unread-threads count + has-unread attribute.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 6: Disco advert
+
+**Files:**
+- Modify: `server/crates/waddle-xmpp-core/src/disco/info/features.rs`
+- Modify: wherever `server_features()` (or equivalent) assembles the disco list
+
+- [ ] **Step 1: Add Feature::threads()**
+
+In `server/crates/waddle-xmpp-core/src/disco/info/features.rs`, find an existing simple feature builder (e.g., `pub fn replies()`) and add adjacent:
+
+```rust
+pub fn threads_query() -> Self {
+    Self::new("urn:waddle:threads:0")
+}
+```
+
+(Named `threads_query` rather than `threads` to avoid colliding with the long-since-removed `urn:xmpp:threads:0` namespace.)
+
+- [ ] **Step 2: Wire into the user-server disco list**
+
+Find where the server crate assembles its user-server disco features (likely `server/crates/waddle-server/src/server/...` — grep `Feature::inbox` or `Feature::replies` to locate the list). Add `Feature::threads_query()` alongside.
+
+- [ ] **Step 3: Add a disco test**
+
+Find the existing disco WS test (`grep -rn 'disco.*info' server/crates/waddle-server/tests/`). Add a new case asserting `urn:waddle:threads:0` appears in the user-server's disco#info `<feature>` list. Mirror the pattern.
+
+- [ ] **Step 4: Run**
+
+```bash
+cargo test -p waddle-server --test <whatever_test_file_you_extended>
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add -u
+git commit -m "feat(server): advertise urn:waddle:threads:0 in disco#info
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 7: Rust IQ builders + parsers in `waddle-xmpp-client`
+
+**Files:**
+- Create: `server/crates/waddle-xmpp-client/src/xep/threads.rs`
+- Modify: `server/crates/waddle-xmpp-client/src/xep/mod.rs` (re-export)
+- Modify: `server/crates/waddle-xmpp-client/src/lib.rs` (re-export at crate root if siblings are there)
+
+- [ ] **Step 1: Read the sibling for pattern**
+
+```bash
+sed -n '1,200p' server/crates/waddle-xmpp-client/src/xep/xep0292.rs
+```
+
+That file does for vcard4 exactly what this task does for threads: typed value, IQ builder (`build_publish_vcard4_iq`, `build_fetch_vcard4_iq`), IQ parser (`parse_pep_vcard4`). Mirror that shape.
+
+- [ ] **Step 2: Write the threads module**
+
+Create `server/crates/waddle-xmpp-client/src/xep/threads.rs`:
+
+```rust
+//! Client-side typed value + IQ builder/parser for urn:waddle:threads:0.
+
+use minidom::Element;
+
+/// Namespace.
+pub const NS_THREADS: &str = "urn:waddle:threads:0";
+const NS_CLIENT: &str = "jabber:client";
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadEntry {
+    pub channel: String,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    pub last_activity: String, // RFC 3339
+    pub unread: u32,
+    pub reply_count: u32,
+    pub has_unread: bool,
+    pub root_author: Option<String>,
+    pub preview: Option<String>,
+    pub thread_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsPage {
+    pub total: u64,
+    pub unread_threads: u64,
+    pub entries: Vec<ThreadEntry>,
+    pub next_cursor: Option<String>,
+}
+
+/// Build a `<iq type='get'>` requesting the user's threads.
+pub fn build_fetch_threads_iq(
+    request_id: &str,
+    page_size: Option<u32>,
+    after_cursor: Option<&str>,
+) -> Element {
+    let mut query = Element::builder("query", NS_THREADS).build();
+    if page_size.is_some() || after_cursor.is_some() {
+        let mut set = Element::builder("set", NS_RSM).build();
+        if let Some(max) = page_size {
+            let mut max_el = Element::builder("max", NS_RSM).build();
+            max_el.append_text_node(max.to_string());
+            set.append_child(max_el);
+        }
+        if let Some(after) = after_cursor {
+            let mut after_el = Element::builder("after", NS_RSM).build();
+            after_el.append_text_node(after);
+            set.append_child(after_el);
+        }
+        query.append_child(set);
+    }
+
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("id", request_id)
+        .append(query)
+        .build()
+}
+
+/// Parse the `<iq type='result'>` response into a typed `ThreadsPage`.
+pub fn parse_threads_response(iq: &Element) -> Option<ThreadsPage> {
+    let threads = iq.get_child("threads", NS_THREADS)?;
+    let total: u64 = threads
+        .attr("total")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let unread_threads: u64 = threads
+        .attr("unread-threads")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    let entries: Vec<ThreadEntry> = threads
+        .children()
+        .filter(|c| c.name() == "thread" && c.ns() == NS_THREADS)
+        .map(|t| ThreadEntry {
+            channel: t.attr("channel").unwrap_or("").to_string(),
+            thread_id: t.attr("thread-id").unwrap_or("").to_string(),
+            last_stanza_id: t.attr("last-stanza-id").unwrap_or("").to_string(),
+            last_activity: t.attr("last-activity").unwrap_or("").to_string(),
+            unread: t.attr("unread").and_then(|s| s.parse().ok()).unwrap_or(0),
+            reply_count: t
+                .attr("reply-count")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+            has_unread: t.attr("has-unread") == Some("true"),
+            root_author: t
+                .get_child("root-author", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+            preview: t
+                .get_child("preview", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+            thread_title: t
+                .get_child("thread-title", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+        })
+        .collect();
+
+    let next_cursor = threads
+        .get_child("set", NS_RSM)
+        .and_then(|s| s.get_child("last", NS_RSM))
+        .map(|e| e.text())
+        .filter(|s| !s.is_empty());
+
+    Some(ThreadsPage {
+        total,
+        unread_threads,
+        entries,
+        next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_iq_has_correct_namespace_and_type() {
+        let iq = build_fetch_threads_iq("r-1", Some(25), Some("CUR"));
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("id"), Some("r-1"));
+        let query = iq.get_child("query", NS_THREADS).expect("query");
+        let set = query.get_child("set", NS_RSM).expect("rsm set");
+        assert_eq!(
+            set.get_child("max", NS_RSM).map(|e| e.text()),
+            Some("25".into())
+        );
+        assert_eq!(
+            set.get_child("after", NS_RSM).map(|e| e.text()),
+            Some("CUR".into())
+        );
+    }
+
+    #[test]
+    fn parse_extracts_entries_and_cursor() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                     <threads xmlns='urn:waddle:threads:0' total='2' unread-threads='1'>\
+                       <thread channel='room@x' thread-id='t1' \
+                               last-stanza-id='S1' last-activity='2026-01-01T00:00:00Z' \
+                               unread='2' reply-count='5' has-unread='true'>\
+                         <preview>hi</preview>\
+                       </thread>\
+                       <thread channel='room@x' thread-id='t2' \
+                               last-stanza-id='S2' last-activity='2025-12-31T00:00:00Z' \
+                               unread='0' reply-count='3' has-unread='false'/>\
+                       <set xmlns='http://jabber.org/protocol/rsm'>\
+                         <last>LAST-CUR</last><count>2</count>\
+                       </set>\
+                     </threads>\
+                   </iq>";
+        let iq: Element = xml.parse().unwrap();
+        let page = parse_threads_response(&iq).expect("parses");
+        assert_eq!(page.total, 2);
+        assert_eq!(page.unread_threads, 1);
+        assert_eq!(page.entries.len(), 2);
+        assert_eq!(page.entries[0].thread_id, "t1");
+        assert!(page.entries[0].has_unread);
+        assert!(!page.entries[1].has_unread);
+        assert_eq!(page.next_cursor.as_deref(), Some("LAST-CUR"));
+    }
+
+    #[test]
+    fn parse_returns_none_when_threads_missing() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'/>";
+        let iq: Element = xml.parse().unwrap();
+        assert!(parse_threads_response(&iq).is_none());
+    }
+}
+```
+
+- [ ] **Step 3: Re-export from `xep/mod.rs`**
+
+In `server/crates/waddle-xmpp-client/src/xep/mod.rs`, find the existing `pub mod xep0292;` line and add directly after:
+
+```rust
+pub mod threads;
+```
+
+If the crate root (`lib.rs`) re-exports xep0292 builders for convenience, mirror that for threads.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p waddle-xmpp-client --lib xep::threads
+cargo clippy -p waddle-xmpp-client --all-targets -- -D warnings
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add -u
+git commit -m "feat(server): waddle-xmpp-client typed value + IQ builders for threads
+
+Adds ThreadEntry, ThreadsPage, build_fetch_threads_iq, and
+parse_threads_response in xep/threads.rs — the client-side mirror of
+the server's wire shape. Three unit tests cover IQ build, full
+response parse, and the missing-element branch.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 8: Wasm bindings — `fetch_threads`
+
+**Files:**
+- Modify: `server/crates/waddle-xmpp-client-wasm/src/types.rs`
+- Modify: `server/crates/waddle-xmpp-client-wasm/src/client_account.rs` (or wherever account-scoped methods live — grep `fetch_inbox` to find it)
+- Modify: `server/crates/waddle-xmpp-client-wasm/src/lib.rs`
+
+- [ ] **Step 1: Read existing wasm method pattern**
+
+```bash
+grep -n 'fetch_inbox\|publish_vcard4\|fetch_vcard4' server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+```
+
+Open the file and read those methods end-to-end. The threads fetch method is structurally identical: build IQ → send → parse → convert to serde-serializable wasm type → return `Promise`.
+
+- [ ] **Step 2: Add the wasm-facing types**
+
+Append to `server/crates/waddle-xmpp-client-wasm/src/types.rs`:
+
+```rust
+/// XEP-style payload for one entry in a urn:waddle:threads:0 response,
+/// shaped for JS consumption.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WaddleThreadEntry {
+    pub channel: String,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    /// RFC 3339 timestamp.
+    pub last_activity: String,
+    pub unread: u32,
+    pub reply_count: u32,
+    pub has_unread: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_title: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct WaddleThreadsPage {
+    pub total: u64,
+    pub unread_threads: u64,
+    pub entries: Vec<WaddleThreadEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+```
+
+- [ ] **Step 3: Add the wasm method**
+
+In `server/crates/waddle-xmpp-client-wasm/src/client_account.rs` (or the file that hosts `fetch_inbox` — same file), add a `fetch_threads` method mirroring `fetch_inbox`'s structure:
+
+```rust
+#[wasm_bindgen]
+impl WaddleXmppClient {
+    /// Fetch the global threads view (urn:waddle:threads:0).
+    #[wasm_bindgen]
+    pub fn fetch_threads(
+        &self,
+        page_size: Option<u32>,
+        after_cursor: Option<String>,
+    ) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let request_id = Uuid::new_v4().to_string();
+            let iq = build_fetch_threads_iq(
+                &request_id,
+                page_size,
+                after_cursor.as_deref(),
+            );
+            let response = inner.send_iq(iq).await.map_err(to_js_err)?;
+            let page = parse_threads_response(&response)
+                .ok_or_else(|| JsValue::from_str("malformed threads response"))?;
+            to_js_value(&WaddleThreadsPage {
+                total: page.total,
+                unread_threads: page.unread_threads,
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|e| WaddleThreadEntry {
+                        channel: e.channel,
+                        thread_id: e.thread_id,
+                        last_stanza_id: e.last_stanza_id,
+                        last_activity: e.last_activity,
+                        unread: e.unread,
+                        reply_count: e.reply_count,
+                        has_unread: e.has_unread,
+                        root_author: e.root_author,
+                        preview: e.preview,
+                        thread_title: e.thread_title,
+                    })
+                    .collect(),
+                next_cursor: page.next_cursor,
+            })
+        })
+    }
+}
+```
+
+(Imports `build_fetch_threads_iq`, `parse_threads_response`, `WaddleThreadEntry`, `WaddleThreadsPage`, `Uuid`, `to_js_err`, `to_js_value`, `future_to_promise` as the sibling methods do — copy the import block from the vcard4 method.)
+
+- [ ] **Step 4: Rebuild wasm package**
+
+```bash
+cd chat && bun run wasm:build && cd ..
+```
+
+This regenerates `server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.{js,d.ts}`.
+
+- [ ] **Step 5: Run checks**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --check
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -u
+git add server/wasm-pkg/
+git commit -m "feat(server): wasm bindings for fetch_threads
+
+Adds WaddleThreadEntry / WaddleThreadsPage and the fetch_threads method
+on WaddleXmppClient. Regenerated wasm-pkg bindings included.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 9: TypeScript types + client wrapper
+
+**Files:**
+- Modify: `chat/src/lib/xmpp/wasm-types.ts`
+- Modify: `chat/src/lib/xmpp/client.ts`
+
+- [ ] **Step 1: Add the TS types**
+
+Append to `chat/src/lib/xmpp/wasm-types.ts`, in alphabetical-by-feature order (find the `WasmVCard4` block and add after it):
+
+```ts
+/** One entry in a urn:waddle:threads:0 response. */
+export interface WasmThreadEntry {
+  channel: string;
+  thread_id: string;
+  last_stanza_id: string;
+  /** RFC 3339 timestamp. */
+  last_activity: string;
+  unread: number;
+  reply_count: number;
+  has_unread: boolean;
+  root_author?: string;
+  preview?: string;
+  thread_title?: string;
+}
+
+export interface WasmThreadsPage {
+  total: number;
+  unread_threads: number;
+  entries: WasmThreadEntry[];
+  next_cursor?: string;
+}
+```
+
+- [ ] **Step 2: Add the BrowserXmppClient wrapper**
+
+Find `publishVCard4` / `fetchVCard4` in `chat/src/lib/xmpp/client.ts`. Add a sibling `fetchThreads`:
+
+```ts
+async fetchThreads(
+  pageSize?: number,
+  afterCursor?: string,
+): Promise<WasmThreadsPage | null> {
+  const xmpp = this.xmpp;
+  if (!xmpp) return null;
+  try {
+    const raw = await xmpp.fetch_threads?.(pageSize, afterCursor);
+    return (raw as WasmThreadsPage | undefined) ?? null;
+  } catch (err) {
+    logWarn("fetchThreads failed", err);
+    return null;
+  }
+}
+```
+
+(Match the exact error-handling and logger import the sibling vcard4 methods use.)
+
+- [ ] **Step 3: Run checks**
+
+```bash
+cd chat
+bun run wasm:build
+bun test
+bun run lint
+cd ..
+```
+
+Expected: tests pass, knip clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(chat): wasm-types and BrowserXmppClient wrapper for threads
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 10: ThreadsListPanel + ThreadsListRow Vue components
+
+**Files:**
+- Create: `chat/src/components/chat/ThreadsListPanel.vue`
+- Create: `chat/src/components/chat/ThreadsListRow.vue`
+- Create: `chat/src/pages/threads.astro`
+
+- [ ] **Step 1: Read the inbox page + panel for pattern**
+
+```bash
+ls chat/src/pages/ | grep -E 'inbox|dms|index'
+```
+
+Open the most similar existing page (likely `chat/src/pages/index.astro` or `chat/src/pages/dm/index.astro`). Read the Astro shell, identify how a Vue island is mounted, what props it gets, what session-context wrappers it uses.
+
+Also read `chat/src/components/chat/UserProfileDrawer.vue` (recently touched in #668) as a Vue-component-with-async-fetch pattern.
+
+- [ ] **Step 2: Create the row component**
+
+Create `chat/src/components/chat/ThreadsListRow.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed } from "vue";
+import type { WasmThreadEntry } from "@/lib/xmpp/wasm-types";
+
+const props = defineProps<{
+  entry: WasmThreadEntry;
+}>();
+
+const emit = defineEmits<{
+  open: [entry: WasmThreadEntry];
+}>();
+
+const recencyLabel = computed(() => {
+  const ts = Date.parse(props.entry.last_activity);
+  if (Number.isNaN(ts)) return "";
+  const deltaSec = Math.floor((Date.now() - ts) / 1000);
+  if (deltaSec < 60) return "just now";
+  if (deltaSec < 3600) return `${Math.floor(deltaSec / 60)}m ago`;
+  if (deltaSec < 86_400) return `${Math.floor(deltaSec / 3600)}h ago`;
+  return `${Math.floor(deltaSec / 86_400)}d ago`;
+});
+
+const channelLabel = computed(() => {
+  const local = props.entry.channel.split("@")[0] ?? props.entry.channel;
+  return `#${local}`;
+});
+</script>
+
+<template>
+  <button
+    type="button"
+    class="chat-section-card chat-thread-row glass-panel w-full text-left"
+    @click="emit('open', entry)"
+  >
+    <div class="flex items-center justify-between gap-2">
+      <div class="min-w-0 flex-1">
+        <div class="type-card-title truncate">
+          {{ entry.thread_title ?? entry.preview ?? "Thread" }}
+        </div>
+        <div class="type-caption text-muted-foreground truncate">
+          {{ channelLabel }} · {{ recencyLabel }}
+          <span v-if="entry.reply_count > 0"> · {{ entry.reply_count }} replies</span>
+        </div>
+      </div>
+      <span
+        v-if="entry.has_unread"
+        class="chat-unread-badge"
+        :aria-label="`${entry.unread} unread`"
+      >
+        {{ entry.unread }}
+      </span>
+    </div>
+  </button>
+</template>
+```
+
+- [ ] **Step 3: Create the panel**
+
+Create `chat/src/components/chat/ThreadsListPanel.vue`:
+
+```vue
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { WasmThreadEntry, WasmThreadsPage } from "@/lib/xmpp/wasm-types";
+import ThreadsListRow from "@/components/chat/ThreadsListRow.vue";
+
+const props = defineProps<{
+  xmppClient: BrowserXmppClient | null;
+}>();
+
+const emit = defineEmits<{
+  openThread: [entry: WasmThreadEntry];
+}>();
+
+const loading = ref(true);
+const page = ref<WasmThreadsPage | null>(null);
+const error = ref<string | null>(null);
+
+const unread = computed(
+  () => page.value?.entries.filter((e) => e.has_unread) ?? [],
+);
+const following = computed(
+  () => page.value?.entries.filter((e) => !e.has_unread) ?? [],
+);
+
+onMounted(async () => {
+  if (!props.xmppClient) {
+    loading.value = false;
+    return;
+  }
+  try {
+    page.value = await props.xmppClient.fetchThreads(50);
+  } catch (err) {
+    error.value = String(err);
+  } finally {
+    loading.value = false;
+  }
+});
+</script>
+
+<template>
+  <div class="chat-panel-stack p-4">
+    <h2 class="type-pane-title">Threads</h2>
+
+    <div v-if="loading" class="chat-panel-stack" aria-busy="true">
+      Loading…
+    </div>
+
+    <div v-else-if="error" class="type-caption text-destructive">
+      Couldn't load threads: {{ error }}
+    </div>
+
+    <template v-else-if="page">
+      <section v-if="unread.length > 0" class="chat-panel-stack">
+        <div class="type-section-label text-muted-foreground/75">
+          Unread · {{ unread.length }}
+        </div>
+        <ThreadsListRow
+          v-for="entry in unread"
+          :key="`${entry.channel}|${entry.thread_id}`"
+          :entry="entry"
+          @open="emit('openThread', $event)"
+        />
+      </section>
+
+      <section v-if="following.length > 0" class="chat-panel-stack">
+        <div class="type-section-label text-muted-foreground/75">
+          Following · {{ following.length }}
+        </div>
+        <ThreadsListRow
+          v-for="entry in following"
+          :key="`${entry.channel}|${entry.thread_id}`"
+          :entry="entry"
+          @open="emit('openThread', $event)"
+        />
+      </section>
+
+      <div v-if="unread.length === 0 && following.length === 0" class="type-caption text-muted-foreground">
+        No threads yet. Threads you reply to or get mentioned in will show up here.
+      </div>
+    </template>
+  </div>
+</template>
+```
+
+- [ ] **Step 4: Create the Astro page**
+
+Create `chat/src/pages/threads.astro` by mirroring whatever page mounts the inbox (find via `grep -rn 'InboxPanel\|InboxView' chat/src/pages/`). Apply the same auth-required shell wrapper, mount `<ThreadsListPanel client:only="vue" :xmpp-client="..." @open-thread="..." />`. The `@open-thread` handler delegates to whatever existing controller method opens `ThreadPanel.vue` at `(channel, thread_id)` — check `chat-app-controller.ts` for a `openThread` or similar.
+
+- [ ] **Step 5: Run checks**
+
+```bash
+cd chat
+bun run wasm:build
+bun test
+bun run lint
+cd ..
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add chat/
+git commit -m "feat(chat): ThreadsListPanel + ThreadsListRow + /threads route
+
+Two-section layout (Unread top, Following below) over the
+urn:waddle:threads:0 response. Click opens the existing ThreadPanel
+at (channel, thread_id).
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 11: Sidebar nav entry
+
+**Files:**
+- Modify: the main sidebar component. Locate with `grep -rln 'Inbox\|InboxView\|chat-sidebar' chat/src/components`
+
+- [ ] **Step 1: Find the sidebar**
+
+```bash
+grep -rln '"Inbox"\|"DMs"\|chat-sidebar-item' chat/src/components | head -5
+```
+
+Open the file. The sidebar is likely declarative — find the array/list of nav entries.
+
+- [ ] **Step 2: Add the Threads entry**
+
+Insert a new entry between Inbox and the channel list:
+
+```ts
+{ id: "threads", label: "Threads", icon: ThreadsIcon, href: "/threads",
+  badge: computed(() => unreadThreadsCount.value) }
+```
+
+(Match the existing entry shape — type signatures, icon component, and badge computation pattern. If badges use a store value, the store needs a `unreadThreadsCount` field — wire that from a periodic `fetchThreads` or from a watcher on inbox writes.)
+
+For V1, if badge wiring is fiddly, leave it as a static `0` or omit, and note as a follow-up.
+
+- [ ] **Step 3: Run checks**
+
+```bash
+cd chat && bun test && bun run lint && cd ..
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u
+git commit -m "feat(chat): Threads sidebar nav entry
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 12: Vitest for ThreadsListPanel
+
+**Files:**
+- Create: `chat/src/components/chat/__tests__/ThreadsListPanel.test.ts`
+
+- [ ] **Step 1: Read an existing component test for pattern**
+
+```bash
+ls chat/src/components/chat/__tests__/ 2>/dev/null | head -5
+```
+
+If `__tests__` doesn't exist, look for sibling tests via `find chat/src -name '*.test.ts'`. Mirror the testing-library / Vitest pattern in use.
+
+- [ ] **Step 2: Write tests**
+
+Create `chat/src/components/chat/__tests__/ThreadsListPanel.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/vue";
+import ThreadsListPanel from "@/components/chat/ThreadsListPanel.vue";
+import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { WasmThreadsPage } from "@/lib/xmpp/wasm-types";
+
+function client(page: WasmThreadsPage | null): BrowserXmppClient {
+  return {
+    fetchThreads: vi.fn(async () => page),
+  } as unknown as BrowserXmppClient;
+}
+
+describe("ThreadsListPanel", () => {
+  it("renders empty state when no threads", async () => {
+    render(ThreadsListPanel, {
+      props: { xmppClient: client({ total: 0, unread_threads: 0, entries: [] }) },
+    });
+    expect(await screen.findByText(/No threads yet/i)).toBeTruthy();
+  });
+
+  it("splits unread and following sections", async () => {
+    render(ThreadsListPanel, {
+      props: {
+        xmppClient: client({
+          total: 2,
+          unread_threads: 1,
+          entries: [
+            {
+              channel: "room@x",
+              thread_id: "t1",
+              last_stanza_id: "S1",
+              last_activity: new Date().toISOString(),
+              unread: 2,
+              reply_count: 3,
+              has_unread: true,
+              preview: "Hello",
+            },
+            {
+              channel: "room@x",
+              thread_id: "t2",
+              last_stanza_id: "S2",
+              last_activity: new Date().toISOString(),
+              unread: 0,
+              reply_count: 5,
+              has_unread: false,
+              preview: "Quiet thread",
+            },
+          ],
+        }),
+      },
+    });
+    expect(await screen.findByText(/Unread · 1/)).toBeTruthy();
+    expect(await screen.findByText(/Following · 1/)).toBeTruthy();
+  });
+
+  it("emits openThread when a row is clicked", async () => {
+    const entry = {
+      channel: "room@x",
+      thread_id: "t1",
+      last_stanza_id: "S1",
+      last_activity: new Date().toISOString(),
+      unread: 1,
+      reply_count: 2,
+      has_unread: true,
+      preview: "Click me",
+    };
+    const { emitted, findByText } = render(ThreadsListPanel, {
+      props: { xmppClient: client({ total: 1, unread_threads: 1, entries: [entry] }) },
+    });
+    const row = await findByText(/Click me/);
+    await row.click();
+    expect(emitted("openThread")).toBeTruthy();
+    expect(emitted("openThread")?.[0]?.[0]).toMatchObject({ thread_id: "t1" });
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd chat && bun test ThreadsListPanel && cd ..
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add chat/src/components/chat/__tests__/ThreadsListPanel.test.ts
+git commit -m "test(chat): ThreadsListPanel happy paths
+
+Empty state, two-section split, click emits openThread.
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 13: Audit doc updates
+
+**Files:**
+- Modify: `docs/xep-conformance-audit.md`
+
+- [ ] **Step 1: Correct the XEP-0430 row**
+
+In `docs/xep-conformance-audit.md`, find the row beginning `| 0430 | Inbox`. Replace the namespace cell from `urn:xmpp:inbox:0` with:
+
+```
+urn:waddle:inbox:0 + erlang-solutions.com:xmpp:inbox:0
+```
+
+Update the notes column to:
+
+```
+Waddle private surface (urn:waddle:inbox:0) plus ESL/MongooseIM compat (erlang-solutions.com:xmpp:inbox:0). Conformant XEP-0430 (urn:xmpp:inbox:0 / urn:xmpp:inbox:1) migration is a queued follow-up — see plan in this branch's spec doc.
+```
+
+Change `Status` from `unaudited` to `gap` (since the disco advert was historically wrong about which namespace was implemented; the threads PR doesn't fix the inbox itself but at least the audit doc now reflects reality).
+
+- [ ] **Step 2: Add the new row for urn:waddle:threads:0**
+
+After the XEP-0513 row (the last row in the table), add:
+
+```
+| —    | (Waddle) Threads view                                | urn:waddle:threads:0               |  Y  |  Y   |   Y   | fixed      | Waddle-namespaced (no XEP equivalent — Fluux made the same call for their custom conversation list). Server reads inbox_entries WHERE thread_id != ''; chat client renders two-section view. PR #671. |
+```
+
+(XEP number `—` because there is no XEP. The audit doc table header says "XEP" but the row is informative.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/xep-conformance-audit.md
+git commit -m "docs(server): conformance audit — threads view + correct XEP-0430 row
+
+Adds a row for the new urn:waddle:threads:0 query (no XEP equivalent;
+Fluux precedent for using a vendor namespace for inbox-like surfaces).
+Corrects the XEP-0430 row to match the actual implemented namespaces
+(urn:waddle:inbox:0 + ESL compat).
+
+This commit was created with the assistance of a LLM."
+```
+
+---
+
+## Task 14: Final verification
+
+- [ ] **Step 1: Full workspace test pass**
+
+```bash
+cargo test --workspace
+```
+Expected: green.
+
+- [ ] **Step 2: Clippy across the workspace**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+Expected: zero warnings.
+
+- [ ] **Step 3: cargo fmt check**
+
+```bash
+cargo fmt --check
+```
+
+- [ ] **Step 4: Chat checks**
+
+```bash
+cd chat && bun test && bun run lint && cd ..
+```
+
+- [ ] **Step 5: Push the final commit chain**
+
+```bash
+git push
+```
+
+- [ ] **Step 6: Check CI on PR #671**
+
+```bash
+gh pr checks 671
+```
+
+Address any failures before reporting back.
+
+---
+
+## Out of plan (V2 candidates the spec acknowledges)
+
+- Filter toggles (Unread-only / All in channels I'm in)
+- Thread mute / pin / archive
+- Per-channel Threads tab inside a channel
+- Live thread-delta event hook — covered in "Task 11 step 2" as a TODO if the inbox-write event path is messy to plumb; if it lands cleanly, fold into Task 10
+
+## Self-review notes
+
+Spec coverage check ran. Every spec section maps to at least one task:
+- Goals 1–3 → Tasks 1–13
+- Wire protocol → Tasks 1, 2, 7
+- Server architecture (module layout, ACL, tests) → Tasks 1, 2, 3, 4, 5
+- Client architecture (sidebar, page, components, wasm, live updates) → Tasks 8, 9, 10, 11, 12
+- Audit doc → Task 13
+
+Placeholder scan: no TBDs in code blocks. Some tasks (3, 4, 5, 7, 10, 11, 12) deliberately point the agent at existing files to mirror — the patterns are recent (PRs from the last 24h) and discoverable.
+
+Type-name consistency: `ThreadEntry`/`ThreadsPage` (Rust server) ↔ `ThreadEntry`/`ThreadsPage` (Rust client crate) ↔ `WaddleThreadEntry`/`WaddleThreadsPage` (wasm) ↔ `WasmThreadEntry`/`WasmThreadsPage` (TS). Three different naming surfaces but each is internally consistent and the conversion is explicit at each boundary.
+
+Field-name consistency: `has_unread` (snake_case) preserved across Rust ↔ wasm-serde ↔ TS. `last_activity` is RFC 3339 string in client/TS layers (timezone-safe); `last_activity_secs: i64` on the server side. Conversion is in `build_thread_entry`.

--- a/docs/superpowers/specs/2026-05-17-threads-design.md
+++ b/docs/superpowers/specs/2026-05-17-threads-design.md
@@ -16,7 +16,14 @@ This spec adds a global Threads view to fix that, and cleans up an unrelated CLA
 1. A user can open a single global view that lists every thread they have unread in or have participated in, across all channels and DMs.
 2. The view visually separates "unread for me" from "active but caught up," so both halves of the original ask ("which are active" / "which have new") are answered at a glance.
 3. The new wire shape uses a Waddle-owned namespace so no official XEP namespace is overloaded with Waddle-specific semantics.
-4. Restore conformance for `urn:xmpp:inbox:0` (XEP-0430) by moving Waddle thread extras out of that response shape.
+
+## A spec correction made during plan recon
+
+The original draft of this design assumed the existing inbox IQ used `urn:xmpp:inbox:0` (an official XEP-0430 namespace) and that thread extras carried in its `<conversation/>` elements were a CLAUDE.md hard-rule violation.
+
+That was wrong. Waddle's inbox IQ uses `urn:waddle:inbox:0` for the typed query (see `server/crates/waddle-xmpp/src/xep/xep0430.rs:26`) and `erlang-solutions.com:xmpp:inbox:0` for the ESL-compat surface (see `server/crates/waddle-xmpp-client/src/discovery.rs:39`). Neither is an official `urn:xmpp:*` namespace, so carrying Waddle thread fields inside them is not a violation.
+
+The only artifact that still calls the inbox `urn:xmpp:inbox:0` is one row in `docs/xep-conformance-audit.md` — a doc bug. This PR corrects that row but otherwise leaves the inbox surface alone.
 
 ## Non-goals
 
@@ -36,7 +43,7 @@ This spec adds a global Threads view to fix that, and cleans up an unrelated CLA
 | "Active" means | Recent activity timestamp (server-derivable, not presence-based) | User pick, AskUserQuestion 2 |
 | Layout | Two sections — Unread pinned top, Following below; each ordered by `last_activity DESC` | User pick, mockup B in brainstorm screen 02 |
 | Protocol shape | New `urn:waddle:threads:0` query (Option A) | User approval after Fluux review |
-| Inbox cleanup | Same PR (not a follow-up) | User pick |
+| Inbox cleanup | Dropped — there is no namespace violation (see "A spec correction" above). Only the audit doc row needs fixing. | Recon during plan |
 
 ## Wire protocol
 
@@ -102,11 +109,9 @@ ACL: server returns `<forbidden/>` if the requesting full JID's bare doesn't mat
 
 Disco: `urn:waddle:threads:0` advertised on the user's server in disco#info, alongside the existing `urn:xmpp:inbox:0`.
 
-### Cleanup: drop Waddle extras from `urn:xmpp:inbox:0`
+### Audit-doc correction (replaces the original "inbox cleanup")
 
-XEP-0430 §"Inbox results" defines `<conversation/>` with `jid` and `id` attributes; the per-conversation children defined by the spec are the forwarded message and an unread `<count/>`. Waddle has been emitting additional attributes (`thread-id`) and children (`<thread-title>`, `<reply-count>`, `<root-author>`) inside `<conversation/>` elements served under the `urn:xmpp:inbox:0` namespace. That's an extension of an official namespace with Waddle-private semantics, which CLAUDE.md prohibits.
-
-This PR removes those extras. Any consumer that was reading them switches to the new `urn:waddle:threads:0` query, where the same fields are first-class. No compat shim — there's no production data and per CLAUDE.md "Breaking changes by default."
+`docs/xep-conformance-audit.md` lists XEP-0430 with namespace `urn:xmpp:inbox:0`. The implementation actually uses `urn:waddle:inbox:0` and `erlang-solutions.com:xmpp:inbox:0`. The audit row gets corrected — namespace updated, status note added explaining the two surfaces. No code changes.
 
 ### Disco changes
 
@@ -152,10 +157,6 @@ New module `server/crates/waddle-server/src/threads/`:
 
 IQ handler registered alongside the existing inbox IQ handler.
 
-### Inbox handler change
-
-`server/crates/waddle-server/src/inbox/` codec: stop writing `thread-id`, `<thread-title>`, `<reply-count>`, `<root-author>` into the XEP-0430 response. The columns stay in the DB (the threads query reads them); the wire is what becomes spec-clean.
-
 ### ACL
 
 Bare-JID match on the requesting full JID against the addressed JID. Same pattern as the inbox handler.
@@ -168,10 +169,9 @@ Bare-JID match on the requesting full JID against the addressed JID. Same patter
 - Single channel, multiple threads — returns all, sorted by recency.
 - Pagination: page size 2, three results, cursor round-trips.
 - ACL: querying another user's threads returns `<forbidden/>`.
-- Inbox interaction: `urn:xmpp:inbox:0` response no longer carries `thread-id`/`<thread-title>`/`<reply-count>`/`<root-author>` after this PR.
-- Unread counts match what XEP-0430 inbox reports for the parent conversation.
+- Unread counts match what the existing Waddle inbox reports for the parent conversation.
 
-Existing inbox tests are updated to assert the absence of the cleaned-up fields rather than their presence.
+No changes to existing inbox tests.
 
 ## Client architecture
 
@@ -241,15 +241,14 @@ Pragmatic V1: if a clean event-emission hook isn't easy, fall back to refetching
 
 ## Implementation order (PR commits, conventional + scoped)
 
-1. `fix(server): remove Waddle thread fields from urn:xmpp:inbox:0 entries`
-2. `feat(server): urn:waddle:threads:0 query module`
-3. `test(server): waddle_threads_query_ws`
-4. `feat(server): wasm bindings for fetch_threads`
-5. `feat(chat): Threads sidebar nav entry`
-6. `feat(chat): ThreadsListPanel with Unread/Following sections`
-7. `feat(chat): live thread-delta updates from inbox writes` *(may collapse into 6 if event hook is trivial; or note as a follow-up TODO)*
-8. `test(chat): ThreadsListPanel`
-9. `docs(server): conformance audit — urn:waddle:threads:0 + inbox cleanup`
+1. `feat(server): urn:waddle:threads:0 query module`
+2. `test(server): waddle_threads_query_ws`
+3. `feat(server): wasm bindings for fetch_threads`
+4. `feat(chat): Threads sidebar nav entry`
+5. `feat(chat): ThreadsListPanel with Unread/Following sections`
+6. `feat(chat): live thread-delta updates from inbox writes` *(may collapse into 5 if event hook is trivial; or note as a follow-up TODO)*
+7. `test(chat): ThreadsListPanel`
+8. `docs(server): conformance audit — urn:waddle:threads:0 row + XEP-0430 row correction`
 
 ## Risks and open questions
 
@@ -263,3 +262,11 @@ Pragmatic V1: if a clean event-emission hook isn't easy, fall back to refetching
 - Thread mute/pin/archive.
 - Per-channel Threads tab inside a channel view (mockup A from the brainstorm — viable later if global view isn't enough).
 - Cross-device PEP push for thread state (the data is already server-side; this is only relevant if we ever need offline pre-cached thread lists).
+
+## Queued follow-up: migrate Waddle inbox to XEP-0430
+
+During this brainstorm we identified that Waddle's conversation-level inbox runs on a Waddle-private `urn:waddle:inbox:0` IQ shape (plus an ESL-compat `erlang-solutions.com:xmpp:inbox:0` surface), rather than XEP-0430's `urn:xmpp:inbox:0` / `urn:xmpp:inbox:1`. XEP-0430 is Deferred status (not Draft/Active), but it's the standards-track direction.
+
+Migrating is a real refactor — XEP-0430 streams forwarded `<message>` stanzas with a final `<fin/>` IQ rather than returning an inline list — so it gets its own PR. Threads ships independently because the threads view is a separate Waddle-namespaced query that doesn't depend on which inbox shape we run.
+
+Decision deferred to that PR: keep ESL-compat surface or drop it. Tracking: separate audit-doc row + future PR.

--- a/docs/superpowers/specs/2026-05-17-threads-design.md
+++ b/docs/superpowers/specs/2026-05-17-threads-design.md
@@ -1,0 +1,265 @@
+# Threads view + inbox namespace cleanup
+
+Status: design approved, pre-implementation
+Date: 2026-05-17
+Author: David Flanagan (with Claude)
+Tracking PR: TBD
+
+## Problem
+
+Today a Waddle user has no surface that aggregates threads. The `<thread/>` element (XEP-0201) is preserved on the wire and MAM, the inbox row keys by `(user, partner, thread_id)`, and `ThreadPanel.vue` reads one thread when opened — but there is no view that lists "which threads are active right now" or "which threads have new messages for me." The only thread discovery path today is scrolling a channel and noticing a per-message reply chip.
+
+This spec adds a global Threads view to fix that, and cleans up an unrelated CLAUDE.md hard-rule violation found in the same area along the way.
+
+## Goals
+
+1. A user can open a single global view that lists every thread they have unread in or have participated in, across all channels and DMs.
+2. The view visually separates "unread for me" from "active but caught up," so both halves of the original ask ("which are active" / "which have new") are answered at a glance.
+3. The new wire shape uses a Waddle-owned namespace so no official XEP namespace is overloaded with Waddle-specific semantics.
+4. Restore conformance for `urn:xmpp:inbox:0` (XEP-0430) by moving Waddle thread extras out of that response shape.
+
+## Non-goals
+
+- Thread mute / pin / archive.
+- "All threads in channels I'm in" filter — only participated-or-unread in V1.
+- Replacing or restructuring `ThreadPanel.vue` (the reader). Threads view *opens* the existing panel.
+- Backfilling thread participation state for accounts that have none — empty view with helpful text is fine.
+- New thread creation UX (threads are created today by replying with `<thread/>` and that stays).
+- Cross-device PEP-push synchronization à la Fluux. The data already lives server-side; clients query fresh.
+
+## Decisions
+
+| Question | Decision | Source |
+|---|---|---|
+| Surface | Global "Threads" entry in main sidebar (peer of Inbox/DMs) | User pick, mockup A in brainstorm screen 01 |
+| Filter | Threads I've participated in OR have unread (Slack model) | User pick, AskUserQuestion 1 |
+| "Active" means | Recent activity timestamp (server-derivable, not presence-based) | User pick, AskUserQuestion 2 |
+| Layout | Two sections — Unread pinned top, Following below; each ordered by `last_activity DESC` | User pick, mockup B in brainstorm screen 02 |
+| Protocol shape | New `urn:waddle:threads:0` query (Option A) | User approval after Fluux review |
+| Inbox cleanup | Same PR (not a follow-up) | User pick |
+
+## Wire protocol
+
+### New: `urn:waddle:threads:0` query
+
+The chat client issues this to the user's bare JID. Server applies the participated-or-unread filter implicitly.
+
+Request:
+
+```xml
+<iq type='get' id='th1'>
+  <query xmlns='urn:waddle:threads:0'>
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <max>50</max>
+      <after>OPAQUE-CURSOR</after>     <!-- optional, omitted on first page -->
+    </set>
+  </query>
+</iq>
+```
+
+Response:
+
+```xml
+<iq type='result' id='th1'>
+  <threads xmlns='urn:waddle:threads:0' total='12' unread-threads='2'>
+    <thread channel='room@conference.example'
+            thread-id='t-abc'
+            last-stanza-id='SID'
+            last-activity='2026-05-17T15:42:08Z'
+            unread='2'
+            reply-count='12'
+            has-unread='true'>
+      <root-author>juliet@example</root-author>
+      <preview>Anyone reviewed the doc?</preview>
+      <thread-title>Q3 planning</thread-title>
+    </thread>
+    <!-- ...more entries... -->
+    <set xmlns='http://jabber.org/protocol/rsm'>
+      <first>FIRST-CURSOR</first>
+      <last>LAST-CURSOR</last>
+      <count>12</count>
+    </set>
+  </threads>
+</iq>
+```
+
+Field semantics:
+
+- `channel` — bare JID of the MUC room or DM partner the thread lives in.
+- `thread-id` — XEP-0201 thread ID.
+- `last-stanza-id` — XEP-0359 stanza-id of the most recent message in the thread; the client uses this to anchor MAM follow-on fetches.
+- `last-activity` — RFC 3339 timestamp of the most recent message.
+- `unread` — count of unread messages in this thread for this user.
+- `reply-count` — total messages in the thread (root + replies).
+- `has-unread` — convenience boolean, equivalent to `unread > 0`. Server-set so the client doesn't have to recompute.
+- `<root-author>` — bare JID of the user who started the thread.
+- `<preview>` — short preview of the most-recent message in the thread (already truncated server-side, same rules as inbox previews).
+- `<thread-title>` — display title for the thread, if one has been set.
+
+Ordering is `last-activity DESC` over the entire result set; the two-section split (Unread / Following) is a pure client-side partition of the returned list using `has-unread`.
+
+ACL: server returns `<forbidden/>` if the requesting full JID's bare doesn't match the user.
+
+Disco: `urn:waddle:threads:0` advertised on the user's server in disco#info, alongside the existing `urn:xmpp:inbox:0`.
+
+### Cleanup: drop Waddle extras from `urn:xmpp:inbox:0`
+
+XEP-0430 §"Inbox results" defines `<conversation/>` with `jid` and `id` attributes; the per-conversation children defined by the spec are the forwarded message and an unread `<count/>`. Waddle has been emitting additional attributes (`thread-id`) and children (`<thread-title>`, `<reply-count>`, `<root-author>`) inside `<conversation/>` elements served under the `urn:xmpp:inbox:0` namespace. That's an extension of an official namespace with Waddle-private semantics, which CLAUDE.md prohibits.
+
+This PR removes those extras. Any consumer that was reading them switches to the new `urn:waddle:threads:0` query, where the same fields are first-class. No compat shim — there's no production data and per CLAUDE.md "Breaking changes by default."
+
+### Disco changes
+
+- Add: `urn:waddle:threads:0` on the user-server's disco#info features.
+- No change to advertised features for `urn:xmpp:inbox:0` (still advertised, wire just becomes spec-clean).
+
+## Server architecture
+
+### Data source
+
+The existing `inbox_entries` table is the source of truth. Schema relevant to this work (already in place from prior PRs):
+
+```sql
+inbox_entries (
+  user_jid TEXT,
+  partner_jid TEXT,
+  thread_id TEXT NOT NULL DEFAULT '',
+  kind TEXT,
+  last_stanza_id TEXT,
+  last_updated INTEGER,
+  unread INTEGER,
+  preview TEXT,
+  thread_title TEXT,
+  reply_count INTEGER,
+  author TEXT,
+  PRIMARY KEY (user_jid, partner_jid, thread_id)
+)
+INDEX idx_inbox_entries_user_room_threads (user_jid, partner_jid, thread_id) WHERE thread_id != ''
+```
+
+The threads query reads rows where `user_jid = me AND thread_id != ''`, ordered by `last_updated DESC`, RSM-paginated.
+
+**V1 simplification of "participated or unread":** the inbox writes a row for every thread the user has *seen messages in* (sender or recipient — XEP-0430 inbox semantics), so the V1 query returns "every thread you've been exposed to, plus any with current unread." This is wider than Slack's "followed-or-unread" (Slack tracks explicit follow). It's the right behavior to ship first because the data is already there and the noise floor is low for a normal user. V2 can introduce explicit follow/unfollow and a `participated` filter knob if real usage proves the list is too noisy.
+
+### Module layout
+
+New module `server/crates/waddle-server/src/threads/`:
+
+- `mod.rs` — public entry points
+- `query.rs` — typed `ThreadsQuery` request struct, `ThreadsPage` response struct, builders
+- `storage.rs` — DB read against `inbox_entries`
+- `wire.rs` — typed XML builders for `<threads>` / `<thread>` elements per XEP-0050 / XEP-0059 / RFC 3339 conventions (all via `minidom::Element`, no `format!` for XML)
+
+IQ handler registered alongside the existing inbox IQ handler.
+
+### Inbox handler change
+
+`server/crates/waddle-server/src/inbox/` codec: stop writing `thread-id`, `<thread-title>`, `<reply-count>`, `<root-author>` into the XEP-0430 response. The columns stay in the DB (the threads query reads them); the wire is what becomes spec-clean.
+
+### ACL
+
+Bare-JID match on the requesting full JID against the addressed JID. Same pattern as the inbox handler.
+
+### Tests (dedicated XEP test file per the audit hard rule)
+
+`server/crates/waddle-server/tests/waddle_threads_query_ws.rs` covers:
+
+- Empty result on a fresh account.
+- Single channel, multiple threads — returns all, sorted by recency.
+- Pagination: page size 2, three results, cursor round-trips.
+- ACL: querying another user's threads returns `<forbidden/>`.
+- Inbox interaction: `urn:xmpp:inbox:0` response no longer carries `thread-id`/`<thread-title>`/`<reply-count>`/`<root-author>` after this PR.
+- Unread counts match what XEP-0430 inbox reports for the parent conversation.
+
+Existing inbox tests are updated to assert the absence of the cleaned-up fields rather than their presence.
+
+## Client architecture
+
+### Sidebar entry
+
+A new top-level item "Threads" in the main left sidebar, between Inbox and the channel list. Badge shows `unread-threads` from the most recent `<threads>` response. Lives in the existing nav component — find the inbox/DM entries and follow the pattern.
+
+### Routing
+
+New Astro page: `chat/src/pages/threads.astro`. Mounts a Vue island with `ThreadsListPanel.vue`.
+
+### Components
+
+- `chat/src/components/chat/ThreadsListPanel.vue` — outer shell. Fetches the first page on mount, renders two `<section>` blocks ("Unread", "Following"), handles infinite scroll via RSM cursor.
+- `chat/src/components/chat/ThreadsListRow.vue` — single thread row. Title, channel chip, recency, unread badge, click handler to open the thread.
+- No new design tokens — reuse existing `chat-thread-chip`-adjacent styles where they apply, otherwise inbox-row styles. Match the visual weight of the inbox list.
+
+### Wasm boundary
+
+`server/crates/waddle-xmpp-client/src/xep/threads.rs` (or sibling module):
+
+- Typed `ThreadEntry`, `ThreadsPage` Rust structs.
+- `build_fetch_threads_iq(after_cursor: Option<&str>, page_size: Option<u32>) -> Element`.
+- `parse_threads_response(iq: &Element) -> Option<ThreadsPage>`.
+
+`server/crates/waddle-xmpp-client-wasm/`:
+
+- `fetch_threads(opts: JsValue) -> Promise<ThreadsPage>` (mirrors `fetch_inbox` pattern).
+
+TS-side type in `chat/src/lib/xmpp/wasm-types.ts`:
+
+```ts
+export interface WasmThreadEntry {
+  channel: string;
+  thread_id: string;
+  last_stanza_id: string;
+  last_activity: string;        // RFC 3339
+  unread: number;
+  reply_count: number;
+  has_unread: boolean;
+  root_author?: string;
+  preview?: string;
+  thread_title?: string;
+}
+
+export interface WasmThreadsPage {
+  total: number;
+  unread_threads: number;
+  entries: WasmThreadEntry[];
+  next_cursor?: string;
+}
+```
+
+### Live updates
+
+When the inbox storage writes a row for a non-empty `thread_id`, emit a `WasmThreadsDelta` event the chat client subscribes to. The Threads view applies the delta in place rather than re-fetching the whole page. Implementation hook: the existing inbox-row-update event path (used by the inbox view today) — add a thread-flavored branch.
+
+Pragmatic V1: if a clean event-emission hook isn't easy, fall back to refetching the first page on inbox updates. Note as a TODO in the PR; do not block on it.
+
+### Tests
+
+`chat/src/components/chat/__tests__/ThreadsListPanel.test.ts`:
+
+- Renders empty state when no entries.
+- Splits Unread (top) and Following (bottom) correctly.
+- Click on a row invokes thread-open with `(channel, thread_id)`.
+
+## Implementation order (PR commits, conventional + scoped)
+
+1. `fix(server): remove Waddle thread fields from urn:xmpp:inbox:0 entries`
+2. `feat(server): urn:waddle:threads:0 query module`
+3. `test(server): waddle_threads_query_ws`
+4. `feat(server): wasm bindings for fetch_threads`
+5. `feat(chat): Threads sidebar nav entry`
+6. `feat(chat): ThreadsListPanel with Unread/Following sections`
+7. `feat(chat): live thread-delta updates from inbox writes` *(may collapse into 6 if event hook is trivial; or note as a follow-up TODO)*
+8. `test(chat): ThreadsListPanel`
+9. `docs(server): conformance audit — urn:waddle:threads:0 + inbox cleanup`
+
+## Risks and open questions
+
+- **Inbox event hook for live deltas** — depending on what the current event path looks like, this may be a 5-minute change or a small refactor. Plan allows it to be a TODO if it bloats the PR.
+- **Existing inbox tests** — the cleanup will require updating any test that asserted the presence of the Waddle extras. Mechanical, but it's a chunk of test diff.
+- **Empty-state copy** — what do we say when a user has no threads? "Threads you've replied in or have new messages will show up here." Fine but worth a look during implementation review.
+
+## Out of scope (V2 candidates)
+
+- Filter toggle: Unread only / Following / All in channels I've joined.
+- Thread mute/pin/archive.
+- Per-channel Threads tab inside a channel view (mockup A from the brainstorm — viable later if global view isn't enough).
+- Cross-device PEP push for thread state (the data is already server-side; this is only relevant if we ever need offline pre-cached thread lists).

--- a/docs/xep-conformance-audit.md
+++ b/docs/xep-conformance-audit.md
@@ -100,7 +100,7 @@ or advertises. One row per XEP. Each gap becomes an isolated PR.
 | 0424 | Message Retraction                                   | urn:xmpp:message-retract:1         |  Y  |  Y   |   Y   | unaudited  | |
 | 0425 | Message Moderation                                   | urn:xmpp:message-moderate:1        |  Y  |  Y   |   Y   | unaudited  | |
 | 0428 | Fallback Indication                                  | urn:xmpp:fallback:0                |  Y  |  Y   |   -   | unaudited  | |
-| 0430 | Inbox                                                | urn:xmpp:inbox:0                   |  Y  |  Y   |   -   | unaudited  | Advert added at server crate level |
+| 0430 | Inbox                                                | urn:waddle:inbox:0 + erlang-solutions.com:xmpp:inbox:0 |  Y  |  Y   |   -   | gap        | Waddle private surface (`urn:waddle:inbox:0`) plus ESL/MongooseIM compat (`erlang-solutions.com:xmpp:inbox:0`). Conformant XEP-0430 (`urn:xmpp:inbox:0` / `urn:xmpp:inbox:1`) migration is a queued follow-up — see plan in `docs/superpowers/specs/2026-05-17-threads-design.md`. |
 | 0431 | -                                                    | (assigned)                         |  -  |  Y   |   -   | unaudited  | Verify XEP number |
 | 0433 | -                                                    |                                    |  -  |  Y   |   -   | unaudited  | Verify XEP number |
 | 0437 | Room Activity Indicators                             | urn:xmpp:rai:0                     |  -  |  Y   |   -   | unaudited  | |
@@ -126,6 +126,7 @@ or advertises. One row per XEP. Each gap becomes an isolated PR.
 | 0503 | Spaces                                               | urn:xmpp:spaces:0                  |  Y  |  Y   |   Y   | unaudited  | Advert gated until owner subs done |
 | 0508 | -                                                    |                                    |  -  |  Y   |   -   | unaudited  | Verify XEP number |
 | 0513 | Explicit Mentions                                    | urn:xmpp:mentions:0                |  Y  |  Y   |   Y   | unaudited  | Plus `#channel` profile |
+| —    | (Waddle) Threads view                                | urn:waddle:threads:0               |  Y  |  Y   |   Y   | fixed      | Waddle-namespaced (no XEP equivalent — Fluux made the same call for their custom conversation list). Server reads `inbox_entries WHERE thread_id != ''`; chat client renders a two-section view (Unread / Following). PR #671. |
 
 ## Currently identified gaps (preliminary, pre-deep-audit)
 

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -17,7 +17,6 @@ mod open;
 mod schema;
 
 use codec::{decode_row, encode_kind, SELECT_COLS};
-pub(crate) use codec::{decode_row as decode_inbox_row, SELECT_COLS as INBOX_SELECT_COLS};
 pub use open::build_inbox_storage;
 
 #[derive(Clone)]
@@ -26,13 +25,6 @@ pub struct DatabaseInboxStorage {
 }
 
 impl DatabaseInboxStorage {
-    /// Borrow the underlying logical database — used by sibling
-    /// projections (e.g. the threads view) so they share the same pool
-    /// and schema lifecycle.
-    pub fn db_handle(&self) -> Database {
-        self.db.clone()
-    }
-
     pub async fn open(database_url: Option<&str>) -> Result<Self, InboxStorageError> {
         let db = match database_url {
             Some(database_url) => open::open_database(database_url).await?,
@@ -120,6 +112,27 @@ impl InboxStorage for DatabaseInboxStorage {
             .query(&sql, crate::db_params![user.to_string(), room.to_string()])
             .await?;
 
+        let mut entries = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?
+        {
+            entries.push(decode_row(&row)?);
+        }
+        Ok(entries)
+    }
+
+    #[instrument(skip(self), fields(user = %user))]
+    async fn list_all_threads(&self, user: &BareJid) -> Result<Vec<InboxEntry>, InboxStorageError> {
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM inbox_entries \
+             WHERE user_jid = ? AND thread_id != '' \
+             ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC"
+        );
+        let mut rows = self
+            .query(&sql, crate::db_params![user.to_string()])
+            .await?;
         let mut entries = Vec::new();
         while let Some(row) = rows
             .next()

--- a/server/crates/waddle-server/src/inbox.rs
+++ b/server/crates/waddle-server/src/inbox.rs
@@ -17,6 +17,7 @@ mod open;
 mod schema;
 
 use codec::{decode_row, encode_kind, SELECT_COLS};
+pub(crate) use codec::{decode_row as decode_inbox_row, SELECT_COLS as INBOX_SELECT_COLS};
 pub use open::build_inbox_storage;
 
 #[derive(Clone)]
@@ -25,6 +26,13 @@ pub struct DatabaseInboxStorage {
 }
 
 impl DatabaseInboxStorage {
+    /// Borrow the underlying logical database — used by sibling
+    /// projections (e.g. the threads view) so they share the same pool
+    /// and schema lifecycle.
+    pub fn db_handle(&self) -> Database {
+        self.db.clone()
+    }
+
     pub async fn open(database_url: Option<&str>) -> Result<Self, InboxStorageError> {
         let db = match database_url {
             Some(database_url) => open::open_database(database_url).await?,

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(crate) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorageError> {
+pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorageError> {
     let partner_raw: String = row
         .get(0)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
@@ -70,4 +70,4 @@ fn decode_kind(raw: &str) -> Result<ConversationKind, InboxStorageError> {
     }
 }
 
-pub const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author";
+pub(super) const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author";

--- a/server/crates/waddle-server/src/inbox/codec.rs
+++ b/server/crates/waddle-server/src/inbox/codec.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorageError> {
+pub(crate) fn decode_row(row: &crate::db::Row) -> Result<InboxEntry, InboxStorageError> {
     let partner_raw: String = row
         .get(0)
         .map_err(|error| InboxStorageError::Other(error.to_string()))?;
@@ -70,4 +70,4 @@ fn decode_kind(raw: &str) -> Result<ConversationKind, InboxStorageError> {
     }
 }
 
-pub(super) const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author";
+pub const SELECT_COLS: &str = "partner_jid, thread_id, kind, last_stanza_id, last_updated, unread, preview, thread_title, reply_count, author";

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -22,6 +22,7 @@ pub mod sm_promotion;
 pub mod spaces_pubsub_seed;
 pub mod storage;
 pub mod telemetry;
+pub mod threads;
 pub mod time;
 pub mod vcard;
 

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -417,6 +417,9 @@ async fn create_websocket_state(
                 room_registry,
                 mam_storage,
                 inbox_storage: Arc::clone(&state.inbox_storage),
+                threads_storage: Arc::new(crate::threads::storage::InboxBackedThreadsStorage::new(
+                    Arc::clone(&state.inbox_storage),
+                )),
                 blocking_storage,
                 pending_delivery_storage,
                 command_registry: websocket_command_registry,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -291,6 +291,70 @@ pub(super) async fn handle_archive_inbox_upload_iq(
         }
     }
 
+    // urn:waddle:threads:0 — global threads view (PR #671).
+    if crate::threads::handler::is_threads_iq(iq) {
+        use crate::threads::handler::{handle_threads_iq, ThreadsIqOutcome};
+
+        let request_iq = &iq;
+        let Some(user_jid) = phase.bound_jid().map(|jid| jid.to_bare()) else {
+            return vec![build_iq_error_xml_typed(
+                id,
+                None,
+                None,
+                not_authorized_iq_error("Authentication required."),
+            )];
+        };
+
+        let outcome = handle_threads_iq(
+            state.deps.protocol.threads_storage.as_ref(),
+            request_iq,
+            Some(&user_jid),
+        )
+        .await;
+
+        return match outcome {
+            ThreadsIqOutcome::Result(payload) => {
+                let response = xmpp_parsers::iq::Iq {
+                    from: request_iq.to.clone(),
+                    to: request_iq.from.clone(),
+                    id: request_iq.id.clone(),
+                    payload: xmpp_parsers::iq::IqType::Result(Some(payload)),
+                };
+                vec![iq_to_xml(response)]
+            }
+            ThreadsIqOutcome::BadRequest(err) => {
+                warn!(error = %err, "Invalid urn:waddle:threads:0 query");
+                vec![build_iq_error_xml_typed(
+                    id,
+                    None,
+                    None,
+                    bad_request_iq_error("Malformed IQ payload."),
+                )]
+            }
+            ThreadsIqOutcome::Forbidden => vec![build_iq_error_xml_typed(
+                id,
+                None,
+                None,
+                forbidden_iq_error("Threads query refused for cross-user target."),
+            )],
+            ThreadsIqOutcome::NotAuthorized => vec![build_iq_error_xml_typed(
+                id,
+                None,
+                None,
+                not_authorized_iq_error("Authentication required."),
+            )],
+            ThreadsIqOutcome::InternalError(error) => {
+                warn!(error = %error, jid = %user_jid, "Failed to page threads");
+                vec![build_iq_error_xml_typed(
+                    id,
+                    None,
+                    None,
+                    internal_server_error_iq_error("Internal server error."),
+                )]
+            }
+        };
+    }
+
     // urn:xmpp:carbons:2 enable/disable is now served by
     // protocol::handlers::carbons::CarbonsHandler via the short-circuit above.
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/account.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/account.rs
@@ -20,6 +20,7 @@ pub(super) async fn handle_account_disco_info<'a>(
             Feature::mam(),
             Feature::mam_extended(),
             Feature::fulltext_mam(),
+            Feature::threads_query(),
         ];
         features.extend(pep_features());
         let response = build_disco_info_response(req.request_iq, &identities, &features, None);

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -64,6 +64,9 @@ pub struct ProtocolServices {
     pub mam_storage: Arc<dyn MamStorage>,
     /// Shared Waddle inbox projection storage.
     pub inbox_storage: Arc<dyn InboxStorage>,
+    /// Per-thread cross-channel view (urn:waddle:threads:0). Reads
+    /// from the same backend as the inbox projection.
+    pub threads_storage: Arc<dyn crate::threads::storage::ThreadsStorage>,
     /// Shared XEP-0191 blocking-list storage. Used by the headless
     /// offline-recipient pass (#229 PR15) to seed a transient
     /// recipient state machine's blocklist when delivering to a

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -125,6 +125,9 @@ async fn create_test_websocket_state_with_extension_manager(
         .expect("notification outbox"),
     );
 
+    let test_inbox_storage: Arc<dyn waddle_xmpp::inbox::storage::InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+
     Arc::new(WebSocketState {
             deps: WebSocketDeps {
                 app_state: Arc::clone(&app_state),
@@ -145,8 +148,11 @@ async fn create_test_websocket_state_with_extension_manager(
                             .expect("test secret meets length floor"),
                     )),
                     mam_storage,
-                    inbox_storage: Arc::new(
-                        waddle_xmpp::inbox::storage::InMemoryInboxStorage::new(),
+                    inbox_storage: Arc::clone(&test_inbox_storage),
+                    threads_storage: Arc::new(
+                        crate::threads::storage::InboxBackedThreadsStorage::new(Arc::clone(
+                            &test_inbox_storage,
+                        )),
                     ),
                     blocking_storage: Arc::new(
                         waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new(),

--- a/server/crates/waddle-server/src/threads/handler.rs
+++ b/server/crates/waddle-server/src/threads/handler.rs
@@ -1,0 +1,195 @@
+//! IQ handler glue for `urn:waddle:threads:0`.
+//!
+//! Mirrors the inbox handler shape: parse → ACL → storage page →
+//! build response.
+
+use jid::BareJid;
+use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
+
+use super::query::{ThreadsError, DEFAULT_PAGE_SIZE, NS_THREADS};
+use super::storage::ThreadsStorage;
+use super::wire::{build_threads_response, parse_threads_query};
+
+/// Discriminator: does this IQ carry the `urn:waddle:threads:0` query?
+pub fn is_threads_iq(iq: &Iq) -> bool {
+    let elem = match &iq.payload {
+        IqType::Get(e) | IqType::Set(e) => e,
+        _ => return false,
+    };
+    elem.is("query", NS_THREADS)
+}
+
+/// Outcome of running the threads-IQ handler.
+pub enum ThreadsIqOutcome {
+    /// Built response payload — caller wraps in `<iq type='result'>`.
+    Result(Element),
+    /// Storage error; caller should respond with internal-server-error.
+    InternalError(String),
+    /// Caller should respond with bad-request.
+    BadRequest(ThreadsError),
+    /// Caller should respond with forbidden.
+    Forbidden,
+    /// Caller should respond with not-authorized.
+    NotAuthorized,
+}
+
+/// Run the threads IQ. The caller stamps the request id / from / to and
+/// converts the outcome to an `<iq>` envelope.
+pub async fn handle_threads_iq(
+    storage: &dyn ThreadsStorage,
+    iq: &Iq,
+    requester_bare: Option<&BareJid>,
+) -> ThreadsIqOutcome {
+    let Some(requester) = requester_bare else {
+        return ThreadsIqOutcome::NotAuthorized;
+    };
+
+    // ACL: when the IQ is addressed (`to`), it MUST be the requester's
+    // bare JID. Cross-user threads queries are refused with <forbidden/>.
+    if let Some(ref to) = iq.to {
+        if to.to_bare() != *requester {
+            return ThreadsIqOutcome::Forbidden;
+        }
+    }
+
+    let query = match parse_threads_query(iq) {
+        Ok(q) => q,
+        Err(err) => return ThreadsIqOutcome::BadRequest(err),
+    };
+
+    let page_size = query.page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+
+    match storage
+        .page(requester, page_size, query.after_cursor.as_deref())
+        .await
+    {
+        Ok(page) => ThreadsIqOutcome::Result(build_threads_response(&page)),
+        Err(error) => ThreadsIqOutcome::InternalError(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::threads::query::ThreadsPage;
+    use crate::threads::storage::InboxBackedThreadsStorage;
+    use std::sync::Arc;
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::inbox::storage::InboxStorage;
+    use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+
+    fn jid(value: &str) -> BareJid {
+        value.parse().expect("valid JID")
+    }
+
+    fn empty_query_iq() -> Iq {
+        Iq {
+            from: None,
+            to: None,
+            id: "th-1".into(),
+            payload: IqType::Get(Element::builder("query", NS_THREADS).build()),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_inbox_yields_empty_page_result() {
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        let storage = InboxBackedThreadsStorage::new(inbox);
+        let outcome =
+            handle_threads_iq(&storage, &empty_query_iq(), Some(&jid("me@example.com"))).await;
+        match outcome {
+            ThreadsIqOutcome::Result(elem) => {
+                assert_eq!(elem.name(), "threads");
+                assert_eq!(elem.attr("total"), Some("0"));
+            }
+            _ => panic!("expected Result outcome"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cross_user_addressed_iq_is_forbidden() {
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        let storage = InboxBackedThreadsStorage::new(inbox);
+        let mut iq = empty_query_iq();
+        iq.to = Some(jid::Jid::from(jid("bob@example.com")));
+        let outcome = handle_threads_iq(&storage, &iq, Some(&jid("alice@example.com"))).await;
+        assert!(matches!(outcome, ThreadsIqOutcome::Forbidden));
+    }
+
+    #[tokio::test]
+    async fn missing_requester_is_not_authorized() {
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        let storage = InboxBackedThreadsStorage::new(inbox);
+        let outcome = handle_threads_iq(&storage, &empty_query_iq(), None).await;
+        assert!(matches!(outcome, ThreadsIqOutcome::NotAuthorized));
+    }
+
+    #[tokio::test]
+    async fn populated_inbox_returns_entries() {
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        let user = jid("me@example.com");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s0",
+                    100,
+                ),
+                true,
+            )
+            .await
+            .expect("upsert channel");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s1",
+                    110,
+                )
+                .with_thread("t1"),
+                true,
+            )
+            .await
+            .expect("upsert thread");
+
+        let storage = InboxBackedThreadsStorage::new(inbox);
+        let outcome = handle_threads_iq(&storage, &empty_query_iq(), Some(&user)).await;
+        let elem = match outcome {
+            ThreadsIqOutcome::Result(e) => e,
+            _ => panic!("expected Result outcome"),
+        };
+        assert_eq!(elem.attr("total"), Some("1"));
+        let threads_count = elem.children().filter(|c| c.name() == "thread").count();
+        assert_eq!(threads_count, 1);
+    }
+
+    #[test]
+    fn is_threads_iq_recognises_query() {
+        assert!(is_threads_iq(&empty_query_iq()));
+    }
+
+    #[test]
+    fn is_threads_iq_rejects_other_namespaces() {
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "x".into(),
+            payload: IqType::Get(Element::builder("query", "urn:xmpp:inbox:0").build()),
+        };
+        assert!(!is_threads_iq(&iq));
+    }
+
+    /// `ThreadsPage::default()` is the only path that satisfies the
+    /// type contract for [`ThreadsIqOutcome::Result`] outside `handle_threads_iq`.
+    /// Smoke-test the builder via a default page.
+    #[test]
+    fn builder_produces_threads_element_for_default_page() {
+        let elem = build_threads_response(&ThreadsPage::default());
+        assert_eq!(elem.name(), "threads");
+    }
+}

--- a/server/crates/waddle-server/src/threads/mod.rs
+++ b/server/crates/waddle-server/src/threads/mod.rs
@@ -1,0 +1,15 @@
+//! Waddle threads — per-thread cross-channel aggregation view.
+//!
+//! This module carries the IQ-level protocol for the global threads view:
+//! a single query that returns an ordered list of threads the user has
+//! participated in or has unread in, across every channel.
+//!
+//! Wire shape: `urn:waddle:threads:0`. See
+//! `docs/superpowers/specs/2026-05-17-threads-design.md` for the contract.
+//!
+//! Data source: the existing `inbox_entries` table (rows with non-empty
+//! `thread_id`). No new schema.
+
+pub mod query;
+pub mod storage;
+pub mod wire;

--- a/server/crates/waddle-server/src/threads/mod.rs
+++ b/server/crates/waddle-server/src/threads/mod.rs
@@ -10,6 +10,7 @@
 //! Data source: the existing `inbox_entries` table (rows with non-empty
 //! `thread_id`). No new schema.
 
+pub mod handler;
 pub mod query;
 pub mod storage;
 pub mod wire;

--- a/server/crates/waddle-server/src/threads/query.rs
+++ b/server/crates/waddle-server/src/threads/query.rs
@@ -1,0 +1,66 @@
+//! Typed request and response values for the threads query.
+
+use jid::BareJid;
+
+/// `urn:waddle:threads:0` namespace.
+pub const NS_THREADS: &str = "urn:waddle:threads:0";
+
+/// Maximum entries the server will return on a single page when the
+/// client omits `<set><max>`. Mirrors the existing inbox cap.
+pub const DEFAULT_PAGE_SIZE: u32 = 50;
+
+/// Hard cap on `<set><max>` requested by clients. Same cap as inbox.
+pub const MAX_PAGE_SIZE: u32 = 200;
+
+/// A `<query xmlns='urn:waddle:threads:0'/>` request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsQuery {
+    /// RSM `<max>` — clamped to `MAX_PAGE_SIZE` at parse time.
+    pub page_size: Option<u32>,
+    /// RSM `<after>` cursor — opaque string the server emitted previously.
+    pub after_cursor: Option<String>,
+}
+
+/// One row in a `<threads>` response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadEntry {
+    pub channel: BareJid,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    /// Unix seconds since epoch.
+    pub last_activity_secs: i64,
+    pub unread: u32,
+    pub reply_count: u32,
+    pub root_author: Option<BareJid>,
+    pub preview: Option<String>,
+    pub thread_title: Option<String>,
+}
+
+impl ThreadEntry {
+    pub fn has_unread(&self) -> bool {
+        self.unread > 0
+    }
+}
+
+/// Full response payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsPage {
+    pub entries: Vec<ThreadEntry>,
+    pub total: u64,
+    pub unread_threads: u64,
+    /// `<first>` cursor from RSM, opaque to clients.
+    pub first_cursor: Option<String>,
+    /// `<last>` cursor from RSM.
+    pub last_cursor: Option<String>,
+}
+
+/// Errors returned by threads stanza parsing.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ThreadsError {
+    #[error("expected <{0}/> in '{NS_THREADS}'")]
+    ExpectedElement(&'static str),
+    #[error("invalid integer '{0}'")]
+    InvalidInteger(String),
+    #[error("payload is not the expected IQ type")]
+    WrongIqType,
+}

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -1,20 +1,21 @@
-//! Storage read for the global threads view. Pulls per-thread rows from
-//! the existing `inbox_entries` table — no schema changes.
+//! Storage read for the global threads view. Pulls per-thread rows via
+//! the existing `InboxStorage::list_all_threads` contract — no new
+//! schema, and works with both the SQL and in-memory inbox backends.
+
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 use jid::BareJid;
 use serde::{Deserialize, Serialize};
-use waddle_xmpp::inbox::storage::InboxStorageError;
+use waddle_xmpp::inbox::storage::{InboxStorage, InboxStorageError};
 use waddle_xmpp::inbox::InboxEntry;
 
 use super::query::{ThreadEntry, ThreadsPage, MAX_PAGE_SIZE};
-use crate::db::{Database, IntoParams};
-use crate::inbox::{decode_inbox_row, INBOX_SELECT_COLS};
 
-/// Read trait for the threads view. Implementations read from
-/// `inbox_entries` (or a fixture for tests).
+/// Read trait for the threads view. Implementations read per-thread
+/// inbox rows from whichever backend the inbox storage is using.
 #[async_trait]
 pub trait ThreadsStorage: Send + Sync {
     async fn page(
@@ -25,33 +26,18 @@ pub trait ThreadsStorage: Send + Sync {
     ) -> Result<ThreadsPage, InboxStorageError>;
 }
 
-/// SQL-backed implementation, reading the same `inbox_entries` table as
-/// the inbox feature.
+/// Default implementation: layers RSM-style pagination on top of an
+/// `InboxStorage::list_all_threads` snapshot. The pagination is seek-
+/// based over `(last_updated, partner_jid, thread_id)` so it's stable
+/// under concurrent inserts that change the suffix of the list.
 #[derive(Clone)]
-pub struct DatabaseThreadsStorage {
-    db: Database,
+pub struct InboxBackedThreadsStorage {
+    inbox: Arc<dyn InboxStorage>,
 }
 
-impl DatabaseThreadsStorage {
-    /// Construct from a shared logical database — the same one the
-    /// inbox storage uses.
-    pub fn new(db: Database) -> Self {
-        Self { db }
-    }
-
-    async fn query(
-        &self,
-        sql: &str,
-        params: impl IntoParams,
-    ) -> Result<crate::db::Rows, InboxStorageError> {
-        let conn = self
-            .db
-            .guard()
-            .await
-            .map_err(|error| InboxStorageError::Other(error.to_string()))?;
-        conn.query(sql, params)
-            .await
-            .map_err(|error| InboxStorageError::Other(error.to_string()))
+impl InboxBackedThreadsStorage {
+    pub fn new(inbox: Arc<dyn InboxStorage>) -> Self {
+        Self { inbox }
     }
 }
 
@@ -88,6 +74,21 @@ impl Cursor {
     }
 }
 
+/// Sort order: `last_updated DESC`, then `partner_jid ASC`, then
+/// `thread_id ASC`. Inverted because the row with the *greatest*
+/// `last_updated` is considered the "smallest" position in the ordered
+/// list (it appears first).
+fn entry_is_after_cursor(entry: &ThreadEntry, cursor: &Cursor) -> bool {
+    if entry.last_activity_secs != cursor.last_updated {
+        return entry.last_activity_secs < cursor.last_updated;
+    }
+    let partner = entry.channel.to_string();
+    if partner != cursor.partner_jid {
+        return partner > cursor.partner_jid;
+    }
+    entry.thread_id > cursor.thread_id
+}
+
 fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
     let thread_id = row.thread_id.clone()?;
     if thread_id.is_empty() {
@@ -111,95 +112,52 @@ fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
 }
 
 #[async_trait]
-impl ThreadsStorage for DatabaseThreadsStorage {
+impl ThreadsStorage for InboxBackedThreadsStorage {
     async fn page(
         &self,
         user_jid: &BareJid,
         page_size: u32,
         after_cursor: Option<&str>,
     ) -> Result<ThreadsPage, InboxStorageError> {
-        let limit = page_size.clamp(1, MAX_PAGE_SIZE) as i64;
-
-        // Page (seek-based pagination using the (last_updated, partner_jid,
-        // thread_id) tuple as the sort key — stable under concurrent inserts).
-        let mut entries: Vec<ThreadEntry> = Vec::new();
-        let sql_base = format!(
-            "SELECT {INBOX_SELECT_COLS} FROM inbox_entries \
-             WHERE user_jid = ? AND thread_id != ''"
-        );
-        let mut rows = if let Some(cursor_raw) = after_cursor {
-            let cursor = Cursor::decode(cursor_raw)?;
-            let sql = format!(
-                "{sql_base} AND (\
-                    last_updated < ? \
-                    OR (last_updated = ? AND partner_jid > ?) \
-                    OR (last_updated = ? AND partner_jid = ? AND thread_id > ?)\
-                  ) \
-                  ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC \
-                  LIMIT ?"
-            );
-            self.query(
-                &sql,
-                crate::db_params![
-                    user_jid.to_string(),
-                    cursor.last_updated,
-                    cursor.last_updated,
-                    cursor.partner_jid.clone(),
-                    cursor.last_updated,
-                    cursor.partner_jid,
-                    cursor.thread_id,
-                    limit,
-                ],
-            )
-            .await?
-        } else {
-            let sql = format!(
-                "{sql_base} \
-                 ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC \
-                 LIMIT ?"
-            );
-            self.query(&sql, crate::db_params![user_jid.to_string(), limit])
-                .await?
+        let limit = page_size.clamp(1, MAX_PAGE_SIZE) as usize;
+        let cursor = match after_cursor {
+            Some(raw) => Some(Cursor::decode(raw)?),
+            None => None,
         };
 
-        while let Some(row) = rows
-            .next()
-            .await
-            .map_err(|error| InboxStorageError::Other(error.to_string()))?
-        {
-            let inbox_entry = decode_inbox_row(&row)?;
-            if let Some(thread_entry) = build_thread_entry(&inbox_entry) {
-                entries.push(thread_entry);
+        let mut all_rows = self.inbox.list_all_threads(user_jid).await?;
+        // Backend MAY return rows already ordered; re-sort defensively
+        // to make this layer the single source of truth for ordering.
+        all_rows.sort_by(|a, b| {
+            b.last_updated
+                .cmp(&a.last_updated)
+                .then_with(|| a.partner.to_string().cmp(&b.partner.to_string()))
+                .then_with(|| {
+                    a.thread_id
+                        .as_deref()
+                        .unwrap_or("")
+                        .cmp(b.thread_id.as_deref().unwrap_or(""))
+                })
+        });
+
+        let total: u64 = all_rows.len() as u64;
+        let unread_threads: u64 = all_rows.iter().filter(|e| e.unread > 0).count() as u64;
+
+        let mut entries: Vec<ThreadEntry> = Vec::with_capacity(limit);
+        for row in all_rows {
+            let Some(entry) = build_thread_entry(&row) else {
+                continue;
+            };
+            if let Some(ref c) = cursor {
+                if !entry_is_after_cursor(&entry, c) {
+                    continue;
+                }
+            }
+            entries.push(entry);
+            if entries.len() >= limit {
+                break;
             }
         }
-
-        // Totals: a single round-trip over (count_all_threads,
-        // count_unread_threads) for the same user.
-        let mut totals_rows = self
-            .query(
-                "SELECT \
-                   COUNT(*) AS total, \
-                   COALESCE(SUM(CASE WHEN unread > 0 THEN 1 ELSE 0 END), 0) AS unread_threads \
-                 FROM inbox_entries \
-                 WHERE user_jid = ? AND thread_id != ''",
-                crate::db_params![user_jid.to_string()],
-            )
-            .await?;
-        let (total, unread_threads) = if let Some(row) = totals_rows
-            .next()
-            .await
-            .map_err(|error| InboxStorageError::Other(error.to_string()))?
-        {
-            let total: i64 = row
-                .get(0)
-                .map_err(|error| InboxStorageError::Other(error.to_string()))?;
-            let unread_threads: i64 = row
-                .get(1)
-                .map_err(|error| InboxStorageError::Other(error.to_string()))?;
-            (total.max(0) as u64, unread_threads.max(0) as u64)
-        } else {
-            (0, 0)
-        };
 
         let first_cursor = entries.first().map(Cursor::from_entry);
         let last_cursor = entries.last().map(Cursor::from_entry);
@@ -226,21 +184,19 @@ impl ThreadsStorage for DatabaseThreadsStorage {
 mod tests {
     use super::*;
     use crate::inbox::DatabaseInboxStorage;
-    use waddle_xmpp::inbox::storage::InboxStorage;
     use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
 
     fn jid(value: &str) -> BareJid {
         value.parse().expect("valid JID")
     }
 
-    /// Build a paired (inbox storage, threads storage) backed by the same
-    /// in-memory database. The inbox storage is used to seed rows; the
-    /// threads storage reads via the same `Database` handle.
-    async fn make_storage_pair() -> (DatabaseInboxStorage, DatabaseThreadsStorage) {
-        let inbox = DatabaseInboxStorage::open(Some("sqlite::memory:"))
-            .await
-            .expect("open inbox storage");
-        let threads = DatabaseThreadsStorage::new(inbox.db_handle());
+    async fn make_storage_pair() -> (Arc<DatabaseInboxStorage>, InboxBackedThreadsStorage) {
+        let inbox = Arc::new(
+            DatabaseInboxStorage::open(Some("sqlite::memory:"))
+                .await
+                .expect("open inbox storage"),
+        );
+        let threads = InboxBackedThreadsStorage::new(inbox.clone());
         (inbox, threads)
     }
 
@@ -249,7 +205,6 @@ mod tests {
         let (inbox, threads) = make_storage_pair().await;
         let user = jid("me@example.com");
 
-        // Seed: channel-level row (no thread) — must NOT appear.
         inbox
             .upsert(
                 &user,
@@ -264,7 +219,6 @@ mod tests {
             .await
             .expect("upsert channel");
 
-        // Seed: thread row in room1
         inbox
             .upsert(
                 &user,
@@ -280,7 +234,6 @@ mod tests {
             .await
             .expect("upsert t1");
 
-        // Seed: thread row in room2
         inbox
             .upsert(
                 &user,
@@ -297,11 +250,7 @@ mod tests {
             .expect("upsert t2");
 
         let page = threads.page(&user, 50, None).await.expect("page");
-        assert_eq!(
-            page.entries.len(),
-            2,
-            "expected 2 thread rows, got {page:?}"
-        );
+        assert_eq!(page.entries.len(), 2, "expected 2 thread rows");
         assert!(page.entries.iter().all(|e| !e.thread_id.is_empty()));
         assert_eq!(page.total, 2);
     }
@@ -417,7 +366,6 @@ mod tests {
             )
             .await
             .expect("upsert t2");
-        // Mark t2 as read
         inbox
             .mark_read(&user, &jid("room@muc.example"), Some("t2"))
             .await
@@ -426,5 +374,46 @@ mod tests {
         let page = threads.page(&user, 50, None).await.expect("page");
         assert_eq!(page.total, 2);
         assert_eq!(page.unread_threads, 1);
+    }
+
+    #[tokio::test]
+    async fn page_works_against_in_memory_storage() {
+        let inbox: Arc<dyn InboxStorage> =
+            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+        let threads = InboxBackedThreadsStorage::new(inbox.clone());
+        let user = jid("me@example.com");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s0",
+                    100,
+                ),
+                true,
+            )
+            .await
+            .expect("upsert channel");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s1",
+                    110,
+                )
+                .with_thread("t1"),
+                true,
+            )
+            .await
+            .expect("upsert thread");
+
+        let page = threads.page(&user, 50, None).await.expect("page");
+        assert_eq!(page.entries.len(), 1);
+        assert_eq!(page.total, 1);
+        assert_eq!(page.entries[0].thread_id, "t1");
     }
 }

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -1,2 +1,430 @@
 //! Storage read for the global threads view. Pulls per-thread rows from
 //! the existing `inbox_entries` table — no schema changes.
+
+use async_trait::async_trait;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use jid::BareJid;
+use serde::{Deserialize, Serialize};
+use waddle_xmpp::inbox::storage::InboxStorageError;
+use waddle_xmpp::inbox::InboxEntry;
+
+use super::query::{ThreadEntry, ThreadsPage, MAX_PAGE_SIZE};
+use crate::db::{Database, IntoParams};
+use crate::inbox::{decode_inbox_row, INBOX_SELECT_COLS};
+
+/// Read trait for the threads view. Implementations read from
+/// `inbox_entries` (or a fixture for tests).
+#[async_trait]
+pub trait ThreadsStorage: Send + Sync {
+    async fn page(
+        &self,
+        user_jid: &BareJid,
+        page_size: u32,
+        after_cursor: Option<&str>,
+    ) -> Result<ThreadsPage, InboxStorageError>;
+}
+
+/// SQL-backed implementation, reading the same `inbox_entries` table as
+/// the inbox feature.
+#[derive(Clone)]
+pub struct DatabaseThreadsStorage {
+    db: Database,
+}
+
+impl DatabaseThreadsStorage {
+    /// Construct from a shared logical database — the same one the
+    /// inbox storage uses.
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    async fn query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, InboxStorageError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))
+    }
+}
+
+/// Opaque RSM cursor — Base64URL-encoded JSON. Stable as long as the
+/// `(last_updated, partner_jid, thread_id)` triple is preserved.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Cursor {
+    last_updated: i64,
+    partner_jid: String,
+    thread_id: String,
+}
+
+impl Cursor {
+    fn from_entry(entry: &ThreadEntry) -> Self {
+        Self {
+            last_updated: entry.last_activity_secs,
+            partner_jid: entry.channel.to_string(),
+            thread_id: entry.thread_id.clone(),
+        }
+    }
+
+    fn encode(&self) -> Result<String, InboxStorageError> {
+        let json = serde_json::to_vec(self)
+            .map_err(|error| InboxStorageError::Other(format!("cursor encode: {error}")))?;
+        Ok(URL_SAFE_NO_PAD.encode(json))
+    }
+
+    fn decode(raw: &str) -> Result<Self, InboxStorageError> {
+        let bytes = URL_SAFE_NO_PAD
+            .decode(raw)
+            .map_err(|error| InboxStorageError::Other(format!("cursor decode: {error}")))?;
+        serde_json::from_slice::<Cursor>(&bytes)
+            .map_err(|error| InboxStorageError::Other(format!("cursor json: {error}")))
+    }
+}
+
+fn build_thread_entry(row: &InboxEntry) -> Option<ThreadEntry> {
+    let thread_id = row.thread_id.clone()?;
+    if thread_id.is_empty() {
+        return None;
+    }
+    let root_author = row
+        .author
+        .as_ref()
+        .and_then(|author| author.parse::<BareJid>().ok());
+    Some(ThreadEntry {
+        channel: row.partner.clone(),
+        thread_id,
+        last_stanza_id: row.last_stanza_id.clone(),
+        last_activity_secs: row.last_updated,
+        unread: row.unread,
+        reply_count: row.reply_count,
+        root_author,
+        preview: row.preview.clone(),
+        thread_title: row.thread_title.clone(),
+    })
+}
+
+#[async_trait]
+impl ThreadsStorage for DatabaseThreadsStorage {
+    async fn page(
+        &self,
+        user_jid: &BareJid,
+        page_size: u32,
+        after_cursor: Option<&str>,
+    ) -> Result<ThreadsPage, InboxStorageError> {
+        let limit = page_size.clamp(1, MAX_PAGE_SIZE) as i64;
+
+        // Page (seek-based pagination using the (last_updated, partner_jid,
+        // thread_id) tuple as the sort key — stable under concurrent inserts).
+        let mut entries: Vec<ThreadEntry> = Vec::new();
+        let sql_base = format!(
+            "SELECT {INBOX_SELECT_COLS} FROM inbox_entries \
+             WHERE user_jid = ? AND thread_id != ''"
+        );
+        let mut rows = if let Some(cursor_raw) = after_cursor {
+            let cursor = Cursor::decode(cursor_raw)?;
+            let sql = format!(
+                "{sql_base} AND (\
+                    last_updated < ? \
+                    OR (last_updated = ? AND partner_jid > ?) \
+                    OR (last_updated = ? AND partner_jid = ? AND thread_id > ?)\
+                  ) \
+                  ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC \
+                  LIMIT ?"
+            );
+            self.query(
+                &sql,
+                crate::db_params![
+                    user_jid.to_string(),
+                    cursor.last_updated,
+                    cursor.last_updated,
+                    cursor.partner_jid.clone(),
+                    cursor.last_updated,
+                    cursor.partner_jid,
+                    cursor.thread_id,
+                    limit,
+                ],
+            )
+            .await?
+        } else {
+            let sql = format!(
+                "{sql_base} \
+                 ORDER BY last_updated DESC, partner_jid ASC, thread_id ASC \
+                 LIMIT ?"
+            );
+            self.query(&sql, crate::db_params![user_jid.to_string(), limit])
+                .await?
+        };
+
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?
+        {
+            let inbox_entry = decode_inbox_row(&row)?;
+            if let Some(thread_entry) = build_thread_entry(&inbox_entry) {
+                entries.push(thread_entry);
+            }
+        }
+
+        // Totals: a single round-trip over (count_all_threads,
+        // count_unread_threads) for the same user.
+        let mut totals_rows = self
+            .query(
+                "SELECT \
+                   COUNT(*) AS total, \
+                   COALESCE(SUM(CASE WHEN unread > 0 THEN 1 ELSE 0 END), 0) AS unread_threads \
+                 FROM inbox_entries \
+                 WHERE user_jid = ? AND thread_id != ''",
+                crate::db_params![user_jid.to_string()],
+            )
+            .await?;
+        let (total, unread_threads) = if let Some(row) = totals_rows
+            .next()
+            .await
+            .map_err(|error| InboxStorageError::Other(error.to_string()))?
+        {
+            let total: i64 = row
+                .get(0)
+                .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+            let unread_threads: i64 = row
+                .get(1)
+                .map_err(|error| InboxStorageError::Other(error.to_string()))?;
+            (total.max(0) as u64, unread_threads.max(0) as u64)
+        } else {
+            (0, 0)
+        };
+
+        let first_cursor = entries.first().map(Cursor::from_entry);
+        let last_cursor = entries.last().map(Cursor::from_entry);
+        let first_cursor = match first_cursor {
+            Some(c) => Some(c.encode()?),
+            None => None,
+        };
+        let last_cursor = match last_cursor {
+            Some(c) => Some(c.encode()?),
+            None => None,
+        };
+
+        Ok(ThreadsPage {
+            entries,
+            total,
+            unread_threads,
+            first_cursor,
+            last_cursor,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inbox::DatabaseInboxStorage;
+    use waddle_xmpp::inbox::storage::InboxStorage;
+    use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+
+    fn jid(value: &str) -> BareJid {
+        value.parse().expect("valid JID")
+    }
+
+    /// Build a paired (inbox storage, threads storage) backed by the same
+    /// in-memory database. The inbox storage is used to seed rows; the
+    /// threads storage reads via the same `Database` handle.
+    async fn make_storage_pair() -> (DatabaseInboxStorage, DatabaseThreadsStorage) {
+        let inbox = DatabaseInboxStorage::open(Some("sqlite::memory:"))
+            .await
+            .expect("open inbox storage");
+        let threads = DatabaseThreadsStorage::new(inbox.db_handle());
+        (inbox, threads)
+    }
+
+    #[tokio::test]
+    async fn page_returns_only_thread_rows() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        // Seed: channel-level row (no thread) — must NOT appear.
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room1@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s0",
+                    100,
+                ),
+                true,
+            )
+            .await
+            .expect("upsert channel");
+
+        // Seed: thread row in room1
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room1@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s1",
+                    110,
+                )
+                .with_thread("t1"),
+                true,
+            )
+            .await
+            .expect("upsert t1");
+
+        // Seed: thread row in room2
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room2@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s2",
+                    120,
+                )
+                .with_thread("t2"),
+                true,
+            )
+            .await
+            .expect("upsert t2");
+
+        let page = threads.page(&user, 50, None).await.expect("page");
+        assert_eq!(
+            page.entries.len(),
+            2,
+            "expected 2 thread rows, got {page:?}"
+        );
+        assert!(page.entries.iter().all(|e| !e.thread_id.is_empty()));
+        assert_eq!(page.total, 2);
+    }
+
+    #[tokio::test]
+    async fn page_orders_by_last_updated_desc() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "older",
+                    100,
+                )
+                .with_thread("t-old"),
+                true,
+            )
+            .await
+            .expect("upsert older");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "newer",
+                    200,
+                )
+                .with_thread("t-new"),
+                true,
+            )
+            .await
+            .expect("upsert newer");
+
+        let page = threads.page(&user, 50, None).await.expect("page");
+        assert_eq!(page.entries.len(), 2);
+        assert_eq!(page.entries[0].thread_id, "t-new");
+        assert_eq!(page.entries[1].thread_id, "t-old");
+    }
+
+    #[tokio::test]
+    async fn page_paginates_with_cursor() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        for (idx, ts) in [("t-a", 300_i64), ("t-b", 200), ("t-c", 100)] {
+            inbox
+                .upsert(
+                    &user,
+                    InboxEntry::new(
+                        jid("room@muc.example"),
+                        ConversationKind::MucRoom,
+                        format!("s-{idx}"),
+                        ts,
+                    )
+                    .with_thread(idx),
+                    true,
+                )
+                .await
+                .expect("upsert");
+        }
+
+        let first = threads.page(&user, 2, None).await.expect("first page");
+        assert_eq!(first.entries.len(), 2);
+        assert_eq!(first.entries[0].thread_id, "t-a");
+        assert_eq!(first.entries[1].thread_id, "t-b");
+        assert_eq!(first.total, 3);
+        let cursor = first.last_cursor.clone().expect("last_cursor");
+
+        let second = threads
+            .page(&user, 2, Some(&cursor))
+            .await
+            .expect("second page");
+        assert_eq!(second.entries.len(), 1);
+        assert_eq!(second.entries[0].thread_id, "t-c");
+        assert_eq!(second.total, 3);
+    }
+
+    #[tokio::test]
+    async fn page_counts_unread_threads() {
+        let (inbox, threads) = make_storage_pair().await;
+        let user = jid("me@example.com");
+
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s1",
+                    100,
+                )
+                .with_thread("t1"),
+                true,
+            )
+            .await
+            .expect("upsert t1");
+        inbox
+            .upsert(
+                &user,
+                InboxEntry::new(
+                    jid("room@muc.example"),
+                    ConversationKind::MucRoom,
+                    "s2",
+                    200,
+                )
+                .with_thread("t2"),
+                true,
+            )
+            .await
+            .expect("upsert t2");
+        // Mark t2 as read
+        inbox
+            .mark_read(&user, &jid("room@muc.example"), Some("t2"))
+            .await
+            .expect("mark read");
+
+        let page = threads.page(&user, 50, None).await.expect("page");
+        assert_eq!(page.total, 2);
+        assert_eq!(page.unread_threads, 1);
+    }
+}

--- a/server/crates/waddle-server/src/threads/storage.rs
+++ b/server/crates/waddle-server/src/threads/storage.rs
@@ -1,0 +1,2 @@
+//! Storage read for the global threads view. Pulls per-thread rows from
+//! the existing `inbox_entries` table — no schema changes.

--- a/server/crates/waddle-server/src/threads/wire.rs
+++ b/server/crates/waddle-server/src/threads/wire.rs
@@ -1,0 +1,2 @@
+//! XML wire shape for `urn:waddle:threads:0`. Built via `minidom::Element`
+//! so no XML is ever concatenated as strings (CLAUDE.md hard rule).

--- a/server/crates/waddle-server/src/threads/wire.rs
+++ b/server/crates/waddle-server/src/threads/wire.rs
@@ -1,2 +1,241 @@
 //! XML wire shape for `urn:waddle:threads:0`. Built via `minidom::Element`
 //! so no XML is ever concatenated as strings (CLAUDE.md hard rule).
+
+use minidom::Element;
+use xmpp_parsers::iq::{Iq, IqType};
+
+use super::query::{ThreadEntry, ThreadsError, ThreadsPage, ThreadsQuery, NS_THREADS};
+
+/// XEP-0059 Result Set Management namespace.
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+
+/// Parse a `<query xmlns='urn:waddle:threads:0'/>` IQ payload into a
+/// `ThreadsQuery`. The IQ MUST be a `get` for this to succeed.
+pub fn parse_threads_query(iq: &Iq) -> Result<ThreadsQuery, ThreadsError> {
+    let payload = match &iq.payload {
+        IqType::Get(el) => el,
+        _ => return Err(ThreadsError::WrongIqType),
+    };
+    if !payload.is("query", NS_THREADS) {
+        return Err(ThreadsError::ExpectedElement("query"));
+    }
+
+    let mut q = ThreadsQuery::default();
+    if let Some(rsm) = payload.get_child("set", NS_RSM) {
+        if let Some(max_el) = rsm.get_child("max", NS_RSM) {
+            let text = max_el.text();
+            let parsed: u32 = text
+                .trim()
+                .parse()
+                .map_err(|_| ThreadsError::InvalidInteger(text.clone()))?;
+            q.page_size = Some(parsed);
+        }
+        if let Some(after_el) = rsm.get_child("after", NS_RSM) {
+            let text = after_el.text();
+            if !text.is_empty() {
+                q.after_cursor = Some(text);
+            }
+        }
+    }
+    Ok(q)
+}
+
+/// Build the `<threads>` response element for `page`.
+pub fn build_threads_response(page: &ThreadsPage) -> Element {
+    let mut threads = Element::builder("threads", NS_THREADS)
+        .attr("total", page.total.to_string())
+        .attr("unread-threads", page.unread_threads.to_string())
+        .build();
+
+    for entry in &page.entries {
+        threads.append_child(build_thread_entry(entry));
+    }
+
+    let mut set = Element::builder("set", NS_RSM).build();
+    if let Some(ref first) = page.first_cursor {
+        let mut first_el = Element::builder("first", NS_RSM).build();
+        first_el.append_text_node(first);
+        set.append_child(first_el);
+    }
+    if let Some(ref last) = page.last_cursor {
+        let mut last_el = Element::builder("last", NS_RSM).build();
+        last_el.append_text_node(last);
+        set.append_child(last_el);
+    }
+    let mut count_el = Element::builder("count", NS_RSM).build();
+    count_el.append_text_node(page.total.to_string());
+    set.append_child(count_el);
+    threads.append_child(set);
+
+    threads
+}
+
+fn build_thread_entry(entry: &ThreadEntry) -> Element {
+    let last_activity_iso =
+        chrono::DateTime::<chrono::Utc>::from_timestamp(entry.last_activity_secs, 0)
+            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+            .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_string());
+
+    let mut t = Element::builder("thread", NS_THREADS)
+        .attr("channel", entry.channel.to_string())
+        .attr("thread-id", entry.thread_id.clone())
+        .attr("last-stanza-id", entry.last_stanza_id.clone())
+        .attr("last-activity", last_activity_iso)
+        .attr("unread", entry.unread.to_string())
+        .attr("reply-count", entry.reply_count.to_string())
+        .attr(
+            "has-unread",
+            if entry.has_unread() { "true" } else { "false" },
+        )
+        .build();
+
+    if let Some(ref author) = entry.root_author {
+        let mut author_el = Element::builder("root-author", NS_THREADS).build();
+        author_el.append_text_node(author.to_string());
+        t.append_child(author_el);
+    }
+    if let Some(ref preview) = entry.preview {
+        let mut preview_el = Element::builder("preview", NS_THREADS).build();
+        preview_el.append_text_node(preview);
+        t.append_child(preview_el);
+    }
+    if let Some(ref title) = entry.thread_title {
+        let mut title_el = Element::builder("thread-title", NS_THREADS).build();
+        title_el.append_text_node(title);
+        t.append_child(title_el);
+    }
+    t
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xmpp_parsers::iq::Iq;
+
+    fn make_get_iq(payload: Element) -> Iq {
+        Iq {
+            from: None,
+            to: None,
+            id: "test".into(),
+            payload: IqType::Get(payload),
+        }
+    }
+
+    #[test]
+    fn parse_empty_query() {
+        let payload = Element::builder("query", NS_THREADS).build();
+        let iq = make_get_iq(payload);
+        let q = parse_threads_query(&iq).expect("parses");
+        assert_eq!(q.page_size, None);
+        assert_eq!(q.after_cursor, None);
+    }
+
+    #[test]
+    fn parse_query_with_rsm() {
+        let xml = "<query xmlns='urn:waddle:threads:0'>\
+                     <set xmlns='http://jabber.org/protocol/rsm'>\
+                       <max>25</max>\
+                       <after>CURSOR-1</after>\
+                     </set>\
+                   </query>";
+        let payload: Element = xml.parse().expect("valid XML");
+        let iq = make_get_iq(payload);
+        let q = parse_threads_query(&iq).expect("parses");
+        assert_eq!(q.page_size, Some(25));
+        assert_eq!(q.after_cursor.as_deref(), Some("CURSOR-1"));
+    }
+
+    #[test]
+    fn parse_rejects_non_get_iq() {
+        let payload = Element::builder("query", NS_THREADS).build();
+        let iq = Iq {
+            from: None,
+            to: None,
+            id: "x".into(),
+            payload: IqType::Set(payload),
+        };
+        assert!(matches!(
+            parse_threads_query(&iq),
+            Err(ThreadsError::WrongIqType)
+        ));
+    }
+
+    #[test]
+    fn build_empty_page() {
+        let page = ThreadsPage::default();
+        let elem = build_threads_response(&page);
+        assert_eq!(elem.name(), "threads");
+        assert_eq!(elem.ns(), NS_THREADS);
+        assert_eq!(elem.attr("total"), Some("0"));
+        assert_eq!(elem.attr("unread-threads"), Some("0"));
+        assert!(elem
+            .children()
+            .any(|c| c.name() == "set" && c.ns() == NS_RSM));
+    }
+
+    #[test]
+    fn build_single_entry_round_trip() {
+        let entry = ThreadEntry {
+            channel: "room@conference.example".parse().expect("valid bare JID"),
+            thread_id: "t-1".into(),
+            last_stanza_id: "S-1".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 2,
+            reply_count: 5,
+            root_author: Some("juliet@example.com".parse().expect("valid bare JID")),
+            preview: Some("Anyone reviewed the doc?".into()),
+            thread_title: Some("Q3 planning".into()),
+        };
+        let page = ThreadsPage {
+            entries: vec![entry.clone()],
+            total: 1,
+            unread_threads: 1,
+            first_cursor: Some("F".into()),
+            last_cursor: Some("L".into()),
+        };
+        let elem = build_threads_response(&page);
+
+        let thread_el = elem
+            .children()
+            .find(|c| c.name() == "thread")
+            .expect("has thread");
+        assert_eq!(thread_el.attr("channel"), Some("room@conference.example"));
+        assert_eq!(thread_el.attr("thread-id"), Some("t-1"));
+        assert_eq!(thread_el.attr("unread"), Some("2"));
+        assert_eq!(thread_el.attr("has-unread"), Some("true"));
+        assert_eq!(
+            thread_el
+                .get_child("root-author", NS_THREADS)
+                .map(|e| e.text()),
+            Some("juliet@example.com".into())
+        );
+    }
+
+    #[test]
+    fn has_unread_flag_is_false_when_unread_is_zero() {
+        let entry = ThreadEntry {
+            channel: "room@conference.example".parse().expect("valid bare JID"),
+            thread_id: "t-1".into(),
+            last_stanza_id: "S-1".into(),
+            last_activity_secs: 1_700_000_000,
+            unread: 0,
+            reply_count: 1,
+            root_author: None,
+            preview: None,
+            thread_title: None,
+        };
+        let page = ThreadsPage {
+            entries: vec![entry],
+            total: 1,
+            unread_threads: 0,
+            first_cursor: None,
+            last_cursor: None,
+        };
+        let elem = build_threads_response(&page);
+        let thread_el = elem
+            .children()
+            .find(|c| c.name() == "thread")
+            .expect("has thread");
+        assert_eq!(thread_el.attr("has-unread"), Some("false"));
+    }
+}

--- a/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
@@ -1,0 +1,392 @@
+//! Integration tests for the `urn:waddle:threads:0` IQ over the
+//! WebSocket transport.
+//!
+//! Spec: `docs/superpowers/specs/2026-05-17-threads-design.md`.
+//! Plan: `docs/superpowers/plans/2026-05-17-threads-implementation.md` Task 5.
+
+mod ws_common;
+
+use std::str::FromStr;
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+const CLIENT_NS: &str = "jabber:client";
+const NS_THREADS: &str = "urn:waddle:threads:0";
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+const STANZA_ERROR_NS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
+    let password = server.fixed_account_password().to_string();
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, USERNAME, &password, resource)
+        .await
+        .expect("connect")
+}
+
+async fn extra_client(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource: &str,
+) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, resource)
+        .await
+        .expect("connect extra")
+}
+
+fn threads_query_iq(id: &str, page_size: Option<u32>, after: Option<&str>) -> String {
+    let mut query = Element::builder("query", NS_THREADS).build();
+    if page_size.is_some() || after.is_some() {
+        let mut set = Element::builder("set", NS_RSM).build();
+        if let Some(max) = page_size {
+            let mut max_el = Element::builder("max", NS_RSM).build();
+            max_el.append_text_node(max.to_string());
+            set.append_child(max_el);
+        }
+        if let Some(cursor) = after {
+            let mut after_el = Element::builder("after", NS_RSM).build();
+            after_el.append_text_node(cursor);
+            set.append_child(after_el);
+        }
+        query.append_child(set);
+    }
+    let iq = Element::builder("iq", CLIENT_NS)
+        .attr("type", "get")
+        .attr("id", id)
+        .append(query)
+        .build();
+    element_to_xml(iq)
+}
+
+fn threads_query_iq_to(id: &str, to: &str) -> String {
+    let query = Element::builder("query", NS_THREADS).build();
+    let iq = Element::builder("iq", CLIENT_NS)
+        .attr("type", "get")
+        .attr("id", id)
+        .attr("to", to)
+        .append(query)
+        .build();
+    element_to_xml(iq)
+}
+
+fn element_to_xml(element: Element) -> String {
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize XML");
+    String::from_utf8(buf).expect("UTF-8")
+}
+
+async fn send_iq(client: &mut WsXmppClient, frame: String, id: &str) -> String {
+    client.send(&frame).await.expect("send iq");
+    client
+        .recv_matching(|candidate| candidate.contains(id) && candidate.contains("<iq"))
+        .await
+        .expect("iq response")
+}
+
+async fn join_room(client: &mut WsXmppClient, room: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+fn parse_iq_element(xml: &str, id: &str, iq_type: &str) -> Element {
+    let element = Element::from_str(xml).expect("valid XML response");
+    assert_eq!(element.name(), "iq");
+    assert_eq!(element.attr("id"), Some(id));
+    assert_eq!(
+        element.attr("type"),
+        Some(iq_type),
+        "unexpected iq type in response: {xml}"
+    );
+    element
+}
+
+fn assert_threads_attrs(element: &Element, total: u64, unread_threads: u64) {
+    let threads = element
+        .children()
+        .find(|child| child.name() == "threads" && child.ns() == NS_THREADS)
+        .expect("threads element");
+    assert_eq!(
+        threads.attr("total"),
+        Some(total.to_string().as_str()),
+        "unexpected total: {element:?}"
+    );
+    assert_eq!(
+        threads.attr("unread-threads"),
+        Some(unread_threads.to_string().as_str()),
+        "unexpected unread-threads: {element:?}"
+    );
+}
+
+fn thread_children(element: &Element) -> Vec<&Element> {
+    element
+        .children()
+        .find(|c| c.name() == "threads" && c.ns() == NS_THREADS)
+        .map(|threads| {
+            threads
+                .children()
+                .filter(|c| c.name() == "thread" && c.ns() == NS_THREADS)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn assert_error_condition(xml: &str, condition: &str) {
+    let element = Element::from_str(xml).expect("valid XML");
+    assert_eq!(element.attr("type"), Some("error"), "expected error: {xml}");
+    let error = element
+        .children()
+        .find(|child| child.name() == "error")
+        .expect("error element");
+    assert!(
+        error
+            .children()
+            .any(|child| child.name() == condition && child.ns() == STANZA_ERROR_NS),
+        "expected <{condition}/> in error: {xml}"
+    );
+}
+
+/// Drive a single MUC message with a thread anchor to make the server
+/// project a thread row into the bound user's inbox.
+async fn send_threaded_message(
+    client: &mut WsXmppClient,
+    room: &str,
+    thread_id: &str,
+    body: &str,
+    msg_id: &str,
+) {
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="{msg_id}"><body>{body}</body><thread>{thread_id}</thread></message>"#
+        ))
+        .await
+        .expect("send threaded message");
+    // Wait for the echo so the projection has surely run.
+    client
+        .recv_matching(|frame| frame.contains(body) && frame.contains(thread_id))
+        .await
+        .expect("echoed threaded message");
+}
+
+#[tokio::test]
+async fn fresh_account_returns_empty_page() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-empty").await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-empty-1", None, None),
+        "th-empty-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-empty-1", "result");
+    assert_threads_attrs(&iq, 0, 0);
+    assert!(thread_children(&iq).is_empty());
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn populated_inbox_returns_thread_entries() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-pop").await;
+    let room = format!("threads-pop-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    send_threaded_message(&mut client, &room, "t-one", "first reply", "tm-1").await;
+    send_threaded_message(&mut client, &room, "t-one", "second reply", "tm-2").await;
+    send_threaded_message(&mut client, &room, "t-two", "another thread", "tm-3").await;
+
+    // Give the inbox projection a beat to settle.
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-pop-1", None, None),
+        "th-pop-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-pop-1", "result");
+    let entries = thread_children(&iq);
+    assert!(
+        entries.len() >= 2,
+        "expected at least 2 thread entries, got {}: {iq:?}",
+        entries.len()
+    );
+    let thread_ids: Vec<&str> = entries
+        .iter()
+        .filter_map(|el| el.attr("thread-id"))
+        .collect();
+    assert!(
+        thread_ids.contains(&"t-one"),
+        "missing thread t-one: {thread_ids:?}"
+    );
+    assert!(
+        thread_ids.contains(&"t-two"),
+        "missing thread t-two: {thread_ids:?}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn pagination_round_trips_cursor() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-page").await;
+    let room = format!("threads-page-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    for (idx, label) in ["alpha", "bravo", "charlie"].iter().enumerate() {
+        send_threaded_message(
+            &mut client,
+            &room,
+            &format!("t-{label}"),
+            &format!("entry {label}"),
+            &format!("tm-page-{idx}"),
+        )
+        .await;
+    }
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let first = send_iq(
+        &mut client,
+        threads_query_iq("th-page-1", Some(2), None),
+        "th-page-1",
+    )
+    .await;
+    let first_iq = parse_iq_element(&first, "th-page-1", "result");
+    let first_entries = thread_children(&first_iq);
+    assert_eq!(
+        first_entries.len(),
+        2,
+        "page should return 2 entries: {first_iq:?}"
+    );
+
+    let threads_el = first_iq
+        .children()
+        .find(|c| c.name() == "threads" && c.ns() == NS_THREADS)
+        .expect("threads");
+    let rsm_set = threads_el
+        .children()
+        .find(|c| c.name() == "set" && c.ns() == NS_RSM)
+        .expect("rsm set");
+    let last_cursor = rsm_set
+        .children()
+        .find(|c| c.name() == "last" && c.ns() == NS_RSM)
+        .map(|el| el.text())
+        .expect("last cursor");
+    assert!(!last_cursor.is_empty(), "last cursor must be non-empty");
+
+    let second = send_iq(
+        &mut client,
+        threads_query_iq("th-page-2", Some(2), Some(&last_cursor)),
+        "th-page-2",
+    )
+    .await;
+    let second_iq = parse_iq_element(&second, "th-page-2", "result");
+    let second_entries = thread_children(&second_iq);
+    assert_eq!(
+        second_entries.len(),
+        1,
+        "second page should return 1 entry: {second_iq:?}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn acl_refuses_cross_user_query() {
+    let _guard = TEST_SERIAL.lock().await;
+    let bob_password = format!("ws-test-bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("bob", bob_password.as_str())]);
+    let mut bob = extra_client(&server, "bob", &bob_password, "th-acl-bob").await;
+
+    let resp = send_iq(
+        &mut bob,
+        threads_query_iq_to("th-acl-1", &format!("{USERNAME}@{DOMAIN}")),
+        "th-acl-1",
+    )
+    .await;
+    assert_error_condition(&resp, "forbidden");
+
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn has_unread_attribute_present_on_each_entry() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-hasunread").await;
+    let room = format!("threads-hu-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    send_threaded_message(&mut client, &room, "t-x", "hello", "tm-x").await;
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-hu-1", None, None),
+        "th-hu-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-hu-1", "result");
+    let entries = thread_children(&iq);
+    assert!(
+        !entries.is_empty(),
+        "expected at least one thread entry: {iq:?}"
+    );
+    for entry in entries {
+        let has_unread = entry.attr("has-unread");
+        assert!(
+            matches!(has_unread, Some("true") | Some("false")),
+            "<thread> must have explicit has-unread attribute: {entry:?}"
+        );
+    }
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn response_includes_rsm_set_with_count() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-rsm").await;
+
+    let resp = send_iq(
+        &mut client,
+        threads_query_iq("th-rsm-1", None, None),
+        "th-rsm-1",
+    )
+    .await;
+    let iq = parse_iq_element(&resp, "th-rsm-1", "result");
+    let threads = iq
+        .children()
+        .find(|c| c.name() == "threads" && c.ns() == NS_THREADS)
+        .expect("threads element");
+    let rsm = threads
+        .children()
+        .find(|c| c.name() == "set" && c.ns() == NS_RSM)
+        .expect("rsm set");
+    let count = rsm
+        .children()
+        .find(|c| c.name() == "count" && c.ns() == NS_RSM)
+        .map(|el| el.text())
+        .expect("rsm count");
+    assert_eq!(count, "0");
+
+    let _ = client.close().await;
+}

--- a/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_threads_query_ws.rs
@@ -361,6 +361,39 @@ async fn has_unread_attribute_present_on_each_entry() {
 }
 
 #[tokio::test]
+async fn disco_info_on_self_advertises_threads_query_feature() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut client = admin_client(&server, "th-disco").await;
+    let self_bare = format!("{USERNAME}@{DOMAIN}");
+
+    let disco_payload = Element::builder("query", "http://jabber.org/protocol/disco#info").build();
+    let iq = Element::builder("iq", CLIENT_NS)
+        .attr("type", "get")
+        .attr("id", "th-disco-1")
+        .attr("to", &self_bare)
+        .append(disco_payload)
+        .build();
+    let resp = send_iq(&mut client, element_to_xml(iq), "th-disco-1").await;
+    let iq = parse_iq_element(&resp, "th-disco-1", "result");
+    let query = iq
+        .children()
+        .find(|c| c.name() == "query" && c.ns() == "http://jabber.org/protocol/disco#info")
+        .expect("disco#info query");
+    let features: Vec<&str> = query
+        .children()
+        .filter(|c| c.name() == "feature")
+        .filter_map(|c| c.attr("var"))
+        .collect();
+    assert!(
+        features.contains(&"urn:waddle:threads:0"),
+        "disco#info on self must advertise urn:waddle:threads:0: features={features:?}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
 async fn response_includes_rsm_set_with_count() {
     let _guard = TEST_SERIAL.lock().await;
     let server = TestServer::start();

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -144,6 +144,48 @@ impl WaddleClient {
         })
     }
 
+    /// Fetch the global threads view (`urn:waddle:threads:0`).
+    /// Returns a `WaddleThreadsPage` (empty page on transport failure).
+    pub fn fetch_threads(&self, opts: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let opts: WaddleFetchThreadsOptions = if opts.is_null() || opts.is_undefined() {
+                WaddleFetchThreadsOptions::default()
+            } else {
+                serde_wasm_bindgen::from_value(opts).map_err(|err| js_error(err.to_string()))?
+            };
+            let request_id = uuid::Uuid::new_v4().to_string();
+            let iq =
+                build_fetch_threads_iq(&request_id, opts.page_size, opts.after_cursor.as_deref());
+            let page = match send_iq_command(inner, iq).await {
+                Ok(result) => parse_threads_response(&result).unwrap_or_default(),
+                Err(_) => Default::default(),
+            };
+            let payload = WaddleThreadsPage {
+                total: page.total,
+                unread_threads: page.unread_threads,
+                entries: page
+                    .entries
+                    .into_iter()
+                    .map(|e| WaddleThreadEntry {
+                        channel: e.channel,
+                        thread_id: e.thread_id,
+                        last_stanza_id: e.last_stanza_id,
+                        last_activity: e.last_activity,
+                        unread: e.unread,
+                        reply_count: e.reply_count,
+                        has_unread: e.has_unread,
+                        root_author: e.root_author,
+                        preview: e.preview,
+                        thread_title: e.thread_title,
+                    })
+                    .collect(),
+                next_cursor: page.next_cursor,
+            };
+            to_js_value(&payload)
+        })
+    }
+
     pub fn mark_inbox_read(&self, partner_jid: String, thread_id: Option<String>) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -44,6 +44,7 @@ use waddle_xmpp_client::transport::{
 use waddle_xmpp_client::xep::{
     reply::{FallbackRange, ReplyMarker},
     thread::ThreadRef,
+    threads::{build_fetch_threads_iq, parse_threads_response},
     xep0292::{build_fetch_vcard4_iq, build_publish_vcard4_iq, parse_pep_vcard4, VCard4},
 };
 use waddle_xmpp_client::{

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -568,3 +568,41 @@ pub struct WaddleSendOptions {
     pub markup_spans: Vec<WaddleMarkupSpanInput>,
     pub references: Vec<WaddleReference>,
 }
+
+/// XEP-style payload for one entry in a urn:waddle:threads:0 response,
+/// shaped for JS consumption.
+#[derive(Debug, Clone, Serialize)]
+pub struct WaddleThreadEntry {
+    pub channel: String,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    /// RFC 3339 timestamp.
+    pub last_activity: String,
+    pub unread: u32,
+    pub reply_count: u32,
+    pub has_unread: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_title: Option<String>,
+}
+
+/// Paged response to a urn:waddle:threads:0 query, shaped for JS.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct WaddleThreadsPage {
+    pub total: u64,
+    pub unread_threads: u64,
+    pub entries: Vec<WaddleThreadEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// Options bag for `fetch_threads`. All fields optional.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct WaddleFetchThreadsOptions {
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}

--- a/server/crates/waddle-xmpp-client/src/xep/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/mod.rs
@@ -9,4 +9,5 @@ pub mod encrypted_file;
 pub mod fallback;
 pub mod reply;
 pub mod thread;
+pub mod threads;
 pub mod xep0292;

--- a/server/crates/waddle-xmpp-client/src/xep/threads.rs
+++ b/server/crates/waddle-xmpp-client/src/xep/threads.rs
@@ -1,0 +1,193 @@
+//! Client-side typed value + IQ builder/parser for `urn:waddle:threads:0`.
+//!
+//! Mirrors the wire shape defined by the server in
+//! `waddle-server/src/threads/wire.rs`. The chat client uses the IQ
+//! builder/parser to drive the global Threads view.
+
+use minidom::Element;
+
+/// Namespace for the threads-view query and response.
+pub const NS_THREADS: &str = "urn:waddle:threads:0";
+
+const NS_CLIENT: &str = "jabber:client";
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
+
+/// One entry in a `<threads>` response.
+///
+/// All timestamps are RFC 3339 strings (timezone-safe across the
+/// wasm boundary). The server's typed value uses `i64` seconds; the
+/// conversion happens in the server's `build_thread_entry`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ThreadEntry {
+    pub channel: String,
+    pub thread_id: String,
+    pub last_stanza_id: String,
+    pub last_activity: String,
+    pub unread: u32,
+    pub reply_count: u32,
+    pub has_unread: bool,
+    pub root_author: Option<String>,
+    pub preview: Option<String>,
+    pub thread_title: Option<String>,
+}
+
+/// Full response payload.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThreadsPage {
+    pub total: u64,
+    pub unread_threads: u64,
+    pub entries: Vec<ThreadEntry>,
+    /// Opaque RSM `<last>` cursor — pass to the next request to
+    /// continue paginating.
+    pub next_cursor: Option<String>,
+}
+
+/// Build a `<iq type='get'>` requesting the user's threads.
+pub fn build_fetch_threads_iq(
+    request_id: &str,
+    page_size: Option<u32>,
+    after_cursor: Option<&str>,
+) -> Element {
+    let mut query = Element::builder("query", NS_THREADS).build();
+    if page_size.is_some() || after_cursor.is_some() {
+        let mut set = Element::builder("set", NS_RSM).build();
+        if let Some(max) = page_size {
+            let mut max_el = Element::builder("max", NS_RSM).build();
+            max_el.append_text_node(max.to_string());
+            set.append_child(max_el);
+        }
+        if let Some(after) = after_cursor {
+            let mut after_el = Element::builder("after", NS_RSM).build();
+            after_el.append_text_node(after);
+            set.append_child(after_el);
+        }
+        query.append_child(set);
+    }
+
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("id", request_id)
+        .append(query)
+        .build()
+}
+
+/// Parse the `<iq type='result'>` response into a typed `ThreadsPage`.
+/// Returns `None` when the IQ does not carry a `<threads xmlns='urn:waddle:threads:0'/>`.
+pub fn parse_threads_response(iq: &Element) -> Option<ThreadsPage> {
+    let threads = iq.get_child("threads", NS_THREADS)?;
+    let total: u64 = threads
+        .attr("total")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let unread_threads: u64 = threads
+        .attr("unread-threads")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
+    let entries: Vec<ThreadEntry> = threads
+        .children()
+        .filter(|c| c.name() == "thread" && c.ns() == NS_THREADS)
+        .map(|t| ThreadEntry {
+            channel: t.attr("channel").unwrap_or("").to_string(),
+            thread_id: t.attr("thread-id").unwrap_or("").to_string(),
+            last_stanza_id: t.attr("last-stanza-id").unwrap_or("").to_string(),
+            last_activity: t.attr("last-activity").unwrap_or("").to_string(),
+            unread: t.attr("unread").and_then(|s| s.parse().ok()).unwrap_or(0),
+            reply_count: t
+                .attr("reply-count")
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(0),
+            has_unread: t.attr("has-unread") == Some("true"),
+            root_author: t
+                .get_child("root-author", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+            preview: t
+                .get_child("preview", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+            thread_title: t
+                .get_child("thread-title", NS_THREADS)
+                .map(|e| e.text())
+                .filter(|s| !s.is_empty()),
+        })
+        .collect();
+
+    let next_cursor = threads
+        .get_child("set", NS_RSM)
+        .and_then(|s| s.get_child("last", NS_RSM))
+        .map(|e| e.text())
+        .filter(|s| !s.is_empty());
+
+    Some(ThreadsPage {
+        total,
+        unread_threads,
+        entries,
+        next_cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_iq_has_correct_namespace_and_type() {
+        let iq = build_fetch_threads_iq("r-1", Some(25), Some("CUR"));
+        assert_eq!(iq.attr("type"), Some("get"));
+        assert_eq!(iq.attr("id"), Some("r-1"));
+        let query = iq.get_child("query", NS_THREADS).expect("query");
+        let set = query.get_child("set", NS_RSM).expect("rsm set");
+        assert_eq!(
+            set.get_child("max", NS_RSM).map(|e| e.text()),
+            Some("25".into())
+        );
+        assert_eq!(
+            set.get_child("after", NS_RSM).map(|e| e.text()),
+            Some("CUR".into())
+        );
+    }
+
+    #[test]
+    fn fetch_iq_without_pagination_omits_set() {
+        let iq = build_fetch_threads_iq("r-2", None, None);
+        let query = iq.get_child("query", NS_THREADS).expect("query");
+        assert!(query.get_child("set", NS_RSM).is_none());
+    }
+
+    #[test]
+    fn parse_extracts_entries_and_cursor() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'>\
+                     <threads xmlns='urn:waddle:threads:0' total='2' unread-threads='1'>\
+                       <thread channel='room@x' thread-id='t1' \
+                               last-stanza-id='S1' last-activity='2026-01-01T00:00:00Z' \
+                               unread='2' reply-count='5' has-unread='true'>\
+                         <preview>hi</preview>\
+                       </thread>\
+                       <thread channel='room@x' thread-id='t2' \
+                               last-stanza-id='S2' last-activity='2025-12-31T00:00:00Z' \
+                               unread='0' reply-count='3' has-unread='false'/>\
+                       <set xmlns='http://jabber.org/protocol/rsm'>\
+                         <last>LAST-CUR</last><count>2</count>\
+                       </set>\
+                     </threads>\
+                   </iq>";
+        let iq: Element = xml.parse().expect("valid XML");
+        let page = parse_threads_response(&iq).expect("parses");
+        assert_eq!(page.total, 2);
+        assert_eq!(page.unread_threads, 1);
+        assert_eq!(page.entries.len(), 2);
+        assert_eq!(page.entries[0].thread_id, "t1");
+        assert!(page.entries[0].has_unread);
+        assert_eq!(page.entries[0].preview.as_deref(), Some("hi"));
+        assert!(!page.entries[1].has_unread);
+        assert_eq!(page.next_cursor.as_deref(), Some("LAST-CUR"));
+    }
+
+    #[test]
+    fn parse_returns_none_when_threads_missing() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='r'/>";
+        let iq: Element = xml.parse().expect("valid XML");
+        assert!(parse_threads_response(&iq).is_none());
+    }
+}

--- a/server/crates/waddle-xmpp-core/src/disco/info/features.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/features.rs
@@ -43,6 +43,13 @@ impl Feature {
         Self::new("urn:xmpp:reply:0")
     }
 
+    /// Waddle's global threads view query (`urn:waddle:threads:0`).
+    /// Named `threads_query` rather than `threads` to avoid colliding
+    /// with the deprecated `urn:xmpp:threads:0` namespace.
+    pub fn threads_query() -> Self {
+        Self::new("urn:waddle:threads:0")
+    }
+
     pub fn stanza_ids() -> Self {
         Self::new("urn:xmpp:sid:0")
     }

--- a/server/crates/waddle-xmpp/src/inbox/storage.rs
+++ b/server/crates/waddle-xmpp/src/inbox/storage.rs
@@ -32,6 +32,25 @@ pub trait InboxStorage: Send + Sync {
         room: &BareJid,
     ) -> Result<Vec<InboxEntry>, InboxStorageError>;
 
+    /// Fetch every thread-level inbox entry for `user` across all rooms,
+    /// newest first. Used by the global `urn:waddle:threads:0` view.
+    ///
+    /// Default implementation walks `list` over the user's channel
+    /// conversations and aggregates `list_threads` per room — backends
+    /// SHOULD override with a single-query implementation when one is
+    /// available (the SQL backend does).
+    async fn list_all_threads(&self, user: &BareJid) -> Result<Vec<InboxEntry>, InboxStorageError> {
+        let channels = self.list(user).await?;
+        let mut all = Vec::new();
+        for channel in &channels {
+            let partner = channel.partner.clone();
+            let threads = self.list_threads(user, &partner).await?;
+            all.extend(threads);
+        }
+        all.sort_by_key(|entry| std::cmp::Reverse(entry.last_updated));
+        Ok(all)
+    }
+
     /// Upsert an entry, incrementing unread unless `increment_unread` is
     /// false. Returns the post-upsert state of the entry.
     async fn upsert(

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -65,6 +65,11 @@ export class WaddleClient {
      * here as a rejected Promise.
      */
     fetch_room_pins(room_jid: string): Promise<any>;
+    /**
+     * Fetch the global threads view (`urn:waddle:threads:0`).
+     * Returns a `WaddleThreadsPage` (empty page on transport failure).
+     */
+    fetch_threads(opts: any): Promise<any>;
     fetch_user_pep_profile(jid: string): Promise<any>;
     fetch_vcard4(jid: string): Promise<any>;
     get_resume_state(): any;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -5,7 +5,7 @@ export class WaddleClient {
     free(): void;
     [Symbol.dispose](): void;
     /**
-     * Call the `urn:xmpp:waddle:admin:users:list:0` ad-hoc command
+     * Call the `urn:waddle:admin:users:list:0` ad-hoc command
      * against the user-bearing server domain and return a typed
      * page of matching users. Errors out (rejecting the returned
      * Promise) if the server replies with a stanza error — the

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp9zbflr";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp9zbflr";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp9zbflr";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpa0bmkd";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp9zbflr";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpa0bmkd";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpa1h96u";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mpa0bmkd";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";


### PR DESCRIPTION
## Summary

Add a **global Threads view** backed by a new `urn:waddle:threads:0` IQ query. Users get a single global pane that lists every thread they have unread in or have participated in, across all channels and DMs, partitioned client-side into **Unread** (pinned top) and **Following** (below).

Full design: `docs/superpowers/specs/2026-05-17-threads-design.md`. Implementation plan: `docs/superpowers/plans/2026-05-17-threads-implementation.md`. The spec is the contract; the plan is the build sequence.

## What landed

### Server (Rust)

- `urn:waddle:threads:0` IQ query module (`server/crates/waddle-server/src/threads/`).
- Typed `ThreadsQuery` / `ThreadsPage` / `ThreadEntry` values; no string-blobs at any boundary.
- XML wire built exclusively via `minidom::Element` (no `format!`).
- `InboxStorage::list_all_threads` trait method (SQL backend overrides with a single query; in-memory backend gets a default impl) so the threads view shares the inbox backend without schema duplication.
- IQ handler dispatched alongside the inbox handler; ACL refuses cross-user queries with `<forbidden/>`.
- Disco advert: `urn:waddle:threads:0` on the user's bare-JID self-disco.
- WebSocket integration suite (`waddle_threads_query_ws.rs`): empty result, populated MUC + thread fanout, RSM pagination cursor round-trip, ACL forbidden, has-unread attribute on every entry, RSM `<set><count/>` always present, disco-info advert assertion. 7 cases.
- Lib-level unit tests on the wire builders, storage, and handler: 18 cases across 4 modules.

### Client crates

- `waddle-xmpp-client::xep::threads`: `ThreadEntry`, `ThreadsPage`, `build_fetch_threads_iq`, `parse_threads_response` + 4 unit tests.
- `waddle-xmpp-client-wasm`: `WaddleThreadEntry` / `WaddleThreadsPage` / `WaddleFetchThreadsOptions` + `WaddleClient::fetch_threads` wasm method. Regenerated wasm-pkg bindings included.

### Chat (TypeScript / Vue)

- `wasm-types.ts`: `WasmThreadEntry`, `WasmThreadsPage`, `WasmFetchThreadsOptions`.
- `BrowserXmppClient.fetchThreads({ pageSize, afterCursor })` wrapper.
- `ThreadsListPanel.vue` (two-section layout: Unread / Following) + `ThreadsListRow.vue`.
- New SPA route `/threads` (`page: "threads"` in the route state) mounted via `ThreadsView.vue` inside the existing `ChatReadyShell`.
- Sidebar nav entry at the top of `TopicsPanel.vue`, peer to Feed / Stories / Events. `controller.openThreads()` pushes `/threads`.
- 5 panel-logic unit tests (`threads-list-panel.test.ts`).

### Docs

- `docs/xep-conformance-audit.md`: added a `(Waddle) Threads view` row for `urn:waddle:threads:0`; corrected the XEP-0430 row to reflect the actual implemented namespaces (`urn:waddle:inbox:0` + ESL compat) and flipped its status to `gap` because the prior row mislabelled it.

## Known follow-ups (intentional V1 carry)

- **Live thread-delta updates** — the inbox-projection event path doesn't yet emit a typed thread-delta envelope into the wasm boundary, so the Threads view does not auto-refresh when a peer replies in a thread the user follows. V1 refetches on mount and on navigation back to `/threads`. Spec acknowledges this as a follow-up. The plan task 11 step 2 explicitly allows leaving it as a TODO.
- **Threads sidebar unread badge** — the prop interface accepts `threadsUnreadCount`, but no host wires a value to it in this PR. The badge stays hidden until V2 plumbs a periodic refetch or hooks the inbox-write event stream.
- **Click → thread reader** — `ThreadsView.openThread` navigates to `/r/<channel>#thread=<id>`. The hash isn't yet consumed by the channel page to auto-open the thread; the user lands on the room and re-opens the thread by clicking the reply chip. V2 fix.

## Spec / plan adherence

- Wire shape conforms exactly to the spec (channel, thread-id, last-stanza-id, last-activity RFC3339, unread, reply-count, has-unread, root-author, preview, thread-title; RSM with `<set><first/><last/><count/>`).
- ACL matches the spec: bare-JID match on the requesting full JID against the addressed JID, `<forbidden/>` otherwise.
- Disco-advertised on the user-server.
- One spec/plan note: the original spec section "Inbox namespace cleanup" was **dropped during plan recon** (the spec itself was revised in `04a27301`), because the Waddle inbox uses `urn:waddle:inbox:0`, not `urn:xmpp:inbox:0` — no XEP-namespace violation. This PR carries only the audit-doc correction for that row, not a code change.

## Test plan

- [x] `cargo test --workspace` green — confirmed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean — confirmed.
- [x] `cargo fmt --check` clean — confirmed.
- [x] `cd chat && bun test` — 832/833 pass (the one failure, `startup loading fallback > build output includes the static shell`, is pre-existing on origin/main).
- [x] `cd chat && bunx knip` clean — confirmed.
- [ ] Manual smoke: load `/threads` in a fresh deploy and verify the empty state copy, then send a threaded MUC message and verify the entry surfaces.

This PR was created with the assistance of a LLM.