### PR TITLE
feat(chat): persistent formatting toolbar in composer

### DIFF
--- a/chat/src/components/chat/ComposerFormatButtons.vue
+++ b/chat/src/components/chat/ComposerFormatButtons.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { Bold, Italic, Code, Link as LinkIcon } from "lucide-vue-next";
+import type { Editor } from "@tiptap/core";
+import { formatModShortcut } from "@/lib/composer/format-shortcut";
+
+const props = defineProps<{
+  editor: Editor | null;
+  disabled: boolean;
+  /**
+   * Counter that bumps on every editor transaction so the parent can force
+   * this component to re-evaluate `editor.isActive(...)`. Read in the
+   * `items` computed solely to establish reactivity.
+   */
+  formatVersion: number;
+  linkActive?: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggle: [mark: "bold" | "italic" | "code"];
+  openLink: [];
+}>();
+
+const items = computed(() => {
+  void props.formatVersion;
+  const editor = props.editor;
+  const linkOn = props.linkActive ?? editor?.isActive("link") ?? false;
+  return [
+    {
+      name: "bold" as const,
+      icon: Bold,
+      title: `Bold (${formatModShortcut("Mod-B")})`,
+      isActive: editor?.isActive("bold") ?? false,
+      action: () => emit("toggle", "bold"),
+    },
+    {
+      name: "italic" as const,
+      icon: Italic,
+      title: `Italic (${formatModShortcut("Mod-I")})`,
+      isActive: editor?.isActive("italic") ?? false,
+      action: () => emit("toggle", "italic"),
+    },
+    {
+      name: "code" as const,
+      icon: Code,
+      title: `Inline code (${formatModShortcut("Mod-E")})`,
+      isActive: editor?.isActive("code") ?? false,
+      action: () => emit("toggle", "code"),
+    },
+    {
+      name: "link" as const,
+      icon: LinkIcon,
+      // Tooltip flips so users know whether clicking will surface the existing
+      // link's URL for editing or prompt for a new one.
+      title: `${linkOn ? "Edit link" : "Add link"} (${formatModShortcut("Mod-K")})`,
+      isActive: linkOn,
+      action: () => emit("openLink"),
+    },
+  ];
+});
+</script>
+
+<template>
+  <div class="flex items-center gap-1">
+    <button
+      v-for="item in items"
+      :key="item.name"
+      type="button"
+      class="chat-composer-input-action h-9 w-9 shrink-0 flex items-center justify-center transition-all duration-200 active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
+      :class="
+        disabled
+          ? 'text-muted-foreground'
+          : item.isActive
+            ? 'bg-primary/10 text-primary'
+            : 'text-muted-foreground hover:bg-background/70 hover:text-primary'
+      "
+      :title="item.title"
+      :aria-label="item.title"
+      :aria-pressed="item.isActive"
+      :disabled="disabled"
+      @mousedown.prevent
+      @click="item.action"
+    >
+      <component :is="item.icon" class="w-4 h-4" aria-hidden="true" />
+    </button>
+  </div>
+</template>

--- a/chat/src/components/chat/EditorBubbleToolbar.vue
+++ b/chat/src/components/chat/EditorBubbleToolbar.vue
@@ -1,22 +1,16 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from "vue";
+import { computed } from "vue";
 import type { Editor } from "@tiptap/core";
 import { BubbleMenu } from "@tiptap/vue-3/menus";
-import { Bold, Italic, Strikethrough, Code, Link, List, ListOrdered, TextQuote, SquareCode } from "lucide-vue-next";
+import { Strikethrough, List, ListOrdered, TextQuote, SquareCode } from "lucide-vue-next";
+import { formatModShortcut } from "@/lib/composer/format-shortcut";
 
 const props = defineProps<{
   editor: Editor;
 }>();
 
-const linkUrl = ref("");
-const editingLink = ref(false);
-const linkInputRef = ref<HTMLInputElement | null>(null);
-
 type ToolbarAction =
-  | "bold"
-  | "italic"
   | "strike"
-  | "code"
   | "bulletList"
   | "orderedList"
   | "blockquote"
@@ -25,17 +19,8 @@ type ToolbarAction =
 function runCommand(action: ToolbarAction) {
   const chain = props.editor.chain().focus();
   switch (action) {
-    case "bold":
-      chain.toggleBold().run();
-      break;
-    case "italic":
-      chain.toggleItalic().run();
-      break;
     case "strike":
       chain.toggleStrike().run();
-      break;
-    case "code":
-      chain.toggleCode().run();
       break;
     case "bulletList":
       chain.toggleBulletList().run();
@@ -50,101 +35,43 @@ function runCommand(action: ToolbarAction) {
       chain.toggleCodeBlock().run();
       break;
   }
-  editingLink.value = false;
-}
-
-function openLinkInput() {
-  editingLink.value = true;
-  const href = props.editor.getAttributes("link").href;
-  linkUrl.value = typeof href === "string" && href ? href : "https://";
-  void nextTick(() => linkInputRef.value?.focus());
-}
-
-function applyLink() {
-  const href = sanitizeLinkUrl(linkUrl.value);
-  if (href) {
-    props.editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
-  } else {
-    props.editor.chain().focus().extendMarkRange("link").unsetLink().run();
-  }
-  editingLink.value = false;
-}
-
-function sanitizeLinkUrl(url: string): string | null {
-  const trimmed = url.trim();
-  if (!trimmed) return null;
-  try {
-    const parsed = new URL(trimmed);
-    if (!["http:", "https:", "mailto:"].includes(parsed.protocol)) return null;
-    return parsed.toString();
-  } catch {
-    return null;
-  }
 }
 
 const items = computed(() => [
   {
-    name: "bold",
-    icon: Bold,
-    title: "Bold",
-    action: () => runCommand("bold"),
-    isActive: () => props.editor.isActive("bold"),
-  },
-  {
-    name: "italic",
-    icon: Italic,
-    title: "Italic",
-    action: () => runCommand("italic"),
-    isActive: () => props.editor.isActive("italic"),
-  },
-  {
     name: "strike",
     icon: Strikethrough,
-    title: "Strikethrough",
+    title: `Strikethrough (${formatModShortcut("Mod-Shift-X")})`,
     action: () => runCommand("strike"),
     isActive: () => props.editor.isActive("strike"),
   },
   {
-    name: "code",
-    icon: Code,
-    title: "Inline code",
-    action: () => runCommand("code"),
-    isActive: () => props.editor.isActive("code"),
-  },
-  {
     name: "bullet-list",
     icon: List,
-    title: "Bullet list",
+    title: `Bullet list (${formatModShortcut("Mod-Shift-8")})`,
     action: () => runCommand("bulletList"),
     isActive: () => props.editor.isActive("bulletList"),
   },
   {
     name: "ordered-list",
     icon: ListOrdered,
-    title: "Numbered list",
+    title: `Numbered list (${formatModShortcut("Mod-Shift-7")})`,
     action: () => runCommand("orderedList"),
     isActive: () => props.editor.isActive("orderedList"),
   },
   {
     name: "blockquote",
     icon: TextQuote,
-    title: "Quote",
+    title: `Quote (${formatModShortcut("Mod-Shift-B")})`,
     action: () => runCommand("blockquote"),
     isActive: () => props.editor.isActive("blockquote"),
   },
   {
     name: "code-block",
     icon: SquareCode,
-    title: "Code block",
+    title: `Code block (${formatModShortcut("Mod-Alt-C")})`,
     action: () => runCommand("codeBlock"),
     isActive: () => props.editor.isActive("codeBlock"),
-  },
-  {
-    name: "link",
-    icon: Link,
-    title: "Link",
-    action: openLinkInput,
-    isActive: () => props.editor.isActive("link"),
   },
 ]);
 </script>
@@ -160,27 +87,17 @@ const items = computed(() => [
         type="button"
         class="type-control h-8 w-8 flex items-center justify-center rounded-md transition-all duration-150"
         :class="
-          (editingLink && item.name === 'link') || item.isActive?.()
+          item.isActive?.()
             ? 'bg-primary/10 text-primary'
             : 'text-muted-foreground hover:bg-muted hover:text-foreground'
         "
         :title="item.title"
+        :aria-label="item.title"
+        :aria-pressed="item.isActive?.() ?? false"
         @mousedown.prevent="item.action"
       >
-        <component :is="item.icon" class="w-3.5 h-3.5" />
+        <component :is="item.icon" class="w-3.5 h-3.5" aria-hidden="true" />
       </button>
-      <input
-        v-if="editingLink"
-        ref="linkInputRef"
-        v-model="linkUrl"
-        type="url"
-        inputmode="url"
-        class="type-caption h-8 w-48 rounded-md border border-border bg-background px-2 text-foreground outline-none focus:border-primary"
-        placeholder="https://example.com"
-        @keydown.enter.prevent="applyLink"
-        @keydown.esc.prevent="editingLink = false"
-        @mousedown.stop
-      />
     </div>
   </BubbleMenu>
 </template>

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from "vue";
-import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2, Megaphone, Radio, CornerDownLeft } from "lucide-vue-next";
-import type { JSONContent } from "@tiptap/core";
+import { ref, computed, watch, onBeforeUnmount, nextTick } from "vue";
+import { Send, Paperclip, FileText, Music4, Puzzle, X, Loader2, Megaphone, Radio, CornerDownLeft, CaseSensitive } from "lucide-vue-next";
+import type { JSONContent, Editor as TiptapEditor } from "@tiptap/core";
 import GifPicker from "@/components/chat/GifPicker.vue";
 import ChatEditor from "@/components/chat/ChatEditor.vue";
 import EditorBubbleToolbar from "@/components/chat/EditorBubbleToolbar.vue";
 import SlashCommandPopover from "@/components/chat/SlashCommandPopover.vue";
+import ComposerFormatButtons from "@/components/chat/ComposerFormatButtons.vue";
 import { searchEmoji } from "@/lib/emoji";
 import { getComposerAutocompleteAction, getComposerEscapeAction } from "@/lib/reply-ux";
 import { tiptapToRichMessage } from "@/lib/rich-message";
@@ -15,6 +16,9 @@ import { parseSlashTrigger } from "@/lib/slash-trigger";
 import { filterSlashCandidates, resolveSlashCommand } from "@/lib/slash-match";
 import { buildSlashInvocation, type SlashInvocation } from "@/lib/slash-dispatch";
 import type { DiscoveredExtensionCommand } from "@/lib/xmpp/extension-commands";
+import { sanitizeLinkUrl } from "@/lib/composer/link-url";
+import { formatStripExpanded } from "@/lib/composer/format-strip-state";
+import { formatModShortcut } from "@/lib/composer/format-shortcut";
 import {
   isAudioFile,
   isImageFile,
@@ -93,10 +97,147 @@ const setExtensionButtonRef = (el: HTMLButtonElement | null) => {
   extensionButtonRef.value = el;
 };
 
-const tiptapEditor = computed(() => {
+const tiptapEditor = computed<TiptapEditor | null>(() => {
   const e = editorRef.value as any;
   return e?.editor?.value ?? e?.editor ?? null;
 });
+
+/**
+ * Bumped on every TipTap transaction so reactive consumers (format-button
+ * active state, link-active hint) re-evaluate `editor.isActive(...)`. Vue's
+ * reactivity doesn't track changes inside the Editor instance, so we need an
+ * external ref to invalidate dependent computeds.
+ */
+const formatVersion = ref(0);
+let detachFormatTracker: (() => void) | null = null;
+
+function attachFormatTracker(editor: TiptapEditor): () => void {
+  // selectionUpdate + update cover the two state changes that affect
+  // mark-active reads — caret moves and document edits. Subscribing to
+  // `transaction` would also fire on every IME/Pmod intermediate that
+  // doesn't change visible state, which is wasted reactivity.
+  const bump = () => {
+    formatVersion.value++;
+  };
+  editor.on("selectionUpdate", bump);
+  editor.on("update", bump);
+  return () => {
+    editor.off("selectionUpdate", bump);
+    editor.off("update", bump);
+  };
+}
+
+watch(
+  tiptapEditor,
+  (editor) => {
+    detachFormatTracker?.();
+    detachFormatTracker = null;
+    if (editor) detachFormatTracker = attachFormatTracker(editor);
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  detachFormatTracker?.();
+  detachFormatTracker = null;
+});
+
+const formattingDisabled = computed(() => props.disabled || props.slowModeCooldown > 0);
+
+const linkActive = computed(() => {
+  void formatVersion.value;
+  return tiptapEditor.value?.isActive("link") ?? false;
+});
+
+const showLinkPopover = ref(false);
+const linkInputValue = ref("");
+const linkInputRef = ref<HTMLInputElement | null>(null);
+const setLinkInputRef = (el: HTMLInputElement | null) => {
+  linkInputRef.value = el;
+};
+const linkDialogRef = ref<HTMLElement | null>(null);
+const setLinkDialogRef = (el: HTMLElement | null) => {
+  linkDialogRef.value = el;
+};
+
+const linkShortcutLabel = computed(() => formatModShortcut("Mod-K"));
+
+const canApplyLink = computed(() => sanitizeLinkUrl(linkInputValue.value) !== null);
+
+function toggleMark(mark: "bold" | "italic" | "code") {
+  const editor = tiptapEditor.value;
+  if (!editor || formattingDisabled.value) return;
+  const chain = editor.chain().focus();
+  if (mark === "bold") chain.toggleBold().run();
+  else if (mark === "italic") chain.toggleItalic().run();
+  else chain.toggleCode().run();
+}
+
+function openLinkPopover() {
+  const editor = tiptapEditor.value;
+  if (!editor || formattingDisabled.value) return;
+  const href = editor.getAttributes("link").href;
+  linkInputValue.value = typeof href === "string" && href ? href : "";
+  showLinkPopover.value = true;
+  void nextTick(() => {
+    const input = linkInputRef.value;
+    if (!input) return;
+    input.focus();
+    input.select();
+  });
+}
+
+function cancelLinkPopover() {
+  showLinkPopover.value = false;
+  linkInputValue.value = "";
+  // Hand focus back to the editor so the next keystroke types into the draft.
+  tiptapEditor.value?.commands.focus();
+}
+
+function applyLinkPopover() {
+  const editor = tiptapEditor.value;
+  if (!editor) return;
+  const href = sanitizeLinkUrl(linkInputValue.value);
+  // Apply is only valid for a sanitizable href; the popover disables the
+  // Apply button otherwise. Empty-input → no-op (the Remove button handles
+  // explicit removal so an accidental Apply on an empty field can't silently
+  // strip an existing link).
+  if (!href) return;
+  editor.chain().focus().extendMarkRange("link").setLink({ href }).run();
+  showLinkPopover.value = false;
+  linkInputValue.value = "";
+}
+
+function removeLinkFromSelection() {
+  const editor = tiptapEditor.value;
+  if (!editor) return;
+  editor.chain().focus().extendMarkRange("link").unsetLink().run();
+  showLinkPopover.value = false;
+  linkInputValue.value = "";
+}
+
+function onLinkDialogTab(e: KeyboardEvent) {
+  const root = linkDialogRef.value;
+  if (!root) return;
+  const focusables = Array.from(
+    root.querySelectorAll<HTMLElement>("input, button"),
+  ).filter((el) => !el.hasAttribute("disabled"));
+  if (focusables.length === 0) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  const active = document.activeElement as HTMLElement | null;
+  if (e.shiftKey && active === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && active === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+
+function toggleFormatStrip() {
+  formatStripExpanded.value = !formatStripExpanded.value;
+}
 
 const pendingAttachments = ref<PendingAttachment[]>([]);
 
@@ -504,6 +645,25 @@ function onEditorCancel() {
 }
 
 function onKeydown(e: KeyboardEvent) {
+  // The composer hosts several sibling inputs (forum title, link popover
+  // URL). Mod-K and the autocomplete navigation keys belong to the message
+  // draft, not those inputs — early-return when the event originates from a
+  // native form control so we don't steal keystrokes from them.
+  const target = e.target as HTMLElement | null;
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return;
+  }
+
+  // Mod-K opens the link popover, regardless of autocomplete state. The
+  // existing keymap doesn't bind this combo, so intercepting here matches
+  // the tooltip without colliding with editor or autocomplete handlers.
+  if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+    e.preventDefault();
+    e.stopPropagation();
+    openLinkPopover();
+    return;
+  }
+
   if (activeResults.value.length > 0 && (showMentions.value || showEmoji.value || showSlash.value)) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -844,6 +1004,46 @@ watch(
       >
         <span class="chat-composer-gif-badge" aria-hidden="true">GIF</span>
       </button>
+      <!-- Persistent formatting cluster — wide viewport. Container query in
+           composer-pane.css hides this whole cluster below the threshold
+           where the row would crowd the editor; the Aa toggle + format strip
+           below take over there. `ml-3` is the wider gap that separates the
+           "add to draft" cluster (Paperclip, GIF) from the "format the text"
+           cluster (B, I, Code, Link) — wider than the surrounding `gap-2`
+           between buttons (8px → 12px) so the seam reads as cluster boundary,
+           not as a tighter grouping inside the row. The wrapper exists so CSS
+           owns `display`; the inner `flex` utility from ComposerFormatButtons
+           would win over our container-query rule otherwise (utilities layer
+           beats components). -->
+      <div class="chat-composer-format-wide ml-3">
+        <ComposerFormatButtons
+          :editor="tiptapEditor"
+          :disabled="formattingDisabled"
+          :format-version="formatVersion"
+          :link-active="linkActive"
+          @toggle="toggleMark"
+          @open-link="openLinkPopover"
+        />
+      </div>
+      <!-- Aa toggle — narrow viewport only. Tap to reveal the format strip
+           below the input shell. Disclosure semantics: aria-expanded +
+           aria-controls; not aria-pressed (this isn't a persistent toggled
+           mode in the editor, it just shows/hides a region). `mousedown.prevent`
+           keeps the editor focused so any active selection survives the click. -->
+      <button
+        type="button"
+        class="chat-composer-format-aa chat-composer-input-action ml-3 h-9 w-9 shrink-0 items-center justify-center transition-all duration-200 active:scale-[0.94] disabled:opacity-40 disabled:active:scale-100 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-11"
+        :class="formatStripExpanded ? 'bg-background/80 text-primary' : 'text-muted-foreground hover:bg-background/70 hover:text-primary'"
+        title="Formatting"
+        aria-label="Formatting"
+        :aria-expanded="formatStripExpanded"
+        aria-controls="composer-format-strip"
+        :disabled="formattingDisabled"
+        @mousedown.prevent
+        @click="toggleFormatStrip"
+      >
+        <CaseSensitive class="w-4 h-4" aria-hidden="true" />
+      </button>
       <ChatEditor
         :ref="setEditorRef"
         class="min-w-0"
@@ -885,6 +1085,81 @@ watch(
         <Loader2 v-else-if="isSending" class="w-4 h-4 motion-safe:animate-spin" aria-hidden="true" />
         <Send v-else class="w-4 h-4" aria-hidden="true" />
       </button>
+    </div>
+    <!-- Format strip — narrow viewport only, revealed by the Aa toggle.
+         Hidden via the container query on wide; the v-if controls the open/
+         closed state on narrow. State is session-sticky via the shared
+         `formatStripExpanded` ref. `id` matches the Aa button's
+         `aria-controls`. -->
+    <div
+      v-if="formatStripExpanded"
+      id="composer-format-strip"
+      class="chat-composer-format-strip animate-fade-in"
+    >
+      <ComposerFormatButtons
+        :editor="tiptapEditor"
+        :disabled="formattingDisabled"
+        :format-version="formatVersion"
+        :link-active="linkActive"
+        @toggle="toggleMark"
+        @open-link="openLinkPopover"
+      />
+    </div>
+    <!-- Link URL popover — opened by the Link button in either cluster, or
+         by Mod-K. Anchored to the composer with the same isTopPinned-aware
+         positioning as the other popovers (mentions, emoji, slash). Modeled
+         as a modal dialog: focus moves into the input, is trapped via Tab/
+         Shift-Tab, and returns to the editor on close. The Esc handler lives
+         on the dialog root so it fires regardless of which inner control has
+         focus. -->
+    <div
+      v-if="showLinkPopover"
+      :ref="setLinkDialogRef"
+      class="chat-composer-format-link-popover z-popover absolute glass-panel border border-border rounded-lg shadow-xl animate-fade-in p-2"
+      :class="isTopPinned ? 'top-full mt-2' : 'bottom-full mb-2'"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="linkActive ? `Edit link (${linkShortcutLabel})` : `Add link (${linkShortcutLabel})`"
+      @keydown.esc.prevent.stop="cancelLinkPopover"
+      @keydown.tab="onLinkDialogTab"
+    >
+      <div class="chat-composer-format-link-row flex items-center gap-2">
+        <input
+          :ref="setLinkInputRef"
+          v-model="linkInputValue"
+          type="url"
+          inputmode="url"
+          autocomplete="off"
+          spellcheck="false"
+          class="type-control h-9 min-w-0 flex-1 rounded-md border border-border bg-background px-2 text-foreground outline-none focus:border-primary"
+          placeholder="https://example.com"
+          @keydown.enter.prevent="applyLinkPopover"
+          @mousedown.stop
+        />
+        <button
+          type="button"
+          class="type-control h-9 px-3 rounded-md bg-primary text-primary-foreground transition-all duration-150 hover:brightness-110 active:scale-[0.96] disabled:opacity-40 disabled:hover:brightness-100"
+          :disabled="!canApplyLink"
+          @click="applyLinkPopover"
+        >
+          Apply
+        </button>
+        <button
+          v-if="linkActive"
+          type="button"
+          class="type-control h-9 px-3 rounded-md text-destructive hover:bg-destructive/10 transition-colors"
+          @click="removeLinkFromSelection"
+        >
+          Remove
+        </button>
+        <button
+          type="button"
+          class="type-control h-9 px-3 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          @click="cancelLinkPopover"
+        >
+          Cancel
+        </button>
+      </div>
     </div>
     <EditorBubbleToolbar v-if="tiptapEditor" :editor="tiptapEditor" />
   </div>

--- a/chat/src/lib/composer/format-shortcut.ts
+++ b/chat/src/lib/composer/format-shortcut.ts
@@ -1,0 +1,35 @@
+/**
+ * Build a tooltip-friendly keyboard shortcut string from a Mod-key spec.
+ *
+ * Pass the same spec TipTap uses ("Mod-B", "Mod-Shift-X") and get back a
+ * platform-aware label ("⌘B" on macOS, "Ctrl+B" elsewhere).
+ *
+ * Detection prefers the modern `navigator.userAgentData.platform`; the legacy
+ * `navigator.platform` and a userAgent sniff cover older browsers.
+ */
+export function formatModShortcut(spec: string, ua: NavigatorLike = globalThis.navigator): string {
+  const mac = isMacPlatform(ua);
+  const parts = spec.split("-").map((part) => {
+    if (part === "Mod") return mac ? "⌘" : "Ctrl";
+    if (part === "Shift") return mac ? "⇧" : "Shift";
+    if (part === "Alt") return mac ? "⌥" : "Alt";
+    if (part === "Ctrl") return mac ? "⌃" : "Ctrl";
+    return part;
+  });
+  return mac ? parts.join("") : parts.join("+");
+}
+
+export interface NavigatorLike {
+  readonly platform?: string;
+  readonly userAgent?: string;
+  readonly userAgentData?: { readonly platform?: string };
+}
+
+export function isMacPlatform(ua: NavigatorLike | undefined): boolean {
+  if (!ua) return false;
+  const fromData = ua.userAgentData?.platform;
+  if (fromData) return /mac/i.test(fromData);
+  if (ua.platform && /mac|iphone|ipad|ipod/i.test(ua.platform)) return true;
+  if (ua.userAgent && /Mac|iPhone|iPad|iPod/i.test(ua.userAgent)) return true;
+  return false;
+}

--- a/chat/src/lib/composer/format-strip-state.ts
+++ b/chat/src/lib/composer/format-strip-state.ts
@@ -1,0 +1,11 @@
+import { ref } from "vue";
+
+/**
+ * Session-sticky toggle for the narrow-viewport formatting strip.
+ *
+ * Shared across all `MessageComposer` instances mounted in the same tab so
+ * users who expand the strip once don't have to re-expand it when switching
+ * channels or opening the thread panel. Resets on reload — not persisted to
+ * localStorage; there is no settings UI for it yet.
+ */
+export const formatStripExpanded = ref(false);

--- a/chat/src/lib/composer/link-url.ts
+++ b/chat/src/lib/composer/link-url.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize a user-entered URL into a value safe to apply as a link href.
+ *
+ * Returns the canonical URL string when the input parses to an http(s) or
+ * mailto URL; returns `null` when the input is empty or carries an unsupported
+ * scheme. Used by both the persistent link popover in the composer and the
+ * bubble-menu link affordance.
+ */
+export function sanitizeLinkUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:", "mailto:"].includes(parsed.protocol)) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}

--- a/chat/src/styles/global/composer-pane.css
+++ b/chat/src/styles/global/composer-pane.css
@@ -2,6 +2,54 @@
 .chat-composer {
   padding: var(--chat-composer-block) var(--chat-content-inline);
   box-shadow: var(--shadow-pane);
+  /* The composer measures its own width — sidebar/thread-panel state can
+   * leave plenty of viewport but very little composer, so a viewport-level
+   * breakpoint would misclassify those layouts. */
+  container-type: inline-size;
+  container-name: composer;
+}
+
+/* Persistent formatting cluster — wide-only. Inline `display: flex` mirrors
+ * what the component renders; below the container-query threshold the
+ * cluster yields to the Aa toggle + format strip. */
+.chat-composer-format-wide {
+  display: flex;
+}
+
+.chat-composer-format-aa {
+  display: none;
+}
+
+.chat-composer-format-strip {
+  display: none;
+  padding-top: var(--space-2xs);
+}
+
+@container composer (width < 520px) {
+  .chat-composer-format-wide {
+    display: none;
+  }
+
+  .chat-composer-format-aa {
+    display: flex;
+  }
+
+  /* The v-if on the strip controls open/closed; this rule only governs the
+   * wide-mode hide. Once the v-if elects to render the strip on narrow, it
+   * gets `display: flex` here. */
+  .chat-composer-format-strip {
+    display: flex;
+  }
+}
+
+/* The link popover is intentionally narrower than the full-width composer
+ * popovers (mentions, emoji, slash, GIF). A URL input + 3 buttons doesn't
+ * need to span the whole composer, and a smaller popover sits closer to the
+ * trigger so the visual link between the Link button and its panel survives. */
+.chat-composer-format-link-popover {
+  left: var(--chat-content-inline);
+  right: auto;
+  width: min(28rem, calc(100% - 2 * var(--chat-content-inline)));
 }
 
 /* The composer input-shell is where the user writes — the most

--- a/chat/tests/composer-format-marks.test.ts
+++ b/chat/tests/composer-format-marks.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import { Editor } from "@tiptap/core";
+import { createChatEditorExtensions } from "../src/lib/editor/chat-editor-extensions";
+
+if (typeof globalThis.requestAnimationFrame !== "function") {
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    callback(performance.now());
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+}
+
+function selectWord(editor: Editor, word: string): { from: number; to: number } {
+  const text = editor.state.doc.textContent;
+  const idx = text.indexOf(word);
+  expect(idx).toBeGreaterThanOrEqual(0);
+  // Paragraph contents start at position 1 (after the <p> open token).
+  const from = idx + 1;
+  const to = from + word.length;
+  editor.commands.setTextSelection({ from, to });
+  return { from, to };
+}
+
+function markNames(editor: Editor, pos: number): string[] {
+  const $pos = editor.state.doc.resolve(pos);
+  const marks = $pos.marks();
+  return marks.map((m) => m.type.name);
+}
+
+describe("composer formatting marks", () => {
+  test("toggleBold wraps the selection in a bold mark", () => {
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "hello world" }] }] },
+    });
+
+    const { from } = selectWord(editor, "hello");
+    editor.chain().toggleBold().run();
+
+    expect(editor.isActive("bold")).toBe(true);
+    expect(markNames(editor, from + 1)).toContain("bold");
+  });
+
+  test("toggleItalic and toggleCode produce italic + code marks", () => {
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "alpha beta gamma" }] }] },
+    });
+
+    selectWord(editor, "alpha");
+    editor.chain().toggleItalic().run();
+    expect(editor.isActive("italic")).toBe(true);
+
+    const { from: codeFrom } = selectWord(editor, "gamma");
+    editor.chain().toggleCode().run();
+    expect(editor.isActive("code")).toBe(true);
+    expect(markNames(editor, codeFrom + 1)).toContain("code");
+  });
+
+  test("setLink applies a link mark with the canonical href", () => {
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: { type: "doc", content: [{ type: "paragraph", content: [{ type: "text", text: "click here" }] }] },
+    });
+
+    const { from } = selectWord(editor, "click");
+    editor.chain().setLink({ href: "https://example.com/" }).run();
+
+    expect(editor.isActive("link")).toBe(true);
+    const $pos = editor.state.doc.resolve(from + 1);
+    const link = $pos.marks().find((m) => m.type.name === "link");
+    expect(link?.attrs.href).toBe("https://example.com/");
+  });
+
+  test("unsetLink clears the link mark", () => {
+    const editor = new Editor({
+      enableCoreExtensions: { keymap: false },
+      extensions: createChatEditorExtensions({ includePlaceholder: false }),
+      content: {
+        type: "doc",
+        content: [{
+          type: "paragraph",
+          content: [{
+            type: "text",
+            text: "click",
+            marks: [{ type: "link", attrs: { href: "https://example.com/" } }],
+          }],
+        }],
+      },
+    });
+
+    selectWord(editor, "click");
+    expect(editor.isActive("link")).toBe(true);
+
+    editor.chain().extendMarkRange("link").unsetLink().run();
+    expect(editor.isActive("link")).toBe(false);
+  });
+});

--- a/chat/tests/format-shortcut.test.ts
+++ b/chat/tests/format-shortcut.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { formatModShortcut, isMacPlatform, type NavigatorLike } from "../src/lib/composer/format-shortcut";
+
+const macUserAgentData: NavigatorLike = { userAgentData: { platform: "macOS" } };
+const macPlatform: NavigatorLike = { platform: "MacIntel" };
+const iPad: NavigatorLike = { userAgent: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X)" };
+const linuxFirefox: NavigatorLike = {
+  platform: "Linux x86_64",
+  userAgent: "Mozilla/5.0 (X11; Linux x86_64; rv:121.0) Gecko/20100101 Firefox/121.0",
+};
+const windows: NavigatorLike = { platform: "Win32" };
+
+describe("isMacPlatform", () => {
+  test("trusts modern userAgentData.platform", () => {
+    expect(isMacPlatform(macUserAgentData)).toBe(true);
+  });
+
+  test("falls back to legacy navigator.platform", () => {
+    expect(isMacPlatform(macPlatform)).toBe(true);
+  });
+
+  test("detects iOS as Mac for shortcut purposes", () => {
+    expect(isMacPlatform(iPad)).toBe(true);
+  });
+
+  test("returns false for Linux", () => {
+    expect(isMacPlatform(linuxFirefox)).toBe(false);
+  });
+
+  test("returns false for Windows", () => {
+    expect(isMacPlatform(windows)).toBe(false);
+  });
+
+  test("returns false when navigator is missing", () => {
+    expect(isMacPlatform(undefined)).toBe(false);
+  });
+});
+
+describe("formatModShortcut", () => {
+  test("renders ⌘ glyph on Mac without separators", () => {
+    expect(formatModShortcut("Mod-B", macPlatform)).toBe("⌘B");
+  });
+
+  test("renders Ctrl+ prefix off Mac with + separators", () => {
+    expect(formatModShortcut("Mod-B", windows)).toBe("Ctrl+B");
+  });
+
+  test("composes multiple modifiers on Mac", () => {
+    expect(formatModShortcut("Mod-Shift-X", macPlatform)).toBe("⌘⇧X");
+  });
+
+  test("composes multiple modifiers off Mac", () => {
+    expect(formatModShortcut("Mod-Shift-X", linuxFirefox)).toBe("Ctrl+Shift+X");
+  });
+
+  test("handles Alt on both platforms", () => {
+    expect(formatModShortcut("Mod-Alt-C", macPlatform)).toBe("⌘⌥C");
+    expect(formatModShortcut("Mod-Alt-C", windows)).toBe("Ctrl+Alt+C");
+  });
+});

--- a/chat/tests/link-url.test.ts
+++ b/chat/tests/link-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeLinkUrl } from "../src/lib/composer/link-url";
+
+describe("sanitizeLinkUrl", () => {
+  test("returns the canonical URL for http", () => {
+    expect(sanitizeLinkUrl("http://example.com")).toBe("http://example.com/");
+  });
+
+  test("returns the canonical URL for https", () => {
+    expect(sanitizeLinkUrl("https://example.com/path?q=1")).toBe("https://example.com/path?q=1");
+  });
+
+  test("trims surrounding whitespace before parsing", () => {
+    expect(sanitizeLinkUrl("  https://example.com  ")).toBe("https://example.com/");
+  });
+
+  test("permits mailto: addresses", () => {
+    expect(sanitizeLinkUrl("mailto:user@example.com")).toBe("mailto:user@example.com");
+  });
+
+  test("rejects javascript: URLs", () => {
+    expect(sanitizeLinkUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  test("rejects data: URLs", () => {
+    expect(sanitizeLinkUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  test("rejects file: URLs", () => {
+    expect(sanitizeLinkUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(sanitizeLinkUrl("")).toBeNull();
+    expect(sanitizeLinkUrl("   ")).toBeNull();
+  });
+
+  test("returns null for bare hostnames without a scheme", () => {
+    // sanitizeLinkUrl is strict — we expect the popover to either accept a
+    // fully-qualified URL or treat the input as invalid. Implicit-protocol
+    // handling belongs in the paste flow, not the link button.
+    expect(sanitizeLinkUrl("example.com")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Promote Bold, Italic, Inline code, and Link from the selection-only bubble menu into a persistent, always-visible affordance in the composer's left cluster. Discoverability — users couldn't find formatting because nothing rendered until you selected text. The bubble menu still exists, trimmed to the marks we didn't promote (Strike, Bullet, Ordered, Quote, CodeBlock).

A container query on the composer collapses the cluster behind an "Aa" toggle when the composer is < 520px wide, revealing the same buttons in a strip beneath the input shell. The threshold is composer-width, not viewport-width, so sidebar/thread-panel layouts behave correctly.

## What's in the diff

| Area | Change |
| --- | --- |
| `MessageComposer.vue` | Persistent B/I/Code/Link cluster after Paperclip/GIF (`ml-3` gap); Aa toggle hidden on wide, visible on narrow; format strip beneath input shell when expanded; link popover (modal `role="dialog"`, `aria-modal`, focus trap, Esc on root); `Mod-K` handler scoped to skip sibling inputs; `formatVersion` ref bumped on `selectionUpdate` + `update` to drive reactive active-state. |
| `EditorBubbleToolbar.vue` | Trimmed to 5 marks; tooltips + `aria-label` + `aria-pressed` added; link logic removed (now lives in the persistent popover). |
| `ComposerFormatButtons.vue` (new) | Shared row used by both the wide cluster and the narrow strip. Tooltip flips "Add link" ↔ "Edit link" based on `linkActive`. Active background suppressed when disabled to avoid the "looks active but inert" failure mode. |
| `lib/composer/format-shortcut.ts` (new) | Platform-aware shortcut formatter — `⌘B` on Mac, `Ctrl+B` elsewhere. Prefers `navigator.userAgentData.platform` with legacy fallbacks. |
| `lib/composer/link-url.ts` (new) | `sanitizeLinkUrl` — accepts http/https/mailto, rejects javascript/data/file, returns the canonical URL. Used by Apply + by the `canApplyLink` Apply-button-enable computed. |
| `lib/composer/format-strip-state.ts` (new) | Module-scoped `ref(false)` so the Aa-expanded state survives channel switches and thread-panel opens within the same tab. |
| `styles/global/composer-pane.css` | `.chat-composer` gains `container-type: inline-size; container-name: composer`; new classes for the wide cluster, Aa toggle, format strip, and link popover. Wide cluster wrapped in a plain `<div>` so CSS owns `display` (Tailwind's `flex` utility lives in the `utilities` layer and would otherwise beat our container-query `display: none` from the `components` layer). |
| `tests/format-shortcut.test.ts` (new) | Mac vs. non-Mac formatting; multi-modifier chords; navigator fallbacks. |
| `tests/link-url.test.ts` (new) | Allows http/https/mailto; rejects javascript/data/file; whitespace trimming; empty input. |
| `tests/composer-format-marks.test.ts` (new) | Verifies `toggleBold/Italic/Code` and `setLink/unsetLink` work against the chat editor extensions. |

## Behavior decisions (locked via `/grill-me`)

| Topic | Decision |
| --- | --- |
| Promoted marks | B, I, Inline code, Link |
| Bubble menu | Strike, Bullet, Ordered, Quote, CodeBlock — no overlap with the persistent row |
| Wide layout | `[Paperclip][GIF]  [B][I][Code][Link]  [editor]  [Puzzle][Send]` with `ml-3` cluster gap |
| Narrow layout | `[Paperclip][GIF][Aa]  [editor]  [Puzzle][Send]` + strip beneath when Aa expanded |
| Breakpoint | `@container composer (width < 520px)` |
| Aa state | Session-sticky module ref; resets on reload |
| Active state | `bg-primary/10 text-primary`; suppressed when disabled |
| Disabled gate | `disabled \|\| slowModeCooldown > 0` |
| Mod-K | Wired in `MessageComposer.onKeydown`; scoped to skip sibling inputs (forum title, link URL field) |
| Tooltips | `⌘B`/`Ctrl+B` etc.; link tooltip toggles `Add link` ↔ `Edit link` based on caret context |
| Link popover | Modal dialog, focus trap, Esc on root, `aria-modal`; `max-width: 28rem` so it doesn't span full composer; Apply disabled until URL sanitizes; explicit Remove only when caret is inside an existing link |

## Adversarial review pass

Three reviewers (Vue/TS, A11y, UX) flagged 12 actionable issues. All addressed in the same PR:

- Mod-K hijacking forum-title / link-input fields → scoped via target check.
- Link popover focus trap + Esc-on-root + `aria-modal="true"`.
- Aa toggle: dropped redundant `aria-pressed`; added `aria-controls`.
- Bubble menu buttons gained `aria-label` + `aria-pressed`.
- `ml-1` (smaller than surrounding `gap-2`) → `ml-3`.
- Empty-Apply silently stripping links → Apply gated on sanitizable URL; explicit Remove button when caret is in a link.
- Link popover constrained to `min(28rem, 100% - margins)`.
- Aa button gained `@mousedown.prevent` so clicking it doesn't blur the editor.
- `bg-primary/10` active state suppressed when disabled.
- Transaction listener → `selectionUpdate` + `update` (fewer fires, same coverage).
- Link tooltip toggles `Add link` ↔ `Edit link`.

## Test plan

- [x] `bun test` — 860 pass (24 new) / 0 fail
- [x] `bun run lint` — clean (knip: zero issues)
- [x] `bunx astro check` — no new errors in scope (pre-existing `cloudflare:workers` typing error in `AppLayout.astro` unchanged)
- [ ] Wide composer manual QA: B/I/Code/Link visible; tooltips show `⌘B`/`⌘I`/`⌘E`/`⌘K` on Mac, `Ctrl+` elsewhere
- [ ] Active state reflects cursor position (caret inside bold text → Bold lit)
- [ ] Link popover: Mod-K opens; Tab traps within input/Apply/Remove/Cancel; Esc dismisses from any control; Apply disabled with empty/invalid URL; Remove only visible when caret is in a link
- [ ] Bubble menu shows only Strike/Bullet/Ordered/Quote/CodeBlock on selection — no B/I/Code/Link
- [ ] Narrow composer (DevTools < 520px): Aa toggle appears; tap reveals strip beneath input shell
- [ ] Aa expanded state survives channel switch; resets on reload
- [ ] Disabled channel or `slowModeCooldown > 0` greys out the formatting buttons (no active-state pill when also disabled)
- [ ] Sending a message with bold/italic/code/link still produces correct rich-message body + markup spans

🤖 Generated with [Claude Code](https://claude.com/claude-code)