### PR TITLE
fix(chat): code blocks overflow message bubble instead of scrolling internally

### DIFF
--- a/chat/src/styles/global/rich-text.css
+++ b/chat/src/styles/global/rich-text.css
@@ -17,10 +17,17 @@
    token shrinks the box's min-content intrinsic size to a single character —
    otherwise long URLs/slugs hold the message body wider than the pane and
    produce a horizontal scrollbar on flex/grid layouts. The composer applies
-   the same rule on `.ProseMirror` (see ChatEditor.vue). */
+   the same rule on `.ProseMirror` (see ChatEditor.vue).
+   `width: 100%; max-width: 100%` pin the body to its container width even in
+   flex parents that use `align-items: flex-start` (see
+   `.chat-message-media-stack` in composer-pane.css). Without these the box
+   sizes to its widest *block* child — a long-line `<pre>` would push the
+   styled-body wider than the grid cell instead of scrolling internally. */
 .styled-body {
   overflow-wrap: anywhere;
   min-width: 0;
+  width: 100%;
+  max-width: 100%;
 }
 :where(.styled-body, .chat-editor .ProseMirror) p {
   margin: 0;
@@ -56,6 +63,10 @@
   background: var(--rich-code-bg);
   border: 1px solid var(--rich-code-border);
   border-radius: 8px;
+  /* `max-width: 100%` pins the pre to its container so very-long lines
+     scroll inside the pre instead of pushing the styled-body wider —
+     a sibling-element defense matching the one on `.styled-body`. */
+  max-width: 100%;
   overflow-x: auto;
   margin: 0.5em 0;
 }


### PR DESCRIPTION
## Symptom

Messages containing fenced code blocks with long lines push the
message bubble wider than the channel pane. The horizontal overflow
forces a scrollbar on the page or hides part of the conversation
behind the timeline rail. Expected behaviour: the `<pre>` block
should scroll internally and the bubble should match the channel
pane's width.

## Root cause

`MessageBody.vue` renders the rich body inside
`.chat-message-media-stack` (composer-pane.css:344) — a flex column
with `align-items: flex-start`. In a flex column, `align-items` is
the cross-axis (= horizontal) alignment, and `flex-start` sizes
children to their content rather than stretching them to the
container width. `align-items: flex-start` is correct for the
mixed-width media children of this stack (sticker, image, audio,
video), but for `.styled-body` it lets the body shrink to fit its
widest *block* child.

`.styled-body` had `overflow-wrap: anywhere; min-width: 0` but no
explicit width. With a long-line `<pre>` inside (which has
`overflow-x: auto` set on itself), the styled-body still ends up
content-fit — wider than the grid cell — and the `<pre>`'s internal
scroll never engages because the parent has already grown to fit it.

## Fix

`chat/src/styles/global/rich-text.css`:

- `.styled-body` gets `width: 100%; max-width: 100%`. Pins the body
  to its container width even under `align-items: flex-start`. The
  long-line `<pre>`'s `overflow-x: auto` then engages as intended
  (scrolls internally inside the bubble).
- `:where(.styled-body, .chat-editor .ProseMirror) pre` gets a
  defensive `max-width: 100%` so a future inline width from Shiki
  or a tiptap extension can't override the container.

Both changes are additive — no existing behaviour is removed.

## Scope sweep

The user also asked me to check other parts. I traced every
rich-HTML render site:
- `MessageBody.vue` (the only `v-html=` for rich body content in the
  whole tree) — fixed via the `.styled-body` change above.
- `ChatEditor.vue`'s `.ProseMirror` — already has `width: 100%`,
  `min-width: 0`, `overflow-wrap: anywhere`. Picks up the `<pre>`
  `max-width: 100%` fix from the shared rule.
- Admin / inbox / reply-preview surfaces — render JID/title strings
  inside `truncate` wrappers; not affected by code-block layout.

## Test plan

- [ ] Send a message containing a fenced code block with one very
  long line (no whitespace). The bubble width matches the channel
  pane; the code scrolls horizontally inside the bubble.
- [ ] Same in DM panel and pinned-message rail (compact mode).
- [ ] In the composer, type a long-line code fence — `.ProseMirror`
  stays bounded, code line is reachable via horizontal scroll.
- [ ] `bun run lint` clean in `chat/`.

Draft until I can sanity-check in a running chat instance.