### PR TITLE
fix(server): MUC call XMPP compliance — enforce membership + presence/destroy teardown

### DIFF
--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -348,6 +348,15 @@ async fn create_websocket_state(
     let mut stanza_dispatcher = waddle_xmpp::protocol::StanzaDispatcher::new();
     waddle_xmpp::protocol::handlers::register_default_handlers(&mut stanza_dispatcher);
     waddle_xmpp::protocol::handlers::register_default_message_handlers(&mut stanza_dispatcher);
+    // Holds the `SfuService` after `register_call_handlers` so the
+    // WebSocket layer can also call `unregister_call_participant`
+    // when a session leaves a MUC (graceful unavailable or
+    // disconnect/SM-expiry cleanup). Without this the SFU
+    // participant lingers until LiveKit times them out — a stolen
+    // JWT could replay in the meantime, and the channel UI keeps
+    // showing the user as "in call" until the SFU notices on its
+    // own.
+    let mut sfu_service: Option<std::sync::Arc<dyn waddle_sfu::SfuService>> = None;
     match waddle_sfu::SfuConfig::from_env() {
         Ok(Some(sfu_config)) => {
             let turn_tls_port = sfu_config.turn_tls_port;
@@ -356,10 +365,11 @@ async fn create_websocket_state(
                 std::sync::Arc::new(waddle_sfu::LiveKitSfu::new(sfu_config));
             waddle_xmpp::protocol::handlers::register_call_handlers(
                 &mut stanza_dispatcher,
-                sfu,
+                Arc::clone(&sfu),
                 turn_tls_port,
                 turn_udp_port,
             );
+            sfu_service = Some(sfu);
             tracing::info!(
                 "LiveKit SFU configured; XEP-0166 Jingle + XEP-0215 extdisco handlers registered"
             );
@@ -493,6 +503,7 @@ async fn create_websocket_state(
                 avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                 profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                 pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
+                sfu: sfu_service,
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
             provider_ingress,

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -258,20 +258,24 @@ async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
         let Some(room_actor) = get_room_actor(state, &room_jid).await else {
             continue;
         };
-        // Tab close / SM-expiry: the client never sends a graceful
-        // `request-leave` on `urn:waddle:muc-call:0`, so the SFU
-        // would otherwise hold the participant slot until its own
-        // timeout. Unregister here, before the room actor's `Leave`,
-        // so both XMPP presence and SFU presence go away together.
-        // Idempotent on the SFU side — calling for rooms where the
-        // user was never in a call is a no-op.
-        super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
-        match room_actor
+        let leave_result = room_actor
             .ask(LeaveByRealJid {
                 sender_jid: jid.clone(),
             })
-            .await
-        {
+            .await;
+        // SFU teardown runs *after* the room actor has dropped the
+        // session so the MUC's view of the world is the leading edge
+        // (the membership gate immediately reports the user as a
+        // non-occupant) and the SFU's view is the trailing edge —
+        // matches `handle_muc_leave`'s "XMPP says they left, then
+        // notify SFU" semantics. Tab close / SM-expiry: the client
+        // never sends a graceful `request-leave` on
+        // `urn:waddle:muc-call:0`, so without this call the SFU
+        // would otherwise hold the participant slot until its own
+        // (long) timeout. Idempotent on the SFU side — calling for
+        // rooms where the user was never in a call is a no-op.
+        super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
+        match leave_result {
             Ok(Some(outcome)) => {
                 debug!(
                     room = %room_jid,

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -258,6 +258,14 @@ async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
         let Some(room_actor) = get_room_actor(state, &room_jid).await else {
             continue;
         };
+        // Tab close / SM-expiry: the client never sends a graceful
+        // `request-leave` on `urn:waddle:muc-call:0`, so the SFU
+        // would otherwise hold the participant slot until its own
+        // timeout. Unregister here, before the room actor's `Leave`,
+        // so both XMPP presence and SFU presence go away together.
+        // Idempotent on the SFU side — calling for rooms where the
+        // user was never in a call is a no-op.
+        super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
         match room_actor
             .ask(LeaveByRealJid {
                 sender_jid: jid.clone(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -80,6 +80,7 @@ mod extension_forms;
 mod last_activity;
 mod misc;
 mod muc_admin;
+mod muc_call_gate;
 mod muc_owner_config;
 mod muc_owner_moderation;
 mod permissions;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_call_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_call_gate.rs
@@ -30,7 +30,7 @@ use xmpp_parsers::stanza_error::StanzaError;
 
 use super::super::super::cleanup::get_room_actor;
 use super::super::super::WebSocketState;
-use super::errors::{bad_request_iq_error, forbidden_iq_error};
+use super::errors::{bad_request_iq_error, forbidden_iq_error, internal_server_error_iq_error};
 
 const NS_WADDLE_MUC_CALL: &str = "urn:waddle:muc-call:0";
 const REQUEST_JOIN: &str = "request-join";
@@ -103,11 +103,16 @@ pub(super) async fn verify_muc_call_request(
             "not an occupant of the requested room — join the MUC first",
         ))),
         Err(_) => {
-            // Actor ask flaked — fail closed. Better to surface a
-            // transient `forbidden` than to issue a token in an
-            // ambiguous state. The user can retry; a retry that
-            // succeeds proves they were always entitled.
-            GateOutcome::Deny(Box::new(forbidden_iq_error(
+            // Actor ask flaked — this is a transient server-side
+            // failure, not an authorization decision. RFC 6120
+            // §8.3.3 maps "the server could not process the request
+            // because of a misconfiguration or other transient
+            // problem" to `<internal-server-error/>` with
+            // `type='wait'`, which is also the conventional retry
+            // hint to the client. Returning `forbidden` here would
+            // mis-classify a transient failure as an entitlement
+            // decision and make retries cosmetically wrong.
+            GateOutcome::Deny(Box::new(internal_server_error_iq_error(
                 "could not verify MUC membership; please retry",
             )))
         }
@@ -193,6 +198,54 @@ mod tests {
             verify_muc_call_request(&state, &alice, &request_join_iq("general@muc.example.com"))
                 .await;
         assert!(matches!(outcome, GateOutcome::Allow));
+    }
+
+    #[tokio::test]
+    async fn deny_after_caller_has_left_the_room() {
+        // Regression guard for the leave→gate coupling: a session
+        // that was a valid occupant at one point in time but has
+        // since left must NOT be able to mint a fresh JWT for the
+        // room. Without the gate consulting the live actor on
+        // every request-join, a stale snapshot would let a recently
+        // departed user keep minting tokens.
+        use waddle_xmpp::muc::room_actor::LeaveByRealJid;
+        let state = create_test_websocket_state().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice = full("alice@example.com/web");
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        // Sanity: alice is in the room, gate allows.
+        let outcome =
+            verify_muc_call_request(&state, &alice, &request_join_iq("general@muc.example.com"))
+                .await;
+        assert!(matches!(outcome, GateOutcome::Allow));
+
+        // alice leaves.
+        let actor = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(waddle_xmpp::muc::room_registry_actor::GetRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("room ask")
+            .expect("room actor present");
+        actor
+            .ask(LeaveByRealJid {
+                sender_jid: alice.clone(),
+            })
+            .await
+            .expect("leave");
+
+        // After leave, the gate must deny.
+        let outcome =
+            verify_muc_call_request(&state, &alice, &request_join_iq("general@muc.example.com"))
+                .await;
+        let GateOutcome::Deny(err) = outcome else {
+            panic!("expected Deny after leaving the room");
+        };
+        assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_call_gate.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_call_gate.rs
@@ -1,0 +1,325 @@
+//! XMPP-native membership gate for `urn:waddle:muc-call:0` requests.
+//!
+//! The pure IQ dispatcher (`waddle_xmpp::protocol::handlers::muc_call::MucCallHandler`)
+//! cannot itself enforce MUC membership — it is sans-I/O and has no
+//! handle to the room registry. Without an upstream check, any
+//! authenticated client could send `request-join` for an arbitrary
+//! room JID (guessed, leaked, or scraped from another room) and have
+//! the server mint a LiveKit JWT scoped to that room. The JWT lets the
+//! attacker connect to the SFU room directly even if the MUC
+//! affiliation/role rules would have rejected a regular XEP-0045 join.
+//!
+//! This gate runs immediately before sans-I/O IQ dispatch on the
+//! `urn:waddle:muc-call:0` namespace. For `request-join` it asks the
+//! room actor whether `full_jid` is a current occupant; if not, the
+//! gate short-circuits with `<forbidden/>` and the SFU is never
+//! touched. `request-leave` is intentionally not gated — `unregister`
+//! on the SFU is idempotent and harmless, and an over-eager leave from
+//! a non-occupant is benign cleanup.
+//!
+//! The gate is intentionally minimal: it consults the room actor (the
+//! authoritative source of MUC occupancy) directly, with no caching.
+//! A stale occupancy snapshot would let a recently-departed user mint
+//! a fresh JWT for a few seconds; consulting the actor on every join
+//! request closes that window.
+
+use jid::{BareJid, FullJid};
+use waddle_xmpp::muc::room_actor::GetOccupantByJid;
+use xmpp_parsers::iq::{Iq, IqType};
+use xmpp_parsers::stanza_error::StanzaError;
+
+use super::super::super::cleanup::get_room_actor;
+use super::super::super::WebSocketState;
+use super::errors::{bad_request_iq_error, forbidden_iq_error};
+
+const NS_WADDLE_MUC_CALL: &str = "urn:waddle:muc-call:0";
+const REQUEST_JOIN: &str = "request-join";
+const ATTR_ROOM: &str = "room";
+
+/// Outcome of the muc-call membership gate.
+///
+/// `Allow` means the IQ should continue to the sans-I/O dispatcher;
+/// `Deny` carries a typed `StanzaError` the caller must serialize into
+/// the IQ-error reply frame.
+pub(super) enum GateOutcome {
+    Allow,
+    Deny(Box<StanzaError>),
+}
+
+/// Run the membership pre-check for a `urn:waddle:muc-call:0` IQ.
+///
+/// Returns:
+/// - `Allow` if the IQ is not a `request-join` (other operations are
+///   either passed through or idempotent), or if the caller is a
+///   current occupant of the requested room.
+/// - `Deny(forbidden)` if the IQ is a `request-join` but the caller
+///   is not a current occupant of the room.
+/// - `Deny(bad_request)` if the `room` attribute is missing or not a
+///   valid bare JID.
+pub(super) async fn verify_muc_call_request(
+    state: &WebSocketState,
+    full_jid: &FullJid,
+    iq: &Iq,
+) -> GateOutcome {
+    // Only `request-join` mints tokens; other muc-call operations
+    // (request-leave, future variants) either don't need the gate or
+    // are handled inside the dispatcher's payload validation.
+    let IqType::Set(payload) = &iq.payload else {
+        return GateOutcome::Allow;
+    };
+    if payload.ns() != NS_WADDLE_MUC_CALL || payload.name() != REQUEST_JOIN {
+        return GateOutcome::Allow;
+    }
+
+    let Some(room_attr) = payload.attr(ATTR_ROOM) else {
+        return GateOutcome::Deny(Box::new(bad_request_iq_error(
+            "request-join missing 'room' attribute",
+        )));
+    };
+    let Ok(room_jid) = room_attr.parse::<BareJid>() else {
+        return GateOutcome::Deny(Box::new(bad_request_iq_error(
+            "request-join 'room' attribute is not a bare JID",
+        )));
+    };
+
+    // No room actor → the user definitively hasn't joined the room
+    // through the XEP-0045 path. (The room actor is created on first
+    // MUC join; absence means "no one has joined this room in this
+    // process's lifetime.")
+    let Some(actor) = get_room_actor(state, &room_jid).await else {
+        return GateOutcome::Deny(Box::new(forbidden_iq_error(
+            "not an occupant of the requested room — join the MUC first",
+        )));
+    };
+
+    match actor
+        .ask(GetOccupantByJid {
+            jid: full_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(_occupant)) => GateOutcome::Allow,
+        Ok(None) => GateOutcome::Deny(Box::new(forbidden_iq_error(
+            "not an occupant of the requested room — join the MUC first",
+        ))),
+        Err(_) => {
+            // Actor ask flaked — fail closed. Better to surface a
+            // transient `forbidden` than to issue a token in an
+            // ambiguous state. The user can retry; a retry that
+            // succeeds proves they were always entitled.
+            GateOutcome::Deny(Box::new(forbidden_iq_error(
+                "could not verify MUC membership; please retry",
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::websocket::tests::create_test_websocket_state;
+    use waddle_xmpp::muc::room_actor::Join;
+    use waddle_xmpp::muc::room_registry_actor::CreateInstantRoom;
+    use waddle_xmpp_core::{Affiliation, Role};
+    use xmpp_parsers::iq::IqType;
+    use xmpp_parsers::minidom::Element;
+    use xmpp_parsers::stanza_error::DefinedCondition;
+
+    fn full(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn request_join_iq(room: &str) -> Iq {
+        let payload = Element::builder("request-join", NS_WADDLE_MUC_CALL)
+            .attr(ATTR_ROOM, room)
+            .build();
+        Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some(room.parse().unwrap()),
+            id: "j1".into(),
+            payload: IqType::Set(payload),
+        }
+    }
+
+    fn request_leave_iq(room: &str) -> Iq {
+        let payload = Element::builder("request-leave", NS_WADDLE_MUC_CALL)
+            .attr(ATTR_ROOM, room)
+            .build();
+        Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some(room.parse().unwrap()),
+            id: "l1".into(),
+            payload: IqType::Set(payload),
+        }
+    }
+
+    /// Helper: create + join a MUC room so the gate's occupancy
+    /// lookup returns `Some`. Mirrors the join shape `handle_muc_join`
+    /// uses in production.
+    async fn create_room_and_join(
+        state: &WebSocketState,
+        room: &BareJid,
+        nick: &str,
+        jid: &FullJid,
+    ) {
+        let actor = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(CreateInstantRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("create instant room");
+        actor
+            .ask(Join {
+                nick: nick.to_string(),
+                real_jid: jid.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("join");
+    }
+
+    #[tokio::test]
+    async fn allow_when_caller_is_current_occupant() {
+        let state = create_test_websocket_state().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice = full("alice@example.com/web");
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let outcome =
+            verify_muc_call_request(&state, &alice, &request_join_iq("general@muc.example.com"))
+                .await;
+        assert!(matches!(outcome, GateOutcome::Allow));
+    }
+
+    #[tokio::test]
+    async fn deny_when_caller_is_not_an_occupant() {
+        // Room exists, alice joined, but the call request comes from
+        // mallory who never joined — must be rejected even though the
+        // room itself is "real".
+        let state = create_test_websocket_state().await;
+        let room: BareJid = "general@muc.example.com".parse().unwrap();
+        let alice = full("alice@example.com/web");
+        let mallory = full("mallory@example.com/laptop");
+        create_room_and_join(&state, &room, "alice", &alice).await;
+
+        let outcome = verify_muc_call_request(
+            &state,
+            &mallory,
+            &request_join_iq("general@muc.example.com"),
+        )
+        .await;
+        let GateOutcome::Deny(err) = outcome else {
+            panic!("expected Deny");
+        };
+        assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn deny_when_room_actor_does_not_exist() {
+        // Room JID looks plausible but no actor was ever created —
+        // means no one has joined this room in this process. The
+        // gate denies rather than ask-failing.
+        let state = create_test_websocket_state().await;
+        let alice = full("alice@example.com/web");
+
+        let outcome = verify_muc_call_request(
+            &state,
+            &alice,
+            &request_join_iq("ghost-room@muc.example.com"),
+        )
+        .await;
+        let GateOutcome::Deny(err) = outcome else {
+            panic!("expected Deny");
+        };
+        assert_eq!(err.defined_condition, DefinedCondition::Forbidden);
+    }
+
+    #[tokio::test]
+    async fn allow_for_request_leave_without_membership_check() {
+        // request-leave is idempotent on the SFU; the gate must let
+        // it through even from a non-occupant so a stuck client can
+        // explicitly tell the server it has hung up.
+        let state = create_test_websocket_state().await;
+        let alice = full("alice@example.com/web");
+
+        let outcome =
+            verify_muc_call_request(&state, &alice, &request_leave_iq("general@muc.example.com"))
+                .await;
+        assert!(matches!(outcome, GateOutcome::Allow));
+    }
+
+    #[tokio::test]
+    async fn allow_for_non_set_iq() {
+        // The dispatcher itself rejects non-`set` muc-call IQs with
+        // BadRequest; the gate has nothing to add for those.
+        let state = create_test_websocket_state().await;
+        let alice = full("alice@example.com/web");
+
+        let payload = Element::builder("request-join", NS_WADDLE_MUC_CALL)
+            .attr(ATTR_ROOM, "general@muc.example.com")
+            .build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some("general@muc.example.com".parse().unwrap()),
+            id: "g1".into(),
+            payload: IqType::Get(payload),
+        };
+        let outcome = verify_muc_call_request(&state, &alice, &iq).await;
+        assert!(matches!(outcome, GateOutcome::Allow));
+    }
+
+    #[tokio::test]
+    async fn bad_request_when_room_attribute_missing() {
+        let state = create_test_websocket_state().await;
+        let alice = full("alice@example.com/web");
+
+        let payload = Element::builder("request-join", NS_WADDLE_MUC_CALL).build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some("muc.example.com".parse().unwrap()),
+            id: "j2".into(),
+            payload: IqType::Set(payload),
+        };
+        let outcome = verify_muc_call_request(&state, &alice, &iq).await;
+        let GateOutcome::Deny(err) = outcome else {
+            panic!("expected Deny");
+        };
+        assert_eq!(err.defined_condition, DefinedCondition::BadRequest);
+    }
+
+    // The dedicated "room is not a bare JID" branch returns BadRequest
+    // when `parse::<BareJid>()` fails outright. The `jid` crate is
+    // quite lenient with the bare-JID grammar (it will treat unusual
+    // strings as domain-only JIDs), so for any input that does parse
+    // but doesn't correspond to a real room the gate falls through to
+    // the room-actor lookup — which then returns Forbidden via
+    // `deny_when_room_actor_does_not_exist` above. Both paths share a
+    // user-facing meaning ("you may not call here"), and routing
+    // unparseable-but-not-rejected values to Forbidden is acceptable
+    // defense in depth, so no separate happy-path BadRequest test is
+    // needed beyond `bad_request_when_room_attribute_missing`.
+
+    #[tokio::test]
+    async fn allow_when_payload_namespace_is_not_muc_call() {
+        // The caller in `handle_sans_io_iq` only invokes the gate
+        // when `payload_ns == "urn:waddle:muc-call:0"`, but the gate
+        // itself defends in depth: a non-muc-call namespace falls
+        // through to Allow.
+        let state = create_test_websocket_state().await;
+        let alice = full("alice@example.com/web");
+
+        let payload = Element::builder("request-join", "urn:xmpp:ping").build();
+        let iq = Iq {
+            from: Some("alice@example.com/web".parse().unwrap()),
+            to: Some("muc.example.com".parse().unwrap()),
+            id: "j4".into(),
+            payload: IqType::Set(payload),
+        };
+        let outcome = verify_muc_call_request(&state, &alice, &iq).await;
+        assert!(matches!(outcome, GateOutcome::Allow));
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -147,6 +147,17 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                                 .connection_registry
                                 .try_send_to(&occupant.real_jid, Stanza::Presence(presence));
                         }
+                        // XEP-0045 §10.9 destroy ends every occupant's
+                        // session in the room — their LiveKit
+                        // participant must end with it. Without this
+                        // the SFU keeps the room populated until its
+                        // own timeout even though the XMPP room is
+                        // gone. Idempotent for non-call participants.
+                        super::super::super::muc_call_sfu::unregister_participant_from_room(
+                            state,
+                            &room_jid,
+                            &occupant.real_jid,
+                        );
                     }
                 }
             }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -90,6 +90,24 @@ pub(super) async fn handle_sans_io_iq(
                 .connection_registry
                 .set_carbons_enabled(full_jid, enabled);
         }
+        // XMPP-native MUC-call membership gate: a session may only
+        // mint a LiveKit JWT for a room it has actually joined
+        // through the XEP-0045 path. The pure dispatcher in
+        // `waddle-xmpp` has no handle to the room registry, so the
+        // check has to happen here before dispatch.
+        if payload_ns == "urn:waddle:muc-call:0" {
+            match super::muc_call_gate::verify_muc_call_request(state, full_jid, iq).await {
+                super::muc_call_gate::GateOutcome::Allow => {}
+                super::muc_call_gate::GateOutcome::Deny(stanza_error) => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        *stanza_error,
+                    )];
+                }
+            }
+        }
         let ctx = ProtocolStanzaContext { domain, full_jid };
         let events = state.deps.protocol.dispatcher.dispatch_iq(iq, &ctx);
         let deps = crate::server::routes::interpret::Deps {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -294,6 +294,17 @@ pub async fn handle_muc_leave(
 ) -> Vec<String> {
     info!(room = %room_jid, nick = %nick, sender = %sender_jid, "MUC leave request");
 
+    // Tear down the leaver's SFU participant before the MUC actor
+    // forgets about them. Idempotent on the SFU side, so it's safe
+    // to call even if they were never in a call. Doing it here
+    // (rather than only in the explicit `urn:waddle:muc-call:0`
+    // request-leave path) closes the gap where a client leaves the
+    // MUC without sending the call-specific leave — their SFU
+    // participant otherwise lingers until LiveKit's own timeout.
+    super::super::super::muc_call_sfu::unregister_participant_from_room(
+        state, room_jid, sender_jid,
+    );
+
     let Some(room_actor) = get_room_actor(state, room_jid).await else {
         debug!(room = %room_jid, "Room not found for leave");
         return vec![build_muc_self_unavailable_xml(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -294,19 +294,14 @@ pub async fn handle_muc_leave(
 ) -> Vec<String> {
     info!(room = %room_jid, nick = %nick, sender = %sender_jid, "MUC leave request");
 
-    // Tear down the leaver's SFU participant before the MUC actor
-    // forgets about them. Idempotent on the SFU side, so it's safe
-    // to call even if they were never in a call. Doing it here
-    // (rather than only in the explicit `urn:waddle:muc-call:0`
-    // request-leave path) closes the gap where a client leaves the
-    // MUC without sending the call-specific leave — their SFU
-    // participant otherwise lingers until LiveKit's own timeout.
-    super::super::super::muc_call_sfu::unregister_participant_from_room(
-        state, room_jid, sender_jid,
-    );
-
     let Some(room_actor) = get_room_actor(state, room_jid).await else {
         debug!(room = %room_jid, "Room not found for leave");
+        // Idempotent on the SFU side — the user could have an SFU
+        // participant even when the room actor is gone (process
+        // restart, eviction). Tear that down too.
+        super::super::super::muc_call_sfu::unregister_participant_from_room(
+            state, room_jid, sender_jid,
+        );
         return vec![build_muc_self_unavailable_xml(
             state, room_jid, nick, sender_jid,
         )];
@@ -321,6 +316,11 @@ pub async fn handle_muc_leave(
         Ok(Some(outcome)) => outcome,
         Ok(None) => {
             debug!(room = %room_jid, nick = %nick, sender = %sender_jid, "MUC leave for absent occupant");
+            // No occupant slot to remove, but a stale SFU
+            // participant could still exist — clear it.
+            super::super::super::muc_call_sfu::unregister_participant_from_room(
+                state, room_jid, sender_jid,
+            );
             return vec![build_muc_self_unavailable_xml(
                 state, room_jid, nick, sender_jid,
             )];
@@ -332,6 +332,17 @@ pub async fn handle_muc_leave(
             )];
         }
     };
+
+    // SFU teardown runs after `LeaveByRealJid` so the MUC's
+    // authoritative view drops the occupant first; the membership
+    // gate immediately reports the user as a non-occupant and any
+    // subsequent `request-join` is rejected before the SFU is
+    // touched again. Closes the gap where a client leaves the MUC
+    // without sending the call-specific `request-leave` — their SFU
+    // participant would otherwise linger until LiveKit's timeout.
+    super::super::super::muc_call_sfu::unregister_participant_from_room(
+        state, room_jid, sender_jid,
+    );
 
     // Broadcast unavailable presence to remaining occupants (non-blocking).
     // Drop accounting is handled inside `try_send_to`.

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -73,6 +73,7 @@ mod cleanup;
 mod connection;
 mod frame;
 mod interpret_loop;
+mod muc_call_sfu;
 mod outbound;
 mod parse_errors;
 mod registration;

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -1,0 +1,216 @@
+//! Side-effect glue from MUC presence-unavailable / disconnect cleanup
+//! into the LiveKit SFU registry.
+//!
+//! Without this, a session's SFU participant outlives its XMPP
+//! presence: if a user closes the tab or their stream-management
+//! session expires, the room actor processes a `LeaveByRealJid` but
+//! the SFU never hears about it until LiveKit's own (long) timeout.
+//! Meanwhile the channel UI keeps showing the user as "in call" and
+//! the previously-issued JWT remains replayable.
+//!
+//! The XEP-0045 leave path is the authoritative XMPP signal that a
+//! user is no longer in the room; mirroring it onto
+//! [`waddle_sfu::SfuService::unregister_call_participant`] keeps the
+//! SFU's view of the world in lock-step with XMPP. The SFU call
+//! registry is keyed by the room JID (the call-id) and the user's
+//! full JID (the identity), and `unregister_call_participant` is
+//! idempotent — calling it for rooms the user never had a media
+//! session in is a benign no-op.
+
+use jid::{BareJid, FullJid};
+use waddle_sfu::{CallId, Identity};
+
+use super::state::WebSocketState;
+
+/// Tear down `jid`'s SFU participant in `room_jid`, if a SFU is
+/// configured for this deployment.
+///
+/// No-op when:
+/// - `LIVEKIT_*` env vars were not set (then `state.deps.protocol.sfu`
+///   is `None` and there is no SFU to update),
+/// - the room JID cannot be converted into a valid call-id (the
+///   call-id grammar is stricter than the JID grammar, so this can
+///   theoretically reject some MUC bare JIDs — those are rooms with
+///   no calling capability and there is nothing on the SFU to undo
+///   for them anyway).
+pub(super) fn unregister_participant_from_room(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    jid: &FullJid,
+) {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        return;
+    };
+    let Ok(call_id) = CallId::new(room_jid.to_string()) else {
+        // Room JID couldn't round-trip into a CallId, which means it
+        // could never have been used to mint a join token either —
+        // there's nothing to undo.
+        return;
+    };
+    let identity = Identity::from_jid(jid.clone());
+    let _ = sfu.unregister_call_participant(&call_id, &identity);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::routes::websocket::tests::create_test_websocket_state;
+    use std::sync::{Arc, Mutex};
+    use waddle_sfu::{
+        CallState, JoinToken, Jti, MediaCapabilities, SfuError, SfuService, TurnCredential,
+        TurnHost, WebsocketUrl,
+    };
+
+    /// Recording fake: captures every `(call_id, identity)` passed to
+    /// `unregister_call_participant`. The other trait methods are
+    /// unimplemented because the production code path under test only
+    /// touches the unregister method.
+    #[derive(Default)]
+    struct RecordingSfu {
+        calls: Mutex<Vec<(CallId, Identity)>>,
+    }
+
+    impl RecordingSfu {
+        fn snapshot(&self) -> Vec<(CallId, Identity)> {
+            self.calls.lock().expect("recording lock").clone()
+        }
+    }
+
+    impl SfuService for RecordingSfu {
+        fn issue_join_token(
+            &self,
+            _: &CallId,
+            _: &Identity,
+            _: MediaCapabilities,
+        ) -> Result<JoinToken, SfuError> {
+            unimplemented!("not exercised by these tests")
+        }
+
+        fn issue_turn_credentials(&self, _: &Identity) -> Result<TurnCredential, SfuError> {
+            unimplemented!("not exercised by these tests")
+        }
+
+        fn register_call_participant(&self, _: &CallId, _: &Identity) {}
+
+        fn unregister_call_participant(&self, call_id: &CallId, identity: &Identity) -> CallState {
+            self.calls
+                .lock()
+                .expect("recording lock")
+                .push((call_id.clone(), identity.clone()));
+            CallState::Ended
+        }
+
+        fn is_revoked(&self, _: &Jti) -> bool {
+            false
+        }
+
+        fn ws_url(&self) -> &WebsocketUrl {
+            unimplemented!("not exercised by these tests")
+        }
+
+        fn turn_host(&self) -> &TurnHost {
+            unimplemented!("not exercised by these tests")
+        }
+    }
+
+    #[tokio::test]
+    async fn unregister_is_no_op_when_no_sfu_is_configured() {
+        // Pre-LiveKit deployments: protocol.sfu is None. The cleanup
+        // path must remain a no-op so legacy installs aren't broken
+        // by the teardown hook.
+        let state = create_test_websocket_state().await;
+        assert!(state.deps.protocol.sfu.is_none());
+        let room: BareJid = "room@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+        // Should not panic, not write anywhere.
+        unregister_participant_from_room(&state, &room, &alice);
+    }
+
+    /// Build a test state with a pluggable `SfuService`. The canonical
+    /// fixture (`create_test_websocket_state`) sets `sfu: None` so
+    /// non-call tests don't exercise SFU code paths; this helper
+    /// rebuilds the protocol services with the SFU slot filled.
+    async fn state_with_sfu(sfu: Arc<RecordingSfu>) -> Arc<WebSocketState> {
+        let base = create_test_websocket_state().await;
+        // `Arc::clone` + restamp the field by constructing a new
+        // WebSocketState wrapping the same deps. The `ProtocolServices`
+        // is owned by an `Arc<WebSocketState>`, so we have to clone
+        // each field — they're all `Arc`-shareable except the
+        // SFU slot we want to fill.
+        let deps = &base.deps;
+        Arc::new(WebSocketState {
+            deps: super::super::state::WebSocketDeps {
+                app_state: Arc::clone(&deps.app_state),
+                auth_state: Arc::clone(&deps.auth_state),
+                service_domains: deps.service_domains.clone(),
+                protocol: super::super::state::ProtocolServices {
+                    connection_registry: Arc::clone(&deps.protocol.connection_registry),
+                    room_registry: deps.protocol.room_registry.clone(),
+                    mam_storage: Arc::clone(&deps.protocol.mam_storage),
+                    inbox_storage: Arc::clone(&deps.protocol.inbox_storage),
+                    threads_storage: Arc::clone(&deps.protocol.threads_storage),
+                    blocking_storage: Arc::clone(&deps.protocol.blocking_storage),
+                    pending_delivery_storage: Arc::clone(&deps.protocol.pending_delivery_storage),
+                    command_registry: Arc::clone(&deps.protocol.command_registry),
+                    extension_manager: Arc::clone(&deps.protocol.extension_manager),
+                    dispatcher: Arc::clone(&deps.protocol.dispatcher),
+                    pubsub_storage: Arc::clone(&deps.protocol.pubsub_storage),
+                    push_store: Arc::clone(&deps.protocol.push_store),
+                    push_service: Arc::clone(&deps.protocol.push_service),
+                    notification_outbox: Arc::clone(&deps.protocol.notification_outbox),
+                    notification_settings_projection: Arc::clone(
+                        &deps.protocol.notification_settings_projection,
+                    ),
+                    isr_token_store: Arc::clone(&deps.protocol.isr_token_store),
+                    sm_session_registry: Arc::clone(&deps.protocol.sm_session_registry),
+                    resumable_sessions: Arc::clone(&deps.protocol.resumable_sessions),
+                    caps_resolver: Arc::clone(&deps.protocol.caps_resolver),
+                    avatar_source_locks: Arc::clone(&deps.protocol.avatar_source_locks),
+                    profile_publish_tracker: deps.protocol.profile_publish_tracker.clone(),
+                    pep_feed_bridge: Arc::clone(&deps.protocol.pep_feed_bridge),
+                    sfu: Some(sfu),
+                },
+                occupant_id_secret: deps.occupant_id_secret.clone(),
+                provider_ingress: Arc::clone(&deps.provider_ingress),
+                provider_dispatch_tasks: deps.provider_dispatch_tasks.clone(),
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn unregister_records_call_id_and_identity_on_the_sfu() {
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = state_with_sfu(Arc::clone(&recorder)).await;
+        let room: BareJid = "room@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+
+        unregister_participant_from_room(&state, &room, &alice);
+
+        let recorded = recorder.snapshot();
+        assert_eq!(recorded.len(), 1, "exactly one teardown call expected");
+        let (call_id, identity) = &recorded[0];
+        assert_eq!(call_id.as_str(), "room@muc.example.com");
+        assert_eq!(identity.as_livekit_identity(), "alice@example.com/web");
+    }
+
+    #[tokio::test]
+    async fn unregister_is_idempotent_across_repeated_calls() {
+        // Disconnect cleanup and graceful presence-unavailable may
+        // both fire for the same `(room, jid)` if a tab close races
+        // with an explicit leave. SfuService::unregister is
+        // documented as idempotent — verify the helper passes
+        // through the second call rather than short-circuiting,
+        // since silently skipping would mask bugs in the SFU layer.
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = state_with_sfu(Arc::clone(&recorder)).await;
+        let room: BareJid = "room@muc.example.com".parse().unwrap();
+        let alice: FullJid = "alice@example.com/web".parse().unwrap();
+
+        unregister_participant_from_room(&state, &room, &alice);
+        unregister_participant_from_room(&state, &room, &alice);
+
+        let recorded = recorder.snapshot();
+        assert_eq!(recorded.len(), 2, "both teardown calls reach the SFU");
+        assert_eq!(recorded[0], recorded[1]);
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -141,6 +141,14 @@ pub struct ProtocolServices {
     /// Feed pane surfaces user activity automatically. Holds per-
     /// (user, kind) throttle state.
     pub pep_feed_bridge: Arc<crate::pep_feed_bridge::PepFeedBridge>,
+    /// LiveKit SFU bridge — `Some` iff `LIVEKIT_*` env vars are set
+    /// and `register_call_handlers` was invoked at startup. The
+    /// WebSocket cleanup paths call
+    /// [`waddle_sfu::SfuService::unregister_call_participant`] when a
+    /// session leaves a MUC so a participant's SFU presence doesn't
+    /// outlive their XMPP presence (graceful unavailable, tab close,
+    /// SM-expiry — all go through `cleanup_muc_presence`).
+    pub sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
 }
 
 /// Per-connection mutable state for a single WebSocket XMPP transport.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -183,6 +183,7 @@ async fn create_test_websocket_state_with_extension_manager(
                     avatar_source_locks: Arc::new(crate::profile::AvatarLockMap::new()),
                     profile_publish_tracker: tokio_util::task::TaskTracker::new(),
                     pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
+                    sfu: None,
                 },
                 occupant_id_secret: OccupantIdSecret::new(
                     b"test-occupant-id-secret-32-bytes-long".to_vec(),

--- a/server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs
@@ -101,9 +101,24 @@ impl IqHandler for MucCallHandler {
 }
 
 impl MucCallHandler {
+    /// Parse the `room` attribute into a SFU `CallId` using the JID's
+    /// **canonical form** (lowercased localpart + domain per the
+    /// `jid` crate's stringprep pass).
+    ///
+    /// Using the raw attribute value would let a single MUC room map
+    /// to many distinct SFU rooms when clients submit case-variant
+    /// spellings (`General@MUC.example.com` vs
+    /// `general@muc.example.com`): the membership gate normalizes
+    /// before looking up the room actor, so both spellings pass the
+    /// gate, but the SFU would mint tokens for two separate SFU
+    /// rooms and the participants would end up in different LiveKit
+    /// rooms despite XEP-0045 considering them the same MUC. Always
+    /// normalize via `BareJid::to_string()` so a single MUC has a
+    /// single SFU room.
     fn parse_room(&self, payload: &Element) -> Result<CallId, &'static str> {
         let room = payload.attr(ATTR_ROOM).ok_or("missing 'room' attribute")?;
-        CallId::new(room.to_string()).map_err(|_| "invalid room JID")
+        let bare: jid::BareJid = room.parse().map_err(|_| "invalid room JID")?;
+        CallId::new(bare.to_string()).map_err(|_| "invalid room JID")
     }
 
     fn handle_join(
@@ -360,5 +375,44 @@ mod tests {
             panic!()
         };
         assert_eq!(err.defined_condition, DefinedCondition::BadRequest);
+    }
+
+    #[test]
+    fn request_join_normalizes_room_case_into_canonical_call_id() {
+        // Two clients submitting different case-variant spellings
+        // of the same MUC JID must land on the SAME SFU room, or
+        // they'll talk past each other in LiveKit even though
+        // XEP-0045 treats their room as identical. Verified by
+        // requesting joins with mixed-case spellings and asserting
+        // the SFU's participant count goes up under the canonical
+        // lowercase form only.
+        let sfu = fixture_sfu();
+        let handler = MucCallHandler::new(sfu.clone());
+        let alice: FullJid = "alice@waddle.test/desktop".parse().unwrap();
+        let bob: FullJid = "bob@waddle.test/desktop".parse().unwrap();
+
+        let mixed_case_join = |from: &FullJid, room: &str| -> Iq {
+            let payload = Element::builder(REQUEST_JOIN, NS_WADDLE_MUC_CALL)
+                .attr(ATTR_ROOM, room)
+                .build();
+            Iq {
+                from: Some(jid::Jid::from(from.clone())),
+                to: Some(room.parse().unwrap()),
+                id: "case".into(),
+                payload: IqType::Set(payload),
+            }
+        };
+
+        let _ = handler.handle(&mixed_case_join(&alice, "Room@MUC.Test"), &ctx(&alice));
+        let _ = handler.handle(&mixed_case_join(&bob, "room@muc.test"), &ctx(&bob));
+
+        // Both join requests must have resolved to the same SFU
+        // room — the canonical lowercase form.
+        let canonical = CallId::new("room@muc.test").unwrap();
+        assert_eq!(
+            sfu.participant_count(&canonical),
+            2,
+            "case-variant join attributes must collapse to a single SFU room"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs
@@ -116,11 +116,16 @@ impl MucCallHandler {
             Ok(c) => c,
             Err(text) => return error_reply(iq, DefinedCondition::BadRequest, text),
         };
-        // The room JID is opaque to the SFU — we don't enforce
-        // membership here (the MUC's affiliation rules are
-        // orthogonal). What we DO enforce is that the authenticated
-        // session matches the LiveKit identity: a peer can't mint a
-        // token claiming to be someone else.
+        // MUC membership enforcement happens upstream in the
+        // waddle-server IQ dispatch path, before the dispatcher
+        // reaches this handler — see `handle_sans_io_iq` and the
+        // pre-dispatch room-actor occupancy check. By the time
+        // execution reaches this handler the caller is known to be
+        // a current occupant of `call_id`'s room (or the request
+        // would never have been dispatched). What we DO enforce
+        // here is that the authenticated session matches the
+        // LiveKit identity: a peer can't mint a token claiming to
+        // be someone else.
         let identity = Identity::from_jid(ctx.full_jid.clone());
 
         let token = match self.sfu.issue_join_token(


### PR DESCRIPTION
## Audit context

Follow-up to the XMPP-compliance audit of the MUC call surface. Signaling is already XMPP-native (XEP-0353 JMI for DM ringing, XEP-0166 Jingle for session lifecycle, `urn:waddle:muc-call:0` IQ for group calls — the custom namespace is appropriate per CLAUDE.md since no published XEP covers the SFU-token shape), and LiveKit is only referenced as a Jingle transport (`urn:waddle:transports:livekit:0`).

The audit surfaced two real gaps. This PR closes both, plus two follow-on gaps that adversarial review found.

## Gap 1 — MUC membership not enforced before issuing a join token

`MucCallHandler::handle_join` previously commented that "the room JID is opaque to the SFU — we don't enforce membership here." That meant any authenticated user could mint a LiveKit JWT for any room JID they could guess (managed channels, private rooms, …). The handler is purely sans-I/O and has no handle to the room registry, so the check had to land upstream.

**Fix:** new `muc_call_gate.rs` runs immediately before sans-I/O IQ dispatch on the `urn:waddle:muc-call:0` namespace. For `request-join` it asks the room actor whether the caller is a current occupant; if not, the gate short-circuits with `<forbidden/>` and the SFU is never touched. `request-leave` is intentionally not gated — `unregister` on the SFU is idempotent and harmless.

## Gap 2 — No presence-unavailable → SFU teardown coupling

If a user closes the tab without explicitly hanging up, or their MUC presence goes unavailable for any other reason, their LiveKit participant lingered until the SFU timed them out on its own. The MUC leave path (`handle_muc_leave`) and the disconnect/SM-expiry cleanup (`cleanup_muc_presence`) both call `LeaveByRealJid` on the room actor but didn't tell the SFU.

**Fix:** when a participant leaves a MUC room (graceful presence-unavailable OR connection cleanup OR `<destroy/>`), also call `sfu.unregister_call_participant(call_id, identity)`. The call is idempotent and revokes the JWT as a side effect — so a stolen token can't be replayed after a legitimate leave. New `muc_call_sfu.rs` houses the side-effect glue. Ordering: room actor leave runs FIRST (becomes the authoritative leading edge), then SFU teardown — matches "XMPP says they left, then notify SFU" semantics.

## Gap 3 — disco

Already correct at `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/server_info.rs:67` (gated on `has_iq_handler("urn:xmpp:jingle:1")`). No change.

## Adversarial-review findings (addressed in-PR)

- **Case normalization on room JID**: `MucCallHandler::parse_room` used the raw `room` attribute as a `CallId`, so case-variant spellings of the same MUC (`Room@MUC.Test` vs `room@muc.test`) would mint tokens for different SFU rooms while the gate normalized both to the same room actor. Now parses through `BareJid` first to land all variants on the canonical lowercase form. Test added.
- **`<destroy/>` SFU teardown**: XEP-0045 §10.9 destroy ends every occupant's session — the muc owner moderation path now also tears down SFU participants per-occupant before evicting the room actor.
- **Actor-flake error class**: a transient room-actor ask failure now returns `<internal-server-error/>` (type=`wait`) instead of `<forbidden/>` (type=`auth`), so clients retry rather than treat it as an entitlement decision.

## Known follow-up (out of scope)

- **MUC kick/ban path SFU teardown** (`ApplyAdminItems` in `muc_admin.rs`): a kicked or banned user keeps their SFU participant + replayable JWT until LiveKit timeout. Fixing this requires extending the actor's reply to surface the removed full JIDs and is meaningful scope creep; tracked separately.
- **JWT revocation is local-only**: `is_revoked` writes to an in-memory `DashSet`; LiveKit itself doesn't call back to verify `jti`. A stolen token stays usable until its `exp` regardless. Pre-existing limitation in `waddle-sfu`. Operational mitigation: keep `SfuConfig.token_ttl` short.

## Tests

13 new tests (all green):

Gate (`muc_call_gate::tests`):
- `allow_when_caller_is_current_occupant`
- `deny_when_caller_is_not_an_occupant`
- `deny_when_room_actor_does_not_exist`
- `deny_after_caller_has_left_the_room` (regression guard for the leave→gate coupling)
- `allow_for_request_leave_without_membership_check`
- `allow_for_non_set_iq`
- `bad_request_when_room_attribute_missing`
- `allow_when_payload_namespace_is_not_muc_call`

SFU teardown (`muc_call_sfu::tests`):
- `unregister_records_call_id_and_identity_on_the_sfu`
- `unregister_is_no_op_when_no_sfu_is_configured`
- `unregister_is_idempotent_across_repeated_calls`

Handler (`protocol::handlers::muc_call::tests`):
- `request_join_normalizes_room_case_into_canonical_call_id`

Plus all existing call/MUC tests still pass: `cargo test -p waddle-xmpp`, `cargo test -p waddle-server --lib`, `cargo test -p waddle-server --test calls_e2e_ws`. `cargo clippy -D warnings` clean.

## Files

New:
- `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_call_gate.rs`
- `server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs`

Modified:
- `server/crates/waddle-xmpp/src/protocol/handlers/muc_call.rs` (case normalization + clarifying comment + test)
- `server/crates/waddle-server/src/server/http.rs` (thread SFU into ProtocolServices)
- `server/crates/waddle-server/src/server/routes/websocket/state.rs` (+`sfu: Option<Arc<dyn SfuService>>`)
- `server/crates/waddle-server/src/server/routes/websocket/cleanup.rs` (SFU teardown in disconnect cleanup)
- `server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs` (SFU teardown in handle_muc_leave)
- `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs` (gate wired before dispatch)
- `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs` (SFU teardown on destroy)
- `server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs` + `mod.rs` (module wiring)
- `server/crates/waddle-server/src/server/routes/websocket/tests.rs` (fixture adds `sfu: None`)