### PR TITLE
fix(server): admin ACL uses dynamic community-owner signal, not static env

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -353,9 +353,9 @@ pub async fn register(
 
 type AdminErr = Box<CommandResult>;
 
-fn caller_or_forbidden(ctx: &CommandContext, state: &AppState) -> Result<BareJid, AdminErr> {
+async fn caller_or_forbidden(ctx: &CommandContext, state: &AppState) -> Result<BareJid, AdminErr> {
     let bare = ctx.from.to_bare();
-    if !is_community_owner(state, &bare) {
+    if !is_community_owner(state, &bare).await {
         return Err(Box::new(CommandResult::Error(XmppError::forbidden(Some(
             "Admin commands require the community owner role".to_string(),
         )))));
@@ -374,7 +374,7 @@ fn internal_err(text: impl Into<String>) -> AdminErr {
 }
 
 async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_list_args(ctx.command.form.as_ref()) {
@@ -391,7 +391,7 @@ async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult
 }
 
 async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_create_args(ctx.command.form.as_ref()) {
@@ -408,7 +408,7 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_update_args(ctx.command.form.as_ref()) {
@@ -425,7 +425,7 @@ async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_delete_args(ctx.command.form.as_ref()) {
@@ -442,7 +442,7 @@ async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_occupants(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_occupants_args(ctx.command.form.as_ref()) {
@@ -459,7 +459,7 @@ async fn handle_occupants(ctx: CommandContext, state: Arc<AppState>) -> CommandR
 }
 
 async fn handle_affiliations(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_affiliations_args(ctx.command.form.as_ref()) {
@@ -476,7 +476,7 @@ async fn handle_affiliations(ctx: CommandContext, state: Arc<AppState>) -> Comma
 }
 
 async fn handle_set_affiliation(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_set_affiliation_args(ctx.command.form.as_ref()) {
@@ -497,7 +497,7 @@ async fn handle_kick(
     state: Arc<AppState>,
     connections: Arc<ConnectionRegistry>,
 ) -> CommandResult {
-    let caller_bare = match caller_or_forbidden(&ctx, &state) {
+    let caller_bare = match caller_or_forbidden(&ctx, &state).await {
         Ok(bare) => bare,
         Err(forbidden) => return *forbidden,
     };

--- a/server/crates/waddle-server/src/admin/mod.rs
+++ b/server/crates/waddle-server/src/admin/mod.rs
@@ -1,54 +1,116 @@
-//! Admin V1 — community-owner-gated operations exposed via XEP-0050
+//! Admin V1 + V2 — community-owner-gated operations exposed via XEP-0050
 //! ad-hoc commands.
 //!
 //! Hard rules:
 //!
 //! - **No REST**: admin actions flow over XMPP, specifically XEP-0050.
-//! - **Owner gate**: the helper [`is_community_owner`] is the single
-//!   source of truth for "may this JID see admin surfaces?" — the
-//!   `urn:waddle:admin:*` command handlers MUST call it before
-//!   doing anything else and refuse non-owners with `<forbidden/>`.
+//! - **Owner gate**: the async helper [`is_community_owner`] is the single
+//!   source of truth for "may this JID see admin surfaces?" — every
+//!   `urn:waddle:admin:*` command handler MUST call it before doing
+//!   anything else and refuse non-owners with `<forbidden/>`.
 //! - **Custom namespace**: no XEP defines "list users with prefix
 //!   search," so the V1 command lives under
 //!   `urn:waddle:admin:users:list:0` per the
 //!   "Waddle-namespace only when needed" rule.
 //!
-//! "Community owner" maps onto the server-owner JID set configured
-//! via `WADDLE_SERVER_OWNER_LOCALPARTS` and resolved at startup into
-//! [`crate::server::AppState::server_owner_jids`]. Waddle is
-//! intentionally a single-community deployment in V1; the
-//! XEP-0317-hat layer is descriptive social metadata only (see the
-//! module docs on `waddle_xmpp::xep::xep0317`), so authority is read
-//! from the authoritative server-owner set rather than from
-//! decorative hat URIs.
+//! ## ACL: bootstrap + dynamic signal
+//!
+//! Authority for "community owner" comes from two layered signals:
+//!
+//! 1. **Bootstrap fallback** — the static
+//!    [`crate::server::AppState::server_owner_jids`] set resolved from
+//!    `WADDLE_SERVER_OWNER_LOCALPARTS` at startup. This keeps a fresh
+//!    deployment usable before any dynamic signal exists and matches the
+//!    JIDs that get auto-seeded as PubSub owners on every Spaces node.
+//! 2. **Dynamic signal** — the durable XEP-0060 affiliation table on the
+//!    Spaces (XEP-0503) service. If `jid` holds [`Affiliation::Owner`] on
+//!    *any* node under `spaces_jid`, it counts as a community owner. This
+//!    lets a server owner promote a peer to admin via a normal
+//!    `<affiliations/>` set on a Spaces node — no restart required.
+//!
+//! XEP-0317 hats are intentionally NOT consulted here: per the
+//! `waddle_xmpp::xep::xep0317` module docs, hats are descriptive social
+//! metadata only and carry no authority.
+//!
+//! The check is closed-by-default: if the dynamic lookup errors out, the
+//! gate denies access and logs a `warn!`. We never grant admin on a
+//! storage failure.
 
 pub mod channels;
 pub mod spaces;
 pub mod users_list;
 
 use jid::BareJid;
+use tracing::warn;
+use waddle_xmpp::pubsub::Affiliation;
 
 use crate::server::AppState;
 
-/// `true` iff `jid` (interpreted as a bare JID) is in the configured
-/// community-owner set. Returns `false` for non-bare or unknown JIDs.
+/// `true` iff `jid` is the community owner of this deployment.
 ///
-/// This is the single chokepoint for admin authorization in V1. New
-/// admin commands MUST call this before performing any work.
-pub fn is_community_owner(state: &AppState, jid: &BareJid) -> bool {
-    is_owner_in(&state.server_owner_jids, jid)
+/// Returns `true` if either:
+///
+/// - `jid` is in the configured [`AppState::server_owner_jids`] bootstrap
+///   set, OR
+/// - `jid` holds an [`Affiliation::Owner`] row on any PubSub node under
+///   [`AppState::spaces_jid`].
+///
+/// On a storage error from the dynamic lookup, returns `false` (closed by
+/// default) and logs at `warn!`. We never grant admin access because of an
+/// I/O failure.
+///
+/// This is the single chokepoint for admin authorization. New admin
+/// commands MUST call this (or `caller_or_forbidden` in the per-handler
+/// modules, which wraps it) before performing any work.
+pub async fn is_community_owner(state: &AppState, jid: &BareJid) -> bool {
+    if is_owner_in(&state.server_owner_jids, jid) {
+        return true;
+    }
+    match dynamic_owner_signal(state, jid).await {
+        Ok(is_owner) => is_owner,
+        Err(error) => {
+            warn!(
+                jid = %jid,
+                spaces_jid = %state.spaces_jid,
+                error = %error,
+                "dynamic community-owner lookup failed; denying admin access",
+            );
+            false
+        }
+    }
 }
 
 /// Pure helper used by tests and the public [`is_community_owner`]
-/// entry point. Walks `owners` and returns `true` on the first JID
-/// equal to `jid`.
+/// entry point's bootstrap arm. Walks `owners` and returns `true` on the
+/// first JID equal to `jid`.
 pub fn is_owner_in(owners: &[BareJid], jid: &BareJid) -> bool {
     owners.iter().any(|owner| owner == jid)
+}
+
+/// Query the dynamic community-owner signal: does `jid` hold an explicit
+/// [`Affiliation::Owner`] row on any PubSub node under
+/// [`AppState::spaces_jid`]?
+///
+/// Returns `Err` only when the underlying storage call fails. A successful
+/// "no Owner row found" returns `Ok(false)`.
+async fn dynamic_owner_signal(
+    state: &AppState,
+    jid: &BareJid,
+) -> Result<bool, waddle_xmpp::XmppError> {
+    let rows = state
+        .pubsub_storage
+        .list_entity_affiliations(&state.spaces_jid, jid)
+        .await?;
+    Ok(rows
+        .iter()
+        .any(|(_, affiliation)| matches!(affiliation, Affiliation::Owner)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use std::sync::Arc;
 
     fn jid(s: &str) -> BareJid {
         s.parse().expect("test jid parses")
@@ -78,5 +140,315 @@ mod tests {
         assert!(is_owner_in(&owners, &jid("admin@localhost")));
         assert!(is_owner_in(&owners, &jid("root@localhost")));
         assert!(!is_owner_in(&owners, &jid("alice@localhost")));
+    }
+
+    async fn fresh_state() -> AppState {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("db pool");
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations");
+        AppState::new(Arc::new(db_pool))
+    }
+
+    fn set_owners(state: &mut AppState, owners: Vec<BareJid>) {
+        state.server_owner_jids = Arc::from(owners);
+    }
+
+    #[tokio::test]
+    async fn bootstrap_owner_is_recognized_without_dynamic_signal() {
+        let mut state = fresh_state().await;
+        set_owners(&mut state, vec![jid("admin@localhost")]);
+
+        assert!(is_community_owner(&state, &jid("admin@localhost")).await);
+        assert!(!is_community_owner(&state, &jid("alice@localhost")).await);
+    }
+
+    #[tokio::test]
+    async fn dynamic_pubsub_owner_grants_admin_without_restart() {
+        let state = fresh_state().await;
+        // No bootstrap owners; alice is unknown to the env list.
+        let alice = jid("alice@localhost");
+        assert!(!is_community_owner(&state, &alice).await);
+
+        // Grant an explicit Owner affiliation on a Spaces node — this is
+        // the durable signal the dynamic check consults.
+        state
+            .pubsub_storage
+            .get_or_create_node(&state.spaces_jid, "general")
+            .await
+            .expect("create node");
+        state
+            .pubsub_storage
+            .set_affiliation(&state.spaces_jid, "general", &alice, Affiliation::Owner)
+            .await
+            .expect("grant owner");
+
+        assert!(is_community_owner(&state, &alice).await);
+    }
+
+    #[tokio::test]
+    async fn revoking_dynamic_owner_removes_admin_access() {
+        let state = fresh_state().await;
+        let alice = jid("alice@localhost");
+        state
+            .pubsub_storage
+            .get_or_create_node(&state.spaces_jid, "general")
+            .await
+            .expect("create node");
+        state
+            .pubsub_storage
+            .set_affiliation(&state.spaces_jid, "general", &alice, Affiliation::Owner)
+            .await
+            .expect("grant owner");
+        assert!(is_community_owner(&state, &alice).await);
+
+        // Demote to Member — must drop admin access on the next call.
+        state
+            .pubsub_storage
+            .set_affiliation(&state.spaces_jid, "general", &alice, Affiliation::Member)
+            .await
+            .expect("demote");
+        assert!(!is_community_owner(&state, &alice).await);
+
+        // Removing the row entirely also denies.
+        state
+            .pubsub_storage
+            .set_affiliation(&state.spaces_jid, "general", &alice, Affiliation::None)
+            .await
+            .expect("remove");
+        assert!(!is_community_owner(&state, &alice).await);
+    }
+
+    #[tokio::test]
+    async fn non_owner_affiliation_does_not_grant_admin() {
+        let state = fresh_state().await;
+        let alice = jid("alice@localhost");
+        state
+            .pubsub_storage
+            .get_or_create_node(&state.spaces_jid, "general")
+            .await
+            .expect("create node");
+        // Publisher is the "admin" tier in the V2 vocab mapping but is
+        // explicitly NOT the community-owner signal — only Owner counts.
+        state
+            .pubsub_storage
+            .set_affiliation(&state.spaces_jid, "general", &alice, Affiliation::Publisher)
+            .await
+            .expect("set publisher");
+
+        assert!(!is_community_owner(&state, &alice).await);
+    }
+
+    #[tokio::test]
+    async fn bootstrap_owner_short_circuits_before_dynamic_lookup() {
+        // Even if the dynamic storage would error out, the bootstrap
+        // arm wins before we ever consult storage. We assert this by
+        // installing a storage that fails every call and verifying the
+        // env-listed JID still gets admin.
+        let mut state = fresh_state().await;
+        state.pubsub_storage = Arc::new(failing_storage::FailingStorage);
+        set_owners(&mut state, vec![jid("admin@localhost")]);
+
+        assert!(is_community_owner(&state, &jid("admin@localhost")).await);
+    }
+
+    #[tokio::test]
+    async fn dynamic_signal_storage_error_denies_access() {
+        // Closed-by-default guarantee: a storage failure on the dynamic
+        // lookup must NOT grant admin.
+        let mut state = fresh_state().await;
+        state.pubsub_storage = Arc::new(failing_storage::FailingStorage);
+        // No bootstrap owners — so the dynamic path is the only chance.
+
+        assert!(!is_community_owner(&state, &jid("alice@localhost")).await);
+    }
+
+    /// A `PubSubStorage` that fails every call with an internal error. Used
+    /// to assert the closed-by-default semantics of [`is_community_owner`]
+    /// when the dynamic lookup fails. We implement the full trait surface
+    /// because the storage is loaded into `AppState` via an `Arc<dyn …>`;
+    /// the only method [`is_community_owner`] actually reaches is
+    /// `list_entity_affiliations`, but the other methods need a body so the
+    /// trait object is constructible.
+    mod failing_storage {
+        use async_trait::async_trait;
+        use jid::{BareJid, Jid};
+        use waddle_xmpp::pubsub::{
+            Affiliation, PubSubItem, PubSubNode, PubSubStorage, PublishResult, StoredItem,
+        };
+        use waddle_xmpp::XmppError;
+        use waddle_xmpp_core::pubsub::{SubId, Subscription};
+
+        pub struct FailingStorage;
+
+        fn boom<T>(reason: &str) -> Result<T, XmppError> {
+            Err(XmppError::internal(format!(
+                "failing storage forced error: {reason}"
+            )))
+        }
+
+        #[async_trait]
+        impl PubSubStorage for FailingStorage {
+            async fn get_or_create_node(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<(PubSubNode, bool), XmppError> {
+                boom("get_or_create_node")
+            }
+            async fn get_node(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<Option<PubSubNode>, XmppError> {
+                boom("get_node")
+            }
+            async fn delete_node(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<bool, XmppError> {
+                boom("delete_node")
+            }
+            async fn publish_item(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _item: &PubSubItem,
+                _publisher: Option<&BareJid>,
+                _auto_create: bool,
+            ) -> Result<PublishResult, XmppError> {
+                boom("publish_item")
+            }
+            async fn get_items(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _max_items: Option<u32>,
+                _item_ids: &[String],
+            ) -> Result<Vec<StoredItem>, XmppError> {
+                boom("get_items")
+            }
+            async fn retract_item(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _item_id: &str,
+            ) -> Result<bool, XmppError> {
+                boom("retract_item")
+            }
+            async fn list_nodes(&self, _owner: &BareJid) -> Result<Vec<String>, XmppError> {
+                boom("list_nodes")
+            }
+            async fn find_node_for_item(
+                &self,
+                _owner: &BareJid,
+                _item_id: &str,
+            ) -> Result<Option<PubSubNode>, XmppError> {
+                boom("find_node_for_item")
+            }
+            async fn list_node_names_for_item(
+                &self,
+                _owner: &BareJid,
+                _item_id: &str,
+            ) -> Result<Vec<String>, XmppError> {
+                boom("list_node_names_for_item")
+            }
+            async fn update_node_config(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _config: &waddle_xmpp::pubsub::NodeConfig,
+            ) -> Result<(), XmppError> {
+                boom("update_node_config")
+            }
+            async fn purge_node(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<u64, XmppError> {
+                boom("purge_node")
+            }
+            async fn subscribe(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _subscriber: &Jid,
+            ) -> Result<Subscription, XmppError> {
+                boom("subscribe")
+            }
+            async fn unsubscribe(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _subscriber: &Jid,
+                _subid: Option<&SubId>,
+            ) -> Result<bool, XmppError> {
+                boom("unsubscribe")
+            }
+            async fn list_node_subscriptions(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<Vec<Subscription>, XmppError> {
+                boom("list_node_subscriptions")
+            }
+            async fn list_subscriber_subscriptions(
+                &self,
+                _owner: &BareJid,
+                _subscriber: &Jid,
+            ) -> Result<Vec<(String, Subscription)>, XmppError> {
+                boom("list_subscriber_subscriptions")
+            }
+            async fn get_subscription(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _subid: &SubId,
+            ) -> Result<Option<Subscription>, XmppError> {
+                boom("get_subscription")
+            }
+            async fn list_deliverable_subscribers(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<Vec<Subscription>, XmppError> {
+                boom("list_deliverable_subscribers")
+            }
+            async fn set_affiliation(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _entity: &BareJid,
+                _affiliation: Affiliation,
+            ) -> Result<Affiliation, XmppError> {
+                boom("set_affiliation")
+            }
+            async fn get_affiliation(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+                _entity: &BareJid,
+            ) -> Result<Affiliation, XmppError> {
+                boom("get_affiliation")
+            }
+            async fn list_node_affiliations(
+                &self,
+                _owner: &BareJid,
+                _node_name: &str,
+            ) -> Result<Vec<(BareJid, Affiliation)>, XmppError> {
+                boom("list_node_affiliations")
+            }
+            async fn list_entity_affiliations(
+                &self,
+                _owner: &BareJid,
+                _entity: &BareJid,
+            ) -> Result<Vec<(String, Affiliation)>, XmppError> {
+                boom("list_entity_affiliations")
+            }
+        }
     }
 }

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -289,9 +289,9 @@ pub async fn register(registry: &waddle_xmpp::commands::CommandRegistry, app_sta
 /// compact `Result` without tripping `clippy::result_large_err`.
 type AdminErr = Box<CommandResult>;
 
-fn caller_or_forbidden(ctx: &CommandContext, state: &AppState) -> Result<BareJid, AdminErr> {
+async fn caller_or_forbidden(ctx: &CommandContext, state: &AppState) -> Result<BareJid, AdminErr> {
     let bare = ctx.from.to_bare();
-    if !is_community_owner(state, &bare) {
+    if !is_community_owner(state, &bare).await {
         return Err(Box::new(CommandResult::Error(XmppError::forbidden(Some(
             "Admin commands require the community owner role".to_string(),
         )))));
@@ -314,7 +314,7 @@ fn map_metadata_err(error: SpacesMetadataError) -> AdminErr {
 }
 
 async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_list_args(ctx.command.form.as_ref()) {
@@ -331,7 +331,7 @@ async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult
 }
 
 async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_create_args(ctx.command.form.as_ref()) {
@@ -348,7 +348,7 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_update_args(ctx.command.form.as_ref()) {
@@ -365,7 +365,7 @@ async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_delete_args(ctx.command.form.as_ref()) {
@@ -382,7 +382,7 @@ async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
 }
 
 async fn handle_members(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_members_args(ctx.command.form.as_ref()) {
@@ -399,7 +399,7 @@ async fn handle_members(ctx: CommandContext, state: Arc<AppState>) -> CommandRes
 }
 
 async fn handle_set_role(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
-    if let Err(forbidden) = caller_or_forbidden(&ctx, &state) {
+    if let Err(forbidden) = caller_or_forbidden(&ctx, &state).await {
         return *forbidden;
     }
     let args = match parse_set_role_args(ctx.command.form.as_ref()) {

--- a/server/crates/waddle-server/src/admin/users_list.rs
+++ b/server/crates/waddle-server/src/admin/users_list.rs
@@ -114,7 +114,7 @@ async fn handle(
     xmpp_domain: String,
 ) -> CommandResult {
     let caller_bare = bare_from_jid(&ctx.from);
-    if !caller_is_owner(&caller_bare, &app_state) {
+    if !caller_is_owner(&caller_bare, &app_state).await {
         return CommandResult::Error(XmppError::forbidden(Some(
             "Admin commands require the community owner role".to_string(),
         )));
@@ -145,10 +145,11 @@ async fn handle(
     }
 }
 
-fn caller_is_owner(caller: &Option<BareJid>, app_state: &AppState) -> bool {
-    caller
-        .as_ref()
-        .is_some_and(|jid| is_community_owner(app_state, jid))
+async fn caller_is_owner(caller: &Option<BareJid>, app_state: &AppState) -> bool {
+    let Some(jid) = caller.as_ref() else {
+        return false;
+    };
+    is_community_owner(app_state, jid).await
 }
 
 fn bare_from_jid(jid: &Jid) -> Option<BareJid> {


### PR DESCRIPTION
## Summary

`is_community_owner` previously checked only the static `server_owner_jids` set resolved from `WADDLE_SERVER_OWNER_LOCALPARTS`. That made every admin V2 command require pre-configured operator JIDs and forced a restart to elevate a peer.

This PR makes the ACL dynamic while keeping the env list as a bootstrap fallback. A caller now passes the gate if **either**:

- They are in `AppState::server_owner_jids` (bootstrap), OR
- They hold `Affiliation::Owner` on **any** PubSub node under `AppState::spaces_jid` (dynamic XEP-0060 affiliation row, the same shape `spaces_pubsub_seed` already writes).

## Signal picked

**XEP-0060 PubSub affiliation on the Spaces (XEP-0503) service.** Specifically `list_entity_affiliations(spaces_jid, jid)` filtered for any `Owner` row.

Rationale:

- Already a queryable, durable server-side projection — `PubSubStorage` is on `AppState` and persists across restarts (D1).
- This is the same row `spaces_pubsub_seed::seed_owner_on_all_nodes` writes for server owners on startup, so bootstrap and dynamic agree by construction.
- XEP-0317 Hats are descriptive social metadata only per the `xep0317` module docs — they carry no authority and aren't consulted.
- Promoting a peer is a normal `<affiliations/>` set on a Spaces node; no new wire surface, no new storage trait method, no new env var.

## Behaviour

- `is_community_owner` is `async` (it does a single storage call on the cold path).
- Bootstrap arm short-circuits before any I/O, so a fresh deployment with no Spaces nodes still authorises the configured owner localparts.
- **Closed-by-default**: if the pubsub lookup errors out, the gate denies and logs at `warn!`. We never grant admin on a storage failure.
- `is_owner_in` stays as the pure sync helper for unit tests and the bootstrap arm.

## Plumbing

`caller_or_forbidden` in `admin/spaces.rs` and `admin/channels.rs` is `async`; `caller_is_owner` in `admin/users_list.rs` is `async`. Every existing call site is already inside an `async fn handle_*`, so each just adds `.await`.

## Files

- `server/crates/waddle-server/src/admin/mod.rs` — new async `is_community_owner`, new private `dynamic_owner_signal`, expanded tests (bootstrap, dynamic grant, revocation, non-Owner affiliation negative, bootstrap short-circuit, storage-error denial).
- `server/crates/waddle-server/src/admin/spaces.rs` — `caller_or_forbidden` is now async; 6 await sites.
- `server/crates/waddle-server/src/admin/channels.rs` — `caller_or_forbidden` is now async; 8 await sites.
- `server/crates/waddle-server/src/admin/users_list.rs` — `caller_is_owner` is now async.

## Tests

New (in `admin::tests`):

- `bootstrap_owner_is_recognized_without_dynamic_signal`
- `dynamic_pubsub_owner_grants_admin_without_restart`
- `revoking_dynamic_owner_removes_admin_access` (Owner → Member → None each demote properly)
- `non_owner_affiliation_does_not_grant_admin` (Publisher is NOT an owner signal)
- `bootstrap_owner_short_circuits_before_dynamic_lookup` (env JID still passes even when pubsub storage errors on every call)
- `dynamic_signal_storage_error_denies_access` (closed-by-default proof)

All 836 lib + 40 admin-module tests pass; full `cargo test --workspace` is green.

## Chat-client alignment note

The chat client today determines `canManageCommunity` from `serverRole`, which it reads from `waddle#server_affiliation` in disco#info — and that field comes from the Zanzibar `permission_actor` (`Permission::Owner` on the deployment Server). Bootstrap seeds both Zanzibar and pubsub for the same env JIDs, so bootstrap owners line up. **Dynamic** promotions made by writing a Spaces-node pubsub `Owner` row will pass this new server-side ACL but won't flip the chat UI's `serverRole` indicator until the operator also writes the matching Zanzibar tuple. A follow-up could either bridge the two signals or migrate `serverRole` discovery to read from the pubsub-affiliation projection — out of scope for this PR.

## Migration / compat

- `WADDLE_SERVER_OWNER_LOCALPARTS` keeps working unchanged as the bootstrap path.
- No new env vars.
- No new fields on `AppState` (uses the existing `pubsub_storage` + `spaces_jid`).
- No production-data concerns per CLAUDE.md.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] New tests cover bootstrap, dynamic grant, revocation, non-Owner affiliation, bootstrap short-circuit, storage-error denial
- [x] Existing admin V1 + V2 integration tests still pass

This PR was created with the assistance of a LLM.