### PR TITLE
feat(server): spaces metadata storage (admin V2 plumbing)

### DIFF
--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod push_service;
 pub mod server;
 pub mod sm_persistence;
 pub mod sm_promotion;
+pub mod spaces_metadata;
 pub mod spaces_pubsub_seed;
 pub mod storage;
 pub mod telemetry;

--- a/server/crates/waddle-server/src/server/config.rs
+++ b/server/crates/waddle-server/src/server/config.rs
@@ -11,6 +11,13 @@ pub struct XmppConfig {
     pub mam_database_url: Option<String>,
     /// Inbox database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
     pub inbox_database_url: Option<String>,
+    /// Spaces-metadata database URL — prefers dedicated XMPP DSN, otherwise
+    /// the main runtime DSN. Resolution order matches
+    /// `resolve_xmpp_database_url`:
+    /// `WADDLE_XMPP_SPACES_METADATA_DATABASE_URL` → `WADDLE_DATABASE_URL`.
+    /// When unset, the store falls back to in-memory SQLite — suitable
+    /// for tests only.
+    pub spaces_metadata_database_url: Option<String>,
     /// XEP-0160 offline-message (`pending_delivery`) database URL —
     /// prefers dedicated XMPP DSN, otherwise the main runtime DSN.
     /// Resolution order (matches `resolve_xmpp_database_url`):
@@ -57,6 +64,7 @@ impl Default for XmppConfig {
             domain: "localhost".to_string(),
             mam_database_url: None,
             inbox_database_url: None,
+            spaces_metadata_database_url: None,
             pending_delivery_database_url: None,
             sm_database_url: None,
             pubsub_database_url: None,
@@ -83,6 +91,8 @@ impl XmppConfig {
 
         let mam_database_url = resolve_xmpp_database_url("WADDLE_XMPP_MAM_DATABASE_URL");
         let inbox_database_url = resolve_xmpp_database_url("WADDLE_XMPP_INBOX_DATABASE_URL");
+        let spaces_metadata_database_url =
+            resolve_xmpp_database_url("WADDLE_XMPP_SPACES_METADATA_DATABASE_URL");
         let pending_delivery_database_url =
             resolve_xmpp_database_url("WADDLE_XMPP_PENDING_DELIVERY_DATABASE_URL");
         let sm_database_url = resolve_xmpp_database_url("WADDLE_XMPP_SM_DATABASE_URL");
@@ -111,6 +121,7 @@ impl XmppConfig {
             domain,
             mam_database_url,
             inbox_database_url,
+            spaces_metadata_database_url,
             pending_delivery_database_url,
             sm_database_url,
             pubsub_database_url,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -47,6 +47,7 @@ use crate::config::ServerConfig;
 use crate::db::DatabasePool;
 use crate::inbox::build_inbox_storage;
 use crate::permissions::PermissionActor;
+use crate::spaces_metadata::build_spaces_metadata_store;
 use acme::start_acme_runtime;
 use anyhow::Result;
 use fixed_account::{ensure_fixed_test_account, fixed_test_account_enabled};
@@ -132,6 +133,12 @@ pub async fn start_with_config(
     let inbox_storage = build_inbox_storage(xmpp_config.inbox_database_url.clone())
         .await
         .map_err(|error| anyhow::anyhow!("Failed to initialize inbox storage: {}", error))?;
+    let spaces_metadata_store =
+        build_spaces_metadata_store(xmpp_config.spaces_metadata_database_url.clone())
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("Failed to initialize spaces metadata storage: {}", error)
+            })?;
 
     // Create HTTP state (shares db_pool via Arc)
     let blob_storage = crate::storage::build_blob_storage()
@@ -144,6 +151,7 @@ pub async fn start_with_config(
         Arc::clone(&db_pool),
         blob_storage,
         Arc::clone(&inbox_storage),
+        Arc::clone(&spaces_metadata_store),
         permission_actor.clone(),
         server_owner_jids,
     ));

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -30,6 +30,7 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         Arc::clone(&db_pool),
         blob_storage,
         Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
+        Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
         permission_actor,
         Arc::from(Vec::<jid::BareJid>::new()),
     ));

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -1,5 +1,6 @@
 use crate::permissions::PermissionActor;
 use crate::server::bootstrap_membership;
+use crate::spaces_metadata::SpacesMetadataStore;
 use jid::BareJid;
 use kameo::actor::ActorRef;
 use std::sync::Arc;
@@ -14,6 +15,11 @@ pub struct AppState {
     pub blob_storage: Arc<dyn crate::storage::BlobStorage>,
     /// Shared Waddle inbox projection storage.
     pub inbox_storage: Arc<dyn InboxStorage>,
+    /// Spaces metadata storage (`name`, `description`, `icon_url`) — read
+    /// and written by the admin V2 `spaces:create` / `spaces:update`
+    /// commands. XEP-0503 has no opinion on these human-facing fields;
+    /// they live here as a Waddle-specific projection.
+    pub spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
     /// Shared permission actor handle.
     pub permission_actor: ActorRef<PermissionActor>,
     /// Bare JIDs of server owners (resolved from
@@ -39,6 +45,7 @@ impl AppState {
             db_pool,
             blob_storage,
             Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
+            Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
             permission_actor,
             Arc::from(Vec::<BareJid>::new()),
         )
@@ -48,6 +55,7 @@ impl AppState {
         db_pool: Arc<crate::db::DatabasePool>,
         blob_storage: Arc<dyn crate::storage::BlobStorage>,
         inbox_storage: Arc<dyn InboxStorage>,
+        spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
         permission_actor: ActorRef<PermissionActor>,
         server_owner_jids: Arc<[BareJid]>,
     ) -> Self {
@@ -55,6 +63,7 @@ impl AppState {
             db_pool,
             blob_storage,
             inbox_storage,
+            spaces_metadata_store,
             permission_actor,
             server_owner_jids,
         }

--- a/server/crates/waddle-server/src/spaces_metadata/mod.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/mod.rs
@@ -1,0 +1,313 @@
+//! Storage layer for XEP-0503 spaces metadata.
+//!
+//! Spaces today derive their identity from their pubsub-tree config; there
+//! is no durable place to record the human-facing fields (`name`,
+//! `description`, `icon_url`) that admin V2's `spaces:create` /
+//! `spaces:update` commands need. This module is the typed, server-side
+//! projection that fills that gap.
+//!
+//! Wire shape lives elsewhere — the admin V2 retry adds the IQs that
+//! mutate metadata; this PR ships plumbing only.
+//!
+//! Hard rules:
+//! - typed values (`SpaceMetadata`, `BareJid`, typed error enum) at every
+//!   boundary,
+//! - no `unwrap` in storage paths,
+//! - `CREATE TABLE IF NOT EXISTS` idempotent schema, mirroring the inbox
+//!   migration pattern.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jid::BareJid;
+use thiserror::Error;
+use tracing::{info, instrument};
+
+use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+
+mod schema;
+pub mod storage;
+#[cfg(test)]
+mod tests;
+
+pub use storage::InMemorySpacesMetadataStore;
+
+/// Typed payload for a row in `spaces_metadata`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpaceMetadata {
+    pub space_jid: BareJid,
+    pub name: String,
+    pub description: Option<String>,
+    pub icon_url: Option<String>,
+    /// Unix seconds.
+    pub created_at: i64,
+    /// Unix seconds.
+    pub updated_at: i64,
+}
+
+/// Errors returned by [`SpacesMetadataStore`] implementations.
+#[derive(Debug, Error)]
+pub enum SpacesMetadataError {
+    #[error("spaces metadata storage error: {0}")]
+    Storage(String),
+    #[error("invalid space JID '{raw}': {source}")]
+    InvalidJid {
+        raw: String,
+        #[source]
+        source: jid::Error,
+    },
+}
+
+/// Storage contract for spaces metadata. Admin V2's `spaces:create` /
+/// `spaces:update` / `spaces:delete` handlers (added in a follow-up PR)
+/// reach the table through this trait so the wire layer never speaks SQL
+/// directly.
+#[async_trait]
+pub trait SpacesMetadataStore: Send + Sync {
+    /// Fetch the metadata row for `space_jid` (`Ok(None)` when absent).
+    async fn get(&self, space_jid: &BareJid) -> Result<Option<SpaceMetadata>, SpacesMetadataError>;
+
+    /// Insert or replace the metadata row keyed by `metadata.space_jid`.
+    ///
+    /// On conflict the row is overwritten; the caller is responsible for
+    /// supplying a monotonically-correct `updated_at` (typically
+    /// `time::now_unix_seconds()` at the request boundary).
+    async fn upsert(&self, metadata: &SpaceMetadata) -> Result<(), SpacesMetadataError>;
+
+    /// Delete the metadata row for `space_jid`.
+    ///
+    /// Returns `true` when a row was removed, `false` when no row matched.
+    async fn delete(&self, space_jid: &BareJid) -> Result<bool, SpacesMetadataError>;
+
+    /// Return every metadata row, ordered by ascending `created_at` so
+    /// callers see rows in insertion order. Pagination is intentionally
+    /// out of scope here; the wire layer (admin V2 retry) layers cursors
+    /// on top.
+    async fn list_all(&self) -> Result<Vec<SpaceMetadata>, SpacesMetadataError>;
+}
+
+/// SQLx-backed [`SpacesMetadataStore`].
+#[derive(Clone)]
+pub struct DatabaseSpacesMetadataStore {
+    db: Database,
+}
+
+impl DatabaseSpacesMetadataStore {
+    /// Open (or create) the spaces-metadata storage at `database_url`.
+    /// When `None`, an ephemeral in-memory SQLite database is used; this
+    /// mirrors the inbox storage so tests can spin up without a DSN.
+    pub async fn open(database_url: Option<&str>) -> Result<Self, SpacesMetadataError> {
+        let db = match database_url {
+            Some(url) => open_database(url).await?,
+            None => Database::in_memory("spaces_metadata")
+                .await
+                .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?,
+        };
+        let store = Self { db };
+        schema::initialize(&store).await?;
+        info!(driver = ?store.db.driver(), "Spaces metadata storage initialized");
+        Ok(store)
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<u64, SpacesMetadataError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))
+    }
+
+    pub(crate) async fn query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, SpacesMetadataError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))
+    }
+}
+
+/// Build a trait-object [`SpacesMetadataStore`] for `AppState`. Mirrors
+/// [`crate::inbox::build_inbox_storage`].
+pub async fn build_spaces_metadata_store(
+    database_url: Option<String>,
+) -> Result<Arc<dyn SpacesMetadataStore>, SpacesMetadataError> {
+    Ok(Arc::new(
+        DatabaseSpacesMetadataStore::open(database_url.as_deref()).await?,
+    ))
+}
+
+async fn open_database(database_url: &str) -> Result<Database, SpacesMetadataError> {
+    ensure_sqlite_parent_dir(database_url)?;
+    let driver = infer_database_driver(database_url)?;
+    Database::from_config(
+        "spaces_metadata",
+        &DatabaseConfig::new(driver, database_url.to_string()),
+    )
+    .await
+    .map_err(|error| SpacesMetadataError::Storage(error.to_string()))
+}
+
+fn infer_database_driver(database_url: &str) -> Result<DatabaseDriver, SpacesMetadataError> {
+    let lower = database_url.to_ascii_lowercase();
+    if lower.starts_with("postgres://") || lower.starts_with("postgresql://") {
+        return Ok(DatabaseDriver::Postgres);
+    }
+    if lower.starts_with("sqlite:") {
+        return Ok(DatabaseDriver::Sqlite);
+    }
+    Err(SpacesMetadataError::Storage(format!(
+        "unsupported spaces metadata database URL '{database_url}': expected sqlite: or postgres://"
+    )))
+}
+
+fn ensure_sqlite_parent_dir(database_url: &str) -> Result<(), SpacesMetadataError> {
+    let Some(path) = sqlite_database_path(database_url) else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    }
+    Ok(())
+}
+
+fn sqlite_database_path(database_url: &str) -> Option<&Path> {
+    let path = database_url
+        .strip_prefix("sqlite://")
+        .or_else(|| database_url.strip_prefix("sqlite:"))?;
+    if path.is_empty() || path.starts_with(":memory:") || path.starts_with("file:") {
+        return None;
+    }
+    Some(Path::new(path))
+}
+
+fn decode_row(row: &crate::db::Row) -> Result<SpaceMetadata, SpacesMetadataError> {
+    let space_jid_raw: String = row
+        .get(0)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let space_jid: BareJid =
+        space_jid_raw
+            .parse()
+            .map_err(|error: jid::Error| SpacesMetadataError::InvalidJid {
+                raw: space_jid_raw.clone(),
+                source: error,
+            })?;
+    let name: String = row
+        .get(1)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let description: Option<String> = row
+        .get(2)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let icon_url: Option<String> = row
+        .get(3)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let created_at: i64 = row
+        .get(4)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    let updated_at: i64 = row
+        .get(5)
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    Ok(SpaceMetadata {
+        space_jid,
+        name,
+        description,
+        icon_url,
+        created_at,
+        updated_at,
+    })
+}
+
+const SELECT_COLS: &str = "space_jid, name, description, icon_url, created_at, updated_at";
+
+#[async_trait]
+impl SpacesMetadataStore for DatabaseSpacesMetadataStore {
+    #[instrument(skip(self), fields(space = %space_jid))]
+    async fn get(&self, space_jid: &BareJid) -> Result<Option<SpaceMetadata>, SpacesMetadataError> {
+        let sql = format!("SELECT {SELECT_COLS} FROM spaces_metadata WHERE space_jid = ?");
+        let mut rows = self
+            .query(&sql, crate::db_params![space_jid.to_string()])
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(decode_row(&row)?))
+    }
+
+    #[instrument(skip(self, metadata), fields(space = %metadata.space_jid))]
+    async fn upsert(&self, metadata: &SpaceMetadata) -> Result<(), SpacesMetadataError> {
+        let sql = r#"
+            INSERT INTO spaces_metadata (
+                space_jid, name, description, icon_url, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(space_jid) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                icon_url = excluded.icon_url,
+                updated_at = excluded.updated_at
+        "#;
+        self.execute(
+            sql,
+            crate::db_params![
+                metadata.space_jid.to_string(),
+                metadata.name.clone(),
+                metadata.description.clone(),
+                metadata.icon_url.clone(),
+                metadata.created_at,
+                metadata.updated_at,
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(space = %space_jid))]
+    async fn delete(&self, space_jid: &BareJid) -> Result<bool, SpacesMetadataError> {
+        let affected = self
+            .execute(
+                "DELETE FROM spaces_metadata WHERE space_jid = ?",
+                crate::db_params![space_jid.to_string()],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_all(&self) -> Result<Vec<SpaceMetadata>, SpacesMetadataError> {
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM spaces_metadata ORDER BY created_at ASC, space_jid ASC"
+        );
+        let mut rows = self.query(&sql, ()).await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?
+        {
+            out.push(decode_row(&row)?);
+        }
+        Ok(out)
+    }
+}

--- a/server/crates/waddle-server/src/spaces_metadata/schema.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/schema.rs
@@ -1,0 +1,39 @@
+//! Idempotent `CREATE TABLE IF NOT EXISTS` for `spaces_metadata`,
+//! mirroring the inbox schema migration shape.
+
+use super::{DatabaseSpacesMetadataStore, SpacesMetadataError};
+
+pub(super) async fn initialize(
+    store: &DatabaseSpacesMetadataStore,
+) -> Result<(), SpacesMetadataError> {
+    let i64_type = crate::db::i64_sql_type(store.db.driver());
+    let sql = format!(
+        r#"
+        CREATE TABLE IF NOT EXISTS spaces_metadata (
+            space_jid TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            icon_url TEXT,
+            created_at {i64_type} NOT NULL,
+            updated_at {i64_type} NOT NULL
+        )
+        "#
+    );
+    store.execute(&sql, ()).await?;
+
+    crate::db::widen_postgres_i64_column_to_bigint(&store.db, "spaces_metadata", "created_at")
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+    crate::db::widen_postgres_i64_column_to_bigint(&store.db, "spaces_metadata", "updated_at")
+        .await
+        .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+
+    store
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_spaces_metadata_created_at \
+             ON spaces_metadata (created_at ASC, space_jid ASC)",
+            (),
+        )
+        .await?;
+    Ok(())
+}

--- a/server/crates/waddle-server/src/spaces_metadata/storage.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/storage.rs
@@ -1,0 +1,80 @@
+//! In-memory [`SpacesMetadataStore`] for tests and as the placeholder
+//! `AppState` dependency in unit-test constructors.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use jid::BareJid;
+
+use super::{SpaceMetadata, SpacesMetadataError, SpacesMetadataStore};
+
+#[derive(Debug, Default)]
+pub struct InMemorySpacesMetadataStore {
+    rows: Mutex<HashMap<BareJid, SpaceMetadata>>,
+}
+
+impl InMemorySpacesMetadataStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SpacesMetadataStore for InMemorySpacesMetadataStore {
+    async fn get(&self, space_jid: &BareJid) -> Result<Option<SpaceMetadata>, SpacesMetadataError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        Ok(guard.get(space_jid).cloned())
+    }
+
+    async fn upsert(&self, metadata: &SpaceMetadata) -> Result<(), SpacesMetadataError> {
+        let mut guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        // Preserve created_at on an existing row so callers can supply
+        // it freely on `upsert`; the trait contract says created_at is
+        // assigned at first insert.
+        match guard.get(&metadata.space_jid) {
+            Some(existing) => {
+                let preserved_created_at = existing.created_at;
+                guard.insert(
+                    metadata.space_jid.clone(),
+                    SpaceMetadata {
+                        created_at: preserved_created_at,
+                        ..metadata.clone()
+                    },
+                );
+            }
+            None => {
+                guard.insert(metadata.space_jid.clone(), metadata.clone());
+            }
+        }
+        Ok(())
+    }
+
+    async fn delete(&self, space_jid: &BareJid) -> Result<bool, SpacesMetadataError> {
+        let mut guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        Ok(guard.remove(space_jid).is_some())
+    }
+
+    async fn list_all(&self) -> Result<Vec<SpaceMetadata>, SpacesMetadataError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| SpacesMetadataError::Storage(error.to_string()))?;
+        let mut rows: Vec<SpaceMetadata> = guard.values().cloned().collect();
+        rows.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.space_jid.cmp(&b.space_jid))
+        });
+        Ok(rows)
+    }
+}

--- a/server/crates/waddle-server/src/spaces_metadata/tests.rs
+++ b/server/crates/waddle-server/src/spaces_metadata/tests.rs
@@ -1,0 +1,177 @@
+//! Round-trip tests for the SQLite-backed [`SpacesMetadataStore`].
+
+use jid::BareJid;
+
+use super::{DatabaseSpacesMetadataStore, SpaceMetadata, SpacesMetadataStore};
+
+fn space_jid(local: &str) -> BareJid {
+    format!("{local}@spaces.localhost")
+        .parse()
+        .expect("valid space JID")
+}
+
+fn metadata(
+    space_jid: BareJid,
+    name: &str,
+    description: Option<&str>,
+    icon_url: Option<&str>,
+    created_at: i64,
+    updated_at: i64,
+) -> SpaceMetadata {
+    SpaceMetadata {
+        space_jid,
+        name: name.to_string(),
+        description: description.map(str::to_string),
+        icon_url: icon_url.map(str::to_string),
+        created_at,
+        updated_at,
+    }
+}
+
+async fn fresh_store() -> DatabaseSpacesMetadataStore {
+    DatabaseSpacesMetadataStore::open(Some("sqlite::memory:"))
+        .await
+        .expect("open in-memory spaces_metadata store")
+}
+
+#[tokio::test]
+async fn upsert_then_get_round_trips_full_row() {
+    let store = fresh_store().await;
+    let row = metadata(
+        space_jid("design"),
+        "Design",
+        Some("Shared design space"),
+        Some("https://cdn.example/design.png"),
+        1_700_000_000,
+        1_700_000_000,
+    );
+
+    store.upsert(&row).await.expect("upsert");
+
+    let fetched = store
+        .get(&row.space_jid)
+        .await
+        .expect("get")
+        .expect("row present after upsert");
+    assert_eq!(fetched, row);
+}
+
+#[tokio::test]
+async fn upsert_overwrites_existing_row_and_updates_timestamp() {
+    let store = fresh_store().await;
+    let initial = metadata(
+        space_jid("design"),
+        "Design",
+        Some("v1 desc"),
+        Some("https://cdn.example/v1.png"),
+        1_700_000_000,
+        1_700_000_000,
+    );
+    store.upsert(&initial).await.expect("initial upsert");
+
+    let updated = SpaceMetadata {
+        name: "Design Studio".to_string(),
+        description: Some("v2 desc".to_string()),
+        icon_url: None,
+        updated_at: 1_700_000_500,
+        // created_at is left at its original value — admin V2 callers
+        // pass through the existing value on update.
+        ..initial.clone()
+    };
+    store.upsert(&updated).await.expect("re-upsert");
+
+    let fetched = store
+        .get(&initial.space_jid)
+        .await
+        .expect("get")
+        .expect("row present after re-upsert");
+    assert_eq!(fetched.name, "Design Studio");
+    assert_eq!(fetched.description.as_deref(), Some("v2 desc"));
+    assert!(fetched.icon_url.is_none(), "icon cleared on update");
+    assert_eq!(fetched.updated_at, 1_700_000_500);
+    assert_eq!(
+        fetched.created_at, 1_700_000_000,
+        "created_at preserved across overwrite"
+    );
+}
+
+#[tokio::test]
+async fn delete_returns_true_when_row_present() {
+    let store = fresh_store().await;
+    let row = metadata(
+        space_jid("ops"),
+        "Ops",
+        None,
+        None,
+        1_700_000_000,
+        1_700_000_000,
+    );
+    store.upsert(&row).await.expect("upsert");
+
+    let removed = store.delete(&row.space_jid).await.expect("delete");
+    assert!(removed, "delete returns true when a row was removed");
+    let after = store.get(&row.space_jid).await.expect("get");
+    assert!(after.is_none(), "row absent after delete");
+}
+
+#[tokio::test]
+async fn delete_returns_false_when_row_absent() {
+    let store = fresh_store().await;
+    let removed = store
+        .delete(&space_jid("ghost"))
+        .await
+        .expect("delete missing");
+    assert!(!removed, "delete on missing row returns false");
+}
+
+#[tokio::test]
+async fn get_returns_none_for_unknown_jid() {
+    let store = fresh_store().await;
+    let result = store.get(&space_jid("ghost")).await.expect("get");
+    assert!(result.is_none(), "get returns None for unknown space JID");
+}
+
+#[tokio::test]
+async fn list_all_returns_rows_in_created_at_ascending_order() {
+    let store = fresh_store().await;
+    let alpha = metadata(
+        space_jid("alpha"),
+        "Alpha",
+        None,
+        None,
+        1_700_000_000,
+        1_700_000_000,
+    );
+    let beta = metadata(
+        space_jid("beta"),
+        "Beta",
+        None,
+        None,
+        1_700_000_100,
+        1_700_000_100,
+    );
+    let gamma = metadata(
+        space_jid("gamma"),
+        "Gamma",
+        None,
+        None,
+        1_700_000_200,
+        1_700_000_200,
+    );
+
+    // Insert out of order to confirm ordering is by `created_at`, not by
+    // physical insertion order.
+    store.upsert(&beta).await.expect("upsert beta");
+    store.upsert(&gamma).await.expect("upsert gamma");
+    store.upsert(&alpha).await.expect("upsert alpha");
+
+    let rows = store.list_all().await.expect("list_all");
+    assert_eq!(rows, vec![alpha, beta, gamma]);
+}
+
+#[tokio::test]
+async fn list_all_on_empty_store_returns_empty_vec() {
+    let store = fresh_store().await;
+    let rows = store.list_all().await.expect("list_all empty");
+    assert!(rows.is_empty());
+}


### PR DESCRIPTION
## Summary

Add metadata storage for XEP-0503 spaces — `name`, `description`, `icon_url`. Today a space's identity comes from its pubsub-tree config; there is no place to record the human-facing fields admin V2 needs.

This unblocks `urn:waddle:admin:spaces:create:0` and `urn:waddle:admin:spaces:update:0` in the queued admin V2 retry.

## Plan

1. **Where the storage lives.** Add a `spaces_metadata` SQL table or extend an existing spaces-side table — check `server/crates/waddle-server/src/spaces_pubsub_seed.rs` and `server/crates/waddle-server/src/db/` for the right home. Schema:
   ```sql
   CREATE TABLE IF NOT EXISTS spaces_metadata (
     space_jid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT,
     icon_url TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   )
   ```
   Mirror the inbox schema's migration pattern (idempotent CREATE IF NOT EXISTS).

2. **Typed repository.** A `SpacesMetadataStore` trait + SQLite impl, following the `InboxStorage` shape:
   - `get(space_jid) -> Option<SpaceMetadata>`
   - `upsert(metadata: SpaceMetadata)`
   - `delete(space_jid) -> bool`
   - `list_all() -> Vec<SpaceMetadata>` (paginated callers do cursor logic above this)

3. **Wire it through `AppState`** — add the store as a field reachable from request handlers. Mirror how `InboxStorage` is exposed.

4. **Tests** — `server/crates/waddle-server/src/spaces_metadata/tests.rs` (or wherever the module ends up) covering: insert + get round-trip; update overwrites; delete; list returns all.

## Non-goals

- Wire IQ to mutate metadata (admin V2 retry adds the wire shape on top).
- Existing space-list query paths that currently read from pubsub-config — leave alone; admin V2 reads from the new table.
- Migration of any existing space data (no production data assumption).

## Test plan

- [ ] `cargo test --workspace` green
- [ ] `cargo clippy -D warnings` clean
- [ ] `cargo fmt --check` clean
- [ ] New repository tests cover insert/get/update/delete/list

This PR was created with the assistance of a LLM.
