### PR TITLE
fix(server): align waddle#server_affiliation with PubSub admin ACL

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
@@ -124,29 +124,57 @@ pub(crate) async fn managed_channel_permission_allowed(
     Ok(false)
 }
 
+/// Derive the requester's server-level [`SpaceAffiliation`] from the
+/// same dynamic community-owner signal that gates every admin command.
+///
+/// After #696 the admin ACL is "PubSub-Owner row on the Spaces JID, or
+/// bootstrap localpart from `WADDLE_SERVER_OWNER_LOCALPARTS`" — see
+/// [`crate::admin::is_community_owner`]. This helper drives the
+/// `waddle#server_affiliation` field emitted by server-targeted
+/// `disco#info` (see [`super::disco_info::server_info`]) so the chat
+/// client's `canManageCommunity` UI affordance flips on the same edge
+/// as the ACL. Previously the disco field was driven off the Zanzibar
+/// permission graph, which could disagree with the PubSub affiliation
+/// table for users promoted dynamically.
+///
+/// Returns:
+/// - `Some(Owner)` if [`is_community_owner`] returns `true` for the
+///   session's bare JID,
+/// - `None` otherwise (including unauthenticated callers and sessions
+///   whose JID cannot be derived — the disco field is then omitted
+///   rather than asserting a tier that wasn't earned).
+///
+/// The intermediate Zanzibar-derived tiers (`Publisher`, `Member`)
+/// previously surfaced here had no consumer on the chat side; the
+/// Zanzibar graph itself remains the authority for per-channel and
+/// per-space authorization via [`permission_allowed`] and
+/// [`managed_channel_permission_allowed`].
+///
+/// [`is_community_owner`]: crate::admin::is_community_owner
 pub(super) async fn server_affiliation_for_requester(
     state: &WebSocketState,
     session: Option<&Session>,
 ) -> Option<SpaceAffiliation> {
-    if server_permission_allowed(state, session, Permission::Owner)
-        .await
-        .unwrap_or(false)
-    {
-        return Some(SpaceAffiliation::Owner);
+    let session = session?;
+    let bare_jid = session_bare_jid(state, session)?;
+    if crate::admin::is_community_owner(&state.deps.app_state, &bare_jid).await {
+        Some(SpaceAffiliation::Owner)
+    } else {
+        None
     }
-    if server_permission_allowed(state, session, Permission::Admin)
-        .await
-        .unwrap_or(false)
-    {
-        return Some(SpaceAffiliation::Publisher);
-    }
-    if server_permission_allowed(state, session, Permission::Member)
-        .await
-        .unwrap_or(false)
-    {
-        return Some(SpaceAffiliation::Member);
-    }
-    None
+}
+
+/// Build the session's bare JID from `xmpp_localpart` + the deployment's
+/// configured `xmpp_domain`. Returns `None` if the localpart is missing
+/// or the combination fails to parse as a [`BareJid`] — both cases are
+/// treated as "no derivable identity" rather than panicking, because
+/// this helper feeds disco#info responses on a hot path.
+fn session_bare_jid(state: &WebSocketState, session: &Session) -> Option<BareJid> {
+    let raw = format!(
+        "{}@{}",
+        session.xmpp_localpart, state.deps.auth_state.xmpp_domain
+    );
+    raw.parse().ok()
 }
 
 pub(super) async fn space_affiliation_for_requester(

--- a/server/crates/waddle-server/tests/admin_serverrole_disco_ws.rs
+++ b/server/crates/waddle-server/tests/admin_serverrole_disco_ws.rs
@@ -1,0 +1,241 @@
+//! Server-targeted `disco#info` `waddle#server_affiliation` field must
+//! agree with the admin ACL signal — see PR #697.
+//!
+//! After PR #696 the admin ACL is "is this JID a PubSub Owner on the
+//! Spaces JID? (or in the bootstrap `WADDLE_SERVER_OWNER_LOCALPARTS`)".
+//! The chat client gates its admin UI affordance
+//! (`canManageCommunity`) off the `waddle#server_affiliation` field in
+//! the server's `disco#info` response. Before #697 that field was
+//! sourced from the Zanzibar permission graph — a different store than
+//! the PubSub affiliation table — so a user promoted dynamically via
+//! `spaces:set-role` would gain admin access on the server but the
+//! chat would not show the admin UI until the matching Zanzibar tuple
+//! was also written. #697 bridges them: the disco field now reads from
+//! the same `is_community_owner` signal the ACL uses.
+//!
+//! Test matrix:
+//!
+//! 1. Bootstrap owner (env-list `admin`) sees
+//!    `waddle#server_affiliation='owner'` in disco — preserves the
+//!    pre-existing path.
+//! 2. Non-owner (`alice`) without any Zanzibar tuple and without any
+//!    PubSub Owner row sees no `waddle#server_affiliation` extension
+//!    — there is no implicit tier.
+//! 3. After the bootstrap owner promotes `alice` to PubSub Owner on a
+//!    Spaces node via `spaces:set-role`, `alice`'s disco#info now
+//!    surfaces `waddle#server_affiliation='owner'` — same edge as the
+//!    admin ACL.
+
+mod ws_common;
+
+use tokio::sync::Mutex;
+use ws_common::{disco_info_query, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const ADMIN: &str = "admin";
+const NS_COMMANDS: &str = "http://jabber.org/protocol/commands";
+const NS_DATA: &str = "jabber:x:data";
+const NS_WADDLE_SERVER_INFO: &str = "urn:waddle:server-info:0";
+
+const NODE_SPACES_CREATE: &str = "urn:waddle:admin:spaces:create:0";
+const NODE_SPACES_SET_ROLE: &str = "urn:waddle:admin:spaces:set-role:0";
+
+// Each TestServer spins up an ephemeral cert + listener; serialize the
+// suite to avoid filesystem temp-port races (matches other admin
+// integration tests in this directory).
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect(
+    server: &TestServer,
+    username: &str,
+    password: &str,
+    resource: &str,
+) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, username, password, resource)
+        .await
+        .expect("websocket connect + auth")
+}
+
+async fn send_command(client: &mut WsXmppClient, node: &str, id: &str, form_xml: &str) -> String {
+    let body = format!(
+        r#"<command xmlns="{NS_COMMANDS}" node="{node}" action="execute">{form_xml}</command>"#
+    );
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{id}" to="{DOMAIN}">{body}</iq>"#
+        ))
+        .await
+        .expect("send command iq");
+    client
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && (frame.contains(&format!(r#"id="{id}""#))
+                    || frame.contains(&format!(r#"id='{id}'"#)))
+        })
+        .await
+        .expect("command iq response")
+}
+
+fn submit_form(node: &str, extra: &str) -> String {
+    format!(
+        r#"<x xmlns="{NS_DATA}" type="submit"><field var="FORM_TYPE" type="hidden"><value>{node}</value></field>{extra}</x>"#
+    )
+}
+
+fn text_field(var: &str, value: &str) -> String {
+    format!(r#"<field var="{var}" type="text-single"><value>{value}</value></field>"#)
+}
+
+fn extract_field(frame: &str, var: &str) -> Option<String> {
+    let marker_dq = format!(r#"var="{var}""#);
+    let marker_sq = format!(r#"var='{var}'"#);
+    let idx = frame.find(&marker_dq).or_else(|| frame.find(&marker_sq))?;
+    let after = &frame[idx..];
+    let open = after.find("<value>")?;
+    let inner = &after[open + "<value>".len()..];
+    let close = inner.find("</value>")?;
+    Some(inner[..close].to_string())
+}
+
+/// Returns `true` iff the disco#info `<query/>` carries an extension
+/// `<x type='result'/>` form whose `FORM_TYPE` equals the Waddle
+/// server-info namespace AND whose `waddle#server_affiliation` field
+/// holds `expected`. We deliberately key on the form-type so the
+/// assertion can't be satisfied by a stray field on some other
+/// extension form.
+fn server_role_form_has_value(frame: &str, expected: &str) -> bool {
+    let mut cursor = frame;
+    while let Some(form_start) = cursor.find("<x ") {
+        let after_open = &cursor[form_start..];
+        let Some(form_end_rel) = after_open.find("</x>") else {
+            return false;
+        };
+        let form = &after_open[..form_end_rel + "</x>".len()];
+        if form.contains(NS_WADDLE_SERVER_INFO) {
+            if let Some(value) = extract_field(form, "waddle#server_affiliation") {
+                return value == expected;
+            }
+            return false;
+        }
+        cursor = &after_open[form_end_rel + "</x>".len()..];
+    }
+    false
+}
+
+fn server_role_form_present(frame: &str) -> bool {
+    let mut cursor = frame;
+    while let Some(form_start) = cursor.find("<x ") {
+        let after_open = &cursor[form_start..];
+        let Some(form_end_rel) = after_open.find("</x>") else {
+            return false;
+        };
+        let form = &after_open[..form_end_rel + "</x>".len()];
+        if form.contains(NS_WADDLE_SERVER_INFO) {
+            return true;
+        }
+        cursor = &after_open[form_end_rel + "</x>".len()..];
+    }
+    false
+}
+
+#[tokio::test]
+async fn bootstrap_owner_sees_server_affiliation_owner_in_disco() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let password = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ADMIN, &password, "admin-disco-bootstrap").await;
+
+    let response = disco_info_query(&mut admin, DOMAIN, "disco-bootstrap-owner")
+        .await
+        .expect("disco#info response");
+
+    assert!(
+        server_role_form_has_value(&response, "owner"),
+        "bootstrap owner should see waddle#server_affiliation='owner', got: {response}"
+    );
+    let _ = admin.close().await;
+}
+
+#[tokio::test]
+async fn non_owner_omits_server_affiliation_extension() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_pass)]);
+    let mut alice = connect(&server, "alice", &alice_pass, "alice-disco-baseline").await;
+
+    let response = disco_info_query(&mut alice, DOMAIN, "disco-non-owner")
+        .await
+        .expect("disco#info response");
+
+    assert!(
+        !server_role_form_present(&response),
+        "non-owner should not see an `urn:waddle:server-info:0` extension form, got: {response}"
+    );
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn dynamic_pubsub_owner_promotes_server_affiliation_to_owner() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_pass)]);
+
+    // Step 1 — alice without any promotion has no `owner` form (proven
+    // separately above, but re-checked here so a regression that
+    // surfaces a spurious 'owner' field in the promotion path is
+    // not masked by the previous test running in isolation).
+    let mut alice = connect(&server, "alice", &alice_pass, "alice-disco-promo-pre").await;
+    let pre = disco_info_query(&mut alice, DOMAIN, "disco-alice-pre")
+        .await
+        .expect("disco#info response");
+    assert!(
+        !server_role_form_present(&pre),
+        "alice (unpromoted) should not have `urn:waddle:server-info:0`, got: {pre}"
+    );
+
+    // Step 2 — bootstrap admin creates a space and promotes alice to
+    // owner on that space's pubsub node. This writes an explicit
+    // `Affiliation::Owner` row keyed on alice's bare JID on the
+    // Spaces JID — the exact signal `is_community_owner` consults.
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ADMIN, &admin_pass, "admin-disco-promo").await;
+    let create_resp = send_command(
+        &mut admin,
+        NODE_SPACES_CREATE,
+        "promo-create",
+        &submit_form(NODE_SPACES_CREATE, &text_field("name", "PromoSpace")),
+    )
+    .await;
+    let space_jid = extract_field(&create_resp, "space_jid").expect("space_jid in create response");
+    let promote_extra = format!(
+        "{}{}{}",
+        text_field("space_jid", &space_jid),
+        text_field("member_jid", "alice@localhost"),
+        text_field("role", "owner"),
+    );
+    let set_resp = send_command(
+        &mut admin,
+        NODE_SPACES_SET_ROLE,
+        "promo-set-owner",
+        &submit_form(NODE_SPACES_SET_ROLE, &promote_extra),
+    )
+    .await;
+    assert!(
+        set_resp.contains(r#"type="result""#) || set_resp.contains(r#"type='result'"#),
+        "expected set-role result, got: {set_resp}"
+    );
+    let _ = admin.close().await;
+
+    // Step 3 — alice's next disco#info MUST now surface
+    // `waddle#server_affiliation='owner'`, even though no Zanzibar
+    // tuple was written. This proves the bridge: ACL signal and
+    // disco field are now driven by the same source.
+    let post = disco_info_query(&mut alice, DOMAIN, "disco-alice-post")
+        .await
+        .expect("disco#info response after promotion");
+    assert!(
+        server_role_form_has_value(&post, "owner"),
+        "after dynamic promotion alice should see waddle#server_affiliation='owner', got: {post}"
+    );
+    let _ = alice.close().await;
+}


### PR DESCRIPTION
## Summary

After #696 the server's admin ACL is "is this JID a PubSub Owner on the
Spaces JID, or in the bootstrap `WADDLE_SERVER_OWNER_LOCALPARTS` set?"
(`crate::admin::is_community_owner`). But the chat client gates its
admin UI affordance (`canManageCommunity`) off `serverRole`, which is
derived from the `waddle#server_affiliation` data form field on the
server's `disco#info`. That field was driven by the Zanzibar permission
graph — a *different* store than PubSub affiliations — so a user
promoted dynamically via `spaces:set-role` gained server-side admin
access but didn't see the admin UI until the matching Zanzibar tuple
was also written.

This PR bridges them on a single signal so the disco field and the ACL
agree.

## Path chosen: A (disco field reads from PubSub)

`server_affiliation_for_requester` now calls `is_community_owner`
directly and projects `true → Some(SpaceAffiliation::Owner)` /
`false → None`. The Zanzibar permission graph is untouched and still
powers per-channel / per-space authorization via `permission_allowed`
and `managed_channel_permission_allowed`. The previous Zanzibar-derived
`Publisher` / `Member` tiers on this disco field had no chat-side
consumer (the chat only treats `serverRole === 'owner'` as the admin
affordance), so removing them is a clean simplification rather than a
loss.

### Why Path A over Path B

The brief offered Path A (single signal) or Path B (write Zanzibar
tuple on grant). Picked A because:

- `server_affiliation_for_requester` had exactly one caller — the
  server-target `disco#info` builder in
  `disco_info/server_info.rs`. Switching the source is a localized
  refactor; the call graph is unchanged.
- `is_community_owner` was already `async`, and the disco builder was
  already `async` — no plumbing ripple.
- B (dual-write on grant) would have left two stores in lock-step at
  every promotion / revocation site instead of one, doubling the
  drift surface.

## Tests

New WS integration suite
`server/crates/waddle-server/tests/admin_serverrole_disco_ws.rs`:

- `bootstrap_owner_sees_server_affiliation_owner_in_disco` — env-list
  owner sees `waddle#server_affiliation='owner'`. The existing
  bootstrap path is preserved.
- `non_owner_omits_server_affiliation_extension` — a user with no
  PubSub Owner row and no env-list entry has no
  `urn:waddle:server-info:0` extension form on server `disco#info`.
- `dynamic_pubsub_owner_promotes_server_affiliation_to_owner` — the
  bootstrap admin promotes alice via the V2 `spaces:set-role`
  ad-hoc command (which writes the PubSub `Affiliation::Owner` row
  the new ACL consults). Alice's next `disco#info` carries
  `waddle#server_affiliation='owner'` — no Zanzibar write required.

All admin unit tests in `crate::admin` still pass.

## Test plan

- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cd chat && bun run lint` clean (knip)
- [x] User granted dynamic PubSub Owner sees `serverRole === 'owner'`
- [x] Non-owner sees no `urn:waddle:server-info:0` form
- [x] Bootstrap (env list) path still works

## Files touched

- `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs`
  — `server_affiliation_for_requester` rewired to `is_community_owner`,
  plus a small `session_bare_jid` helper to derive the bare JID from
  the session.
- `server/crates/waddle-server/tests/admin_serverrole_disco_ws.rs`
  (new) — the three integration tests above.

## Zanzibar usage note

The Zanzibar permission graph is still load-bearing for channel
viewing / publishing and managed-channel ACLs (`permission_allowed`,
`managed_channel_permission_allowed`, `permissions::write_*_tuple`).
This PR does NOT remove or alter those code paths. It only disconnects
the Zanzibar-derived signal from the server-affiliation disco field;
admin UI visibility now agrees with admin ACL by construction.

This PR was created with the assistance of a LLM.