### PR TITLE
fix(chat): clear activeCommunitySurface in openThreads

### DIFF
--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1223,6 +1223,12 @@ export function useChatAppController(giphyApiKey: string) {
     ui.showMobileNav.value = false;
     ui.showMobileDetails.value = false;
     ui.activePage.value = "threads";
+    // ChatReadyShell renders FeedPane / StoriesPane / EventsPane on
+    // `activeCommunitySurface` v-else-if branches BEFORE the threads
+    // branch — leaving the surface non-null would let one of those win
+    // and ThreadsView would silently not render even though the URL
+    // changed. Clear the surface so the threads v-else-if matches.
+    ui.activeCommunitySurface.value = null;
     waddles.activeChannelId.value = null;
     dmConversations.closeDm();
     activeRightPanel.value = null;


### PR DESCRIPTION
## Summary

Clicking the Threads sidebar entry while viewing a community surface (feed/stories/events) updated the URL but didn't change the content — the page felt frozen ("click does nothing").

## Root cause

`ChatReadyShell.vue` renders FeedPane / StoriesPane / EventsPane on `activeCommunitySurface === '...'` v-else-if branches that sit *before* the threads branch:

\`\`\`
v-if=\"activePage === 'dashboard'\"          → HomeDashboard
v-else-if=\"activeCommunitySurface === 'feed'\"   → FeedPane
v-else-if=\"activeCommunitySurface === 'stories'\" → StoriesPane
v-else-if=\"activeCommunitySurface === 'events'\"  → EventsPane
v-else-if=\"activePage === 'threads'\"       → ThreadsView   ← never reached
\`\`\`

\`openThreads()\` set \`activePage = \"threads\"\` and pushed the route but left \`activeCommunitySurface\` untouched. One of the surface branches kept winning.

## Fix

One line — clear \`activeCommunitySurface\` in \`openThreads()\` before the route push. Same pattern other navigations already use (channel select, DM open).

## Test plan

- [ ] Click Threads from feed/stories/events: content swaps to ThreadsView
- [ ] Click Threads from dashboard / channel / DM: still works (no regression)
- [ ] URL ends with /threads
- [ ] Page refresh on /threads lands back on ThreadsView