### PR TITLE
debug(chat): scroll-anchor instrumentation for #677

### DIFF
--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -27,6 +27,7 @@ import {
   threadCursorFromLatestPage,
 } from "@/lib/xmpp/mam";
 import { hydratePinnedRoom, pinnedRoomsEpoch } from "@/stores/pinned-messages";
+import { debugScroll } from "@/lib/debug-scroll";
 
 const PAGE_SIZE = 100;
 
@@ -189,7 +190,23 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
         ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
         : null;
+      debugScroll("channels.loadMessages: about to scrollToPinnedEdgeAndPin", {
+        channelId,
+        spaceId,
+        unreadAtLoad,
+        firstUnseenId: firstUnseenId.value,
+        timelineLen: timelineWithQueue.length,
+        feedLen: feedTimeline.length,
+      });
       const pinned = await scrollToPinnedEdgeAndPin();
+      debugScroll("channels.loadMessages: scrollToPinnedEdgeAndPin returned", {
+        channelId,
+        pinned,
+        requestStale:
+          requestId !== messageRequestId ||
+          (activeSpaceId.value ?? "") !== spaceId ||
+          activeChannelId.value !== channelId,
+      });
       if (
         !pinned ||
         requestId !== messageRequestId ||

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -6,6 +6,7 @@ import {
   isTopPinnedScrollDirection,
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
+import { debugScroll } from "@/lib/debug-scroll";
 
 const props = withDefaults(defineProps<{
   items: TimelineMessage[];
@@ -92,12 +93,28 @@ async function scrollToMessageId(messageId: string, align: "start" | "center" | 
 }
 
 async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
-  if (props.items.length === 0) return false;
+  if (props.items.length === 0) {
+    debugScroll("VirtualTimeline.scrollToPinnedEdge: empty items, no-op");
+    return false;
+  }
+  const preEl = scrollElement.value;
+  debugScroll("VirtualTimeline.scrollToPinnedEdge: enter", {
+    mode,
+    items: props.items.length,
+    scrollTop: preEl?.scrollTop,
+    scrollHeight: preEl?.scrollHeight,
+    clientHeight: preEl?.clientHeight,
+  });
   const itemIndex = isTopPinnedScrollDirection(mode) ? 0 : props.items.length - 1;
   virtualizer.value.scrollToIndex(virtualIndexForItemIndex(itemIndex), {
     align: isTopPinnedScrollDirection(mode) ? "start" : "end",
   });
   await nextTick();
+  const postIndexEl = scrollElement.value;
+  debugScroll("VirtualTimeline.scrollToPinnedEdge: after scrollToIndex", {
+    scrollTop: postIndexEl?.scrollTop,
+    scrollHeight: postIndexEl?.scrollHeight,
+  });
   // The virtualizer's `scrollToIndex` plans the scroll using the
   // `estimateSize` heights (112px / 44px); real rows — especially
   // ones with images, code blocks, or extension cards — measure much
@@ -111,7 +128,10 @@ async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
   // always lands at the true edge once measurements settle. Capped
   // at 8 frames so a runaway re-render can't spin the loop.
   const el = scrollElement.value;
-  if (!el) return true;
+  if (!el) {
+    debugScroll("VirtualTimeline.scrollToPinnedEdge: no scrollElement, bail");
+    return true;
+  }
   await new Promise<void>((resolve) => {
     const topPinned = isTopPinnedScrollDirection(mode);
     let lastHeight = -1;
@@ -119,16 +139,46 @@ async function scrollToPinnedEdge(mode: ScrollDirectionMode) {
     let frames = 0;
     function tick() {
       el!.scrollTop = topPinned ? 0 : el!.scrollHeight;
-      if (el!.scrollHeight === lastHeight) {
-        if (++stable >= 2) return resolve();
+      const sh = el!.scrollHeight;
+      debugScroll("VirtualTimeline.RAF tick", {
+        frame: frames,
+        scrollHeight: sh,
+        scrollTop: el!.scrollTop,
+        clientHeight: el!.clientHeight,
+        deltaSinceLast: lastHeight < 0 ? null : sh - lastHeight,
+        stableStreak: sh === lastHeight ? stable + 1 : 0,
+      });
+      if (sh === lastHeight) {
+        if (++stable >= 2) {
+          debugScroll("VirtualTimeline.RAF exit: stable", { frames: frames + 1, scrollHeight: sh });
+          return resolve();
+        }
       } else {
         stable = 0;
-        lastHeight = el!.scrollHeight;
+        lastHeight = sh;
       }
-      if (++frames >= 8) return resolve();
+      if (++frames >= 8) {
+        debugScroll("VirtualTimeline.RAF exit: frames cap (bailed mid-growth)", {
+          frames,
+          scrollHeight: sh,
+          scrollTop: el!.scrollTop,
+          gapFromBottom: sh - el!.scrollTop - el!.clientHeight,
+        });
+        return resolve();
+      }
       requestAnimationFrame(tick);
     }
     requestAnimationFrame(tick);
+  });
+  const finalEl = scrollElement.value;
+  debugScroll("VirtualTimeline.scrollToPinnedEdge: return", {
+    scrollTop: finalEl?.scrollTop,
+    scrollHeight: finalEl?.scrollHeight,
+    clientHeight: finalEl?.clientHeight,
+    gapFromBottom:
+      finalEl
+        ? finalEl.scrollHeight - finalEl.scrollTop - finalEl.clientHeight
+        : null,
   });
   return true;
 }

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -1,4 +1,5 @@
 import { nextTick, ref, type Ref } from "vue";
+import { debugScroll } from "@/lib/debug-scroll";
 import type { BrowserXmppClient, LiveDmMessage } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { TimelineMessage } from "@/lib/chat-ui";
@@ -125,7 +126,18 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       firstUnseenId.value = unreadAtLoad > 0 && feedTimeline.length >= unreadAtLoad
         ? feedTimeline[feedTimeline.length - unreadAtLoad]?.id ?? null
         : null;
+      debugScroll("dms.loadMessages: about to scrollToPinnedEdgeAndPin", {
+        peerJid,
+        unreadAtLoad,
+        firstUnseenId: firstUnseenId.value,
+        timelineLen: timelineWithQueue.length,
+        feedLen: feedTimeline.length,
+      });
       const pinned = await scrollToPinnedEdgeAndPin();
+      debugScroll("dms.loadMessages: scrollToPinnedEdgeAndPin returned", {
+        peerJid,
+        pinned,
+      });
       if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);

--- a/chat/src/lib/debug-scroll.ts
+++ b/chat/src/lib/debug-scroll.ts
@@ -1,0 +1,43 @@
+// Debug-only scroll-anchor instrumentation (issue #677).
+//
+// Enable by setting `localStorage.setItem("WADDLE_DEBUG_SCROLL", "1")` in
+// the browser before reproducing. Logs go to `console.debug` with the
+// `[scroll-debug]` prefix and include monotonic timestamps relative to
+// the first log of the session.
+//
+// Drop this file (and its imports) before shipping.
+
+const PREFIX = "[scroll-debug]";
+
+let enabledMemo: boolean | null = null;
+let originMs: number | null = null;
+
+function readEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage?.getItem("WADDLE_DEBUG_SCROLL") === "1";
+  } catch {
+    return false;
+  }
+}
+
+function debugScrollEnabled(): boolean {
+  if (enabledMemo === null) enabledMemo = readEnabled();
+  return enabledMemo;
+}
+
+function elapsed(): number {
+  const now = typeof performance !== "undefined" ? performance.now() : Date.now();
+  if (originMs === null) originMs = now;
+  return Math.round(now - originMs);
+}
+
+export function debugScroll(event: string, fields?: Record<string, unknown>): void {
+  if (!debugScrollEnabled()) return;
+  const t = elapsed();
+  if (fields && Object.keys(fields).length > 0) {
+    console.debug(`${PREFIX} +${t}ms ${event}`, fields);
+  } else {
+    console.debug(`${PREFIX} +${t}ms ${event}`);
+  }
+}

--- a/chat/src/lib/pinned-edge-scroll.ts
+++ b/chat/src/lib/pinned-edge-scroll.ts
@@ -4,6 +4,7 @@ import {
   isTopPinnedScrollDirection,
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
+import { debugScroll } from "@/lib/debug-scroll";
 
 const PINNED_EDGE_TOLERANCE_PX = 64;
 
@@ -126,17 +127,52 @@ export function createPinnedEdgeScroller(options: {
     const target = captureTarget();
     settleGeneration = target.token;
     settleObserver?.disconnect();
+    const settleStartedAt = typeof performance !== "undefined" ? performance.now() : Date.now();
+    let resizeEventCount = 0;
     settleObserver = new ResizeObserver(() => {
-      if (settleGeneration !== generation) return;
+      if (settleGeneration !== generation) {
+        debugScroll("pinned-edge.settleObserver: stale fire, drop", {
+          settleGeneration,
+          generation,
+        });
+        return;
+      }
+      resizeEventCount++;
+      const elapsed = (typeof performance !== "undefined" ? performance.now() : Date.now()) - settleStartedAt;
+      debugScroll("pinned-edge.settleObserver: fire -> pinTarget", {
+        elapsedMs: Math.round(elapsed),
+        eventCount: resizeEventCount,
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+        gapFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+      });
       void pinTarget(target);
     });
     settleObserver.observe(el);
+    let childCount = 0;
     for (const child of Array.from(el.children)) {
       settleObserver.observe(child);
+      childCount++;
     }
+    debugScroll("pinned-edge.refreshSettleLock: observer armed", {
+      childCount,
+      windowMs: 500,
+      generation,
+    });
 
     if (settleTimer) clearTimeout(settleTimer);
-    settleTimer = setTimeout(disconnectSettleLock, 500);
+    settleTimer = setTimeout(() => {
+      const elapsed = (typeof performance !== "undefined" ? performance.now() : Date.now()) - settleStartedAt;
+      debugScroll("pinned-edge.settleTimer: expired", {
+        elapsedMs: Math.round(elapsed),
+        resizeEvents: resizeEventCount,
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        gapFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+      });
+      disconnectSettleLock();
+    }, 500);
   }
 
   async function scrollToPinnedEdge(optionsForScroll: { settle?: boolean } = {}) {


### PR DESCRIPTION
Not a fix — instrumentation for #677.

Adds opt-in `console.debug` logging on three hot paths in the bootstrap scroll-anchor flow:

- `chat/src/components/chat/VirtualTimeline.vue:scrollToPinnedEdge` — entry, post-`scrollToIndex`, every RAF tick (frame, scrollHeight, deltaSinceLast, stableStreak, scrollTop, clientHeight), and the exit reason (`stable` vs `frames cap (bailed mid-growth)`).
- `chat/src/lib/pinned-edge-scroll.ts:refreshSettleLock` — observer-armed event, every `ResizeObserver` fire during the 500ms window (with elapsed-ms + gap-from-bottom), and the timer-expired event with the final state.
- `chat/src/channels/mam-paging.ts:loadMessages` + `chat/src/dms/mam-paging.ts:loadMessages` — about-to-scroll and scroll-returned, including unread/firstUnseenId state and the request-stale flags.

## How to use

1. Open the affected Waddle deployment in the browser.
2. Open DevTools → Console, then run:
   ```js
   localStorage.setItem("WADDLE_DEBUG_SCROLL", "1")
   ```
3. Cmd+R the page on the affected channel.
4. After the page loads (and the scroll lands wrong), copy the `[scroll-debug]` lines from the console.
5. Paste the log block onto #677 (or share with the investigator).
6. Once captured: `localStorage.removeItem("WADDLE_DEBUG_SCROLL")`.

## Reading the logs

The most diagnostic lines:
- `VirtualTimeline.RAF exit: stable` vs `VirtualTimeline.RAF exit: frames cap (bailed mid-growth)` — tells us whether the 8-frame cap was the gate.
- `gapFromBottom` on the RAF-exit and settleTimer-expired lines — how many pixels short of the edge the user is at each checkpoint.
- `pinned-edge.settleObserver: fire -> pinTarget` count and elapsed timing — how often the ResizeObserver re-pinned, and whether async content kept growing inside the 500ms window or after it.

## Strip plan

Single revert when the data has been captured. The instrumentation has no side effects when `WADDLE_DEBUG_SCROLL` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)