### PR TITLE
fix(chat,server): unblock group calls — wasm parser + visible pre-transition errors

### DIFF
--- a/chat/src/components/XmppProvider.vue
+++ b/chat/src/components/XmppProvider.vue
@@ -8,6 +8,7 @@ import { installInstrumentation } from "@/lib/xmpp/xmpp-instrumentation";
 import IncomingCallToast from "@/components/calls/IncomingCallToast.vue";
 import OutgoingCallToast from "@/components/calls/OutgoingCallToast.vue";
 import CallOverlay from "@/components/calls/CallOverlay.vue";
+import CallErrorToast from "@/components/calls/CallErrorToast.vue";
 
 const props = defineProps<{
   serverBaseUrl: string;
@@ -84,4 +85,7 @@ onUnmounted(() => {
   <IncomingCallToast />
   <OutgoingCallToast />
   <CallOverlay />
+  <!-- Renders only when phase is idle/ended; covers pre-transition
+       call errors that the other three surfaces never see. -->
+  <CallErrorToast />
 </template>

--- a/chat/src/components/calls/CallErrorToast.vue
+++ b/chat/src/components/calls/CallErrorToast.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "@nanostores/vue";
+import { AlertCircle } from "lucide-vue-next";
+import { $callState, $lastCallError, clearLastCallError } from "@/lib/calls/call-store";
+
+const state = useStore($callState);
+const lastError = useStore($lastCallError);
+
+// `IncomingCallToast`, `OutgoingCallToast` (live branch), and
+// `CallOverlay` already render `$lastCallError` inline when their
+// phase is active. This toast covers the gap: pre-transition
+// rejections from `beginMucCall` / `beginOutgoingCall` set the
+// error before `$callState` ever leaves `idle`, so without a
+// surface that mounts in idle the error is invisible — and clicking
+// the channel call button just appears to do nothing. The `ended`
+// branch of `OutgoingCallToast` also omits the error row, so cover
+// that too.
+const visible = computed(() => {
+  if (!lastError.value) return false;
+  const phase = state.value.phase;
+  return phase === "idle" || phase === "ended";
+});
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="fixed top-6 right-6 z-50 max-w-sm rounded-xl border border-destructive/30 bg-destructive/10 p-3 shadow-2xl glass-surface"
+    role="alert"
+    aria-live="assertive"
+    aria-label="Call error"
+  >
+    <div class="flex items-start gap-2">
+      <AlertCircle class="w-4 h-4 mt-0.5 text-destructive flex-shrink-0" />
+      <div class="min-w-0 flex-1 type-caption text-destructive">{{ lastError }}</div>
+      <button
+        class="chat-icon-button chat-icon-button--sm text-destructive/70 hover:bg-destructive/10 hover:text-destructive"
+        type="button"
+        aria-label="Dismiss"
+        @click="clearLastCallError"
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+  </div>
+</template>

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -230,6 +230,20 @@ export function reportCallError(err: unknown): void {
 }
 
 /**
+ * Drop the active error without touching `$callState`. Used by the
+ * global error toast's dismiss button — `clearCallState` is the
+ * wrong tool when phase is already `idle` or `ended`, since it
+ * would still emit a redundant state set.
+ */
+export function clearLastCallError(): void {
+  if (clearTimer) {
+    clearTimeout(clearTimer);
+    clearTimer = null;
+  }
+  $lastCallError.set(null);
+}
+
+/**
  * Best-effort teardown for the live call slot before the XMPP
  * connection drops or the call surface unmounts. Sends the
  * appropriate XEP-0166 / XEP-0353 stanza to the peer (so they don't

--- a/chat/tests/call-store.test.ts
+++ b/chat/tests/call-store.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
   $callState,
+  $lastCallError,
   applyCallEvent,
   beginOutgoingCall,
   clearCallState,
+  clearLastCallError,
   reduceCallState,
+  reportCallError,
 } from "../src/lib/calls/call-store";
 import type { CallMedia, LiveKitJoin } from "../src/lib/calls/types";
 
@@ -350,5 +353,21 @@ describe("call-store reducer", () => {
       media: audioVideo,
     });
     expect(next).toBe(current);
+  });
+});
+
+describe("clearLastCallError", () => {
+  test("clears the error without touching $callState", () => {
+    // Pre-transition rejection scenario: a `beginMucCall` failure
+    // sets the error while phase stays idle. `clearCallState` is
+    // overkill here (it would emit a redundant state set);
+    // `clearLastCallError` is the targeted helper.
+    clearCallState();
+    reportCallError(new Error("muc-call: transport missing @url"));
+    expect($lastCallError.get()).toBe("muc-call: transport missing @url");
+    const phaseBefore = $callState.get().phase;
+    clearLastCallError();
+    expect($lastCallError.get()).toBeNull();
+    expect($callState.get().phase).toBe(phaseBefore);
   });
 });

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -6,8 +6,59 @@ use waddle_xmpp_client::messaging::{
 };
 
 const NS_WADDLE_MUC_CALL: &str = "urn:waddle:muc-call:0";
+const NS_WADDLE_LIVEKIT_TRANSPORT: &str = "urn:waddle:transports:livekit:0";
 
 const NS_JABBER_CLIENT: &str = "jabber:client";
+
+/// Walk an `<iq type='result'>` payload from the server's
+/// `<request-join xmlns='urn:waddle:muc-call:0'/>` IQ and pull out
+/// the typed `WaddleLiveKitJoin`.
+///
+/// The wire shape (canonical, see `WaddleLiveKitTransport::to_element`
+/// in `waddle-xmpp/src/xep/xep_waddle_livekit_transport.rs`) is:
+///
+/// ```xml
+/// <iq type='result'>
+///   <joined xmlns='urn:waddle:muc-call:0'>
+///     <transport xmlns='urn:waddle:transports:livekit:0'
+///                url='...' room='...' identity='...'>
+///       <token>JWT</token>
+///     </transport>
+///   </joined>
+/// </iq>
+/// ```
+///
+/// `url`, `room`, `identity` are **attributes** of `<transport>`;
+/// `<token>` is the sole child element. Reading any of the first
+/// three via `get_child(...)` (as a pre-#495 draft of this parser
+/// did) silently turns every server-issued join into a parse
+/// error, which surfaces as a never-resolved call promise on the
+/// chat side and a UI that does nothing when the user clicks the
+/// channel call button.
+fn parse_muc_call_join_result(result: &Element) -> Result<crate::types::WaddleLiveKitJoin, String> {
+    let joined = result
+        .get_child("joined", NS_WADDLE_MUC_CALL)
+        .ok_or_else(|| "muc-call: response missing <joined/>".to_string())?;
+    let transport = joined
+        .get_child("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .ok_or_else(|| "muc-call: <joined/> missing <transport/>".to_string())?;
+    let attr = |name: &str| -> Result<String, String> {
+        transport
+            .attr(name)
+            .map(str::to_owned)
+            .ok_or_else(|| format!("muc-call: transport missing @{name}"))
+    };
+    let token = transport
+        .get_child("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .map(|c| c.text())
+        .ok_or_else(|| "muc-call: transport missing <token/>".to_string())?;
+    Ok(crate::types::WaddleLiveKitJoin {
+        url: attr("url")?,
+        room: attr("room")?,
+        identity: attr("identity")?,
+        token,
+    })
+}
 
 fn message_with_jmi(to: &str, jmi: Element) -> Element {
     Element::builder("message", NS_JABBER_CLIENT)
@@ -188,29 +239,7 @@ impl WaddleClient {
                 .append(payload)
                 .build();
             let result = send_iq_command(inner, stanza).await?;
-            // Walk `<iq><joined xmlns='urn:waddle:muc-call:0'>
-            // <transport xmlns='urn:waddle:transports:livekit:0'>
-            // <url/><room/><identity/><token/></transport></joined>`
-            // and return a typed JS object.
-            let joined = result
-                .get_child("joined", NS_WADDLE_MUC_CALL)
-                .ok_or_else(|| js_error("muc-call: response missing <joined/>"))?;
-            let transport = joined
-                .get_child("transport", "urn:waddle:transports:livekit:0")
-                .ok_or_else(|| js_error("muc-call: <joined/> missing <transport/>"))?;
-            let field = |name: &str| -> Result<String, JsValue> {
-                let child = transport.get_child(name, "urn:waddle:transports:livekit:0");
-                match child {
-                    Some(c) => Ok(c.text()),
-                    None => Err(js_error(format!("muc-call: transport missing <{name}/>"))),
-                }
-            };
-            let join = crate::types::WaddleLiveKitJoin {
-                url: field("url")?,
-                room: field("room")?,
-                identity: field("identity")?,
-                token: field("token")?,
-            };
+            let join = parse_muc_call_join_result(&result).map_err(js_error)?;
             to_js_value(&join)
         })
     }
@@ -264,8 +293,94 @@ impl WaddleClient {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use jid::FullJid;
     use std::str::FromStr;
+
+    fn canonical_join_iq_result() -> Element {
+        // Mirrors the exact byte layout emitted by
+        // `MucCallHandler::handle_join` (see
+        // `waddle-xmpp/src/protocol/handlers/muc_call.rs`) — keeps
+        // this parser locked to the real wire shape rather than a
+        // hand-typed approximation.
+        let xml = "<iq xmlns='jabber:client' type='result' id='abc'>\
+                <joined xmlns='urn:waddle:muc-call:0'>\
+                    <transport xmlns='urn:waddle:transports:livekit:0' \
+                               url='wss://livekit.waddle.test/' \
+                               room='chat@muc.waddle.test' \
+                               identity='alice@waddle.test/web-1'>\
+                        <token>eyJhbGciOiJIUzI1NiJ9.payload.sig</token>\
+                    </transport>\
+                </joined>\
+            </iq>";
+        xml.parse().expect("test fixture parses")
+    }
+
+    #[test]
+    fn parse_muc_call_join_result_reads_canonical_response() {
+        let iq = canonical_join_iq_result();
+        let join = parse_muc_call_join_result(&iq).expect("canonical response parses");
+        assert_eq!(join.url, "wss://livekit.waddle.test/");
+        assert_eq!(join.room, "chat@muc.waddle.test");
+        assert_eq!(join.identity, "alice@waddle.test/web-1");
+        assert_eq!(join.token, "eyJhbGciOiJIUzI1NiJ9.payload.sig");
+    }
+
+    #[test]
+    fn parse_muc_call_join_result_rejects_missing_joined() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='abc'/>"
+            .parse()
+            .unwrap();
+        let err = parse_muc_call_join_result(&iq).unwrap_err();
+        assert!(err.contains("missing <joined/>"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_muc_call_join_result_rejects_missing_transport() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='abc'>\
+                <joined xmlns='urn:waddle:muc-call:0'/>\
+            </iq>"
+            .parse()
+            .unwrap();
+        let err = parse_muc_call_join_result(&iq).unwrap_err();
+        assert!(err.contains("missing <transport/>"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_muc_call_join_result_rejects_missing_attribute() {
+        // Drop the `url` attribute — parser must reject rather than
+        // silently leaving the field blank and propagating a half-
+        // valid join object to the chat client.
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='abc'>\
+                <joined xmlns='urn:waddle:muc-call:0'>\
+                    <transport xmlns='urn:waddle:transports:livekit:0' \
+                               room='chat@muc.waddle.test' \
+                               identity='alice@waddle.test/web-1'>\
+                        <token>jwt</token>\
+                    </transport>\
+                </joined>\
+            </iq>"
+            .parse()
+            .unwrap();
+        let err = parse_muc_call_join_result(&iq).unwrap_err();
+        assert!(err.contains("@url"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_muc_call_join_result_rejects_missing_token() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='abc'>\
+                <joined xmlns='urn:waddle:muc-call:0'>\
+                    <transport xmlns='urn:waddle:transports:livekit:0' \
+                               url='wss://livekit.waddle.test/' \
+                               room='chat@muc.waddle.test' \
+                               identity='alice@waddle.test/web-1'/>\
+                </joined>\
+            </iq>"
+            .parse()
+            .unwrap();
+        let err = parse_muc_call_join_result(&iq).unwrap_err();
+        assert!(err.contains("missing <token/>"), "got: {err}");
+    }
 
     /// `parse_full_jid` itself returns `Result<FullJid, JsValue>`,
     /// and `wasm_bindgen::JsValue` panics under `cargo test` on

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpbun1h4";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpbvvpxa";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpbun1h4";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";


### PR DESCRIPTION
## Summary

Two-commit chain to unblock channel group calls end-to-end.

### Commit 1: wasm parser reads `<transport>` attributes, not children

`MucCallHandler::handle_join` (`server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs`) emits the canonical `urn:waddle:transports:livekit:0` shape — `url`/`room`/`identity` as **attributes** on `<transport>`, `<token>` as the sole child element:

```xml
<iq type='result'>
  <joined xmlns='urn:waddle:muc-call:0'>
    <transport xmlns='urn:waddle:transports:livekit:0'
               url='wss://livekit.waddle.social/'
               room='chat@muc.waddle.social'
               identity='alice@waddle.social/web-1'>
      <token>JWT</token>
    </transport>
  </joined>
</iq>
```

`send_muc_call_join` in `server/crates/waddle-xmpp-client-wasm/src/client_calls.rs` read all four via `transport.get_child(...)`. Every successful join failed with `"muc-call: transport missing <url/>"`. `beginMucCall` rejected before transitioning `$callState` to `active`, so the LiveKit overlay never mounted even though the server replied with a valid JWT.

Extract the walk into a pure helper `parse_muc_call_join_result(&Element)` and back it with five unit tests (canonical response + four error paths) per CLAUDE.md's XEP-test rule.

### Commit 2: surface pre-transition call errors via a global toast

The wasm rejection in commit 1 set `$lastCallError` but had no visible surface. `IncomingCallToast`, `OutgoingCallToast`'s live branch, and `CallOverlay` are the only renderers — each gated on a non-idle phase. Pre-transition rejections from `beginMucCall` / `beginOutgoingCall` set the error before `$callState` ever leaves `idle`, so the user sees nothing.

Add `CallErrorToast.vue` mounted at `XmppProvider` root alongside the other call surfaces. Renders only when phase is `idle` or `ended` and an error is set; dismissible via × button. New `clearLastCallError()` helper avoids bouncing through `clearCallState` (which would emit a redundant phase set).

This also covers the gap where `OutgoingCallToast`'s `ended` branch omits the inline error row.

## Changes

- `server/crates/waddle-xmpp-client-wasm/src/client_calls.rs` — extract parser into `parse_muc_call_join_result`, read transport attributes correctly, add 5 unit tests.
- `server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js` — regenerated.
- `chat/src/lib/calls/call-store.ts` — expose `clearLastCallError()`.
- `chat/src/components/calls/CallErrorToast.vue` — new component, mounted at root.
- `chat/src/components/XmppProvider.vue` — mount the new toast.
- `chat/tests/call-store.test.ts` — test the new helper.

## Test plan

- [x] `cargo test -p waddle-xmpp-client-wasm --lib client_calls::tests` — 8 pass (3 existing + 5 new)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p waddle-xmpp-client-wasm --all-targets -- -D warnings` clean
- [x] `bun test` in chat — 937 pass, 0 fail (936 existing + 1 new)
- [x] `bun run lint` in chat — knip clean
- [ ] After merge + deploy: confirm clicking the channel call button transitions `$callState` to `active`, the CallOverlay mounts with the LiveKit join token, and if anything in the call flow rejects, the global error toast shows the message

🤖 Generated with [Claude Code](https://claude.com/claude-code)