### PR TITLE
feat(chat): admin V2 UI — wasm bindings + Spaces/Channels panels + mobile drawer

### DIFF
--- a/chat/src/components/admin/AdminLayout.vue
+++ b/chat/src/components/admin/AdminLayout.vue
@@ -1,20 +1,31 @@
 <script setup lang="ts">
-import { computed } from "vue";
-import { ChevronLeft, Users, FolderTree, ScrollText, BellRing, Settings as SettingsIcon } from "lucide-vue-next";
+// Admin V2 — responsive shell. The left navigation is a pinned 16rem
+// column on `lg+` and slides in as a drawer from the left on `<lg`.
+// The hamburger toggle in the mobile header opens the drawer; tapping
+// the backdrop or selecting a panel closes it.
+import { computed, ref } from "vue";
+import {
+  BellRing,
+  ChevronLeft,
+  FolderTree,
+  Hash,
+  Menu,
+  ScrollText,
+  Settings as SettingsIcon,
+  Users,
+  X,
+} from "lucide-vue-next";
 import { buildAdminPath, type AdminPanel } from "@/shell/navigation";
-
-type StubPanel = Exclude<AdminPanel, "users">;
 
 interface PanelDef {
   slug: AdminPanel;
   label: string;
   icon: typeof Users;
-  /** V1 stubs are visually present so the IA is legible but cannot be navigated to. */
   enabled: boolean;
 }
 
 const props = defineProps<{
-  /** Slug of the currently rendered panel. V1 only renders "users"; other slugs receive a stub view. */
+  /** Slug of the currently rendered panel. */
   activePanel: AdminPanel;
 }>();
 
@@ -25,11 +36,14 @@ const emit = defineEmits<{
 
 const PANELS: ReadonlyArray<PanelDef> = [
   { slug: "users", label: "Users", icon: Users, enabled: true },
-  { slug: "spaces", label: "Spaces", icon: FolderTree, enabled: false },
+  { slug: "spaces", label: "Spaces", icon: FolderTree, enabled: true },
+  { slug: "channels", label: "Channels", icon: Hash, enabled: true },
   { slug: "audit", label: "Audit log", icon: ScrollText, enabled: false },
   { slug: "push-health", label: "Push health", icon: BellRing, enabled: false },
   { slug: "settings", label: "Settings", icon: SettingsIcon, enabled: false },
 ];
+
+const sidebarOpen = ref(false);
 
 function isActive(panel: PanelDef): boolean {
   return panel.slug === props.activePanel;
@@ -37,61 +51,153 @@ function isActive(panel: PanelDef): boolean {
 
 function onPanelClick(panel: PanelDef): void {
   if (!panel.enabled) return;
+  sidebarOpen.value = false;
   emit("navigate", buildAdminPath(panel.slug));
 }
 
-const stubLabel = computed(() => {
+const activeLabel = computed(() => {
   const found = PANELS.find((p) => p.slug === props.activePanel);
   return found ? found.label : "Admin";
+});
+
+const isStub = computed(() => {
+  const found = PANELS.find((p) => p.slug === props.activePanel);
+  return !found || !found.enabled;
 });
 </script>
 
 <template>
-  <div class="admin-layout">
-    <aside class="admin-sidebar" aria-label="Admin sections">
-      <header class="admin-sidebar-header">
+  <div class="grid h-[100dvh] w-full grid-cols-1 lg:grid-cols-[16rem_1fr] bg-background text-foreground">
+    <!-- Mobile header with hamburger (visible <lg) -->
+    <header class="flex h-12 items-center gap-2 border-b border-border px-3 lg:hidden">
+      <button
+        type="button"
+        class="chat-icon-button hover:bg-muted"
+        aria-label="Open admin navigation"
+        @click="sidebarOpen = true"
+      >
+        <Menu class="h-5 w-5" />
+      </button>
+      <span class="type-pane-title flex-1 truncate">{{ activeLabel }}</span>
+      <button
+        type="button"
+        class="chat-icon-button hover:bg-muted"
+        aria-label="Back to chat"
+        @click="emit('back')"
+      >
+        <ChevronLeft class="h-5 w-5" />
+      </button>
+    </header>
+
+    <!-- Sidebar: pinned on lg+, slide-from-left drawer on <lg -->
+    <aside
+      class="hidden flex-col gap-3 border-r border-border bg-card/50 p-3 lg:flex lg:row-span-2"
+      aria-label="Admin sections"
+    >
+      <div class="flex flex-col gap-1.5 px-2 pt-2">
         <button
           type="button"
-          class="admin-back-button"
+          class="inline-flex items-center gap-1 self-start type-caption text-muted-foreground hover:text-foreground"
           aria-label="Back to chat"
           @click="emit('back')"
         >
-          <ChevronLeft :size="16" aria-hidden="true" />
+          <ChevronLeft class="h-4 w-4" />
           <span>Back to chat</span>
         </button>
-        <h1 class="admin-title">Admin</h1>
-      </header>
-      <nav class="admin-nav">
-        <ul>
+        <h1 class="type-pane-title">Admin</h1>
+      </div>
+      <nav>
+        <ul class="flex flex-col gap-0.5">
           <li v-for="panel in PANELS" :key="panel.slug">
             <button
               type="button"
-              class="admin-nav-item"
-              :class="{
-                'is-active': isActive(panel),
-                'is-disabled': !panel.enabled,
-              }"
+              class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 type-control text-left transition-colors"
+              :class="[
+                isActive(panel) ? 'bg-primary/10 text-primary font-semibold' : 'hover:bg-muted',
+                !panel.enabled ? 'opacity-50 cursor-not-allowed' : '',
+              ]"
               :aria-current="isActive(panel) ? 'page' : undefined"
               :aria-disabled="!panel.enabled"
               :disabled="!panel.enabled"
               :title="!panel.enabled ? 'Coming soon' : undefined"
               @click="onPanelClick(panel)"
             >
-              <component :is="panel.icon" :size="16" aria-hidden="true" />
-              <span>{{ panel.label }}</span>
-              <span v-if="!panel.enabled" class="admin-soon-pill" aria-hidden="true">Soon</span>
+              <component :is="panel.icon" class="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+              <span class="truncate flex-1">{{ panel.label }}</span>
+              <span v-if="!panel.enabled" class="rounded-full bg-muted px-2 py-0.5 type-caption">Soon</span>
             </button>
           </li>
         </ul>
       </nav>
     </aside>
-    <main class="admin-main" role="main">
+
+    <!-- Mobile drawer overlay -->
+    <Teleport to="body">
+      <Transition name="drawer">
+        <div
+          v-if="sidebarOpen"
+          class="z-modal fixed inset-0 lg:hidden"
+          @keydown.esc="sidebarOpen = false"
+        >
+          <div
+            class="absolute inset-0 bg-background/60 backdrop-blur-md"
+            aria-hidden="true"
+            @click="sidebarOpen = false"
+          />
+          <aside
+            class="absolute left-0 top-0 h-[100dvh] w-[var(--chat-drawer-width)] glass-panel border-r border-border shadow-2xl flex flex-col"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Admin navigation drawer"
+            @click.stop
+          >
+            <div class="h-12 flex items-center justify-between px-3 border-b border-border">
+              <span class="type-pane-title">Admin</span>
+              <button
+                type="button"
+                class="chat-icon-button hover:bg-muted"
+                aria-label="Close admin navigation"
+                @click="sidebarOpen = false"
+              >
+                <X class="w-4 h-4" />
+              </button>
+            </div>
+            <nav class="flex-1 overflow-y-auto p-3">
+              <ul class="flex flex-col gap-0.5">
+                <li v-for="panel in PANELS" :key="panel.slug">
+                  <button
+                    type="button"
+                    class="flex w-full items-center gap-2 rounded-md px-2.5 py-2 type-control text-left transition-colors"
+                    :class="[
+                      isActive(panel) ? 'bg-primary/10 text-primary font-semibold' : 'hover:bg-muted',
+                      !panel.enabled ? 'opacity-50 cursor-not-allowed' : '',
+                    ]"
+                    :aria-current="isActive(panel) ? 'page' : undefined"
+                    :aria-disabled="!panel.enabled"
+                    :disabled="!panel.enabled"
+                    @click="onPanelClick(panel)"
+                  >
+                    <component :is="panel.icon" class="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                    <span class="truncate flex-1">{{ panel.label }}</span>
+                    <span v-if="!panel.enabled" class="rounded-full bg-muted px-2 py-0.5 type-caption">Soon</span>
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          </aside>
+        </div>
+      </Transition>
+    </Teleport>
+
+    <!-- Main panel mount -->
+    <main class="overflow-y-auto" role="main">
       <slot v-if="activePanel === 'users'" name="users" />
-      <div v-else class="admin-stub" role="status">
-        <h2>{{ stubLabel }}</h2>
-        <p>
-          This admin panel is part of the V1 frame but isn't implemented yet.
-          The Users panel is the only fully wired surface for now.
+      <slot v-else-if="activePanel === 'spaces'" name="spaces" />
+      <slot v-else-if="activePanel === 'channels'" name="channels" />
+      <div v-else-if="isStub" class="mx-auto max-w-md p-6 text-center" role="status">
+        <h2 class="type-pane-title mb-2">{{ activeLabel }}</h2>
+        <p class="type-caption text-muted-foreground">
+          This admin panel is in the IA but isn't implemented yet.
         </p>
       </div>
     </main>
@@ -99,105 +205,12 @@ const stubLabel = computed(() => {
 </template>
 
 <style scoped>
-.admin-layout {
-  display: grid;
-  grid-template-columns: 16rem 1fr;
-  height: 100dvh;
-  background: var(--background, #f4f5f7);
-  color: var(--foreground, #0c0d12);
+.drawer-enter-active,
+.drawer-leave-active {
+  transition: opacity 150ms ease;
 }
-
-.admin-sidebar {
-  display: flex;
-  flex-direction: column;
-  border-right: 1px solid var(--border, rgba(15, 18, 25, 0.08));
-  background: var(--sidebar, rgba(255, 255, 255, 0.72));
-  padding: 1rem 0.75rem;
-  gap: 0.75rem;
+.drawer-enter-from,
+.drawer-leave-to {
+  opacity: 0;
 }
-
-.admin-sidebar-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  padding: 0.25rem 0.5rem;
-}
-
-.admin-back-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-size: 0.85rem;
-  color: var(--muted-foreground, rgba(15, 18, 25, 0.65));
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  padding: 0.25rem 0;
-}
-
-.admin-back-button:hover { color: var(--foreground, #0c0d12); }
-
-.admin-title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 0;
-}
-
-.admin-nav { padding-top: 0.5rem; }
-.admin-nav ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.125rem; }
-
-.admin-nav-item {
-  width: 100%;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.625rem;
-  border-radius: 0.5rem;
-  background: transparent;
-  border: 0;
-  color: var(--foreground, #0c0d12);
-  font-size: 0.9rem;
-  cursor: pointer;
-  text-align: left;
-  transition: background-color 120ms ease;
-}
-
-.admin-nav-item:hover:not(.is-disabled) { background: var(--accent, rgba(15, 18, 25, 0.06)); }
-
-.admin-nav-item.is-active {
-  background: var(--accent-strong, rgba(53, 99, 233, 0.12));
-  color: var(--accent-foreground, #1f3aa3);
-  font-weight: 600;
-}
-
-.admin-nav-item.is-disabled {
-  cursor: not-allowed;
-  color: var(--muted-foreground, rgba(15, 18, 25, 0.45));
-}
-
-.admin-soon-pill {
-  margin-left: auto;
-  font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  background: rgba(15, 18, 25, 0.06);
-  padding: 0.05rem 0.4rem;
-  border-radius: 999px;
-}
-
-.admin-main {
-  overflow: auto;
-  padding: 1.5rem 2rem;
-}
-
-.admin-stub {
-  margin: 4rem auto;
-  max-width: 32rem;
-  text-align: center;
-  color: var(--muted-foreground, rgba(15, 18, 25, 0.65));
-}
-
-.admin-stub h2 { font-size: 1.25rem; margin: 0 0 0.5rem 0; color: var(--foreground, #0c0d12); }
-.admin-stub p { font-size: 0.9rem; line-height: 1.5; }
 </style>

--- a/chat/src/components/admin/AdminView.vue
+++ b/chat/src/components/admin/AdminView.vue
@@ -3,6 +3,8 @@ import { computed, onMounted, ref } from "vue";
 import { ChevronLeft } from "lucide-vue-next";
 import AdminLayout from "@/components/admin/AdminLayout.vue";
 import UsersPanel from "@/components/admin/UsersPanel.vue";
+import SpacesPanel from "@/components/admin/SpacesPanel.vue";
+import ChannelsPanel from "@/components/admin/ChannelsPanel.vue";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { AdminPanel } from "@/shell/navigation";
 
@@ -79,6 +81,12 @@ onMounted(() => {
   >
     <template #users>
       <UsersPanel :load-page="loadUsers" />
+    </template>
+    <template #spaces>
+      <SpacesPanel :xmpp-client="xmppClient" />
+    </template>
+    <template #channels>
+      <ChannelsPanel :xmpp-client="xmppClient" />
     </template>
   </AdminLayout>
 </template>

--- a/chat/src/components/admin/AffiliationRow.vue
+++ b/chat/src/components/admin/AffiliationRow.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+// Admin V2 — single affiliation row used by ChannelDetailDrawer.
+// Decoupled from the drawer so the mutation choice (set new
+// affiliation) is composed via a v-model-style event and the parent
+// owns the network call.
+import type { WasmAdminChannelAffiliationEntry } from "@/lib/xmpp";
+
+type Affiliation = "owner" | "admin" | "member" | "none" | "outcast";
+const AFFILIATIONS: Affiliation[] = ["owner", "admin", "member", "none", "outcast"];
+
+defineProps<{
+  entry: WasmAdminChannelAffiliationEntry;
+  mutating?: boolean;
+}>();
+
+const emit = defineEmits<{
+  change: [affiliation: Affiliation];
+}>();
+
+function onSelect(event: Event) {
+  const target = event.target as HTMLSelectElement;
+  const value = target.value as Affiliation;
+  emit("change", value);
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-2">
+    <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+      <span class="font-mono type-caption truncate">{{ entry.jid }}</span>
+      <span v-if="entry.reason" class="type-caption text-muted-foreground truncate">{{ entry.reason }}</span>
+    </div>
+    <select
+      :value="entry.affiliation"
+      :disabled="mutating"
+      class="chat-field-control type-caption"
+      :aria-label="`Affiliation for ${entry.jid}`"
+      @change="onSelect"
+    >
+      <option v-for="a in AFFILIATIONS" :key="a" :value="a">{{ a }}</option>
+    </select>
+  </div>
+</template>

--- a/chat/src/components/admin/ChannelCreateDialog.vue
+++ b/chat/src/components/admin/ChannelCreateDialog.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+// Admin V2 — modal for `adminChannelsCreate`. `is_public` defaults to
+// `true` per the V2 spec; the helper text reflects that.
+import { ref, watch } from "vue";
+import { X } from "lucide-vue-next";
+import AppDialog from "@/components/ui/AppDialog.vue";
+
+const open = defineModel<boolean>("open", { required: true });
+
+const props = defineProps<{
+  isSubmitting?: boolean;
+  spaces?: { space_jid: string; name: string }[];
+}>();
+
+const emit = defineEmits<{
+  submit: [payload: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }];
+}>();
+
+const name = ref("");
+const topic = ref("");
+const spaceJid = ref("");
+const isPublic = ref(true);
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    name.value = "";
+    topic.value = "";
+    spaceJid.value = "";
+    isPublic.value = true;
+  }
+});
+
+function onSubmit() {
+  if (!name.value.trim() || props.isSubmitting) return;
+  emit("submit", {
+    name: name.value.trim(),
+    topic: topic.value.trim() || null,
+    spaceJid: spaceJid.value || null,
+    isPublic: isPublic.value,
+  });
+}
+</script>
+
+<template>
+  <AppDialog v-model:open="open">
+    <div class="chat-dialog-header">
+      <h2 class="type-dialog-title">New Channel</h2>
+      <button
+        class="chat-icon-button hover:bg-muted"
+        type="button"
+        aria-label="Close create-channel dialog"
+        @click="open = false"
+      >
+        <X class="w-4 h-4 text-muted-foreground" />
+      </button>
+    </div>
+
+    <form class="chat-dialog-body flex flex-col gap-3" @submit.prevent="onSubmit">
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Name</span>
+        <input
+          v-model="name"
+          type="text"
+          required
+          maxlength="80"
+          autocomplete="off"
+          class="chat-field-control type-field"
+          placeholder="general"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Topic (optional)</span>
+        <textarea
+          v-model="topic"
+          rows="2"
+          class="chat-field-control chat-textarea-control type-field"
+          placeholder="What's this channel for?"
+        />
+      </label>
+      <label v-if="spaces && spaces.length > 0" class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Space (optional)</span>
+        <select v-model="spaceJid" class="chat-field-control type-field">
+          <option value="">No space</option>
+          <option v-for="s in spaces" :key="s.space_jid" :value="s.space_jid">{{ s.name }}</option>
+        </select>
+      </label>
+      <div class="flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input v-model="isPublic" type="checkbox" />
+          <span class="type-control">Public</span>
+        </label>
+        <p class="type-caption text-muted-foreground">
+          Anyone in the community can join. Uncheck to require explicit
+          membership.
+        </p>
+      </div>
+    </form>
+
+    <div class="chat-dialog-footer">
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--secondary type-control"
+        :disabled="isSubmitting"
+        @click="open = false"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--primary type-action disabled:opacity-30"
+        :disabled="!name.trim() || isSubmitting"
+        @click="onSubmit"
+      >
+        {{ isSubmitting ? "Creating…" : "Create channel" }}
+      </button>
+    </div>
+  </AppDialog>
+</template>

--- a/chat/src/components/admin/ChannelDetailDrawer.vue
+++ b/chat/src/components/admin/ChannelDetailDrawer.vue
@@ -1,0 +1,313 @@
+<script setup lang="ts">
+// Admin V2 — slide-from-right drawer for editing a channel. Three
+// tabs (Config / Affiliations / Occupants) + a danger section with a
+// destroy-room confirm flow.
+import { computed, onMounted, ref, watch } from "vue";
+import AppDrawer from "@/components/ui/AppDrawer.vue";
+import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
+import AffiliationRow from "@/components/admin/AffiliationRow.vue";
+import OccupantRow from "@/components/admin/OccupantRow.vue";
+import type { BrowserXmppClient } from "@/lib/xmpp";
+import type {
+  WasmAdminChannelAffiliationEntry,
+  WasmAdminChannelListEntry,
+  WasmAdminChannelOccupantEntry,
+} from "@/lib/xmpp";
+
+type Affiliation = "owner" | "admin" | "member" | "none" | "outcast";
+type Tab = "config" | "affiliations" | "occupants";
+
+const props = defineProps<{
+  open: boolean;
+  xmppClient: BrowserXmppClient | null;
+  channel: WasmAdminChannelListEntry;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  changed: [];
+  deleted: [];
+}>();
+
+const openLocal = ref(props.open);
+watch(() => props.open, (v) => { openLocal.value = v; });
+watch(openLocal, (v) => { if (!v) emit("close"); });
+
+const tab = ref<Tab>("config");
+
+// Config edit state
+const editName = ref(props.channel.name);
+const editTopic = ref(props.channel.topic ?? "");
+const editIsPublic = ref(props.channel.is_public);
+const editing = ref(false);
+const editError = ref("");
+
+// Affiliations
+const affiliations = ref<WasmAdminChannelAffiliationEntry[]>([]);
+const affiliationsLoading = ref(false);
+const affiliationsError = ref("");
+const affiliationMutating = ref<string | null>(null);
+
+// Occupants
+const occupants = ref<WasmAdminChannelOccupantEntry[]>([]);
+const occupantsLoading = ref(false);
+const occupantsError = ref("");
+const occupantKicking = ref<string | null>(null);
+
+// Delete
+const showDelete = ref(false);
+const deleting = ref(false);
+const deleteError = ref("");
+
+watch(() => props.channel, (c) => {
+  editName.value = c.name;
+  editTopic.value = c.topic ?? "";
+  editIsPublic.value = c.is_public;
+  void loadAffiliations();
+  void loadOccupants();
+}, { immediate: false });
+
+async function loadAffiliations() {
+  if (!props.xmppClient) return;
+  affiliationsLoading.value = true;
+  affiliationsError.value = "";
+  try {
+    const page = await props.xmppClient.adminChannelsAffiliations({
+      channelJid: props.channel.channel_jid,
+      pageSize: 200,
+    });
+    affiliations.value = page.entries;
+  } catch (err: unknown) {
+    affiliationsError.value = err instanceof Error ? err.message : "Failed to load affiliations.";
+  } finally {
+    affiliationsLoading.value = false;
+  }
+}
+
+async function loadOccupants() {
+  if (!props.xmppClient) return;
+  occupantsLoading.value = true;
+  occupantsError.value = "";
+  try {
+    const page = await props.xmppClient.adminChannelsOccupants({
+      channelJid: props.channel.channel_jid,
+      pageSize: 200,
+    });
+    occupants.value = page.entries;
+  } catch (err: unknown) {
+    occupantsError.value = err instanceof Error ? err.message : "Failed to load occupants.";
+  } finally {
+    occupantsLoading.value = false;
+  }
+}
+
+async function saveConfig() {
+  if (!props.xmppClient) return;
+  if (!editName.value.trim()) return;
+  editing.value = true;
+  editError.value = "";
+  try {
+    await props.xmppClient.adminChannelsUpdate({
+      channelJid: props.channel.channel_jid,
+      name: editName.value.trim(),
+      topic: editTopic.value.trim() || null,
+      isPublic: editIsPublic.value,
+    });
+    emit("changed");
+  } catch (err: unknown) {
+    editError.value = err instanceof Error ? err.message : "Failed to update channel.";
+  } finally {
+    editing.value = false;
+  }
+}
+
+async function changeAffiliation(entry: WasmAdminChannelAffiliationEntry, next: Affiliation) {
+  if (!props.xmppClient) return;
+  affiliationMutating.value = entry.jid;
+  try {
+    await props.xmppClient.adminChannelsSetAffiliation({
+      channelJid: props.channel.channel_jid,
+      memberJid: entry.jid,
+      affiliation: next,
+    });
+    await loadAffiliations();
+    emit("changed");
+  } catch (err: unknown) {
+    affiliationsError.value = err instanceof Error ? err.message : "Failed to update affiliation.";
+  } finally {
+    affiliationMutating.value = null;
+  }
+}
+
+async function kickOccupant(entry: WasmAdminChannelOccupantEntry) {
+  if (!props.xmppClient) return;
+  // Derive a bare JID from the full real_jid the server emits.
+  const bareJid = entry.real_jid.split("/")[0] ?? entry.real_jid;
+  occupantKicking.value = entry.real_jid;
+  try {
+    await props.xmppClient.adminChannelsKick({
+      channelJid: props.channel.channel_jid,
+      occupantJid: bareJid,
+    });
+    await loadOccupants();
+    emit("changed");
+  } catch (err: unknown) {
+    occupantsError.value = err instanceof Error ? err.message : "Failed to kick occupant.";
+  } finally {
+    occupantKicking.value = null;
+  }
+}
+
+async function confirmDelete() {
+  if (!props.xmppClient) return;
+  deleting.value = true;
+  deleteError.value = "";
+  try {
+    await props.xmppClient.adminChannelsDelete({ channelJid: props.channel.channel_jid });
+    showDelete.value = false;
+    emit("deleted");
+  } catch (err: unknown) {
+    deleteError.value = err instanceof Error ? err.message : "Failed to delete channel.";
+  } finally {
+    deleting.value = false;
+  }
+}
+
+onMounted(() => {
+  void loadAffiliations();
+  void loadOccupants();
+});
+
+const tabs: { value: Tab; label: string }[] = [
+  { value: "config", label: "Config" },
+  { value: "affiliations", label: "Affiliations" },
+  { value: "occupants", label: "Occupants" },
+];
+
+const affiliationCountLabel = computed(() => {
+  if (affiliations.value.length === 0) return "";
+  return ` (${affiliations.value.length})`;
+});
+const occupantCountLabel = computed(() => {
+  if (occupants.value.length === 0) return "";
+  return ` (${occupants.value.length})`;
+});
+</script>
+
+<template>
+  <AppDrawer v-model:open="openLocal" side="right" label="Channel details" width-class="w-full max-w-md lg:max-w-lg">
+    <template #title>
+      <span class="type-pane-title truncate">{{ channel.name }}</span>
+    </template>
+
+    <div class="flex flex-col gap-4 p-4">
+      <!-- Tabs -->
+      <div class="flex items-center gap-1 border-b border-border" role="tablist">
+        <button
+          v-for="t in tabs"
+          :key="t.value"
+          type="button"
+          role="tab"
+          :aria-selected="tab === t.value"
+          class="px-3 py-1.5 type-control border-b-2 -mb-px transition-colors"
+          :class="tab === t.value ? 'border-primary text-primary' : 'border-transparent text-muted-foreground hover:text-foreground'"
+          @click="tab = t.value"
+        >
+          {{ t.label }}<template v-if="t.value === 'affiliations'">{{ affiliationCountLabel }}</template>
+          <template v-else-if="t.value === 'occupants'">{{ occupantCountLabel }}</template>
+        </button>
+      </div>
+
+      <!-- Config tab -->
+      <section v-if="tab === 'config'" class="flex flex-col gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Name</span>
+          <input v-model="editName" type="text" maxlength="80" class="chat-field-control type-field" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Topic</span>
+          <textarea v-model="editTopic" rows="3" class="chat-field-control chat-textarea-control type-field" />
+        </label>
+        <div class="flex flex-col gap-1.5 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+          <label class="flex items-center gap-2 cursor-pointer">
+            <input v-model="editIsPublic" type="checkbox" />
+            <span class="type-control">Public</span>
+          </label>
+          <p class="type-caption text-muted-foreground">
+            Anyone in the community can join. Uncheck to require explicit
+            membership.
+          </p>
+        </div>
+        <div v-if="editError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ editError }}</div>
+        <div class="flex justify-end">
+          <button
+            type="button"
+            class="chat-action-button chat-action-button--primary type-action disabled:opacity-30"
+            :disabled="editing || !editName.trim()"
+            @click="saveConfig"
+          >
+            {{ editing ? "Saving…" : "Save changes" }}
+          </button>
+        </div>
+
+        <div class="flex flex-col gap-2 border-t border-border pt-4 mt-2">
+          <h3 class="type-section-label text-destructive">Danger zone</h3>
+          <p class="type-caption text-muted-foreground">
+            Deleting this channel destroys the MUC room. Occupants are
+            ejected and history may be lost.
+          </p>
+          <div v-if="deleteError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ deleteError }}</div>
+          <button
+            type="button"
+            class="chat-action-button chat-action-button--destructive type-action"
+            @click="showDelete = true"
+          >
+            Delete channel
+          </button>
+        </div>
+      </section>
+
+      <!-- Affiliations tab -->
+      <section v-else-if="tab === 'affiliations'" class="flex flex-col gap-2">
+        <div v-if="affiliationsError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ affiliationsError }}</div>
+        <p v-if="affiliationsLoading" class="type-caption text-muted-foreground">Loading…</p>
+        <template v-else>
+          <AffiliationRow
+            v-for="entry in affiliations"
+            :key="entry.jid"
+            :entry="entry"
+            :mutating="affiliationMutating === entry.jid"
+            @change="(value) => changeAffiliation(entry, value)"
+          />
+          <p v-if="affiliations.length === 0" class="type-caption text-muted-foreground">No persistent affiliations set.</p>
+        </template>
+      </section>
+
+      <!-- Occupants tab -->
+      <section v-else class="flex flex-col gap-2">
+        <div v-if="occupantsError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ occupantsError }}</div>
+        <p v-if="occupantsLoading" class="type-caption text-muted-foreground">Loading…</p>
+        <template v-else>
+          <OccupantRow
+            v-for="entry in occupants"
+            :key="entry.real_jid"
+            :entry="entry"
+            :kicking="occupantKicking === entry.real_jid"
+            @kick="kickOccupant(entry)"
+          />
+          <p v-if="occupants.length === 0" class="type-caption text-muted-foreground">No one is here right now.</p>
+        </template>
+      </section>
+    </div>
+
+    <ConfirmDialog
+      v-model:open="showDelete"
+      title="Delete channel?"
+      :message="`This destroys the room '${channel.name}' (${channel.channel_jid}). Occupants are ejected.`"
+      confirm-label="Delete"
+      destructive
+      :loading="deleting"
+      @confirm="confirmDelete"
+    />
+  </AppDrawer>
+</template>

--- a/chat/src/components/admin/ChannelsPanel.vue
+++ b/chat/src/components/admin/ChannelsPanel.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+// Admin V2 — Channels panel. Mirrors `SpacesPanel.vue` plus a row of
+// space-filter chips above the search input.
+import { computed, onMounted, ref, watch } from "vue";
+import { Plus, Search } from "lucide-vue-next";
+import type { BrowserXmppClient } from "@/lib/xmpp";
+import type {
+  WasmAdminChannelListEntry,
+  WasmAdminChannelsListResult,
+  WasmAdminSpaceListEntry,
+} from "@/lib/xmpp";
+import ChannelCreateDialog from "@/components/admin/ChannelCreateDialog.vue";
+import ChannelDetailDrawer from "@/components/admin/ChannelDetailDrawer.vue";
+
+const props = defineProps<{
+  xmppClient: BrowserXmppClient | null;
+}>();
+
+const SEARCH_DEBOUNCE_MS = 200;
+const PAGE_SIZE = 50;
+
+const entries = ref<WasmAdminChannelListEntry[]>([]);
+const cursor = ref<string | null>(null);
+const isLoading = ref(false);
+const isLoadingMore = ref(false);
+const errorMessage = ref("");
+const prefix = ref("");
+const debouncedPrefix = ref("");
+const spaceFilter = ref<string | null>(null);
+const spaces = ref<WasmAdminSpaceListEntry[]>([]);
+const showCreate = ref(false);
+const isSubmitting = ref(false);
+const selected = ref<WasmAdminChannelListEntry | null>(null);
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let requestId = 0;
+
+async function loadSpaces() {
+  if (!props.xmppClient) return;
+  try {
+    const page = await props.xmppClient.adminSpacesList({ pageSize: 200 });
+    spaces.value = page.entries;
+  } catch {
+    /* ignored — the filter row gracefully degrades to "All" */
+  }
+}
+
+async function fetchFirstPage(currentPrefix: string, currentSpace: string | null): Promise<void> {
+  if (!props.xmppClient) return;
+  const localRequestId = ++requestId;
+  isLoading.value = true;
+  errorMessage.value = "";
+  try {
+    const page: WasmAdminChannelsListResult = await props.xmppClient.adminChannelsList({
+      spaceJid: currentSpace ?? null,
+      prefix: currentPrefix || null,
+      pageSize: PAGE_SIZE,
+    });
+    if (requestId !== localRequestId) return;
+    entries.value = page.entries;
+    cursor.value = page.next_cursor ?? null;
+  } catch (err: unknown) {
+    if (requestId !== localRequestId) return;
+    errorMessage.value = err instanceof Error ? err.message : "Failed to load channels.";
+  } finally {
+    if (requestId === localRequestId) isLoading.value = false;
+  }
+}
+
+async function loadMore(): Promise<void> {
+  if (!props.xmppClient || !cursor.value || isLoadingMore.value) return;
+  isLoadingMore.value = true;
+  try {
+    const page = await props.xmppClient.adminChannelsList({
+      spaceJid: spaceFilter.value ?? null,
+      prefix: prefix.value || null,
+      pageSize: PAGE_SIZE,
+      afterCursor: cursor.value,
+    });
+    entries.value = entries.value.concat(page.entries);
+    cursor.value = page.next_cursor ?? null;
+  } catch (err: unknown) {
+    errorMessage.value = err instanceof Error ? err.message : "Failed to load more channels.";
+  } finally {
+    isLoadingMore.value = false;
+  }
+}
+
+async function onCreate(payload: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }) {
+  if (!props.xmppClient) return;
+  isSubmitting.value = true;
+  try {
+    await props.xmppClient.adminChannelsCreate(payload);
+    showCreate.value = false;
+    await fetchFirstPage(prefix.value, spaceFilter.value);
+  } catch (err: unknown) {
+    errorMessage.value = err instanceof Error ? err.message : "Failed to create channel.";
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function openDetail(entry: WasmAdminChannelListEntry) {
+  selected.value = entry;
+}
+function closeDetail() {
+  selected.value = null;
+}
+async function onDetailChanged() {
+  await fetchFirstPage(prefix.value, spaceFilter.value);
+}
+async function onDetailDeleted() {
+  selected.value = null;
+  await fetchFirstPage(prefix.value, spaceFilter.value);
+}
+
+watch(prefix, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debouncedPrefix.value = value;
+  }, SEARCH_DEBOUNCE_MS);
+});
+
+watch(debouncedPrefix, (value) => {
+  void fetchFirstPage(value, spaceFilter.value);
+});
+
+watch(spaceFilter, (value) => {
+  void fetchFirstPage(prefix.value, value);
+});
+
+onMounted(() => {
+  void loadSpaces();
+  void fetchFirstPage("", null);
+});
+
+const hasMore = computed(() => cursor.value !== null);
+const showEmptyState = computed(
+  () => !isLoading.value && entries.value.length === 0 && !errorMessage.value,
+);
+const dialogSpaces = computed(() => spaces.value.map((s) => ({ space_jid: s.space_jid, name: s.name })));
+</script>
+
+<template>
+  <section class="flex flex-col gap-4 p-4 max-w-4xl mx-auto w-full" aria-labelledby="channels-panel-heading">
+    <header class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <h2 id="channels-panel-heading" class="type-pane-title">Channels</h2>
+          <p class="type-caption text-muted-foreground max-w-prose">
+            All MUC rooms on this server. Click a row to edit
+            config, manage affiliations, or kick occupants.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="chat-action-button chat-action-button--primary type-action"
+          aria-label="Create channel"
+          @click="showCreate = true"
+        >
+          <Plus class="w-4 h-4" />
+          <span>New channel</span>
+        </button>
+      </div>
+
+      <!-- Space filter chips -->
+      <div v-if="spaces.length > 0" class="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by space">
+        <button
+          type="button"
+          class="rounded-full border px-2.5 py-0.5 type-caption transition-colors"
+          :class="spaceFilter === null ? 'border-primary/40 bg-primary/10 text-primary' : 'border-border bg-card hover:bg-muted'"
+          @click="spaceFilter = null"
+        >
+          All
+        </button>
+        <button
+          v-for="s in spaces"
+          :key="s.space_jid"
+          type="button"
+          class="rounded-full border px-2.5 py-0.5 type-caption transition-colors"
+          :class="spaceFilter === s.space_jid ? 'border-primary/40 bg-primary/10 text-primary' : 'border-border bg-card hover:bg-muted'"
+          @click="spaceFilter = s.space_jid"
+        >
+          {{ s.name }}
+        </button>
+      </div>
+
+      <div class="flex items-center gap-2 chat-field-control max-w-md">
+        <Search class="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+        <input
+          v-model="prefix"
+          type="search"
+          autocomplete="off"
+          placeholder="Search channels"
+          aria-label="Filter channels by prefix"
+          class="flex-1 bg-transparent border-0 outline-none type-field"
+        />
+      </div>
+    </header>
+
+    <div
+      v-if="errorMessage"
+      class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive"
+      role="alert"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div v-if="isLoading && entries.length === 0" class="py-12 text-center type-caption text-muted-foreground" role="status">
+      Loading channels…
+    </div>
+
+    <ul v-else-if="entries.length > 0" class="flex flex-col gap-2" role="list">
+      <li v-for="entry in entries" :key="entry.channel_jid">
+        <button
+          type="button"
+          class="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left hover:bg-muted transition-colors"
+          :aria-label="`Open ${entry.name}`"
+          @click="openDetail(entry)"
+        >
+          <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+            <div class="flex items-center gap-2 min-w-0">
+              <span class="type-control truncate">{{ entry.name }}</span>
+              <span v-if="!entry.is_public" class="type-caption rounded-full bg-muted px-2 py-0.5 flex-shrink-0">Private</span>
+            </div>
+            <span class="type-caption text-muted-foreground truncate font-mono">{{ entry.channel_jid }}</span>
+            <span v-if="entry.topic" class="type-caption text-muted-foreground truncate">{{ entry.topic }}</span>
+          </div>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.occupant_count }} live</span>
+            <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.member_count }} mem</span>
+          </div>
+        </button>
+      </li>
+    </ul>
+
+    <div v-else-if="showEmptyState" class="py-12 text-center type-caption text-muted-foreground" role="status">
+      <p v-if="prefix">No channels match “{{ prefix }}”.</p>
+      <p v-else-if="spaceFilter">No channels in this space yet.</p>
+      <p v-else>No channels yet. Create one to get started.</p>
+    </div>
+
+    <div v-if="hasMore" class="flex justify-center pt-2">
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--secondary type-control"
+        :disabled="isLoadingMore"
+        @click="loadMore"
+      >
+        {{ isLoadingMore ? "Loading…" : "Load more" }}
+      </button>
+    </div>
+
+    <ChannelCreateDialog
+      v-model:open="showCreate"
+      :is-submitting="isSubmitting"
+      :spaces="dialogSpaces"
+      @submit="onCreate"
+    />
+    <ChannelDetailDrawer
+      v-if="selected"
+      :open="!!selected"
+      :xmpp-client="xmppClient"
+      :channel="selected"
+      @close="closeDetail"
+      @changed="onDetailChanged"
+      @deleted="onDetailDeleted"
+    />
+  </section>
+</template>

--- a/chat/src/components/admin/OccupantRow.vue
+++ b/chat/src/components/admin/OccupantRow.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+// Admin V2 — single occupant row used by ChannelDetailDrawer. Shows
+// nick + real JID + role/affiliation chips and a "Kick" button.
+import { UserMinus } from "lucide-vue-next";
+import type { WasmAdminChannelOccupantEntry } from "@/lib/xmpp";
+
+defineProps<{
+  entry: WasmAdminChannelOccupantEntry;
+  kicking?: boolean;
+}>();
+
+const emit = defineEmits<{
+  kick: [];
+}>();
+</script>
+
+<template>
+  <div class="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-2">
+    <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+      <span class="type-control truncate">{{ entry.nick }}</span>
+      <span class="font-mono type-caption text-muted-foreground truncate">{{ entry.real_jid }}</span>
+      <div class="flex flex-wrap items-center gap-1">
+        <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.role }}</span>
+        <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.affiliation }}</span>
+      </div>
+    </div>
+    <button
+      type="button"
+      class="chat-action-button chat-action-button--destructive type-control"
+      :disabled="kicking"
+      :aria-label="`Kick ${entry.nick}`"
+      @click="emit('kick')"
+    >
+      <UserMinus class="w-4 h-4" />
+      <span class="hidden sm:inline">{{ kicking ? "Kicking…" : "Kick" }}</span>
+    </button>
+  </div>
+</template>

--- a/chat/src/components/admin/SpaceCreateDialog.vue
+++ b/chat/src/components/admin/SpaceCreateDialog.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+// Admin V2 — modal for `adminSpacesCreate`. Mirrors the dialog
+// surface used elsewhere in chat (AppDialog + `chat-dialog-*` classes)
+// so the surface feels native to the rest of the admin shell.
+import { ref, watch } from "vue";
+import { X } from "lucide-vue-next";
+import AppDialog from "@/components/ui/AppDialog.vue";
+
+const open = defineModel<boolean>("open", { required: true });
+
+const props = defineProps<{
+  isSubmitting?: boolean;
+}>();
+
+const emit = defineEmits<{
+  /** Caller invokes `adminSpacesCreate` with these args and resolves. */
+  submit: [payload: { name: string; description?: string | null; iconUrl?: string | null }];
+}>();
+
+const name = ref("");
+const description = ref("");
+const iconUrl = ref("");
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    name.value = "";
+    description.value = "";
+    iconUrl.value = "";
+  }
+});
+
+function onSubmit() {
+  if (!name.value.trim() || props.isSubmitting) return;
+  emit("submit", {
+    name: name.value.trim(),
+    description: description.value.trim() || null,
+    iconUrl: iconUrl.value.trim() || null,
+  });
+}
+</script>
+
+<template>
+  <AppDialog v-model:open="open">
+    <div class="chat-dialog-header">
+      <h2 class="type-dialog-title">New Space</h2>
+      <button
+        class="chat-icon-button hover:bg-muted"
+        type="button"
+        aria-label="Close create-space dialog"
+        @click="open = false"
+      >
+        <X class="w-4 h-4 text-muted-foreground" />
+      </button>
+    </div>
+
+    <form class="chat-dialog-body flex flex-col gap-3" @submit.prevent="onSubmit">
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Name</span>
+        <input
+          v-model="name"
+          type="text"
+          required
+          maxlength="80"
+          autocomplete="off"
+          class="chat-field-control type-field"
+          placeholder="Engineering"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Description (optional)</span>
+        <textarea
+          v-model="description"
+          rows="3"
+          class="chat-field-control chat-textarea-control type-field"
+          placeholder="What's this space for?"
+        />
+      </label>
+      <label class="flex flex-col gap-1">
+        <span class="type-section-label text-muted-foreground">Icon URL (optional)</span>
+        <input
+          v-model="iconUrl"
+          type="url"
+          autocomplete="off"
+          class="chat-field-control type-field"
+          placeholder="https://…"
+        />
+      </label>
+    </form>
+
+    <div class="chat-dialog-footer">
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--secondary type-control"
+        :disabled="isSubmitting"
+        @click="open = false"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--primary type-action disabled:opacity-30"
+        :disabled="!name.trim() || isSubmitting"
+        @click="onSubmit"
+      >
+        {{ isSubmitting ? "Creating…" : "Create space" }}
+      </button>
+    </div>
+  </AppDialog>
+</template>

--- a/chat/src/components/admin/SpaceDetailDrawer.vue
+++ b/chat/src/components/admin/SpaceDetailDrawer.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+// Admin V2 — slide-from-right drawer for editing a single space.
+// Three sections: editor, members, danger (delete).
+import { onMounted, ref, watch } from "vue";
+import AppDrawer from "@/components/ui/AppDrawer.vue";
+import ConfirmDialog from "@/components/ui/ConfirmDialog.vue";
+import type { BrowserXmppClient } from "@/lib/xmpp";
+import type {
+  WasmAdminSpaceListEntry,
+  WasmAdminSpaceMemberEntry,
+} from "@/lib/xmpp";
+
+const props = defineProps<{
+  open: boolean;
+  xmppClient: BrowserXmppClient | null;
+  space: WasmAdminSpaceListEntry;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  changed: [];
+  deleted: [];
+}>();
+
+type Role = "owner" | "admin" | "member" | "none";
+const ROLES: Role[] = ["owner", "admin", "member", "none"];
+
+const openLocal = ref(props.open);
+watch(() => props.open, (v) => { openLocal.value = v; });
+watch(openLocal, (v) => { if (!v) emit("close"); });
+
+const editName = ref(props.space.name);
+const editDescription = ref(props.space.description ?? "");
+const editIconUrl = ref(props.space.icon_url ?? "");
+const editing = ref(false);
+const editError = ref("");
+
+const members = ref<WasmAdminSpaceMemberEntry[]>([]);
+const membersLoading = ref(false);
+const membersError = ref("");
+const memberMutating = ref<string | null>(null);
+
+const showDelete = ref(false);
+const deleting = ref(false);
+const deleteError = ref("");
+
+watch(() => props.space, (s) => {
+  editName.value = s.name;
+  editDescription.value = s.description ?? "";
+  editIconUrl.value = s.icon_url ?? "";
+  void loadMembers();
+}, { immediate: false });
+
+async function loadMembers() {
+  if (!props.xmppClient) return;
+  membersLoading.value = true;
+  membersError.value = "";
+  try {
+    const page = await props.xmppClient.adminSpacesMembers({ spaceJid: props.space.space_jid, pageSize: 200 });
+    members.value = page.entries;
+  } catch (err: unknown) {
+    membersError.value = err instanceof Error ? err.message : "Failed to load members.";
+  } finally {
+    membersLoading.value = false;
+  }
+}
+
+async function saveEdits() {
+  if (!props.xmppClient) return;
+  if (!editName.value.trim()) return;
+  editing.value = true;
+  editError.value = "";
+  try {
+    await props.xmppClient.adminSpacesUpdate({
+      spaceJid: props.space.space_jid,
+      name: editName.value.trim(),
+      description: editDescription.value.trim() || null,
+      iconUrl: editIconUrl.value.trim() || null,
+    });
+    emit("changed");
+  } catch (err: unknown) {
+    editError.value = err instanceof Error ? err.message : "Failed to update space.";
+  } finally {
+    editing.value = false;
+  }
+}
+
+async function changeMemberRole(member: WasmAdminSpaceMemberEntry, newRole: Role) {
+  if (!props.xmppClient) return;
+  memberMutating.value = member.jid;
+  try {
+    await props.xmppClient.adminSpacesSetRole({
+      spaceJid: props.space.space_jid,
+      memberJid: member.jid,
+      role: newRole,
+    });
+    await loadMembers();
+    emit("changed");
+  } catch (err: unknown) {
+    membersError.value = err instanceof Error ? err.message : "Failed to update role.";
+  } finally {
+    memberMutating.value = null;
+  }
+}
+
+async function confirmDelete() {
+  if (!props.xmppClient) return;
+  deleting.value = true;
+  deleteError.value = "";
+  try {
+    await props.xmppClient.adminSpacesDelete({ spaceJid: props.space.space_jid });
+    showDelete.value = false;
+    emit("deleted");
+  } catch (err: unknown) {
+    deleteError.value = err instanceof Error ? err.message : "Failed to delete space.";
+  } finally {
+    deleting.value = false;
+  }
+}
+
+onMounted(() => { void loadMembers(); });
+</script>
+
+<template>
+  <AppDrawer v-model:open="openLocal" side="right" label="Space details" width-class="w-full max-w-md lg:max-w-lg">
+    <template #title>
+      <span class="type-pane-title truncate">{{ space.name }}</span>
+    </template>
+    <div class="flex flex-col gap-6 p-4">
+      <!-- Editor -->
+      <section class="flex flex-col gap-3">
+        <h3 class="type-section-label text-muted-foreground">Edit</h3>
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Name</span>
+          <input v-model="editName" type="text" maxlength="80" class="chat-field-control type-field" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Description</span>
+          <textarea v-model="editDescription" rows="3" class="chat-field-control chat-textarea-control type-field" />
+        </label>
+        <label class="flex flex-col gap-1">
+          <span class="type-section-label text-muted-foreground">Icon URL</span>
+          <input v-model="editIconUrl" type="url" class="chat-field-control type-field" />
+        </label>
+        <div v-if="editError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ editError }}</div>
+        <div class="flex justify-end">
+          <button
+            type="button"
+            class="chat-action-button chat-action-button--primary type-action disabled:opacity-30"
+            :disabled="editing || !editName.trim()"
+            @click="saveEdits"
+          >
+            {{ editing ? "Saving…" : "Save changes" }}
+          </button>
+        </div>
+      </section>
+
+      <!-- Members -->
+      <section class="flex flex-col gap-3 border-t border-border pt-4">
+        <h3 class="type-section-label text-muted-foreground">Members</h3>
+        <div v-if="membersError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ membersError }}</div>
+        <div v-if="membersLoading" class="type-caption text-muted-foreground">Loading…</div>
+        <ul v-else-if="members.length > 0" class="flex flex-col gap-1.5" role="list">
+          <li v-for="m in members" :key="m.jid" class="flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-2">
+            <span class="flex-1 truncate font-mono type-caption">{{ m.jid }}</span>
+            <select
+              :value="m.role"
+              :disabled="memberMutating === m.jid"
+              class="chat-field-control type-caption"
+              :aria-label="`Role for ${m.jid}`"
+              @change="changeMemberRole(m, ($event.target as HTMLSelectElement).value as Role)"
+            >
+              <option v-for="r in ROLES" :key="r" :value="r">{{ r }}</option>
+            </select>
+          </li>
+        </ul>
+        <p v-else class="type-caption text-muted-foreground">No members yet.</p>
+      </section>
+
+      <!-- Danger -->
+      <section class="flex flex-col gap-3 border-t border-border pt-4">
+        <h3 class="type-section-label text-destructive">Danger zone</h3>
+        <p class="type-caption text-muted-foreground">
+          Deleting this space cascade-destroys
+          <strong>{{ space.channel_count }}</strong>
+          {{ space.channel_count === 1 ? "channel" : "channels" }} under it. This cannot be undone.
+        </p>
+        <div v-if="deleteError" class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive" role="alert">{{ deleteError }}</div>
+        <button
+          type="button"
+          class="chat-action-button chat-action-button--destructive type-action"
+          @click="showDelete = true"
+        >
+          Delete space
+        </button>
+      </section>
+    </div>
+
+    <ConfirmDialog
+      v-model:open="showDelete"
+      title="Delete space?"
+      :message="`This will delete '${space.name}' and ${space.channel_count} channel${space.channel_count === 1 ? '' : 's'} under it. This cannot be undone.`"
+      confirm-label="Delete"
+      destructive
+      :loading="deleting"
+      @confirm="confirmDelete"
+    />
+  </AppDrawer>
+</template>

--- a/chat/src/components/admin/SpacesPanel.vue
+++ b/chat/src/components/admin/SpacesPanel.vue
@@ -1,0 +1,221 @@
+<script setup lang="ts">
+// Admin V2 — Spaces panel. Mirrors the V1 `UsersPanel` shape (prefix
+// search + paginated list) and layers in a "+" create button and a
+// click-to-open detail drawer.
+import { computed, onMounted, ref, watch } from "vue";
+import { Plus, Search } from "lucide-vue-next";
+import type { BrowserXmppClient } from "@/lib/xmpp";
+import type {
+  WasmAdminSpaceListEntry,
+  WasmAdminSpacesListResult,
+} from "@/lib/xmpp";
+import SpaceCreateDialog from "@/components/admin/SpaceCreateDialog.vue";
+import SpaceDetailDrawer from "@/components/admin/SpaceDetailDrawer.vue";
+
+const props = defineProps<{
+  xmppClient: BrowserXmppClient | null;
+}>();
+
+const SEARCH_DEBOUNCE_MS = 200;
+const PAGE_SIZE = 50;
+
+const entries = ref<WasmAdminSpaceListEntry[]>([]);
+const cursor = ref<string | null>(null);
+const isLoading = ref(false);
+const isLoadingMore = ref(false);
+const errorMessage = ref("");
+const prefix = ref("");
+const debouncedPrefix = ref("");
+const showCreate = ref(false);
+const isSubmitting = ref(false);
+const selected = ref<WasmAdminSpaceListEntry | null>(null);
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let requestId = 0;
+
+async function fetchFirstPage(currentPrefix: string): Promise<void> {
+  if (!props.xmppClient) return;
+  const localRequestId = ++requestId;
+  isLoading.value = true;
+  errorMessage.value = "";
+  try {
+    const page: WasmAdminSpacesListResult = await props.xmppClient.adminSpacesList({
+      prefix: currentPrefix || null,
+      pageSize: PAGE_SIZE,
+    });
+    if (requestId !== localRequestId) return;
+    entries.value = page.entries;
+    cursor.value = page.next_cursor ?? null;
+  } catch (err: unknown) {
+    if (requestId !== localRequestId) return;
+    errorMessage.value = err instanceof Error ? err.message : "Failed to load spaces.";
+  } finally {
+    if (requestId === localRequestId) isLoading.value = false;
+  }
+}
+
+async function loadMore(): Promise<void> {
+  if (!props.xmppClient || !cursor.value || isLoadingMore.value) return;
+  isLoadingMore.value = true;
+  try {
+    const page = await props.xmppClient.adminSpacesList({
+      prefix: prefix.value || null,
+      pageSize: PAGE_SIZE,
+      afterCursor: cursor.value,
+    });
+    entries.value = entries.value.concat(page.entries);
+    cursor.value = page.next_cursor ?? null;
+  } catch (err: unknown) {
+    errorMessage.value = err instanceof Error ? err.message : "Failed to load more spaces.";
+  } finally {
+    isLoadingMore.value = false;
+  }
+}
+
+async function onCreate(payload: { name: string; description?: string | null; iconUrl?: string | null }) {
+  if (!props.xmppClient) return;
+  isSubmitting.value = true;
+  try {
+    await props.xmppClient.adminSpacesCreate(payload);
+    showCreate.value = false;
+    await fetchFirstPage(prefix.value);
+  } catch (err: unknown) {
+    errorMessage.value = err instanceof Error ? err.message : "Failed to create space.";
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+
+function openDetail(entry: WasmAdminSpaceListEntry) {
+  selected.value = entry;
+}
+function closeDetail() {
+  selected.value = null;
+}
+async function onDetailChanged() {
+  await fetchFirstPage(prefix.value);
+}
+async function onDetailDeleted() {
+  selected.value = null;
+  await fetchFirstPage(prefix.value);
+}
+
+watch(prefix, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debouncedPrefix.value = value;
+  }, SEARCH_DEBOUNCE_MS);
+});
+
+watch(debouncedPrefix, (value) => {
+  void fetchFirstPage(value);
+});
+
+onMounted(() => {
+  void fetchFirstPage("");
+});
+
+const hasMore = computed(() => cursor.value !== null);
+const showEmptyState = computed(
+  () => !isLoading.value && entries.value.length === 0 && !errorMessage.value,
+);
+</script>
+
+<template>
+  <section class="flex flex-col gap-4 p-4 max-w-4xl mx-auto w-full" aria-labelledby="spaces-panel-heading">
+    <header class="flex flex-col gap-2">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <h2 id="spaces-panel-heading" class="type-pane-title">Spaces</h2>
+          <p class="type-caption text-muted-foreground max-w-prose">
+            Create, edit, and delete community spaces. Cascade-deletes
+            child channels.
+          </p>
+        </div>
+        <button
+          type="button"
+          class="chat-action-button chat-action-button--primary type-action"
+          aria-label="Create space"
+          @click="showCreate = true"
+        >
+          <Plus class="w-4 h-4" />
+          <span>New space</span>
+        </button>
+      </div>
+      <div class="flex items-center gap-2 chat-field-control max-w-md">
+        <Search class="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+        <input
+          v-model="prefix"
+          type="search"
+          autocomplete="off"
+          placeholder="Search spaces"
+          aria-label="Filter spaces by prefix"
+          class="flex-1 bg-transparent border-0 outline-none type-field"
+        />
+      </div>
+    </header>
+
+    <div
+      v-if="errorMessage"
+      class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 type-caption text-destructive"
+      role="alert"
+    >
+      {{ errorMessage }}
+    </div>
+
+    <div v-if="isLoading && entries.length === 0" class="py-12 text-center type-caption text-muted-foreground" role="status">
+      Loading spaces…
+    </div>
+
+    <ul v-else-if="entries.length > 0" class="flex flex-col gap-2" role="list">
+      <li v-for="entry in entries" :key="entry.space_jid">
+        <button
+          type="button"
+          class="w-full flex items-center justify-between gap-3 rounded-lg border border-border bg-card px-3 py-2.5 text-left hover:bg-muted transition-colors"
+          :aria-label="`Open ${entry.name}`"
+          @click="openDetail(entry)"
+        >
+          <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+            <span class="type-control truncate">{{ entry.name }}</span>
+            <span class="type-caption text-muted-foreground truncate font-mono">{{ entry.space_jid }}</span>
+            <span v-if="entry.description" class="type-caption text-muted-foreground truncate">{{ entry.description }}</span>
+          </div>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.channel_count }} ch</span>
+            <span class="type-caption rounded-full bg-muted px-2 py-0.5">{{ entry.member_count }} mem</span>
+          </div>
+        </button>
+      </li>
+    </ul>
+
+    <div v-else-if="showEmptyState" class="py-12 text-center type-caption text-muted-foreground" role="status">
+      <p v-if="prefix">No spaces match “{{ prefix }}”.</p>
+      <p v-else>No spaces yet. Create one to get started.</p>
+    </div>
+
+    <div v-if="hasMore" class="flex justify-center pt-2">
+      <button
+        type="button"
+        class="chat-action-button chat-action-button--secondary type-control"
+        :disabled="isLoadingMore"
+        @click="loadMore"
+      >
+        {{ isLoadingMore ? "Loading…" : "Load more" }}
+      </button>
+    </div>
+
+    <SpaceCreateDialog
+      v-model:open="showCreate"
+      :is-submitting="isSubmitting"
+      @submit="onCreate"
+    />
+    <SpaceDetailDrawer
+      v-if="selected"
+      :open="!!selected"
+      :xmpp-client="xmppClient"
+      :space="selected"
+      @close="closeDetail"
+      @changed="onDetailChanged"
+      @deleted="onDetailDeleted"
+    />
+  </section>
+</template>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -95,6 +95,16 @@ import {
   roomMessageFromArchived,
 } from "./wasm-message-codecs";
 import type {
+  WasmAdminChannelRef,
+  WasmAdminChannelsAffiliationsResult,
+  WasmAdminChannelsKickResult,
+  WasmAdminChannelsListResult,
+  WasmAdminChannelsOccupantsResult,
+  WasmAdminChannelsSetAffiliationResult,
+  WasmAdminSpaceRef,
+  WasmAdminSpacesListResult,
+  WasmAdminSpacesMembersResult,
+  WasmAdminSpacesSetRoleResult,
   WasmArchivedMessage,
   WasmAvatar,
   WasmFetchThreadsOptions,
@@ -186,6 +196,20 @@ type WasmClient = import("@waddle/xmpp-client-wasm").WaddleClient & {
     afterCursor: string | null,
   ) => Promise<AdminUsersPage>;
   is_community_owner?: () => Promise<boolean>;
+  admin_spaces_list?: (args: unknown) => Promise<WasmAdminSpacesListResult>;
+  admin_spaces_create?: (args: unknown) => Promise<WasmAdminSpaceRef>;
+  admin_spaces_update?: (args: unknown) => Promise<WasmAdminSpaceRef>;
+  admin_spaces_delete?: (args: unknown) => Promise<boolean>;
+  admin_spaces_members?: (args: unknown) => Promise<WasmAdminSpacesMembersResult>;
+  admin_spaces_set_role?: (args: unknown) => Promise<WasmAdminSpacesSetRoleResult>;
+  admin_channels_list?: (args: unknown) => Promise<WasmAdminChannelsListResult>;
+  admin_channels_create?: (args: unknown) => Promise<WasmAdminChannelRef>;
+  admin_channels_update?: (args: unknown) => Promise<WasmAdminChannelRef>;
+  admin_channels_delete?: (args: unknown) => Promise<boolean>;
+  admin_channels_occupants?: (args: unknown) => Promise<WasmAdminChannelsOccupantsResult>;
+  admin_channels_affiliations?: (args: unknown) => Promise<WasmAdminChannelsAffiliationsResult>;
+  admin_channels_set_affiliation?: (args: unknown) => Promise<WasmAdminChannelsSetAffiliationResult>;
+  admin_channels_kick?: (args: unknown) => Promise<WasmAdminChannelsKickResult>;
 };
 
 /**
@@ -1299,6 +1323,138 @@ export class BrowserXmppClient {
       throw new Error("admin_users_list binding missing — server does not support admin V1");
     }
     return await xmpp.admin_users_list(opts.prefix ?? null, opts.pageSize ?? null, opts.afterCursor ?? null);
+  }
+  /**
+   * Admin V2 spaces: list. Wraps `WaddleClient.admin_spaces_list`.
+   *
+   * The wasm method consumes a serde-typed `WaddleAdminSpacesListArgs`
+   * struct, so this wrapper must pass snake_case keys verbatim.
+   */
+  async adminSpacesList(opts: { prefix?: string | null; pageSize?: number | null; afterCursor?: string | null } = {}): Promise<WasmAdminSpacesListResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_list) {
+      throw new Error("admin_spaces_list binding missing — server does not support admin V2");
+    }
+    return await xmpp.admin_spaces_list({
+      prefix: opts.prefix ?? null,
+      page_size: opts.pageSize ?? null,
+      after_cursor: opts.afterCursor ?? null,
+    });
+  }
+  async adminSpacesCreate(opts: { name: string; description?: string | null; iconUrl?: string | null }): Promise<WasmAdminSpaceRef> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_create) throw new Error("admin_spaces_create binding missing");
+    return await xmpp.admin_spaces_create({
+      name: opts.name,
+      description: opts.description ?? null,
+      icon_url: opts.iconUrl ?? null,
+    });
+  }
+  async adminSpacesUpdate(opts: { spaceJid: string; name?: string | null; description?: string | null; iconUrl?: string | null }): Promise<WasmAdminSpaceRef> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_update) throw new Error("admin_spaces_update binding missing");
+    return await xmpp.admin_spaces_update({
+      space_jid: opts.spaceJid,
+      name: opts.name ?? null,
+      description: opts.description ?? null,
+      icon_url: opts.iconUrl ?? null,
+    });
+  }
+  async adminSpacesDelete(opts: { spaceJid: string }): Promise<boolean> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_delete) throw new Error("admin_spaces_delete binding missing");
+    return await xmpp.admin_spaces_delete({ space_jid: opts.spaceJid, confirm: "yes" });
+  }
+  async adminSpacesMembers(opts: { spaceJid: string; pageSize?: number | null; afterCursor?: string | null }): Promise<WasmAdminSpacesMembersResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_members) throw new Error("admin_spaces_members binding missing");
+    return await xmpp.admin_spaces_members({
+      space_jid: opts.spaceJid,
+      page_size: opts.pageSize ?? null,
+      after_cursor: opts.afterCursor ?? null,
+    });
+  }
+  async adminSpacesSetRole(opts: { spaceJid: string; memberJid: string; role: "owner" | "admin" | "member" | "none" }): Promise<WasmAdminSpacesSetRoleResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_spaces_set_role) throw new Error("admin_spaces_set_role binding missing");
+    return await xmpp.admin_spaces_set_role({
+      space_jid: opts.spaceJid,
+      member_jid: opts.memberJid,
+      role: opts.role,
+    });
+  }
+  async adminChannelsList(opts: { spaceJid?: string | null; prefix?: string | null; pageSize?: number | null; afterCursor?: string | null } = {}): Promise<WasmAdminChannelsListResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_list) throw new Error("admin_channels_list binding missing");
+    return await xmpp.admin_channels_list({
+      space_jid: opts.spaceJid ?? null,
+      prefix: opts.prefix ?? null,
+      page_size: opts.pageSize ?? null,
+      after_cursor: opts.afterCursor ?? null,
+    });
+  }
+  async adminChannelsCreate(opts: { name: string; topic?: string | null; spaceJid?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_create) throw new Error("admin_channels_create binding missing");
+    return await xmpp.admin_channels_create({
+      name: opts.name,
+      topic: opts.topic ?? null,
+      space_jid: opts.spaceJid ?? null,
+      is_public: opts.isPublic ?? null,
+    });
+  }
+  async adminChannelsUpdate(opts: { channelJid: string; name?: string | null; topic?: string | null; isPublic?: boolean | null }): Promise<WasmAdminChannelRef> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_update) throw new Error("admin_channels_update binding missing");
+    return await xmpp.admin_channels_update({
+      channel_jid: opts.channelJid,
+      name: opts.name ?? null,
+      topic: opts.topic ?? null,
+      is_public: opts.isPublic ?? null,
+    });
+  }
+  async adminChannelsDelete(opts: { channelJid: string }): Promise<boolean> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_delete) throw new Error("admin_channels_delete binding missing");
+    return await xmpp.admin_channels_delete({ channel_jid: opts.channelJid, confirm: "yes" });
+  }
+  async adminChannelsOccupants(opts: { channelJid: string; pageSize?: number | null; afterCursor?: string | null }): Promise<WasmAdminChannelsOccupantsResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_occupants) throw new Error("admin_channels_occupants binding missing");
+    return await xmpp.admin_channels_occupants({
+      channel_jid: opts.channelJid,
+      page_size: opts.pageSize ?? null,
+      after_cursor: opts.afterCursor ?? null,
+    });
+  }
+  async adminChannelsAffiliations(opts: { channelJid: string; filter?: string | null; pageSize?: number | null; afterCursor?: string | null }): Promise<WasmAdminChannelsAffiliationsResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_affiliations) throw new Error("admin_channels_affiliations binding missing");
+    return await xmpp.admin_channels_affiliations({
+      channel_jid: opts.channelJid,
+      filter: opts.filter ?? null,
+      page_size: opts.pageSize ?? null,
+      after_cursor: opts.afterCursor ?? null,
+    });
+  }
+  async adminChannelsSetAffiliation(opts: { channelJid: string; memberJid: string; affiliation: "owner" | "admin" | "member" | "none" | "outcast"; reason?: string | null }): Promise<WasmAdminChannelsSetAffiliationResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_set_affiliation) throw new Error("admin_channels_set_affiliation binding missing");
+    return await xmpp.admin_channels_set_affiliation({
+      channel_jid: opts.channelJid,
+      member_jid: opts.memberJid,
+      affiliation: opts.affiliation,
+      reason: opts.reason ?? null,
+    });
+  }
+  async adminChannelsKick(opts: { channelJid: string; occupantJid: string; reason?: string | null }): Promise<WasmAdminChannelsKickResult> {
+    const xmpp = await this.requireConnectedXmpp();
+    if (!xmpp.admin_channels_kick) throw new Error("admin_channels_kick binding missing");
+    return await xmpp.admin_channels_kick({
+      channel_jid: opts.channelJid,
+      occupant_jid: opts.occupantJid,
+      reason: opts.reason ?? null,
+    });
   }
   async searchUsers(query: string): Promise<UserSearchResult[]> { if (!query.trim()) return []; const xmpp = await this.requireConnectedXmpp(); const users = await xmpp.search_users?.(query) as WasmUserSearchResult[]; return (users ?? []).map((user) => ({ id: user.jid, jid: user.jid, username: user.username ?? user.nick ?? user.jid.split("@")[0] ?? user.jid, display_name: user.display_name ?? user.name ?? null, avatar_url: null })); }
   async fetchUserAvatar(jid: string): Promise<string | null> {

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -3,6 +3,23 @@ export {
   RoomMemberListUnavailableError,
 } from "./client";
 export type { AdminUserEntry, AdminUsersPage } from "./client";
+export type {
+  WasmAdminChannelAffiliationEntry,
+  WasmAdminChannelListEntry,
+  WasmAdminChannelOccupantEntry,
+  WasmAdminChannelRef,
+  WasmAdminChannelsAffiliationsResult,
+  WasmAdminChannelsKickResult,
+  WasmAdminChannelsListResult,
+  WasmAdminChannelsOccupantsResult,
+  WasmAdminChannelsSetAffiliationResult,
+  WasmAdminSpaceListEntry,
+  WasmAdminSpaceMemberEntry,
+  WasmAdminSpaceRef,
+  WasmAdminSpacesListResult,
+  WasmAdminSpacesMembersResult,
+  WasmAdminSpacesSetRoleResult,
+} from "./wasm-types";
 export {
   barePeerJid,
   jidDomain,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -3,22 +3,20 @@ export {
   RoomMemberListUnavailableError,
 } from "./client";
 export type { AdminUserEntry, AdminUsersPage } from "./client";
+// Admin V2 — types re-exported for consumption by SpacesPanel,
+// ChannelsPanel, and their detail drawers. The `*Ref` /
+// `*SetRoleResult` / `*SetAffiliationResult` / `*KickResult` shapes
+// are not re-exported because they only ever flow back to the panel
+// via the wrapper return type and never need to be named at a
+// component boundary.
 export type {
   WasmAdminChannelAffiliationEntry,
   WasmAdminChannelListEntry,
   WasmAdminChannelOccupantEntry,
-  WasmAdminChannelRef,
-  WasmAdminChannelsAffiliationsResult,
-  WasmAdminChannelsKickResult,
   WasmAdminChannelsListResult,
-  WasmAdminChannelsOccupantsResult,
-  WasmAdminChannelsSetAffiliationResult,
   WasmAdminSpaceListEntry,
   WasmAdminSpaceMemberEntry,
-  WasmAdminSpaceRef,
   WasmAdminSpacesListResult,
-  WasmAdminSpacesMembersResult,
-  WasmAdminSpacesSetRoleResult,
 } from "./wasm-types";
 export {
   barePeerJid,

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -342,3 +342,110 @@ export interface WasmSendOptions {
   markup_spans?: WasmMarkupSpan[];
   references?: WasmReference[];
 }
+
+// ─── Admin V2 — Spaces ────────────────────────────────────────────────
+//
+// TypeScript mirrors of the typed Result structs in
+// `server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs`.
+// snake_case matches the serde wire form. The Args structs are not
+// re-exported here because `BrowserXmppClient` wrappers expose
+// camelCase parameter objects and translate to snake_case before
+// invoking wasm.
+
+export interface WasmAdminSpaceListEntry {
+  space_jid: string;
+  name: string;
+  description?: string | null;
+  icon_url?: string | null;
+  channel_count: number;
+  member_count: number;
+}
+
+export interface WasmAdminSpacesListResult {
+  entries: WasmAdminSpaceListEntry[];
+  next_cursor?: string | null;
+}
+
+export interface WasmAdminSpaceRef {
+  space_jid: string;
+  name: string;
+  description?: string | null;
+  icon_url?: string | null;
+}
+
+export interface WasmAdminSpaceMemberEntry {
+  jid: string;
+  /** `owner` | `admin` | `member` | `none`. */
+  role: string;
+}
+
+export interface WasmAdminSpacesMembersResult {
+  entries: WasmAdminSpaceMemberEntry[];
+  next_cursor?: string | null;
+}
+
+export interface WasmAdminSpacesSetRoleResult {
+  member_jid: string;
+  role: string;
+}
+
+// ─── Admin V2 — Channels ──────────────────────────────────────────────
+
+export interface WasmAdminChannelListEntry {
+  channel_jid: string;
+  name: string;
+  topic?: string | null;
+  is_public: boolean;
+  members_only: boolean;
+  occupant_count: number;
+  owner_count: number;
+  admin_count: number;
+  member_count: number;
+  outcast_count: number;
+}
+
+export interface WasmAdminChannelsListResult {
+  entries: WasmAdminChannelListEntry[];
+  next_cursor?: string | null;
+}
+
+export interface WasmAdminChannelRef {
+  channel_jid: string;
+  name: string;
+  topic?: string | null;
+  is_public: boolean;
+}
+
+export interface WasmAdminChannelOccupantEntry {
+  nick: string;
+  real_jid: string;
+  /** `moderator` | `participant` | `visitor` | `none`. */
+  role: string;
+  /** `owner` | `admin` | `member` | `none` | `outcast`. */
+  affiliation: string;
+}
+
+export interface WasmAdminChannelsOccupantsResult {
+  entries: WasmAdminChannelOccupantEntry[];
+  next_cursor?: string | null;
+}
+
+export interface WasmAdminChannelAffiliationEntry {
+  jid: string;
+  affiliation: string;
+  reason?: string | null;
+}
+
+export interface WasmAdminChannelsAffiliationsResult {
+  entries: WasmAdminChannelAffiliationEntry[];
+  next_cursor?: string | null;
+}
+
+export interface WasmAdminChannelsSetAffiliationResult {
+  member_jid: string;
+  affiliation: string;
+}
+
+export interface WasmAdminChannelsKickResult {
+  occupant_jid: string;
+}

--- a/chat/src/pages/admin/channels.astro
+++ b/chat/src/pages/admin/channels.astro
@@ -1,0 +1,5 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+---
+
+<AppLayout />

--- a/chat/src/pages/admin/spaces.astro
+++ b/chat/src/pages/admin/spaces.astro
@@ -1,0 +1,5 @@
+---
+import AppLayout from "@/layouts/AppLayout.astro";
+---
+
+<AppLayout />

--- a/chat/src/shell/navigation.ts
+++ b/chat/src/shell/navigation.ts
@@ -19,8 +19,14 @@ interface RouteState {
   adminPanel: AdminPanel | null;
 }
 
-/** Slugs the admin layout understands. V1 only implements `users`. */
-export type AdminPanel = "users" | "spaces" | "audit" | "push-health" | "settings";
+/** Slugs the admin layout understands. */
+export type AdminPanel =
+  | "users"
+  | "spaces"
+  | "channels"
+  | "audit"
+  | "push-health"
+  | "settings";
 
 const SETTINGS_PATH = "/settings";
 const ADMIN_PATH_PREFIX = "/admin";
@@ -34,6 +40,7 @@ function parseAdminPanel(slug: string | undefined): AdminPanel | null {
       return DEFAULT_ADMIN_PANEL;
     case "users":
     case "spaces":
+    case "channels":
     case "audit":
     case "push-health":
     case "settings":

--- a/chat/tests/admin-channels-panel.test.ts
+++ b/chat/tests/admin-channels-panel.test.ts
@@ -1,0 +1,200 @@
+// Admin V2 Channels panel — happy paths.
+//
+// Same shape as admin-spaces-panel.test.ts: model the panel's state
+// machine and exercise it against a fake `BrowserXmppClient`.
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  WasmAdminChannelListEntry,
+  WasmAdminChannelsListResult,
+} from "@/lib/xmpp";
+
+interface FakeClient {
+  adminChannelsList: ReturnType<typeof mock>;
+  adminChannelsCreate: ReturnType<typeof mock>;
+  adminChannelsDelete: ReturnType<typeof mock>;
+  adminChannelsAffiliations: ReturnType<typeof mock>;
+  adminChannelsOccupants: ReturnType<typeof mock>;
+  adminChannelsKick: ReturnType<typeof mock>;
+  adminChannelsSetAffiliation: ReturnType<typeof mock>;
+}
+
+const entry = (
+  jid: string,
+  opts: Partial<WasmAdminChannelListEntry> = {},
+): WasmAdminChannelListEntry => ({
+  channel_jid: jid,
+  name: jid.split("@")[0] ?? jid,
+  topic: null,
+  is_public: true,
+  members_only: false,
+  occupant_count: 0,
+  owner_count: 0,
+  admin_count: 0,
+  member_count: 0,
+  outcast_count: 0,
+  ...opts,
+});
+
+class ChannelsPanelModel {
+  prefix = "";
+  spaceFilter: string | null = null;
+  entries: WasmAdminChannelListEntry[] = [];
+  cursor: string | null = null;
+  isLoading = false;
+  errorMessage = "";
+  selected: WasmAdminChannelListEntry | null = null;
+  private requestId = 0;
+  constructor(private client: FakeClient) {}
+
+  async fetchFirstPage(prefix: string, spaceFilter: string | null): Promise<void> {
+    const localRequestId = ++this.requestId;
+    this.isLoading = true;
+    this.errorMessage = "";
+    try {
+      const page: WasmAdminChannelsListResult = await this.client.adminChannelsList({
+        spaceJid: spaceFilter ?? null,
+        prefix: prefix || null,
+        pageSize: 50,
+      });
+      if (this.requestId !== localRequestId) return;
+      this.entries = page.entries;
+      this.cursor = page.next_cursor ?? null;
+    } catch (err: unknown) {
+      if (this.requestId !== localRequestId) return;
+      this.errorMessage = err instanceof Error ? err.message : "Failed to load channels.";
+    } finally {
+      if (this.requestId === localRequestId) this.isLoading = false;
+    }
+  }
+
+  async create(name: string): Promise<void> {
+    await this.client.adminChannelsCreate({ name, isPublic: true });
+    await this.fetchFirstPage(this.prefix, this.spaceFilter);
+  }
+
+  async deleteSelected(): Promise<void> {
+    if (!this.selected) return;
+    await this.client.adminChannelsDelete({ channelJid: this.selected.channel_jid });
+    this.selected = null;
+  }
+
+  async kickFirstOccupant(): Promise<void> {
+    if (!this.selected) return;
+    const page = await this.client.adminChannelsOccupants({
+      channelJid: this.selected.channel_jid,
+    });
+    const occupants = page.entries as Array<{ real_jid: string }>;
+    if (occupants.length === 0) return;
+    const bareJid = occupants[0]!.real_jid.split("/")[0] ?? occupants[0]!.real_jid;
+    await this.client.adminChannelsKick({
+      channelJid: this.selected.channel_jid,
+      occupantJid: bareJid,
+    });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────
+
+describe("ChannelsPanel model — list + filter + search", () => {
+  test("first-page fetch populates entries", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({
+        entries: [entry("general@muc.localhost", { occupant_count: 5 })],
+        next_cursor: null,
+      })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    await model.fetchFirstPage("", null);
+    expect(model.entries[0]?.occupant_count).toBe(5);
+  });
+
+  test("space filter is forwarded to the loader", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    await model.fetchFirstPage("", "eng@spaces.localhost");
+    expect(client.adminChannelsList).toHaveBeenCalledWith({
+      spaceJid: "eng@spaces.localhost",
+      prefix: null,
+      pageSize: 50,
+    });
+  });
+
+  test("create call defaults to isPublic=true (spec)", async () => {
+    let capturedArgs: { name?: string; isPublic?: boolean } | null = null;
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async (args: { name: string; isPublic?: boolean }) => {
+        capturedArgs = args;
+        return { channel_jid: "x@muc.localhost", name: args.name, is_public: true };
+      }),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    await model.create("general");
+    expect(capturedArgs).not.toBeNull();
+    expect(capturedArgs!.isPublic).toBe(true);
+  });
+});
+
+describe("ChannelsPanel model — destructive actions", () => {
+  test("delete clears selected and calls adminChannelsDelete", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsDelete: mock(async (args: { channelJid: string }) => {
+        expect(args.channelJid).toBe("general@muc.localhost");
+        return true;
+      }),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({ entries: [] })),
+      adminChannelsKick: mock(async () => ({})),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    model.selected = entry("general@muc.localhost");
+    await model.deleteSelected();
+    expect(model.selected).toBe(null);
+    expect(client.adminChannelsDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test("kick forwards the bare JID (resource stripped)", async () => {
+    const client: FakeClient = {
+      adminChannelsList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminChannelsCreate: mock(async () => ({})),
+      adminChannelsDelete: mock(async () => true),
+      adminChannelsAffiliations: mock(async () => ({ entries: [] })),
+      adminChannelsOccupants: mock(async () => ({
+        entries: [{ nick: "alice", real_jid: "alice@localhost/web", role: "participant", affiliation: "member" }],
+      })),
+      adminChannelsKick: mock(async (args: { channelJid: string; occupantJid: string }) => {
+        expect(args.channelJid).toBe("general@muc.localhost");
+        expect(args.occupantJid).toBe("alice@localhost");
+        return { occupant_jid: args.occupantJid };
+      }),
+      adminChannelsSetAffiliation: mock(async () => ({})),
+    };
+    const model = new ChannelsPanelModel(client);
+    model.selected = entry("general@muc.localhost");
+    await model.kickFirstOccupant();
+    expect(client.adminChannelsKick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/chat/tests/admin-spaces-panel.test.ts
+++ b/chat/tests/admin-spaces-panel.test.ts
@@ -1,0 +1,259 @@
+// Admin V2 Spaces panel — happy paths.
+//
+// Mirrors `admin-users-panel.test.ts`: rather than mounting Vue, we
+// model the SpacesPanel state machine and exercise it against a
+// fake `BrowserXmppClient` whose `adminSpaces*` methods return
+// canned responses. This is the same trade-off the V1 admin tests
+// make and avoids spinning a wasm/jsdom harness.
+
+import { describe, expect, mock, test } from "bun:test";
+import type {
+  WasmAdminSpaceListEntry,
+  WasmAdminSpaceMemberEntry,
+  WasmAdminSpacesListResult,
+  WasmAdminSpacesMembersResult,
+} from "@/lib/xmpp";
+
+// ── Fake client surface ───────────────────────────────────────────
+
+interface FakeClient {
+  adminSpacesList: ReturnType<typeof mock>;
+  adminSpacesCreate: ReturnType<typeof mock>;
+  adminSpacesUpdate: ReturnType<typeof mock>;
+  adminSpacesDelete: ReturnType<typeof mock>;
+  adminSpacesMembers: ReturnType<typeof mock>;
+  adminSpacesSetRole: ReturnType<typeof mock>;
+}
+
+const entry = (jid: string, channels = 0, members = 0): WasmAdminSpaceListEntry => ({
+  space_jid: jid,
+  name: jid.split("@")[0] ?? jid,
+  description: null,
+  icon_url: null,
+  channel_count: channels,
+  member_count: members,
+});
+
+// ── SpacesPanel model — mirrors the panel's state machine ─────────
+
+class SpacesPanelModel {
+  prefix = "";
+  entries: WasmAdminSpaceListEntry[] = [];
+  cursor: string | null = null;
+  isLoading = false;
+  isLoadingMore = false;
+  errorMessage = "";
+  selected: WasmAdminSpaceListEntry | null = null;
+  showCreate = false;
+  private requestId = 0;
+  constructor(private client: FakeClient) {}
+
+  async fetchFirstPage(prefix: string): Promise<void> {
+    const localRequestId = ++this.requestId;
+    this.isLoading = true;
+    this.errorMessage = "";
+    try {
+      const page: WasmAdminSpacesListResult = await this.client.adminSpacesList({
+        prefix: prefix || null,
+        pageSize: 50,
+      });
+      if (this.requestId !== localRequestId) return;
+      this.entries = page.entries;
+      this.cursor = page.next_cursor ?? null;
+    } catch (err: unknown) {
+      if (this.requestId !== localRequestId) return;
+      this.errorMessage = err instanceof Error ? err.message : "Failed to load spaces.";
+    } finally {
+      if (this.requestId === localRequestId) this.isLoading = false;
+    }
+  }
+
+  async loadMore(): Promise<void> {
+    if (!this.cursor || this.isLoadingMore) return;
+    this.isLoadingMore = true;
+    try {
+      const page = await this.client.adminSpacesList({
+        prefix: this.prefix || null,
+        pageSize: 50,
+        afterCursor: this.cursor,
+      });
+      this.entries = this.entries.concat(page.entries);
+      this.cursor = page.next_cursor ?? null;
+    } catch (err: unknown) {
+      this.errorMessage = err instanceof Error ? err.message : "Failed to load more.";
+    } finally {
+      this.isLoadingMore = false;
+    }
+  }
+
+  openDetail(e: WasmAdminSpaceListEntry) {
+    this.selected = e;
+  }
+  closeDetail() {
+    this.selected = null;
+  }
+
+  async create(name: string): Promise<void> {
+    await this.client.adminSpacesCreate({ name });
+    this.showCreate = false;
+    await this.fetchFirstPage(this.prefix);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────
+
+describe("SpacesPanel model — list + search", () => {
+  test("first-page fetch populates entries", async () => {
+    const client: FakeClient = {
+      adminSpacesList: mock(async () => ({
+        entries: [entry("eng@spaces.localhost", 3, 5)],
+        next_cursor: null,
+      })),
+      adminSpacesCreate: mock(async () => ({})),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    await model.fetchFirstPage("");
+    expect(model.entries.length).toBe(1);
+    expect(model.entries[0]?.channel_count).toBe(3);
+    expect(model.cursor).toBe(null);
+    expect(client.adminSpacesList).toHaveBeenCalledTimes(1);
+  });
+
+  test("prefix is forwarded to the loader", async () => {
+    const client: FakeClient = {
+      adminSpacesList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminSpacesCreate: mock(async () => ({})),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    await model.fetchFirstPage("eng");
+    expect(client.adminSpacesList).toHaveBeenCalledWith({ prefix: "eng", pageSize: 50 });
+  });
+
+  test("load-more threads cursor and appends entries", async () => {
+    let call = 0;
+    const client: FakeClient = {
+      adminSpacesList: mock(async (opts: { afterCursor?: string }) => {
+        call += 1;
+        if (call === 1) {
+          return { entries: [entry("eng@spaces.localhost")], next_cursor: "eng@spaces.localhost" };
+        }
+        expect(opts.afterCursor).toBe("eng@spaces.localhost");
+        return { entries: [entry("design@spaces.localhost")], next_cursor: null };
+      }),
+      adminSpacesCreate: mock(async () => ({})),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    await model.fetchFirstPage("");
+    await model.loadMore();
+    expect(model.entries.length).toBe(2);
+    expect(model.cursor).toBe(null);
+  });
+
+  test("error from loader surfaces into errorMessage", async () => {
+    const client: FakeClient = {
+      adminSpacesList: mock(async () => {
+        throw new Error("forbidden");
+      }),
+      adminSpacesCreate: mock(async () => ({})),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    await model.fetchFirstPage("");
+    expect(model.errorMessage).toBe("forbidden");
+  });
+});
+
+describe("SpacesPanel model — click + create", () => {
+  test("openDetail captures the clicked entry", () => {
+    const client: FakeClient = {
+      adminSpacesList: mock(async () => ({ entries: [], next_cursor: null })),
+      adminSpacesCreate: mock(async () => ({})),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    const target = entry("eng@spaces.localhost");
+    model.openDetail(target);
+    expect(model.selected).toBe(target);
+    model.closeDetail();
+    expect(model.selected).toBe(null);
+  });
+
+  test("create flow calls adminSpacesCreate and refetches", async () => {
+    const calls: string[] = [];
+    const client: FakeClient = {
+      adminSpacesList: mock(async () => {
+        calls.push("list");
+        return { entries: [], next_cursor: null };
+      }),
+      adminSpacesCreate: mock(async (args: { name: string }) => {
+        calls.push(`create:${args.name}`);
+        return { space_jid: "x@spaces.localhost", name: args.name };
+      }),
+      adminSpacesUpdate: mock(async () => ({})),
+      adminSpacesDelete: mock(async () => true),
+      adminSpacesMembers: mock(async () => ({ entries: [] })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const model = new SpacesPanelModel(client);
+    await model.create("Engineering");
+    expect(calls).toEqual(["create:Engineering", "list"]);
+    expect(model.showCreate).toBe(false);
+  });
+});
+
+describe("SpaceDetailDrawer — members + role + delete (model-level)", () => {
+  test("loading members surfaces typed entries", async () => {
+    const members: WasmAdminSpaceMemberEntry[] = [
+      { jid: "alice@localhost", role: "owner" },
+      { jid: "bob@localhost", role: "member" },
+    ];
+    const client = {
+      adminSpacesMembers: mock<() => Promise<WasmAdminSpacesMembersResult>>(async () => ({ entries: members })),
+      adminSpacesSetRole: mock(async () => ({})),
+    };
+    const result = await client.adminSpacesMembers();
+    expect(result.entries[0]?.role).toBe("owner");
+  });
+
+  test("setRole call constructs expected typed payload", async () => {
+    const client = {
+      adminSpacesSetRole: mock(async (args: { spaceJid: string; memberJid: string; role: string }) => {
+        expect(args.spaceJid).toBe("eng@spaces.localhost");
+        expect(args.memberJid).toBe("bob@localhost");
+        expect(args.role).toBe("admin");
+        return { member_jid: args.memberJid, role: args.role };
+      }),
+    };
+    await client.adminSpacesSetRole({ spaceJid: "eng@spaces.localhost", memberJid: "bob@localhost", role: "admin" });
+    expect(client.adminSpacesSetRole).toHaveBeenCalledTimes(1);
+  });
+
+  test("delete confirm hits adminSpacesDelete with confirm semantics", async () => {
+    const client = {
+      adminSpacesDelete: mock(async (args: { spaceJid: string }) => {
+        expect(args.spaceJid).toBe("eng@spaces.localhost");
+        return true;
+      }),
+    };
+    await client.adminSpacesDelete({ spaceJid: "eng@spaces.localhost" });
+    expect(client.adminSpacesDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs
@@ -1,0 +1,1106 @@
+//! Wasm bindings for the V2 admin Spaces + Channels panels.
+//!
+//! Exposes 14 typed wasm-bindgen methods, one per `urn:waddle:admin:*`
+//! ad-hoc command shipped server-side in PRs #685 / #691:
+//!
+//! Spaces (6):
+//! - `admin_spaces_list` — paginated read with optional prefix.
+//! - `admin_spaces_create` — name + optional description / icon.
+//! - `admin_spaces_update` — patch name / description / icon.
+//! - `admin_spaces_delete` — cascade-destroy a space and its channels.
+//! - `admin_spaces_members` — paginated read of a space's pubsub roster.
+//! - `admin_spaces_set_role` — owner | admin | member | none.
+//!
+//! Channels (8):
+//! - `admin_channels_list` — paginated read with optional space filter.
+//! - `admin_channels_create` — name + optional topic / space / is_public.
+//! - `admin_channels_update` — patch name / topic / is_public.
+//! - `admin_channels_delete` — destroy a MUC room.
+//! - `admin_channels_occupants` — live occupancy snapshot.
+//! - `admin_channels_affiliations` — persistent affiliation list,
+//!   optionally tier-filtered.
+//! - `admin_channels_set_affiliation` — owner|admin|member|none|outcast.
+//! - `admin_channels_kick` — XEP-0045 §9.1 role→none.
+//!
+//! All commands follow the V1 `client_admin.rs` shape: serde-typed
+//! Args/Result structs cross the JS boundary via `serde_wasm_bindgen`,
+//! the XEP-0050 IQ is built with `minidom::Element` (no `format!` per
+//! the XML-generation hard rule), and the response form is parsed once
+//! into a typed value. JS never sees raw XML.
+
+use super::*;
+
+// ─── Namespace constants (mirrors server::waddle_xmpp::admin::*) ──────
+
+const NS_ADMIN_SPACES_LIST: &str = "urn:waddle:admin:spaces:list:0";
+const NS_ADMIN_SPACES_CREATE: &str = "urn:waddle:admin:spaces:create:0";
+const NS_ADMIN_SPACES_UPDATE: &str = "urn:waddle:admin:spaces:update:0";
+const NS_ADMIN_SPACES_DELETE: &str = "urn:waddle:admin:spaces:delete:0";
+const NS_ADMIN_SPACES_MEMBERS: &str = "urn:waddle:admin:spaces:members:0";
+const NS_ADMIN_SPACES_SET_ROLE: &str = "urn:waddle:admin:spaces:set-role:0";
+
+const NS_ADMIN_CHANNELS_LIST: &str = "urn:waddle:admin:channels:list:0";
+const NS_ADMIN_CHANNELS_CREATE: &str = "urn:waddle:admin:channels:create:0";
+const NS_ADMIN_CHANNELS_UPDATE: &str = "urn:waddle:admin:channels:update:0";
+const NS_ADMIN_CHANNELS_DELETE: &str = "urn:waddle:admin:channels:delete:0";
+const NS_ADMIN_CHANNELS_OCCUPANTS: &str = "urn:waddle:admin:channels:occupants:0";
+const NS_ADMIN_CHANNELS_AFFILIATIONS: &str = "urn:waddle:admin:channels:affiliations:0";
+const NS_ADMIN_CHANNELS_SET_AFFILIATION: &str = "urn:waddle:admin:channels:set-affiliation:0";
+const NS_ADMIN_CHANNELS_KICK: &str = "urn:waddle:admin:channels:kick:0";
+
+const NS_XDATA: &str = "jabber:x:data";
+
+// ─── Typed Args / Result structs ──────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminSpacesListArgs {
+    pub prefix: Option<String>,
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpaceListEntry {
+    pub space_jid: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub icon_url: Option<String>,
+    pub channel_count: u32,
+    pub member_count: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminSpacesListResult {
+    pub entries: Vec<WaddleAdminSpaceListEntry>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesCreateArgs {
+    pub name: String,
+    pub description: Option<String>,
+    pub icon_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpaceRef {
+    pub space_jid: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub icon_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesUpdateArgs {
+    pub space_jid: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub icon_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesDeleteArgs {
+    pub space_jid: String,
+    /// MUST be the literal string "yes"; mirrors the server-side guard.
+    pub confirm: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesMembersArgs {
+    pub space_jid: String,
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpaceMemberEntry {
+    pub jid: String,
+    /// `owner` | `admin` | `member` | `none`.
+    pub role: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminSpacesMembersResult {
+    pub entries: Vec<WaddleAdminSpaceMemberEntry>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesSetRoleArgs {
+    pub space_jid: String,
+    pub member_jid: String,
+    /// `owner` | `admin` | `member` | `none`.
+    pub role: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminSpacesSetRoleResult {
+    pub member_jid: String,
+    pub role: String,
+}
+
+// ── Channels typed payloads ──────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminChannelsListArgs {
+    pub space_jid: Option<String>,
+    pub prefix: Option<String>,
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelListEntry {
+    pub channel_jid: String,
+    pub name: String,
+    pub topic: Option<String>,
+    pub is_public: bool,
+    pub members_only: bool,
+    pub occupant_count: u32,
+    pub owner_count: u32,
+    pub admin_count: u32,
+    pub member_count: u32,
+    pub outcast_count: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminChannelsListResult {
+    pub entries: Vec<WaddleAdminChannelListEntry>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsCreateArgs {
+    pub name: String,
+    pub topic: Option<String>,
+    pub space_jid: Option<String>,
+    /// Defaults to `true` per the V2 spec; the client wrapper passes
+    /// this through verbatim. The server enforces the same default
+    /// when the field is absent.
+    pub is_public: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelRef {
+    pub channel_jid: String,
+    pub name: String,
+    pub topic: Option<String>,
+    pub is_public: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsUpdateArgs {
+    pub channel_jid: String,
+    pub name: Option<String>,
+    pub topic: Option<String>,
+    pub is_public: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsDeleteArgs {
+    pub channel_jid: String,
+    /// MUST be the literal string "yes".
+    pub confirm: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsOccupantsArgs {
+    pub channel_jid: String,
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelOccupantEntry {
+    pub nick: String,
+    pub real_jid: String,
+    /// `moderator` | `participant` | `visitor` | `none`.
+    pub role: String,
+    /// `owner` | `admin` | `member` | `none` | `outcast`.
+    pub affiliation: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminChannelsOccupantsResult {
+    pub entries: Vec<WaddleAdminChannelOccupantEntry>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsAffiliationsArgs {
+    pub channel_jid: String,
+    /// Optional tier filter: `owner` | `admin` | `member` | `outcast` | `none`.
+    pub filter: Option<String>,
+    pub page_size: Option<u32>,
+    pub after_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelAffiliationEntry {
+    pub jid: String,
+    pub affiliation: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct WaddleAdminChannelsAffiliationsResult {
+    pub entries: Vec<WaddleAdminChannelAffiliationEntry>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsSetAffiliationArgs {
+    pub channel_jid: String,
+    pub member_jid: String,
+    pub affiliation: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsSetAffiliationResult {
+    pub member_jid: String,
+    pub affiliation: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsKickArgs {
+    pub channel_jid: String,
+    pub occupant_jid: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaddleAdminChannelsKickResult {
+    pub occupant_jid: String,
+}
+
+// ─── #[wasm_bindgen] methods ──────────────────────────────────────────
+
+#[wasm_bindgen]
+impl WaddleClient {
+    pub fn admin_spaces_list(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesListArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_list_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let page = parse_spaces_list_result(&result)?;
+            to_js_value(&page)
+        })
+    }
+
+    pub fn admin_spaces_create(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesCreateArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_create_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let space = parse_space_ref_result(&result)?;
+            to_js_value(&space)
+        })
+    }
+
+    pub fn admin_spaces_update(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesUpdateArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_update_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let space = parse_space_ref_result(&result)?;
+            to_js_value(&space)
+        })
+    }
+
+    pub fn admin_spaces_delete(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesDeleteArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_delete_iq(&domain, &parsed);
+            let _ = send_iq_command(inner, iq).await?;
+            Ok(JsValue::TRUE)
+        })
+    }
+
+    pub fn admin_spaces_members(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesMembersArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_members_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let page = parse_spaces_members_result(&result)?;
+            to_js_value(&page)
+        })
+    }
+
+    pub fn admin_spaces_set_role(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminSpacesSetRoleArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_spaces_set_role_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let payload = parse_spaces_set_role_result(&result)?;
+            to_js_value(&payload)
+        })
+    }
+
+    pub fn admin_channels_list(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsListArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_list_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let page = parse_channels_list_result(&result)?;
+            to_js_value(&page)
+        })
+    }
+
+    pub fn admin_channels_create(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsCreateArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_create_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let channel = parse_channel_ref_result(&result)?;
+            to_js_value(&channel)
+        })
+    }
+
+    pub fn admin_channels_update(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsUpdateArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_update_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let channel = parse_channel_ref_result(&result)?;
+            to_js_value(&channel)
+        })
+    }
+
+    pub fn admin_channels_delete(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsDeleteArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_delete_iq(&domain, &parsed);
+            let _ = send_iq_command(inner, iq).await?;
+            Ok(JsValue::TRUE)
+        })
+    }
+
+    pub fn admin_channels_occupants(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsOccupantsArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_occupants_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let page = parse_channels_occupants_result(&result)?;
+            to_js_value(&page)
+        })
+    }
+
+    pub fn admin_channels_affiliations(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsAffiliationsArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_affiliations_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let page = parse_channels_affiliations_result(&result)?;
+            to_js_value(&page)
+        })
+    }
+
+    pub fn admin_channels_set_affiliation(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsSetAffiliationArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_set_affiliation_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let payload = parse_channels_set_affiliation_result(&result)?;
+            to_js_value(&payload)
+        })
+    }
+
+    pub fn admin_channels_kick(&self, args: JsValue) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            let parsed: WaddleAdminChannelsKickArgs =
+                serde_wasm_bindgen::from_value(args).map_err(|e| js_error(e.to_string()))?;
+            let domain = caller_domain(&inner);
+            let iq = build_channels_kick_iq(&domain, &parsed);
+            let result = send_iq_command(inner, iq).await?;
+            let payload = parse_channels_kick_result(&result)?;
+            to_js_value(&payload)
+        })
+    }
+}
+
+// ─── IQ helpers ───────────────────────────────────────────────────────
+
+fn caller_domain(inner: &Rc<RefCell<WaddleClientInner>>) -> String {
+    let stored = inner.borrow().config.clone();
+    jid_domain(&stored.jid)
+}
+
+fn text_single_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_XDATA)
+        .attr("var", var)
+        .attr("type", "text-single")
+        .append(Element::builder("value", NS_XDATA).append(value).build())
+        .build()
+}
+
+fn boolean_field(var: &str, value: bool) -> Element {
+    Element::builder("field", NS_XDATA)
+        .attr("var", var)
+        .attr("type", "boolean")
+        .append(
+            Element::builder("value", NS_XDATA)
+                .append(if value { "1" } else { "0" })
+                .build(),
+        )
+        .build()
+}
+
+fn jid_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_XDATA)
+        .attr("var", var)
+        .attr("type", "jid-single")
+        .append(Element::builder("value", NS_XDATA).append(value).build())
+        .build()
+}
+
+fn submit_form_with_type(form_type: &str) -> minidom::element::ElementBuilder {
+    Element::builder("x", NS_XDATA)
+        .attr("type", "submit")
+        .append(
+            Element::builder("field", NS_XDATA)
+                .attr("var", "FORM_TYPE")
+                .attr("type", "hidden")
+                .append(
+                    Element::builder("value", NS_XDATA)
+                        .append(form_type)
+                        .build(),
+                )
+                .build(),
+        )
+}
+
+fn wrap_command_iq(server_domain: &str, node: &str, form: Element) -> Element {
+    let command = Element::builder("command", NS_ADHOC_COMMANDS)
+        .attr("node", node)
+        .attr("action", "execute")
+        .append(form)
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
+        .attr("id", uuid::Uuid::new_v4().to_string())
+        .attr("to", server_domain)
+        .append(command)
+        .build()
+}
+
+// ─── IQ builders ──────────────────────────────────────────────────────
+
+fn build_spaces_list_iq(server_domain: &str, args: &WaddleAdminSpacesListArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_SPACES_LIST);
+    if let Some(prefix) = args.prefix.as_deref() {
+        form = form.append(text_single_field("prefix", prefix));
+    }
+    if let Some(page_size) = args.page_size {
+        form = form.append(text_single_field("page_size", &page_size.to_string()));
+    }
+    if let Some(after_cursor) = args.after_cursor.as_deref() {
+        form = form.append(text_single_field("after_cursor", after_cursor));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_LIST, form.build())
+}
+
+fn build_spaces_create_iq(server_domain: &str, args: &WaddleAdminSpacesCreateArgs) -> Element {
+    let mut form =
+        submit_form_with_type(NS_ADMIN_SPACES_CREATE).append(text_single_field("name", &args.name));
+    if let Some(description) = args.description.as_deref() {
+        form = form.append(text_single_field("description", description));
+    }
+    if let Some(icon_url) = args.icon_url.as_deref() {
+        form = form.append(text_single_field("icon_url", icon_url));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_CREATE, form.build())
+}
+
+fn build_spaces_update_iq(server_domain: &str, args: &WaddleAdminSpacesUpdateArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_SPACES_UPDATE)
+        .append(jid_field("space_jid", &args.space_jid));
+    if let Some(name) = args.name.as_deref() {
+        form = form.append(text_single_field("name", name));
+    }
+    if let Some(description) = args.description.as_deref() {
+        form = form.append(text_single_field("description", description));
+    }
+    if let Some(icon_url) = args.icon_url.as_deref() {
+        form = form.append(text_single_field("icon_url", icon_url));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_UPDATE, form.build())
+}
+
+fn build_spaces_delete_iq(server_domain: &str, args: &WaddleAdminSpacesDeleteArgs) -> Element {
+    let form = submit_form_with_type(NS_ADMIN_SPACES_DELETE)
+        .append(jid_field("space_jid", &args.space_jid))
+        .append(text_single_field("confirm", &args.confirm));
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_DELETE, form.build())
+}
+
+fn build_spaces_members_iq(server_domain: &str, args: &WaddleAdminSpacesMembersArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_SPACES_MEMBERS)
+        .append(jid_field("space_jid", &args.space_jid));
+    if let Some(page_size) = args.page_size {
+        form = form.append(text_single_field("page_size", &page_size.to_string()));
+    }
+    if let Some(after_cursor) = args.after_cursor.as_deref() {
+        form = form.append(text_single_field("after_cursor", after_cursor));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_MEMBERS, form.build())
+}
+
+fn build_spaces_set_role_iq(server_domain: &str, args: &WaddleAdminSpacesSetRoleArgs) -> Element {
+    let form = submit_form_with_type(NS_ADMIN_SPACES_SET_ROLE)
+        .append(jid_field("space_jid", &args.space_jid))
+        .append(jid_field("member_jid", &args.member_jid))
+        .append(text_single_field("role", &args.role));
+    wrap_command_iq(server_domain, NS_ADMIN_SPACES_SET_ROLE, form.build())
+}
+
+fn build_channels_list_iq(server_domain: &str, args: &WaddleAdminChannelsListArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_LIST);
+    if let Some(space_jid) = args.space_jid.as_deref() {
+        form = form.append(jid_field("space_jid", space_jid));
+    }
+    if let Some(prefix) = args.prefix.as_deref() {
+        form = form.append(text_single_field("prefix", prefix));
+    }
+    if let Some(page_size) = args.page_size {
+        form = form.append(text_single_field("page_size", &page_size.to_string()));
+    }
+    if let Some(after_cursor) = args.after_cursor.as_deref() {
+        form = form.append(text_single_field("after_cursor", after_cursor));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_LIST, form.build())
+}
+
+fn build_channels_create_iq(server_domain: &str, args: &WaddleAdminChannelsCreateArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_CREATE)
+        .append(text_single_field("name", &args.name));
+    if let Some(topic) = args.topic.as_deref() {
+        form = form.append(text_single_field("topic", topic));
+    }
+    if let Some(space_jid) = args.space_jid.as_deref() {
+        form = form.append(jid_field("space_jid", space_jid));
+    }
+    if let Some(is_public) = args.is_public {
+        form = form.append(boolean_field("is_public", is_public));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_CREATE, form.build())
+}
+
+fn build_channels_update_iq(server_domain: &str, args: &WaddleAdminChannelsUpdateArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_UPDATE)
+        .append(jid_field("channel_jid", &args.channel_jid));
+    if let Some(name) = args.name.as_deref() {
+        form = form.append(text_single_field("name", name));
+    }
+    if let Some(topic) = args.topic.as_deref() {
+        form = form.append(text_single_field("topic", topic));
+    }
+    if let Some(is_public) = args.is_public {
+        form = form.append(boolean_field("is_public", is_public));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_UPDATE, form.build())
+}
+
+fn build_channels_delete_iq(server_domain: &str, args: &WaddleAdminChannelsDeleteArgs) -> Element {
+    let form = submit_form_with_type(NS_ADMIN_CHANNELS_DELETE)
+        .append(jid_field("channel_jid", &args.channel_jid))
+        .append(text_single_field("confirm", &args.confirm));
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_DELETE, form.build())
+}
+
+fn build_channels_occupants_iq(
+    server_domain: &str,
+    args: &WaddleAdminChannelsOccupantsArgs,
+) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_OCCUPANTS)
+        .append(jid_field("channel_jid", &args.channel_jid));
+    if let Some(page_size) = args.page_size {
+        form = form.append(text_single_field("page_size", &page_size.to_string()));
+    }
+    if let Some(after_cursor) = args.after_cursor.as_deref() {
+        form = form.append(text_single_field("after_cursor", after_cursor));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_OCCUPANTS, form.build())
+}
+
+fn build_channels_affiliations_iq(
+    server_domain: &str,
+    args: &WaddleAdminChannelsAffiliationsArgs,
+) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_AFFILIATIONS)
+        .append(jid_field("channel_jid", &args.channel_jid));
+    if let Some(filter) = args.filter.as_deref() {
+        form = form.append(text_single_field("filter", filter));
+    }
+    if let Some(page_size) = args.page_size {
+        form = form.append(text_single_field("page_size", &page_size.to_string()));
+    }
+    if let Some(after_cursor) = args.after_cursor.as_deref() {
+        form = form.append(text_single_field("after_cursor", after_cursor));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_AFFILIATIONS, form.build())
+}
+
+fn build_channels_set_affiliation_iq(
+    server_domain: &str,
+    args: &WaddleAdminChannelsSetAffiliationArgs,
+) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_SET_AFFILIATION)
+        .append(jid_field("channel_jid", &args.channel_jid))
+        .append(jid_field("member_jid", &args.member_jid))
+        .append(text_single_field("affiliation", &args.affiliation));
+    if let Some(reason) = args.reason.as_deref() {
+        form = form.append(text_single_field("reason", reason));
+    }
+    wrap_command_iq(
+        server_domain,
+        NS_ADMIN_CHANNELS_SET_AFFILIATION,
+        form.build(),
+    )
+}
+
+fn build_channels_kick_iq(server_domain: &str, args: &WaddleAdminChannelsKickArgs) -> Element {
+    let mut form = submit_form_with_type(NS_ADMIN_CHANNELS_KICK)
+        .append(jid_field("channel_jid", &args.channel_jid))
+        .append(jid_field("occupant_jid", &args.occupant_jid));
+    if let Some(reason) = args.reason.as_deref() {
+        form = form.append(text_single_field("reason", reason));
+    }
+    wrap_command_iq(server_domain, NS_ADMIN_CHANNELS_KICK, form.build())
+}
+
+// ─── Response parsers ─────────────────────────────────────────────────
+
+fn command_form(iq: &Element) -> Result<&Element, JsValue> {
+    let command = iq
+        .get_child("command", NS_ADHOC_COMMANDS)
+        .ok_or_else(|| js_error("admin response missing <command/>"))?;
+    command
+        .get_child("x", NS_XDATA)
+        .ok_or_else(|| js_error("admin response missing <x xmlns='jabber:x:data'/>"))
+}
+
+fn maybe_command_form(iq: &Element) -> Option<&Element> {
+    iq.get_child("command", NS_ADHOC_COMMANDS)
+        .and_then(|cmd| cmd.get_child("x", NS_XDATA))
+}
+
+fn field_text(item: &Element, var: &str) -> Option<String> {
+    item.children()
+        .filter(|c| c.name() == "field" && c.attr("var") == Some(var))
+        .find_map(|field| field.get_child("value", NS_XDATA).map(|value| value.text()))
+}
+
+fn field_text_required(item: &Element, var: &str) -> String {
+    field_text(item, var).unwrap_or_default()
+}
+
+fn field_bool(item: &Element, var: &str) -> bool {
+    field_text(item, var)
+        .map(|raw| matches!(raw.as_str(), "1" | "true"))
+        .unwrap_or(false)
+}
+
+fn field_u32(item: &Element, var: &str) -> u32 {
+    field_text(item, var)
+        .and_then(|raw| raw.parse::<u32>().ok())
+        .unwrap_or(0)
+}
+
+fn top_level_next_cursor(form: &Element) -> Option<String> {
+    form.children()
+        .filter(|c| c.name() == "field" && c.attr("var") == Some("next_cursor"))
+        .find_map(|field| {
+            field
+                .get_child("value", NS_XDATA)
+                .map(|value| value.text())
+                .filter(|s| !s.is_empty())
+        })
+}
+
+fn parse_spaces_list_result(iq: &Element) -> Result<WaddleAdminSpacesListResult, JsValue> {
+    let Some(form) = maybe_command_form(iq) else {
+        return Ok(WaddleAdminSpacesListResult::default());
+    };
+    let mut entries = Vec::new();
+    for item in form.children().filter(|c| c.name() == "item") {
+        entries.push(WaddleAdminSpaceListEntry {
+            space_jid: field_text_required(item, "space_jid"),
+            name: field_text_required(item, "name"),
+            description: field_text(item, "description").filter(|s| !s.is_empty()),
+            icon_url: field_text(item, "icon_url").filter(|s| !s.is_empty()),
+            channel_count: field_u32(item, "channel_count"),
+            member_count: field_u32(item, "member_count"),
+        });
+    }
+    Ok(WaddleAdminSpacesListResult {
+        entries,
+        next_cursor: top_level_next_cursor(form),
+    })
+}
+
+fn parse_space_ref_result(iq: &Element) -> Result<WaddleAdminSpaceRef, JsValue> {
+    let form = command_form(iq)?;
+    Ok(WaddleAdminSpaceRef {
+        space_jid: top_level_field_text(form, "space_jid"),
+        name: top_level_field_text(form, "name"),
+        description: top_level_field_text_opt(form, "description"),
+        icon_url: top_level_field_text_opt(form, "icon_url"),
+    })
+}
+
+fn top_level_field_text(form: &Element, var: &str) -> String {
+    form.children()
+        .filter(|c| c.name() == "field" && c.attr("var") == Some(var))
+        .find_map(|field| field.get_child("value", NS_XDATA).map(|value| value.text()))
+        .unwrap_or_default()
+}
+
+fn top_level_field_text_opt(form: &Element, var: &str) -> Option<String> {
+    let text = top_level_field_text(form, var);
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn parse_spaces_members_result(iq: &Element) -> Result<WaddleAdminSpacesMembersResult, JsValue> {
+    let Some(form) = maybe_command_form(iq) else {
+        return Ok(WaddleAdminSpacesMembersResult::default());
+    };
+    let mut entries = Vec::new();
+    for item in form.children().filter(|c| c.name() == "item") {
+        entries.push(WaddleAdminSpaceMemberEntry {
+            jid: field_text_required(item, "jid"),
+            role: field_text_required(item, "role"),
+        });
+    }
+    Ok(WaddleAdminSpacesMembersResult {
+        entries,
+        next_cursor: top_level_next_cursor(form),
+    })
+}
+
+fn parse_spaces_set_role_result(iq: &Element) -> Result<WaddleAdminSpacesSetRoleResult, JsValue> {
+    let form = command_form(iq)?;
+    Ok(WaddleAdminSpacesSetRoleResult {
+        member_jid: top_level_field_text(form, "member_jid"),
+        role: top_level_field_text(form, "role"),
+    })
+}
+
+fn parse_channels_list_result(iq: &Element) -> Result<WaddleAdminChannelsListResult, JsValue> {
+    let Some(form) = maybe_command_form(iq) else {
+        return Ok(WaddleAdminChannelsListResult::default());
+    };
+    let mut entries = Vec::new();
+    for item in form.children().filter(|c| c.name() == "item") {
+        entries.push(WaddleAdminChannelListEntry {
+            channel_jid: field_text_required(item, "channel_jid"),
+            name: field_text_required(item, "name"),
+            topic: field_text(item, "topic").filter(|s| !s.is_empty()),
+            is_public: field_bool(item, "is_public"),
+            members_only: field_bool(item, "members_only"),
+            occupant_count: field_u32(item, "occupant_count"),
+            owner_count: field_u32(item, "owner_count"),
+            admin_count: field_u32(item, "admin_count"),
+            member_count: field_u32(item, "member_count"),
+            outcast_count: field_u32(item, "outcast_count"),
+        });
+    }
+    Ok(WaddleAdminChannelsListResult {
+        entries,
+        next_cursor: top_level_next_cursor(form),
+    })
+}
+
+fn parse_channel_ref_result(iq: &Element) -> Result<WaddleAdminChannelRef, JsValue> {
+    let form = command_form(iq)?;
+    Ok(WaddleAdminChannelRef {
+        channel_jid: top_level_field_text(form, "channel_jid"),
+        name: top_level_field_text(form, "name"),
+        topic: top_level_field_text_opt(form, "topic"),
+        is_public: matches!(
+            top_level_field_text(form, "is_public").as_str(),
+            "1" | "true"
+        ),
+    })
+}
+
+fn parse_channels_occupants_result(
+    iq: &Element,
+) -> Result<WaddleAdminChannelsOccupantsResult, JsValue> {
+    let Some(form) = maybe_command_form(iq) else {
+        return Ok(WaddleAdminChannelsOccupantsResult::default());
+    };
+    let mut entries = Vec::new();
+    for item in form.children().filter(|c| c.name() == "item") {
+        entries.push(WaddleAdminChannelOccupantEntry {
+            nick: field_text_required(item, "nick"),
+            real_jid: field_text_required(item, "real_jid"),
+            role: field_text_required(item, "role"),
+            affiliation: field_text_required(item, "affiliation"),
+        });
+    }
+    Ok(WaddleAdminChannelsOccupantsResult {
+        entries,
+        next_cursor: top_level_next_cursor(form),
+    })
+}
+
+fn parse_channels_affiliations_result(
+    iq: &Element,
+) -> Result<WaddleAdminChannelsAffiliationsResult, JsValue> {
+    let Some(form) = maybe_command_form(iq) else {
+        return Ok(WaddleAdminChannelsAffiliationsResult::default());
+    };
+    let mut entries = Vec::new();
+    for item in form.children().filter(|c| c.name() == "item") {
+        entries.push(WaddleAdminChannelAffiliationEntry {
+            jid: field_text_required(item, "jid"),
+            affiliation: field_text_required(item, "affiliation"),
+            reason: field_text(item, "reason").filter(|s| !s.is_empty()),
+        });
+    }
+    Ok(WaddleAdminChannelsAffiliationsResult {
+        entries,
+        next_cursor: top_level_next_cursor(form),
+    })
+}
+
+fn parse_channels_set_affiliation_result(
+    iq: &Element,
+) -> Result<WaddleAdminChannelsSetAffiliationResult, JsValue> {
+    let form = command_form(iq)?;
+    Ok(WaddleAdminChannelsSetAffiliationResult {
+        member_jid: top_level_field_text(form, "member_jid"),
+        affiliation: top_level_field_text(form, "affiliation"),
+    })
+}
+
+fn parse_channels_kick_result(iq: &Element) -> Result<WaddleAdminChannelsKickResult, JsValue> {
+    let form = command_form(iq)?;
+    Ok(WaddleAdminChannelsKickResult {
+        occupant_jid: top_level_field_text(form, "occupant_jid"),
+    })
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrap_response(node: &str, form_inner: &str) -> Element {
+        let raw = format!(
+            r#"<iq xmlns='jabber:client' type='result' id='test'><command xmlns='http://jabber.org/protocol/commands' node='{node}' status='completed'><x xmlns='jabber:x:data' type='result'><field type="hidden" var="FORM_TYPE"><value>{node}</value></field>{form_inner}</x></command></iq>"#
+        );
+        raw.parse().expect("parse iq")
+    }
+
+    #[test]
+    fn parse_spaces_list_handles_empty_form() {
+        let iq = wrap_response(NS_ADMIN_SPACES_LIST, "");
+        let result = parse_spaces_list_result(&iq).expect("ok");
+        assert!(result.entries.is_empty());
+        assert!(result.next_cursor.is_none());
+    }
+
+    #[test]
+    fn parse_spaces_list_extracts_counts_and_cursor() {
+        let item = r#"<item>
+            <field var="space_jid"><value>eng@spaces.localhost</value></field>
+            <field var="name"><value>Engineering</value></field>
+            <field var="description"><value>Hack stuff</value></field>
+            <field var="icon_url"><value></value></field>
+            <field var="channel_count"><value>3</value></field>
+            <field var="member_count"><value>5</value></field>
+        </item>"#;
+        let cursor = r#"<field var="next_cursor" type="text-single"><value>eng@spaces.localhost</value></field>"#;
+        let iq = wrap_response(NS_ADMIN_SPACES_LIST, &format!("{item}{cursor}"));
+        let result = parse_spaces_list_result(&iq).expect("ok");
+        assert_eq!(result.entries.len(), 1);
+        let entry = &result.entries[0];
+        assert_eq!(entry.space_jid, "eng@spaces.localhost");
+        assert_eq!(entry.name, "Engineering");
+        assert_eq!(entry.description.as_deref(), Some("Hack stuff"));
+        assert!(entry.icon_url.is_none());
+        assert_eq!(entry.channel_count, 3);
+        assert_eq!(entry.member_count, 5);
+        assert_eq!(result.next_cursor.as_deref(), Some("eng@spaces.localhost"));
+    }
+
+    #[test]
+    fn parse_space_ref_round_trip() {
+        let inner = r#"<field var="space_jid"><value>eng@spaces.localhost</value></field>
+            <field var="name"><value>Engineering</value></field>
+            <field var="description"><value>Hack stuff</value></field>"#;
+        let iq = wrap_response(NS_ADMIN_SPACES_CREATE, inner);
+        let space = parse_space_ref_result(&iq).expect("ok");
+        assert_eq!(space.space_jid, "eng@spaces.localhost");
+        assert_eq!(space.name, "Engineering");
+        assert_eq!(space.description.as_deref(), Some("Hack stuff"));
+        assert!(space.icon_url.is_none());
+    }
+
+    #[test]
+    fn parse_spaces_members_extracts_roles() {
+        let inner = r#"<item>
+            <field var="jid"><value>alice@localhost</value></field>
+            <field var="role"><value>owner</value></field>
+        </item>
+        <item>
+            <field var="jid"><value>bob@localhost</value></field>
+            <field var="role"><value>member</value></field>
+        </item>"#;
+        let iq = wrap_response(NS_ADMIN_SPACES_MEMBERS, inner);
+        let result = parse_spaces_members_result(&iq).expect("ok");
+        assert_eq!(result.entries.len(), 2);
+        assert_eq!(result.entries[0].role, "owner");
+        assert_eq!(result.entries[1].jid, "bob@localhost");
+    }
+
+    #[test]
+    fn parse_channels_list_extracts_booleans_and_counts() {
+        let item = r#"<item>
+            <field var="channel_jid"><value>general@muc.localhost</value></field>
+            <field var="name"><value>General</value></field>
+            <field var="topic"><value>All things</value></field>
+            <field var="is_public" type="boolean"><value>1</value></field>
+            <field var="members_only" type="boolean"><value>0</value></field>
+            <field var="occupant_count"><value>7</value></field>
+            <field var="owner_count"><value>1</value></field>
+            <field var="admin_count"><value>2</value></field>
+            <field var="member_count"><value>3</value></field>
+            <field var="outcast_count"><value>0</value></field>
+        </item>"#;
+        let iq = wrap_response(NS_ADMIN_CHANNELS_LIST, item);
+        let result = parse_channels_list_result(&iq).expect("ok");
+        assert_eq!(result.entries.len(), 1);
+        let entry = &result.entries[0];
+        assert!(entry.is_public);
+        assert!(!entry.members_only);
+        assert_eq!(entry.occupant_count, 7);
+        assert_eq!(entry.owner_count, 1);
+        assert_eq!(entry.admin_count, 2);
+        assert_eq!(entry.member_count, 3);
+    }
+
+    #[test]
+    fn parse_channels_occupants_extracts_role_and_affiliation() {
+        let inner = r#"<item>
+            <field var="nick"><value>alice</value></field>
+            <field var="real_jid"><value>alice@localhost/web</value></field>
+            <field var="role"><value>moderator</value></field>
+            <field var="affiliation"><value>owner</value></field>
+        </item>"#;
+        let iq = wrap_response(NS_ADMIN_CHANNELS_OCCUPANTS, inner);
+        let result = parse_channels_occupants_result(&iq).expect("ok");
+        assert_eq!(result.entries.len(), 1);
+        let entry = &result.entries[0];
+        assert_eq!(entry.nick, "alice");
+        assert_eq!(entry.role, "moderator");
+        assert_eq!(entry.affiliation, "owner");
+    }
+
+    #[test]
+    fn build_spaces_list_iq_omits_unset_fields() {
+        let args = WaddleAdminSpacesListArgs::default();
+        let iq = build_spaces_list_iq("localhost", &args);
+        assert_eq!(iq.name(), "iq");
+        assert_eq!(iq.attr("to"), Some("localhost"));
+        let cmd = iq.get_child("command", NS_ADHOC_COMMANDS).expect("command");
+        assert_eq!(cmd.attr("node"), Some(NS_ADMIN_SPACES_LIST));
+        let form = cmd.get_child("x", NS_XDATA).expect("form");
+        let var_names: Vec<&str> = form
+            .children()
+            .filter(|c| c.name() == "field")
+            .filter_map(|f| f.attr("var"))
+            .collect();
+        assert_eq!(var_names, vec!["FORM_TYPE"]);
+    }
+
+    #[test]
+    fn build_channels_create_iq_includes_all_optional_fields() {
+        let args = WaddleAdminChannelsCreateArgs {
+            name: "general".to_string(),
+            topic: Some("All things".to_string()),
+            space_jid: Some("eng@spaces.localhost".to_string()),
+            is_public: Some(true),
+        };
+        let iq = build_channels_create_iq("localhost", &args);
+        let form = iq
+            .get_child("command", NS_ADHOC_COMMANDS)
+            .and_then(|c| c.get_child("x", NS_XDATA))
+            .expect("form");
+        let var_names: Vec<&str> = form
+            .children()
+            .filter(|c| c.name() == "field")
+            .filter_map(|f| f.attr("var"))
+            .collect();
+        assert!(var_names.contains(&"name"));
+        assert!(var_names.contains(&"topic"));
+        assert!(var_names.contains(&"space_jid"));
+        assert!(var_names.contains(&"is_public"));
+    }
+
+    #[test]
+    fn build_spaces_delete_iq_carries_confirm() {
+        let args = WaddleAdminSpacesDeleteArgs {
+            space_jid: "eng@spaces.localhost".to_string(),
+            confirm: "yes".to_string(),
+        };
+        let iq = build_spaces_delete_iq("localhost", &args);
+        let form = iq
+            .get_child("command", NS_ADHOC_COMMANDS)
+            .and_then(|c| c.get_child("x", NS_XDATA))
+            .expect("form");
+        let confirm_value = form
+            .children()
+            .filter(|c| c.name() == "field" && c.attr("var") == Some("confirm"))
+            .find_map(|f| f.get_child("value", NS_XDATA).map(|v| v.text()))
+            .expect("confirm field");
+        assert_eq!(confirm_value, "yes");
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -58,6 +58,7 @@ use wasm_bindgen_futures::{future_to_promise, spawn_local};
 
 mod client_account;
 mod client_admin;
+mod client_admin_v2;
 mod client_core;
 mod client_extensions;
 mod client_history;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -4,6 +4,20 @@
 export class WaddleClient {
     free(): void;
     [Symbol.dispose](): void;
+    admin_channels_affiliations(args: any): Promise<any>;
+    admin_channels_create(args: any): Promise<any>;
+    admin_channels_delete(args: any): Promise<any>;
+    admin_channels_kick(args: any): Promise<any>;
+    admin_channels_list(args: any): Promise<any>;
+    admin_channels_occupants(args: any): Promise<any>;
+    admin_channels_set_affiliation(args: any): Promise<any>;
+    admin_channels_update(args: any): Promise<any>;
+    admin_spaces_create(args: any): Promise<any>;
+    admin_spaces_delete(args: any): Promise<any>;
+    admin_spaces_list(args: any): Promise<any>;
+    admin_spaces_members(args: any): Promise<any>;
+    admin_spaces_set_role(args: any): Promise<any>;
+    admin_spaces_update(args: any): Promise<any>;
     /**
      * Call the `urn:waddle:admin:users:list:0` ad-hoc command
      * against the user-bearing server domain and return a typed

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpa1h96u";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpay6lak";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpay6lak";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpay6lak";
 
 let initPromise;
 
@@ -26,4 +26,4 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mpa1h96u";
+export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mpay6lak";


### PR DESCRIPTION
## Summary

Chat UI follow-up to the admin V2 server cut (#685, #690, #691). Lights up the Spaces and Channels admin panels with full read+write over the 14 `urn:waddle:admin:*` ad-hoc commands the server ships, and makes the entire admin surface mobile-friendly.

Spec: `docs/superpowers/specs/2026-05-17-admin-v2-design.md`. Plan (tasks 9–14): `docs/superpowers/plans/2026-05-17-admin-v2-implementation.md`.

## What's in

### Wasm bindings (14 typed methods)
`server/crates/waddle-xmpp-client-wasm/src/client_admin_v2.rs` — one `#[wasm_bindgen]` method per command, serde-typed Args/Result structs across the JS boundary, XEP-0050 IQs built with `minidom::Element` (no `format!`), responses parsed once into typed Rust values.

Spaces: `admin_spaces_{list,create,update,delete,members,set_role}`.
Channels: `admin_channels_{list,create,update,delete,occupants,affiliations,set_affiliation,kick}`.

9 unit tests cover the parsers + IQ shape guarantees.

### TypeScript wrappers
`chat/src/lib/xmpp/client.ts` — 14 camelCase `BrowserXmppClient` methods (`adminSpacesList`, `adminChannelsKick`, …). Args interfaces are inlined in each wrapper signature; Result interfaces live in `wasm-types.ts` and are re-exported from `lib/xmpp` for the components.

### Vue components
`chat/src/components/admin/`:

- **`SpacesPanel.vue`** — prefix search (200ms debounce) + paginated list + "+" create button. Rows show name, JID, channel + member count chips.
- **`SpaceDetailDrawer.vue`** — slide-from-right drawer with editor (name/description/icon), members (list + per-row role dropdown), and danger zone (delete with cascade-confirmation).
- **`SpaceCreateDialog.vue`** — modal with name + optional description + optional icon URL.
- **`ChannelsPanel.vue`** — same shape as SpacesPanel, with a space-filter chip row above the search input. Rows show name, JID, topic, live + member count chips, and a "Private" chip for non-public rooms.
- **`ChannelDetailDrawer.vue`** — three-tab slide-from-right drawer:
  - **Config** — edit name / topic / is_public + danger-zone delete.
  - **Affiliations** — list + per-row affiliation dropdown (owner/admin/member/none/outcast).
  - **Occupants** — live list + per-row kick (strips the resource off `real_jid` before calling `adminChannelsKick`).
- **`ChannelCreateDialog.vue`** — name + topic + optional space picker + `is_public` toggle (default `true`, helper text "Anyone in the community can join").
- **`AffiliationRow.vue` / `OccupantRow.vue`** — reusable row components.

`chat/src/pages/admin/{spaces,channels}.astro` — mounts the new panels via `AdminView` + `AdminLayout`.

### Mobile AdminLayout
`AdminLayout.vue` refactored: pinned 16rem sidebar column on `lg+`, slide-from-left drawer below `lg` toggled by a hamburger in the mobile header. Backdrop tap / ESC / panel selection closes the drawer. Mirrors the existing `ChatMobileDrawers` UX pattern.

### Tests
`chat/tests/admin-spaces-panel.test.ts` + `chat/tests/admin-channels-panel.test.ts` — 14 state-machine tests against a fake `BrowserXmppClient`. Same modelling style as the existing V1 `admin-users-panel.test.ts`.

## Wire surface

No new wire shapes — all 14 commands were already shipped server-side in #685 / #690 / #691.

## Test plan

- [x] `cargo test -p waddle-xmpp-client-wasm` → 29 pass (9 new V2 parser/builder tests)
- [x] `cargo clippy -p waddle-xmpp-client-wasm --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bun test tests/admin-{spaces,channels,users}-panel.test.ts` → 22 pass
- [x] `bun run lint` (knip) clean
- [x] `bunx tsc --noEmit` clean
- [ ] Manual mobile breakpoint check at 375px
- [ ] Manual create / edit / delete round-trip against a running server

This PR was created with the assistance of a LLM.