### PR TITLE
fix(chat): re-export wasm free functions so xep0392 hue survives publish

### DIFF
--- a/chat/scripts/build-and-publish-wasm.mjs
+++ b/chat/scripts/build-and-publish-wasm.mjs
@@ -58,7 +58,11 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js";
+// Re-export every public binding wasm-pack emitted — classes (WaddleClient,
+// WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
+// xep0392_consistent_color, …). A hand-curated list silently drops new
+// #[wasm_bindgen] free functions until somebody notices the chat crashing.
+export * from "./waddle_xmpp_client_wasm_bg.js";
 `,
 );
 

--- a/chat/scripts/build-xmpp-wasm.mjs
+++ b/chat/scripts/build-xmpp-wasm.mjs
@@ -94,7 +94,11 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=${buildId}";
+// Re-export every public binding wasm-pack emitted — classes (WaddleClient,
+// WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
+// xep0392_consistent_color, …). A hand-curated list silently drops new
+// #[wasm_bindgen] free functions until somebody notices the chat crashing.
+export * from "./waddle_xmpp_client_wasm_bg.js?b=${buildId}";
 `,
 );
 

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -335,8 +335,15 @@ function djb2FallbackHue(input: string): number {
 
 /** Install the spec-conformant hue implementation. Called at app boot
  * once the wasm module is loaded; subsequent `consistentColor` calls
- * return XEP-0392 values. */
+ * return XEP-0392 values.
+ *
+ * Refuses non-function inputs so a stale wasm bundle that lacks
+ * `xep0392_consistent_hue` (e.g. when wasm-pack's named re-export list
+ * has fallen behind the Rust source) degrades to the DJB2 fallback
+ * instead of replacing `hueImpl` with `undefined` and crashing every
+ * `AppAvatar` render with "T is not a function". */
 export function setConsistentColorBackend(fn: (input: string) => number): void {
+  if (typeof fn !== "function") return;
   hueImpl = fn;
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -145,16 +145,73 @@ export class WaddleClient {
     search_dm_history(peer_jid: string, query: string, max: number): Promise<any>;
     search_room_history(room_jid: string, query: string, max: number): Promise<any>;
     search_users(query: string): Promise<any>;
+    send_call_finish(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_proceed(peer_full_jid: string, sid_str: string): Promise<any>;
+    /**
+     * Send a JMI `<propose/>` to the peer's bare JID (XEP-0353
+     * §5.1.1). The bare JID lets the responder's server ring every
+     * connected resource until one of them proceeds/rejects.
+     */
+    send_call_propose(peer_bare_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
+    send_call_reject(peer_full_jid: string, sid_str: string): Promise<any>;
+    send_call_retract(peer_full_jid: string, sid_str: string): Promise<any>;
+    /**
+     * Send a Jingle `session-accept` IQ in response to a received
+     * session-initiate. `initiator` and `responder` are validated
+     * as full JIDs at the wasm boundary so a malformed JID surfaces
+     * as a clear `JsError` rather than a wire-rejected stanza.
+     */
+    send_call_session_accept(peer_full_jid: string, initiator_full_jid: string, responder_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
+    /**
+     * Send a Jingle `session-initiate` IQ to the peer's full JID
+     * (XEP-0166 §6.4). The `initiator` attribute names the call
+     * originator; the server's Jingle handler additionally
+     * validates the authenticated session matches it.
+     */
+    send_call_session_initiate(peer_full_jid: string, initiator_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
+    send_call_session_terminate(peer_full_jid: string, sid_str: string, reason?: string | null): Promise<any>;
     send_chat_message(peer_jid: string, body: string, options: any): Promise<any>;
     send_chat_state(to: string, msg_type: string, state: string): Promise<any>;
     send_correction(to: string, msg_type: string, body: string, replaces_id: string, options: any): Promise<any>;
     send_displayed(to: string, msg_type: string, message_id: string): Promise<any>;
     send_groupchat_message(room_jid: string, body: string, options: any): Promise<any>;
     send_moderation(to: string, msg_type: string, target_id: string, reason?: string | null): Promise<any>;
+    /**
+     * Send a Jingle `session-terminate` IQ to hang up. `reason` is
+     * one of the XEP-0166 §7.4 condition names ("success",
+     * "decline", "cancel", "busy", "gone", …) parsed against
+     * `xmpp_parsers::jingle::Reason`; unknown values are rejected
+     * at the wasm boundary so a typo can't ship a malformed
+     * condition over the wire.
+     * Send `<request-join xmlns='urn:waddle:muc-call:0' room='ROOM_JID'/>`
+     * to the MUC room and return the issued LiveKit join credentials
+     * as a typed `{ url, room, identity, token }` object. The XML
+     * is built via `minidom::Element::builder` (XML hard rule
+     * from CLAUDE.md — no string concatenation at the wire
+     * boundary).
+     */
+    send_muc_call_join(room_jid: string): Promise<any>;
+    /**
+     * Send `<request-leave xmlns='urn:waddle:muc-call:0' room='ROOM_JID'/>`
+     * to the MUC room. Server unregisters the participant + revokes
+     * every jti it minted for `(room, identity)`. Resolves with no
+     * payload.
+     */
+    send_muc_call_leave(room_jid: string): Promise<any>;
     send_presence(status?: string | null, show?: string | null): Promise<any>;
     send_raw_iq(xml: string): Promise<any>;
     send_reaction(to: string, msg_type: string, target_id: string, emojis: string[]): Promise<any>;
     send_retraction(to: string, msg_type: string, retracts_id: string): Promise<any>;
+    /**
+     * Register a callback for inbound XMPP-native call events
+     * (XEP-0353 JMI envelopes + XEP-0166 Jingle session control
+     * carrying a `urn:waddle:transports:livekit:0` transport).
+     * The callback receives a [`WaddleCallEvent`]-shaped object
+     * with a `kind` discriminator and optional `media` / `join` /
+     * `reason` fields. See `messaging::call::parse_call_event` on
+     * the Rust side for the typed input.
+     */
+    set_on_call(cb: Function): void;
     set_on_connected(cb: Function): void;
     set_on_disconnected(cb: Function): void;
     set_on_error(cb: Function): void;
@@ -196,6 +253,17 @@ export class WaddleClient {
      * [`Self::pin_message`].
      */
     unpin_message(room_jid: string, target_stanza_id: string): Promise<any>;
+    /**
+     * Update our MUC presence in `room_jid/nick` with (or without)
+     * the `<call xmlns='urn:waddle:muc-call:0'/>` extension. Sent as
+     * a fresh available-presence so other occupants discover that
+     * we've joined or left the room's group call without polling.
+     *
+     * `active=true` advertises us as a current participant; `false`
+     * emits the extension with `state='inactive'` so legacy
+     * presence-replay buffers eventually drop the prior `active`.
+     */
+    update_muc_call_presence(room_jid: string, nick: string, active: boolean, call_id: string): Promise<any>;
     /**
      * Fetch the latest calendar events from the community events
      * node. Returns ALL items including past events; chat-side

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mp5tmxfj";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mp5tmxfj";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mp5tmxfj";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpbun1h4";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";
 
 let initPromise;
 
@@ -26,4 +26,8 @@ export default async function init() {
   return initPromise;
 }
 
-export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js?b=mp5tmxfj";
+// Re-export every public binding wasm-pack emitted — classes (WaddleClient,
+// WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
+// xep0392_consistent_color, …). A hand-curated list silently drops new
+// #[wasm_bindgen] free functions until somebody notices the chat crashing.
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";


### PR DESCRIPTION
## Summary

Production chat threw `TypeError: T is not a function` on every `AppAvatar` re-render, knocking out channel views and breaking group calls. Root cause is the wasm publish entry stripping every Rust free function.

### Root cause

Both `chat/scripts/build-xmpp-wasm.mjs` (local dev) and `chat/scripts/build-and-publish-wasm.mjs` (CI publish) overwrote `waddle_xmpp_client_wasm.js` with a hand-curated:

```js
export { WaddleClient, WaddleConfig } from "./waddle_xmpp_client_wasm_bg.js";
```

…so every Rust `#[wasm_bindgen]` free function was silently dropped on the way to GitHub Packages. `xep0392_consistent_hue` (introduced in #644) never reached production, so `chat/src/lib/xmpp/client.ts:311` ran `setConsistentColorBackend(undefined)`, clobbering the DJB2 fallback. Every subsequent `consistentColor(name)` call (notably `AppAvatar.vue:41`'s `bgColor` computed) threw — taking the channel UI with it.

The `<request-join xmlns='urn:waddle:muc-call:0'/>` IQ still made it to the wire because `send_muc_call_join` is a method on `WaddleClient`, which IS re-exported. But the surrounding UI died before the LiveKit overlay could mount, so group calls appeared to silently fail.

## Changes

- `chat/scripts/build-xmpp-wasm.mjs` and `chat/scripts/build-and-publish-wasm.mjs`: replace the hand-curated `export { … }` with `export * from "./waddle_xmpp_client_wasm_bg.js…"` so every wasm-pack-emitted binding (classes + free functions) flows through. Future `#[wasm_bindgen]` additions no longer need a script edit to ship.
- `chat/src/lib/chat-ui.ts`: `setConsistentColorBackend` ignores non-function inputs. Defense in depth — a stale wasm bundle now degrades to the DJB2 fallback instead of crashing every avatar render.
- `server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.{js,d.ts}`: regenerated via `REBUILD_WASM=1` against the fixed script. `bg.js` (gitignored, regenerated each build) now contains `xep0392_consistent_hue` and `xep0392_consistent_color`.

## Test plan

- [x] `cd chat && bun test` — 936 pass, 0 fail
- [x] `cd chat && bun run lint` — knip clean
- [x] Verified regenerated `waddle_xmpp_client_wasm_bg.js` contains `export function xep0392_consistent_hue` and `export function xep0392_consistent_color`
- [ ] After merge: confirm the publish workflow pushes a fresh `@waddle/xmpp-client-wasm` with the new exports
- [ ] After deploy: confirm prod channel renders without the TypeError and that group-call `<request-join/>` drives the LiveKit overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)