### PR TITLE
fix(chat): threads list — read threads should not show unread badge

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -136,6 +136,7 @@ mod deps;
 mod direct_archive;
 mod direct_inbox;
 mod direct_retraction;
+mod displayed_marker;
 mod groupchat_archive;
 mod groupchat_inbox;
 mod groupchat_validation;
@@ -157,6 +158,7 @@ use carbons::send_carbons;
 use direct_archive::archive_direct;
 use direct_inbox::project_direct_inbox;
 use direct_retraction::apply_retraction_tombstone;
+use displayed_marker::mark_inbox_read_from_displayed;
 use groupchat_archive::{
     apply_groupchat_retraction_tombstone, archive_groupchat_message, project_groupchat_inbox,
 };
@@ -394,6 +396,13 @@ async fn interpret_with_depth(
                 exclude,
             } => {
                 send_carbons(registry, deps, owner, message, kind, exclude).await;
+            }
+            OutboundEvent::MarkInboxReadFromDisplayed {
+                owner,
+                room,
+                displayed_message_id,
+            } => {
+                mark_inbox_read_from_displayed(deps, owner, room, displayed_message_id).await;
             }
             OutboundEvent::LookupArchivedMessage {
                 id,

--- a/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
@@ -147,8 +147,8 @@ mod tests {
     use waddle_xmpp::mam::{ArchivedMessage as MamArchivedMessage, RichMessageId};
     use waddle_xmpp::registry::ConnectionRegistry;
     use waddle_xmpp_core::mam::ThreadId;
-    use waddle_xmpp_core::ThreadInfo;
     use waddle_xmpp_core::xep0359::StanzaId as Xep0359StanzaId;
+    use waddle_xmpp_core::ThreadInfo;
     use xmpp_parsers::message::MessageType;
 
     fn bare(value: &str) -> BareJid {

--- a/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
@@ -1,0 +1,296 @@
+//! Interpreter arm for
+//! [`waddle_xmpp::protocol::OutboundEvent::MarkInboxReadFromDisplayed`].
+//!
+//! Bridges XEP-0333 displayed markers to the Waddle inbox: when the
+//! sender has displayed a groupchat message, we look the message up in
+//! MAM (keyed by `(room, wire_message_id)`), read its `<thread/>`
+//! payload, and clear `unread` on:
+//!
+//! - the channel-level inbox row `(owner, room, thread_id='')`
+//! - the thread-level row `(owner, room, thread_id=<message thread>)`
+//!   when the displayed message belongs to a thread.
+//!
+//! Both rows are pushed through [`push_inbox_update`] so the user's
+//! other resources fan out the read-state flip without waiting for a
+//! fresh `urn:waddle:inbox:0` / `urn:waddle:threads:0` query (XEP-0430
+//! §"Mark as read" cross-device sync semantic).
+//!
+//! XEP-0490 MDS coexistence: MDS keys PEP items by chat JID (the room),
+//! which makes thread-keyed mark-read impossible to express through MDS
+//! alone. This arm covers the gap by deriving the thread from the
+//! displayed message id via MAM.
+
+use jid::BareJid;
+use tracing::{debug, warn};
+use waddle_xmpp::inbox::storage::InboxStorage;
+
+use super::groupchat_archive::push_inbox_update;
+use super::Deps;
+
+/// Drive [`OutboundEvent::MarkInboxReadFromDisplayed`] effects against
+/// MAM (for the thread lookup) and the inbox storage (for the
+/// mark-read writes + push fan-out).
+pub(super) async fn mark_inbox_read_from_displayed(
+    deps: &Deps<'_>,
+    owner: BareJid,
+    room: BareJid,
+    displayed_message_id: String,
+) {
+    let Some(inbox_storage) = deps.inbox_storage else {
+        debug!(
+            %owner,
+            %room,
+            displayed_id = %displayed_message_id,
+            "MarkInboxReadFromDisplayed: no inbox_storage in Deps; skipping"
+        );
+        return;
+    };
+    let thread_id = resolve_thread_id(deps, &room, &displayed_message_id).await;
+
+    apply_mark_read(
+        deps.connection_registry,
+        inbox_storage.as_ref(),
+        &owner,
+        &room,
+        None,
+    )
+    .await;
+    if let Some(ref thread_id) = thread_id {
+        apply_mark_read(
+            deps.connection_registry,
+            inbox_storage.as_ref(),
+            &owner,
+            &room,
+            Some(thread_id.as_str()),
+        )
+        .await;
+    }
+}
+
+/// Look up the displayed message's `<thread/>` id from MAM. Returns
+/// `None` when the message was not found, has no thread, or MAM is not
+/// wired (unit-test fixtures). The mark-read still applies to the
+/// channel-level row in all cases.
+async fn resolve_thread_id(
+    deps: &Deps<'_>,
+    room: &BareJid,
+    displayed_message_id: &str,
+) -> Option<String> {
+    let mam_storage = deps.mam_storage?;
+    match mam_storage
+        .get_message_by_message_id(room, displayed_message_id)
+        .await
+    {
+        Ok(Some(archived)) => archived
+            .thread
+            .map(|thread| thread.id.as_str().to_owned()),
+        Ok(None) => {
+            debug!(
+                %room,
+                displayed_id = %displayed_message_id,
+                "MarkInboxReadFromDisplayed: target message not in MAM; \
+                 marking only the channel row read"
+            );
+            None
+        }
+        Err(error) => {
+            warn!(
+                %room,
+                displayed_id = %displayed_message_id,
+                %error,
+                "MarkInboxReadFromDisplayed: MAM lookup failed; \
+                 falling back to channel-row mark-read"
+            );
+            None
+        }
+    }
+}
+
+/// Run the inbox `mark_read` write for one `(owner, room, thread_id)`
+/// key and push the post-update entry to the owner's other resources.
+async fn apply_mark_read(
+    connection_registry: &waddle_xmpp::registry::ConnectionRegistry,
+    inbox_storage: &dyn InboxStorage,
+    owner: &BareJid,
+    room: &BareJid,
+    thread_id: Option<&str>,
+) {
+    match inbox_storage.mark_read(owner, room, thread_id).await {
+        Ok(Some(entry)) => {
+            push_inbox_update(connection_registry, owner, &entry).await;
+        }
+        Ok(None) => {
+            debug!(
+                %owner,
+                %room,
+                thread = thread_id.unwrap_or(""),
+                "MarkInboxReadFromDisplayed: no matching inbox row; no-op"
+            );
+        }
+        Err(error) => {
+            warn!(
+                %owner,
+                %room,
+                thread = thread_id.unwrap_or(""),
+                %error,
+                "MarkInboxReadFromDisplayed: mark_read failed"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use waddle_xmpp::inbox::storage::{InMemoryInboxStorage, InboxStorage};
+    use waddle_xmpp::inbox::{ConversationKind, InboxEntry};
+    use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage};
+    use waddle_xmpp::mam::{ArchivedMessage as MamArchivedMessage, RichMessageId};
+    use waddle_xmpp::registry::ConnectionRegistry;
+    use waddle_xmpp_core::mam::{ThreadId, ThreadInfo};
+    use waddle_xmpp_core::xep0359::StanzaId as Xep0359StanzaId;
+    use xmpp_parsers::message::MessageType;
+
+    fn bare(value: &str) -> BareJid {
+        value.parse().expect("valid bare jid")
+    }
+
+    fn make_archive_with_thread(
+        room: &BareJid,
+        wire_id: &str,
+        thread: Option<&str>,
+    ) -> MamArchivedMessage {
+        let archive_jid = jid::Jid::from(room.clone());
+        let thread_info = thread.and_then(|raw| {
+            ThreadId::new(raw.to_string()).map(|id| ThreadInfo { id, parent: None })
+        });
+        let stanza_id = Some(Xep0359StanzaId::new(wire_id.to_string(), archive_jid.clone()));
+        MamArchivedMessage {
+            id: wire_id.to_string(),
+            timestamp: chrono::Utc::now(),
+            from: jid::Jid::from(bare("alice@example.com")),
+            to: archive_jid,
+            body: Some("hi".into()),
+            stanza_id,
+            thread: thread_info,
+            reply: None,
+            origin_id: None,
+            message_type: MessageType::Groupchat,
+            stanza_xml: None,
+            rich: None,
+            nickname_generation: Some(0),
+        }
+    }
+
+    async fn seed_inbox(
+        storage: &Arc<dyn InboxStorage>,
+        owner: &BareJid,
+        room: &BareJid,
+        thread: Option<&str>,
+    ) {
+        let mut entry = InboxEntry::new(room.clone(), ConversationKind::MucRoom, "sid", 0);
+        if let Some(thread_id) = thread {
+            entry = entry.with_thread(thread_id);
+        }
+        storage
+            .upsert(owner, entry, true)
+            .await
+            .expect("seed inbox row with unread=1");
+    }
+
+    fn deps_for_test<'a>(
+        registry: &'a ConnectionRegistry,
+        mam_storage: &'a Arc<dyn MamStorage>,
+        inbox_storage: &'a Arc<dyn InboxStorage>,
+    ) -> Deps<'a> {
+        Deps::test_with_storage(registry, mam_storage, inbox_storage)
+    }
+
+    /// Use `RichMessageId::new` only for its non-empty pre-condition;
+    /// silences the unused-import lint when the test module is enabled.
+    #[allow(dead_code)]
+    fn rich_id_is_typed_constructor() {
+        let _ = RichMessageId::new("anchor");
+    }
+
+    #[tokio::test]
+    async fn mark_read_clears_channel_row_when_message_has_no_thread() {
+        let owner = bare("alice@example.com");
+        let room = bare("team@conf.example.com");
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        seed_inbox(&inbox, &owner, &room, None).await;
+
+        let archived = make_archive_with_thread(&room, "msg-1", None);
+        mam.store_message(&room, &archived).await.expect("archive");
+
+        let registry = ConnectionRegistry::new();
+        let deps = deps_for_test(&registry, &mam, &inbox);
+
+        mark_inbox_read_from_displayed(&deps, owner.clone(), room.clone(), "msg-1".into()).await;
+
+        let rows = inbox.list(&owner).await.expect("list inbox");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].unread, 0, "channel row unread must be cleared");
+    }
+
+    #[tokio::test]
+    async fn mark_read_clears_thread_and_channel_rows_when_message_has_thread() {
+        let owner = bare("alice@example.com");
+        let room = bare("team@conf.example.com");
+        let thread = "t-roadmap";
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        seed_inbox(&inbox, &owner, &room, None).await;
+        seed_inbox(&inbox, &owner, &room, Some(thread)).await;
+
+        let archived = make_archive_with_thread(&room, "msg-7", Some(thread));
+        mam.store_message(&room, &archived).await.expect("archive");
+
+        let registry = ConnectionRegistry::new();
+        let deps = deps_for_test(&registry, &mam, &inbox);
+
+        mark_inbox_read_from_displayed(&deps, owner.clone(), room.clone(), "msg-7".into()).await;
+
+        let channels = inbox.list(&owner).await.expect("list channels");
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].unread, 0, "channel row must clear");
+        let threads = inbox.list_threads(&owner, &room).await.expect("list threads");
+        assert_eq!(threads.len(), 1);
+        assert_eq!(
+            threads[0].unread, 0,
+            "thread row must clear when the displayed message belongs to it"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_read_is_a_no_op_when_message_is_missing_from_mam() {
+        let owner = bare("alice@example.com");
+        let room = bare("team@conf.example.com");
+        let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+        let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+        seed_inbox(&inbox, &owner, &room, None).await;
+        seed_inbox(&inbox, &owner, &room, Some("t-1")).await;
+
+        let registry = ConnectionRegistry::new();
+        let deps = deps_for_test(&registry, &mam, &inbox);
+
+        // MAM has no message → channel row still clears, thread row stays.
+        mark_inbox_read_from_displayed(
+            &deps,
+            owner.clone(),
+            room.clone(),
+            "missing-id".into(),
+        )
+        .await;
+
+        let channels = inbox.list(&owner).await.expect("list");
+        assert_eq!(channels[0].unread, 0, "channel still clears");
+        let threads = inbox.list_threads(&owner, &room).await.expect("list");
+        assert_eq!(
+            threads[0].unread, 1,
+            "thread row stays unread when MAM lookup fails"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/displayed_marker.rs
@@ -81,9 +81,7 @@ async fn resolve_thread_id(
         .get_message_by_message_id(room, displayed_message_id)
         .await
     {
-        Ok(Some(archived)) => archived
-            .thread
-            .map(|thread| thread.id.as_str().to_owned()),
+        Ok(Some(archived)) => archived.thread.map(|thread| thread.id.as_str().to_owned()),
         Ok(None) => {
             debug!(
                 %room,
@@ -148,7 +146,8 @@ mod tests {
     use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage};
     use waddle_xmpp::mam::{ArchivedMessage as MamArchivedMessage, RichMessageId};
     use waddle_xmpp::registry::ConnectionRegistry;
-    use waddle_xmpp_core::mam::{ThreadId, ThreadInfo};
+    use waddle_xmpp_core::mam::ThreadId;
+    use waddle_xmpp_core::ThreadInfo;
     use waddle_xmpp_core::xep0359::StanzaId as Xep0359StanzaId;
     use xmpp_parsers::message::MessageType;
 
@@ -165,7 +164,10 @@ mod tests {
         let thread_info = thread.and_then(|raw| {
             ThreadId::new(raw.to_string()).map(|id| ThreadInfo { id, parent: None })
         });
-        let stanza_id = Some(Xep0359StanzaId::new(wire_id.to_string(), archive_jid.clone()));
+        let stanza_id = Some(Xep0359StanzaId::new(
+            wire_id.to_string(),
+            archive_jid.clone(),
+        ));
         MamArchivedMessage {
             id: wire_id.to_string(),
             timestamp: chrono::Utc::now(),
@@ -256,7 +258,10 @@ mod tests {
         let channels = inbox.list(&owner).await.expect("list channels");
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].unread, 0, "channel row must clear");
-        let threads = inbox.list_threads(&owner, &room).await.expect("list threads");
+        let threads = inbox
+            .list_threads(&owner, &room)
+            .await
+            .expect("list threads");
         assert_eq!(threads.len(), 1);
         assert_eq!(
             threads[0].unread, 0,
@@ -277,13 +282,8 @@ mod tests {
         let deps = deps_for_test(&registry, &mam, &inbox);
 
         // MAM has no message → channel row still clears, thread row stays.
-        mark_inbox_read_from_displayed(
-            &deps,
-            owner.clone(),
-            room.clone(),
-            "missing-id".into(),
-        )
-        .await;
+        mark_inbox_read_from_displayed(&deps, owner.clone(), room.clone(), "missing-id".into())
+            .await;
 
         let channels = inbox.list(&owner).await.expect("list");
         assert_eq!(channels[0].unread, 0, "channel still clears");

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -291,6 +291,32 @@ pub enum OutboundEvent {
         kind: CarbonKind,
         exclude: FullJid,
     },
+    /// XEP-0333 §3 — the sender displayed a message up to
+    /// `displayed_message_id` in a MUC room. The interpreter resolves
+    /// the message's thread via MAM and clears the matching inbox row(s)
+    /// — both the channel-level row and the thread-level row when the
+    /// displayed message belongs to a thread.
+    ///
+    /// Emitted by the room handler chain's displayed-marker handler at
+    /// most once per dispatch — for the **sender only**, since a
+    /// displayed marker reports the sender's own read state. Reflected
+    /// markers received as recipients do NOT trigger a mark-read here:
+    /// that would cross-clear other users' inboxes.
+    ///
+    /// `room` is the MUC bare JID (where the displayed message was
+    /// archived); `owner` is the sender's bare JID (whose inbox is
+    /// being mark-read); `displayed_message_id` is the wire id
+    /// referenced by the `<displayed id='…'/>` element. The interpreter
+    /// looks it up in `MamStorage` keyed by `room` to derive the
+    /// thread.
+    MarkInboxReadFromDisplayed {
+        /// Sender's bare JID — whose inbox is being mark-read.
+        owner: BareJid,
+        /// Room bare JID — the MAM archive holding the displayed message.
+        room: BareJid,
+        /// Wire id from `<displayed id='…' xmlns='urn:xmpp:chat-markers:0'/>`.
+        displayed_message_id: String,
+    },
 
     // -------------------------------------------------------------------
     // Async delegations (two-phase callback pattern — see plan §Design

--- a/server/crates/waddle-xmpp/src/protocol/room/displayed_marker.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/displayed_marker.rs
@@ -1,0 +1,216 @@
+//! XEP-0333 displayed-marker → inbox mark-read for the room handler chain.
+//!
+//! The chat client sends a `<message type='groupchat'>` containing a
+//! `<displayed xmlns='urn:xmpp:chat-markers:0' id='…'/>` element when
+//! the user has displayed a room message. The room reflects the marker
+//! to every occupant per XEP-0333 §3.4 (existing
+//! [`super::reflector::ReflectorHandler`] behaviour); this handler runs
+//! the **sender-side** side-effect: emit
+//! [`super::super::event::OutboundEvent::MarkInboxReadFromDisplayed`]
+//! so the interpreter clears the sender's inbox unread for the
+//! channel-level row and — when the displayed message belongs to a
+//! thread — the thread-level row too.
+//!
+//! Only the sender's mark-read is emitted. A recipient observing a
+//! reflected marker is observing *somebody else's* read state, which
+//! must not cross-clear their own inbox. The state machine has no
+//! identity of the displayed message's archive thread here — that lives
+//! in MAM — so the interpreter performs the lookup and applies the
+//! mark-read on both rows.
+
+use super::super::event::OutboundEvent;
+use super::context::RoomContext;
+use super::traits::{RoomHandler, RoomHandlerOutcome};
+use crate::xep::xep0333::{extract_marker_from_message, Marker};
+use xmpp_parsers::message::Message;
+
+/// XEP-0333 displayed-marker handler for the room handler chain.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MucDisplayedMarkerHandler;
+
+impl RoomHandler for MucDisplayedMarkerHandler {
+    fn name(&self) -> &'static str {
+        "xep-0333-muc-displayed-marker"
+    }
+
+    fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
+        let displayed_id = match extract_marker_from_message(message) {
+            Some(Marker::Displayed(id)) => id,
+            _ => return RoomHandlerOutcome::Continue(Vec::new()),
+        };
+        // Sender's inbox is the only one we mark-read from a displayed
+        // marker: the marker reports the sender's own read state.
+        // Synthetic sends without an inbox projection also skip here.
+        if !ctx.project_sender_inbox {
+            return RoomHandlerOutcome::Continue(Vec::new());
+        }
+        let Some(sender_snapshot) = ctx.sender_snapshot() else {
+            return RoomHandlerOutcome::Continue(Vec::new());
+        };
+        let owner = sender_snapshot.bare_jid();
+        let event = OutboundEvent::MarkInboxReadFromDisplayed {
+            owner,
+            room: ctx.room.clone(),
+            displayed_message_id: displayed_id,
+        };
+        RoomHandlerOutcome::Continue(vec![event])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::context::OccupantSnapshot;
+    use crate::types::{Affiliation, Role};
+    use crate::xep::xep0333::build_displayed_element;
+    use crate::xep::xep0421::OccupantIdSecret;
+    use jid::{BareJid, FullJid, Jid};
+    use xmpp_parsers::message::{Message, MessageType};
+
+    fn full(value: &str) -> FullJid {
+        value.parse().expect("valid full jid")
+    }
+
+    fn bare(value: &str) -> BareJid {
+        value.parse().expect("valid bare jid")
+    }
+
+    fn occupant(full_jid: FullJid, nick: &str) -> OccupantSnapshot {
+        OccupantSnapshot {
+            full_jid,
+            nick: nick.to_string(),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }
+    }
+
+    fn groupchat_with_marker(sender: &FullJid, id: &str) -> Message {
+        let mut msg = Message::new(None::<Jid>);
+        msg.from = Some(Jid::from(sender.clone()));
+        msg.type_ = MessageType::Groupchat;
+        msg.payloads.push(build_displayed_element(id));
+        msg
+    }
+
+    fn run(
+        room: &BareJid,
+        sender: &FullJid,
+        occupants: &[OccupantSnapshot],
+        msg: &mut Message,
+    ) -> Vec<OutboundEvent> {
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let ctx = RoomContext {
+            room,
+            sender_full: sender,
+            occupants,
+            managed_room_forbidden: false,
+            room_moderated: false,
+            pin_permission: crate::muc::PinPermission::default(),
+            id_gen: &id_gen,
+            occupant_id_secret: &secret,
+            sender_nickname_generation: 0,
+            project_sender_inbox: true,
+            dispatch_timestamp: 0,
+        };
+        match MucDisplayedMarkerHandler.handle(msg, &ctx) {
+            RoomHandlerOutcome::Continue(events) => events,
+            RoomHandlerOutcome::Halt(_) => panic!("displayed-marker handler never halts"),
+        }
+    }
+
+    #[test]
+    fn emits_mark_read_for_sender_on_displayed_marker() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let bob = full("bob@example.com/desk");
+        let occupants = vec![occupant(alice.clone(), "alice"), occupant(bob, "bob")];
+        let mut msg = groupchat_with_marker(&alice, "msg-42");
+
+        let events = run(&room, &alice, &occupants, &mut msg);
+
+        assert_eq!(events.len(), 1, "expected exactly one mark-read event");
+        match &events[0] {
+            OutboundEvent::MarkInboxReadFromDisplayed {
+                owner,
+                room: marked_room,
+                displayed_message_id,
+            } => {
+                assert_eq!(owner, &bare("alice@example.com"));
+                assert_eq!(marked_room, &room);
+                assert_eq!(displayed_message_id, "msg-42");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ignores_messages_without_a_displayed_marker() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let occupants = vec![occupant(alice.clone(), "alice")];
+        let mut msg = Message::new(None::<Jid>);
+        msg.from = Some(Jid::from(alice.clone()));
+        msg.type_ = MessageType::Groupchat;
+        msg.bodies
+            .insert(String::new(), xmpp_parsers::message::Body("hi".into()));
+
+        let events = run(&room, &alice, &occupants, &mut msg);
+
+        assert!(events.is_empty(), "non-marker messages must not emit");
+    }
+
+    #[test]
+    fn ignores_markable_only_messages() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let occupants = vec![occupant(alice.clone(), "alice")];
+        let mut msg = Message::new(None::<Jid>);
+        msg.from = Some(Jid::from(alice.clone()));
+        msg.type_ = MessageType::Groupchat;
+        msg.id = Some("anchor".into());
+        msg.bodies
+            .insert(String::new(), xmpp_parsers::message::Body("hi".into()));
+        msg.payloads
+            .push(crate::xep::xep0333::build_markable_element());
+
+        let events = run(&room, &alice, &occupants, &mut msg);
+
+        assert!(
+            events.is_empty(),
+            "markable-only request must not produce mark-read"
+        );
+    }
+
+    #[test]
+    fn ignores_displayed_with_empty_id() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let occupants = vec![occupant(alice.clone(), "alice")];
+        let mut msg = groupchat_with_marker(&alice, "");
+
+        let events = run(&room, &alice, &occupants, &mut msg);
+
+        assert!(
+            events.is_empty(),
+            "empty id is malformed and must not emit mark-read"
+        );
+    }
+
+    #[test]
+    fn ignores_sender_not_present_in_occupants() {
+        let room = bare("team@conf.example.com");
+        let alice = full("alice@example.com/web");
+        let other = full("bob@example.com/desk");
+        let occupants = vec![occupant(other, "bob")];
+        let mut msg = groupchat_with_marker(&alice, "msg-42");
+
+        let events = run(&room, &alice, &occupants, &mut msg);
+
+        assert!(
+            events.is_empty(),
+            "the gate enforces occupancy; this handler degenerates safely when the snapshot omits the sender"
+        );
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -35,6 +35,7 @@
 pub mod archive;
 pub mod canonicalize;
 pub mod context;
+pub mod displayed_marker;
 pub mod dispatch;
 pub mod errors;
 pub mod inbox;
@@ -58,6 +59,7 @@ pub fn register_default_room_handlers(dispatcher: &mut RoomDispatcher) {
     dispatcher.register(Arc::new(subject::MucSubjectHandler));
     dispatcher.register(Arc::new(archive::MucArchiveHandler));
     dispatcher.register(Arc::new(inbox::MucInboxHandler));
+    dispatcher.register(Arc::new(displayed_marker::MucDisplayedMarkerHandler));
     dispatcher.register(Arc::new(reflector::ReflectorHandler));
 }
 
@@ -82,6 +84,7 @@ pub fn register_room_pipeline_handlers(dispatcher: &mut RoomDispatcher) {
     dispatcher.register(Arc::new(subject::MucSubjectHandler));
     dispatcher.register(Arc::new(archive::MucArchiveHandler));
     dispatcher.register(Arc::new(inbox::MucInboxHandler));
+    dispatcher.register(Arc::new(displayed_marker::MucDisplayedMarkerHandler));
     dispatcher.register(Arc::new(reflector::ReflectorHandler));
 }
 
@@ -99,15 +102,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_dispatcher_registers_seven_handlers() {
+    fn default_dispatcher_registers_eight_handlers() {
         let d = default_room_dispatcher();
-        assert_eq!(d.handler_count(), 7);
+        assert_eq!(d.handler_count(), 8);
     }
 
     #[test]
-    fn pipeline_dispatcher_registers_six_handlers() {
+    fn pipeline_dispatcher_registers_seven_handlers() {
         let d = default_room_pipeline_dispatcher();
-        assert_eq!(d.handler_count(), 6);
+        assert_eq!(d.handler_count(), 7);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/room/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/mod.rs
@@ -35,8 +35,8 @@
 pub mod archive;
 pub mod canonicalize;
 pub mod context;
-pub mod displayed_marker;
 pub mod dispatch;
+pub mod displayed_marker;
 pub mod errors;
 pub mod inbox;
 pub mod occupancy_validation;

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
@@ -358,6 +358,7 @@ fn outbound_variant_name(event: &OutboundEvent) -> &'static str {
         OutboundEvent::SetTimer { .. } => "SetTimer",
         OutboundEvent::CancelTimer(_) => "CancelTimer",
         OutboundEvent::QueueOfflineDelivery { .. } => "QueueOfflineDelivery",
+        OutboundEvent::MarkInboxReadFromDisplayed { .. } => "MarkInboxReadFromDisplayed",
     }
 }
 


### PR DESCRIPTION
## Summary

Per user screenshot: every row in the Threads list shows an unread-count badge, even threads where the user is caught up. \`UNREAD · 46\` header is correct, but individual rows don\'t lose their badge after the user reads them.

## Investigation needed

Three possible root causes:

1. **Server-side \`has-unread\` computed wrong** — the urn:waddle:threads:0 query response\'s \`has-unread\` attribute is true even when \`unread = 0\`.
2. **Per-thread unread not decremented** — when the user opens/reads a thread, the inbox row\'s thread_id-keyed unread counter never gets reset.
3. **Read marker dispatch not thread-aware** — XEP-0333 \`<displayed/>\` markers or XEP-0490 MDS publish only updates the conversation-level inbox row, not the thread-level row.

Likely (3) — XEP-0490 MDS only publishes per-chat-JID, and Waddle\'s inbox is keyed (user, partner, thread_id). The MDS-to-inbox reconciler may only touch the \`thread_id=\'\'\` row.

## Fix

1. Reproduce by reading a thread and re-querying urn:waddle:threads:0; verify \`has-unread\` flips to false.
2. If it doesn\'t: trace the read-marker write path in \`server/crates/waddle-server/src/inbox/\` and \`server/crates/waddle-server/src/server/routes/websocket/handlers/iq/\` for XEP-0333 and XEP-0490 inbox update. Identify whether they update thread-keyed rows.
3. Fix the gap with a typed test.

## Test plan

- [ ] Server: read marker for a thread message decrements the inbox row\'s unread counter for (user, partner, thread_id)
- [ ] Server: integration test — publish 3 messages in a thread, mark displayed, query threads, assert \`unread=0\` and \`has-unread=false\`
- [ ] `cargo test --workspace` green

This PR was created with the assistance of a LLM.