### PR TITLE
feat(server): channels↔space link storage (admin V2 plumbing)

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -39,6 +39,7 @@ use waddle_xmpp::XmppError;
 use waddle_xmpp::{Affiliation, Role, Stanza};
 
 use crate::admin::is_community_owner;
+use crate::channel_space_links::{ChannelSpaceLink, ChannelSpaceLinkError};
 use crate::server::AppState;
 
 // ---------------------------------------------------------------------------
@@ -759,6 +760,20 @@ async fn run_list(
         .map_err(send_err("room_registry ask ListRooms"))?;
     rooms.sort();
 
+    // Narrow by `space_jid` against the channel↔space link projection.
+    // A channel belongs to at most one space; rooms with no link row
+    // are not in any space, so they are filtered out when a
+    // `space_jid` filter is supplied.
+    if let Some(space_jid) = args.space_jid.as_ref() {
+        let in_space = state
+            .channel_space_link_store
+            .list_channels_in_space(space_jid)
+            .await
+            .map_err(map_link_err)?;
+        let permitted: std::collections::HashSet<BareJid> = in_space.into_iter().collect();
+        rooms.retain(|jid| permitted.contains(jid));
+    }
+
     if let Some(cursor) = args.after_cursor.as_deref() {
         rooms.retain(|jid| jid.to_string().as_str() > cursor);
     }
@@ -831,16 +846,18 @@ async fn run_list(
     } else {
         None
     };
-    // V2 scope: space_jid filter is a no-op in this minimal cut because the
-    // server doesn't yet track channel→space links via the room registry;
-    // the filter parses successfully so the wire surface is stable, and
-    // future PRs can implement the actual filtering against the spaces
-    // metadata projection.
-    let _ = args.space_jid.as_ref();
     Ok(ChannelsListResult {
         entries,
         next_cursor,
     })
+}
+
+fn map_link_err(error: ChannelSpaceLinkError) -> AdminErr {
+    internal_err(format!("channel-space link storage: {error}"))
+}
+
+fn now_unix_seconds() -> i64 {
+    chrono::Utc::now().timestamp()
 }
 
 fn mint_channel_localpart(name: &str) -> String {
@@ -896,6 +913,22 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         })
         .await
         .map_err(send_err("room_registry ask CreateRoom"))?;
+
+    // Persist the channel↔space link when the caller supplied a
+    // `space_jid`. The link drives `channels:list` filtering and
+    // `spaces:delete` cascade behavior; the room itself lives in the
+    // MUC registry independent of any space.
+    if let Some(space_jid) = args.space_jid.as_ref() {
+        state
+            .channel_space_link_store
+            .set(&ChannelSpaceLink {
+                channel_jid: channel_jid.clone(),
+                space_jid: space_jid.clone(),
+                created_at: now_unix_seconds(),
+            })
+            .await
+            .map_err(map_link_err)?;
+    }
 
     Ok(ChannelRef {
         channel_jid,
@@ -960,6 +993,14 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
         })
         .await
         .map_err(send_err("room_registry ask DestroyRoom"))?;
+    // Best-effort: drop the channel↔space link row if any. We
+    // intentionally don't fail the delete on a missing link; the room
+    // is gone, the link projection has nothing left to point at.
+    let _ = state
+        .channel_space_link_store
+        .clear(&args.channel_jid)
+        .await
+        .map_err(map_link_err)?;
     Ok(())
 }
 

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -740,23 +740,43 @@ async fn run_update(state: &AppState, args: &SpacesUpdateArgs) -> Result<SpaceRe
 }
 
 async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), AdminErr> {
-    // Cascade destroy: every channel bookmark item on the space node is
-    // a managed-room JID; ask the room registry to destroy them, then
-    // delete the node + metadata row.
+    // Cascade destroy. There are two sources of "channels in this
+    // space" we need to honor:
+    //   1. The persistent channel↔space link projection
+    //      (`channel_space_link_store`) — populated by admin V2's
+    //      `channels:create`. This is the authoritative source for
+    //      admin-managed channels.
+    //   2. Legacy/bookmark items stored on the space's pubsub node
+    //      (each item's `id` is a managed-room JID).
+    // Both are unioned so the cascade is total.
     let Some(node_name) = space_node_name(&args.space_jid) else {
         return Err(bad_request("space_jid must have a localpart"));
     };
+
+    // Collect channels-to-destroy from both sources.
+    let mut targets: std::collections::BTreeSet<BareJid> = std::collections::BTreeSet::new();
+
+    let linked = state
+        .channel_space_link_store
+        .list_channels_in_space(&args.space_jid)
+        .await
+        .map_err(|e| internal_err(format!("channel-space link storage: {e}")))?;
+    for jid in linked {
+        targets.insert(jid);
+    }
 
     let items = state
         .pubsub_storage
         .get_items(&state.spaces_jid, &node_name, None, &[])
         .await
         .map_err(|e| internal_err(format!("pubsub get_items failed: {e}")))?;
-
     for stored in items {
-        let Ok(room_jid) = stored.id.parse::<BareJid>() else {
-            continue;
-        };
+        if let Ok(room_jid) = stored.id.parse::<BareJid>() {
+            targets.insert(room_jid);
+        }
+    }
+
+    for room_jid in targets {
         // Best-effort destroy — non-existent rooms are fine.
         if let Err(error) = state
             .room_registry
@@ -769,6 +789,17 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                 error = %error,
                 room = %room_jid,
                 "cascade destroy: room registry ask failed",
+            );
+        }
+        // Drop the link row regardless of room-destroy outcome; the
+        // space is being torn down, so leaving the link row dangling
+        // would make `channels:list space_jid=…` keep returning JIDs
+        // for a space that no longer exists.
+        if let Err(error) = state.channel_space_link_store.clear(&room_jid).await {
+            tracing::warn!(
+                error = %error,
+                room = %room_jid,
+                "cascade destroy: clearing channel-space link failed",
             );
         }
     }

--- a/server/crates/waddle-server/src/channel_space_links/mod.rs
+++ b/server/crates/waddle-server/src/channel_space_links/mod.rs
@@ -1,0 +1,339 @@
+//! Storage layer for the channel → space link.
+//!
+//! XEP-0503 in Waddle treats a channel as belonging to at most one space.
+//! Admin V2's `channels:list` accepts a `space_jid` filter argument that
+//! today no-ops because no persistent channel↔space association exists in
+//! the server. This module is the typed projection that records the
+//! association so the filter actually narrows results.
+//!
+//! Mirrors the [`crate::spaces_metadata`] pattern:
+//! - typed values (`ChannelSpaceLink`, `BareJid`, typed error enum) at
+//!   every boundary,
+//! - no `unwrap` in storage paths,
+//! - `CREATE TABLE IF NOT EXISTS` idempotent schema migration,
+//! - in-memory + SQLite-backed implementations under one trait.
+//!
+//! Schema is intentionally minimal — one row per `channel_jid`, pointing
+//! at the parent `space_jid`. There is no per-channel metadata table
+//! today; channel name/topic/visibility live on the MUC `RoomConfig`. If
+//! we ever want richer channel metadata, this module is the natural place
+//! to grow it (extra columns / sibling tables).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use jid::BareJid;
+use thiserror::Error;
+use tracing::{info, instrument};
+
+use crate::db::{Database, DatabaseConfig, DatabaseDriver, IntoParams};
+
+mod schema;
+pub mod storage;
+#[cfg(test)]
+mod tests;
+
+pub use storage::InMemoryChannelSpaceLinkStore;
+
+/// Typed payload for a row in `channel_space_links`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChannelSpaceLink {
+    pub channel_jid: BareJid,
+    pub space_jid: BareJid,
+    /// Unix seconds.
+    pub created_at: i64,
+}
+
+/// Errors returned by [`ChannelSpaceLinkStore`] implementations.
+#[derive(Debug, Error)]
+pub enum ChannelSpaceLinkError {
+    #[error("channel-space link storage error: {0}")]
+    Storage(String),
+    #[error("invalid JID '{raw}': {source}")]
+    InvalidJid {
+        raw: String,
+        #[source]
+        source: jid::Error,
+    },
+}
+
+/// Storage contract for the channel → space link. Admin V2 reaches the
+/// table through this trait so the wire layer never speaks SQL directly.
+#[async_trait]
+pub trait ChannelSpaceLinkStore: Send + Sync {
+    /// Insert or replace the link keyed by `channel_jid`. A channel
+    /// belongs to at most one space; calling `set` overwrites any prior
+    /// row for that channel.
+    ///
+    /// The caller is responsible for supplying `created_at` (typically
+    /// `time::now_unix_seconds()` at the request boundary). On an
+    /// overwrite, the implementation preserves the original
+    /// `created_at` so `list_*` ordering is stable.
+    async fn set(&self, link: &ChannelSpaceLink) -> Result<(), ChannelSpaceLinkError>;
+
+    /// Remove the link for `channel_jid`. Returns `true` when a row was
+    /// removed, `false` when no row matched.
+    async fn clear(&self, channel_jid: &BareJid) -> Result<bool, ChannelSpaceLinkError>;
+
+    /// Fetch the link row for `channel_jid` (`Ok(None)` when absent).
+    async fn get(
+        &self,
+        channel_jid: &BareJid,
+    ) -> Result<Option<ChannelSpaceLink>, ChannelSpaceLinkError>;
+
+    /// Return every `channel_jid` linked to `space_jid`, ordered by
+    /// ascending `created_at` so callers see channels in insertion order.
+    async fn list_channels_in_space(
+        &self,
+        space_jid: &BareJid,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError>;
+
+    /// Return every link row, ordered by ascending `created_at` then
+    /// `channel_jid` so the listing is deterministic.
+    async fn list_all(&self) -> Result<Vec<ChannelSpaceLink>, ChannelSpaceLinkError>;
+}
+
+/// SQLx-backed [`ChannelSpaceLinkStore`].
+#[derive(Clone)]
+pub struct DatabaseChannelSpaceLinkStore {
+    db: Database,
+}
+
+impl DatabaseChannelSpaceLinkStore {
+    /// Open (or create) the link storage at `database_url`. When `None`,
+    /// an ephemeral in-memory SQLite database is used — this mirrors the
+    /// spaces-metadata storage so tests can spin up without a DSN.
+    pub async fn open(database_url: Option<&str>) -> Result<Self, ChannelSpaceLinkError> {
+        let db = match database_url {
+            Some(url) => open_database(url).await?,
+            None => Database::in_memory("channel_space_links")
+                .await
+                .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?,
+        };
+        let store = Self { db };
+        schema::initialize(&store).await?;
+        info!(driver = ?store.db.driver(), "Channel-space link storage initialized");
+        Ok(store)
+    }
+
+    pub(crate) async fn execute(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<u64, ChannelSpaceLinkError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        conn.execute(sql, params)
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))
+    }
+
+    pub(crate) async fn query(
+        &self,
+        sql: &str,
+        params: impl IntoParams,
+    ) -> Result<crate::db::Rows, ChannelSpaceLinkError> {
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        conn.query(sql, params)
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))
+    }
+}
+
+/// Build a trait-object [`ChannelSpaceLinkStore`] for `AppState`.
+/// Mirrors [`crate::spaces_metadata::build_spaces_metadata_store`].
+pub async fn build_channel_space_link_store(
+    database_url: Option<String>,
+) -> Result<Arc<dyn ChannelSpaceLinkStore>, ChannelSpaceLinkError> {
+    Ok(Arc::new(
+        DatabaseChannelSpaceLinkStore::open(database_url.as_deref()).await?,
+    ))
+}
+
+async fn open_database(database_url: &str) -> Result<Database, ChannelSpaceLinkError> {
+    ensure_sqlite_parent_dir(database_url)?;
+    let driver = infer_database_driver(database_url)?;
+    Database::from_config(
+        "channel_space_links",
+        &DatabaseConfig::new(driver, database_url.to_string()),
+    )
+    .await
+    .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))
+}
+
+fn infer_database_driver(database_url: &str) -> Result<DatabaseDriver, ChannelSpaceLinkError> {
+    let lower = database_url.to_ascii_lowercase();
+    if lower.starts_with("postgres://") || lower.starts_with("postgresql://") {
+        return Ok(DatabaseDriver::Postgres);
+    }
+    if lower.starts_with("sqlite:") {
+        return Ok(DatabaseDriver::Sqlite);
+    }
+    Err(ChannelSpaceLinkError::Storage(format!(
+        "unsupported channel_space_links database URL '{database_url}': expected sqlite: or postgres://"
+    )))
+}
+
+fn ensure_sqlite_parent_dir(database_url: &str) -> Result<(), ChannelSpaceLinkError> {
+    let Some(path) = sqlite_database_path(database_url) else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+    }
+    Ok(())
+}
+
+fn sqlite_database_path(database_url: &str) -> Option<&Path> {
+    let path = database_url
+        .strip_prefix("sqlite://")
+        .or_else(|| database_url.strip_prefix("sqlite:"))?;
+    if path.is_empty() || path.starts_with(":memory:") || path.starts_with("file:") {
+        return None;
+    }
+    Some(Path::new(path))
+}
+
+fn decode_row(row: &crate::db::Row) -> Result<ChannelSpaceLink, ChannelSpaceLinkError> {
+    let channel_jid_raw: String = row
+        .get(0)
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+    let channel_jid: BareJid =
+        channel_jid_raw
+            .parse()
+            .map_err(|error: jid::Error| ChannelSpaceLinkError::InvalidJid {
+                raw: channel_jid_raw.clone(),
+                source: error,
+            })?;
+    let space_jid_raw: String = row
+        .get(1)
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+    let space_jid: BareJid =
+        space_jid_raw
+            .parse()
+            .map_err(|error: jid::Error| ChannelSpaceLinkError::InvalidJid {
+                raw: space_jid_raw.clone(),
+                source: error,
+            })?;
+    let created_at: i64 = row
+        .get(2)
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+    Ok(ChannelSpaceLink {
+        channel_jid,
+        space_jid,
+        created_at,
+    })
+}
+
+const SELECT_COLS: &str = "channel_jid, space_jid, created_at";
+
+#[async_trait]
+impl ChannelSpaceLinkStore for DatabaseChannelSpaceLinkStore {
+    #[instrument(skip(self, link), fields(channel = %link.channel_jid, space = %link.space_jid))]
+    async fn set(&self, link: &ChannelSpaceLink) -> Result<(), ChannelSpaceLinkError> {
+        // Preserve the original `created_at` on overwrite so list
+        // ordering is stable.
+        let sql = r#"
+            INSERT INTO channel_space_links (
+                channel_jid, space_jid, created_at
+            ) VALUES (?, ?, ?)
+            ON CONFLICT(channel_jid) DO UPDATE SET
+                space_jid = excluded.space_jid
+        "#;
+        self.execute(
+            sql,
+            crate::db_params![
+                link.channel_jid.to_string(),
+                link.space_jid.to_string(),
+                link.created_at,
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(channel = %channel_jid))]
+    async fn clear(&self, channel_jid: &BareJid) -> Result<bool, ChannelSpaceLinkError> {
+        let affected = self
+            .execute(
+                "DELETE FROM channel_space_links WHERE channel_jid = ?",
+                crate::db_params![channel_jid.to_string()],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
+    #[instrument(skip(self), fields(channel = %channel_jid))]
+    async fn get(
+        &self,
+        channel_jid: &BareJid,
+    ) -> Result<Option<ChannelSpaceLink>, ChannelSpaceLinkError> {
+        let sql = format!("SELECT {SELECT_COLS} FROM channel_space_links WHERE channel_jid = ?");
+        let mut rows = self
+            .query(&sql, crate::db_params![channel_jid.to_string()])
+            .await?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+        Ok(Some(decode_row(&row)?))
+    }
+
+    #[instrument(skip(self), fields(space = %space_jid))]
+    async fn list_channels_in_space(
+        &self,
+        space_jid: &BareJid,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError> {
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM channel_space_links \
+             WHERE space_jid = ? \
+             ORDER BY created_at ASC, channel_jid ASC"
+        );
+        let mut rows = self
+            .query(&sql, crate::db_params![space_jid.to_string()])
+            .await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?
+        {
+            out.push(decode_row(&row)?.channel_jid);
+        }
+        Ok(out)
+    }
+
+    #[instrument(skip(self))]
+    async fn list_all(&self) -> Result<Vec<ChannelSpaceLink>, ChannelSpaceLinkError> {
+        let sql = format!(
+            "SELECT {SELECT_COLS} FROM channel_space_links \
+             ORDER BY created_at ASC, channel_jid ASC"
+        );
+        let mut rows = self.query(&sql, ()).await?;
+        let mut out = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?
+        {
+            out.push(decode_row(&row)?);
+        }
+        Ok(out)
+    }
+}

--- a/server/crates/waddle-server/src/channel_space_links/schema.rs
+++ b/server/crates/waddle-server/src/channel_space_links/schema.rs
@@ -1,0 +1,40 @@
+//! Idempotent `CREATE TABLE IF NOT EXISTS` for `channel_space_links`,
+//! mirroring the `spaces_metadata` schema migration shape.
+
+use super::{ChannelSpaceLinkError, DatabaseChannelSpaceLinkStore};
+
+pub(super) async fn initialize(
+    store: &DatabaseChannelSpaceLinkStore,
+) -> Result<(), ChannelSpaceLinkError> {
+    let i64_type = crate::db::i64_sql_type(store.db.driver());
+    let sql = format!(
+        r#"
+        CREATE TABLE IF NOT EXISTS channel_space_links (
+            channel_jid TEXT PRIMARY KEY,
+            space_jid TEXT NOT NULL,
+            created_at {i64_type} NOT NULL
+        )
+        "#
+    );
+    store.execute(&sql, ()).await?;
+
+    crate::db::widen_postgres_i64_column_to_bigint(&store.db, "channel_space_links", "created_at")
+        .await
+        .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+
+    store
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_channel_space_links_space \
+             ON channel_space_links (space_jid, created_at ASC, channel_jid ASC)",
+            (),
+        )
+        .await?;
+    store
+        .execute(
+            "CREATE INDEX IF NOT EXISTS idx_channel_space_links_created_at \
+             ON channel_space_links (created_at ASC, channel_jid ASC)",
+            (),
+        )
+        .await?;
+    Ok(())
+}

--- a/server/crates/waddle-server/src/channel_space_links/storage.rs
+++ b/server/crates/waddle-server/src/channel_space_links/storage.rs
@@ -1,0 +1,103 @@
+//! In-memory [`ChannelSpaceLinkStore`] for tests and as the placeholder
+//! `AppState` dependency in unit-test constructors.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use jid::BareJid;
+
+use super::{ChannelSpaceLink, ChannelSpaceLinkError, ChannelSpaceLinkStore};
+
+#[derive(Debug, Default)]
+pub struct InMemoryChannelSpaceLinkStore {
+    rows: Mutex<HashMap<BareJid, ChannelSpaceLink>>,
+}
+
+impl InMemoryChannelSpaceLinkStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl ChannelSpaceLinkStore for InMemoryChannelSpaceLinkStore {
+    async fn set(&self, link: &ChannelSpaceLink) -> Result<(), ChannelSpaceLinkError> {
+        let mut guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        // Preserve `created_at` on an existing row to keep list
+        // ordering stable across overwrites, matching the SQLite impl.
+        match guard.get(&link.channel_jid) {
+            Some(existing) => {
+                let preserved_created_at = existing.created_at;
+                guard.insert(
+                    link.channel_jid.clone(),
+                    ChannelSpaceLink {
+                        created_at: preserved_created_at,
+                        ..link.clone()
+                    },
+                );
+            }
+            None => {
+                guard.insert(link.channel_jid.clone(), link.clone());
+            }
+        }
+        Ok(())
+    }
+
+    async fn clear(&self, channel_jid: &BareJid) -> Result<bool, ChannelSpaceLinkError> {
+        let mut guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        Ok(guard.remove(channel_jid).is_some())
+    }
+
+    async fn get(
+        &self,
+        channel_jid: &BareJid,
+    ) -> Result<Option<ChannelSpaceLink>, ChannelSpaceLinkError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        Ok(guard.get(channel_jid).cloned())
+    }
+
+    async fn list_channels_in_space(
+        &self,
+        space_jid: &BareJid,
+    ) -> Result<Vec<BareJid>, ChannelSpaceLinkError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        let mut rows: Vec<ChannelSpaceLink> = guard
+            .values()
+            .filter(|row| &row.space_jid == space_jid)
+            .cloned()
+            .collect();
+        rows.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.channel_jid.cmp(&b.channel_jid))
+        });
+        Ok(rows.into_iter().map(|row| row.channel_jid).collect())
+    }
+
+    async fn list_all(&self) -> Result<Vec<ChannelSpaceLink>, ChannelSpaceLinkError> {
+        let guard = self
+            .rows
+            .lock()
+            .map_err(|error| ChannelSpaceLinkError::Storage(error.to_string()))?;
+        let mut rows: Vec<ChannelSpaceLink> = guard.values().cloned().collect();
+        rows.sort_by(|a, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.channel_jid.cmp(&b.channel_jid))
+        });
+        Ok(rows)
+    }
+}

--- a/server/crates/waddle-server/src/channel_space_links/tests.rs
+++ b/server/crates/waddle-server/src/channel_space_links/tests.rs
@@ -1,0 +1,161 @@
+//! Round-trip tests for the SQLite-backed [`ChannelSpaceLinkStore`].
+
+use jid::BareJid;
+
+use super::{ChannelSpaceLink, ChannelSpaceLinkStore, DatabaseChannelSpaceLinkStore};
+
+fn channel_jid(local: &str) -> BareJid {
+    format!("{local}@muc.localhost")
+        .parse()
+        .expect("valid channel JID")
+}
+
+fn space_jid(local: &str) -> BareJid {
+    format!("{local}@spaces.localhost")
+        .parse()
+        .expect("valid space JID")
+}
+
+fn link(channel: BareJid, space: BareJid, created_at: i64) -> ChannelSpaceLink {
+    ChannelSpaceLink {
+        channel_jid: channel,
+        space_jid: space,
+        created_at,
+    }
+}
+
+async fn fresh_store() -> DatabaseChannelSpaceLinkStore {
+    DatabaseChannelSpaceLinkStore::open(Some("sqlite::memory:"))
+        .await
+        .expect("open in-memory channel_space_links store")
+}
+
+#[tokio::test]
+async fn set_then_get_round_trips_full_row() {
+    let store = fresh_store().await;
+    let row = link(channel_jid("general"), space_jid("eng"), 1_700_000_000);
+
+    store.set(&row).await.expect("set");
+
+    let fetched = store
+        .get(&row.channel_jid)
+        .await
+        .expect("get")
+        .expect("row present after set");
+    assert_eq!(fetched, row);
+}
+
+#[tokio::test]
+async fn set_preserves_created_at_when_relinking_channel() {
+    // Reassigning a channel to a different space MUST keep the original
+    // `created_at` so the list ordering stays stable.
+    let store = fresh_store().await;
+    let initial = link(channel_jid("general"), space_jid("eng"), 1_700_000_000);
+    store.set(&initial).await.expect("set initial");
+
+    let relinked = ChannelSpaceLink {
+        space_jid: space_jid("design"),
+        created_at: 1_700_000_500,
+        ..initial.clone()
+    };
+    store.set(&relinked).await.expect("relink");
+
+    let fetched = store
+        .get(&initial.channel_jid)
+        .await
+        .expect("get")
+        .expect("row present after relink");
+    assert_eq!(fetched.space_jid, space_jid("design"));
+    assert_eq!(
+        fetched.created_at, 1_700_000_000,
+        "created_at preserved across relink"
+    );
+}
+
+#[tokio::test]
+async fn clear_returns_true_when_row_present() {
+    let store = fresh_store().await;
+    let row = link(channel_jid("general"), space_jid("eng"), 1_700_000_000);
+    store.set(&row).await.expect("set");
+
+    let removed = store.clear(&row.channel_jid).await.expect("clear");
+    assert!(removed, "clear returns true when a row was removed");
+    let after = store.get(&row.channel_jid).await.expect("get");
+    assert!(after.is_none(), "row absent after clear");
+}
+
+#[tokio::test]
+async fn clear_returns_false_when_row_absent() {
+    let store = fresh_store().await;
+    let removed = store
+        .clear(&channel_jid("ghost"))
+        .await
+        .expect("clear missing");
+    assert!(!removed, "clear on missing row returns false");
+}
+
+#[tokio::test]
+async fn get_returns_none_for_unknown_channel() {
+    let store = fresh_store().await;
+    let result = store.get(&channel_jid("ghost")).await.expect("get");
+    assert!(result.is_none(), "get returns None for unknown channel JID");
+}
+
+#[tokio::test]
+async fn list_channels_in_space_filters_by_space_and_orders_by_created_at() {
+    let store = fresh_store().await;
+    let alpha = link(channel_jid("alpha"), space_jid("eng"), 1_700_000_000);
+    let beta = link(channel_jid("beta"), space_jid("eng"), 1_700_000_100);
+    let gamma = link(channel_jid("gamma"), space_jid("eng"), 1_700_000_200);
+    let unrelated = link(channel_jid("delta"), space_jid("design"), 1_700_000_050);
+
+    // Insert out of order to confirm ordering is by `created_at`, not by
+    // physical insertion order.
+    store.set(&beta).await.expect("set beta");
+    store.set(&unrelated).await.expect("set unrelated");
+    store.set(&gamma).await.expect("set gamma");
+    store.set(&alpha).await.expect("set alpha");
+
+    let in_eng = store
+        .list_channels_in_space(&space_jid("eng"))
+        .await
+        .expect("list eng");
+    assert_eq!(
+        in_eng,
+        vec![alpha.channel_jid, beta.channel_jid, gamma.channel_jid]
+    );
+
+    let in_design = store
+        .list_channels_in_space(&space_jid("design"))
+        .await
+        .expect("list design");
+    assert_eq!(in_design, vec![unrelated.channel_jid]);
+
+    let in_empty = store
+        .list_channels_in_space(&space_jid("ghost"))
+        .await
+        .expect("list ghost");
+    assert!(in_empty.is_empty());
+}
+
+#[tokio::test]
+async fn list_all_orders_by_created_at_ascending() {
+    let store = fresh_store().await;
+    let alpha = link(channel_jid("alpha"), space_jid("eng"), 1_700_000_000);
+    let beta = link(channel_jid("beta"), space_jid("design"), 1_700_000_100);
+    let gamma = link(channel_jid("gamma"), space_jid("eng"), 1_700_000_200);
+
+    store.set(&gamma).await.expect("set gamma");
+    store.set(&alpha).await.expect("set alpha");
+    store.set(&beta).await.expect("set beta");
+
+    let rows = store.list_all().await.expect("list_all");
+    assert_eq!(rows, vec![alpha, beta, gamma]);
+}
+
+#[tokio::test]
+async fn list_all_on_empty_store_returns_empty_vec() {
+    let store = fresh_store().await;
+    let rows = store.list_all().await.expect("list_all empty");
+    assert!(rows.is_empty());
+}

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod admin;
 pub mod auth;
+pub mod channel_space_links;
 pub mod config;
 pub mod db;
 pub mod inbox;

--- a/server/crates/waddle-server/src/server/config.rs
+++ b/server/crates/waddle-server/src/server/config.rs
@@ -29,6 +29,12 @@ pub struct XmppConfig {
     /// When unset, the store falls back to in-memory SQLite — suitable
     /// for tests only.
     pub spaces_metadata_database_url: Option<String>,
+    /// Channel-space-link database URL — prefers dedicated XMPP DSN,
+    /// otherwise the main runtime DSN. Resolution order:
+    /// `WADDLE_XMPP_CHANNEL_SPACE_LINKS_DATABASE_URL` →
+    /// `WADDLE_DATABASE_URL`. When unset, the store falls back to
+    /// in-memory SQLite — suitable for tests only.
+    pub channel_space_links_database_url: Option<String>,
     /// XEP-0160 offline-message (`pending_delivery`) database URL —
     /// prefers dedicated XMPP DSN, otherwise the main runtime DSN.
     /// Resolution order (matches `resolve_xmpp_database_url`):
@@ -83,6 +89,7 @@ impl Default for XmppConfig {
             mam_database_url: None,
             inbox_database_url: None,
             spaces_metadata_database_url: None,
+            channel_space_links_database_url: None,
             pending_delivery_database_url: None,
             sm_database_url: None,
             pubsub_database_url: None,
@@ -142,6 +149,8 @@ impl XmppConfig {
         let inbox_database_url = resolve_xmpp_database_url("WADDLE_XMPP_INBOX_DATABASE_URL");
         let spaces_metadata_database_url =
             resolve_xmpp_database_url("WADDLE_XMPP_SPACES_METADATA_DATABASE_URL");
+        let channel_space_links_database_url =
+            resolve_xmpp_database_url("WADDLE_XMPP_CHANNEL_SPACE_LINKS_DATABASE_URL");
         let pending_delivery_database_url =
             resolve_xmpp_database_url("WADDLE_XMPP_PENDING_DELIVERY_DATABASE_URL");
         let sm_database_url = resolve_xmpp_database_url("WADDLE_XMPP_SM_DATABASE_URL");
@@ -173,6 +182,7 @@ impl XmppConfig {
             mam_database_url,
             inbox_database_url,
             spaces_metadata_database_url,
+            channel_space_links_database_url,
             pending_delivery_database_url,
             sm_database_url,
             pubsub_database_url,

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -43,6 +43,7 @@ pub mod xmpp_state;
 pub use config::{XmppAcmeConfig, XmppConfig};
 pub use state::{resolve_server_owner_jids, AppState, AppStateDeps};
 
+use crate::channel_space_links::build_channel_space_link_store;
 use crate::config::ServerConfig;
 use crate::db::DatabasePool;
 use crate::inbox::build_inbox_storage;
@@ -140,6 +141,12 @@ pub async fn start_with_config(
             .map_err(|error| {
                 anyhow::anyhow!("Failed to initialize spaces metadata storage: {}", error)
             })?;
+    let channel_space_link_store =
+        build_channel_space_link_store(xmpp_config.channel_space_links_database_url.clone())
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("Failed to initialize channel-space link storage: {}", error)
+            })?;
     // Build the shared XEP-0060 PubSub/PEP storage and the MUC
     // (XEP-0045) room registry here so the resulting handles live on
     // `AppState`. Admin V2 handlers reach them via `state.*` instead of
@@ -173,6 +180,7 @@ pub async fn start_with_config(
         blob_storage,
         inbox_storage: Arc::clone(&inbox_storage),
         spaces_metadata_store: Arc::clone(&spaces_metadata_store),
+        channel_space_link_store: Arc::clone(&channel_space_link_store),
         pubsub_storage: Arc::clone(&pubsub_storage),
         room_registry: room_registry.clone(),
         spaces_jid: xmpp_config.spaces_jid.clone(),

--- a/server/crates/waddle-server/src/server/routes/uploads/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/uploads/tests.rs
@@ -44,6 +44,9 @@ async fn create_test_upload_state() -> (Arc<UploadState>, std::path::PathBuf) {
         blob_storage,
         inbox_storage: Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new()),
         spaces_metadata_store: Arc::new(crate::spaces_metadata::InMemorySpacesMetadataStore::new()),
+        channel_space_link_store: Arc::new(
+            crate::channel_space_links::InMemoryChannelSpaceLinkStore::new(),
+        ),
         pubsub_storage: Arc::new(InMemoryPubSubStorage::new()),
         room_registry,
         spaces_jid: "spaces.example.com".parse().expect("spaces JID parses"),

--- a/server/crates/waddle-server/src/server/state.rs
+++ b/server/crates/waddle-server/src/server/state.rs
@@ -1,3 +1,4 @@
+use crate::channel_space_links::ChannelSpaceLinkStore;
 use crate::permissions::PermissionActor;
 use crate::server::bootstrap_membership;
 use crate::spaces_metadata::SpacesMetadataStore;
@@ -22,6 +23,12 @@ pub struct AppState {
     /// commands. XEP-0503 has no opinion on these human-facing fields;
     /// they live here as a Waddle-specific projection.
     pub spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
+    /// Channel → space link storage. Records which space (XEP-0503)
+    /// owns a given channel (XEP-0045 room) so admin V2's
+    /// `channels:list` `space_jid` filter can narrow results to the
+    /// channels of a single space, and so `spaces:delete` can cascade
+    /// destroy its linked channels.
+    pub channel_space_link_store: Arc<dyn ChannelSpaceLinkStore>,
     /// Shared PubSub/PEP storage (XEP-0060/XEP-0163). Exposed on
     /// `AppState` so admin V2 `spaces:list` / `channels:list` handlers
     /// can enumerate pubsub-tree node membership without re-routing
@@ -89,6 +96,9 @@ impl AppState {
             spaces_metadata_store: Arc::new(
                 crate::spaces_metadata::InMemorySpacesMetadataStore::new(),
             ),
+            channel_space_link_store: Arc::new(
+                crate::channel_space_links::InMemoryChannelSpaceLinkStore::new(),
+            ),
             pubsub_storage: Arc::new(InMemoryPubSubStorage::new()),
             room_registry,
             spaces_jid,
@@ -107,6 +117,7 @@ impl AppState {
             blob_storage,
             inbox_storage,
             spaces_metadata_store,
+            channel_space_link_store,
             pubsub_storage,
             room_registry,
             spaces_jid,
@@ -119,6 +130,7 @@ impl AppState {
             blob_storage,
             inbox_storage,
             spaces_metadata_store,
+            channel_space_link_store,
             pubsub_storage,
             room_registry,
             spaces_jid,
@@ -137,6 +149,7 @@ pub struct AppStateDeps {
     pub blob_storage: Arc<dyn crate::storage::BlobStorage>,
     pub inbox_storage: Arc<dyn InboxStorage>,
     pub spaces_metadata_store: Arc<dyn SpacesMetadataStore>,
+    pub channel_space_link_store: Arc<dyn ChannelSpaceLinkStore>,
     pub pubsub_storage: Arc<dyn PubSubStorage>,
     pub room_registry: ActorRef<RoomRegistryActor>,
     pub spaces_jid: BareJid,

--- a/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
+++ b/server/crates/waddle-server/tests/admin_channel_space_link_ws.rs
@@ -1,0 +1,255 @@
+//! Integration suite for the persistent channel ↔ space link.
+//!
+//! Today admin V2's `channels:list` accepts a `space_jid` filter but no
+//! persistent link exists in the server, so the filter is a no-op. PR
+//! #691 wires up the link projection. This suite drives the four
+//! end-to-end behaviors over the production WebSocket transport:
+//!
+//! 1. `channels:create` with `space_jid=A` and `space_jid=B` records
+//!    independent link rows.
+//! 2. `channels:list space_jid=A` returns only the channels linked to A
+//!    (not the channels linked to B, not unlinked channels).
+//! 3. `channels:list` without `space_jid` returns the full set.
+//! 4. `channels:delete <chA>` drops the link row, so the filter narrows
+//!    further.
+//! 5. `spaces:delete <spB>` cascades to destroy the linked channel and
+//!    drop its link row.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const ADMIN: &str = "admin";
+const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
+const NS_DATA: &str = "jabber:x:data";
+
+const NODE_SPACES_CREATE: &str = "urn:waddle:admin:spaces:create:0";
+const NODE_SPACES_DELETE: &str = "urn:waddle:admin:spaces:delete:0";
+
+const NODE_CHANNELS_LIST: &str = "urn:waddle:admin:channels:list:0";
+const NODE_CHANNELS_CREATE: &str = "urn:waddle:admin:channels:create:0";
+const NODE_CHANNELS_DELETE: &str = "urn:waddle:admin:channels:delete:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
+    let password = server.fixed_account_password().to_string();
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, ADMIN, &password, resource)
+        .await
+        .expect("admin connect")
+}
+
+async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml: &str) -> String {
+    let body = format!(
+        r#"<command xmlns="{NS_COMMANDS}" node="{node}" action="execute">{form_xml}</command>"#
+    );
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{DOMAIN}">{body}</iq>"#
+        ))
+        .await
+        .expect("send iq");
+    client
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && (frame.contains(&format!(r#"id="{id}""#))
+                    || frame.contains(&format!(r#"id='{id}'"#)))
+        })
+        .await
+        .expect("iq response")
+}
+
+fn submit_form(node: &str, extra: &str) -> String {
+    format!(
+        r#"<x xmlns="{NS_DATA}" type="submit"><field var="FORM_TYPE" type="hidden"><value>{node}</value></field>{extra}</x>"#
+    )
+}
+
+fn text_field(var: &str, value: &str) -> String {
+    format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
+}
+
+fn is_result(frame: &str) -> bool {
+    frame.contains(r#"type="result""#) || frame.contains(r#"type='result'"#)
+}
+
+fn extract_field(frame: &str, var: &str) -> Option<String> {
+    let marker_dq = format!(r#"var="{var}""#);
+    let marker_sq = format!(r#"var='{var}'"#);
+    let idx = frame.find(&marker_dq).or_else(|| frame.find(&marker_sq))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let inner = &after[open + "<value>".len()..];
+    let close = inner.find("</value>")?;
+    Some(inner[..close].to_string())
+}
+
+async fn create_space(admin: &mut WsXmppClient, name: &str, id: &str) -> String {
+    let resp = send_command(
+        admin,
+        NODE_SPACES_CREATE,
+        id,
+        &submit_form(NODE_SPACES_CREATE, &text_field("name", name)),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected spaces:create result, got: {resp}"
+    );
+    extract_field(&resp, "space_jid").expect("space_jid in spaces:create response")
+}
+
+async fn create_channel_in_space(
+    admin: &mut WsXmppClient,
+    name: &str,
+    space_jid: &str,
+    id: &str,
+) -> String {
+    let extra = format!(
+        "{}{}",
+        text_field("name", name),
+        text_field("space_jid", space_jid)
+    );
+    let resp = send_command(
+        admin,
+        NODE_CHANNELS_CREATE,
+        id,
+        &submit_form(NODE_CHANNELS_CREATE, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected channels:create result, got: {resp}"
+    );
+    extract_field(&resp, "channel_jid").expect("channel_jid in channels:create response")
+}
+
+async fn list_channels(admin: &mut WsXmppClient, space_jid: Option<&str>, id: &str) -> String {
+    let extra = match space_jid {
+        Some(jid) => text_field("space_jid", jid),
+        None => String::new(),
+    };
+    let resp = send_command(
+        admin,
+        NODE_CHANNELS_LIST,
+        id,
+        &submit_form(NODE_CHANNELS_LIST, &extra),
+    )
+    .await;
+    assert!(
+        is_result(&resp),
+        "expected channels:list result, got: {resp}"
+    );
+    resp
+}
+
+#[tokio::test]
+async fn channels_list_space_jid_filter_narrows_results_and_survives_lifecycle() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "admin-csl-1").await;
+
+    // Two spaces, two channels — one channel per space.
+    let space_a = create_space(&mut admin, "AlphaSpace", "csl-mk-space-a").await;
+    let space_b = create_space(&mut admin, "BetaSpace", "csl-mk-space-b").await;
+
+    let channel_a =
+        create_channel_in_space(&mut admin, "alpha-room", &space_a, "csl-mk-chan-a").await;
+    let channel_b =
+        create_channel_in_space(&mut admin, "beta-room", &space_b, "csl-mk-chan-b").await;
+
+    // (2) `channels:list space_jid=A` returns only channel A.
+    let only_a = list_channels(&mut admin, Some(&space_a), "csl-list-only-a").await;
+    assert!(
+        only_a.contains(&channel_a),
+        "filter by space A should include channel A '{channel_a}', got: {only_a}"
+    );
+    assert!(
+        !only_a.contains(&channel_b),
+        "filter by space A should exclude channel B '{channel_b}', got: {only_a}"
+    );
+
+    // (3) `channels:list` without filter returns both channels.
+    let unfiltered = list_channels(&mut admin, None, "csl-list-all").await;
+    assert!(
+        unfiltered.contains(&channel_a),
+        "unfiltered list missing channel A '{channel_a}', got: {unfiltered}"
+    );
+    assert!(
+        unfiltered.contains(&channel_b),
+        "unfiltered list missing channel B '{channel_b}', got: {unfiltered}"
+    );
+
+    // (4) Delete channel A and confirm the filter narrows further.
+    let del_a = send_command(
+        &mut admin,
+        NODE_CHANNELS_DELETE,
+        "csl-del-a",
+        &submit_form(
+            NODE_CHANNELS_DELETE,
+            &format!(
+                "{}{}",
+                text_field("channel_jid", &channel_a),
+                text_field("confirm", "yes")
+            ),
+        ),
+    )
+    .await;
+    assert!(
+        is_result(&del_a),
+        "expected channels:delete result, got: {del_a}"
+    );
+
+    let after_delete = list_channels(&mut admin, Some(&space_a), "csl-list-after-del-a").await;
+    assert!(
+        !after_delete.contains(&channel_a),
+        "deleted channel A '{channel_a}' should not appear in space-A filter, got: {after_delete}"
+    );
+    assert!(
+        !after_delete.contains(&channel_b),
+        "channel B '{channel_b}' is in space B; space-A filter should still exclude it, got: {after_delete}"
+    );
+
+    // (5) Delete space B and confirm the cascade tore down channel B
+    // and dropped its link row (so the space-B filter is empty).
+    let del_b = send_command(
+        &mut admin,
+        NODE_SPACES_DELETE,
+        "csl-del-space-b",
+        &submit_form(
+            NODE_SPACES_DELETE,
+            &format!(
+                "{}{}",
+                text_field("space_jid", &space_b),
+                text_field("confirm", "yes")
+            ),
+        ),
+    )
+    .await;
+    assert!(
+        is_result(&del_b),
+        "expected spaces:delete result, got: {del_b}"
+    );
+
+    let after_space_delete =
+        list_channels(&mut admin, Some(&space_b), "csl-list-after-del-space-b").await;
+    assert!(
+        !after_space_delete.contains(&channel_b),
+        "cascade-deleted channel B '{channel_b}' should be gone from space-B filter, got: {after_space_delete}"
+    );
+
+    // And the unfiltered list should no longer include either channel.
+    let final_unfiltered = list_channels(&mut admin, None, "csl-list-final").await;
+    assert!(
+        !final_unfiltered.contains(&channel_a),
+        "deleted channel A '{channel_a}' should be absent from unfiltered list, got: {final_unfiltered}"
+    );
+    assert!(
+        !final_unfiltered.contains(&channel_b),
+        "cascade-deleted channel B '{channel_b}' should be absent from unfiltered list, got: {final_unfiltered}"
+    );
+
+    let _ = admin.close().await;
+}


### PR DESCRIPTION
## Summary

Wire up the persistent channel→space association so admin V2's `urn:waddle:admin:channels:list:0` `space_jid` filter actually narrows results. Today the wire accepts the field but the storage layer doesn't record any link, so the filter no-ops.

## Plan

1. Decide where the link lives. Two candidates:
   - **Option A:** new column `space_jid TEXT NULL` on the existing channels/MUC-room metadata table (if there is one).
   - **Option B:** new `channel_space_links` table keyed `(channel_jid, space_jid)`. More flexible (allows channels in multiple spaces later) but heavier.
   
   **Pick A** unless the existing channels table doesn't exist or isn't conducive — XEP-0503 in Waddle treats a channel as belonging to at most one space.

2. **Schema migration**: idempotent `CREATE TABLE IF NOT EXISTS` (or `ALTER TABLE ADD COLUMN IF NOT EXISTS` if a channels table already exists). Mirror the spaces_metadata schema pattern.

3. **Storage trait method** on whatever channel store exists: `set_channel_space(channel_jid, space_jid)`, `clear_channel_space(channel_jid)`, `get_channel_space(channel_jid) -> Option<BareJid>`, `list_channels_in_space(space_jid) -> Vec<BareJid>`.

4. **Wire `channels:create` to record the link** when the args include `space_jid`. Already shipped in #685 but the link was dropped.

5. **Wire `channels:list`** to filter by `space_jid` against the new store.

6. **Wire `channels:delete`** to remove the link.

7. **Wire `spaces:delete`** to cascade — destroy all linked channels (already partially in spec, now needs the link to honor it).

8. **Integration test** in `tests/admin_channels_ws.rs` or new `tests/admin_channel_space_link_ws.rs`:
   - Create channel with `space_jid=spaceA` → `channels:list space_jid=spaceA` returns it.
   - Create another in spaceB → `channels:list space_jid=spaceA` does NOT return it.
   - Delete channel → link gone.

## Non-goals

- Multi-space membership (one channel per space).
- Backfill of existing channels — no production data assumption.
- UI changes (admin V2 chat UI follow-up handles that).

## Test plan

- [ ] `cargo test --workspace` green
- [ ] `cargo clippy -D warnings` clean
- [ ] `cargo fmt --check` clean

This PR was created with the assistance of a LLM.
