### PR TITLE
fix(server): groupchat reflection uses try_send_peer_to so one zombie can't wedge the room (#699)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -103,6 +103,45 @@ pub(super) async fn deliver_peer_to_full(
     target: &jid::FullJid,
     stanza: &Stanza,
 ) {
+    // Issue #699: the MUC reflector emits one `RouteToConnection` per
+    // occupant. Sending with the blocking `send_peer_to` (which
+    // `mpsc::Sender::send().await`s on a 256-slot per-connection
+    // channel) means a single zombie WebSocket peer — TCP gone
+    // without FIN, consumer task hung on `Sink::send` — wedges every
+    // subsequent groupchat dispatch through the same interpreter
+    // loop. In prod that froze global MAM + inbox writes for hours
+    // until a pod restart. Groupchat reflection is a fan-out by
+    // design, so route it through the non-blocking `try_send_peer_to`
+    // and tolerate `DroppedFull` for slow consumers. 1:1 chat
+    // (message type='chat', IQ, presence-to-full-JID) keeps the
+    // blocking path: those targets are singular and the natural
+    // backpressure is desirable.
+    let is_groupchat_reflection = matches!(
+        stanza,
+        Stanza::Message(message)
+            if message.type_ == xmpp_parsers::message::MessageType::Groupchat
+    );
+    if is_groupchat_reflection {
+        match registry.try_send_peer_to(target, stanza.clone()) {
+            waddle_xmpp::registry::BroadcastOutcome::Delivered => {
+                debug!(jid = %target, "RouteToConnection: groupchat reflection queued for recipient pass");
+            }
+            waddle_xmpp::registry::BroadcastOutcome::DroppedFull => {
+                // Per-recipient log at debug; the broadcast-level
+                // Prometheus counter (`waddle_broadcast_dropped_full_total`)
+                // is the canonical signal under load.
+                debug!(
+                    jid = %target,
+                    "RouteToConnection: groupchat reflection dropped (recipient mpsc full)"
+                );
+            }
+            waddle_xmpp::registry::BroadcastOutcome::NotConnected
+            | waddle_xmpp::registry::BroadcastOutcome::DroppedClosed => {
+                deliver_to_detached(sm_session_registry, target, stanza).await;
+            }
+        }
+        return;
+    }
     // The live-send path needs ownership for `send_peer_to`; the
     // detached fallback only borrows. Clone once here on the live
     // branch so the caller hands us an `&Stanza` and avoids a
@@ -114,46 +153,56 @@ pub(super) async fn deliver_peer_to_full(
         }
         waddle_xmpp::registry::SendResult::NotConnected
         | waddle_xmpp::registry::SendResult::ChannelClosed => {
-            // Known limitation (Copilot review on PR #276): queues the
-            // pre-recipient-pass stanza into the detached XEP-0198
-            // replay buffer. Replay sends the stored XML verbatim
-            // WITHOUT a recipient-pass dispatch, so the replayed
-            // message is missing the recipient-side
-            // `<stanza-id by='recipient'/>` (XEP-0359 §5) and
-            // recipient-side filtering / archive / inbox effects don't
-            // fire. Matches LEGACY behaviour (which had no recipient
-            // pass at all) and is therefore not a regression. Closing
-            // the gap properly requires running the headless recipient
-            // pass per detached target and queueing its `SendStanza`
-            // output — tracked as a follow-up to #229.
-            if let Some(sm) = sm_session_registry {
-                match sm
-                    .record_stanza_for_detached_bound_resource(target, stanza, chrono::Utc::now())
-                    .await
-                {
-                    Ok(true) => {
-                        debug!(
-                            jid = %target,
-                            "RouteToConnection: recipient detached, queued for XEP-0198 replay"
-                        );
-                    }
-                    Ok(false) => {
-                        debug!(
-                            jid = %target,
-                            "RouteToConnection: target offline and no detached session, dropping"
-                        );
-                    }
-                    Err(error) => {
-                        warn!(
-                            jid = %target,
-                            %error,
-                            "RouteToConnection: failed to record stanza for detached resource"
-                        );
-                    }
-                }
-            } else {
-                debug!(jid = %target, "RouteToConnection: target offline, dropping");
-            }
+            deliver_to_detached(sm_session_registry, target, stanza).await;
+        }
+    }
+}
+
+/// Shared "live target unavailable" fallback. Queues the stanza
+/// into the recipient's detached XEP-0198 replay buffer if a
+/// resumable session exists, otherwise drops with a debug log.
+///
+/// Known limitation (Copilot review on PR #276): the buffered XML
+/// is the pre-recipient-pass form, so replay on resume sends it
+/// verbatim WITHOUT running the recipient-pass chain. The replayed
+/// message is missing the recipient-side `<stanza-id by='recipient'/>`
+/// (XEP-0359 §5) and recipient-side filtering / archive / inbox
+/// effects don't fire. Matches LEGACY behaviour (which had no
+/// recipient pass at all) and is therefore not a regression. Closing
+/// the gap properly requires running the headless recipient pass per
+/// detached target and queueing its `SendStanza` output — tracked as
+/// a follow-up to #229.
+async fn deliver_to_detached(
+    sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    target: &jid::FullJid,
+    stanza: &Stanza,
+) {
+    let Some(sm) = sm_session_registry else {
+        debug!(jid = %target, "RouteToConnection: target offline, dropping");
+        return;
+    };
+    match sm
+        .record_stanza_for_detached_bound_resource(target, stanza, chrono::Utc::now())
+        .await
+    {
+        Ok(true) => {
+            debug!(
+                jid = %target,
+                "RouteToConnection: recipient detached, queued for XEP-0198 replay"
+            );
+        }
+        Ok(false) => {
+            debug!(
+                jid = %target,
+                "RouteToConnection: target offline and no detached session, dropping"
+            );
+        }
+        Err(error) => {
+            warn!(
+                jid = %target,
+                %error,
+                "RouteToConnection: failed to record stanza for detached resource"
+            );
         }
     }
 }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -120,20 +120,64 @@ impl ConnectionRegistry {
         }
     }
 
-    /// Non-blocking send. Returns a typed `BroadcastOutcome` describing
-    /// delivery, absence, or which silent-drop path was taken.
+    /// Non-blocking send as [`DeliveryKind::DirectFrame`]. Returns a
+    /// typed `BroadcastOutcome` describing delivery, absence, or
+    /// which silent-drop path was taken.
     ///
-    /// Intended for fan-out paths (MUC broadcasts) where a slow or zombied
-    /// consumer must never stall the producer task. On `Closed` the stale
-    /// entry is evicted, but only if the current registry entry's sender is
-    /// still closed — a concurrent `register` for the same FullJid may have
-    /// installed a fresh, live sender between our `get` and `try_send`, and
-    /// we must not wipe the newcomer. On `Full` the stanza is dropped
-    /// without touching the registry (the consumer may just be catching up).
+    /// Intended for fan-out paths (XEP-0163 PEP fanout, MUC presence
+    /// broadcasts, roster pushes, …) where a slow or zombied
+    /// consumer must never stall the producer task.
     ///
-    /// Every outcome bumps a Prometheus counter so production drop rates
-    /// are visible even when callers discard the return value.
+    /// For peer-routed groupchat reflection that needs the recipient
+    /// pass (XEP-0359 recipient stamp, XEP-0313 archive, XEP-0280
+    /// received-carbons, inbox projection), use
+    /// [`Self::try_send_peer_to`] instead — same non-blocking
+    /// guarantees, but the destination's main loop runs its state
+    /// machine before writing to the wire.
     pub fn try_send_to(&self, jid: &FullJid, stanza: Stanza) -> BroadcastOutcome {
+        self.try_send_to_with_kind(jid, stanza, DeliveryKind::DirectFrame)
+    }
+
+    /// Non-blocking [`DeliveryKind::PeerStanza`] send. Locked Q-fix
+    /// #699: the MUC reflector emits one `RouteToConnection` per
+    /// occupant and must NOT block on any single connection's mpsc
+    /// — one zombie WebSocket peer with a hung consumer task was
+    /// enough to stall every groupchat dispatch through the same
+    /// interpreter loop (and therefore archive + inbox writes for
+    /// every other user of the room) until the pod restarted.
+    ///
+    /// Same `BroadcastOutcome` contract as [`Self::try_send_to`];
+    /// the destination's main loop feeds the stanza through its
+    /// state machine as `InboundEvent::StanzaFromPeer` so the
+    /// recipient pass still runs when the channel has capacity.
+    pub fn try_send_peer_to(&self, jid: &FullJid, stanza: Stanza) -> BroadcastOutcome {
+        self.try_send_to_with_kind(jid, stanza, DeliveryKind::PeerStanza)
+    }
+
+    /// Shared non-blocking send path. The only thing the public
+    /// callers vary is the [`DeliveryKind`] tag on the queued
+    /// [`OutboundStanza`], which is built via the same
+    /// [`OutboundStanza::new`] / [`OutboundStanza::peer_stanza`]
+    /// constructors as the blocking [`Self::send_to_with_kind`] — no
+    /// manual struct literal here so the kind→constructor mapping
+    /// stays in one place.
+    ///
+    /// On `Closed` the stale entry is evicted, but only if the
+    /// current registry entry's sender is still closed — a
+    /// concurrent `register` for the same FullJid may have installed
+    /// a fresh, live sender between our `get` and `try_send`, and we
+    /// must not wipe the newcomer. On `Full` the stanza is dropped
+    /// without touching the registry (the consumer may just be
+    /// catching up).
+    ///
+    /// Every outcome bumps a Prometheus counter so production drop
+    /// rates are visible even when callers discard the return value.
+    fn try_send_to_with_kind(
+        &self,
+        jid: &FullJid,
+        stanza: Stanza,
+        kind: DeliveryKind,
+    ) -> BroadcastOutcome {
         let sender = match self.connections.get(jid) {
             Some(entry) => entry.value().sender.clone(),
             None => {
@@ -142,7 +186,10 @@ impl ConnectionRegistry {
             }
         };
 
-        let outbound = OutboundStanza::new(stanza);
+        let outbound = match kind {
+            DeliveryKind::DirectFrame => OutboundStanza::new(stanza),
+            DeliveryKind::PeerStanza => OutboundStanza::peer_stanza(stanza),
+        };
 
         match sender.try_send(outbound) {
             Ok(()) => {
@@ -160,6 +207,7 @@ impl ConnectionRegistry {
                 // out every other signal on the pod.
                 debug!(
                     jid = %jid,
+                    ?kind,
                     "Outbound channel full; broadcast stanza dropped"
                 );
                 BroadcastOutcome::DroppedFull

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
@@ -249,6 +249,73 @@ async fn test_send_to_waits_for_capacity_instead_of_dropping() {
     );
 }
 
+/// Issue #699: the MUC reflector emits one `RouteToConnection` per
+/// occupant. If even ONE recipient's per-connection mpsc is full
+/// (slow consumer, zombie WebSocket, paused VM, …) the reflector's
+/// caller must NOT block — every subsequent groupchat dispatch goes
+/// through the same interpreter loop, and a blocking send wedges
+/// archive + inbox writes for the whole room until the pod
+/// restarts. `try_send_peer_to` is the non-blocking variant the
+/// reflector now uses.
+#[tokio::test(start_paused = true)]
+async fn try_send_peer_to_returns_immediately_when_recipient_channel_is_full() {
+    let registry = ConnectionRegistry::new();
+    let jid = test_jid("zombie");
+    // Capacity 1 + never-drained receiver simulates the zombie
+    // WebSocket: consumer task hung on `Sink::send`, mpsc is full,
+    // producer must not stall.
+    let (tx, _rx_never_drains) = mpsc::channel(1);
+    registry.register(jid.clone(), tx);
+
+    // Saturate the channel.
+    let prime = make_test_message("zombie@example.com");
+    assert!(matches!(
+        registry.send_to(&jid, Stanza::Message(prime)).await,
+        SendResult::Sent
+    ));
+
+    // Now the channel is full. A blocking `send_peer_to` would
+    // await forever (1.5h+ in prod before this fix). The
+    // non-blocking variant returns `DroppedFull` synchronously.
+    let drop_target = make_test_message("zombie@example.com");
+    let start = tokio::time::Instant::now();
+    let outcome = registry.try_send_peer_to(&jid, Stanza::Message(drop_target));
+    let elapsed = start.elapsed();
+
+    assert_eq!(outcome, BroadcastOutcome::DroppedFull);
+    // The whole point: bounded synchronous cost regardless of
+    // recipient state.
+    assert!(
+        elapsed < Duration::from_millis(10),
+        "try_send_peer_to must not await capacity — took {elapsed:?}"
+    );
+}
+
+/// `try_send_peer_to` must tag the outbound as `PeerStanza` so the
+/// destination's main loop runs the recipient pass (XEP-0359
+/// recipient stanza-id, XEP-0313 archive, XEP-0280 received-carbons,
+/// inbox projection). If this regressed to `DirectFrame`, groupchat
+/// reflection would skip every recipient-side side-effect and look
+/// like silent message loss to anyone other than the sender.
+#[tokio::test]
+async fn try_send_peer_to_emits_peer_stanza_kind() {
+    let registry = ConnectionRegistry::new();
+    let jid = test_jid("alice");
+    let (tx, mut rx) = mpsc::channel(4);
+    registry.register(jid.clone(), tx);
+
+    let msg = make_test_message("alice@example.com");
+    let outcome = registry.try_send_peer_to(&jid, Stanza::Message(msg));
+    assert_eq!(outcome, BroadcastOutcome::Delivered);
+
+    let outbound = rx.recv().await.expect("queued stanza");
+    assert_eq!(
+        outbound.kind,
+        DeliveryKind::PeerStanza,
+        "groupchat reflection must run through the recipient-pass pipeline"
+    );
+}
+
 #[test]
 fn test_list_connections() {
     let registry = ConnectionRegistry::new();


### PR DESCRIPTION
Closes #699.

## Summary

The MUC reflector emits one `RouteToConnection` per occupant. The interpreter loop processes those serially via blocking `registry.send_peer_to(target, …).await` (`routes/interpret/routing.rs:111`), which `mpsc::Sender::send().await`s on a 256-slot per-connection channel.

If even ONE recipient's consumer task is hung — TCP gone without FIN, paused VM, slow disk on the WebSocket sink — every subsequent groupchat dispatch in the same interpreter task wedges behind it, and so do the `ArchiveGroupchat` and inbox events that share the loop. Prod observed exactly this on 2026-05-18: a single zombie WS froze global MAM + inbox writes for ~2 hours until a pod restart.

## Fix

Switch the groupchat branch of `deliver_peer_to_full` to the non-blocking `try_send_peer_to`. `BroadcastOutcome::DroppedFull` returns synchronously when the recipient's mpsc is full — that specific recipient loses the reflection (correct: they're either zombie or unrecoverably backpressured), but every other occupant in the room and every other event on the interpreter loop keeps moving.

1:1 chat (`message type='chat'`), IQs, and presence-to-full-JID keep the blocking `send_peer_to`: those targets are singular and the natural backpressure is desirable.

## Changes

- `connection_registry/sending.rs`: refactor `try_send_to` into a private `try_send_to_with_kind(kind)`; expose `try_send_to` (DirectFrame, unchanged) and new `try_send_peer_to` (PeerStanza) so the recipient-pass pipeline (XEP-0359 recipient-side stanza-id, XEP-0313 archive, XEP-0280 received-carbons, inbox projection) still runs on the non-blocking path.
- `routes/interpret/routing.rs`: in `deliver_peer_to_full`, branch on `Stanza::Message` with `MessageType::Groupchat` and use `try_send_peer_to`; extract the offline/closed → detached-replay fallback into a shared `deliver_to_detached` helper used by both paths.
- `connection_registry/tests.rs`: regression test that fills a recipient's mpsc, then asserts `try_send_peer_to` returns `DroppedFull` within <10ms (the wedge took 1.5h+ in prod). Plus a kind-assertion test that catches a regression to `DirectFrame`.

## Out of scope (separate follow-up)

#699 also mentioned a WebSocket write timeout on `send_ws_message` as defence in depth. With `try_send_peer_to` in place the wedge is gone (interpreter loop never blocks), so the write-timeout is no longer urgent — but it's still worth doing because individual connections whose consumer hangs will sit in the registry until the kernel TCP keepalive eventually closes them (~2h on Linux defaults). Tracked separately so this PR stays focused on the wedge fix.

## Test plan

- [x] `cargo test -p waddle-xmpp -p waddle-server` — all green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p waddle-xmpp -p waddle-server --all-targets -- -D warnings` clean
- [ ] After deploy: confirm that artificial backpressure on one MUC occupant no longer correlates with a global `mam_messages` / `inbox_entries` write pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)