### PR TITLE
fix(server): enforce exact DM push sender policy

### DIFF
--- a/server/crates/waddle-server/src/db/blocking.rs
+++ b/server/crates/waddle-server/src/db/blocking.rs
@@ -4,7 +4,7 @@
 //! persistent storage.
 
 use crate::db::IntoParams;
-use jid::BareJid;
+use jid::{BareJid, Jid};
 use tracing::{debug, instrument};
 
 use super::Database;
@@ -90,6 +90,35 @@ impl DatabaseBlockingStorage {
             }
         }
         debug!(count = entries.len(), "Loaded typed blocklist");
+        Ok(entries)
+    }
+
+    /// Get all blocked JIDs for a user as their stored XEP-0191 JID form.
+    ///
+    /// This preserves full-JID and domain-JID entries for policy checks that
+    /// must honor the complete XEP-0191 matching surface. Malformed legacy rows
+    /// are skipped with the same warning policy as [`Self::list_blocked_jids`].
+    #[instrument(skip(self), fields(user = %user_jid))]
+    pub async fn list_blocked_jid_entries(
+        &self,
+        user_jid: &BareJid,
+    ) -> Result<Vec<Jid>, BlockingStorageError> {
+        let raw = self.get_blocklist(user_jid).await?;
+        let mut entries = Vec::with_capacity(raw.len());
+        for blocked in raw {
+            match blocked.parse::<Jid>() {
+                Ok(jid) => entries.push(jid),
+                Err(error) => {
+                    tracing::warn!(
+                        user = %user_jid,
+                        blocked = %blocked,
+                        %error,
+                        "Skipping malformed blocklist row"
+                    );
+                }
+            }
+        }
+        debug!(count = entries.len(), "Loaded typed blocklist entries");
         Ok(entries)
     }
 
@@ -248,6 +277,15 @@ impl waddle_xmpp::xep::xep0191::BlockingStorage for DatabaseBlockingStorage {
             .await
             .map_err(waddle_xmpp::xep::xep0191::BlockingStorageError::new)
     }
+
+    async fn list_blocked_jid_entries(
+        &self,
+        user: &BareJid,
+    ) -> Result<Vec<Jid>, waddle_xmpp::xep::xep0191::BlockingStorageError> {
+        Self::list_blocked_jid_entries(self, user)
+            .await
+            .map_err(waddle_xmpp::xep::xep0191::BlockingStorageError::new)
+    }
 }
 
 #[cfg(test)]
@@ -376,6 +414,26 @@ mod tests {
         assert_eq!(entries.len(), 1);
         let bob: BareJid = "bob@example.com".parse().unwrap();
         assert_eq!(entries[0], bob);
+    }
+
+    #[tokio::test]
+    async fn list_blocked_jid_entries_preserves_full_and_domain_jids() {
+        let db = setup_test_db().await;
+        let storage = DatabaseBlockingStorage::new(db);
+
+        let user_jid: BareJid = "alice@example.com".parse().unwrap();
+        let blocked = vec![
+            "bob@example.com/phone".to_string(),
+            "blocked.example.com".to_string(),
+        ];
+        storage.add_blocks(&user_jid, &blocked).await.unwrap();
+
+        let entries = storage.list_blocked_jid_entries(&user_jid).await.unwrap();
+        let expected: Vec<Jid> = blocked
+            .iter()
+            .map(|entry| entry.parse().expect("valid blocked JID"))
+            .collect();
+        assert_eq!(entries, expected);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -158,7 +158,6 @@ pub struct NotificationCandidate {
     recipient_bare_jid: BareJid,
     conversation_jid: BareJid,
     sender_jid: Jid,
-    sender_jid_exact: bool,
     thread_id: NotificationThreadId,
     archive_stanza_id: StanzaId,
     class: NotificationClass,
@@ -172,20 +171,7 @@ impl NotificationCandidate {
         sender_jid: Jid,
         archive_stanza_id: StanzaId,
     ) -> Result<Self, NotificationOutboxError> {
-        Self::direct_message_with_sender_provenance(
-            recipient_bare_jid,
-            sender_jid,
-            true,
-            archive_stanza_id,
-        )
-    }
-
-    pub fn direct_message_with_sender_provenance(
-        recipient_bare_jid: BareJid,
-        sender_jid: Jid,
-        sender_jid_exact: bool,
-        archive_stanza_id: StanzaId,
-    ) -> Result<Self, NotificationOutboxError> {
+        require_full_sender_jid(&sender_jid)?;
         let expected_by = Jid::from(recipient_bare_jid.clone());
         if archive_stanza_id.by != expected_by {
             return Err(NotificationOutboxError::ArchiveStanzaIdOwnerMismatch {
@@ -197,7 +183,6 @@ impl NotificationCandidate {
             recipient_bare_jid,
             conversation_jid: sender_jid.to_bare(),
             sender_jid,
-            sender_jid_exact,
             thread_id: NotificationThreadId::root(),
             archive_stanza_id,
             class: NotificationClass::DirectMessage,
@@ -216,10 +201,6 @@ impl NotificationCandidate {
 
     pub fn sender_jid(&self) -> &Jid {
         &self.sender_jid
-    }
-
-    pub fn sender_jid_exact(&self) -> bool {
-        self.sender_jid_exact
     }
 
     pub fn thread_id(&self) -> &NotificationThreadId {
@@ -271,7 +252,6 @@ pub struct NotificationOutboxJob {
     conversation_jid: BareJid,
     sender_jid: Jid,
     sender_jids: Vec<Jid>,
-    sender_jids_exact: bool,
     thread_id: NotificationThreadId,
     class: NotificationClass,
     message_count: u32,
@@ -309,10 +289,6 @@ impl NotificationOutboxJob {
 
     pub fn sender_jids(&self) -> &[Jid] {
         &self.sender_jids
-    }
-
-    pub fn sender_jids_exact(&self) -> bool {
-        self.sender_jids_exact
     }
 
     pub fn thread_id(&self) -> &NotificationThreadId {
@@ -424,6 +400,14 @@ pub enum NotificationOutboxError {
     InvalidSenderJid(String),
     #[error("invalid sender JID set in notification outbox: {0}")]
     InvalidSenderJids(String),
+    #[error("notification sender JID must include a resource: {0}")]
+    SenderJidMissingResource(Jid),
+    #[error("notification sender JID set must not be empty")]
+    MissingSenderJidSet,
+    #[error("notification sender JID {sender} does not match conversation JID {conversation}")]
+    SenderConversationMismatch { sender: Jid, conversation: BareJid },
+    #[error("notification sender JID set does not include scalar sender JID {0}")]
+    SenderJidSetMissingScalar(Jid),
     #[error("invalid archive stanza-id by JID in notification candidate: {0}")]
     InvalidArchiveStanzaIdBy(String),
     #[error("invalid stored notification context XML: {0}")]
@@ -432,6 +416,61 @@ pub enum NotificationOutboxError {
     ArchiveStanzaIdOwnerMismatch { expected: Jid, actual: Jid },
     #[error("message count is out of range: {0}")]
     InvalidMessageCount(i64),
+    #[error("notification outbox coalesce contention persisted after retry")]
+    OutboxCoalesceContention,
+}
+
+fn require_full_sender_jid(sender_jid: &Jid) -> Result<(), NotificationOutboxError> {
+    if sender_jid.resource().is_some() {
+        Ok(())
+    } else {
+        Err(NotificationOutboxError::SenderJidMissingResource(
+            sender_jid.clone(),
+        ))
+    }
+}
+
+fn require_full_sender_jid_set(sender_jids: &[Jid]) -> Result<(), NotificationOutboxError> {
+    if sender_jids.is_empty() {
+        return Err(NotificationOutboxError::MissingSenderJidSet);
+    }
+    sender_jids.iter().try_for_each(require_full_sender_jid)
+}
+
+fn require_sender_matches_conversation(
+    sender_jid: &Jid,
+    conversation_jid: &BareJid,
+) -> Result<(), NotificationOutboxError> {
+    if sender_jid.to_bare() == *conversation_jid {
+        Ok(())
+    } else {
+        Err(NotificationOutboxError::SenderConversationMismatch {
+            sender: sender_jid.clone(),
+            conversation: conversation_jid.clone(),
+        })
+    }
+}
+
+fn require_sender_set_matches_conversation(
+    sender_jids: &[Jid],
+    conversation_jid: &BareJid,
+) -> Result<(), NotificationOutboxError> {
+    sender_jids.iter().try_for_each(|sender_jid| {
+        require_sender_matches_conversation(sender_jid, conversation_jid)
+    })
+}
+
+fn require_sender_set_contains_scalar(
+    sender_jids: &[Jid],
+    sender_jid: &Jid,
+) -> Result<(), NotificationOutboxError> {
+    if sender_jids.iter().any(|candidate| candidate == sender_jid) {
+        Ok(())
+    } else {
+        Err(NotificationOutboxError::SenderJidSetMissingScalar(
+            sender_jid.clone(),
+        ))
+    }
 }
 
 #[derive(Clone)]
@@ -455,7 +494,6 @@ impl NotificationOutboxStore {
                     recipient_bare_jid TEXT NOT NULL,
                     conversation_jid TEXT NOT NULL,
                     sender_jid TEXT NOT NULL,
-                    sender_jid_exact INTEGER NOT NULL DEFAULT 1,
                     thread_id TEXT NOT NULL DEFAULT '',
                     stanza_id_by TEXT NOT NULL,
                     stanza_id TEXT NOT NULL,
@@ -472,16 +510,8 @@ impl NotificationOutboxStore {
             (),
         )
         .await?;
-        self.add_column_if_missing(
-            "notification_candidates",
-            "sender_jid TEXT NOT NULL DEFAULT ''",
-        )
-        .await?;
-        self.add_column_if_missing(
-            "notification_candidates",
-            "sender_jid_exact INTEGER NOT NULL DEFAULT 0",
-        )
-        .await?;
+        self.query("SELECT sender_jid FROM notification_candidates LIMIT 0", ())
+            .await?;
         self.add_column_if_missing(
             "notification_candidates",
             "policy_error_count INTEGER NOT NULL DEFAULT 0",
@@ -490,11 +520,6 @@ impl NotificationOutboxStore {
         let candidate_next_attempt_column = format!("next_attempt_at_ms {i64_type}");
         self.add_column_if_missing("notification_candidates", &candidate_next_attempt_column)
             .await?;
-        self.execute(
-            "UPDATE notification_candidates SET sender_jid = conversation_jid WHERE sender_jid = ''",
-            (),
-        )
-        .await?;
         self.execute(
             "CREATE INDEX IF NOT EXISTS idx_notification_candidates_recipient_created \
              ON notification_candidates (recipient_bare_jid, created_at_ms)",
@@ -531,8 +556,7 @@ impl NotificationOutboxStore {
                     node TEXT NOT NULL,
                     conversation_jid TEXT NOT NULL,
                     sender_jid TEXT NOT NULL,
-                    sender_jids TEXT NOT NULL DEFAULT '[]',
-                    sender_jids_exact INTEGER NOT NULL DEFAULT 1,
+                    sender_jids TEXT NOT NULL,
                     thread_id TEXT NOT NULL DEFAULT '',
                     class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
                     message_count INTEGER NOT NULL,
@@ -553,28 +577,16 @@ impl NotificationOutboxStore {
             (),
         )
         .await?;
+        self.query(
+            "SELECT sender_jid, sender_jids FROM notification_outbox LIMIT 0",
+            (),
+        )
+        .await?;
         self.add_column_if_missing("notification_outbox", "claim_token TEXT")
             .await?;
-        self.add_column_if_missing("notification_outbox", "sender_jid TEXT NOT NULL DEFAULT ''")
-            .await?;
-        self.add_column_if_missing(
-            "notification_outbox",
-            "sender_jids TEXT NOT NULL DEFAULT '[]'",
-        )
-        .await?;
-        self.add_column_if_missing(
-            "notification_outbox",
-            "sender_jids_exact INTEGER NOT NULL DEFAULT 0",
-        )
-        .await?;
         self.add_column_if_missing(
             "notification_outbox",
             "policy_error_count INTEGER NOT NULL DEFAULT 0",
-        )
-        .await?;
-        self.execute(
-            "UPDATE notification_outbox SET sender_jid = conversation_jid WHERE sender_jid = ''",
-            (),
         )
         .await?;
         self.execute(
@@ -669,7 +681,6 @@ impl NotificationOutboxStore {
                     recipient_bare_jid,
                     conversation_jid,
                     sender_jid,
-                    sender_jid_exact,
                     thread_id,
                     stanza_id_by,
                     stanza_id,
@@ -679,18 +690,13 @@ impl NotificationOutboxStore {
                     policy_error_count,
                     next_attempt_at_ms,
                     outboxed_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
                 ON CONFLICT DO NOTHING
                 "#,
                 crate::db_params![
                     candidate.recipient_bare_jid.to_string(),
                     candidate.conversation_jid.to_string(),
                     candidate.sender_jid.to_string(),
-                    if candidate.sender_jid_exact {
-                        1_i64
-                    } else {
-                        0_i64
-                    },
                     candidate.thread_id.as_str(),
                     candidate.archive_stanza_id.by.to_string(),
                     candidate.archive_stanza_id.id.clone(),
@@ -820,7 +826,6 @@ impl NotificationOutboxStore {
                 SELECT recipient_bare_jid,
                        conversation_jid,
                        sender_jid,
-                       sender_jid_exact,
                        thread_id,
                        stanza_id_by,
                        stanza_id,
@@ -845,9 +850,62 @@ impl NotificationOutboxStore {
             .await?;
         let mut candidates = Vec::new();
         while let Some(row) = rows.next().await? {
-            candidates.push(decode_candidate(&row)?);
+            match decode_candidate(&row) {
+                Ok(candidate) => candidates.push(candidate),
+                Err(error) => {
+                    self.mark_malformed_candidate_outboxed(&row, &error).await?;
+                }
+            }
         }
         Ok(candidates)
+    }
+
+    async fn mark_malformed_candidate_outboxed(
+        &self,
+        row: &Row,
+        error: &NotificationOutboxError,
+    ) -> Result<(), NotificationOutboxError> {
+        let recipient_raw: String = row.get(0)?;
+        let conversation_raw: String = row.get(1)?;
+        let sender_raw = row
+            .get::<Option<String>>(2)?
+            .unwrap_or_else(|| "<null>".to_string());
+        let thread_id: String = row.get(3)?;
+        let stanza_id_by_raw: String = row.get(4)?;
+        let stanza_id: String = row.get(5)?;
+        let class: String = row.get(6)?;
+        tracing::warn!(
+            recipient = %recipient_raw,
+            conversation = %conversation_raw,
+            sender = %sender_raw,
+            stanza_id = %stanza_id,
+            %error,
+            "dropping malformed XEP-0357 notification candidate fail-closed"
+        );
+        self.execute(
+            r#"
+            UPDATE notification_candidates
+            SET outboxed_at_ms = ?
+            WHERE recipient_bare_jid = ?
+              AND conversation_jid = ?
+              AND thread_id = ?
+              AND stanza_id_by = ?
+              AND stanza_id = ?
+              AND class = ?
+              AND outboxed_at_ms IS NULL
+            "#,
+            crate::db_params![
+                crate::time::now_ms(),
+                recipient_raw,
+                conversation_raw,
+                thread_id,
+                stanza_id_by_raw,
+                stanza_id,
+                class,
+            ],
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn pending_outbox_jobs(
@@ -863,7 +921,6 @@ impl NotificationOutboxStore {
                        conversation_jid,
                        sender_jid,
                        sender_jids,
-                       sender_jids_exact,
                        thread_id,
                        class,
                        message_count,
@@ -903,7 +960,6 @@ impl NotificationOutboxStore {
                        conversation_jid,
                        sender_jid,
                        sender_jids,
-                       sender_jids_exact,
                        thread_id,
                        class,
                        message_count,
@@ -935,7 +991,19 @@ impl NotificationOutboxStore {
             .await?;
         let mut selected = Vec::new();
         while let Some(row) = rows.next().await? {
-            selected.push(decode_outbox_job(&row)?);
+            let job_id_raw: String = row.get(0)?;
+            match decode_outbox_job(&row) {
+                Ok(job) => selected.push(job),
+                Err(error) => {
+                    tracing::warn!(
+                        job_id = %job_id_raw,
+                        %error,
+                        "failing malformed XEP-0357 notification outbox job fail-closed"
+                    );
+                    self.mark_malformed_outbox_job_failed(job_id_raw.as_str(), &error.to_string())
+                        .await?;
+                }
+            }
         }
 
         let mut claimed = Vec::new();
@@ -983,6 +1051,38 @@ impl NotificationOutboxStore {
             }
         }
         Ok(claimed)
+    }
+
+    async fn mark_malformed_outbox_job_failed(
+        &self,
+        job_id: &str,
+        error: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        let now_ms = crate::time::now_ms();
+        self.execute(
+            r#"
+            UPDATE notification_outbox
+            SET status = ?,
+                policy_error_count = 0,
+                last_error = ?,
+                next_attempt_at_ms = NULL,
+                claimed_at_ms = NULL,
+                claim_token = NULL,
+                updated_at_ms = ?
+            WHERE job_id = ?
+              AND status IN (?, ?)
+            "#,
+            crate::db_params![
+                STATUS_FAILED,
+                format!("malformed notification outbox job: {error}"),
+                now_ms,
+                job_id,
+                STATUS_QUEUED,
+                STATUS_IN_PROGRESS,
+            ],
+        )
+        .await?;
+        Ok(())
     }
 
     pub async fn drain_due_outbox_jobs(
@@ -1443,23 +1543,15 @@ async fn xep0191_blocks_notification_candidate(
         .list_blocked_jid_entries(candidate.recipient_bare_jid())
         .await?;
     Ok(blocked.into_iter().any(|blocked_jid| {
-        xep0191_block_entry_matches_sender(
-            &blocked_jid,
-            candidate.sender_jid(),
-            candidate.sender_jid_exact(),
-        )
+        xep0191_block_entry_matches_sender(&blocked_jid, candidate.sender_jid())
     }))
 }
 
 fn xep0191_block_entry_matches_outbox_job(blocked_jid: &Jid, job: &NotificationOutboxJob) -> bool {
     if blocked_jid.resource().is_some() {
-        if job.sender_jids_exact() {
-            job.sender_jids()
-                .iter()
-                .any(|sender_jid| blocked_jid == sender_jid)
-        } else {
-            blocked_jid.to_bare() == *job.conversation_jid()
-        }
+        job.sender_jids()
+            .iter()
+            .any(|sender_jid| blocked_jid == sender_jid)
     } else if blocked_jid.node().is_some() {
         blocked_jid.to_bare() == *job.conversation_jid()
     } else {
@@ -1467,17 +1559,9 @@ fn xep0191_block_entry_matches_outbox_job(blocked_jid: &Jid, job: &NotificationO
     }
 }
 
-fn xep0191_block_entry_matches_sender(
-    blocked_jid: &Jid,
-    sender_jid: &Jid,
-    sender_jid_exact: bool,
-) -> bool {
+fn xep0191_block_entry_matches_sender(blocked_jid: &Jid, sender_jid: &Jid) -> bool {
     if blocked_jid.resource().is_some() {
-        if sender_jid_exact {
-            blocked_jid == sender_jid
-        } else {
-            blocked_jid.to_bare() == sender_jid.to_bare()
-        }
+        blocked_jid == sender_jid
     } else if blocked_jid.node().is_some() {
         blocked_jid.to_bare() == sender_jid.to_bare()
     } else {
@@ -1511,15 +1595,34 @@ async fn enqueue_outbox_job_tx(
     context: &Element,
     now_ms: i64,
 ) -> Result<(), NotificationOutboxError> {
-    let job_id = NotificationOutboxJobId::fresh();
     // The durable schema stores XML as TEXT; keep protocol context typed until this DB write edge.
     let context_xml = String::from(context);
-    let sender_jids = if candidate.sender_jid_exact() {
-        encode_sender_jids(std::slice::from_ref(&candidate.sender_jid))?
-    } else {
-        encode_sender_jids(&[])?
-    };
-    let inserted = tx
+    for _ in 0..8 {
+        let inserted =
+            insert_outbox_job_tx(tx, candidate, target, context_xml.as_str(), now_ms).await?;
+        if inserted > 0 {
+            return Ok(());
+        }
+        match merge_outbox_job_tx(tx, candidate, target, context_xml.as_str(), now_ms).await? {
+            OutboxMergeOutcome::Merged => return Ok(()),
+            OutboxMergeOutcome::MalformedExistingJobFailed
+            | OutboxMergeOutcome::QueuedJobNotFound
+            | OutboxMergeOutcome::QueuedJobChanged => {}
+        }
+    }
+    Err(NotificationOutboxError::OutboxCoalesceContention)
+}
+
+async fn insert_outbox_job_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    candidate: &NotificationCandidate,
+    target: &NotificationOutboxTarget,
+    context_xml: &str,
+    now_ms: i64,
+) -> Result<u64, NotificationOutboxError> {
+    let job_id = NotificationOutboxJobId::fresh();
+    let sender_jids = encode_sender_jids(std::slice::from_ref(&candidate.sender_jid))?;
+    Ok(tx
         .execute(
             r#"
             INSERT INTO notification_outbox (
@@ -1530,7 +1633,6 @@ async fn enqueue_outbox_job_tx(
                 conversation_jid,
                 sender_jid,
                 sender_jids,
-                sender_jids_exact,
                 thread_id,
                 class,
                 message_count,
@@ -1545,7 +1647,7 @@ async fn enqueue_outbox_job_tx(
                 created_at_ms,
                 updated_at_ms,
                 published_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 0, 0, NULL, NULL, NULL, NULL, ?, ?, NULL)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 0, 0, NULL, NULL, NULL, NULL, ?, ?, NULL)
             ON CONFLICT DO NOTHING
             "#,
             crate::db_params![
@@ -1556,20 +1658,22 @@ async fn enqueue_outbox_job_tx(
                 candidate.conversation_jid.to_string(),
                 candidate.sender_jid.to_string(),
                 sender_jids,
-                if candidate.sender_jid_exact() { 1_i64 } else { 0_i64 },
                 candidate.thread_id.as_str(),
                 candidate.class.as_db_value(),
-                context_xml.as_str(),
+                context_xml,
                 STATUS_QUEUED,
                 now_ms,
                 now_ms,
             ],
         )
-        .await?;
-    if inserted == 0 {
-        merge_outbox_job_tx(tx, candidate, target, context_xml.as_str(), now_ms).await?;
-    }
-    Ok(())
+        .await?)
+}
+
+enum OutboxMergeOutcome {
+    Merged,
+    MalformedExistingJobFailed,
+    QueuedJobNotFound,
+    QueuedJobChanged,
 }
 
 async fn merge_outbox_job_tx(
@@ -1578,11 +1682,11 @@ async fn merge_outbox_job_tx(
     target: &NotificationOutboxTarget,
     context_xml: &str,
     now_ms: i64,
-) -> Result<(), NotificationOutboxError> {
+) -> Result<OutboxMergeOutcome, NotificationOutboxError> {
     let mut rows = tx
         .query(
             r#"
-            SELECT sender_jid, sender_jids, sender_jids_exact
+            SELECT job_id, sender_jid, sender_jids
             FROM notification_outbox
             WHERE recipient_bare_jid = ?
               AND push_service_jid = ?
@@ -1605,65 +1709,116 @@ async fn merge_outbox_job_tx(
         )
         .await?;
     let Some(row) = rows.next().await? else {
-        return Ok(());
+        return Ok(OutboxMergeOutcome::QueuedJobNotFound);
     };
-    let existing_sender_raw: String = row.get(0)?;
-    let mut sender_jids = decode_sender_jids(&row.get::<String>(1)?)?;
-    let sender_jids_exact = row.get::<i64>(2)? != 0;
-    let merged_sender_jids_exact = sender_jids_exact && candidate.sender_jid_exact();
-    if !merged_sender_jids_exact {
-        sender_jids.clear();
-    } else if sender_jids.is_empty() {
-        sender_jids.push(
-            existing_sender_raw
-                .parse()
-                .map_err(|_| NotificationOutboxError::InvalidSenderJid(existing_sender_raw))?,
-        );
-    }
-    if merged_sender_jids_exact
-        && !sender_jids
-            .iter()
-            .any(|sender_jid| sender_jid == &candidate.sender_jid)
+    let job_id_raw: String = row.get(0)?;
+    let sender_raw = row
+        .get::<Option<String>>(1)?
+        .ok_or_else(|| NotificationOutboxError::InvalidSenderJid("<null>".to_string()));
+    let sender_jids_raw = row
+        .get::<Option<String>>(2)?
+        .ok_or(NotificationOutboxError::MissingSenderJidSet);
+    let existing_sender_jid = match sender_raw.and_then(|raw| {
+        let sender_jid = raw
+            .parse()
+            .map_err(|_| NotificationOutboxError::InvalidSenderJid(raw))?;
+        require_full_sender_jid(&sender_jid)?;
+        require_sender_matches_conversation(&sender_jid, &candidate.conversation_jid)?;
+        Ok(sender_jid)
+    }) {
+        Ok(sender_jid) => sender_jid,
+        Err(error) => {
+            mark_malformed_outbox_job_failed_tx(
+                tx,
+                job_id_raw.as_str(),
+                &error.to_string(),
+                now_ms,
+            )
+            .await?;
+            return Ok(OutboxMergeOutcome::MalformedExistingJobFailed);
+        }
+    };
+    let mut sender_jids = match sender_jids_raw.and_then(|raw| {
+        let sender_jids = decode_sender_jids(&raw)?;
+        require_full_sender_jid_set(&sender_jids)?;
+        require_sender_set_matches_conversation(&sender_jids, &candidate.conversation_jid)?;
+        require_sender_set_contains_scalar(&sender_jids, &existing_sender_jid)?;
+        Ok(sender_jids)
+    }) {
+        Ok(sender_jids) => sender_jids,
+        Err(error) => {
+            mark_malformed_outbox_job_failed_tx(
+                tx,
+                job_id_raw.as_str(),
+                &error.to_string(),
+                now_ms,
+            )
+            .await?;
+            return Ok(OutboxMergeOutcome::MalformedExistingJobFailed);
+        }
+    };
+    if !sender_jids
+        .iter()
+        .any(|sender_jid| sender_jid == &candidate.sender_jid)
     {
         sender_jids.push(candidate.sender_jid.clone());
     }
     let sender_jids = encode_sender_jids(&sender_jids)?;
-    tx.execute(
-        r#"
+    let affected = tx
+        .execute(
+            r#"
         UPDATE notification_outbox
         SET message_count = message_count + 1,
             context_xml = ?,
             sender_jid = ?,
             sender_jids = ?,
-            sender_jids_exact = ?,
             policy_error_count = 0,
             last_error = NULL,
             next_attempt_at_ms = NULL,
             updated_at_ms = ?
-        WHERE recipient_bare_jid = ?
-          AND push_service_jid = ?
-          AND node = ?
-          AND conversation_jid = ?
-          AND thread_id = ?
-          AND class = ?
+        WHERE job_id = ?
+          AND status = ?
+        "#,
+            crate::db_params![
+                context_xml,
+                candidate.sender_jid.to_string(),
+                sender_jids,
+                now_ms,
+                job_id_raw,
+                STATUS_QUEUED,
+            ],
+        )
+        .await?;
+    if affected == 0 {
+        return Ok(OutboxMergeOutcome::QueuedJobChanged);
+    }
+    Ok(OutboxMergeOutcome::Merged)
+}
+
+async fn mark_malformed_outbox_job_failed_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    job_id: &str,
+    error: &str,
+    now_ms: i64,
+) -> Result<(), NotificationOutboxError> {
+    tx.execute(
+        r#"
+        UPDATE notification_outbox
+        SET status = ?,
+            policy_error_count = 0,
+            last_error = ?,
+            next_attempt_at_ms = NULL,
+            claimed_at_ms = NULL,
+            claim_token = NULL,
+            updated_at_ms = ?
+        WHERE job_id = ?
           AND status = ?
         "#,
         crate::db_params![
-            context_xml,
-            candidate.sender_jid.to_string(),
-            sender_jids,
-            if merged_sender_jids_exact {
-                1_i64
-            } else {
-                0_i64
-            },
+            STATUS_FAILED,
+            format!("malformed notification outbox job: {error}"),
             now_ms,
-            candidate.recipient_bare_jid.to_string(),
-            target.push_service_jid.to_string(),
-            target.node.as_str(),
-            candidate.conversation_jid.to_string(),
-            candidate.thread_id.as_str(),
-            candidate.class.as_db_value(),
+            job_id,
             STATUS_QUEUED,
         ],
     )
@@ -1778,29 +1933,34 @@ async fn current_unread_count_for_job(
 fn decode_candidate(row: &Row) -> Result<NotificationCandidate, NotificationOutboxError> {
     let recipient_raw: String = row.get(0)?;
     let conversation_raw: String = row.get(1)?;
-    let sender_raw: String = row.get(2)?;
-    let stanza_id_by_raw: String = row.get(5)?;
+    let sender_raw = row
+        .get::<Option<String>>(2)?
+        .ok_or_else(|| NotificationOutboxError::InvalidSenderJid("<null>".to_string()))?;
+    let sender_jid = sender_raw
+        .parse()
+        .map_err(|_| NotificationOutboxError::InvalidSenderJid(sender_raw))?;
+    require_full_sender_jid(&sender_jid)?;
+    let conversation_jid: BareJid = conversation_raw
+        .parse()
+        .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?;
+    require_sender_matches_conversation(&sender_jid, &conversation_jid)?;
+    let stanza_id_by_raw: String = row.get(4)?;
     Ok(NotificationCandidate {
         recipient_bare_jid: recipient_raw
             .parse()
             .map_err(|_| NotificationOutboxError::InvalidRecipientBareJid(recipient_raw))?,
-        conversation_jid: conversation_raw
-            .parse()
-            .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?,
-        sender_jid: sender_raw
-            .parse()
-            .map_err(|_| NotificationOutboxError::InvalidSenderJid(sender_raw))?,
-        sender_jid_exact: row.get::<i64>(3)? != 0,
-        thread_id: NotificationThreadId::new(row.get::<String>(4)?),
+        conversation_jid,
+        sender_jid,
+        thread_id: NotificationThreadId::new(row.get::<String>(3)?),
         archive_stanza_id: StanzaId::new(
-            row.get::<String>(6)?,
+            row.get::<String>(5)?,
             stanza_id_by_raw
                 .parse()
                 .map_err(|_| NotificationOutboxError::InvalidArchiveStanzaIdBy(stanza_id_by_raw))?,
         ),
-        class: NotificationClass::from_db_value(&row.get::<String>(7)?)?,
-        reason: NotificationReason::from_db_value(&row.get::<String>(8)?)?,
-        policy_error_count: row.get(9)?,
+        class: NotificationClass::from_db_value(&row.get::<String>(6)?)?,
+        reason: NotificationReason::from_db_value(&row.get::<String>(7)?)?,
+        policy_error_count: row.get(8)?,
     })
 }
 
@@ -1808,14 +1968,26 @@ fn decode_outbox_job(row: &Row) -> Result<NotificationOutboxJob, NotificationOut
     let recipient_raw: String = row.get(1)?;
     let push_service_raw: String = row.get(2)?;
     let conversation_raw: String = row.get(4)?;
-    let sender_raw: String = row.get(5)?;
-    let sender_jids_raw: String = row.get(6)?;
-    let message_count: i64 = row.get(10)?;
-    let context_xml: String = row.get(11)?;
+    let sender_raw = row
+        .get::<Option<String>>(5)?
+        .ok_or_else(|| NotificationOutboxError::InvalidSenderJid("<null>".to_string()))?;
+    let sender_jids_raw = row
+        .get::<Option<String>>(6)?
+        .ok_or(NotificationOutboxError::MissingSenderJidSet)?;
+    let message_count: i64 = row.get(9)?;
+    let context_xml: String = row.get(10)?;
     let sender_jid: Jid = sender_raw
         .parse()
         .map_err(|_| NotificationOutboxError::InvalidSenderJid(sender_raw))?;
+    require_full_sender_jid(&sender_jid)?;
+    let conversation_jid: BareJid = conversation_raw
+        .parse()
+        .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?;
+    require_sender_matches_conversation(&sender_jid, &conversation_jid)?;
     let sender_jids = decode_sender_jids(&sender_jids_raw)?;
+    require_full_sender_jid_set(&sender_jids)?;
+    require_sender_set_matches_conversation(&sender_jids, &conversation_jid)?;
+    require_sender_set_contains_scalar(&sender_jids, &sender_jid)?;
     Ok(NotificationOutboxJob {
         job_id: NotificationOutboxJobId::from(row.get::<String>(0)?),
         recipient_bare_jid: recipient_raw
@@ -1825,23 +1997,20 @@ fn decode_outbox_job(row: &Row) -> Result<NotificationOutboxJob, NotificationOut
             .parse()
             .map_err(|_| NotificationOutboxError::InvalidPushServiceBareJid(push_service_raw))?,
         node: PushServiceNodeName::new(row.get::<String>(3)?)?,
-        conversation_jid: conversation_raw
-            .parse()
-            .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?,
+        conversation_jid,
         sender_jid,
         sender_jids,
-        sender_jids_exact: row.get::<i64>(7)? != 0,
-        thread_id: NotificationThreadId::new(row.get::<String>(8)?),
-        class: NotificationClass::from_db_value(&row.get::<String>(9)?)?,
+        thread_id: NotificationThreadId::new(row.get::<String>(7)?),
+        class: NotificationClass::from_db_value(&row.get::<String>(8)?)?,
         message_count: u32::try_from(message_count)
             .map_err(|_| NotificationOutboxError::InvalidMessageCount(message_count))?,
         context: context_xml
             .parse::<Element>()
             .map_err(|error| NotificationOutboxError::InvalidContextXml(error.to_string()))?,
-        status: NotificationOutboxStatus::from_db_value(&row.get::<String>(12)?)?,
-        attempt_count: row.get(13)?,
-        policy_error_count: row.get(14)?,
-        claim_token: row.get(15)?,
+        status: NotificationOutboxStatus::from_db_value(&row.get::<String>(11)?)?,
+        attempt_count: row.get(12)?,
+        policy_error_count: row.get(13)?,
+        claim_token: row.get(14)?,
     })
 }
 
@@ -1944,7 +2113,13 @@ mod tests {
     }
 
     fn candidate_for(recipient: &BareJid, sender: &BareJid, id: &str) -> NotificationCandidate {
-        candidate_for_sender_jid(recipient, Jid::from(sender.clone()), id)
+        candidate_for_sender_jid(
+            recipient,
+            format!("{sender}/test-resource")
+                .parse()
+                .expect("full sender jid"),
+            id,
+        )
     }
 
     fn candidate_for_sender_jid(
@@ -1958,6 +2133,22 @@ mod tests {
             StanzaId::new(id, Jid::from(recipient.clone())),
         )
         .expect("candidate")
+    }
+
+    async fn failed_outbox_jobs_count(store: &NotificationOutboxStore) -> i64 {
+        let mut rows = store
+            .query(
+                "SELECT COUNT(*) FROM notification_outbox WHERE status = ?",
+                crate::db_params![STATUS_FAILED],
+            )
+            .await
+            .expect("failed outbox count query");
+        rows.next()
+            .await
+            .expect("failed outbox count row")
+            .expect("failed outbox count")
+            .get(0)
+            .expect("failed outbox count")
     }
 
     fn target() -> NotificationOutboxTarget {
@@ -1984,6 +2175,89 @@ mod tests {
             .expect("store")
     }
 
+    #[tokio::test]
+    async fn store_initialization_rejects_candidate_schema_without_sender_provenance_column() {
+        let db = Database::in_memory("notification-outbox-missing-candidate-sender")
+            .await
+            .unwrap();
+        let conn = db.guard().await.expect("db guard");
+        conn.execute(
+            r#"
+            CREATE TABLE notification_candidates (
+                recipient_bare_jid TEXT NOT NULL,
+                conversation_jid TEXT NOT NULL,
+                thread_id TEXT NOT NULL DEFAULT '',
+                stanza_id_by TEXT NOT NULL,
+                stanza_id TEXT NOT NULL,
+                class TEXT NOT NULL,
+                reason TEXT NOT NULL,
+                created_at_ms INTEGER NOT NULL,
+                policy_error_count INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at_ms INTEGER,
+                outboxed_at_ms INTEGER,
+                PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create incompatible candidate table");
+        drop(conn);
+
+        match NotificationOutboxStore::new(db).await {
+            Ok(_) => panic!("store must not add missing sender provenance candidate columns"),
+            Err(error) => assert!(
+                error.to_string().contains("sender_jid"),
+                "unexpected schema error: {error}"
+            ),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_initialization_rejects_outbox_schema_without_sender_provenance_columns() {
+        let db = Database::in_memory("notification-outbox-missing-job-senders")
+            .await
+            .unwrap();
+        let conn = db.guard().await.expect("db guard");
+        conn.execute(
+            r#"
+            CREATE TABLE notification_outbox (
+                job_id TEXT PRIMARY KEY,
+                recipient_bare_jid TEXT NOT NULL,
+                push_service_jid TEXT NOT NULL,
+                node TEXT NOT NULL,
+                conversation_jid TEXT NOT NULL,
+                thread_id TEXT NOT NULL DEFAULT '',
+                class TEXT NOT NULL,
+                message_count INTEGER NOT NULL,
+                context_xml TEXT NOT NULL,
+                status TEXT NOT NULL,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                policy_error_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                next_attempt_at_ms INTEGER,
+                claimed_at_ms INTEGER,
+                claim_token TEXT,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                published_at_ms INTEGER
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create incompatible outbox table");
+        drop(conn);
+
+        match NotificationOutboxStore::new(db).await {
+            Ok(_) => panic!("store must not add missing sender provenance outbox columns"),
+            Err(error) => assert!(
+                error.to_string().contains("sender_jid"),
+                "unexpected schema error: {error}"
+            ),
+        }
+    }
+
     async fn enqueue_jobs_for_test(
         store: &NotificationOutboxStore,
         candidate: &NotificationCandidate,
@@ -2005,6 +2279,21 @@ mod tests {
                 .expect("enqueue outbox job");
         }
         tx.commit().await.expect("commit tx");
+    }
+
+    #[test]
+    fn direct_message_candidate_requires_full_sender_jid() {
+        let recipient = bare("alice@example.com");
+        let result = NotificationCandidate::direct_message(
+            recipient.clone(),
+            Jid::from(bare("bob@example.com")),
+            StanzaId::new("archive-bare-sender", Jid::from(recipient)),
+        );
+
+        assert!(matches!(
+            result,
+            Err(NotificationOutboxError::SenderJidMissingResource(_))
+        ));
     }
 
     async fn register_push_target(
@@ -2242,6 +2531,248 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn candidate_worker_marks_malformed_bare_sender_candidate_terminal() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        let candidate = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-malformed-candidate-bare-sender",
+        );
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("candidate insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET sender_jid = ? WHERE stanza_id = ?",
+                crate::db_params!["bob@example.com", "archive-malformed-candidate-bare-sender"],
+            )
+            .await
+            .expect("make candidate sender malformed");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            0
+        );
+
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
+        let mut rows = store
+            .query(
+                "SELECT outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["archive-malformed-candidate-bare-sender"],
+            )
+            .await
+            .expect("candidate marker query");
+        let row = rows
+            .next()
+            .await
+            .expect("candidate marker row")
+            .expect("candidate marker row");
+        assert!(row
+            .get::<Option<i64>>(0)
+            .expect("outboxed marker")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_marks_empty_sender_candidate_terminal_without_conversation_fallback()
+    {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        let candidate = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-malformed-candidate-empty-sender",
+        );
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("candidate insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET sender_jid = ? WHERE stanza_id = ?",
+                crate::db_params!["", "archive-malformed-candidate-empty-sender"],
+            )
+            .await
+            .expect("make candidate sender empty");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            0
+        );
+
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
+        let mut rows = store
+            .query(
+                "SELECT outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["archive-malformed-candidate-empty-sender"],
+            )
+            .await
+            .expect("candidate marker query");
+        let row = rows
+            .next()
+            .await
+            .expect("candidate marker row")
+            .expect("candidate marker row");
+        assert!(row
+            .get::<Option<i64>>(0)
+            .expect("outboxed marker")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_marks_mismatched_sender_candidate_terminal() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        let candidate = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-malformed-candidate-mismatch",
+        );
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("candidate insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET conversation_jid = ? WHERE stanza_id = ?",
+                crate::db_params!["carol@example.com", "archive-malformed-candidate-mismatch"],
+            )
+            .await
+            .expect("make candidate sender mismatch conversation");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            0
+        );
+
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_marks_malformed_conversation_candidate_terminal_and_continues() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let malformed_recipient = bare("alice@example.com");
+        let valid_recipient = bare("carol@example.com");
+        register_push_target(&push_store, &malformed_recipient, &target).await;
+        register_push_target(&push_store, &valid_recipient, &target).await;
+        let malformed = candidate_for_sender_jid(
+            &malformed_recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-malformed-candidate-conversation",
+        );
+        let valid = candidate_for_sender_jid(
+            &valid_recipient,
+            "dave@example.com/phone".parse().expect("valid sender"),
+            "archive-valid-after-malformed-candidate",
+        );
+        store
+            .insert_candidate(&malformed)
+            .await
+            .expect("malformed candidate insert");
+        store
+            .insert_candidate(&valid)
+            .await
+            .expect("valid candidate insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET conversation_jid = ? WHERE stanza_id = ?",
+                crate::db_params!["not a jid", "archive-malformed-candidate-conversation"],
+            )
+            .await
+            .expect("make candidate conversation malformed");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            1
+        );
+
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].recipient_bare_jid(), &valid_recipient);
+    }
+
+    #[tokio::test]
     async fn candidate_worker_coalesces_distinct_sender_resources_into_one_bare_conversation_job() {
         let store = store().await;
         let target = target();
@@ -2305,7 +2836,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn candidate_worker_downgrades_coalesced_outbox_job_when_legacy_sender_is_merged() {
+    async fn candidate_worker_fails_malformed_coalesced_job_before_requeueing_exact_sender() {
         let store = store().await;
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
@@ -2313,12 +2844,12 @@ mod tests {
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
-        let exact = candidate_for_sender_jid(
+        let phone = candidate_for_sender_jid(
             &recipient,
             "bob@example.com/phone".parse().expect("phone sender"),
-            "archive-exact-phone",
+            "archive-malformed-existing-phone",
         );
-        store.insert_candidate(&exact).await.expect("exact insert");
+        store.insert_candidate(&phone).await.expect("phone insert");
         assert_eq!(
             store
                 .drain_pending_candidates_into_outbox(
@@ -2328,26 +2859,27 @@ mod tests {
                     16,
                 )
                 .await
-                .expect("drain exact candidate"),
+                .expect("drain first candidate"),
             1
         );
-
-        let legacy = candidate_for_sender_jid(
-            &recipient,
-            "bob@example.com/laptop".parse().expect("laptop sender"),
-            "archive-legacy-laptop",
-        );
-        store
-            .insert_candidate(&legacy)
-            .await
-            .expect("legacy insert");
         store
             .execute(
-                "UPDATE notification_candidates SET sender_jid = conversation_jid, sender_jid_exact = 0 WHERE stanza_id = ?",
-                crate::db_params!["archive-legacy-laptop"],
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["bob@example.com", "[]"],
             )
             .await
-            .expect("simulate legacy backfill");
+            .expect("make queued job malformed");
+
+        let laptop_sender = "bob@example.com/laptop".parse().expect("laptop sender");
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            laptop_sender,
+            "archive-malformed-existing-laptop",
+        );
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
         assert_eq!(
             store
                 .drain_pending_candidates_into_outbox(
@@ -2357,15 +2889,297 @@ mod tests {
                     16,
                 )
                 .await
-                .expect("drain legacy candidate"),
+                .expect("drain second candidate"),
             1
         );
 
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
         let jobs = store.pending_outbox_jobs().await.expect("jobs");
         assert_eq!(jobs.len(), 1);
-        assert_eq!(jobs[0].message_count(), 2);
-        assert!(!jobs[0].sender_jids_exact());
-        assert!(jobs[0].sender_jids().is_empty());
+        assert_eq!(jobs[0].message_count(), 1);
+        assert_eq!(
+            jobs[0].sender_jids(),
+            &["bob@example.com/laptop"
+                .parse::<Jid>()
+                .expect("laptop sender")]
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_fails_malformed_sender_jids_json_before_requeueing_exact_sender() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-malformed-json-phone",
+        );
+        store.insert_candidate(&phone).await.expect("phone insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain first candidate"),
+            1
+        );
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["bob@example.com/phone", "not-json"],
+            )
+            .await
+            .expect("make queued job sender_jids malformed");
+
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-malformed-json-laptop",
+        );
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain second candidate"),
+            1
+        );
+
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].message_count(), 1);
+        assert_eq!(
+            jobs[0].sender_jids(),
+            &["bob@example.com/laptop"
+                .parse::<Jid>()
+                .expect("laptop sender")]
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_fails_sender_set_missing_scalar_before_requeueing_exact_sender() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-missing-scalar-phone",
+        );
+        store.insert_candidate(&phone).await.expect("phone insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain first candidate"),
+            1
+        );
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jids = ?",
+                crate::db_params!["[\"bob@example.com/laptop\"]"],
+            )
+            .await
+            .expect("make queued job sender_jids omit scalar sender");
+
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-missing-scalar-laptop",
+        );
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain second candidate"),
+            1
+        );
+
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].message_count(), 1);
+        assert_eq!(
+            jobs[0].sender_jids(),
+            &["bob@example.com/laptop"
+                .parse::<Jid>()
+                .expect("laptop sender")]
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_fails_semantically_invalid_sender_jids_before_requeueing_exact_sender(
+    ) {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-invalid-sender-jids-phone",
+        );
+        store.insert_candidate(&phone).await.expect("phone insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain first candidate"),
+            1
+        );
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["bob@example.com/phone", "[\"carol@example.com/phone\"]"],
+            )
+            .await
+            .expect("make queued job sender_jids semantically invalid");
+
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-invalid-sender-jids-laptop",
+        );
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain second candidate"),
+            1
+        );
+
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].message_count(), 1);
+        assert_eq!(
+            jobs[0].sender_jids(),
+            &["bob@example.com/laptop"
+                .parse::<Jid>()
+                .expect("laptop sender")]
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_fails_mismatched_scalar_sender_before_requeueing_exact_sender() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-invalid-scalar-phone",
+        );
+        store.insert_candidate(&phone).await.expect("phone insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain first candidate"),
+            1
+        );
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?",
+                crate::db_params!["carol@example.com/phone"],
+            )
+            .await
+            .expect("make queued job scalar sender invalid");
+
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-invalid-scalar-laptop",
+        );
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain second candidate"),
+            1
+        );
+
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].message_count(), 1);
+        assert_eq!(
+            jobs[0].sender_jids(),
+            &["bob@example.com/laptop"
+                .parse::<Jid>()
+                .expect("laptop sender")]
+        );
     }
 
     #[tokio::test]
@@ -2418,60 +3232,6 @@ mod tests {
         assert_eq!(jobs[0].conversation_jid(), &bare("bob@example.com"));
         assert_eq!(jobs[0].sender_jid().to_string(), "bob@example.com/laptop");
         assert_eq!(jobs[0].message_count(), 1);
-    }
-
-    #[tokio::test]
-    async fn candidate_worker_full_jid_block_suppresses_legacy_candidate_without_exact_sender() {
-        let store = store().await;
-        let target = target();
-        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
-        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
-        let recipient = bare("alice@example.com");
-        register_push_target(&push_store, &recipient, &target).await;
-        blocking.set_blocklist_jids(
-            recipient.clone(),
-            vec!["bob@example.com/phone".parse().expect("blocked sender")],
-        );
-        let candidate = candidate_for_sender_jid(
-            &recipient,
-            "bob@example.com/phone".parse().expect("phone sender"),
-            "archive-legacy-candidate",
-        );
-        store
-            .insert_candidate(&candidate)
-            .await
-            .expect("candidate insert");
-        store
-            .execute(
-                "UPDATE notification_candidates SET sender_jid = conversation_jid, sender_jid_exact = 0 WHERE stanza_id = ?",
-                crate::db_params!["archive-legacy-candidate"],
-            )
-            .await
-            .expect("simulate legacy backfill");
-
-        assert_eq!(
-            store
-                .drain_pending_candidates_into_outbox(
-                    &push_store,
-                    &blocking,
-                    &bare("push.example.com"),
-                    16,
-                )
-                .await
-                .expect("drain candidates"),
-            1
-        );
-
-        assert!(store
-            .pending_outbox_jobs()
-            .await
-            .expect("pending jobs")
-            .is_empty());
-        assert!(store
-            .pending_candidates(16)
-            .await
-            .expect("pending candidates")
-            .is_empty());
     }
 
     #[tokio::test]
@@ -2595,40 +3355,6 @@ mod tests {
             .await
             .expect("pending jobs")
             .is_empty());
-    }
-
-    #[test]
-    fn xep0191_full_jid_block_fails_closed_for_legacy_outbox_job_without_sender_provenance() {
-        let job = NotificationOutboxJob {
-            job_id: NotificationOutboxJobId::fresh(),
-            recipient_bare_jid: bare("alice@example.com"),
-            push_service_jid: bare("push.example.com"),
-            node: PushServiceNodeName::new("web-node").expect("node"),
-            conversation_jid: bare("bob@example.com"),
-            sender_jid: Jid::from(bare("bob@example.com")),
-            sender_jids: Vec::new(),
-            sender_jids_exact: false,
-            thread_id: NotificationThreadId::root(),
-            class: NotificationClass::DirectMessage,
-            message_count: 1,
-            context: Element::builder("context", WADDLE_PUSH_CONTEXT_NS).build(),
-            status: NotificationOutboxStatus::Queued,
-            attempt_count: 0,
-            policy_error_count: 0,
-            claim_token: None,
-        };
-
-        assert!(xep0191_block_entry_matches_outbox_job(
-            &"bob@example.com/phone".parse().expect("full blocked JID"),
-            &job,
-        ));
-        assert!(
-            !xep0191_block_entry_matches_outbox_job(
-                &"carol@example.com".parse().expect("bare blocked JID"),
-                &job,
-            ),
-            "bare-JID blocks still match the durable bare conversation identity"
-        );
     }
 
     #[tokio::test]
@@ -2843,6 +3569,200 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_malformed_sender_set_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(&store, &candidate("archive-malformed-claim"), &[target()]).await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["bob@example.com", "[]"],
+            )
+            .await
+            .expect("make queued job malformed");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_empty_sender_without_conversation_fallback() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-empty-sender-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["", "[]"],
+            )
+            .await
+            .expect("make queued job sender provenance empty");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_malformed_sender_jids_json_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-malformed-json-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params!["bob@example.com/test-resource", "not-json"],
+            )
+            .await
+            .expect("make queued job sender_jids malformed");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_sender_set_missing_scalar_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-missing-scalar-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jids = ?",
+                crate::db_params!["[\"bob@example.com/laptop\"]"],
+            )
+            .await
+            .expect("make queued job sender_jids omit scalar sender");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_semantically_invalid_sender_jids_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-invalid-sender-jids-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?, sender_jids = ?",
+                crate::db_params![
+                    "bob@example.com/test-resource",
+                    "[\"carol@example.com/phone\"]"
+                ],
+            )
+            .await
+            .expect("make queued job sender_jids semantically invalid");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_mismatched_scalar_sender_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-invalid-scalar-sender-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET sender_jid = ?",
+                crate::db_params!["carol@example.com/phone"],
+            )
+            .await
+            .expect("make queued job scalar sender invalid");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn claim_due_outbox_jobs_fails_malformed_context_before_publish() {
+        let store = store().await;
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-malformed-context-claim"),
+            &[target()],
+        )
+        .await;
+        store
+            .execute(
+                "UPDATE notification_outbox SET context_xml = ?",
+                crate::db_params!["<context"],
+            )
+            .await
+            .expect("make queued job context malformed");
+
+        let claimed = store.claim_due_outbox_jobs(16).await.expect("claim");
+
+        assert!(claimed.is_empty());
+        assert_eq!(failed_outbox_jobs_count(&store).await, 1);
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn stale_in_progress_outbox_job_is_claimable_again() {
         let store = store().await;
         let target = target();
@@ -3030,6 +3950,76 @@ mod tests {
             .expect("fresh queued job");
         assert_eq!(queued.message_count(), 1);
         assert_ne!(queued.job_id(), claimed[0].job_id());
+    }
+
+    #[tokio::test]
+    async fn coalesce_retry_creates_fresh_job_when_queued_job_is_claimed_after_select() {
+        let store = store().await;
+        let target = target();
+        enqueue_jobs_for_test(
+            &store,
+            &candidate("archive-race-1"),
+            std::slice::from_ref(&target),
+        )
+        .await;
+        store
+            .db
+            .guard()
+            .await
+            .expect("db guard")
+            .execute(
+                r#"
+                CREATE TRIGGER simulate_notification_outbox_claim_race
+                BEFORE UPDATE OF message_count ON notification_outbox
+                WHEN OLD.status = 'queued'
+                BEGIN
+                    UPDATE notification_outbox
+                    SET status = 'in-progress',
+                        claimed_at_ms = OLD.updated_at_ms + 1,
+                        claim_token = 'race-claim',
+                        updated_at_ms = OLD.updated_at_ms + 1
+                    WHERE job_id = OLD.job_id;
+                    SELECT RAISE(IGNORE);
+                END;
+                "#,
+                (),
+            )
+            .await
+            .expect("install coalesce race trigger");
+
+        enqueue_jobs_for_test(&store, &candidate("archive-race-2"), &[target]).await;
+
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 2);
+        assert!(jobs
+            .iter()
+            .any(|job| job.status() == NotificationOutboxStatus::InProgress
+                && job.message_count() == 1
+                && job.claim_token() == Some("race-claim")));
+        let queued = jobs
+            .iter()
+            .find(|job| job.status() == NotificationOutboxStatus::Queued)
+            .expect("fresh queued job from retry");
+        assert_eq!(queued.message_count(), 1);
+        assert_eq!(
+            queued.sender_jids(),
+            &["bob@example.com/test-resource"
+                .parse::<Jid>()
+                .expect("sender resource")]
+        );
+        let claimed = store
+            .claim_due_outbox_jobs(16)
+            .await
+            .expect("claim replacement job");
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].status(), NotificationOutboxStatus::InProgress);
+        assert_eq!(claimed[0].message_count(), 1);
+        assert_ne!(claimed[0].claim_token(), Some("race-claim"));
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -172,6 +172,20 @@ impl NotificationCandidate {
         sender_jid: Jid,
         archive_stanza_id: StanzaId,
     ) -> Result<Self, NotificationOutboxError> {
+        Self::direct_message_with_sender_provenance(
+            recipient_bare_jid,
+            sender_jid,
+            true,
+            archive_stanza_id,
+        )
+    }
+
+    pub fn direct_message_with_sender_provenance(
+        recipient_bare_jid: BareJid,
+        sender_jid: Jid,
+        sender_jid_exact: bool,
+        archive_stanza_id: StanzaId,
+    ) -> Result<Self, NotificationOutboxError> {
         let expected_by = Jid::from(recipient_bare_jid.clone());
         if archive_stanza_id.by != expected_by {
             return Err(NotificationOutboxError::ArchiveStanzaIdOwnerMismatch {
@@ -183,7 +197,7 @@ impl NotificationCandidate {
             recipient_bare_jid,
             conversation_jid: sender_jid.to_bare(),
             sender_jid,
-            sender_jid_exact: true,
+            sender_jid_exact,
             thread_id: NotificationThreadId::root(),
             archive_stanza_id,
             class: NotificationClass::DirectMessage,

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use waddle_xmpp::inbox::storage::InboxStorage;
 use waddle_xmpp::pubsub::PubSubItem;
 use waddle_xmpp::push::PushSubscriptionStore;
+use waddle_xmpp::xep::xep0191::{BlockingStorage, BlockingStorageError};
 use waddle_xmpp::xep::{NS_DATA_FORMS, NS_PUBSUB_PUBLISH_OPTIONS};
 use waddle_xmpp_core::xep0359::StanzaId;
 
@@ -23,6 +24,7 @@ const STATUS_PUBLISHED: &str = "published";
 const STATUS_FAILED: &str = "failed";
 const MAX_OUTBOX_ATTEMPTS: i64 = 5;
 const BASE_RETRY_DELAY_MS: i64 = 5_000;
+const BASE_POLICY_RETRY_DELAY_MS: i64 = 60_000;
 const MAX_RETRY_DELAY_MS: i64 = 300_000;
 const OUTBOX_CLAIM_TIMEOUT_MS: i64 = 300_000;
 
@@ -155,16 +157,19 @@ impl NotificationOutboxStatus {
 pub struct NotificationCandidate {
     recipient_bare_jid: BareJid,
     conversation_jid: BareJid,
+    sender_jid: Jid,
+    sender_jid_exact: bool,
     thread_id: NotificationThreadId,
     archive_stanza_id: StanzaId,
     class: NotificationClass,
     reason: NotificationReason,
+    policy_error_count: i64,
 }
 
 impl NotificationCandidate {
     pub fn direct_message(
         recipient_bare_jid: BareJid,
-        sender_bare_jid: BareJid,
+        sender_jid: Jid,
         archive_stanza_id: StanzaId,
     ) -> Result<Self, NotificationOutboxError> {
         let expected_by = Jid::from(recipient_bare_jid.clone());
@@ -176,11 +181,14 @@ impl NotificationCandidate {
         }
         Ok(Self {
             recipient_bare_jid,
-            conversation_jid: sender_bare_jid,
+            conversation_jid: sender_jid.to_bare(),
+            sender_jid,
+            sender_jid_exact: true,
             thread_id: NotificationThreadId::root(),
             archive_stanza_id,
             class: NotificationClass::DirectMessage,
             reason: NotificationReason::OfflineDirectMessage,
+            policy_error_count: 0,
         })
     }
 
@@ -190,6 +198,14 @@ impl NotificationCandidate {
 
     pub fn conversation_jid(&self) -> &BareJid {
         &self.conversation_jid
+    }
+
+    pub fn sender_jid(&self) -> &Jid {
+        &self.sender_jid
+    }
+
+    pub fn sender_jid_exact(&self) -> bool {
+        self.sender_jid_exact
     }
 
     pub fn thread_id(&self) -> &NotificationThreadId {
@@ -239,12 +255,16 @@ pub struct NotificationOutboxJob {
     push_service_jid: BareJid,
     node: PushServiceNodeName,
     conversation_jid: BareJid,
+    sender_jid: Jid,
+    sender_jids: Vec<Jid>,
+    sender_jids_exact: bool,
     thread_id: NotificationThreadId,
     class: NotificationClass,
     message_count: u32,
     context: Element,
     status: NotificationOutboxStatus,
     attempt_count: i64,
+    policy_error_count: i64,
     claim_token: Option<String>,
 }
 
@@ -269,6 +289,18 @@ impl NotificationOutboxJob {
         &self.conversation_jid
     }
 
+    pub fn sender_jid(&self) -> &Jid {
+        &self.sender_jid
+    }
+
+    pub fn sender_jids(&self) -> &[Jid] {
+        &self.sender_jids
+    }
+
+    pub fn sender_jids_exact(&self) -> bool {
+        self.sender_jids_exact
+    }
+
     pub fn thread_id(&self) -> &NotificationThreadId {
         &self.thread_id
     }
@@ -291,6 +323,10 @@ impl NotificationOutboxJob {
 
     pub fn attempt_count(&self) -> i64 {
         self.attempt_count
+    }
+
+    pub fn policy_error_count(&self) -> i64 {
+        self.policy_error_count
     }
 
     pub fn claim_token(&self) -> Option<&str> {
@@ -352,6 +388,8 @@ pub enum NotificationOutboxError {
     Push(String),
     #[error("inbox error: {0}")]
     Inbox(String),
+    #[error("blocking storage error: {0}")]
+    Blocking(#[from] BlockingStorageError),
     #[error("XMPP error: {0}")]
     Xmpp(String),
     #[error("invalid push service node")]
@@ -368,6 +406,10 @@ pub enum NotificationOutboxError {
     InvalidPushServiceBareJid(String),
     #[error("invalid conversation JID in notification outbox: {0}")]
     InvalidConversationJid(String),
+    #[error("invalid sender JID in notification outbox: {0}")]
+    InvalidSenderJid(String),
+    #[error("invalid sender JID set in notification outbox: {0}")]
+    InvalidSenderJids(String),
     #[error("invalid archive stanza-id by JID in notification candidate: {0}")]
     InvalidArchiveStanzaIdBy(String),
     #[error("invalid stored notification context XML: {0}")]
@@ -398,17 +440,44 @@ impl NotificationOutboxStore {
                 CREATE TABLE IF NOT EXISTS notification_candidates (
                     recipient_bare_jid TEXT NOT NULL,
                     conversation_jid TEXT NOT NULL,
+                    sender_jid TEXT NOT NULL,
+                    sender_jid_exact INTEGER NOT NULL DEFAULT 1,
                     thread_id TEXT NOT NULL DEFAULT '',
                     stanza_id_by TEXT NOT NULL,
                     stanza_id TEXT NOT NULL,
                     class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
                     reason TEXT NOT NULL CHECK (reason IN ('offline_dm')),
                     created_at_ms {i64_type} NOT NULL,
+                    policy_error_count INTEGER NOT NULL DEFAULT 0,
+                    next_attempt_at_ms {i64_type},
                     outboxed_at_ms {i64_type},
                     PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
                 )
                 "#
             ),
+            (),
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "sender_jid TEXT NOT NULL DEFAULT ''",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "sender_jid_exact INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_candidates",
+            "policy_error_count INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        let candidate_next_attempt_column = format!("next_attempt_at_ms {i64_type}");
+        self.add_column_if_missing("notification_candidates", &candidate_next_attempt_column)
+            .await?;
+        self.execute(
+            "UPDATE notification_candidates SET sender_jid = conversation_jid WHERE sender_jid = ''",
             (),
         )
         .await?;
@@ -447,12 +516,16 @@ impl NotificationOutboxStore {
                     push_service_jid TEXT NOT NULL,
                     node TEXT NOT NULL,
                     conversation_jid TEXT NOT NULL,
+                    sender_jid TEXT NOT NULL,
+                    sender_jids TEXT NOT NULL DEFAULT '[]',
+                    sender_jids_exact INTEGER NOT NULL DEFAULT 1,
                     thread_id TEXT NOT NULL DEFAULT '',
                     class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
                     message_count INTEGER NOT NULL,
                     context_xml TEXT NOT NULL,
                     status TEXT NOT NULL CHECK (status IN ('queued', 'in-progress', 'published', 'failed')),
                     attempt_count INTEGER NOT NULL DEFAULT 0,
+                    policy_error_count INTEGER NOT NULL DEFAULT 0,
                     last_error TEXT,
                     next_attempt_at_ms {i64_type},
                     claimed_at_ms {i64_type},
@@ -463,6 +536,35 @@ impl NotificationOutboxStore {
                 )
                 "#
             ),
+            (),
+        )
+        .await?;
+        self.add_column_if_missing("notification_outbox", "claim_token TEXT")
+            .await?;
+        self.add_column_if_missing("notification_outbox", "sender_jid TEXT NOT NULL DEFAULT ''")
+            .await?;
+        self.add_column_if_missing(
+            "notification_outbox",
+            "sender_jids TEXT NOT NULL DEFAULT '[]'",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_outbox",
+            "sender_jids_exact INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.add_column_if_missing(
+            "notification_outbox",
+            "policy_error_count INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
+        self.execute(
+            "UPDATE notification_outbox SET sender_jid = conversation_jid WHERE sender_jid = ''",
+            (),
+        )
+        .await?;
+        self.execute(
+            "DROP INDEX IF EXISTS idx_notification_outbox_queued_coalesce",
             (),
         )
         .await?;
@@ -497,8 +599,6 @@ impl NotificationOutboxStore {
             (),
         )
         .await?;
-        self.add_column_if_missing("notification_outbox", "claim_token TEXT")
-            .await?;
         Ok(())
     }
 
@@ -554,25 +654,36 @@ impl NotificationOutboxStore {
                 INSERT INTO notification_candidates (
                     recipient_bare_jid,
                     conversation_jid,
+                    sender_jid,
+                    sender_jid_exact,
                     thread_id,
                     stanza_id_by,
                     stanza_id,
                     class,
                     reason,
                     created_at_ms,
+                    policy_error_count,
+                    next_attempt_at_ms,
                     outboxed_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
                 ON CONFLICT DO NOTHING
                 "#,
                 crate::db_params![
                     candidate.recipient_bare_jid.to_string(),
                     candidate.conversation_jid.to_string(),
+                    candidate.sender_jid.to_string(),
+                    if candidate.sender_jid_exact {
+                        1_i64
+                    } else {
+                        0_i64
+                    },
                     candidate.thread_id.as_str(),
                     candidate.archive_stanza_id.by.to_string(),
                     candidate.archive_stanza_id.id.clone(),
                     candidate.class.as_db_value(),
                     candidate.reason.as_db_value(),
                     now_ms,
+                    0_i64,
                 ],
             )
             .await?;
@@ -585,6 +696,7 @@ impl NotificationOutboxStore {
     pub async fn drain_pending_candidates_into_outbox(
         &self,
         push_store: &dyn PushSubscriptionStore,
+        blocking_storage: &dyn BlockingStorage,
         first_party_service_jid: &BareJid,
         batch_size: usize,
     ) -> Result<usize, NotificationOutboxError> {
@@ -593,6 +705,29 @@ impl NotificationOutboxStore {
             std::collections::BTreeMap::<BareJid, Vec<NotificationOutboxTarget>>::new();
         let mut processed = 0usize;
         for candidate in candidates {
+            match xep0191_blocks_notification_candidate(&candidate, blocking_storage).await {
+                Ok(true) => {
+                    let now_ms = crate::time::now_ms();
+                    let mut tx = self.db.begin().await?;
+                    let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
+                    tx.commit().await?;
+                    if claimed > 0 {
+                        processed += 1;
+                    }
+                    continue;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        recipient = %candidate.recipient_bare_jid(),
+                        sender = %candidate.sender_jid(),
+                        %error,
+                        "XEP-0191 blocklist load failed; deferring notification candidate fail-closed"
+                    );
+                    self.defer_candidate_policy_error(&candidate).await?;
+                    continue;
+                }
+            }
             let recipient_key = candidate.recipient_bare_jid.clone();
             if !target_cache.contains_key(&recipient_key) {
                 let resolved = resolve_first_party_targets(
@@ -624,6 +759,42 @@ impl NotificationOutboxStore {
         Ok(processed)
     }
 
+    async fn defer_candidate_policy_error(
+        &self,
+        candidate: &NotificationCandidate,
+    ) -> Result<(), NotificationOutboxError> {
+        let now_ms = crate::time::now_ms();
+        let next_policy_error_count = candidate.policy_error_count + 1;
+        self.execute(
+            r#"
+            UPDATE notification_candidates
+            SET policy_error_count = ?,
+                next_attempt_at_ms = ?
+            WHERE recipient_bare_jid = ?
+              AND conversation_jid = ?
+              AND sender_jid = ?
+              AND thread_id = ?
+              AND stanza_id_by = ?
+              AND stanza_id = ?
+              AND class = ?
+              AND outboxed_at_ms IS NULL
+            "#,
+            crate::db_params![
+                next_policy_error_count,
+                now_ms.saturating_add(policy_retry_delay_ms(next_policy_error_count)),
+                candidate.recipient_bare_jid.to_string(),
+                candidate.conversation_jid.to_string(),
+                candidate.sender_jid.to_string(),
+                candidate.thread_id.as_str(),
+                candidate.archive_stanza_id.by.to_string(),
+                candidate.archive_stanza_id.id.clone(),
+                candidate.class.as_db_value(),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
     async fn pending_candidates(
         &self,
         batch_size: usize,
@@ -634,23 +805,28 @@ impl NotificationOutboxStore {
                 r#"
                 SELECT recipient_bare_jid,
                        conversation_jid,
+                       sender_jid,
+                       sender_jid_exact,
                        thread_id,
                        stanza_id_by,
                        stanza_id,
                        class,
-                       reason
+                       reason,
+                       policy_error_count
                 FROM notification_candidates
                 WHERE outboxed_at_ms IS NULL
+                  AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)
                 ORDER BY created_at_ms ASC,
                          recipient_bare_jid ASC,
                          conversation_jid ASC,
+                         sender_jid ASC,
                          thread_id ASC,
                          stanza_id_by ASC,
                          stanza_id ASC,
                          class ASC
                 LIMIT ?
                 "#,
-                crate::db_params![batch_size as i64],
+                crate::db_params![crate::time::now_ms(), batch_size as i64],
             )
             .await?;
         let mut candidates = Vec::new();
@@ -671,12 +847,16 @@ impl NotificationOutboxStore {
                        push_service_jid,
                        node,
                        conversation_jid,
+                       sender_jid,
+                       sender_jids,
+                       sender_jids_exact,
                        thread_id,
                        class,
                        message_count,
                        context_xml,
                        status,
                        attempt_count,
+                       policy_error_count,
                        claim_token
                 FROM notification_outbox
                 WHERE status IN (?, ?)
@@ -707,12 +887,16 @@ impl NotificationOutboxStore {
                        push_service_jid,
                        node,
                        conversation_jid,
+                       sender_jid,
+                       sender_jids,
+                       sender_jids_exact,
                        thread_id,
                        class,
                        message_count,
                        context_xml,
                        status,
                        attempt_count,
+                       policy_error_count,
                        claim_token
                 FROM notification_outbox
                 WHERE (
@@ -792,6 +976,7 @@ impl NotificationOutboxStore {
         push_service: &crate::push_service::DatabasePushServiceStore,
         push_store: &dyn PushSubscriptionStore,
         inbox_storage: &dyn InboxStorage,
+        blocking_storage: &dyn BlockingStorage,
         first_party_service_jid: &BareJid,
         batch_size: usize,
     ) -> Result<Vec<NotificationOutboxPublishOutcome>, NotificationOutboxError> {
@@ -804,6 +989,7 @@ impl NotificationOutboxStore {
                     push_service,
                     push_store,
                     inbox_storage,
+                    blocking_storage,
                     first_party_service_jid,
                 )
                 .await
@@ -867,6 +1053,7 @@ impl NotificationOutboxStore {
                 WHERE (
                     recipient_bare_jid,
                     conversation_jid,
+                    sender_jid,
                     thread_id,
                     stanza_id_by,
                     stanza_id,
@@ -874,6 +1061,7 @@ impl NotificationOutboxStore {
                 ) IN (
                     SELECT recipient_bare_jid,
                            conversation_jid,
+                           sender_jid,
                            thread_id,
                            stanza_id_by,
                            stanza_id,
@@ -884,6 +1072,7 @@ impl NotificationOutboxStore {
                     ORDER BY outboxed_at_ms ASC,
                              recipient_bare_jid ASC,
                              conversation_jid ASC,
+                             sender_jid ASC,
                              thread_id ASC,
                              stanza_id_by ASC,
                              stanza_id ASC,
@@ -902,6 +1091,7 @@ impl NotificationOutboxStore {
         push_service: &crate::push_service::DatabasePushServiceStore,
         push_store: &dyn PushSubscriptionStore,
         inbox_storage: &dyn InboxStorage,
+        blocking_storage: &dyn BlockingStorage,
         first_party_service_jid: &BareJid,
     ) -> Result<NotificationOutboxPublishOutcome, NotificationOutboxError> {
         if job.push_service_jid() != first_party_service_jid {
@@ -919,6 +1109,31 @@ impl NotificationOutboxStore {
             return Ok(NotificationOutboxPublishOutcome::RetryScheduled {
                 job_id: job.job_id.clone(),
             });
+        }
+
+        match xep0191_blocks_notification_job(job, blocking_storage).await {
+            Ok(true) => {
+                if self
+                    .mark_job_failed(job, "recipient blocked sender before XEP-0357 publish")
+                    .await?
+                {
+                    return Ok(NotificationOutboxPublishOutcome::Failed {
+                        job_id: job.job_id.clone(),
+                    });
+                }
+                return Ok(NotificationOutboxPublishOutcome::RetryScheduled {
+                    job_id: job.job_id.clone(),
+                });
+            }
+            Ok(false) => {}
+            Err(error) => {
+                return self
+                    .defer_claimed_job_without_attempt(
+                        job,
+                        format!("XEP-0191 blocklist load failed: {error}"),
+                    )
+                    .await;
+            }
         }
 
         let registrations = push_store
@@ -1032,6 +1247,44 @@ impl NotificationOutboxStore {
         }
     }
 
+    async fn defer_claimed_job_without_attempt(
+        &self,
+        job: &NotificationOutboxJob,
+        error: String,
+    ) -> Result<NotificationOutboxPublishOutcome, NotificationOutboxError> {
+        let now_ms = crate::time::now_ms();
+        let next_policy_error_count = job.policy_error_count + 1;
+        self.execute(
+            r#"
+            UPDATE notification_outbox
+            SET status = ?,
+                policy_error_count = ?,
+                last_error = ?,
+                next_attempt_at_ms = ?,
+                claimed_at_ms = NULL,
+                claim_token = NULL,
+                updated_at_ms = ?
+            WHERE job_id = ?
+              AND status = ?
+              AND claim_token = ?
+            "#,
+            crate::db_params![
+                STATUS_QUEUED,
+                next_policy_error_count,
+                error,
+                now_ms.saturating_add(policy_retry_delay_ms(next_policy_error_count)),
+                now_ms,
+                job.job_id.as_str(),
+                STATUS_IN_PROGRESS,
+                job.claim_token.as_deref(),
+            ],
+        )
+        .await?;
+        Ok(NotificationOutboxPublishOutcome::RetryScheduled {
+            job_id: job.job_id.clone(),
+        })
+    }
+
     async fn mark_job_published(
         &self,
         job: &NotificationOutboxJob,
@@ -1042,6 +1295,7 @@ impl NotificationOutboxStore {
                 r#"
             UPDATE notification_outbox
             SET status = ?,
+                policy_error_count = 0,
                 last_error = NULL,
                 next_attempt_at_ms = NULL,
                 claimed_at_ms = NULL,
@@ -1076,6 +1330,7 @@ impl NotificationOutboxStore {
                 r#"
             UPDATE notification_outbox
             SET status = ?,
+                policy_error_count = 0,
                 last_error = ?,
                 next_attempt_at_ms = NULL,
                 claimed_at_ms = NULL,
@@ -1119,6 +1374,7 @@ impl NotificationOutboxStore {
             UPDATE notification_outbox
             SET status = ?,
                 attempt_count = ?,
+                policy_error_count = 0,
                 last_error = ?,
                 next_attempt_at_ms = ?,
                 claimed_at_ms = NULL,
@@ -1147,6 +1403,93 @@ impl NotificationOutboxStore {
     }
 }
 
+async fn xep0191_blocks_notification_job(
+    job: &NotificationOutboxJob,
+    blocking_storage: &dyn BlockingStorage,
+) -> Result<bool, BlockingStorageError> {
+    if job.class() != NotificationClass::DirectMessage {
+        return Ok(false);
+    }
+    let blocked = blocking_storage
+        .list_blocked_jid_entries(job.recipient_bare_jid())
+        .await?;
+    Ok(blocked
+        .into_iter()
+        .any(|blocked_jid| xep0191_block_entry_matches_outbox_job(&blocked_jid, job)))
+}
+
+async fn xep0191_blocks_notification_candidate(
+    candidate: &NotificationCandidate,
+    blocking_storage: &dyn BlockingStorage,
+) -> Result<bool, BlockingStorageError> {
+    if candidate.class() != NotificationClass::DirectMessage {
+        return Ok(false);
+    }
+    let blocked = blocking_storage
+        .list_blocked_jid_entries(candidate.recipient_bare_jid())
+        .await?;
+    Ok(blocked.into_iter().any(|blocked_jid| {
+        xep0191_block_entry_matches_sender(
+            &blocked_jid,
+            candidate.sender_jid(),
+            candidate.sender_jid_exact(),
+        )
+    }))
+}
+
+fn xep0191_block_entry_matches_outbox_job(blocked_jid: &Jid, job: &NotificationOutboxJob) -> bool {
+    if blocked_jid.resource().is_some() {
+        if job.sender_jids_exact() {
+            job.sender_jids()
+                .iter()
+                .any(|sender_jid| blocked_jid == sender_jid)
+        } else {
+            blocked_jid.to_bare() == *job.conversation_jid()
+        }
+    } else if blocked_jid.node().is_some() {
+        blocked_jid.to_bare() == *job.conversation_jid()
+    } else {
+        blocked_jid.domain() == job.conversation_jid().domain()
+    }
+}
+
+fn xep0191_block_entry_matches_sender(
+    blocked_jid: &Jid,
+    sender_jid: &Jid,
+    sender_jid_exact: bool,
+) -> bool {
+    if blocked_jid.resource().is_some() {
+        if sender_jid_exact {
+            blocked_jid == sender_jid
+        } else {
+            blocked_jid.to_bare() == sender_jid.to_bare()
+        }
+    } else if blocked_jid.node().is_some() {
+        blocked_jid.to_bare() == sender_jid.to_bare()
+    } else {
+        blocked_jid.domain() == sender_jid.domain()
+    }
+}
+
+fn encode_sender_jids(sender_jids: &[Jid]) -> Result<String, NotificationOutboxError> {
+    let values: Vec<String> = sender_jids.iter().map(ToString::to_string).collect();
+    serde_json::to_string(&values)
+        .map_err(|error| NotificationOutboxError::InvalidSenderJids(error.to_string()))
+}
+
+fn decode_sender_jids(raw: &str) -> Result<Vec<Jid>, NotificationOutboxError> {
+    let values: Vec<String> = serde_json::from_str(raw)
+        .map_err(|error| NotificationOutboxError::InvalidSenderJids(error.to_string()))?;
+    values
+        .into_iter()
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|_| NotificationOutboxError::InvalidSenderJid(value))
+        })
+        .collect()
+}
+
 async fn enqueue_outbox_job_tx(
     tx: &mut crate::db::Transaction<'_>,
     candidate: &NotificationCandidate,
@@ -1157,20 +1500,30 @@ async fn enqueue_outbox_job_tx(
     let job_id = NotificationOutboxJobId::fresh();
     // The durable schema stores XML as TEXT; keep protocol context typed until this DB write edge.
     let context_xml = String::from(context);
-    tx.execute(
-        r#"
+    let sender_jids = if candidate.sender_jid_exact() {
+        encode_sender_jids(std::slice::from_ref(&candidate.sender_jid))?
+    } else {
+        encode_sender_jids(&[])?
+    };
+    let inserted = tx
+        .execute(
+            r#"
             INSERT INTO notification_outbox (
                 job_id,
                 recipient_bare_jid,
                 push_service_jid,
                 node,
                 conversation_jid,
+                sender_jid,
+                sender_jids,
+                sender_jids_exact,
                 thread_id,
                 class,
                 message_count,
                 context_xml,
                 status,
                 attempt_count,
+                policy_error_count,
                 last_error,
                 next_attempt_at_ms,
                 claimed_at_ms,
@@ -1178,34 +1531,126 @@ async fn enqueue_outbox_job_tx(
                 created_at_ms,
                 updated_at_ms,
                 published_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 0, NULL, NULL, NULL, NULL, ?, ?, NULL)
-            ON CONFLICT (
-                recipient_bare_jid,
-                push_service_jid,
-                node,
-                conversation_jid,
-                thread_id,
-                class
-            ) WHERE status = 'queued'
-            DO UPDATE SET
-                message_count = notification_outbox.message_count + 1,
-                context_xml = excluded.context_xml,
-                last_error = NULL,
-                next_attempt_at_ms = NULL,
-                updated_at_ms = excluded.updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, 0, 0, NULL, NULL, NULL, NULL, ?, ?, NULL)
+            ON CONFLICT DO NOTHING
             "#,
+            crate::db_params![
+                job_id.as_str(),
+                candidate.recipient_bare_jid.to_string(),
+                target.push_service_jid.to_string(),
+                target.node.as_str(),
+                candidate.conversation_jid.to_string(),
+                candidate.sender_jid.to_string(),
+                sender_jids,
+                if candidate.sender_jid_exact() { 1_i64 } else { 0_i64 },
+                candidate.thread_id.as_str(),
+                candidate.class.as_db_value(),
+                context_xml.as_str(),
+                STATUS_QUEUED,
+                now_ms,
+                now_ms,
+            ],
+        )
+        .await?;
+    if inserted == 0 {
+        merge_outbox_job_tx(tx, candidate, target, context_xml.as_str(), now_ms).await?;
+    }
+    Ok(())
+}
+
+async fn merge_outbox_job_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    candidate: &NotificationCandidate,
+    target: &NotificationOutboxTarget,
+    context_xml: &str,
+    now_ms: i64,
+) -> Result<(), NotificationOutboxError> {
+    let mut rows = tx
+        .query(
+            r#"
+            SELECT sender_jid, sender_jids, sender_jids_exact
+            FROM notification_outbox
+            WHERE recipient_bare_jid = ?
+              AND push_service_jid = ?
+              AND node = ?
+              AND conversation_jid = ?
+              AND thread_id = ?
+              AND class = ?
+              AND status = ?
+            LIMIT 1
+            "#,
+            crate::db_params![
+                candidate.recipient_bare_jid.to_string(),
+                target.push_service_jid.to_string(),
+                target.node.as_str(),
+                candidate.conversation_jid.to_string(),
+                candidate.thread_id.as_str(),
+                candidate.class.as_db_value(),
+                STATUS_QUEUED,
+            ],
+        )
+        .await?;
+    let Some(row) = rows.next().await? else {
+        return Ok(());
+    };
+    let existing_sender_raw: String = row.get(0)?;
+    let mut sender_jids = decode_sender_jids(&row.get::<String>(1)?)?;
+    let sender_jids_exact = row.get::<i64>(2)? != 0;
+    let merged_sender_jids_exact = sender_jids_exact && candidate.sender_jid_exact();
+    if !merged_sender_jids_exact {
+        sender_jids.clear();
+    } else if sender_jids.is_empty() {
+        sender_jids.push(
+            existing_sender_raw
+                .parse()
+                .map_err(|_| NotificationOutboxError::InvalidSenderJid(existing_sender_raw))?,
+        );
+    }
+    if merged_sender_jids_exact
+        && !sender_jids
+            .iter()
+            .any(|sender_jid| sender_jid == &candidate.sender_jid)
+    {
+        sender_jids.push(candidate.sender_jid.clone());
+    }
+    let sender_jids = encode_sender_jids(&sender_jids)?;
+    tx.execute(
+        r#"
+        UPDATE notification_outbox
+        SET message_count = message_count + 1,
+            context_xml = ?,
+            sender_jid = ?,
+            sender_jids = ?,
+            sender_jids_exact = ?,
+            policy_error_count = 0,
+            last_error = NULL,
+            next_attempt_at_ms = NULL,
+            updated_at_ms = ?
+        WHERE recipient_bare_jid = ?
+          AND push_service_jid = ?
+          AND node = ?
+          AND conversation_jid = ?
+          AND thread_id = ?
+          AND class = ?
+          AND status = ?
+        "#,
         crate::db_params![
-            job_id.as_str(),
+            context_xml,
+            candidate.sender_jid.to_string(),
+            sender_jids,
+            if merged_sender_jids_exact {
+                1_i64
+            } else {
+                0_i64
+            },
+            now_ms,
             candidate.recipient_bare_jid.to_string(),
             target.push_service_jid.to_string(),
             target.node.as_str(),
             candidate.conversation_jid.to_string(),
             candidate.thread_id.as_str(),
             candidate.class.as_db_value(),
-            context_xml.as_str(),
             STATUS_QUEUED,
-            now_ms,
-            now_ms,
         ],
     )
     .await?;
@@ -1224,6 +1669,7 @@ async fn mark_candidate_outboxed_tx(
             SET outboxed_at_ms = ?
             WHERE recipient_bare_jid = ?
               AND conversation_jid = ?
+              AND sender_jid = ?
               AND thread_id = ?
               AND stanza_id_by = ?
               AND stanza_id = ?
@@ -1234,6 +1680,7 @@ async fn mark_candidate_outboxed_tx(
                 now_ms,
                 candidate.recipient_bare_jid.to_string(),
                 candidate.conversation_jid.to_string(),
+                candidate.sender_jid.to_string(),
                 candidate.thread_id.as_str(),
                 candidate.archive_stanza_id.by.to_string(),
                 candidate.archive_stanza_id.id.clone(),
@@ -1317,7 +1764,8 @@ async fn current_unread_count_for_job(
 fn decode_candidate(row: &Row) -> Result<NotificationCandidate, NotificationOutboxError> {
     let recipient_raw: String = row.get(0)?;
     let conversation_raw: String = row.get(1)?;
-    let stanza_id_by_raw: String = row.get(3)?;
+    let sender_raw: String = row.get(2)?;
+    let stanza_id_by_raw: String = row.get(5)?;
     Ok(NotificationCandidate {
         recipient_bare_jid: recipient_raw
             .parse()
@@ -1325,15 +1773,20 @@ fn decode_candidate(row: &Row) -> Result<NotificationCandidate, NotificationOutb
         conversation_jid: conversation_raw
             .parse()
             .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?,
-        thread_id: NotificationThreadId::new(row.get::<String>(2)?),
+        sender_jid: sender_raw
+            .parse()
+            .map_err(|_| NotificationOutboxError::InvalidSenderJid(sender_raw))?,
+        sender_jid_exact: row.get::<i64>(3)? != 0,
+        thread_id: NotificationThreadId::new(row.get::<String>(4)?),
         archive_stanza_id: StanzaId::new(
-            row.get::<String>(4)?,
+            row.get::<String>(6)?,
             stanza_id_by_raw
                 .parse()
                 .map_err(|_| NotificationOutboxError::InvalidArchiveStanzaIdBy(stanza_id_by_raw))?,
         ),
-        class: NotificationClass::from_db_value(&row.get::<String>(5)?)?,
-        reason: NotificationReason::from_db_value(&row.get::<String>(6)?)?,
+        class: NotificationClass::from_db_value(&row.get::<String>(7)?)?,
+        reason: NotificationReason::from_db_value(&row.get::<String>(8)?)?,
+        policy_error_count: row.get(9)?,
     })
 }
 
@@ -1341,8 +1794,14 @@ fn decode_outbox_job(row: &Row) -> Result<NotificationOutboxJob, NotificationOut
     let recipient_raw: String = row.get(1)?;
     let push_service_raw: String = row.get(2)?;
     let conversation_raw: String = row.get(4)?;
-    let message_count: i64 = row.get(7)?;
-    let context_xml: String = row.get(8)?;
+    let sender_raw: String = row.get(5)?;
+    let sender_jids_raw: String = row.get(6)?;
+    let message_count: i64 = row.get(10)?;
+    let context_xml: String = row.get(11)?;
+    let sender_jid: Jid = sender_raw
+        .parse()
+        .map_err(|_| NotificationOutboxError::InvalidSenderJid(sender_raw))?;
+    let sender_jids = decode_sender_jids(&sender_jids_raw)?;
     Ok(NotificationOutboxJob {
         job_id: NotificationOutboxJobId::from(row.get::<String>(0)?),
         recipient_bare_jid: recipient_raw
@@ -1355,16 +1814,20 @@ fn decode_outbox_job(row: &Row) -> Result<NotificationOutboxJob, NotificationOut
         conversation_jid: conversation_raw
             .parse()
             .map_err(|_| NotificationOutboxError::InvalidConversationJid(conversation_raw))?,
-        thread_id: NotificationThreadId::new(row.get::<String>(5)?),
-        class: NotificationClass::from_db_value(&row.get::<String>(6)?)?,
+        sender_jid,
+        sender_jids,
+        sender_jids_exact: row.get::<i64>(7)? != 0,
+        thread_id: NotificationThreadId::new(row.get::<String>(8)?),
+        class: NotificationClass::from_db_value(&row.get::<String>(9)?)?,
         message_count: u32::try_from(message_count)
             .map_err(|_| NotificationOutboxError::InvalidMessageCount(message_count))?,
         context: context_xml
             .parse::<Element>()
             .map_err(|error| NotificationOutboxError::InvalidContextXml(error.to_string()))?,
-        status: NotificationOutboxStatus::from_db_value(&row.get::<String>(9)?)?,
-        attempt_count: row.get(10)?,
-        claim_token: row.get(11)?,
+        status: NotificationOutboxStatus::from_db_value(&row.get::<String>(12)?)?,
+        attempt_count: row.get(13)?,
+        policy_error_count: row.get(14)?,
+        claim_token: row.get(15)?,
     })
 }
 
@@ -1421,6 +1884,13 @@ fn retry_delay_ms(attempt_count: i64) -> i64 {
         .min(MAX_RETRY_DELAY_MS)
 }
 
+fn policy_retry_delay_ms(policy_error_count: i64) -> i64 {
+    let exponent = (policy_error_count - 1).clamp(0, 10) as u32;
+    BASE_POLICY_RETRY_DELAY_MS
+        .saturating_mul(2_i64.saturating_pow(exponent))
+        .min(MAX_RETRY_DELAY_MS)
+}
+
 pub fn target_from_subscription(
     subscription: &waddle_xmpp::push::PushSubscription,
 ) -> Result<Option<NotificationOutboxTarget>, NotificationOutboxError> {
@@ -1460,9 +1930,17 @@ mod tests {
     }
 
     fn candidate_for(recipient: &BareJid, sender: &BareJid, id: &str) -> NotificationCandidate {
+        candidate_for_sender_jid(recipient, Jid::from(sender.clone()), id)
+    }
+
+    fn candidate_for_sender_jid(
+        recipient: &BareJid,
+        sender_jid: Jid,
+        id: &str,
+    ) -> NotificationCandidate {
         NotificationCandidate::direct_message(
             recipient.clone(),
-            sender.clone(),
+            sender_jid,
             StanzaId::new(id, Jid::from(recipient.clone())),
         )
         .expect("candidate")
@@ -1558,6 +2036,113 @@ mod tests {
         inbox
     }
 
+    async fn drain_dm_outbox_with_blocking(
+        archive_id: &str,
+        blocking: &dyn BlockingStorage,
+    ) -> (
+        Vec<NotificationOutboxPublishOutcome>,
+        usize,
+        Vec<NotificationOutboxJob>,
+    ) {
+        drain_dm_outbox_with_sender_jid(
+            archive_id,
+            "bob@example.com/phone".parse().expect("sender JID"),
+            blocking,
+        )
+        .await
+    }
+
+    async fn drain_dm_outbox_with_sender_jid(
+        archive_id: &str,
+        sender_jid: Jid,
+        blocking: &dyn BlockingStorage,
+    ) -> (
+        Vec<NotificationOutboxPublishOutcome>,
+        usize,
+        Vec<NotificationOutboxJob>,
+    ) {
+        let store = store().await;
+        let recipient = bare("alice@example.com");
+        let sender = sender_jid.to_bare();
+        let push_db_name = format!("push-service-{archive_id}");
+        let push_service = crate::push_service::DatabasePushServiceStore::new(
+            Database::in_memory(&push_db_name).await.unwrap(),
+        )
+        .await
+        .expect("push service");
+        crate::push_registrations::DatabasePushRegistrationStore::new(push_service.database())
+            .await
+            .expect("push registration schema");
+        let push_node = push_service
+            .ensure_node(&recipient, "web")
+            .await
+            .expect("push node");
+        push_service
+            .upsert_device(
+                &recipient,
+                crate::push_service::PushDeviceRegistration::new(
+                    "web-1",
+                    push_node.node(),
+                    crate::push_service::PushDevicePlatform::Web,
+                    "test",
+                ),
+            )
+            .await
+            .expect("push device");
+        push_service
+            .register_first_party_node_for_owner(
+                &recipient,
+                "push.example.com",
+                push_node.node(),
+                None,
+            )
+            .await
+            .expect("first-party registration");
+        let target = NotificationOutboxTarget::new(
+            bare("push.example.com"),
+            PushServiceNodeName::new(push_node.node()).expect("push node target"),
+        );
+        enqueue_jobs_for_test(
+            &store,
+            &candidate_for_sender_jid(&recipient, sender_jid, archive_id),
+            &[target],
+        )
+        .await;
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        push_store
+            .register(waddle_xmpp::push::PushSubscription {
+                user_jid: recipient.to_string(),
+                service_jid: "push.example.com".to_string(),
+                node: Some(push_node.node().to_string()),
+                publish_options: None,
+                endpoint: None,
+                p256dh: None,
+                auth_key: None,
+            })
+            .await
+            .expect("xep0357 registration");
+        let inbox = inbox_with_unread(&recipient, &sender, 1).await;
+
+        let outcomes = store
+            .drain_due_outbox_jobs(
+                &push_service,
+                &push_store,
+                &inbox,
+                blocking,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain outbox");
+        let queued_push_job_count = push_service
+            .queued_publish_jobs()
+            .await
+            .expect("queued push jobs")
+            .len();
+        let pending = store.pending_outbox_jobs().await.expect("pending jobs");
+        (outcomes, queued_push_job_count, pending)
+    }
+
     async fn reclaim_stale_job(
         store: &NotificationOutboxStore,
     ) -> (NotificationOutboxJob, NotificationOutboxJob) {
@@ -1593,6 +2178,7 @@ mod tests {
         let store = store().await;
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
         let first = candidate("archive-1");
         let duplicate = candidate("archive-1");
         let second = candidate("archive-2");
@@ -1624,7 +2210,12 @@ mod tests {
             .is_empty());
         assert_eq!(
             store
-                .drain_pending_candidates_into_outbox(&push_store, &bare("push.example.com"), 16,)
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
                 .await
                 .expect("drain candidates"),
             2
@@ -1637,10 +2228,401 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn candidate_worker_coalesces_distinct_sender_resources_into_one_bare_conversation_job() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-bob-phone",
+        );
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-bob-laptop",
+        );
+        assert_eq!(
+            store.insert_candidate(&phone).await.expect("phone insert"),
+            NotificationCandidateInsertOutcome::Inserted
+        );
+        assert_eq!(
+            store
+                .insert_candidate(&laptop)
+                .await
+                .expect("laptop insert"),
+            NotificationCandidateInsertOutcome::Inserted
+        );
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            2
+        );
+
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].conversation_jid(), &bare("bob@example.com"));
+        assert_eq!(jobs[0].message_count(), 2);
+        let mut sender_jids = jobs[0]
+            .sender_jids()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        sender_jids.sort();
+        assert_eq!(
+            sender_jids,
+            vec![
+                "bob@example.com/laptop".to_string(),
+                "bob@example.com/phone".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_downgrades_coalesced_outbox_job_when_legacy_sender_is_merged() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let exact = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-exact-phone",
+        );
+        store.insert_candidate(&exact).await.expect("exact insert");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain exact candidate"),
+            1
+        );
+
+        let legacy = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-legacy-laptop",
+        );
+        store
+            .insert_candidate(&legacy)
+            .await
+            .expect("legacy insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET sender_jid = conversation_jid, sender_jid_exact = 0 WHERE stanza_id = ?",
+                crate::db_params!["archive-legacy-laptop"],
+            )
+            .await
+            .expect("simulate legacy backfill");
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain legacy candidate"),
+            1
+        );
+
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].message_count(), 2);
+        assert!(!jobs[0].sender_jids_exact());
+        assert!(jobs[0].sender_jids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_filters_full_jid_block_before_bare_conversation_coalescing() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        blocking.set_blocklist_jids(
+            recipient.clone(),
+            vec!["bob@example.com/phone".parse().expect("blocked sender")],
+        );
+
+        let blocked_phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-blocked-phone",
+        );
+        let allowed_laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-allowed-laptop",
+        );
+        store
+            .insert_candidate(&blocked_phone)
+            .await
+            .expect("blocked insert");
+        store
+            .insert_candidate(&allowed_laptop)
+            .await
+            .expect("allowed insert");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            2
+        );
+
+        let jobs = store.pending_outbox_jobs().await.expect("jobs");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].conversation_jid(), &bare("bob@example.com"));
+        assert_eq!(jobs[0].sender_jid().to_string(), "bob@example.com/laptop");
+        assert_eq!(jobs[0].message_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_full_jid_block_suppresses_legacy_candidate_without_exact_sender() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        blocking.set_blocklist_jids(
+            recipient.clone(),
+            vec!["bob@example.com/phone".parse().expect("blocked sender")],
+        );
+        let candidate = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-legacy-candidate",
+        );
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("candidate insert");
+        store
+            .execute(
+                "UPDATE notification_candidates SET sender_jid = conversation_jid, sender_jid_exact = 0 WHERE stanza_id = ?",
+                crate::db_params!["archive-legacy-candidate"],
+            )
+            .await
+            .expect("simulate legacy backfill");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            1
+        );
+
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("pending candidates")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn xep0191_full_jid_block_added_after_coalescing_suppresses_dm_push_job() {
+        let store = store().await;
+        let recipient = bare("alice@example.com");
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let push_service = crate::push_service::DatabasePushServiceStore::new(
+            Database::in_memory("push-service-coalesced-full-jid-block")
+                .await
+                .unwrap(),
+        )
+        .await
+        .expect("push service");
+        crate::push_registrations::DatabasePushRegistrationStore::new(push_service.database())
+            .await
+            .expect("push registration schema");
+        let push_node = push_service
+            .ensure_node(&recipient, "web")
+            .await
+            .expect("push node");
+        push_service
+            .upsert_device(
+                &recipient,
+                crate::push_service::PushDeviceRegistration::new(
+                    "web-1",
+                    push_node.node(),
+                    crate::push_service::PushDevicePlatform::Web,
+                    "test",
+                ),
+            )
+            .await
+            .expect("push device");
+        push_service
+            .register_first_party_node_for_owner(
+                &recipient,
+                "push.example.com",
+                push_node.node(),
+                None,
+            )
+            .await
+            .expect("first-party registration");
+        let target = NotificationOutboxTarget::new(
+            bare("push.example.com"),
+            PushServiceNodeName::new(push_node.node()).expect("push node target"),
+        );
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let phone = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/phone".parse().expect("phone sender"),
+            "archive-coalesced-phone",
+        );
+        let laptop = candidate_for_sender_jid(
+            &recipient,
+            "bob@example.com/laptop".parse().expect("laptop sender"),
+            "archive-coalesced-laptop",
+        );
+        store.insert_candidate(&phone).await.expect("phone insert");
+        store
+            .insert_candidate(&laptop)
+            .await
+            .expect("laptop insert");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            2
+        );
+        let pending = store.pending_outbox_jobs().await.expect("pending");
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].message_count(), 2);
+        assert!(pending[0]
+            .sender_jids()
+            .contains(&"bob@example.com/phone".parse().expect("phone sender")));
+
+        blocking.set_blocklist_jids(
+            recipient.clone(),
+            vec!["bob@example.com/phone".parse().expect("blocked sender")],
+        );
+
+        let publish_push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        register_push_target(&publish_push_store, &recipient, &target).await;
+        let inbox = inbox_with_unread(&recipient, &bare("bob@example.com"), 2).await;
+
+        let outcomes = store
+            .drain_due_outbox_jobs(
+                &push_service,
+                &publish_push_store,
+                &inbox,
+                &blocking,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain outbox");
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::Failed { .. }
+        ));
+        assert!(
+            push_service
+                .queued_publish_jobs()
+                .await
+                .expect("queued push jobs")
+                .is_empty(),
+            "a coalesced job that includes a blocked full sender JID must not publish"
+        );
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+    }
+
+    #[test]
+    fn xep0191_full_jid_block_fails_closed_for_legacy_outbox_job_without_sender_provenance() {
+        let job = NotificationOutboxJob {
+            job_id: NotificationOutboxJobId::fresh(),
+            recipient_bare_jid: bare("alice@example.com"),
+            push_service_jid: bare("push.example.com"),
+            node: PushServiceNodeName::new("web-node").expect("node"),
+            conversation_jid: bare("bob@example.com"),
+            sender_jid: Jid::from(bare("bob@example.com")),
+            sender_jids: Vec::new(),
+            sender_jids_exact: false,
+            thread_id: NotificationThreadId::root(),
+            class: NotificationClass::DirectMessage,
+            message_count: 1,
+            context: Element::builder("context", WADDLE_PUSH_CONTEXT_NS).build(),
+            status: NotificationOutboxStatus::Queued,
+            attempt_count: 0,
+            policy_error_count: 0,
+            claim_token: None,
+        };
+
+        assert!(xep0191_block_entry_matches_outbox_job(
+            &"bob@example.com/phone".parse().expect("full blocked JID"),
+            &job,
+        ));
+        assert!(
+            !xep0191_block_entry_matches_outbox_job(
+                &"carol@example.com".parse().expect("bare blocked JID"),
+                &job,
+            ),
+            "bare-JID blocks still match the durable bare conversation identity"
+        );
+    }
+
+    #[tokio::test]
     async fn candidate_worker_skips_malformed_registration_and_continues_batch() {
         let store = store().await;
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
         let alice = bare("alice@example.com");
         let carol = bare("carol@example.com");
         let bob = bare("bob@example.com");
@@ -1678,7 +2660,12 @@ mod tests {
 
         assert_eq!(
             store
-                .drain_pending_candidates_into_outbox(&push_store, &bare("push.example.com"), 16,)
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
                 .await
                 .expect("drain candidates"),
             2
@@ -1688,6 +2675,97 @@ mod tests {
         assert_eq!(jobs.len(), 1);
         assert_eq!(jobs[0].recipient_bare_jid(), &carol);
         assert_eq!(jobs[0].message_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn candidate_worker_defers_candidates_fail_closed_when_blocklist_load_fails() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+        store
+            .insert_candidate(&candidate_for(
+                &recipient,
+                &bare("bob@example.com"),
+                "archive-policy-error-1",
+            ))
+            .await
+            .expect("first insert");
+        store
+            .insert_candidate(&candidate_for(
+                &recipient,
+                &bare("carol@example.com"),
+                "archive-policy-error-2",
+            ))
+            .await
+            .expect("second insert");
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &FailingBlockingStorage,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            0
+        );
+
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        assert!(store
+            .pending_candidates(16)
+            .await
+            .expect("backed-off pending candidates")
+            .is_empty());
+
+        let mut rows = store
+            .query(
+                "SELECT policy_error_count FROM notification_candidates ORDER BY stanza_id",
+                (),
+            )
+            .await
+            .expect("policy count query");
+        let mut policy_error_counts = Vec::new();
+        while let Some(row) = rows.next().await.expect("policy count row") {
+            policy_error_counts.push(row.get::<i64>(0).expect("policy count"));
+        }
+        assert_eq!(policy_error_counts, vec![1, 1]);
+
+        store
+            .execute(
+                "UPDATE notification_candidates SET next_attempt_at_ms = NULL",
+                (),
+            )
+            .await
+            .expect("release backoff");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("retry drain candidates"),
+            2
+        );
+        assert_eq!(
+            store
+                .pending_outbox_jobs()
+                .await
+                .expect("retried pending jobs")
+                .len(),
+            2
+        );
     }
 
     #[test]
@@ -1822,6 +2900,7 @@ mod tests {
     async fn stale_claim_does_not_enqueue_push_service_publish_job() {
         let store = store().await;
         let recipient = bare("alice@example.com");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
         let push_service = crate::push_service::DatabasePushServiceStore::new(
             Database::in_memory("push-service").await.unwrap(),
         )
@@ -1887,6 +2966,7 @@ mod tests {
                 &push_service,
                 &push_store,
                 &inbox,
+                &blocking,
                 &bare("push.example.com"),
             )
             .await
@@ -2021,6 +3101,7 @@ mod tests {
     async fn publish_rejects_non_first_party_outbox_target() {
         let store = store().await;
         enqueue_jobs_for_test(&store, &candidate("archive-1"), &[foreign_target()]).await;
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
         let push_service = crate::push_service::DatabasePushServiceStore::new(
             Database::in_memory("push-service").await.unwrap(),
         )
@@ -2039,6 +3120,7 @@ mod tests {
                 &push_service,
                 &push_store,
                 &inbox,
+                &blocking,
                 &bare("push.example.com"),
                 16,
             )
@@ -2058,6 +3140,140 @@ mod tests {
                 .is_empty(),
             "foreign outbox target must not enqueue a first-party Push Service job"
         );
+    }
+
+    #[tokio::test]
+    async fn xep0191_blocked_dm_outbox_job_does_not_publish_push_notification() {
+        let recipient = bare("alice@example.com");
+        let sender = bare("bob@example.com");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        blocking.set_blocklist(recipient.clone(), vec![sender.clone()]);
+        let (outcomes, queued_push_job_count, pending_jobs) =
+            drain_dm_outbox_with_blocking("archive-blocked-bare", &blocking).await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::Failed { .. }
+        ));
+        assert_eq!(
+            queued_push_job_count, 0,
+            "XEP-0191-blocked DMs must not enqueue XEP-0357 push publish jobs"
+        );
+        assert!(
+            pending_jobs.is_empty(),
+            "blocked notification jobs should become terminal instead of retrying forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep0191_full_jid_block_suppresses_dm_push_candidate() {
+        let recipient = bare("alice@example.com");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        blocking.set_blocklist_jids(
+            recipient,
+            vec!["bob@example.com/phone".parse().expect("full blocked JID")],
+        );
+
+        let (outcomes, queued_push_job_count, pending_jobs) =
+            drain_dm_outbox_with_blocking("archive-blocked-full", &blocking).await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::Failed { .. }
+        ));
+        assert_eq!(queued_push_job_count, 0);
+        assert!(pending_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn xep0191_full_jid_block_does_not_suppress_other_sender_resource() {
+        let recipient = bare("alice@example.com");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        blocking.set_blocklist_jids(
+            recipient,
+            vec!["bob@example.com/phone".parse().expect("full blocked JID")],
+        );
+
+        let (outcomes, queued_push_job_count, pending_jobs) = drain_dm_outbox_with_sender_jid(
+            "archive-full-block-other-resource",
+            "bob@example.com/laptop".parse().expect("sender resource"),
+            &blocking,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::Published { .. }
+        ));
+        assert_eq!(
+            queued_push_job_count, 1,
+            "a full-JID XEP-0191 block must not suppress another resource from the same bare JID"
+        );
+        assert!(pending_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn xep0191_domain_block_suppresses_dm_push_candidate() {
+        let recipient = bare("alice@example.com");
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        blocking.set_blocklist_jids(
+            recipient,
+            vec!["example.com".parse().expect("domain blocked JID")],
+        );
+
+        let (outcomes, queued_push_job_count, pending_jobs) =
+            drain_dm_outbox_with_blocking("archive-blocked-domain", &blocking).await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::Failed { .. }
+        ));
+        assert_eq!(queued_push_job_count, 0);
+        assert!(pending_jobs.is_empty());
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("blocking storage unavailable")]
+    struct BlockingStorageUnavailable;
+
+    struct FailingBlockingStorage;
+
+    #[async_trait::async_trait]
+    impl BlockingStorage for FailingBlockingStorage {
+        async fn list_blocked_jids(
+            &self,
+            _user: &BareJid,
+        ) -> Result<Vec<BareJid>, BlockingStorageError> {
+            Err(BlockingStorageError::new(BlockingStorageUnavailable))
+        }
+    }
+
+    #[tokio::test]
+    async fn xep0191_blocklist_load_error_preserves_outbox_job_without_spending_attempt() {
+        let (outcomes, queued_push_job_count, pending_jobs) = drain_dm_outbox_with_blocking(
+            "archive-blocking-storage-error",
+            &FailingBlockingStorage,
+        )
+        .await;
+
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(
+            outcomes[0],
+            NotificationOutboxPublishOutcome::RetryScheduled { .. }
+        ));
+        assert_eq!(
+            queued_push_job_count, 0,
+            "policy-read failures must not publish before XEP-0191 can be enforced"
+        );
+        assert_eq!(pending_jobs.len(), 1);
+        assert_eq!(pending_jobs[0].status(), NotificationOutboxStatus::Queued);
+        assert_eq!(pending_jobs[0].attempt_count(), 0);
+        assert_eq!(pending_jobs[0].policy_error_count(), 1);
+        assert!(pending_jobs[0].claim_token().is_none());
     }
 
     struct FailingPushStore;
@@ -2120,6 +3336,7 @@ mod tests {
             &[target_named("web-node-1"), target_named("web-node-2")],
         )
         .await;
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
         let push_service = crate::push_service::DatabasePushServiceStore::new(
             Database::in_memory("push-service").await.unwrap(),
         )
@@ -2133,6 +3350,7 @@ mod tests {
                 &push_service,
                 &FailingPushStore,
                 &inbox,
+                &blocking,
                 &bare("push.example.com"),
                 16,
             )

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -215,20 +215,42 @@ async fn enqueue_xep0357_notification_candidate_from_committed_archive(
             return NotificationCandidateQueueOutcome::RetryLater;
         }
     };
-    let sender_jid = archived.from.clone();
+    let parsed_original_message =
+        super::archive_lookup::parse_archived_message_xml(archived.stanza_xml.as_deref());
+    let (sender_jid, sender_jid_exact) =
+        notification_sender_provenance(&archived, parsed_original_message.as_ref());
     let sender = sender_jid.to_bare();
-    let original_message =
-        super::archive_lookup::parse_archived_message_xml(archived.stanza_xml.as_deref())
-            .unwrap_or_else(|| super::archive_lookup::fallback_archived_message(&archived));
+    let original_message = parsed_original_message
+        .unwrap_or_else(|| super::archive_lookup::fallback_archived_message(&archived));
     enqueue_xep0357_notification_candidate_for_message(
         state,
         recipient,
         &sender,
         &sender_jid,
+        sender_jid_exact,
         archive_stanza_id,
         &original_message,
     )
     .await
+}
+
+fn notification_sender_provenance(
+    archived: &MamArchivedMessage,
+    original_message: Option<&Message>,
+) -> (Jid, bool) {
+    if let Some(from) = original_message.and_then(|message| message.from.clone()) {
+        if from.to_bare() == archived.from.to_bare() {
+            return (from, true);
+        }
+        warn!(
+            archive_sender = %archived.from,
+            stanza_sender = %from,
+            "Archived stanza XML sender did not match MAM row sender; using row sender without exact resource provenance"
+        );
+    }
+
+    let sender_jid_exact = archived.from.resource().is_some();
+    (archived.from.clone(), sender_jid_exact)
 }
 
 async fn enqueue_xep0357_notification_candidate_for_message(
@@ -236,6 +258,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     recipient: &BareJid,
     sender: &BareJid,
     sender_jid: &Jid,
+    sender_jid_exact: bool,
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
@@ -263,9 +286,10 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             return NotificationCandidateQueueOutcome::Completed;
         }
     }
-    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
+    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message_with_sender_provenance(
         recipient.clone(),
         sender_jid.clone(),
+        sender_jid_exact,
         archive_stanza_id.clone(),
     ) {
         Ok(candidate) => candidate,

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -217,8 +217,16 @@ async fn enqueue_xep0357_notification_candidate_from_committed_archive(
     };
     let parsed_original_message =
         super::archive_lookup::parse_archived_message_xml(archived.stanza_xml.as_deref());
-    let (sender_jid, sender_jid_exact) =
-        notification_sender_provenance(&archived, parsed_original_message.as_ref());
+    let Some(sender_jid) = notification_sender_jid(&archived, parsed_original_message.as_ref())
+    else {
+        warn!(
+            recipient = %recipient,
+            stanza_id = %archive_stanza_id,
+            archive_sender = %archived.from,
+            "XEP-0357 notification candidate skipped because exact sender resource provenance is unavailable"
+        );
+        return NotificationCandidateQueueOutcome::Completed;
+    };
     let sender = sender_jid.to_bare();
     let original_message = parsed_original_message
         .unwrap_or_else(|| super::archive_lookup::fallback_archived_message(&archived));
@@ -227,30 +235,39 @@ async fn enqueue_xep0357_notification_candidate_from_committed_archive(
         recipient,
         &sender,
         &sender_jid,
-        sender_jid_exact,
         archive_stanza_id,
         &original_message,
     )
     .await
 }
 
-fn notification_sender_provenance(
+fn notification_sender_jid(
     archived: &MamArchivedMessage,
     original_message: Option<&Message>,
-) -> (Jid, bool) {
+) -> Option<Jid> {
     if let Some(from) = original_message.and_then(|message| message.from.clone()) {
-        if from.to_bare() == archived.from.to_bare() {
-            return (from, true);
+        if let Some(_resource) = from.resource() {
+            if archived.from.resource().is_some() {
+                if from == archived.from {
+                    return Some(from);
+                }
+            } else if from.to_bare() == archived.from.to_bare() {
+                return Some(from);
+            }
         }
         warn!(
             archive_sender = %archived.from,
             stanza_sender = %from,
-            "Archived stanza XML sender did not match MAM row sender; using row sender without exact resource provenance"
+            "Archived stanza XML sender conflicted with MAM row sender; skipping push candidate"
         );
+        return None;
     }
 
-    let sender_jid_exact = archived.from.resource().is_some();
-    (archived.from.clone(), sender_jid_exact)
+    if archived.from.resource().is_some() {
+        Some(archived.from.clone())
+    } else {
+        None
+    }
 }
 
 async fn enqueue_xep0357_notification_candidate_for_message(
@@ -258,7 +275,6 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     recipient: &BareJid,
     sender: &BareJid,
     sender_jid: &Jid,
-    sender_jid_exact: bool,
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
@@ -286,10 +302,9 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             return NotificationCandidateQueueOutcome::Completed;
         }
     }
-    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message_with_sender_provenance(
+    let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
         recipient.clone(),
         sender_jid.clone(),
-        sender_jid_exact,
         archive_stanza_id.clone(),
     ) {
         Ok(candidate) => candidate,

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -215,7 +215,8 @@ async fn enqueue_xep0357_notification_candidate_from_committed_archive(
             return NotificationCandidateQueueOutcome::RetryLater;
         }
     };
-    let sender = archived.from.to_bare();
+    let sender_jid = archived.from.clone();
+    let sender = sender_jid.to_bare();
     let original_message =
         super::archive_lookup::parse_archived_message_xml(archived.stanza_xml.as_deref())
             .unwrap_or_else(|| super::archive_lookup::fallback_archived_message(&archived));
@@ -223,6 +224,7 @@ async fn enqueue_xep0357_notification_candidate_from_committed_archive(
         state,
         recipient,
         &sender,
+        &sender_jid,
         archive_stanza_id,
         &original_message,
     )
@@ -233,6 +235,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     state: &WebSocketState,
     recipient: &BareJid,
     sender: &BareJid,
+    sender_jid: &Jid,
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
@@ -262,7 +265,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     }
     let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
         recipient.clone(),
-        sender.clone(),
+        sender_jid.clone(),
         archive_stanza_id.clone(),
     ) {
         Ok(candidate) => candidate,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1070,11 +1070,396 @@ async fn notification_candidate_recovery_preserves_sender_resource_from_archived
         .expect("notification outbox jobs");
     assert_eq!(outbox_jobs.len(), 1);
     assert_eq!(outbox_jobs[0].conversation_jid(), &sender_bare);
-    assert!(
-        outbox_jobs[0].sender_jids_exact(),
-        "resource provenance should come from archived stanza_xml, not the bare MAM row"
-    );
     assert_eq!(outbox_jobs[0].sender_jids(), &[sender_full]);
+}
+
+#[tokio::test]
+async fn notification_candidate_recovery_skips_full_mam_sender_when_stanza_sender_conflicts() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender_full: jid::Jid = "alice@example.com/web".parse().expect("sender full jid");
+    let node = state
+        .deps
+        .protocol
+        .push_service
+        .ensure_node(&recipient, "web")
+        .await
+        .expect("push node");
+    state
+        .deps
+        .protocol
+        .push_service
+        .upsert_device(
+            &recipient,
+            crate::push_service::PushDeviceRegistration::new(
+                "web-1",
+                node.node(),
+                crate::push_service::PushDevicePlatform::Web,
+                "test",
+            ),
+        )
+        .await
+        .expect("push device");
+    state
+        .deps
+        .protocol
+        .push_service
+        .register_first_party_node_for_owner(&recipient, "push.example.com", node.node(), None)
+        .await
+        .expect("first-party push registration");
+
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-recovery-full-row-mismatched-stanza-1",
+        jid::Jid::from(recipient.clone()),
+    );
+    let mut stanza_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(recipient.clone())));
+    stanza_message.from = Some("alice@example.com/phone".parse().expect("stanza sender"));
+    stanza_message.id = Some("wire-recovery-full-row-mismatched-stanza-1".to_string());
+    stanza_message.type_ = XmppMessageType::Chat;
+    stanza_message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("recover from full MAM row".to_string()),
+    );
+    let archived = waddle_xmpp_core::mam::ArchivedMessage {
+        id: archive_stanza_id.id.clone(),
+        body: Some("recover from full MAM row".to_string()),
+        stanza_id: Some(archive_stanza_id.clone()),
+        message_type: XmppMessageType::Chat,
+        stanza_xml: Some(
+            waddle_xmpp::parser::message_to_string(&stanza_message)
+                .expect("serialize mismatched archived message"),
+        ),
+        ..waddle_xmpp_core::mam::ArchivedMessage::for_test(
+            sender_full.clone(),
+            jid::Jid::from(recipient.clone()),
+        )
+    };
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .store_message(&recipient, &archived)
+        .await
+        .expect("store MAM row");
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert pending_delivery row");
+
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        drain_notification_candidates_for_test(state.as_ref()).await,
+        0
+    );
+    assert!(state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs")
+        .is_empty());
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        0,
+        "conflicted sender provenance is terminal"
+    );
+}
+
+#[tokio::test]
+async fn notification_candidate_recovery_skips_bare_stanza_sender_even_with_full_mam_sender() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender_bare: BareJid = "alice@example.com".parse().expect("sender");
+    let sender_full: jid::Jid = "alice@example.com/web".parse().expect("sender full jid");
+    let node = state
+        .deps
+        .protocol
+        .push_service
+        .ensure_node(&recipient, "web")
+        .await
+        .expect("push node");
+    state
+        .deps
+        .protocol
+        .push_service
+        .upsert_device(
+            &recipient,
+            crate::push_service::PushDeviceRegistration::new(
+                "web-1",
+                node.node(),
+                crate::push_service::PushDevicePlatform::Web,
+                "test",
+            ),
+        )
+        .await
+        .expect("push device");
+    state
+        .deps
+        .protocol
+        .push_service
+        .register_first_party_node_for_owner(&recipient, "push.example.com", node.node(), None)
+        .await
+        .expect("first-party push registration");
+
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-recovery-full-row-bare-stanza-1",
+        jid::Jid::from(recipient.clone()),
+    );
+    let mut stanza_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(recipient.clone())));
+    stanza_message.from = Some(jid::Jid::from(sender_bare));
+    stanza_message.id = Some("wire-recovery-full-row-bare-stanza-1".to_string());
+    stanza_message.type_ = XmppMessageType::Chat;
+    stanza_message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("do not recover bare stanza sender".to_string()),
+    );
+    let archived = waddle_xmpp_core::mam::ArchivedMessage {
+        id: archive_stanza_id.id.clone(),
+        body: Some("do not recover bare stanza sender".to_string()),
+        stanza_id: Some(archive_stanza_id.clone()),
+        message_type: XmppMessageType::Chat,
+        stanza_xml: Some(
+            waddle_xmpp::parser::message_to_string(&stanza_message)
+                .expect("serialize bare-sender archived message"),
+        ),
+        ..waddle_xmpp_core::mam::ArchivedMessage::for_test(
+            sender_full,
+            jid::Jid::from(recipient.clone()),
+        )
+    };
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .store_message(&recipient, &archived)
+        .await
+        .expect("store MAM row");
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert pending_delivery row");
+
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        drain_notification_candidates_for_test(state.as_ref()).await,
+        0
+    );
+    assert!(state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs")
+        .is_empty());
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        0,
+        "bare stanza sender conflicts with exact MAM sender provenance"
+    );
+}
+
+#[tokio::test]
+async fn notification_candidate_recovery_skips_bare_only_sender_provenance_terminally() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender: BareJid = "alice@example.com".parse().expect("sender");
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-recovery-bare-sender-1",
+        jid::Jid::from(recipient.clone()),
+    );
+    let archived = waddle_xmpp_core::mam::ArchivedMessage {
+        id: archive_stanza_id.id.clone(),
+        body: Some("do not recover without resource".to_string()),
+        stanza_id: Some(archive_stanza_id.clone()),
+        message_type: XmppMessageType::Chat,
+        stanza_xml: None,
+        ..waddle_xmpp_core::mam::ArchivedMessage::for_test(
+            jid::Jid::from(sender),
+            jid::Jid::from(recipient.clone()),
+        )
+    };
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .store_message(&recipient, &archived)
+        .await
+        .expect("store MAM row");
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert pending_delivery row");
+
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        drain_notification_candidates_for_test(state.as_ref()).await,
+        0
+    );
+    assert!(state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs")
+        .is_empty());
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        0,
+        "pending_delivery marker should prevent retrying terminal no-provenance rows"
+    );
+}
+
+#[tokio::test]
+async fn notification_candidate_recovery_skips_mismatched_stanza_sender_terminally() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let archive_sender: BareJid = "alice@example.com".parse().expect("archive sender");
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-recovery-mismatched-sender-1",
+        jid::Jid::from(recipient.clone()),
+    );
+    let mut stanza_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(recipient.clone())));
+    stanza_message.from = Some("mallory@example.com/web".parse().expect("stanza sender"));
+    stanza_message.id = Some("wire-recovery-mismatched-sender-1".to_string());
+    stanza_message.type_ = XmppMessageType::Chat;
+    stanza_message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("do not recover mismatched sender".to_string()),
+    );
+    let archived = waddle_xmpp_core::mam::ArchivedMessage {
+        id: archive_stanza_id.id.clone(),
+        body: Some("do not recover mismatched sender".to_string()),
+        stanza_id: Some(archive_stanza_id.clone()),
+        message_type: XmppMessageType::Chat,
+        stanza_xml: Some(
+            waddle_xmpp::parser::message_to_string(&stanza_message)
+                .expect("serialize mismatched archived message"),
+        ),
+        ..waddle_xmpp_core::mam::ArchivedMessage::for_test(
+            jid::Jid::from(archive_sender),
+            jid::Jid::from(recipient.clone()),
+        )
+    };
+    state
+        .deps
+        .protocol
+        .mam_storage
+        .store_message(&recipient, &archived)
+        .await
+        .expect("store MAM row");
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert pending_delivery row");
+
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        1
+    );
+    assert_eq!(
+        drain_notification_candidates_for_test(state.as_ref()).await,
+        0
+    );
+    assert!(state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs")
+        .is_empty());
+    assert_eq!(
+        crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+            state.as_ref(),
+            16,
+        )
+        .await,
+        0,
+        "pending_delivery marker should prevent retrying terminal mismatched-provenance rows"
+    );
 }
 
 #[tokio::test]
@@ -1438,8 +1823,8 @@ async fn handle_message_direct_chat_to_bare_jid_fans_out_to_all_connected_resour
         mobile_chat.expect("mobile resource should receive original bare-JID message");
     // RFC 6121 §8.5.2.1.1: bare-JID fan-out delivers the original
     // stanza to each available resource without rewriting the
-    // `to` attribute. The dispatcher path preserves this; legacy
-    // `handle_message` rewrote `to` to the per-resource full JID,
+    // `to` attribute. The dispatcher path preserves this; the prior
+    // `handle_message` behavior rewrote `to` to the per-resource full JID,
     // which was a deviation from the RFC. Both resources received
     // the stanza — the reachability semantic — and that is what
     // this unit test now asserts.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -72,6 +72,7 @@ async fn drain_notification_candidates_for_test(state: &WebSocketState) -> usize
         .notification_outbox
         .drain_pending_candidates_into_outbox(
             state.deps.protocol.push_store.as_ref(),
+            state.deps.protocol.blocking_storage.as_ref(),
             &push_service_jid,
             16,
         )
@@ -219,6 +220,7 @@ async fn queue_offline_delivery_publishes_first_party_xep0357_notification_witho
             state.deps.protocol.push_service.as_ref(),
             state.deps.protocol.push_store.as_ref(),
             state.deps.protocol.inbox_storage.as_ref(),
+            state.deps.protocol.blocking_storage.as_ref(),
             &push_service_jid,
             16,
         )

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -971,6 +971,113 @@ async fn notification_candidate_recovery_rebuilds_from_committed_pending_deliver
 }
 
 #[tokio::test]
+async fn notification_candidate_recovery_preserves_sender_resource_from_archived_stanza_xml() {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender_bare: BareJid = "alice@example.com".parse().expect("sender");
+    let sender_full: jid::Jid = "alice@example.com/web".parse().expect("sender full jid");
+    let node = state
+        .deps
+        .protocol
+        .push_service
+        .ensure_node(&recipient, "web")
+        .await
+        .expect("push node");
+    state
+        .deps
+        .protocol
+        .push_service
+        .upsert_device(
+            &recipient,
+            crate::push_service::PushDeviceRegistration::new(
+                "web-1",
+                node.node(),
+                crate::push_service::PushDevicePlatform::Web,
+                "test",
+            ),
+        )
+        .await
+        .expect("push device");
+    state
+        .deps
+        .protocol
+        .push_service
+        .register_first_party_node_for_owner(&recipient, "push.example.com", node.node(), None)
+        .await
+        .expect("first-party push registration");
+
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        "archive-recovery-resource-1",
+        jid::Jid::from(recipient.clone()),
+    );
+    let mut message = xmpp_parsers::message::Message::new(Some(jid::Jid::from(recipient.clone())));
+    message.from = Some(sender_full.clone());
+    message.id = Some("wire-recovery-resource-1".to_string());
+    message.type_ = XmppMessageType::Chat;
+    message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("recover me".to_string()),
+    );
+    message
+        .payloads
+        .push(waddle_xmpp_core::xep0359::build_stanza_id_element(
+            archive_stanza_id.id.as_str(),
+            &archive_stanza_id.by,
+        ));
+
+    let deps = build_interpret_deps(state.as_ref(), None);
+    crate::server::routes::interpret::interpret(
+        vec![waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
+            archive_jid: recipient.clone(),
+            from: sender_bare.clone(),
+            to: recipient.clone(),
+            message: Box::new(message),
+        }],
+        &deps,
+    )
+    .await;
+    state
+        .deps
+        .protocol
+        .pending_delivery_storage
+        .insert(waddle_xmpp::pending_delivery::PendingRow {
+            id: waddle_xmpp::pending_delivery::PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert pending_delivery row");
+
+    let recovered = crate::server::routes::interpret::reconcile_xep0357_notification_candidates(
+        state.as_ref(),
+        16,
+    )
+    .await;
+    assert_eq!(recovered, 1);
+    assert_eq!(
+        drain_notification_candidates_for_test(state.as_ref()).await,
+        1
+    );
+    let outbox_jobs = state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs");
+    assert_eq!(outbox_jobs.len(), 1);
+    assert_eq!(outbox_jobs[0].conversation_jid(), &sender_bare);
+    assert!(
+        outbox_jobs[0].sender_jids_exact(),
+        "resource provenance should come from archived stanza_xml, not the bare MAM row"
+    );
+    assert_eq!(outbox_jobs[0].sender_jids(), &[sender_full]);
+}
+
+#[tokio::test]
 async fn handle_message_direct_rejects_client_authored_extension_envelope() {
     let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
     let recipient_jid: FullJid = "bob@example.com/mobile".parse().expect("recipient jid");

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -523,6 +523,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 .notification_outbox
                 .drain_pending_candidates_into_outbox(
                     state.deps.protocol.push_store.as_ref(),
+                    state.deps.protocol.blocking_storage.as_ref(),
                     &first_party_service_jid,
                     batch_size,
                 )
@@ -550,6 +551,7 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                     state.deps.protocol.push_service.as_ref(),
                     state.deps.protocol.push_store.as_ref(),
                     state.deps.protocol.inbox_storage.as_ref(),
+                    state.deps.protocol.blocking_storage.as_ref(),
                     &first_party_service_jid,
                     batch_size,
                 )

--- a/server/crates/waddle-xmpp/src/xep/xep0191.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0191.rs
@@ -48,7 +48,7 @@
 //! ```
 
 use async_trait::async_trait;
-use jid::BareJid;
+use jid::{BareJid, Jid};
 use minidom::Element;
 use tracing::debug;
 use xmpp_parsers::iq::Iq;
@@ -107,16 +107,34 @@ pub trait BlockingStorage: Send + Sync {
     /// [`super::super::protocol::handlers::blocking_filter::BlockingFilterHandler`].
     async fn list_blocked_jids(&self, user: &BareJid)
         -> Result<Vec<BareJid>, BlockingStorageError>;
+
+    /// Return blocked JID entries in their stored XEP-0191 form.
+    ///
+    /// XEP-0191 block items may be bare JIDs, full JIDs, or domain JIDs.
+    /// Existing session snapshots still consume [`Self::list_blocked_jids`]
+    /// because that path currently performs bare-JID matching only; policy
+    /// gates that must honor full/domain entries use this read.
+    async fn list_blocked_jid_entries(
+        &self,
+        user: &BareJid,
+    ) -> Result<Vec<Jid>, BlockingStorageError> {
+        Ok(self
+            .list_blocked_jids(user)
+            .await?
+            .into_iter()
+            .map(Jid::from)
+            .collect())
+    }
 }
 
 /// In-memory [`BlockingStorage`] implementation for tests.
 ///
-/// Backed by a `Mutex<HashMap<BareJid, Vec<BareJid>>>`. Used by the
+/// Backed by a `Mutex<HashMap<BareJid, Vec<Jid>>>`. Used by the
 /// offline-recipient-pass tests in `waddle-server` and any handler-level
 /// fixture that wants to seed a blocklist without a real database.
 #[derive(Debug, Default)]
 pub struct InMemoryBlockingStorage {
-    per_user: std::sync::Mutex<std::collections::HashMap<BareJid, Vec<BareJid>>>,
+    per_user: std::sync::Mutex<std::collections::HashMap<BareJid, Vec<Jid>>>,
 }
 
 impl InMemoryBlockingStorage {
@@ -127,6 +145,11 @@ impl InMemoryBlockingStorage {
 
     /// Replace the blocklist for `user` with `entries`.
     pub fn set_blocklist(&self, user: BareJid, entries: Vec<BareJid>) {
+        self.set_blocklist_jids(user, entries.into_iter().map(Jid::from).collect());
+    }
+
+    /// Replace the blocklist for `user` with full XEP-0191 JID entries.
+    pub fn set_blocklist_jids(&self, user: BareJid, entries: Vec<Jid>) {
         let mut guard = self
             .per_user
             .lock()
@@ -152,6 +175,23 @@ impl BlockingStorage for InMemoryBlockingStorage {
         &self,
         user: &BareJid,
     ) -> Result<Vec<BareJid>, BlockingStorageError> {
+        let guard = self
+            .per_user
+            .lock()
+            .map_err(|_| BlockingStorageError::new(InMemoryBlockingStorageError))?;
+        Ok(guard
+            .get(user)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|entry| entry.try_into().ok())
+            .collect())
+    }
+
+    async fn list_blocked_jid_entries(
+        &self,
+        user: &BareJid,
+    ) -> Result<Vec<Jid>, BlockingStorageError> {
         let guard = self
             .per_user
             .lock()

--- a/server/crates/waddle-xmpp/src/xep/xep0191/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0191/tests.rs
@@ -222,6 +222,31 @@ fn test_build_blocklist_response() {
     }
 }
 
+#[tokio::test]
+async fn in_memory_blocking_storage_preserves_stored_jid_forms() {
+    let storage = InMemoryBlockingStorage::new();
+    let user: BareJid = "alice@example.com".parse().unwrap();
+    let entries: Vec<Jid> = vec![
+        "bob@example.com/phone".parse().unwrap(),
+        "blocked.example.com".parse().unwrap(),
+    ];
+
+    storage.set_blocklist_jids(user.clone(), entries.clone());
+
+    assert_eq!(
+        storage
+            .list_blocked_jid_entries(&user)
+            .await
+            .expect("stored JID entries"),
+        entries
+    );
+    assert!(storage
+        .list_blocked_jids(&user)
+        .await
+        .expect("bare JID snapshot")
+        .contains(&"blocked.example.com".parse().unwrap()));
+}
+
 #[test]
 fn test_build_empty_blocklist_response() {
     let blocklist_elem = Element::builder("blocklist", NS_BLOCKING).build();


### PR DESCRIPTION
## Plan

Follow issue #506 in implementation order, finishing the DM push candidate policy slice for XEP-0191 + XEP-0357.

- Preserve exact full sender JID provenance for durable DM push candidates and outbox jobs.
- Enforce XEP-0191 bare, full, and domain JID block entries before candidate coalescing and again before Push Service publish.
- Keep XEP-0357 pushes first-party and summary-only.
- Fail closed when exact sender provenance is missing, malformed, or conflicting.
- Avoid normal publish retry burn on policy-store failures.

## Completed

- Added stored JID-form blocklist reads so policy checks can distinguish bare JIDs, full JIDs, and domain JIDs.
- Removed the sender-provenance compatibility shim: no `sender_jid = conversation_jid` backfill, no exactness flags, and no runtime sender-provenance column upgrade for old notification tables.
- Required full sender JIDs for direct-message notification candidates and outbox jobs.
- Coalesced DM push jobs by bare conversation while retaining all exact sender resources for publish-time full-JID blocking.
- Failed malformed durable candidate/outbox rows closed, including empty sender rows, invalid sender sets, scalar/set mismatches, bad context XML, and invalid conversation data.
- Made outbox coalescing prove persistence before marking candidates outboxed by retrying insert/merge when a queued row is claimed during the coalesce window.
- Recovered sender resources from archived stanza XML only when the serialized stanza and MAM row agree; conflicting or bare-only provenance is skipped terminally.
- Deferred candidate policy-read failures with durable backoff, and deferred publish policy-read failures without spending normal publish attempts.

## Verification

- `cargo test --manifest-path server/Cargo.toml -p waddle-server notification_outbox --lib`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server notification_candidate_recovery --lib`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server queue_offline_delivery --lib`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server xep0357 --lib`
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --test xep0357_push_service_ws`
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-server --all-targets -- -D warnings`
- `git diff --check`

## Review

Adversarial code, security, and test reviews were run after the provenance-shim removal. Findings around broad malformed-row quarantine, missing shim-regression tests, and the queued-job claim/coalesce race were fixed and re-reviewed clean.

## Notes

No Docker was used. `./xeps/xep-0191.xml` and `./xeps/xep-0357.xml` were checked for the relevant blocklist and push payload semantics.
