### PR TITLE
fix(infra): point LIVEKIT_WS_URL at sfu.waddle.social (DNS that actually exists)

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/livekit-external-secret.yaml
@@ -20,8 +20,18 @@ spec:
       # Plain `envFrom: secretRef` mounts every key under this
       # Secret as a process env var. Names match the schema
       # `waddle-sfu::SfuConfig::from_env` consumes.
+      #
+      # `LIVEKIT_WS_URL` must match the hostname the browser can
+      # actually reach: the LiveKit signal `<r ../rtc/v1>` runs
+      # through the `livekit-sfu` HTTPRoute (`livekit` namespace,
+      # `sfu.waddle.social` → `livekit-sfu:7880`). A previous value
+      # of `wss://livekit.waddle.social` had no DNS record and the
+      # browser failed every MUC-call connect with
+      # `net::ERR_NAME_NOT_RESOLVED` after the server's IQ result
+      # handed back the URL verbatim. `turn.waddle.social` resolves
+      # independently (separate ingress + DNS).
       data:
-        LIVEKIT_WS_URL: "wss://livekit.waddle.social"
+        LIVEKIT_WS_URL: "wss://sfu.waddle.social"
         LIVEKIT_TURN_HOST: "turn.waddle.social"
         LIVEKIT_TURN_TLS_PORT: "443"
         LIVEKIT_TURN_UDP_PORT: "3478"


### PR DESCRIPTION
## Symptom

After PR #702 unblocked the muc-call IQ flow, the chat still couldn't connect to LiveKit. Browser console:

\`\`\`
WebSocket connection to 'wss://livekit.waddle.social/rtc/v1?access_token=…' failed:
GET https://livekit.waddle.social/rtc/v1/validate?… net::ERR_NAME_NOT_RESOLVED
\`\`\`

## Root cause

\`\`\`
$ dig +short livekit.waddle.social
(empty)

$ dig +short sfu.waddle.social
51.159.109.202
\`\`\`

The cluster exposes the LiveKit signal under **`sfu.waddle.social`**, via the `livekit-sfu` HTTPRoute (`livekit` namespace, parentRef `waddle-gateway/https-sfu`, backend `livekit-sfu:7880`). There is no DNS or HTTPRoute for `livekit.waddle.social`.

The server's muc-call IQ result hands the URL back to the chat verbatim from the `LIVEKIT_WS_URL` env var, so the chat dials the bogus hostname and fails before the WebSocket handshake.

## Fix

One line in the ExternalSecret template:

\`\`\`yaml
-        LIVEKIT_WS_URL: "wss://livekit.waddle.social"
+        LIVEKIT_WS_URL: "wss://sfu.waddle.social"
\`\`\`

## Test plan

- [x] `dig +short sfu.waddle.social` returns the gateway IP
- [x] `kubectl get httproute -n livekit livekit-sfu` confirms `sfu.waddle.social` → `livekit-sfu:7880`
- [ ] After merge: Flux reconciles the ExternalSecret → next waddle-server rollout (`kubectl rollout restart deployment/waddle-server -n waddle`) picks up the corrected env value
- [ ] Browser console no longer reports `ERR_NAME_NOT_RESOLVED` on call connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)