### PR TITLE
feat(server): wire pubsub_storage, room_registry, spaces_jid, muc_domain onto AppState

### DIFF
--- a/server/crates/waddle-server/src/server/config.rs
+++ b/server/crates/waddle-server/src/server/config.rs
@@ -1,4 +1,7 @@
+use anyhow::Context;
+use jid::{BareJid, DomainPart};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// XMPP server configuration loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -7,6 +10,14 @@ pub struct XmppConfig {
     pub enabled: bool,
     /// XMPP server domain (default: "localhost")
     pub domain: String,
+    /// Bare JID of the community spaces (XEP-0503) service for this
+    /// deployment. Defaults to `spaces.<domain>`; overridable via
+    /// `WADDLE_SPACES_JID` for deployments whose spaces component lives
+    /// on a non-default subdomain.
+    pub spaces_jid: BareJid,
+    /// Domain of the MUC (XEP-0045) service for this deployment.
+    /// Defaults to `muc.<domain>`; overridable via `WADDLE_MUC_DOMAIN`.
+    pub muc_domain: DomainPart,
     /// MAM database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
     pub mam_database_url: Option<String>,
     /// Inbox database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
@@ -59,9 +70,16 @@ pub struct XmppAcmeConfig {
 
 impl Default for XmppConfig {
     fn default() -> Self {
+        let domain = "localhost".to_string();
+        let spaces_jid = derived_spaces_jid(&domain)
+            .expect("default xmpp domain 'localhost' yields a valid spaces JID");
+        let muc_domain = derived_muc_domain(&domain)
+            .expect("default xmpp domain 'localhost' yields a valid muc domain");
         Self {
             enabled: true,
-            domain: "localhost".to_string(),
+            domain,
+            spaces_jid,
+            muc_domain,
             mam_database_url: None,
             inbox_database_url: None,
             spaces_metadata_database_url: None,
@@ -79,15 +97,46 @@ impl Default for XmppConfig {
     }
 }
 
+/// Build the conventional `spaces.<domain>` JID for a deployment whose
+/// `WADDLE_SPACES_JID` env var is not set.
+fn derived_spaces_jid(xmpp_domain: &str) -> anyhow::Result<BareJid> {
+    let raw = format!("spaces.{xmpp_domain}");
+    raw.parse::<BareJid>().with_context(|| {
+        format!("failed to parse derived spaces JID 'spaces.{xmpp_domain}' as BareJid")
+    })
+}
+
+/// Build the conventional `muc.<domain>` host for a deployment whose
+/// `WADDLE_MUC_DOMAIN` env var is not set.
+fn derived_muc_domain(xmpp_domain: &str) -> anyhow::Result<DomainPart> {
+    let raw = format!("muc.{xmpp_domain}");
+    DomainPart::from_str(&raw).with_context(|| {
+        format!("failed to parse derived MUC domain 'muc.{xmpp_domain}' as DomainPart")
+    })
+}
+
 impl XmppConfig {
     /// Load XMPP configuration from environment variables.
-    pub fn from_env() -> Self {
+    ///
+    /// Returns an error when `WADDLE_SPACES_JID` or `WADDLE_MUC_DOMAIN`
+    /// is set but cannot be parsed into a typed `BareJid` / `DomainPart`
+    /// respectively. Both env vars are optional — when unset the
+    /// conventional `spaces.<domain>` / `muc.<domain>` derivations from
+    /// `WADDLE_XMPP_DOMAIN` are used.
+    pub fn from_env() -> anyhow::Result<Self> {
         let enabled = std::env::var("WADDLE_XMPP_ENABLED")
             .map(|v| v.to_lowercase() != "false" && v != "0")
             .unwrap_or(true);
 
         let domain =
             std::env::var("WADDLE_XMPP_DOMAIN").unwrap_or_else(|_| "localhost".to_string());
+
+        let spaces_jid = parse_optional_env_value::<BareJid>("WADDLE_SPACES_JID")?
+            .map(Ok)
+            .unwrap_or_else(|| derived_spaces_jid(&domain))?;
+        let muc_domain = parse_optional_env_value::<DomainPart>("WADDLE_MUC_DOMAIN")?
+            .map(Ok)
+            .unwrap_or_else(|| derived_muc_domain(&domain))?;
 
         let mam_database_url = resolve_xmpp_database_url("WADDLE_XMPP_MAM_DATABASE_URL");
         let inbox_database_url = resolve_xmpp_database_url("WADDLE_XMPP_INBOX_DATABASE_URL");
@@ -116,9 +165,11 @@ impl XmppConfig {
             .map(|v| v.to_lowercase() == "true" || v == "1")
             .unwrap_or(false);
 
-        Self {
+        Ok(Self {
             enabled,
             domain,
+            spaces_jid,
+            muc_domain,
             mam_database_url,
             inbox_database_url,
             spaces_metadata_database_url,
@@ -132,8 +183,30 @@ impl XmppConfig {
                 cache_dir: acme_cache_dir,
                 production: acme_production,
             },
-        }
+        })
     }
+}
+
+/// Parse an optional typed env var. Returns `Ok(None)` when the var is
+/// unset (or empty after trimming); `Ok(Some(value))` when set and
+/// parsed successfully; `Err` with a clear context when set but
+/// unparseable.
+fn parse_optional_env_value<T>(env_key: &str) -> anyhow::Result<Option<T>>
+where
+    T: FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    let raw = match std::env::var(env_key) {
+        Ok(value) => value.trim().to_string(),
+        Err(_) => return Ok(None),
+    };
+    if raw.is_empty() {
+        return Ok(None);
+    }
+    raw.parse::<T>()
+        .map(Some)
+        .map_err(|error| anyhow::anyhow!("{env_key}='{raw}' failed to parse: {error}"))
+        .with_context(|| format!("invalid {env_key} environment variable"))
 }
 
 pub(crate) fn resolve_xmpp_database_url(env_key: &str) -> Option<String> {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -31,13 +31,19 @@ use tower_http::{
 };
 use tracing::{info, warn, Level};
 use waddle_xmpp::mam::{MamStorage, SqlxMamStorage};
-use waddle_xmpp::{muc::room_registry_actor::RoomRegistryActor, registry::ConnectionRegistry};
+use waddle_xmpp::registry::ConnectionRegistry;
 
 pub(crate) struct HttpServerDeps {
     pub(crate) state: Arc<AppState>,
     pub(crate) server_config: ServerConfig,
     pub(crate) xmpp_config: XmppConfig,
     pub(crate) mam_storage: Arc<dyn MamStorage>,
+    /// Concrete `DatabasePubSubStorage` handle built once in
+    /// `start_with_config`. Threaded down here so the notification
+    /// settings projection can attach to the same SQL database without
+    /// re-opening it. The trait-object view lives on
+    /// [`AppState::pubsub_storage`] for the rest of the WebSocket graph.
+    pub(crate) pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
     pub(crate) acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
     pub(crate) listener: tokio::net::TcpListener,
     pub(crate) stop_token: tokio_util::sync::CancellationToken,
@@ -55,21 +61,23 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         server_config,
         xmpp_config,
         mam_storage,
+        pubsub_database_storage,
         acme_http01_challenge_service,
         listener,
         stop_token,
         drain_complete,
     } = deps;
 
-    let app = create_router(
+    let app = create_router(RouterDeps {
         state,
         server_config,
         xmpp_config,
         mam_storage,
+        pubsub_database_storage,
         acme_http01_challenge_service,
-        stop_token.clone(),
-        drain_complete.clone(),
-    )
+        shutdown_stop_token: stop_token.clone(),
+        drain_complete: drain_complete.clone(),
+    })
     .await?;
 
     let addr = listener.local_addr()?;
@@ -107,16 +115,33 @@ pub(crate) async fn create_websocket_mam_storage(
     Ok(Arc::new(storage))
 }
 
+/// Explicit dependency bundle for [`create_router`]. Grouped into a
+/// single struct so the signature stays under clippy's
+/// `too_many_arguments` threshold as new deps are wired in (e.g. the
+/// admin V2 plumbing PR additions to `AppState`).
+pub(crate) struct RouterDeps {
+    pub(crate) state: Arc<AppState>,
+    pub(crate) server_config: ServerConfig,
+    pub(crate) xmpp_config: XmppConfig,
+    pub(crate) mam_storage: Arc<dyn MamStorage>,
+    pub(crate) pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
+    pub(crate) acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
+    pub(crate) shutdown_stop_token: tokio_util::sync::CancellationToken,
+    pub(crate) drain_complete: Arc<tokio::sync::Notify>,
+}
+
 /// Create the Axum router with all routes and middleware.
-pub(crate) async fn create_router(
-    state: Arc<AppState>,
-    server_config: ServerConfig,
-    xmpp_config: XmppConfig,
-    mam_storage: Arc<dyn MamStorage>,
-    acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
-    shutdown_stop_token: tokio_util::sync::CancellationToken,
-    drain_complete: Arc<tokio::sync::Notify>,
-) -> Result<Router> {
+pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
+    let RouterDeps {
+        state,
+        server_config,
+        xmpp_config,
+        mam_storage,
+        pubsub_database_storage,
+        acme_http01_challenge_service,
+        shutdown_stop_token,
+        drain_complete,
+    } = deps;
     // Create auth broker state
     let auth_state = Arc::new(AuthState::new(
         state.clone(),
@@ -130,6 +155,7 @@ pub(crate) async fn create_router(
         &xmpp_config,
         Arc::clone(&auth_state),
         mam_storage,
+        pubsub_database_storage,
     )
     .await?;
 
@@ -292,17 +318,18 @@ async fn create_websocket_state(
     xmpp_config: &XmppConfig,
     auth_state: Arc<AuthState>,
     mam_storage: Arc<dyn MamStorage>,
+    pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
 ) -> Result<Arc<WebSocketState>> {
     // Create connection registry for WebSocket message routing
     let connection_registry = Arc::new(ConnectionRegistry::new());
 
-    // Create MUC room registry with the XMPP domain (not the HTTP base_url host)
+    // Read the MUC room registry and PubSub storage off the shared
+    // `AppState` — both are built in `start_with_config` so admin V2
+    // handlers and the WebSocket transport operate on the same handles.
     let xmpp_domain = auth_state.xmpp_domain.clone();
     let service_domains = XmppServiceDomains::new(&xmpp_domain);
-    let room_registry = kameo::spawn(RoomRegistryActor::new(
-        service_domains.muc.clone(),
-        server_config.occupant_id_secret.clone(),
-    ));
+    let room_registry = state.room_registry.clone();
+    let pubsub_storage = Arc::clone(&state.pubsub_storage);
 
     let deferred_extension_host_tools = Arc::new(DeferredExtensionHostTools::default());
     let extension_manager = build_extension_manager(
@@ -323,12 +350,6 @@ async fn create_websocket_state(
     waddle_xmpp::protocol::handlers::register_default_message_handlers(&mut stanza_dispatcher);
     let stanza_dispatcher = Arc::new(stanza_dispatcher);
 
-    // Shared durable PubSub/PEP storage for the WebSocket transport (XEP-0060/0163).
-    let pubsub_database_storage =
-        crate::pubsub::build_database_pubsub_storage(xmpp_config.pubsub_database_url.clone())
-            .await?;
-    let pubsub_storage: Arc<dyn waddle_xmpp::pubsub::PubSubStorage> =
-        pubsub_database_storage.clone();
     let extension_pubsub_owner: jid::BareJid = service_domains.extensions.parse()?;
     register_extension_commands(
         Arc::clone(&extension_manager),

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -41,7 +41,7 @@ pub(crate) mod routes;
 pub mod xmpp_state;
 
 pub use config::{XmppAcmeConfig, XmppConfig};
-pub use state::{resolve_server_owner_jids, AppState};
+pub use state::{resolve_server_owner_jids, AppState, AppStateDeps};
 
 use crate::config::ServerConfig;
 use crate::db::DatabasePool;
@@ -64,7 +64,8 @@ pub async fn start(
     server_config: ServerConfig,
     inherited: Option<waddle_ecdysis::ListenerSet>,
 ) -> Result<()> {
-    let xmpp_config = XmppConfig::from_env();
+    let xmpp_config = XmppConfig::from_env()
+        .map_err(|error| anyhow::anyhow!("Failed to load XMPP configuration: {}", error))?;
 
     start_with_config(db_pool, xmpp_config, server_config, inherited).await
 }
@@ -139,6 +140,26 @@ pub async fn start_with_config(
             .map_err(|error| {
                 anyhow::anyhow!("Failed to initialize spaces metadata storage: {}", error)
             })?;
+    // Build the shared XEP-0060 PubSub/PEP storage and the MUC
+    // (XEP-0045) room registry here so the resulting handles live on
+    // `AppState`. Admin V2 handlers reach them via `state.*` instead of
+    // threading per-connection `ProtocolServices` references through
+    // every site that mutates rooms or pubsub nodes. The concrete
+    // `DatabasePubSubStorage` handle is also passed onward into the
+    // HTTP server so the notification-settings projection can read the
+    // same database without re-opening it.
+    let pubsub_database_storage =
+        crate::pubsub::build_database_pubsub_storage(xmpp_config.pubsub_database_url.clone())
+            .await
+            .map_err(|error| anyhow::anyhow!("Failed to initialize PubSub storage: {}", error))?;
+    let pubsub_storage: Arc<dyn waddle_xmpp::pubsub::PubSubStorage> =
+        pubsub_database_storage.clone();
+    let room_registry = kameo::spawn(
+        waddle_xmpp::muc::room_registry_actor::RoomRegistryActor::new(
+            xmpp_config.muc_domain.to_string(),
+            server_config.occupant_id_secret.clone(),
+        ),
+    );
 
     // Create HTTP state (shares db_pool via Arc)
     let blob_storage = crate::storage::build_blob_storage()
@@ -147,14 +168,18 @@ pub async fn start_with_config(
         &bootstrap_membership::BootstrapMembershipConfig::from_env(),
         &xmpp_config.domain,
     );
-    let state = Arc::new(AppState::new_with_deps(
-        Arc::clone(&db_pool),
+    let state = Arc::new(AppState::new_with_deps(AppStateDeps {
+        db_pool: Arc::clone(&db_pool),
         blob_storage,
-        Arc::clone(&inbox_storage),
-        Arc::clone(&spaces_metadata_store),
-        permission_actor.clone(),
+        inbox_storage: Arc::clone(&inbox_storage),
+        spaces_metadata_store: Arc::clone(&spaces_metadata_store),
+        pubsub_storage: Arc::clone(&pubsub_storage),
+        room_registry: room_registry.clone(),
+        spaces_jid: xmpp_config.spaces_jid.clone(),
+        muc_domain: xmpp_config.muc_domain.clone(),
+        permission_actor: permission_actor.clone(),
         server_owner_jids,
-    ));
+    }));
     let websocket_mam_storage =
         create_websocket_mam_storage(xmpp_config.mam_database_url.clone()).await?;
     let acme_runtime = start_acme_runtime(&xmpp_config, stop_token.clone());
@@ -174,12 +199,14 @@ pub async fn start_with_config(
     // stop_token cancels so axum doesn't tear down mid-drain.
     let drain_complete = Arc::new(tokio::sync::Notify::new());
     let http_drain_complete = Arc::clone(&drain_complete);
+    let http_pubsub_database_storage = Arc::clone(&pubsub_database_storage);
     let http_handle = tokio::spawn(async move {
         start_http_server(HttpServerDeps {
             state: http_state,
             server_config: http_server_config,
             xmpp_config: http_xmpp_config,
             mam_storage: http_mam_storage,
+            pubsub_database_storage: http_pubsub_database_storage,
             acme_http01_challenge_service,
             listener: http_listener,
             stop_token: http_stop,

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -1,10 +1,15 @@
 use super::*;
 use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
 use crate::permissions::PermissionActor;
+use crate::server::AppStateDeps;
 use axum::body::Body;
 use axum::http::Request;
 use http_body_util::BodyExt;
+use std::str::FromStr;
 use tower::ServiceExt;
+use waddle_xmpp::muc::room_registry_actor::RoomRegistryActor;
+use waddle_xmpp::pubsub::InMemoryPubSubStorage;
+use waddle_xmpp::xep::xep0421::OccupantIdSecret;
 
 async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
     let config = DatabaseConfig::default();
@@ -26,14 +31,26 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
     let permission_actor = kameo::spawn(PermissionActor::new_for_tests(Arc::new(
         db_pool.global().clone(),
     )));
-    let app_state = Arc::new(AppState::new_with_deps(
-        Arc::clone(&db_pool),
-        blob_storage,
-        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
-        Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
-        permission_actor,
-        Arc::from(Vec::<jid::BareJid>::new()),
+    let muc_domain = jid::DomainPart::from_str("muc.example.com").expect("muc domain parses");
+    let occupant_id_secret =
+        OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
+            .expect("test occupant-id secret meets length floor");
+    let room_registry = kameo::spawn(RoomRegistryActor::new(
+        muc_domain.to_string(),
+        occupant_id_secret,
     ));
+    let app_state = Arc::new(AppState::new_with_deps(AppStateDeps {
+        db_pool: Arc::clone(&db_pool),
+        blob_storage,
+        inbox_storage: Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
+        spaces_metadata_store: Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
+        pubsub_storage: Arc::new(InMemoryPubSubStorage::new()),
+        room_registry,
+        spaces_jid: "spaces.example.com".parse().expect("spaces JID parses"),
+        muc_domain,
+        permission_actor,
+        server_owner_jids: Arc::from(Vec::<jid::BareJid>::new()),
+    }));
 
     (Arc::new(UploadState::new(app_state)), upload_dir)
 }

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -1,11 +1,13 @@
 use crate::permissions::PermissionActor;
 use crate::server::bootstrap_membership;
 use crate::spaces_metadata::SpacesMetadataStore;
-use jid::BareJid;
+use jid::{BareJid, DomainPart};
 use kameo::actor::ActorRef;
 use std::sync::Arc;
 use tracing::warn;
 use waddle_xmpp::inbox::storage::InboxStorage;
+use waddle_xmpp::muc::room_registry_actor::RoomRegistryActor;
+use waddle_xmpp::pubsub::PubSubStorage;
 
 /// Server application state
 pub struct AppState {
@@ -20,6 +22,29 @@ pub struct AppState {
     /// commands. XEP-0503 has no opinion on these human-facing fields;
     /// they live here as a Waddle-specific projection.
     pub spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
+    /// Shared PubSub/PEP storage (XEP-0060/XEP-0163). Exposed on
+    /// `AppState` so admin V2 `spaces:list` / `channels:list` handlers
+    /// can enumerate pubsub-tree node membership without re-routing
+    /// through the per-connection `ProtocolServices` graph.
+    pub pubsub_storage: Arc<dyn PubSubStorage>,
+    /// Actor-backed MUC room registry (XEP-0045). Exposed on `AppState`
+    /// so admin V2 channel CRUD handlers (`channels:create`,
+    /// `channels:update`, `channels:delete`, `channels:kick`,
+    /// `channels:set-affiliation`) can issue room messages independent
+    /// of any user's live WebSocket connection.
+    pub room_registry: ActorRef<RoomRegistryActor>,
+    /// Bare JID of the community spaces (XEP-0503) service for this
+    /// deployment. Resolved from [`crate::server::XmppConfig::spaces_jid`]
+    /// (env override `WADDLE_SPACES_JID`, defaulted to
+    /// `spaces.<xmpp-domain>`). Admin V2 `spaces:*` handlers use this to
+    /// scope pubsub-tree reads/writes.
+    pub spaces_jid: BareJid,
+    /// MUC (XEP-0045) service domain for this deployment. Resolved
+    /// from [`crate::server::XmppConfig::muc_domain`] (env override
+    /// `WADDLE_MUC_DOMAIN`, defaulted to `muc.<xmpp-domain>`). Admin V2
+    /// `channels:create` constructs new managed room JIDs against this
+    /// domain.
+    pub muc_domain: DomainPart,
     /// Shared permission actor handle.
     pub permission_actor: ActorRef<PermissionActor>,
     /// Bare JIDs of server owners (resolved from
@@ -36,38 +61,88 @@ impl AppState {
     /// dependency is explicit.
     #[cfg(test)]
     pub fn new(db_pool: Arc<crate::db::DatabasePool>) -> Self {
+        use std::str::FromStr;
+        use waddle_xmpp::pubsub::InMemoryPubSubStorage;
+        use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
         let blob_storage = crate::storage::build_blob_storage()
             .unwrap_or_else(|e| panic!("failed to initialize blob storage: {e}"));
         let permission_actor = kameo::spawn(PermissionActor::new_for_tests(Arc::new(
             db_pool.global().clone(),
         )));
-        Self::new_with_deps(
+        let muc_domain = DomainPart::from_str("muc.localhost")
+            .expect("test MUC domain 'muc.localhost' parses as DomainPart");
+        let occupant_id_secret =
+            OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
+                .expect("test occupant-id secret meets length floor");
+        let room_registry = kameo::spawn(RoomRegistryActor::new(
+            muc_domain.to_string(),
+            occupant_id_secret,
+        ));
+        let spaces_jid: BareJid = "spaces.localhost"
+            .parse()
+            .expect("test spaces JID 'spaces.localhost' parses as BareJid");
+        Self::new_with_deps(AppStateDeps {
             db_pool,
             blob_storage,
-            Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
-            Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
+            inbox_storage: Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
+            spaces_metadata_store: Arc::new(
+                crate::spaces_metadata::InMemorySpacesMetadataStore::new(),
+            ),
+            pubsub_storage: Arc::new(InMemoryPubSubStorage::new()),
+            room_registry,
+            spaces_jid,
+            muc_domain,
             permission_actor,
-            Arc::from(Vec::<BareJid>::new()),
-        )
+            server_owner_jids: Arc::from(Vec::<BareJid>::new()),
+        })
     }
 
-    pub fn new_with_deps(
-        db_pool: Arc<crate::db::DatabasePool>,
-        blob_storage: Arc<dyn crate::storage::BlobStorage>,
-        inbox_storage: Arc<dyn InboxStorage>,
-        spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
-        permission_actor: ActorRef<PermissionActor>,
-        server_owner_jids: Arc<[BareJid]>,
-    ) -> Self {
+    /// Construct an `AppState` from its explicit dependencies. Callers
+    /// pass [`AppStateDeps`] so adding a new dependency does not widen
+    /// the constructor signature.
+    pub fn new_with_deps(deps: AppStateDeps) -> Self {
+        let AppStateDeps {
+            db_pool,
+            blob_storage,
+            inbox_storage,
+            spaces_metadata_store,
+            pubsub_storage,
+            room_registry,
+            spaces_jid,
+            muc_domain,
+            permission_actor,
+            server_owner_jids,
+        } = deps;
         Self {
             db_pool,
             blob_storage,
             inbox_storage,
             spaces_metadata_store,
+            pubsub_storage,
+            room_registry,
+            spaces_jid,
+            muc_domain,
             permission_actor,
             server_owner_jids,
         }
     }
+}
+
+/// Explicit `AppState` dependency bundle. Construction grouped into a
+/// single struct so adding a new dependency does not widen the
+/// `new_with_deps` argument list (clippy `too_many_arguments`).
+pub struct AppStateDeps {
+    pub db_pool: Arc<crate::db::DatabasePool>,
+    pub blob_storage: Arc<dyn crate::storage::BlobStorage>,
+    pub inbox_storage: Arc<dyn InboxStorage>,
+    pub spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
+    pub pubsub_storage: Arc<dyn PubSubStorage>,
+    pub room_registry: ActorRef<RoomRegistryActor>,
+    pub spaces_jid: BareJid,
+    pub muc_domain: DomainPart,
+    pub permission_actor: ActorRef<PermissionActor>,
+    pub server_owner_jids: Arc<[BareJid]>,
 }
 
 /// Resolve `WADDLE_SERVER_OWNER_LOCALPARTS` localparts into bare JIDs against
@@ -91,4 +166,33 @@ pub fn resolve_server_owner_jids(
         }
     }
     Arc::from(jids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+
+    #[tokio::test]
+    async fn new_with_deps_populates_admin_v2_dependencies() {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("db pool");
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations");
+        let state = AppState::new(Arc::new(db_pool));
+
+        // pubsub_storage and room_registry are concrete handles — their
+        // mere existence is the contract, since admin V2 talks to them
+        // via the trait / actor protocol.
+        assert!(Arc::strong_count(&state.pubsub_storage) >= 1);
+        assert!(
+            state.room_registry.is_alive(),
+            "room registry actor should be live immediately after spawn"
+        );
+        assert_eq!(state.spaces_jid.to_string(), "spaces.localhost");
+        assert_eq!(state.muc_domain.as_str(), "muc.localhost");
+    }
 }

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -17,7 +17,7 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
     ENV_MUTEX
         .get_or_init(|| std::sync::Mutex::new(()))
         .lock()
-        .expect("env mutex")
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// XmppConfig for unit tests: uses in-memory SQLite for all storage backends.
@@ -241,7 +241,7 @@ fn test_xmpp_config_prefers_dedicated_database_urls() {
     std::env::set_var("WADDLE_XMPP_MAM_DATABASE_URL", "postgres://mam/runtime");
     std::env::set_var("WADDLE_XMPP_INBOX_DATABASE_URL", "postgres://inbox/runtime");
 
-    let config = XmppConfig::from_env();
+    let config = XmppConfig::from_env().expect("config parses");
     assert_eq!(
         config.mam_database_url.as_deref(),
         Some("postgres://mam/runtime")
@@ -273,7 +273,7 @@ fn test_xmpp_config_falls_back_to_main_database_url() {
 
     std::env::set_var("WADDLE_DATABASE_URL", "postgres://main/runtime");
 
-    let config = XmppConfig::from_env();
+    let config = XmppConfig::from_env().expect("config parses");
     assert_eq!(
         config.mam_database_url.as_deref(),
         Some("postgres://main/runtime")
@@ -284,6 +284,89 @@ fn test_xmpp_config_falls_back_to_main_database_url() {
     );
 
     std::env::remove_var("WADDLE_DATABASE_URL");
+}
+
+/// Reset the env vars this test suite mutates between cases. Keeps each
+/// `from_env` call observation-independent of every other.
+fn reset_xmpp_config_env() {
+    for key in [
+        "WADDLE_XMPP_DOMAIN",
+        "WADDLE_SPACES_JID",
+        "WADDLE_MUC_DOMAIN",
+    ] {
+        std::env::remove_var(key);
+    }
+}
+
+#[test]
+fn test_xmpp_config_defaults_spaces_and_muc_from_xmpp_domain() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    std::env::set_var("WADDLE_XMPP_DOMAIN", "waddle.example");
+
+    let config = XmppConfig::from_env().expect("config parses");
+    assert_eq!(config.spaces_jid.to_string(), "spaces.waddle.example");
+    assert_eq!(config.muc_domain.as_str(), "muc.waddle.example");
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_env_overrides_spaces_and_muc() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    std::env::set_var("WADDLE_XMPP_DOMAIN", "waddle.example");
+    std::env::set_var("WADDLE_SPACES_JID", "communities.waddle.example");
+    std::env::set_var("WADDLE_MUC_DOMAIN", "rooms.waddle.example");
+
+    let config = XmppConfig::from_env().expect("config parses");
+    assert_eq!(config.spaces_jid.to_string(), "communities.waddle.example");
+    assert_eq!(config.muc_domain.as_str(), "rooms.waddle.example");
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_rejects_invalid_spaces_jid() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    // `@<domain>` with an empty nodepart violates `BareJid`'s
+    // grammar (`Error::NodeEmpty`).
+    std::env::set_var("WADDLE_SPACES_JID", "@example.com");
+
+    let error = XmppConfig::from_env().expect_err("invalid spaces jid must fail-fast");
+    let chain = format!("{error:?}");
+    assert!(
+        chain.contains("WADDLE_SPACES_JID"),
+        "error chain should name the offending env var: {chain}"
+    );
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_rejects_invalid_muc_domain() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    // An empty string violates `DomainPart::from_str`
+    // (`Error::DomainEmpty`); the trim in `parse_optional_env_value`
+    // returns `Ok(None)` only when the trimmed result is empty, so we
+    // need an explicitly invalid non-empty value. A 2000-byte string
+    // exceeds the 1023-byte nameprep limit.
+    std::env::set_var("WADDLE_MUC_DOMAIN", "a".repeat(2000));
+
+    let error = XmppConfig::from_env().expect_err("invalid muc domain must fail-fast");
+    let chain = format!("{error:?}");
+    assert!(
+        chain.contains("WADDLE_MUC_DOMAIN"),
+        "error chain should name the offending env var: {chain}"
+    );
+
+    reset_xmpp_config_env();
 }
 
 #[test]
@@ -598,15 +681,21 @@ async fn test_app() -> Router {
     let state = create_test_state().await;
     let server_config = ServerConfig::test_homeserver();
     let mam_storage = http::create_websocket_mam_storage(None).await.unwrap();
-    http::create_router(
+    let pubsub_database_storage = Arc::new(
+        crate::pubsub::DatabasePubSubStorage::open(Some("sqlite::memory:"))
+            .await
+            .expect("test pubsub storage"),
+    );
+    http::create_router(http::RouterDeps {
         state,
         server_config,
-        test_xmpp_config(),
+        xmpp_config: test_xmpp_config(),
         mam_storage,
-        None,
-        tokio_util::sync::CancellationToken::new(),
-        std::sync::Arc::new(tokio::sync::Notify::new()),
-    )
+        pubsub_database_storage,
+        acme_http01_challenge_service: None,
+        shutdown_stop_token: tokio_util::sync::CancellationToken::new(),
+        drain_complete: std::sync::Arc::new(tokio::sync::Notify::new()),
+    })
     .await
     .unwrap()
 }


### PR DESCRIPTION
## Summary

Final plumbing PR before the admin V2 retry. Mirrors the `spaces_metadata_store` precedent from #682 and adds the four remaining dependencies admin V2 handlers need to operate independently of any user's WebSocket connection:

- `pubsub_storage: Arc<dyn PubSubStorage>` — admin V2 `spaces:list` / `channels:list` enumerate pubsub-tree node membership.
- `room_registry: ActorRef<RoomRegistryActor>` — admin V2 channel CRUD (`channels:create/update/delete/kick/set-affiliation`) issues messages against the MUC actor regardless of whether the target user is connected.
- `spaces_jid: BareJid` — scopes admin V2 spaces queries; resolved from `XmppConfig::spaces_jid` (env override `WADDLE_SPACES_JID`, defaulted to `spaces.<xmpp-domain>`).
- `muc_domain: DomainPart` — used to construct new managed room JIDs in `channels:create`; resolved from `XmppConfig::muc_domain` (env override `WADDLE_MUC_DOMAIN`, defaulted to `muc.<xmpp-domain>`).

After this PR, admin V2 `spaces.rs` / `channels.rs` handlers can pull all four directly off `state.<field>` — the handler bodies become small.

## What changed

- `AppState` gains the four typed fields. Both env vars (`WADDLE_SPACES_JID`, `WADDLE_MUC_DOMAIN`) are optional; when unset the conventional `spaces.<domain>` / `muc.<domain>` derivations from `WADDLE_XMPP_DOMAIN` are used. When set but unparseable, `XmppConfig::from_env` returns a typed `anyhow::Error` with `Context` and the server fails to start.
- `pubsub_storage` and `room_registry` are now built once in `start_with_config` (concrete `Arc<DatabasePubSubStorage>` + `RoomRegistryActor`) and threaded through to the WebSocket graph via `state.*`. The notification-settings projection still receives the concrete handle via a new `HttpServerDeps.pubsub_database_storage` field, so we don't open the SQL backend twice.
- `AppState::new_with_deps` takes an `AppStateDeps` struct (and `create_router` takes a `RouterDeps`) to keep new dependencies from widening positional argument lists — no `#[allow(clippy::too_many_arguments)]` introduced.
- Typed payloads end-to-end: `BareJid` and `DomainPart` from `jid`, never `String`/`&str`, on every new field and config value.

## Files touched

- `server/crates/waddle-server/src/server/state.rs` — adds the four fields, `AppStateDeps` struct, in-memory test ctor seeds, dedicated test asserting they are populated.
- `server/crates/waddle-server/src/server/config.rs` — `XmppConfig::spaces_jid`/`muc_domain`, `XmppConfig::from_env` returns `Result`, fail-fast parsing.
- `server/crates/waddle-server/src/server/mod.rs` — builds `pubsub_database_storage` and `room_registry` once, passes them onward.
- `server/crates/waddle-server/src/server/http.rs` — `HttpServerDeps.pubsub_database_storage`, `RouterDeps`, `create_websocket_state` reads `state.pubsub_storage` / `state.room_registry`.
- `server/crates/waddle-server/src/server/routes/uploads/tests.rs` — field-add ripple.
- `server/crates/waddle-server/src/server/tests.rs` — `create_router` call-site ripple + four new env-var tests (defaults, overrides, fail-fast on invalid spaces JID, fail-fast on invalid muc domain).

## Note on the existing per-connection `room_registry`

Before this PR, `RoomRegistryActor` lived only in `WebSocketState.deps.protocol.room_registry`. That meant admin operations targeting rooms could only be issued from a connection that had reached `ProtocolServices`. Admin V2 needs to act on rooms regardless of any user's connection state (e.g. force-kicking from an HTTP-triggered admin command, deleting a room whose owner is offline). Lifting the registry onto `AppState` is the smallest possible change that unblocks the server-bypass requirement.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New env vars round-trip through `XmppConfig::from_env` (defaults + overrides + fail-fast)
- [x] `AppState::new` test ctor still works for all existing test suites
- [x] `AppState` test asserts the four new fields are populated

This PR was created with the assistance of a LLM.