### PR TITLE
fix(server): emit role='none' on MUC kick/ban/leave presence (XEP-0045 §9.1)

### DIFF
--- a/server/crates/waddle-server/tests/xep0045_kick_presence_broadcast_ws.rs
+++ b/server/crates/waddle-server/tests/xep0045_kick_presence_broadcast_ws.rs
@@ -1,0 +1,251 @@
+//! XEP-0045 §9.1 kick presence broadcast integration test over WebSocket.
+//!
+//! XEP-0045 §9.1.1 ("Kicking an Occupant"), normative:
+//!
+//! > The service MUST then remove the kicked occupant by sending a presence
+//! > stanza of type "unavailable" to each kicked occupant, including status
+//! > code 307 in the extended presence information, optionally along with
+//! > the reason (if provided) and the JID of the actor who initiated the
+//! > kick.
+//! >
+//! > The service MUST then inform all of the remaining occupants that the
+//! > kicked occupant is no longer in the room by sending presence stanzas
+//! > of type "unavailable" from the individual's room-nick (i.e.,
+//! > `<room@service/nick>`) to all the remaining occupants.
+//!
+//! Three occupants (admin/owner, alice/participant, bob/participant) join
+//! a MUC. The owner kicks bob via an admin IQ setting `role='none'` and
+//! the test asserts:
+//!
+//! - alice receives `<presence type='unavailable' from='room/bob'>` with
+//!   `<x xmlns='http://jabber.org/protocol/muc#user'>` carrying
+//!   `<item role='none'>` (with the `<reason/>` and `<actor jid='.../admin'/>`
+//!   children) and `<status code='307'/>`.
+//! - bob receives the same shape, additionally carrying
+//!   `<status code='110'/>` (self-presence per XEP-0045 §6.6).
+//! - The admin IQ returns `type='result'`.
+//!
+//! The wire format is parsed via `minidom::Element` and asserted
+//! structurally so reordering of children or attribute-quoting changes
+//! do not flake the test.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
+
+const DOMAIN: &str = "localhost";
+const ADMIN: &str = "admin";
+const ALICE: &str = "alice";
+const BOB: &str = "bob";
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
+const NS_MUC_ADMIN: &str = "http://jabber.org/protocol/muc#admin";
+
+// Each test spawns a fresh waddle-server binary; serialize so the harness
+// temp-port slot does not race when several tests run in parallel.
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect(server: &TestServer, user: &str, password: &str, resource: &str) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, user, password, resource)
+        .await
+        .expect("connect and auth")
+}
+
+/// Send a XEP-0045 join presence to `room/nick` and drain frames until
+/// the historical-subject ack arrives (last frame in the join sequence).
+async fn join_room(client: &mut WsXmppClient, room: &str, nick: &str) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{nick}"><x xmlns="{NS_MUC}"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
+
+/// Find a descendant element with the given local-name and namespace.
+fn find_descendant<'a>(root: &'a Element, name: &str, ns: &str) -> Option<&'a Element> {
+    for child in root.children() {
+        if child.name() == name && child.ns() == ns {
+            return Some(child);
+        }
+        if let Some(found) = find_descendant(child, name, ns) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Find the `<x xmlns='muc#user'>` child of a `<presence>` element.
+fn muc_user_payload(presence: &Element) -> Option<&Element> {
+    find_descendant(presence, "x", NS_MUC_USER)
+}
+
+/// Find a `<status code='N'/>` child of a `<x xmlns='muc#user'>` payload.
+fn has_status_code(muc_user: &Element, code: &str) -> bool {
+    muc_user
+        .children()
+        .filter(|child| child.name() == "status" && child.ns() == NS_MUC_USER)
+        .any(|status| status.attr("code") == Some(code))
+}
+
+/// Assert the broadcast shape required by XEP-0045 §9.1.1 / §6.6 for the
+/// kicked occupant or a remaining occupant.
+fn assert_kick_presence(
+    frame: &str,
+    expected_from: &str,
+    expected_reason: &str,
+    expected_actor_contains: &str,
+    is_self: bool,
+) {
+    let element = frame
+        .parse::<Element>()
+        .unwrap_or_else(|err| panic!("frame must parse as XML: {err}; frame={frame}"));
+    assert_eq!(element.name(), "presence", "expected <presence>: {frame}");
+    assert_eq!(
+        element.attr("type"),
+        Some("unavailable"),
+        "kick presence must have type='unavailable': {frame}"
+    );
+    assert_eq!(
+        element.attr("from"),
+        Some(expected_from),
+        "kick presence must come from the kicked occupant's room-nick: {frame}"
+    );
+
+    let muc_user = muc_user_payload(&element).unwrap_or_else(|| {
+        panic!("kick presence missing <x xmlns='muc#user'>: {frame}");
+    });
+    assert!(
+        has_status_code(muc_user, "307"),
+        "XEP-0045 §9.1.1 requires <status code='307'/>: {frame}"
+    );
+    if is_self {
+        assert!(
+            has_status_code(muc_user, "110"),
+            "XEP-0045 §6.6: self-presence to the kicked occupant must include <status code='110'/>: {frame}"
+        );
+    }
+
+    let item = muc_user
+        .children()
+        .find(|child| child.name() == "item" && child.ns() == NS_MUC_USER)
+        .unwrap_or_else(|| panic!("kick presence missing <item> in muc#user: {frame}"));
+    assert_eq!(
+        item.attr("role"),
+        Some("none"),
+        "kicked occupant must have role='none': {frame}"
+    );
+
+    let reason = item
+        .get_child("reason", NS_MUC_USER)
+        .unwrap_or_else(|| panic!("kick presence missing <reason>: {frame}"));
+    assert_eq!(
+        reason.text().trim(),
+        expected_reason,
+        "kick reason should carry through: {frame}"
+    );
+
+    let actor = item
+        .get_child("actor", NS_MUC_USER)
+        .unwrap_or_else(|| panic!("kick presence missing <actor>: {frame}"));
+    let actor_jid = actor
+        .attr("jid")
+        .unwrap_or_else(|| panic!("<actor> must carry the kicker's jid: {frame}"));
+    assert!(
+        actor_jid.contains(expected_actor_contains),
+        "<actor jid='...'> must mention the kicker '{expected_actor_contains}' (got '{actor_jid}'): {frame}"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_kick_broadcasts_status_307_to_all_occupants() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_pass = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[(ALICE, &alice_pass), (BOB, &bob_pass)]);
+
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ADMIN, &admin_pass, "kick-admin").await;
+    let mut alice = connect(&server, ALICE, &alice_pass, "kick-alice").await;
+    let mut bob = connect(&server, BOB, &bob_pass, "kick-bob").await;
+
+    let room = format!("kick-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+
+    // Admin joins first — opening the room makes admin the owner per
+    // XEP-0045 §10.1.3 (instant room). Then alice and bob join as
+    // participants. Drain alice/bob's presence-from-others frames so
+    // the only frames in flight after this point are kick-related.
+    join_room(&mut admin, &room, ADMIN).await;
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, BOB).await;
+
+    // Owner sends the kick IQ. XEP-0045 §9.1 says role='none' on the
+    // <item> is the kick verb.
+    let kick_id = format!("kick-iq-{}", uuid::Uuid::new_v4());
+    let reason = "spam";
+    admin
+        .send(&format!(
+            r#"<iq type="set" id="{kick_id}" to="{room}"><query xmlns="{NS_MUC_ADMIN}"><item nick="{BOB}" role="none"><reason>{reason}</reason></item></query></iq>"#
+        ))
+        .await
+        .expect("send kick iq");
+
+    // Admin should receive the IQ result. Drain admin's frames until we
+    // see the matching id — the admin also receives its own broadcast
+    // copy because the §9.1.1 send-to-all loop includes the admin.
+    let admin_result = admin
+        .recv_matching(|frame| frame.contains(&kick_id) && frame.contains("<iq"))
+        .await
+        .expect("admin iq result");
+    assert!(
+        admin_result.contains(r#"type="result""#) || admin_result.contains(r#"type='result'"#),
+        "kick IQ must succeed: {admin_result}"
+    );
+
+    let expected_from = format!("{room}/{BOB}");
+
+    // Bob (kicked) MUST receive an unavailable presence with code 307
+    // and code 110 (self), from his own room-nick.
+    let bob_kick = bob
+        .recv_matching(|frame| {
+            frame.contains("<presence") && frame.contains("type=\"unavailable\"")
+                || frame.contains("type='unavailable'")
+        })
+        .await
+        .expect("bob receives kick presence");
+    assert_kick_presence(&bob_kick, &expected_from, reason, ADMIN, true);
+
+    // Alice (remaining occupant) MUST receive the same unavailable
+    // presence from bob's room-nick, with code 307 but NOT 110.
+    let alice_kick = alice
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && (frame.contains("type=\"unavailable\"") || frame.contains("type='unavailable'"))
+                && frame.contains(&format!("/{BOB}"))
+        })
+        .await
+        .expect("alice receives kick broadcast");
+    assert_kick_presence(&alice_kick, &expected_from, reason, ADMIN, false);
+
+    // The same broadcast also goes to the admin's session per §9.1.1
+    // ("inform all of the remaining occupants"). Drain it so the close
+    // exchange below does not see leftover frames.
+    let _admin_kick = admin
+        .recv_matching(|frame| {
+            frame.contains("<presence")
+                && (frame.contains("type=\"unavailable\"") || frame.contains("type='unavailable'"))
+                && frame.contains(&format!("/{BOB}"))
+        })
+        .await
+        .expect("admin also receives kick broadcast");
+
+    let _ = admin.close().await;
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -13,6 +13,79 @@ use xmpp_parsers::presence::{Presence, Type as PresenceType};
 use crate::types::{Affiliation, Role};
 use crate::xep::xep0421::OccupantIdentity;
 
+/// Serialize an `Affiliation` to its XEP-0045 wire token. The
+/// `xmpp_parsers` `MucAffiliation` enum's `IntoAttributeValue` impl
+/// omits the attribute entirely when it equals the default
+/// (`MucAffiliation::None`), which violates XEP-0045 §9.1.1 / §10.2
+/// where `affiliation` is `Required` on `<item>`. Building the `<item>`
+/// via `minidom::Element` lets us write the literal token every time.
+fn affiliation_token(aff: Affiliation) -> &'static str {
+    match aff {
+        Affiliation::Owner => "owner",
+        Affiliation::Admin => "admin",
+        Affiliation::Member => "member",
+        Affiliation::Outcast => "outcast",
+        Affiliation::None => "none",
+    }
+}
+
+/// Build the `<item>` child of an `<x xmlns='muc#user'>` payload with
+/// the `affiliation` and `role` attributes ALWAYS present on the wire,
+/// regardless of value. `xmpp_parsers`' macro-generated serializer
+/// elides default attribute values, so building the element directly
+/// is the only way to satisfy XEP-0045 §9.1.1 / §10.2 / §7.14, where
+/// the wire form requires `role='none'` on the kicked/banned/leaving
+/// occupant's item.
+fn build_muc_user_item(
+    affiliation: Affiliation,
+    role_token: &'static str,
+    occupant_real_jid: Option<&FullJid>,
+    reason: Option<&str>,
+    actor: Option<&BareJid>,
+) -> Element {
+    let mut item = Element::builder("item", NS_MUC_USER)
+        .attr("affiliation", affiliation_token(affiliation))
+        .attr("role", role_token);
+    if let Some(jid) = occupant_real_jid {
+        item = item.attr("jid", jid.to_string());
+    }
+    if let Some(actor_bare) = actor {
+        // XEP-0045 §9.1.2 / §10.2 example: `<actor jid='admin'/>`. The
+        // schema accepts either a bare JID or a `nick` attribute; we
+        // emit `jid` because the room knows the kicker's real bare JID
+        // via the IQ `from`.
+        item = item.append(
+            Element::builder("actor", NS_MUC_USER)
+                .attr("jid", actor_bare.to_string())
+                .build(),
+        );
+    }
+    if let Some(reason_text) = reason {
+        item = item.append(
+            Element::builder("reason", NS_MUC_USER)
+                .append(reason_text)
+                .build(),
+        );
+    }
+    item.build()
+}
+
+/// Build the `<x xmlns='muc#user'>` payload that wraps a single
+/// occupant `<item>` plus the supplied status codes. Used by the
+/// kick / ban / leave builders, all of which need
+/// `affiliation` and `role` present on the wire.
+fn build_muc_user_x_element(item: Element, status_codes: &[&str]) -> Element {
+    let mut x = Element::builder("x", NS_MUC_USER).append(item);
+    for code in status_codes {
+        x = x.append(
+            Element::builder("status", NS_MUC_USER)
+                .attr("code", *code)
+                .build(),
+        );
+    }
+    x.build()
+}
+
 mod outbound;
 mod parser;
 #[cfg(test)]
@@ -119,6 +192,17 @@ fn strip_server_controlled_presence_payloads(presence: &mut Presence) {
 }
 
 /// Build a MUC unavailable presence for when a user leaves.
+///
+/// Per XEP-0045 §7.14 the wire form is
+/// `<presence type='unavailable' from='room/nick' to='occupant'>
+///     <x xmlns='muc#user'>
+///       <item affiliation='…' role='none'/>
+///     </x>
+///   </presence>`.
+/// The `role='none'` attribute is required on the wire even though
+/// it is the default for `xmpp_parsers::muc::user::Role`; we therefore
+/// build the `<x>` payload via `minidom::Element` so the attribute
+/// is always serialized.
 pub fn build_leave_presence(
     from_room_jid: &FullJid, // room@domain/nick of the user leaving
     to_jid: &FullJid,        // recipient's real JID
@@ -130,35 +214,18 @@ pub fn build_leave_presence(
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
-    // Build the MUC user element
-    let mut statuses = Vec::new();
-
+    let mut status_codes: Vec<&str> = Vec::new();
     if identity.real_jid.is_some() {
-        statuses.push(Status::NonAnonymousRoom);
+        status_codes.push("100");
     }
-
     if is_self {
-        statuses.push(Status::SelfPresence);
+        status_codes.push("110");
     }
 
-    // For leave, role is None
-    let item = Item {
-        affiliation: affiliation_to_muc(affiliation),
-        role: MucRole::None,
-        jid: identity.real_jid.cloned(),
-        nick: None,
-        actor: None,
-        continue_: None,
-        reason: None,
-    };
-
-    let muc_user = MucUser {
-        status: statuses,
-        items: vec![item],
-    };
-
-    let muc_element: Element = muc_user.into();
-    presence.payloads.push(muc_element);
+    let item = build_muc_user_item(affiliation, "none", identity.real_jid, None, None);
+    presence
+        .payloads
+        .push(build_muc_user_x_element(item, &status_codes));
     add_presence_identity_payloads(&mut presence, from_room_jid, identity);
 
     presence
@@ -211,9 +278,26 @@ fn role_to_muc(role: Role) -> MucRole {
 
 /// Build a kick presence notification (role changed to none).
 ///
-/// Per XEP-0045 §8.2: When a user is kicked, an unavailable presence is sent
-/// with status code 307 to all occupants. The kicked user also receives
-/// status code 110 to indicate it's about themselves.
+/// Per XEP-0045 §9.1.1 ("Kicking an Occupant"), normative:
+///
+/// > The service MUST then remove the kicked occupant by sending a
+/// > presence stanza of type "unavailable" to each kicked occupant,
+/// > including status code 307 in the extended presence information,
+/// > optionally along with the reason (if provided) and the JID of
+/// > the actor who initiated the kick.
+/// >
+/// > The service MUST then inform all of the remaining occupants that
+/// > the kicked occupant is no longer in the room by sending presence
+/// > stanzas of type "unavailable" from the individual's room-nick
+/// > (i.e., `<room@service/nick>`) to all the remaining occupants.
+///
+/// The kicked occupant additionally receives `<status code='110'/>`
+/// (XEP-0045 §6.6) so the client recognises the presence as its own.
+///
+/// We build the `<x xmlns='muc#user'>` payload via `minidom::Element`
+/// because `xmpp_parsers`' macro-generated `Item` serializer omits
+/// `role='none'` when role is the default — and XEP-0045 §9.1.1
+/// example shows `role='none'` is required on the wire for kicks.
 ///
 /// # Arguments
 /// * `from_room_jid` - The room@domain/nick of the kicked user
@@ -221,7 +305,7 @@ fn role_to_muc(role: Role) -> MucRole {
 /// * `affiliation` - The kicked user's affiliation (unchanged by kick)
 /// * `is_self` - True if this presence is going to the kicked user
 /// * `reason` - Optional reason for the kick
-/// * `actor` - Optional JID of who performed the kick
+/// * `actor` - Optional bare JID of who performed the kick
 pub fn build_kick_presence(
     from_room_jid: &FullJid,
     to_jid: &FullJid,
@@ -235,40 +319,18 @@ pub fn build_kick_presence(
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
-    let mut statuses = vec![Status::Kicked];
+    let mut status_codes: Vec<&str> = vec!["307"];
     if identity.real_jid.is_some() {
-        statuses.push(Status::NonAnonymousRoom);
+        status_codes.push("100");
     }
     if is_self {
-        statuses.push(Status::SelfPresence);
+        status_codes.push("110");
     }
 
-    // Build actor element if provided
-    // Actor is an enum with Jid(FullJid) or Nick(String) variants
-    // We use the FullJid variant, adding a synthetic resource to the BareJid
-    let actor_elem = actor.and_then(|a| {
-        a.with_resource_str("admin")
-            .ok()
-            .map(xmpp_parsers::muc::user::Actor::Jid)
-    });
-
-    let item = Item {
-        affiliation: affiliation_to_muc(affiliation),
-        role: MucRole::None, // Kicked = role none
-        jid: identity.real_jid.cloned(),
-        nick: None,
-        actor: actor_elem,
-        continue_: None,
-        reason: reason.map(|r| xmpp_parsers::muc::user::Reason(r.to_string())),
-    };
-
-    let muc_user = MucUser {
-        status: statuses,
-        items: vec![item],
-    };
-
-    let muc_element: Element = muc_user.into();
-    presence.payloads.push(muc_element);
+    let item = build_muc_user_item(affiliation, "none", identity.real_jid, reason, actor);
+    presence
+        .payloads
+        .push(build_muc_user_x_element(item, &status_codes));
     add_presence_identity_payloads(&mut presence, from_room_jid, identity);
 
     presence
@@ -276,16 +338,23 @@ pub fn build_kick_presence(
 
 /// Build a ban presence notification (affiliation changed to outcast).
 ///
-/// Per XEP-0045 §9.1: When a user is banned, an unavailable presence is sent
-/// with status code 301 to all occupants. The banned user also receives
-/// status code 110 to indicate it's about themselves.
+/// Per XEP-0045 §10.2 ("Banning a User"), normative:
+///
+/// > The service MUST remove the banned user from the room and inform
+/// > all remaining occupants by sending presence of type "unavailable"
+/// > with status code 301 from the affected occupant's room-nick.
+///
+/// The wire form is `<item affiliation='outcast' role='none' …>` —
+/// both attributes MUST appear on the wire. We build the `<x>` payload
+/// via `minidom::Element` because `xmpp_parsers`' macro-generated
+/// serializer drops attributes that match their default.
 ///
 /// # Arguments
 /// * `from_room_jid` - The room@domain/nick of the banned user
 /// * `to_jid` - The recipient's full JID
 /// * `is_self` - True if this presence is going to the banned user
 /// * `reason` - Optional reason for the ban
-/// * `actor` - Optional JID of who performed the ban
+/// * `actor` - Optional bare JID of who performed the ban
 pub fn build_ban_presence(
     from_room_jid: &FullJid,
     to_jid: &FullJid,
@@ -298,40 +367,24 @@ pub fn build_ban_presence(
     presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(to_jid.clone()));
 
-    let mut statuses = vec![Status::Banned];
+    let mut status_codes: Vec<&str> = vec!["301"];
     if identity.real_jid.is_some() {
-        statuses.push(Status::NonAnonymousRoom);
+        status_codes.push("100");
     }
     if is_self {
-        statuses.push(Status::SelfPresence);
+        status_codes.push("110");
     }
 
-    // Build actor element if provided
-    // Actor is an enum with Jid(FullJid) or Nick(String) variants
-    // We use the FullJid variant, adding a synthetic resource to the BareJid
-    let actor_elem = actor.and_then(|a| {
-        a.with_resource_str("admin")
-            .ok()
-            .map(xmpp_parsers::muc::user::Actor::Jid)
-    });
-
-    let item = Item {
-        affiliation: MucAffiliation::Outcast, // Banned = outcast
-        role: MucRole::None,                  // Banned = role none
-        jid: identity.real_jid.cloned(),
-        nick: None,
-        actor: actor_elem,
-        continue_: None,
-        reason: reason.map(|r| xmpp_parsers::muc::user::Reason(r.to_string())),
-    };
-
-    let muc_user = MucUser {
-        status: statuses,
-        items: vec![item],
-    };
-
-    let muc_element: Element = muc_user.into();
-    presence.payloads.push(muc_element);
+    let item = build_muc_user_item(
+        Affiliation::Outcast,
+        "none",
+        identity.real_jid,
+        reason,
+        actor,
+    );
+    presence
+        .payloads
+        .push(build_muc_user_x_element(item, &status_codes));
     add_presence_identity_payloads(&mut presence, from_room_jid, identity);
 
     presence

--- a/server/crates/waddle-xmpp/src/muc/presence/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence/tests.rs
@@ -171,6 +171,193 @@ fn test_build_leave_presence() {
         .get_child("item", NS_MUC_USER)
         .expect("MUC item payload");
     assert_eq!(item.attr("jid"), Some("leaver@example.com/phone"));
+    assert_eq!(item.attr("affiliation"), Some("member"));
+    // XEP-0045 §7.14: leave presence MUST carry `role='none'` on the
+    // wire so receivers can distinguish "I have left" from a no-op
+    // presence update.
+    assert_eq!(item.attr("role"), Some("none"));
+}
+
+/// XEP-0045 §9.1.1 ("Kicking an Occupant"), normative:
+///
+/// > The service MUST then remove the kicked occupant by sending a
+/// > presence stanza of type "unavailable" to each kicked occupant,
+/// > including status code 307 in the extended presence information,
+/// > optionally along with the reason (if provided) and the JID of
+/// > the actor who initiated the kick.
+///
+/// The wire form is `<presence type='unavailable' from='room/nick'>
+/// <x xmlns='muc#user'><item affiliation='…' role='none'><actor jid='…'/>
+/// <reason>…</reason></item><status code='307'/></x></presence>`.
+#[test]
+fn test_build_kick_presence_self_includes_307_and_110_and_actor_reason() {
+    use jid::BareJid;
+    let from: FullJid = "room@muc.example.com/bob".parse().unwrap();
+    let to: FullJid = "bob@example.com/desk".parse().unwrap();
+    let target_jid: FullJid = "bob@example.com/desk".parse().unwrap();
+    let actor: BareJid = "alice@example.com".parse().unwrap();
+
+    let secret = test_secret();
+    let target_bare = target_jid.to_bare();
+    let presence = build_kick_presence(
+        &from,
+        &to,
+        Affiliation::Member,
+        true,
+        Some("spam"),
+        Some(&actor),
+        &OccupantIdentity {
+            bare_jid: &target_bare,
+            real_jid: Some(&target_jid),
+            secret: &secret,
+        },
+    );
+
+    assert_eq!(presence.type_, PresenceType::Unavailable);
+    let muc_user = presence
+        .payloads
+        .iter()
+        .find(|payload| payload.is("x", NS_MUC_USER))
+        .expect("muc#user payload");
+    let item = muc_user
+        .get_child("item", NS_MUC_USER)
+        .expect("muc#user item");
+
+    assert_eq!(item.attr("affiliation"), Some("member"));
+    assert_eq!(item.attr("role"), Some("none"));
+    assert_eq!(item.attr("jid"), Some("bob@example.com/desk"));
+
+    let actor_elem = item.get_child("actor", NS_MUC_USER).expect("actor element");
+    assert_eq!(actor_elem.attr("jid"), Some("alice@example.com"));
+
+    let reason = item
+        .get_child("reason", NS_MUC_USER)
+        .expect("reason element");
+    assert_eq!(reason.text(), "spam");
+
+    let codes: Vec<&str> = muc_user
+        .children()
+        .filter(|child| child.is("status", NS_MUC_USER))
+        .filter_map(|status| status.attr("code"))
+        .collect();
+    assert!(
+        codes.contains(&"307"),
+        "kick presence MUST carry status code 307; got {codes:?}"
+    );
+    assert!(
+        codes.contains(&"110"),
+        "self-presence to the kicked occupant MUST carry status code 110; got {codes:?}"
+    );
+}
+
+/// XEP-0045 §9.1.1: a kick broadcast to a *remaining* occupant MUST
+/// have status code 307 but MUST NOT carry status code 110, since
+/// 110 means "this presence is about you".
+#[test]
+fn test_build_kick_presence_remaining_excludes_110() {
+    use jid::BareJid;
+    let from: FullJid = "room@muc.example.com/bob".parse().unwrap();
+    let to: FullJid = "charlie@example.com/desk".parse().unwrap();
+    let target_jid: FullJid = "bob@example.com/desk".parse().unwrap();
+    let actor: BareJid = "alice@example.com".parse().unwrap();
+
+    let secret = test_secret();
+    let target_bare = target_jid.to_bare();
+    let presence = build_kick_presence(
+        &from,
+        &to,
+        Affiliation::Member,
+        false,
+        None,
+        Some(&actor),
+        &OccupantIdentity {
+            bare_jid: &target_bare,
+            real_jid: Some(&target_jid),
+            secret: &secret,
+        },
+    );
+
+    let muc_user = presence
+        .payloads
+        .iter()
+        .find(|payload| payload.is("x", NS_MUC_USER))
+        .expect("muc#user payload");
+    let codes: Vec<&str> = muc_user
+        .children()
+        .filter(|child| child.is("status", NS_MUC_USER))
+        .filter_map(|status| status.attr("code"))
+        .collect();
+    assert!(
+        codes.contains(&"307"),
+        "remaining-occupant kick broadcast MUST carry status code 307; got {codes:?}"
+    );
+    assert!(
+        !codes.contains(&"110"),
+        "remaining-occupant kick broadcast MUST NOT carry status code 110; got {codes:?}"
+    );
+
+    let item = muc_user
+        .get_child("item", NS_MUC_USER)
+        .expect("muc#user item");
+    assert_eq!(item.attr("role"), Some("none"));
+    // No reason provided, so no <reason/> child.
+    assert!(item.get_child("reason", NS_MUC_USER).is_none());
+}
+
+/// XEP-0045 §10.2 ("Banning a User"): unavailable presence with
+/// `<item affiliation='outcast' role='none'>` and status code 301.
+#[test]
+fn test_build_ban_presence_self_includes_301_outcast_role_none() {
+    use jid::BareJid;
+    let from: FullJid = "room@muc.example.com/bob".parse().unwrap();
+    let to: FullJid = "bob@example.com/desk".parse().unwrap();
+    let target_jid: FullJid = "bob@example.com/desk".parse().unwrap();
+    let actor: BareJid = "alice@example.com".parse().unwrap();
+
+    let secret = test_secret();
+    let target_bare = target_jid.to_bare();
+    let presence = build_ban_presence(
+        &from,
+        &to,
+        true,
+        Some("trolling"),
+        Some(&actor),
+        &OccupantIdentity {
+            bare_jid: &target_bare,
+            real_jid: Some(&target_jid),
+            secret: &secret,
+        },
+    );
+
+    let muc_user = presence
+        .payloads
+        .iter()
+        .find(|payload| payload.is("x", NS_MUC_USER))
+        .expect("muc#user payload");
+    let item = muc_user
+        .get_child("item", NS_MUC_USER)
+        .expect("muc#user item");
+    assert_eq!(item.attr("affiliation"), Some("outcast"));
+    assert_eq!(item.attr("role"), Some("none"));
+
+    let codes: Vec<&str> = muc_user
+        .children()
+        .filter(|child| child.is("status", NS_MUC_USER))
+        .filter_map(|status| status.attr("code"))
+        .collect();
+    assert!(
+        codes.contains(&"301"),
+        "ban presence MUST carry status code 301; got {codes:?}"
+    );
+    assert!(
+        codes.contains(&"110"),
+        "self-presence to the banned occupant MUST carry status code 110; got {codes:?}"
+    );
+
+    let reason = item
+        .get_child("reason", NS_MUC_USER)
+        .expect("reason element");
+    assert_eq!(reason.text(), "trolling");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Bug: every MUC kick (XEP-0045 §9.1.1), ban (§10.2), and voluntary
leave (§7.14) presence broadcast was emitted **without the `role`
attribute on the wire `<item>`**, leaving clients unable to recognise
the unavailable presence as a kick / ban / leave.

The broadcast plumbing through `RoomActor::ApplyAdminItems` was
already in place and delivering presence to every remaining
occupant + the kicked occupant + the kicker (see
`server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs`).
The defect was downstream of that: the wire serializer was eating
the `role='none'` attribute.

## Root cause

`xmpp_parsers::muc::user::Item` is generated via the
`generate_attribute!` macro. The macro's `IntoAttributeValue` impl
returns `None` when the value equals the enum's `Default`
(`Role::None`), so `Role::None` serializes to **no attribute** on the
`<item>`. Every kick / ban / leave path that set `role: MucRole::None`
on the typed `Item` therefore produced a wire `<item>` that omitted
`role` entirely.

Captured server output before the fix (the integration test added
in this PR failed with this):

```xml
<presence type="unavailable" from=".../bob" to="bob@.../kick-bob">
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <status code="307"/>
    <status code="100"/>
    <status code="110"/>
    <item affiliation="member" jid="bob@.../kick-bob">  <!-- role missing -->
      <actor jid="admin@.../admin"/>
      <reason>spam</reason>
    </item>
  </x>
</presence>
```

The 307 status code was emitted correctly; only the `role` attribute
on `<item>` was dropped.

## Spec reference

XEP-0045 §9.1.1 ("Kicking an Occupant"), normative:

> The service MUST then remove the kicked occupant by sending a
> presence stanza of type "unavailable" to each kicked occupant,
> including status code 307 in the extended presence information,
> optionally along with the reason (if provided) and the JID of the
> actor who initiated the kick.
>
> The service MUST then inform all of the remaining occupants that
> the kicked occupant is no longer in the room by sending presence
> stanzas of type "unavailable" from the individual's room-nick
> (i.e., `<room@service/nick>`) to all the remaining occupants.

Required wire shape:

```xml
<presence type='unavailable' from='room@service/nick'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <item affiliation='member' role='none'>
      <actor jid='kicker@host'/>
      <reason>spam</reason>
    </item>
    <status code='307'/>
  </x>
</presence>
```

## Fix

Build the `<x xmlns='muc#user'>` payload for `build_kick_presence`,
`build_ban_presence`, and `build_leave_presence` via
`minidom::Element::builder` instead of going through the
`xmpp_parsers::muc::user::Item` macro-generated serializer.
`affiliation` and `role` are written unconditionally — matching the
XEP-0045 examples that show both attributes on the wire.

This mirrors the pattern already in `build_destroy_notification`,
which side-stepped the same bug for the `<item affiliation='none' role='none'/>`
wire shape in XEP-0045 §10.9 destroy.

Status code constants (307 / 301 / 110 / 100) are emitted via
`minidom::Element` too, so there is no risk of a future
`xmpp_parsers` default change silently dropping one of them.

No behavioural change to join, role-change, or affiliation-change
builders — those don't hit the defaulting hazard on `role` because
the room only emits those for occupants with a non-`None` role.

## Tests

- New unit tests in `crates/waddle-xmpp/src/muc/presence/tests.rs`:
  - `test_build_kick_presence_self_includes_307_and_110_and_actor_reason`
  - `test_build_kick_presence_remaining_excludes_110`
  - `test_build_ban_presence_self_includes_301_outcast_role_none`
  - extended `test_build_leave_presence` to assert
    `affiliation='member'` + `role='none'`.

- New integration test
  `crates/waddle-server/tests/xep0045_kick_presence_broadcast_ws.rs`
  that drives the full WebSocket transport end-to-end: admin/owner,
  alice, and bob join a MUC, admin issues a `muc#admin` IQ kicking
  bob with `role='none'` and a reason, the test asserts the broadcast
  reaches every occupant (kicked + remaining + the admin's own
  session) with the correct `from` room-nick, `<status code='307'/>`,
  `<actor jid='admin@.../...'/>`, and `<reason>...</reason>`.

## Test plan

- [x] `cargo test --workspace` green (new tests + no regression)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] XEP-0045 §9.1.1 conformance test passes against the new behavior

## Scope notes

Originally framed as a kick-only fix; the same root cause affected
the ban (§10.2) and voluntary-leave (§7.14) builders. Since the
single helper introduced here fixes all three, and CLAUDE.md's XEP
conformance hard rule requires the wire shape to match the XEP
exactly, all three are corrected in this PR rather than carrying
known-broken paths.

This PR was created with the assistance of a LLM.