### PR TITLE
feat(server): RoomActor::ListAffiliations message (admin V2 plumbing)

### DIFF
--- a/server/crates/waddle-xmpp/src/muc/affiliation/list.rs
+++ b/server/crates/waddle-xmpp/src/muc/affiliation/list.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use chrono::{DateTime, Utc};
 use jid::BareJid;
 
 use crate::types::Affiliation;
@@ -11,6 +12,14 @@ pub struct AffiliationEntry {
     pub jid: BareJid,
     /// The user's affiliation
     pub affiliation: Affiliation,
+    /// When this affiliation was granted, if recorded.
+    ///
+    /// Today's in-memory `AffiliationList` does not record grant
+    /// timestamps, so this field is always `None`. Persistence of
+    /// `granted_at` is a follow-up tracked under the admin V2
+    /// spaces-metadata plumbing (see
+    /// `docs/superpowers/specs/2026-05-17-admin-v2-design.md`).
+    pub granted_at: Option<DateTime<Utc>>,
     /// Optional reason/notes
     pub reason: Option<String>,
 }
@@ -21,6 +30,7 @@ impl AffiliationEntry {
         Self {
             jid,
             affiliation,
+            granted_at: None,
             reason: None,
         }
     }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -11,6 +11,7 @@ use kameo::Actor;
 use std::convert::Infallible;
 use thiserror::Error;
 
+use super::affiliation::AffiliationEntry;
 use super::pin::{PinStateChange, PinnedEntry};
 use super::room_registry::RoomInfo;
 use super::{MucRoom, RoomConfig, RoomSubjectTexts, SubjectState};
@@ -425,6 +426,50 @@ impl kameo::message::Message<GetAffiliation> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         Ok(self.room.get_affiliation(&msg.jid))
+    }
+}
+
+/// Read the full persistent affiliation roster for the room,
+/// optionally filtered to a single tier.
+///
+/// Returns every JID currently recorded in the room's
+/// [`super::affiliation::AffiliationList`], wrapped as
+/// [`AffiliationEntry`] values and sorted by JID ascending so callers
+/// get a stable, deterministic ordering. When `filter` is
+/// `Some(tier)`, only entries whose `affiliation == tier` are
+/// returned; when `None`, every entry is returned.
+///
+/// Plumbing for the admin V2 `channels:affiliations` command (see
+/// `docs/superpowers/specs/2026-05-17-admin-v2-design.md`). The
+/// per-JID [`GetAffiliation`] message remains for point lookups;
+/// batched roster readers must use this message rather than folding
+/// over `GetAffiliation`.
+///
+/// `Affiliation::None` is never stored, so passing
+/// `filter = Some(Affiliation::None)` always yields an empty `Vec`.
+pub struct ListAffiliations {
+    pub filter: Option<Affiliation>,
+}
+
+impl kameo::message::Message<ListAffiliations> for RoomActor {
+    type Reply = Vec<AffiliationEntry>;
+
+    async fn handle(
+        &mut self,
+        msg: ListAffiliations,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut entries: Vec<AffiliationEntry> = self
+            .room
+            .get_all_affiliations()
+            .into_iter()
+            .filter(|entry| match msg.filter {
+                Some(tier) => entry.affiliation == tier,
+                None => true,
+            })
+            .collect();
+        entries.sort_by(|a, b| a.jid.cmp(&b.jid));
+        entries
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -631,3 +631,170 @@ async fn is_dormant_true_after_last_occupant_leaves_with_no_stored_state() {
          and safe for the room dormancy janitor to reap"
     );
 }
+
+// ---------------------------------------------------------------------------
+// ListAffiliations
+// ---------------------------------------------------------------------------
+
+fn bare(s: &str) -> BareJid {
+    s.parse().expect("valid bare jid")
+}
+
+async fn seed_one_per_tier(actor: &ActorRef<RoomActor>) {
+    // Distinct local parts so the JID-ascending sort order is well
+    // defined and verifiable in each test: alice < bob < carol < dave.
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("seed owner");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("bob@example.com"),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("seed admin");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("carol@example.com"),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("seed member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("dave@example.com"),
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("seed outcast");
+}
+
+#[tokio::test]
+async fn list_affiliations_empty_room_returns_empty_vec() {
+    let actor = spawn_room_actor().await;
+
+    let entries = actor
+        .ask(ListAffiliations { filter: None })
+        .await
+        .expect("ask");
+    assert!(entries.is_empty(), "fresh room has no stored affiliations");
+}
+
+#[tokio::test]
+async fn list_affiliations_no_filter_returns_all_tiers_sorted_by_jid() {
+    let actor = spawn_room_actor().await;
+    seed_one_per_tier(&actor).await;
+
+    let entries = actor
+        .ask(ListAffiliations { filter: None })
+        .await
+        .expect("ask");
+
+    let jids: Vec<String> = entries.iter().map(|e| e.jid.to_string()).collect();
+    assert_eq!(
+        jids,
+        vec![
+            "alice@example.com".to_string(),
+            "bob@example.com".to_string(),
+            "carol@example.com".to_string(),
+            "dave@example.com".to_string(),
+        ],
+        "entries must be sorted ascending by JID"
+    );
+
+    let tiers: Vec<Affiliation> = entries.iter().map(|e| e.affiliation).collect();
+    assert_eq!(
+        tiers,
+        vec![
+            Affiliation::Owner,
+            Affiliation::Admin,
+            Affiliation::Member,
+            Affiliation::Outcast,
+        ],
+        "each seeded tier must be present"
+    );
+
+    // granted_at is intentionally None today — storage gap noted in
+    // AffiliationEntry's doc-comment.
+    assert!(
+        entries.iter().all(|e| e.granted_at.is_none()),
+        "granted_at is not yet recorded by the in-memory store"
+    );
+}
+
+#[tokio::test]
+async fn list_affiliations_filter_outcast_returns_only_outcasts() {
+    let actor = spawn_room_actor().await;
+    seed_one_per_tier(&actor).await;
+
+    let entries = actor
+        .ask(ListAffiliations {
+            filter: Some(Affiliation::Outcast),
+        })
+        .await
+        .expect("ask");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].jid, bare("dave@example.com"));
+    assert_eq!(entries[0].affiliation, Affiliation::Outcast);
+}
+
+#[tokio::test]
+async fn list_affiliations_filter_member_returns_only_members() {
+    let actor = spawn_room_actor().await;
+    seed_one_per_tier(&actor).await;
+    // Add a second member to verify filter returns *all* matches, not
+    // just the first.
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("erin@example.com"),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("seed second member");
+
+    let entries = actor
+        .ask(ListAffiliations {
+            filter: Some(Affiliation::Member),
+        })
+        .await
+        .expect("ask");
+
+    let jids: Vec<String> = entries.iter().map(|e| e.jid.to_string()).collect();
+    assert_eq!(
+        jids,
+        vec![
+            "carol@example.com".to_string(),
+            "erin@example.com".to_string(),
+        ],
+        "member filter returns all members in JID-ascending order"
+    );
+    assert!(entries.iter().all(|e| e.affiliation == Affiliation::Member));
+}
+
+#[tokio::test]
+async fn list_affiliations_filter_none_tier_returns_empty() {
+    // Affiliation::None is the implicit default and is never stored in
+    // the affiliation list (see `AffiliationList::set` — assigning
+    // Affiliation::None removes the entry). A filter request for it
+    // must therefore always come back empty even when other tiers are
+    // populated.
+    let actor = spawn_room_actor().await;
+    seed_one_per_tier(&actor).await;
+
+    let entries = actor
+        .ask(ListAffiliations {
+            filter: Some(Affiliation::None),
+        })
+        .await
+        .expect("ask");
+
+    assert!(
+        entries.is_empty(),
+        "Affiliation::None is not stored; filter must return empty"
+    );
+}


### PR DESCRIPTION
## Summary

Add a `RoomActor::ListAffiliations` message that returns the full affiliation roster for a room (owner / admin / member / outcast), optionally filtered by tier. Currently only `GetAffiliation(jid)` exists — per-JID lookup. Admin V2's `channels:affiliations` command (and any other batched roster reader) needs a list, not a fold over `GetAffiliation`.

## Plan

1. Find the affiliation store the actor reads from (search `MucAffiliationStore` / `affiliations` field in `room_actor.rs`).
2. Add a `ListAffiliations { filter: Option<MucAffiliation> }` actor message returning `Vec<(BareJid, MucAffiliation, Option<DateTime<Utc>>, Option<String>)>` — JID + tier + granted-at + reason. RFC 3339 timestamp comes from whatever the store records today (if it doesn't record granted_at yet, return `None` and note the gap).
3. Mirror `GetAffiliation`'s reply pattern (kameo `Reply<...>`).
4. Dedicated unit test in `room_actor` tests covering: full list, filtered by tier, empty room, room with all four tiers populated.

## Non-goals

- New wire IQ — this is an internal actor message; XEP-0045 §9.3/10.5 list-affiliations IQs already work for room-joined occupants.
- Pagination — V1 lists are small enough; admin V2 will paginate at the wire layer if needed.
- Adding granted_at / reason storage if missing — flag as a follow-up.

## Test plan

- [ ] `cargo test --workspace` green
- [ ] `cargo clippy -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] Unit tests cover the filter matrix (none / owner / admin / member / outcast)

This PR was created with the assistance of a LLM.
