### PR TITLE
feat(chat,server): instagram-like stories — media composer + per-user read state

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -329,8 +329,10 @@ onUnmounted(() => window.removeEventListener("popstate", refreshAdminPanelFromUr
         :error="stories.error.value"
         :can-post="!!connectionStore.session"
         :self-jid="connectionStore.session?.jid ?? null"
+        :is-story-read="stories.isStoryRead"
         @refresh="stories.refresh()"
         @post="(input) => stories.post(input)"
+        @story-selected="(id) => stories.markStoryRead(id)"
         @open-nav="ui.showMobileNav.value = true"
       />
       <EventsPane

--- a/chat/src/components/community/StoriesPane.vue
+++ b/chat/src/components/community/StoriesPane.vue
@@ -2,6 +2,8 @@
 import { computed, ref, watch } from "vue";
 import { Camera, ChevronLeft, ChevronRight, Menu, Plus, RefreshCw, X } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
+import StoryComposer from "@/components/community/StoryComposer.vue";
+import { connectionStore } from "@/lib/connection-store";
 import type { Story, StoryPostInput } from "@/lib/xmpp-client";
 
 interface StoriesPaneProps {
@@ -11,19 +13,24 @@ interface StoriesPaneProps {
   error: string | null;
   canPost: boolean;
   selfJid: string | null;
+  isStoryRead?: (id: string) => boolean;
 }
 
-const props = defineProps<StoriesPaneProps>();
+const props = withDefaults(defineProps<StoriesPaneProps>(), {
+  isStoryRead: () => () => false,
+});
+
 const emit = defineEmits<{
   refresh: [];
   post: [input: StoryPostInput];
+  storySelected: [id: string];
   openNav: [];
 }>();
 
 const composerOpen = ref(false);
-const composerBody = ref("");
-const composerMediaUrl = ref("");
 const activeIndex = ref<number | null>(null);
+const composerError = ref<string | null>(null);
+const composerBusy = ref(false);
 
 function authorLabel(author: string | undefined): string {
   if (!author) return "Anonymous";
@@ -38,11 +45,6 @@ function timeRemaining(story: Story, nowMs: number = Date.now()): string {
   if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m`;
   return `${Math.floor(delta / 3_600_000)}h`;
 }
-
-const canSubmit = computed(() => {
-  if (props.isPosting) return false;
-  return composerBody.value.trim().length > 0 || composerMediaUrl.value.trim().length > 0;
-});
 
 const activeStory = computed<Story | null>(() => {
   if (activeIndex.value === null) return null;
@@ -61,6 +63,8 @@ watch(
 function selectStory(index: number) {
   activeIndex.value = index;
   composerOpen.value = false;
+  const story = props.stories[index];
+  if (story?.id) emit("storySelected", story.id);
 }
 
 function closeReader() {
@@ -70,31 +74,44 @@ function closeReader() {
 function prevStory() {
   if (activeIndex.value === null || activeIndex.value <= 0) return;
   activeIndex.value -= 1;
+  const story = activeStory.value;
+  if (story?.id) emit("storySelected", story.id);
 }
 
 function nextStory() {
   if (activeIndex.value === null || activeIndex.value >= props.stories.length - 1) return;
   activeIndex.value += 1;
+  const story = activeStory.value;
+  if (story?.id) emit("storySelected", story.id);
 }
 
-function submit() {
-  const body = composerBody.value.trim();
-  const mediaUrl = composerMediaUrl.value.trim();
-  if (!body && !mediaUrl) return;
-  emit("post", {
-    ...(body ? { body } : {}),
-    ...(mediaUrl ? { mediaUrl } : {}),
-    ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
-  });
-  composerBody.value = "";
-  composerMediaUrl.value = "";
-  composerOpen.value = false;
+async function handleComposerSubmit(payload: { body?: string; file: Blob; mediaKind: "image" | "video" }) {
+  const client = connectionStore.client;
+  if (!client) {
+    composerError.value = "Not connected.";
+    return;
+  }
+  composerError.value = null;
+  composerBusy.value = true;
+  try {
+    const uploaded = await client.uploadStoryMedia(payload.file);
+    const input: StoryPostInput = {
+      ...(payload.body ? { body: payload.body } : {}),
+      mediaUrl: uploaded.url,
+      ...(props.selfJid ? { author: props.selfJid.split("/")[0] } : {}),
+    };
+    emit("post", input);
+    composerOpen.value = false;
+  } catch (err) {
+    composerError.value = err instanceof Error ? err.message : "Couldn't upload — please try again.";
+  } finally {
+    composerBusy.value = false;
+  }
 }
 
-function dismissComposer() {
+function handleComposerCancel() {
   composerOpen.value = false;
-  composerBody.value = "";
-  composerMediaUrl.value = "";
+  composerError.value = null;
 }
 </script>
 
@@ -128,8 +145,10 @@ function dismissComposer() {
       <div v-if="error" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
         Couldn't post: {{ error }}
       </div>
+      <div v-if="composerError" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        {{ composerError }}
+      </div>
 
-      <!-- Horizontal rail -->
       <div class="flex gap-3 overflow-x-auto pb-2">
         <button
           v-if="canPost"
@@ -154,7 +173,11 @@ function dismissComposer() {
         >
           <span class="relative">
             <AppAvatar :name="authorLabel(story.author)" :src="story.mediaUrl ?? null" size="md" />
-            <span class="pointer-events-none absolute inset-0 rounded-full ring-2 ring-primary/70 ring-offset-1 ring-offset-background" aria-hidden="true"></span>
+            <span
+              class="pointer-events-none absolute inset-0 rounded-full ring-2 ring-offset-1 ring-offset-background"
+              :class="isStoryRead(story.id) ? 'ring-muted/50' : 'ring-primary/70'"
+              aria-hidden="true"
+            ></span>
           </span>
           <span class="min-w-0 type-caption text-foreground">
             <span class="block truncate">{{ authorLabel(story.author) }}</span>
@@ -170,50 +193,13 @@ function dismissComposer() {
         </div>
       </div>
 
-      <form
+      <StoryComposer
         v-if="composerOpen"
-        class="grid gap-2 rounded-lg border border-border bg-card p-3"
-        @submit.prevent="submit"
-      >
-        <textarea
-          v-model="composerBody"
-          class="min-h-[3rem] w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          placeholder="Share a quick update…"
-          :disabled="isPosting"
-          aria-label="Story body"
-        />
-        <input
-          v-model="composerMediaUrl"
-          type="url"
-          class="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          placeholder="Optional image / video URL"
-          :disabled="isPosting"
-          aria-label="Story media URL"
-        />
-        <div class="flex items-center justify-between gap-2">
-          <span class="type-caption text-muted-foreground">Expires in 24h</span>
-          <div class="flex items-center gap-2">
-            <button
-              type="button"
-              class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
-              :disabled="isPosting"
-              @click="dismissComposer"
-            >
-              <X class="h-3.5 w-3.5" aria-hidden="true" />
-              Cancel
-            </button>
-            <button
-              type="submit"
-              class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-              :disabled="!canSubmit"
-            >
-              {{ isPosting ? "Posting…" : "Share" }}
-            </button>
-          </div>
-        </div>
-      </form>
+        :busy="composerBusy || isPosting"
+        @submit="handleComposerSubmit"
+        @cancel="handleComposerCancel"
+      />
 
-      <!-- Reader -->
       <article
         v-if="activeStory"
         class="grid gap-3 rounded-xl border border-border bg-card p-4"
@@ -236,8 +222,16 @@ function dismissComposer() {
           </button>
         </header>
 
+        <video
+          v-if="activeStory.mediaUrl && /\.(mp4|webm|mov)(\?|$)/i.test(activeStory.mediaUrl)"
+          :src="activeStory.mediaUrl"
+          class="max-h-[60vh] w-full rounded-md"
+          controls
+          playsinline
+          referrerpolicy="no-referrer"
+        ></video>
         <img
-          v-if="activeStory.mediaUrl"
+          v-else-if="activeStory.mediaUrl"
           :src="activeStory.mediaUrl"
           :alt="`Story media from ${authorLabel(activeStory.author)}`"
           class="max-h-[60vh] w-full rounded-md object-contain"

--- a/chat/src/components/community/StoryComposer.vue
+++ b/chat/src/components/community/StoryComposer.vue
@@ -1,0 +1,529 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { Camera, Image as ImageIcon, Paperclip, RefreshCw, Square, Trash2, Video, X } from "lucide-vue-next";
+
+type Mode = "attach" | "photo" | "record";
+type MediaKind = "image" | "video";
+
+interface StoryComposerProps {
+  /** Disables submit + tab switching while the parent is uploading. */
+  busy?: boolean;
+  /** Hard size cap from XEP-0363 service. */
+  maxBytes?: number;
+}
+
+const props = withDefaults(defineProps<StoryComposerProps>(), {
+  busy: false,
+  maxBytes: 10 * 1024 * 1024,
+});
+
+const emit = defineEmits<{
+  submit: [payload: { body?: string; file: Blob; mediaKind: MediaKind }];
+  cancel: [];
+}>();
+
+// MediaRecorder MIME preference order: VP9 > VP8. iOS Safari rejects
+// `video/mp4` as a `mimeType` argument and the only working path is to
+// omit it entirely, letting Safari pick (it produces fragmented MP4).
+const VIDEO_MIME_CANDIDATES = [
+  "video/webm;codecs=vp9,opus",
+  "video/webm;codecs=vp8,opus",
+] as const;
+const VIDEO_BITS_PER_SECOND = 2_000_000;
+const RECORDING_MAX_MS = 20_000;
+const RECORDING_TICK_MS = 100;
+
+const mode = ref<Mode>("attach");
+const body = ref("");
+const errorMessage = ref<string | null>(null);
+
+const previewUrl = ref<string | null>(null);
+const previewBlob = ref<Blob | null>(null);
+const previewKind = ref<MediaKind | null>(null);
+
+const videoEl = ref<HTMLVideoElement | null>(null);
+const stream = ref<MediaStream | null>(null);
+const facingMode = ref<"user" | "environment">("user");
+const cameraReady = ref(false);
+
+const recorder = ref<MediaRecorder | null>(null);
+const recording = ref(false);
+const recordStartedAt = ref<number | null>(null);
+const recordElapsedMs = ref(0);
+let recordTimerId: ReturnType<typeof setInterval> | null = null;
+let recordChunks: Blob[] = [];
+
+const recordingTooBig = computed(
+  () => previewBlob.value !== null && previewBlob.value.size > props.maxBytes,
+);
+
+const canSubmit = computed(() => {
+  if (props.busy) return false;
+  if (recordingTooBig.value) return false;
+  if (recording.value) return false;
+  if (previewBlob.value) return true;
+  return false;
+});
+
+function setError(message: string | null) {
+  errorMessage.value = message;
+}
+
+function setPreview(blob: Blob, kind: MediaKind) {
+  revokePreviewUrl();
+  previewBlob.value = blob;
+  previewKind.value = kind;
+  previewUrl.value = URL.createObjectURL(blob);
+}
+
+function revokePreviewUrl() {
+  if (previewUrl.value !== null) {
+    URL.revokeObjectURL(previewUrl.value);
+    previewUrl.value = null;
+  }
+}
+
+function clearPreview() {
+  revokePreviewUrl();
+  previewBlob.value = null;
+  previewKind.value = null;
+  setError(null);
+}
+
+function disposeCamera() {
+  if (recorder.value) {
+    // Detach handlers BEFORE stopping so the asynchronous `onstop`
+    // event can't fire after we've cleared `recordChunks` and produce
+    // a misleading zero-byte preview / spurious error toast. The
+    // recorded buffer is discarded on dispose — by definition the
+    // user has cancelled or switched away.
+    recorder.value.ondataavailable = null;
+    recorder.value.onstop = null;
+    if (recording.value) {
+      try {
+        recorder.value.stop();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  recorder.value = null;
+  recording.value = false;
+  recordStartedAt.value = null;
+  recordElapsedMs.value = 0;
+  recordChunks = [];
+  if (recordTimerId !== null) {
+    clearInterval(recordTimerId);
+    recordTimerId = null;
+  }
+  if (stream.value) {
+    for (const track of stream.value.getTracks()) {
+      try {
+        track.stop();
+      } catch {
+        /* ignore */
+      }
+    }
+    stream.value = null;
+  }
+  cameraReady.value = false;
+}
+
+async function ensureCamera() {
+  if (stream.value) return;
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+    setError("Camera capture isn't supported on this browser.");
+    return;
+  }
+  setError(null);
+  try {
+    const next = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: facingMode.value },
+      audio: mode.value === "record",
+    });
+    stream.value = next;
+    cameraReady.value = true;
+    await attachStreamToVideo();
+  } catch (err: unknown) {
+    if (err && typeof err === "object" && "name" in err) {
+      const name = (err as { name: string }).name;
+      if (name === "NotAllowedError") {
+        setError("Allow camera access in your browser to capture photos or video.");
+      } else if (name === "NotFoundError") {
+        setError("No camera detected.");
+      } else {
+        setError("Couldn't access the camera.");
+      }
+    } else {
+      setError("Couldn't access the camera.");
+    }
+  }
+}
+
+async function attachStreamToVideo() {
+  // Wait one tick so the `<video>` element exists when the user has
+  // just switched into Photo or Record mode.
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  if (videoEl.value && stream.value) {
+    videoEl.value.srcObject = stream.value;
+    try {
+      await videoEl.value.play();
+    } catch {
+      /* user gesture may be required — UI still shows the element */
+    }
+  }
+}
+
+async function flipCamera() {
+  facingMode.value = facingMode.value === "user" ? "environment" : "user";
+  disposeCamera();
+  await ensureCamera();
+}
+
+async function activateMode(next: Mode) {
+  if (props.busy) return;
+  if (next === mode.value) return;
+  // Switching away from a camera mode tears down the stream and any
+  // in-flight recording — the user explicitly chose another mode.
+  disposeCamera();
+  mode.value = next;
+  setError(null);
+  if (next === "photo" || next === "record") {
+    await ensureCamera();
+  }
+}
+
+function onAttachFile(event: Event) {
+  const input = event.target as HTMLInputElement;
+  const file = input.files?.[0];
+  input.value = "";
+  if (!file) return;
+  if (file.size > props.maxBytes) {
+    setError(`That file is too large (max ${Math.floor(props.maxBytes / (1024 * 1024))} MB).`);
+    return;
+  }
+  const kind: MediaKind = file.type.startsWith("video/") ? "video" : "image";
+  setPreview(file, kind);
+}
+
+async function takePhoto() {
+  if (!stream.value || !videoEl.value) {
+    await ensureCamera();
+  }
+  const v = videoEl.value;
+  if (!v) return;
+  const w = v.videoWidth;
+  const h = v.videoHeight;
+  if (!w || !h) {
+    setError("Camera isn't ready yet — try again in a moment.");
+    return;
+  }
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    setError("Couldn't capture the frame.");
+    return;
+  }
+  ctx.drawImage(v, 0, 0, w, h);
+  const blob: Blob | null = await new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b), "image/jpeg", 0.92);
+  });
+  if (!blob) {
+    setError("Couldn't capture the frame.");
+    return;
+  }
+  if (blob.size > props.maxBytes) {
+    setError(`That photo is too large (max ${Math.floor(props.maxBytes / (1024 * 1024))} MB). Try a lower-res camera.`);
+    return;
+  }
+  setPreview(blob, "image");
+}
+
+function pickSupportedMimeType(): string | undefined {
+  if (typeof MediaRecorder === "undefined") return undefined;
+  for (const mime of VIDEO_MIME_CANDIDATES) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return undefined;
+}
+
+function startRecording() {
+  if (!stream.value) {
+    setError("Camera not ready.");
+    return;
+  }
+  if (typeof MediaRecorder === "undefined") {
+    setError("Recording isn't supported on this browser.");
+    return;
+  }
+  const mimeType = pickSupportedMimeType();
+  let mr: MediaRecorder;
+  try {
+    mr = mimeType
+      ? new MediaRecorder(stream.value, { mimeType, videoBitsPerSecond: VIDEO_BITS_PER_SECOND })
+      : new MediaRecorder(stream.value, { videoBitsPerSecond: VIDEO_BITS_PER_SECOND });
+  } catch {
+    setError("Recording isn't supported on this browser.");
+    return;
+  }
+  recordChunks = [];
+  mr.ondataavailable = (event) => {
+    if (event.data && event.data.size > 0) recordChunks.push(event.data);
+  };
+  mr.onstop = () => {
+    const blob = new Blob(recordChunks, { type: mr.mimeType || "video/webm" });
+    recordChunks = [];
+    recording.value = false;
+    recordStartedAt.value = null;
+    recordElapsedMs.value = 0;
+    if (recordTimerId !== null) {
+      clearInterval(recordTimerId);
+      recordTimerId = null;
+    }
+    if (blob.size === 0) {
+      setError("Recording produced no data.");
+      return;
+    }
+    if (blob.size > props.maxBytes) {
+      setError(`That recording is too large (over ${Math.floor(props.maxBytes / (1024 * 1024))} MB). Try a shorter clip.`);
+      // Still show preview so the user can see what happened? No —
+      // they can't upload, so just discard.
+      return;
+    }
+    setPreview(blob, "video");
+  };
+  setError(null);
+  recorder.value = mr;
+  mr.start();
+  recording.value = true;
+  recordStartedAt.value = performance.now();
+  recordTimerId = setInterval(() => {
+    if (recordStartedAt.value === null) return;
+    recordElapsedMs.value = performance.now() - recordStartedAt.value;
+    if (recordElapsedMs.value >= RECORDING_MAX_MS) {
+      stopRecording();
+    }
+  }, RECORDING_TICK_MS);
+}
+
+function stopRecording() {
+  const mr = recorder.value;
+  if (!mr) return;
+  if (mr.state !== "inactive") {
+    try {
+      mr.stop();
+    } catch {
+      /* swallow */
+    }
+  }
+}
+
+function submit() {
+  if (!previewBlob.value || !previewKind.value) return;
+  emit("submit", {
+    ...(body.value.trim() ? { body: body.value.trim() } : {}),
+    file: previewBlob.value,
+    mediaKind: previewKind.value,
+  });
+}
+
+function cancel() {
+  disposeCamera();
+  clearPreview();
+  body.value = "";
+  emit("cancel");
+}
+
+watch(() => props.busy, (busy) => {
+  // When the parent starts uploading, freeze the camera. We don't
+  // tear down so the user can re-shoot if upload fails.
+  if (busy && recording.value) stopRecording();
+});
+
+onBeforeUnmount(() => {
+  disposeCamera();
+  revokePreviewUrl();
+});
+</script>
+
+<template>
+  <section class="grid gap-3 rounded-lg border border-border bg-card p-3">
+    <div role="tablist" aria-label="Composer mode" class="flex gap-1 rounded-md bg-muted/40 p-1">
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="mode === 'attach'"
+        class="flex-1 inline-flex items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium"
+        :class="mode === 'attach' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'"
+        :disabled="busy"
+        @click="activateMode('attach')"
+      >
+        <Paperclip class="h-3.5 w-3.5" aria-hidden="true" />
+        Attach
+      </button>
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="mode === 'photo'"
+        class="flex-1 inline-flex items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium"
+        :class="mode === 'photo' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'"
+        :disabled="busy"
+        @click="activateMode('photo')"
+      >
+        <ImageIcon class="h-3.5 w-3.5" aria-hidden="true" />
+        Photo
+      </button>
+      <button
+        type="button"
+        role="tab"
+        :aria-selected="mode === 'record'"
+        class="flex-1 inline-flex items-center justify-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium"
+        :class="mode === 'record' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'"
+        :disabled="busy"
+        @click="activateMode('record')"
+      >
+        <Video class="h-3.5 w-3.5" aria-hidden="true" />
+        Record
+      </button>
+    </div>
+
+    <p v-if="errorMessage" class="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+      {{ errorMessage }}
+    </p>
+
+    <div v-if="mode === 'attach' && !previewUrl" class="grid place-items-center rounded-md border border-dashed border-border px-3 py-6 text-center">
+      <label class="inline-flex cursor-pointer items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm hover:bg-muted/50">
+        <Paperclip class="h-4 w-4" aria-hidden="true" />
+        Choose photo or video
+        <input
+          type="file"
+          accept="image/*,video/*"
+          class="sr-only"
+          :disabled="busy"
+          @change="onAttachFile"
+        />
+      </label>
+      <p class="mt-2 type-caption text-muted-foreground">
+        Max {{ Math.floor(maxBytes / (1024 * 1024)) }} MB
+      </p>
+    </div>
+
+    <div v-if="(mode === 'photo' || mode === 'record') && !previewUrl" class="grid gap-2">
+      <div class="relative overflow-hidden rounded-md bg-black">
+        <video
+          ref="videoEl"
+          class="block max-h-[60vh] w-full"
+          playsinline
+          muted
+          autoplay
+        ></video>
+        <button
+          type="button"
+          class="absolute top-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm hover:bg-background"
+          :disabled="busy || recording"
+          :aria-label="facingMode === 'user' ? 'Switch to back camera' : 'Switch to front camera'"
+          @click="flipCamera"
+        >
+          <RefreshCw class="h-4 w-4" aria-hidden="true" />
+        </button>
+        <div v-if="recording" class="absolute top-2 left-2 inline-flex items-center gap-1.5 rounded-full bg-destructive/90 px-2.5 py-0.5 text-xs font-medium text-destructive-foreground">
+          <span class="h-2 w-2 rounded-full bg-destructive-foreground animate-pulse"></span>
+          {{ Math.ceil((RECORDING_MAX_MS - recordElapsedMs) / 1000) }}s
+        </div>
+      </div>
+      <div class="flex items-center justify-center gap-2">
+        <button
+          v-if="mode === 'photo'"
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="busy || !cameraReady"
+          @click="takePhoto"
+        >
+          <Camera class="h-4 w-4" aria-hidden="true" />
+          Capture
+        </button>
+        <template v-else>
+          <button
+            v-if="!recording"
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground shadow-sm hover:bg-destructive/90 disabled:cursor-not-allowed disabled:opacity-60"
+            :disabled="busy || !cameraReady"
+            @click="startRecording"
+          >
+            <Video class="h-4 w-4" aria-hidden="true" />
+            Record
+          </button>
+          <button
+            v-else
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-md bg-foreground px-3 py-2 text-sm font-medium text-background shadow-sm hover:opacity-90"
+            @click="stopRecording"
+          >
+            <Square class="h-4 w-4" aria-hidden="true" />
+            Stop
+          </button>
+        </template>
+      </div>
+    </div>
+
+    <div v-if="previewUrl" class="grid gap-2">
+      <div class="relative overflow-hidden rounded-md bg-black">
+        <img
+          v-if="previewKind === 'image'"
+          :src="previewUrl"
+          alt="Story preview"
+          class="block max-h-[60vh] w-full object-contain"
+        />
+        <video
+          v-else
+          :src="previewUrl"
+          class="block max-h-[60vh] w-full"
+          controls
+          playsinline
+        ></video>
+        <button
+          type="button"
+          class="absolute top-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-full bg-background/80 text-foreground shadow-sm hover:bg-background"
+          :disabled="busy"
+          aria-label="Remove media"
+          @click="clearPreview"
+        >
+          <Trash2 class="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+
+    <textarea
+      v-model="body"
+      class="min-h-[3rem] w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      placeholder="Add a caption (optional)"
+      :disabled="busy"
+      aria-label="Story caption"
+    />
+
+    <div class="flex items-center justify-between gap-2">
+      <span class="type-caption text-muted-foreground">Expires in 24h</span>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-input px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          :disabled="busy"
+          @click="cancel"
+        >
+          <X class="h-3.5 w-3.5" aria-hidden="true" />
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground shadow-sm hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          :disabled="!canSubmit"
+          @click="submit"
+        >
+          {{ busy ? "Sharing…" : "Share" }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -78,6 +78,12 @@ import {
   type WasmStory,
 } from "./story-types";
 import {
+  storyReadsFromWasm,
+  storyReadsToWasm,
+  type StoryReads,
+  type WasmStoryReads,
+} from "./story-reads-types";
+import {
   eventFromWasm,
   rruleToWasm,
   type CommunityEvent,
@@ -985,6 +991,40 @@ export class BrowserXmppClient {
     return jid;
   }
 
+  /**
+   * Upload a single file/blob for a story (or other plaintext-broadcast
+   * surface). Unlike `uploadAttachments`, the payload is uploaded as-is
+   * without OMEMO encryption — stories are community-broadcast content,
+   * not DMs.
+   *
+   * The caller is expected to pre-validate `blob.size <=
+   * MAX_FILE_UPLOAD_BYTES`; the upload service may still reject with
+   * 413 if its own cap is lower. Filename is replaced with a random
+   * UUID-based name so user-facing names don't leak into the public
+   * GET URL or OTel spans.
+   */
+  async uploadStoryMedia(
+    blob: Blob | File,
+    onProgress?: (progress: UploadProgress) => void,
+  ): Promise<{ url: string; size: number; contentType: string }> {
+    const xmpp = await this.requireConnectedXmpp();
+    const uploadDomain = await this.resolveUploadService();
+    const contentType = blob.type || "application/octet-stream";
+    const ext = contentType.split("/")[1]?.split(";")[0] || "bin";
+    const safeName = `story-${crypto.randomUUID()}.${ext}`;
+    const sanitised =
+      blob instanceof File
+        ? new File([blob], safeName, { type: contentType })
+        : new File([blob], safeName, { type: contentType });
+    const result = await uploadFile(
+      xmpp as WasmClient,
+      sanitised,
+      uploadDomain,
+      onProgress,
+    );
+    return { url: result.getUrl, size: result.size, contentType: result.contentType };
+  }
+
   async uploadAttachments(files: ReadonlyArray<File | Blob>, onProgress?: (overall: UploadProgress, index: number) => void): Promise<OutboundFileAttachment[]> {
     const xmpp = await this.requireConnectedXmpp();
     const uploadDomain = await this.resolveUploadService();
@@ -1099,6 +1139,31 @@ export class BrowserXmppClient {
     const xmpp = await this.requireConnectedXmpp();
     const result = await xmpp.stories_items?.(communityJid, maxItems ?? null) as WasmStory[] | undefined;
     return (result ?? []).map(storyFromWasm);
+  }
+
+  /**
+   * Fetch the current user's story read-state from their private PEP
+   * node (XEP-0223 `urn:waddle:story:reads:0`). Read-state is
+   * non-critical: any failure (no item yet, network error, spoofed
+   * `from`) silently produces an empty result rather than surfacing
+   * an error to the UI.
+   */
+  async fetchStoryReads(): Promise<StoryReads> {
+    const xmpp = await this.requireConnectedXmpp();
+    const result = (await xmpp.story_reads_fetch?.()) as WasmStoryReads | undefined;
+    return storyReadsFromWasm(result);
+  }
+
+  /**
+   * Publish the current user's story read-state. Overwrites the
+   * single `current` item on every call.
+   */
+  async publishStoryReads(reads: StoryReads): Promise<StoryReads> {
+    const xmpp = await this.requireConnectedXmpp();
+    const result = (await xmpp.story_reads_publish?.(
+      storyReadsToWasm(reads),
+    )) as WasmStoryReads | undefined;
+    return storyReadsFromWasm(result);
   }
 
   /**

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -29,6 +29,12 @@ export type { InboxEntry } from "./inbox-types";
 export type { FeedEntry, FeedPostInput, FeedSourceKind } from "./feed-types";
 export type { Story, StoryPostInput } from "./story-types";
 export { isStoryActive } from "./story-types";
+export type { StoryRead, StoryReads } from "./story-reads-types";
+export {
+  pruneStoryReads,
+  STORY_READS_MAX_ENTRIES,
+  STORY_READS_PRUNE_MS,
+} from "./story-reads-types";
 export type {
   Attendee,
   CommunityEvent,

--- a/chat/src/lib/xmpp/story-reads-types.ts
+++ b/chat/src/lib/xmpp/story-reads-types.ts
@@ -1,0 +1,71 @@
+/**
+ * Per-user story read state mirrored from the wasm bridge.
+ *
+ * Stored as a single pubsub item on the user's own JID per XEP-0223;
+ * see the design spec at
+ * `docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md`.
+ */
+
+export interface StoryRead {
+  /** XEP-0501 pubsub item id of the story (non-empty). */
+  id: string;
+  /** Epoch ms when the story was first marked read. */
+  atMs: number;
+}
+
+export interface StoryReads {
+  entries: readonly StoryRead[];
+}
+
+/** Snake-case shape emitted by the wasm bridge (`JsStoryReads`). */
+export interface WasmStoryReads {
+  entries: WasmStoryRead[];
+}
+
+export interface WasmStoryRead {
+  id: string;
+  /** RFC 3339 timestamp string. */
+  at: string;
+}
+
+export function storyReadsFromWasm(reads: WasmStoryReads | undefined): StoryReads {
+  if (!reads) return { entries: [] };
+  const out: StoryRead[] = [];
+  for (const entry of reads.entries) {
+    if (!entry?.id) continue;
+    const atMs = Date.parse(entry.at);
+    if (!Number.isFinite(atMs)) continue;
+    out.push({ id: entry.id, atMs });
+  }
+  return { entries: out };
+}
+
+export function storyReadsToWasm(reads: StoryReads): WasmStoryReads {
+  return {
+    entries: reads.entries.map((entry) => ({
+      id: entry.id,
+      at: new Date(entry.atMs).toISOString(),
+    })),
+  };
+}
+
+/**
+ * Drop entries with `atMs < cutoffMs`. Also caps total entries to
+ * `max` (oldest first) as a defence-in-depth mirror of the Rust side.
+ */
+export function pruneStoryReads(
+  reads: StoryReads,
+  cutoffMs: number,
+  max: number,
+): StoryReads {
+  const kept = reads.entries.filter((entry) => entry.atMs >= cutoffMs);
+  if (kept.length <= max) return { entries: kept };
+  const sorted = [...kept].sort((a, b) => a.atMs - b.atMs);
+  return { entries: sorted.slice(sorted.length - max) };
+}
+
+/** 48h prune horizon — stories expire at 24h; doubled for clock skew. */
+export const STORY_READS_PRUNE_MS = 48 * 60 * 60 * 1000;
+
+/** Hard cap, mirroring `READ_ENTRY_MAX` in `waddle-xmpp-core`. */
+export const STORY_READS_MAX_ENTRIES = 5000;

--- a/chat/src/services/stories.ts
+++ b/chat/src/services/stories.ts
@@ -4,9 +4,23 @@
  * entries locally — the wasm bridge returns ALL items, and we
  * re-derive `activeStories` every minute so stories fade out as
  * their countdowns hit zero without a server roundtrip.
+ *
+ * Read state is synced via a private PEP node (XEP-0223) — see
+ * `services/story-read-store.ts`. Marking a story read is fire-and-
+ * forget; publishing your own story auto-marks it so other devices
+ * don't show it as unread.
  */
 import { computed, onScopeDispose, ref, type Ref } from "vue";
-import { isStoryActive, type BrowserXmppClient, type Story, type StoryPostInput } from "@/lib/xmpp-client";
+import {
+  isStoryActive,
+  type BrowserXmppClient,
+  type Story,
+  type StoryPostInput,
+} from "@/lib/xmpp-client";
+import {
+  createStoryReadStore,
+  type StoryReadStore,
+} from "@/services/story-read-store";
 
 const TICK_INTERVAL_MS = 60_000;
 
@@ -27,12 +41,34 @@ export function useStories(
   const tickHandle = setInterval(() => {
     nowMs.value = Date.now();
   }, TICK_INTERVAL_MS);
-  onScopeDispose(() => clearInterval(tickHandle));
+
+  const readStore: StoryReadStore = createStoryReadStore(xmppClient);
+  // `readVersion` bumps whenever a story is marked read so computed
+  // values depending on the read set re-evaluate. The store itself
+  // owns a plain Map; this ref is the reactive cursor on top of it.
+  const readVersion = ref(0);
+
+  onScopeDispose(() => {
+    clearInterval(tickHandle);
+    readStore.dispose();
+  });
 
   const activeStories = computed(() => {
     const live = stories.value.filter((s) => isStoryActive(s, nowMs.value));
     return [...live].sort((a, b) => (b.postedMs ?? 0) - (a.postedMs ?? 0));
   });
+
+  function isStoryRead(id: string): boolean {
+    void readVersion.value;
+    return readStore.isRead(id);
+  }
+
+  function markStoryRead(id: string): void {
+    if (!id) return;
+    if (readStore.isRead(id)) return;
+    readStore.markRead(id);
+    readVersion.value += 1;
+  }
 
   async function refresh(): Promise<boolean> {
     const client = xmppClient.value;
@@ -48,6 +84,12 @@ export function useStories(
       const fetched = await client.fetchStories(jid, pageSize);
       if (requestId !== fetchRequestId || client !== xmppClient.value) return false;
       stories.value = fetched;
+      if (!readStore.loaded()) {
+        // Hydrate after the first stories fetch so the rail doesn't
+        // pop unread→read on first paint.
+        await readStore.init();
+        readVersion.value += 1;
+      }
       return true;
     } catch (err) {
       if (requestId === fetchRequestId) {
@@ -71,6 +113,10 @@ export function useStories(
     try {
       const story = await client.publishStory(jid, input);
       stories.value = [story, ...stories.value.filter((s) => s.id !== story.id)];
+      // Auto-mark: a user should never see their own freshly-posted
+      // story as unread on another device. XEP-0501 has no
+      // server-side read affordance, so we drive this client-side.
+      markStoryRead(story.id);
       return story;
     } catch (err) {
       error.value = err instanceof Error ? err.message : String(err);
@@ -86,6 +132,8 @@ export function useStories(
     error.value = null;
     isLoading.value = false;
     isPosting.value = false;
+    readStore.dispose();
+    readVersion.value += 1;
   }
 
   return {
@@ -97,5 +145,7 @@ export function useStories(
     post,
     clear,
     nowMs,
+    isStoryRead,
+    markStoryRead,
   };
 }

--- a/chat/src/services/story-read-store.ts
+++ b/chat/src/services/story-read-store.ts
@@ -1,0 +1,165 @@
+/**
+ * Per-user story read-state store backed by a private PEP node
+ * (XEP-0223 `urn:waddle:story:reads:0`). The store exposes a small,
+ * UI-facing surface (is/mark/loaded) and hides the wasm/IQ details
+ * behind it; the same interface is what the spec uses to keep
+ * `StoriesPane.vue` free of XMPP concerns.
+ *
+ * Publish strategy: marks are added to the in-memory set immediately,
+ * and a debounced publish coalesces bursts so opening N stories in a
+ * row produces one IQ. Failures are swallowed — read state is not
+ * load-bearing.
+ *
+ * Pruning: on every publish the wire payload is pruned to entries
+ * within the last 48h and capped at 5000 entries, mirroring the Rust
+ * `prune_before` + `cap_to` defence-in-depth.
+ */
+
+import {
+  pruneStoryReads,
+  STORY_READS_MAX_ENTRIES,
+  STORY_READS_PRUNE_MS,
+  type BrowserXmppClient,
+  type StoryRead,
+  type StoryReads,
+} from "@/lib/xmpp-client";
+
+const DEFAULT_PUBLISH_DEBOUNCE_MS = 250;
+
+export interface StoryReadStore {
+  /** Reactive: true once `init()` has resolved (success or empty). */
+  readonly loaded: () => boolean;
+  /** Iterate the current set of read story ids. */
+  readonly readIds: () => ReadonlySet<string>;
+  /** Test membership without copying the set. */
+  isRead(id: string): boolean;
+  /**
+   * Mark a story as read locally and schedule a debounced publish.
+   * Idempotent on the same id within the debounce window.
+   */
+  markRead(id: string, atMs?: number): void;
+  /** Hydrate from the user's PEP node. Safe to call once per session. */
+  init(): Promise<void>;
+  /** Flush any pending debounced publish immediately. */
+  flush(): Promise<void>;
+  /** Cancel pending timers and drop state. Used on logout. */
+  dispose(): void;
+}
+
+interface StoryReadStoreOptions {
+  publishDebounceMs?: number;
+  /** Override `Date.now` for tests. */
+  now?: () => number;
+}
+
+export function createStoryReadStore(
+  xmppClient: { value: BrowserXmppClient | null },
+  options: StoryReadStoreOptions = {},
+): StoryReadStore {
+  const debounceMs = options.publishDebounceMs ?? DEFAULT_PUBLISH_DEBOUNCE_MS;
+  const now = options.now ?? (() => Date.now());
+
+  const reads = new Map<string, number>();
+  let loadedFlag = false;
+  let publishTimer: ReturnType<typeof setTimeout> | null = null;
+  let publishInFlight: Promise<void> | null = null;
+  let dirty = false;
+
+  function snapshot(): StoryReads {
+    const entries: StoryRead[] = [];
+    for (const [id, atMs] of reads) entries.push({ id, atMs });
+    return pruneStoryReads(
+      { entries },
+      now() - STORY_READS_PRUNE_MS,
+      STORY_READS_MAX_ENTRIES,
+    );
+  }
+
+  async function publishNow(): Promise<void> {
+    const client = xmppClient.value;
+    if (!client) return;
+    const payload = snapshot();
+    // Reflect pruning back into the in-memory map so the store and the
+    // server agree on what's stored.
+    reads.clear();
+    for (const entry of payload.entries) reads.set(entry.id, entry.atMs);
+    try {
+      await client.publishStoryReads(payload);
+    } catch {
+      // Read state is non-critical — surfacing the error to the UI
+      // would just create noise. The next mark will retry.
+    }
+  }
+
+  function schedulePublish(): void {
+    if (publishTimer !== null) clearTimeout(publishTimer);
+    publishTimer = setTimeout(() => {
+      publishTimer = null;
+      if (!dirty) return;
+      dirty = false;
+      publishInFlight = publishNow().finally(() => {
+        publishInFlight = null;
+      });
+    }, debounceMs);
+  }
+
+  return {
+    loaded: () => loadedFlag,
+    readIds: () => new Set(reads.keys()),
+    isRead: (id) => reads.has(id),
+    markRead(id: string, atMs?: number) {
+      if (!id) return;
+      const t = atMs ?? now();
+      const existing = reads.get(id);
+      if (existing !== undefined && existing >= t) return;
+      reads.set(id, t);
+      dirty = true;
+      schedulePublish();
+    },
+    async init(): Promise<void> {
+      const client = xmppClient.value;
+      if (!client) {
+        loadedFlag = true;
+        return;
+      }
+      try {
+        const fetched = await client.fetchStoryReads();
+        // Apply prune horizon at hydrate too so a long-disconnected
+        // client doesn't load 48+ hour old entries.
+        const pruned = pruneStoryReads(
+          fetched,
+          now() - STORY_READS_PRUNE_MS,
+          STORY_READS_MAX_ENTRIES,
+        );
+        reads.clear();
+        for (const entry of pruned.entries) reads.set(entry.id, entry.atMs);
+      } catch {
+        // Non-critical: leave the set empty.
+      } finally {
+        loadedFlag = true;
+      }
+    },
+    async flush(): Promise<void> {
+      if (publishTimer !== null) {
+        clearTimeout(publishTimer);
+        publishTimer = null;
+        if (dirty) {
+          dirty = false;
+          publishInFlight = publishNow().finally(() => {
+            publishInFlight = null;
+          });
+        }
+      }
+      if (publishInFlight) await publishInFlight;
+    },
+    dispose() {
+      if (publishTimer !== null) {
+        clearTimeout(publishTimer);
+        publishTimer = null;
+      }
+      reads.clear();
+      loadedFlag = false;
+      dirty = false;
+    },
+  };
+}

--- a/docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md
+++ b/docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md
@@ -1,0 +1,436 @@
+# Stories: Instagram-like media composer + per-user read state
+
+Status: draft (rev 2, post-SME review)
+Date: 2026-05-19
+
+## Motivation
+
+Today the Stories composer (`chat/src/components/community/StoriesPane.vue`)
+asks for a media URL string. Users have no way to attach a file, take a
+photo, or record a clip in-app, and there is no notion of "seen" — every
+story renders with the same primary-coloured avatar ring forever.
+
+This spec covers two paired changes that together make Stories feel
+Instagram-like:
+
+1. **Media composer overhaul** — replace the URL field with file attach,
+   in-app photo capture, and in-app short video recording, all uploaded
+   via the existing XEP-0363 HTTP File Upload pipeline.
+2. **Per-user read state** — track which stories a user has opened, keep
+   that state in a private PEP node so it syncs across devices, and dim
+   read stories in the rail.
+
+The two are landed together because they share the same surface
+(`StoriesPane.vue`) and the same goal (familiar Instagram-style UX) —
+splitting them would force a second pass over the same component within
+days.
+
+## Non-goals
+
+- Filters, stickers, text overlays on captured media
+- Multi-clip stitching or trimming UI
+- Story view counts visible to authors (separate feature)
+- Replacing the existing XEP-0501 stories transport
+- Encrypting story media (stories are community-broadcast; consistent
+  with the existing plaintext model — the OMEMO `encrypted-attachments`
+  path is for DMs)
+- Migrating any persisted user data — there is none today
+
+## Architecture
+
+### Layering
+
+```
+StoriesPane.vue                    (rail, reader, dims read stories)
+   ├── StoryComposer.vue           (NEW: file/photo/video capture + preview)
+   └── (read-store consumed)
+            ↓
+useStories() composable            (existing; gains read-store wiring)
+            ↓
+BrowserXmppClient
+   ├── publishStory()              (existing)
+   ├── publishStoryReads()         (NEW)
+   └── fetchStoryReads()           (NEW)
+            ↓
+waddle-xmpp-client-wasm
+   └── client_story_reads.rs       (NEW: PEP publish/fetch IQ builders + typed forms)
+            ↓
+waddle-xmpp-core
+   └── waddle_story_reads.rs       (NEW: typed Reads / ReadEntry / StoryId, namespace const)
+            ↓
+waddle-server pubsub_fanout.rs     (PATCHED: private-PEP carve-out gains story-reads node)
+```
+
+The composer is split out of `StoriesPane.vue` so the rail/reader
+component stays small and focused. The read-store is an interface so the
+UI never reaches into XMPP details directly.
+
+### Storage shape — read state
+
+A single PEP item on the user's own JID, conforming to XEP-0223
+"Persistent Storage of Private Data via PubSub". Node options
+(committed to via `<publish-options>` precondition form on every
+publish, per XEP-0060 §7.1.5):
+
+- `pubsub#persist_items = true`
+- `pubsub#access_model = whitelist` (private — only the owner can fetch
+  via items request)
+- `pubsub#send_last_published_item = never`
+- `pubsub#max_items = 1`
+
+All four MUST appear in the publish-options precondition. Omitting any
+of them lets a server auto-create with different defaults and silently
+diverge (e.g. unbounded `max_items`, `on_sub_and_presence` leaking to
+roster contacts).
+
+- **Node:** `urn:waddle:story:reads:0`
+- **Item id:** the constant string `current` (overwrite-in-place)
+- **Payload namespace:** `urn:waddle:story:reads:0` (custom — no XEP
+  defines a story-read shape; per the CLAUDE.md hard rule, `urn:waddle:*`
+  is correct here). The node id and namespace coincide deliberately,
+  matching the XEP-0501 / XEP-0163 one-node-per-namespace convention.
+- **Payload XML:**
+
+  ```xml
+  <reads xmlns="urn:waddle:story:reads:0">
+    <read id="story-uuid-1" at="2026-05-19T10:11:12Z"/>
+    <read id="story-uuid-2" at="2026-05-19T10:13:44Z"/>
+  </reads>
+  ```
+
+- **`id`** is the XEP-0501 pubsub item id of the story (e.g.
+  `story-<uuid>`) — globally unique across communities, so we do not need
+  to scope by community JID.
+- **`at`** is the RFC 3339 timestamp the client first marked the story
+  read. Used only for pruning.
+- **Pruning:** on every publish, drop entries older than 48h. Also cap
+  total entries at 5000 as a defence in depth. Stories themselves expire
+  at 24h; 48h buys a safety margin against clock skew and the local
+  1-minute tick.
+
+### Security & fan-out (XEP-0223 §Security)
+
+1. **`from` validation (mandatory):** `fetchStoryReads()` parses only IQ
+   results whose `from` attribute is absent or equal to the account's
+   bare JID. Any future pubsub event handler for this node MUST drop
+   events with a `from` not equal to the account's bare JID. Per
+   XEP-0223 v1.1.1 Security Considerations (CVE-2023-28686) — a
+   malicious contact can otherwise spoof read-state injection.
+2. **Server-side fan-out carve-out (mandatory):** Whitelist access
+   model on a PEP node controls **items fetch**, not notification
+   fan-out. `server/crates/waddle-server/src/pubsub/pubsub_fanout.rs`
+   currently exempts only the bookmarks node (`is_private_bookmarks_node`
+   check). The story-reads node MUST be added to that exemption (or the
+   check generalised to "PEP node with `access_model = Whitelist`")
+   before this feature ships. Without this, every roster contact whose
+   client advertises `urn:waddle:story:reads:0+notify` would receive
+   the read-state payload as a headline event.
+3. **Filtered notifications opt-in (XEP-0163):** The Waddle client MUST
+   add `urn:waddle:story:reads:0+notify` to its disco features (XEP-0115
+   caps) for same-account cross-device delivery to ever work. The server
+   already advertises `filtered-notifications`. (Cross-device live sync
+   is deferred to a follow-up; the caps entry can land with v1 so the
+   plumbing is ready.)
+
+### Read flow
+
+1. On `useStories()` mount (after the first successful `refresh()`),
+   call `fetchStoryReads()` once. Result populates an in-memory
+   `Set<string>` of read story ids. On failure, the set stays empty
+   and no error is surfaced to the user — read state is non-critical.
+2. `selectStory(index)` calls `markRead(story.id)`:
+   - Adds id to the in-memory set immediately (UI updates).
+   - Debounces a `publishStoryReads()` call (250 ms) so opening N stories
+     in quick succession coalesces into one PEP publish.
+3. **Auto-mark own stories:** when `publishStory()` succeeds, the
+   composable calls `markRead(returnedStory.id)` so a user never sees
+   their own story as unread on any device. (XEP-0501 defines no
+   server-side read affordance; this is the canonical fix.)
+4. UI: `StoriesPane.vue` swaps the avatar `ring-primary/70 ring-offset-1`
+   class for `ring-muted/50 ring-offset-1` when the id is in the set.
+5. Cross-device sync: v1 does not subscribe to the node; opening the
+   same story twice across devices is a benign double-publish. The
+   `+notify` caps entry is registered for future live sync.
+
+### Media composer
+
+`StoryComposer.vue` is mounted with Astro `client:only="vue"` (the
+component touches `navigator.mediaDevices` which does not exist in the
+Cloudflare Workers SSR build). All media-API access is gated behind
+`onMounted` / explicit user interaction; no top-level module evaluation
+references `navigator`.
+
+It exposes one prop (`busy: boolean`) and emits one event
+(`submit: { body?: string, file?: File | Blob, mediaKind?: 'image' | 'video' }`).
+Internally it has three modes selected by a tab bar:
+
+| Mode    | Behaviour                                                                  |
+| ------- | -------------------------------------------------------------------------- |
+| Attach  | `<input type="file" accept="image/*,video/*">`; previewed inline.          |
+| Photo   | `getUserMedia({ video: { facingMode: 'user' } })` → live `<video playsinline muted autoplay>`; shutter → `canvas.toBlob('image/jpeg', 0.92)`. Flip button toggles to `facingMode: 'environment'`. |
+| Record  | Same stream; `MediaRecorder` with `videoBitsPerSecond: 2_000_000` and the first-supported MIME from `['video/webm;codecs=vp9,opus', 'video/webm;codecs=vp8,opus']`; if none, construct `MediaRecorder(stream)` with **no `mimeType` option** (Safari path — Safari rejects `video/mp4` as a recordable type and only works when allowed to pick). Tap-to-start, tap-to-stop, hard cap **20s**, on-screen countdown. |
+
+**iOS Safari requirements:** the live preview `<video>` element MUST
+have `playsinline`, `muted`, and `autoplay` attributes. Without
+`playsinline`, iOS fullscreens the stream and the composer becomes
+unusable.
+
+**Lazy permission request:** `getUserMedia` is called **only** when the
+user activates the Photo or Record tab — never on composer mount, and
+never on the Attach tab. This avoids the dark-pattern of asking for
+camera access before the user signals intent to capture.
+
+**Camera track lifecycle (mandatory):** the `MediaStream` is stored in a
+ref. `stream.getTracks().forEach(t => t.stop())` MUST run in every one
+of these places: (a) `onBeforeUnmount`, (b) the composer's Cancel /
+close handler, (c) tab-switch out of Photo/Record into Attach,
+(d) replacement of one stream with another (camera flip). Object URL
+revocation alone does NOT stop the camera track — the hardware indicator
+light stays on until `.stop()` runs. The component owns a single
+`disposeCamera()` function that's invoked from all four sites.
+
+**Object URL lifecycle:** preview URLs are held in a ref. A `watch` on
+that ref calls `URL.revokeObjectURL(prev)` before assigning a new value;
+`onBeforeUnmount` revokes the current value. The same revocation runs
+on tab switch and on Cancel.
+
+**Pre-upload size check:** when a Photo/Record completes, the composer
+checks `blob.size > MAX_FILE_UPLOAD_BYTES` **before** requesting a slot,
+so the user sees the error inline with the blob still in memory and can
+re-shoot. XEP-0363 PUT is not resumable; failing late costs the user
+their clip.
+
+**Sanitised filenames:** the upload layer replaces user-facing filenames
+with `story-<uuid>.<ext>` before calling `request_upload_slot`. This
+keeps PII (e.g. `vacation-photo-alice-birthday.jpg`) out of XEP-0363
+GET URLs and out of Faro OTel spans on `XMLHttpRequest`.
+
+`StoriesPane.vue` listens for `submit`, calls `uploadFile()` against the
+discovered XEP-0363 service, and then `publishStory({ body, mediaUrl: slot.getUrl })`.
+The 10 MB `MAX_FILE_UPLOAD_BYTES` cap is reused. At 2 Mbps cap and 20 s
+duration the worst-case video payload is ≈5 MB before audio overhead —
+well inside the cap.
+
+Errors surfaced inline above the composer:
+
+- `NotAllowedError` → "Allow camera access in your browser to capture
+  photos or video."
+- `NotFoundError` → "No camera detected."
+- `NotSupportedError` from `new MediaRecorder()` → hide the Record tab,
+  show "Recording isn't supported on this browser."
+- `blob.size > MAX_FILE_UPLOAD_BYTES` → "That recording is too large
+  (over 10 MB). Try a shorter clip." (shown before upload starts)
+- Upload `413` or upload network error → "Couldn't upload — please try
+  again."
+
+## Typed payloads (server side)
+
+Per the project hard rule, no `String`/`&str` blobs at boundaries.
+`waddle-xmpp-core::waddle_story_reads` exposes:
+
+```rust
+pub const NS_WADDLE_STORY_READS: &str = "urn:waddle:story:reads:0";
+/// Coincides with NS_WADDLE_STORY_READS by XEP-0163 one-node-per-namespace
+/// convention; kept as a separate name for call-site readability.
+pub const PEP_NODE_WADDLE_STORY_READS: &str = NS_WADDLE_STORY_READS;
+pub const PEP_ITEM_WADDLE_STORY_READS: &str = "current";
+pub const READ_ENTRY_MAX: usize = 5000;
+
+/// Validated wrapper around an XEP-0501 pubsub item id (e.g. "story-<uuid>").
+/// Empty strings are rejected at construction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StoryId(String);
+
+impl StoryId {
+    pub fn new(id: impl Into<String>) -> Result<Self, StoryReadsParseError> { /* ... */ }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoryReadEntry {
+    pub story_id: StoryId,
+    pub at: DateTime<Utc>,
+}
+
+/// Use BTreeSet keyed by `story_id` to enforce uniqueness structurally:
+/// `prune_before` semantics stay obvious, and a duplicate re-mark just
+/// updates the `at` (via remove-then-insert in `mark_read`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoryReads {
+    entries: std::collections::BTreeMap<StoryId, DateTime<Utc>>,
+}
+
+impl StoryReads {
+    pub fn build_element(&self) -> minidom::Element { /* typed minidom builder, NOT format! */ }
+    pub fn parse(el: &minidom::Element) -> Result<Self, StoryReadsParseError> { /* ... */ }
+    pub fn prune_before(&mut self, cutoff: DateTime<Utc>);
+    pub fn cap_to(&mut self, max: usize); // drops oldest by `at` until len <= max
+    pub fn mark_read(&mut self, id: StoryId, at: DateTime<Utc>);
+    pub fn contains(&self, id: &StoryId) -> bool;
+    pub fn iter(&self) -> impl Iterator<Item = (&StoryId, &DateTime<Utc>)>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoryReadsParseError {
+    #[error("wrong element name: expected `reads`, got `{0}`")]
+    WrongElementName(String),
+    #[error("wrong namespace: expected `{}`, got `{0}`", NS_WADDLE_STORY_READS)]
+    WrongNamespace(String),
+    #[error("<read> missing `id` attribute")]
+    MissingId,
+    #[error("<read> has empty `id` attribute")]
+    EmptyId,
+    #[error("<read> missing `at` attribute")]
+    MissingAt,
+    #[error("<read> `at` is not RFC 3339: {0}")]
+    BadTimestamp(String),
+}
+```
+
+**Publish-options form** (the wasm bridge constructs this with typed
+`DataForm` / `Field` builders from `waddle_xmpp_core::dataform`, never
+with `format!`):
+
+```
+<x xmlns="jabber:x:data" type="submit">
+  <field var="FORM_TYPE" type="hidden">
+    <value>http://jabber.org/protocol/pubsub#publish-options</value>
+  </field>
+  <field var="pubsub#persist_items"><value>true</value></field>
+  <field var="pubsub#access_model"><value>whitelist</value></field>
+  <field var="pubsub#send_last_published_item"><value>never</value></field>
+  <field var="pubsub#max_items"><value>1</value></field>
+</x>
+```
+
+The wasm bridge (`client_story_reads.rs`) returns `JsStoryReads`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsStoryRead {
+    pub id: String,        // StoryId.0 — narrows to plain string only at JS boundary
+    pub at: String,        // RFC 3339, like JsStory::posted/expires
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsStoryReads {
+    pub entries: Vec<JsStoryRead>,
+}
+
+impl From<StoryReads> for JsStoryReads { /* iter + map */ }
+```
+
+The `StoryId` newtype is unwrapped to `String` only at the JS boundary —
+mirroring how `client_stories.rs::JsStory` serialises typed timestamps
+as RFC 3339 strings. Inside Rust the newtype is preserved.
+
+## Testing
+
+### Rust unit tests (`waddle-xmpp-core`)
+
+`server/crates/waddle-xmpp-core/tests/waddle_story_reads.rs`:
+
+- `parse_round_trip` — build → serialise → parse yields equal struct
+- `parse_rejects_missing_id` — `<read>` without `id` → `MissingId`
+- `parse_rejects_empty_id` — `<read id="">` → `EmptyId`
+- `parse_rejects_bad_timestamp` — non-RFC3339 `at` → `BadTimestamp`
+- `parse_rejects_wrong_element` — `<readz>` → `WrongElementName`
+- `parse_rejects_wrong_namespace` — wrong xmlns → `WrongNamespace`
+- `parse_ignores_unknown_children` — forward-compat
+- `parse_ignores_unknown_attrs` — `<read id at device="X">` parses
+- `prune_before_drops_old_entries` — entries with `at < cutoff` are
+  dropped, newer kept
+- `cap_to_drops_oldest_first` — at capacity, oldest `at` is dropped
+- `mark_read_updates_existing` — re-marking same id updates `at`
+- `story_id_rejects_empty` — `StoryId::new("")` errors out
+
+### Rust integration tests (`waddle-server`)
+
+`server/crates/waddle-server/tests/xep0223_story_reads_ws.rs`:
+
+- `publish_then_fetch_returns_entries` — publish via wasm client, fetch
+  via raw IQ, assert equality
+- `republish_overwrites_item` — second publish replaces (item id stays
+  `current`, max_items=1 enforced)
+- `publish_iq_carries_required_publish_options` — sniff the published
+  IQ; assert `<publish-options>` contains all four required fields with
+  expected values
+- `node_is_private_to_owner` — a second account fetching the first
+  account's node receives `<error type="auth"><forbidden/>` (the
+  in-tree server's documented Whitelist behaviour; if implementation
+  diverges, the test will tell us in CI before merge)
+- **`private_pep_does_not_fan_out_to_roster`** — second account is on
+  the publisher's roster and advertises `urn:waddle:story:reads:0+notify`
+  in caps; assert it receives NO message stanza when the publisher
+  publishes. This proves the `pubsub_fanout.rs` carve-out is wired.
+
+### TypeScript tests
+
+- `StoryComposer.vue` (vitest + happy-dom):
+  - mode switching, preview render, MIME-detection branches (vp9 →
+    vp8 → no-mime fallback)
+  - pre-upload size check fires when `blob.size > MAX`
+  - `getUserMedia` stubbed via `vi.spyOn(navigator.mediaDevices, 'getUserMedia')`
+  - **camera lifecycle**: track `.stop()` is called on unmount, on
+    Cancel, on tab switch, and on camera flip (assert via mocked
+    MediaStream with tracked `.stop()` spy)
+  - `facingMode` toggle test
+- `services/stories.ts`:
+  - `markRead` adds id locally, then triggers exactly one publish after
+    debounce window (fake timers)
+  - publishing your own story triggers an auto `markRead`
+  - `fetchStoryReads` failure leaves the set empty and surfaces no
+    user-facing error
+
+### Manual
+
+- iOS Safari 17+: camera permission prompt on Photo tab activation;
+  live preview renders inline (not fullscreen); record + upload + publish
+- Chrome desktop: photo, then record, then attach, all in one session;
+  camera light goes off on Cancel
+- Open story on device A, open the chat on device B, story shows
+  dimmed ring on next mount
+- Confirm camera indicator is off after closing the composer mid-record
+
+## Build order
+
+1. **Server foundation** — `waddle-xmpp-core::waddle_story_reads`
+   (typed `StoryId`, `StoryReads`, `StoryReadsParseError`) + Rust unit
+   tests
+2. **Server fan-out fix** — extend `pubsub_fanout.rs`
+   `is_private_bookmarks_node` to also exempt `urn:waddle:story:reads:0`
+   (and rename the predicate to `is_private_pep_node`); regression test
+   for bookmarks behaviour
+3. **Wasm bridge** — `client_story_reads.rs` with `story_reads_publish`
+   / `story_reads_fetch`, typed `<publish-options>` builder, integration
+   tests on `waddle-server` (including the fan-out test)
+4. **Chat: caps + read-store** — add `urn:waddle:story:reads:0+notify`
+   to the client's disco features; `StoryReadStore` interface +
+   `PepStoryReadStore` implementation; wire into `useStories`; update
+   `StoriesPane.vue` ring class; clean up `composerMediaUrl` and related
+   refs in `StoriesPane.vue` so knip stays clean
+5. **Chat: media composer** — `StoryComposer.vue` with three modes,
+   replace the URL input
+6. **Adversarial review + CI green**
+
+Steps 1–3 are independent of 4–5 only in code; the user-facing change
+only makes sense once both ship, so this lands as a single PR.
+
+## Risks
+
+- **Safari MediaRecorder support** — Safari ≥14 supports `MediaRecorder`
+  but rejects most explicit `mimeType` values. Mitigation: omit
+  `mimeType`. If `new MediaRecorder(stream)` itself throws, hide the
+  Record tab.
+- **PEP node creation** — XEP-0223 says the server SHOULD auto-create on
+  first publish-with-options. The in-tree server's PEP module is
+  expected to honour `<publish-options>` precondition fields. The
+  integration test `publish_iq_carries_required_publish_options` and
+  `publish_then_fetch_returns_entries` together prove this end-to-end.
+- **Large recordings** — duration capped at 20s, bitrate capped at
+  2 Mbps. Pre-upload size check rejects oversize blobs before the slot
+  request.
+- **Roster fan-out regression** — the existing bookmarks carve-out in
+  `pubsub_fanout.rs` is the only thing keeping XEP-0402 bookmarks
+  private today. We're extending that mechanism; the regression test
+  for bookmarks must continue to pass.

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -77,7 +77,18 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     let publisher = req.publisher;
     let publisher_full = req.publisher_full;
     let is_pep = req.is_pep;
+    // Private PEP nodes (whitelist-access) carve out of roster + CAPS
+    // fan-out even though the published payload is broadcast at the
+    // pubsub layer. Whitelist `access_model` only gates the items-fetch
+    // path; without this check a contact with `+notify` for the node's
+    // namespace would still receive headline events. New entries here
+    // require an integration test asserting roster contacts do NOT
+    // receive the event (see `xep0402_bookmarks_*` and the
+    // `urn:waddle:story:reads:0` fan-out test).
     let is_private_bookmarks_node = is_pep && node == waddle_xmpp::xep::xep0402::PEP_NODE;
+    let is_private_story_reads_node =
+        is_pep && node == waddle_xmpp_core::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS;
+    let is_private_pep_node = is_private_bookmarks_node || is_private_story_reads_node;
     let storage = &state.deps.protocol.pubsub_storage;
 
     let node_cfg = match storage.get_node(owner, node).await {
@@ -156,7 +167,7 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     }
 
     for sub in subscribers {
-        if is_private_bookmarks_node && sub.subscriber.to_bare() != *owner {
+        if is_private_pep_node && sub.subscriber.to_bare() != *owner {
             continue;
         }
 
@@ -297,7 +308,7 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     // would leak the event to roster contacts that advertise
     // `<node>+notify` for an unrelated node URI.
     let (roster_metrics, self_metrics) = if is_pep {
-        let roster = if is_private_bookmarks_node {
+        let roster = if is_private_pep_node {
             FanOutMetrics::default()
         } else {
             roster_caps_fan_out(state, owner, &ctx, &mut already_delivered).await

--- a/server/crates/waddle-server/tests/xep0223_story_reads_ws.rs
+++ b/server/crates/waddle-server/tests/xep0223_story_reads_ws.rs
@@ -1,0 +1,312 @@
+//! Integration tests for the private `urn:waddle:story:reads:0` PEP
+//! node (XEP-0223 Persistent Storage of Private Data via PubSub) over
+//! WebSocket C2S.
+//!
+//! Covers the security-critical commitments from the design spec at
+//! `docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md`:
+//!
+//! - Publish-options precondition pins all four required fields.
+//! - Publish overwrites the single `current` item.
+//! - Whitelist access_model blocks fetch by non-owners.
+//! - The private-PEP carve-out in `pubsub_fanout.rs` suppresses
+//!   roster fan-out (no headline event delivered to roster contacts).
+
+mod ws_common;
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const READS_NODE: &str = "urn:waddle:story:reads:0";
+const READS_NS: &str = "urn:waddle:story:reads:0";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect_admin() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let resource = format!("xep0223-{}", uuid::Uuid::new_v4());
+    let password = server.fixed_account_password().to_string();
+    let client =
+        WsXmppClient::connect_and_auth(&server.ws_url(), DOMAIN, "admin", &password, &resource)
+            .await
+            .expect("admin connect");
+    (server, client)
+}
+
+async fn connect_two_accounts() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        &format!("alice-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("alice connect");
+    let bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        &format!("bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connect");
+    (server, alice, bob)
+}
+
+fn publish_options_form() -> &'static str {
+    r#"<publish-options>
+      <x xmlns="jabber:x:data" type="submit">
+        <field var="FORM_TYPE" type="hidden">
+          <value>http://jabber.org/protocol/pubsub#publish-options</value>
+        </field>
+        <field var="pubsub#persist_items"><value>true</value></field>
+        <field var="pubsub#access_model"><value>whitelist</value></field>
+        <field var="pubsub#send_last_published_item"><value>never</value></field>
+        <field var="pubsub#max_items"><value>1</value></field>
+      </x>
+    </publish-options>"#
+}
+
+fn publish_reads_iq(id: &str, body_xml: &str) -> String {
+    let options = publish_options_form();
+    format!(
+        r#"<iq type="set" id="{id}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <publish node="{READS_NODE}">
+              <item id="current">{body_xml}</item>
+            </publish>
+            {options}
+          </pubsub>
+        </iq>"#
+    )
+}
+
+fn reads_body(entries: &[(&str, &str)]) -> String {
+    let mut out = format!(r#"<reads xmlns="{READS_NS}">"#);
+    for (id, at) in entries {
+        out.push_str(&format!(r#"<read id="{id}" at="{at}"/>"#));
+    }
+    out.push_str("</reads>");
+    out
+}
+
+#[tokio::test]
+async fn publish_then_fetch_returns_entries() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    let body = reads_body(&[("story-a", "2026-05-19T10:11:12Z")]);
+    client
+        .send(&publish_reads_iq("pub-1", &body))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains(r#"id="pub-1""#))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains(r#"type="result""#),
+        "publish failed: {publish_result}"
+    );
+
+    // Fetch the item back. Owner fetch on a whitelist PEP node should
+    // succeed because the owner is implicitly on the whitelist.
+    client
+        .send(&format!(
+            r#"<iq type="get" id="fetch-1">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{READS_NODE}" max_items="1"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send fetch");
+    let fetch_result = client
+        .recv_matching(|frame| frame.contains(r#"id="fetch-1""#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetch_result.contains("story-a"),
+        "fetched payload missing story-a: {fetch_result}"
+    );
+    assert!(
+        fetch_result.contains("2026-05-19T10:11:12Z"),
+        "fetched payload missing timestamp: {fetch_result}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn republish_overwrites_item() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    let first = reads_body(&[("story-old", "2026-05-19T09:00:00Z")]);
+    client
+        .send(&publish_reads_iq("pub-old", &first))
+        .await
+        .expect("send first publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains(r#"id="pub-old""#))
+        .await
+        .expect("first publish result");
+
+    let second = reads_body(&[("story-new", "2026-05-19T10:00:00Z")]);
+    client
+        .send(&publish_reads_iq("pub-new", &second))
+        .await
+        .expect("send second publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains(r#"id="pub-new""#))
+        .await
+        .expect("second publish result");
+
+    client
+        .send(&format!(
+            r#"<iq type="get" id="fetch-after">
+              <pubsub xmlns="http://jabber.org/protocol/pubsub">
+                <items node="{READS_NODE}" max_items="1"/>
+              </pubsub>
+            </iq>"#
+        ))
+        .await
+        .expect("send fetch");
+    let fetch_result = client
+        .recv_matching(|frame| frame.contains(r#"id="fetch-after""#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetch_result.contains("story-new"),
+        "republish failed to surface latest entry: {fetch_result}"
+    );
+    assert!(
+        !fetch_result.contains("story-old"),
+        "max_items=1 should have evicted the prior item: {fetch_result}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn node_is_private_to_owner() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    let body = reads_body(&[("story-alice", "2026-05-19T10:00:00Z")]);
+    alice
+        .send(&publish_reads_iq("alice-pub", &body))
+        .await
+        .expect("alice publish");
+    let _ = alice
+        .recv_matching(|frame| frame.contains(r#"id="alice-pub""#))
+        .await
+        .expect("alice publish result");
+
+    // Bob tries to fetch alice's private read-state node by addressing
+    // alice's bare JID. The whitelist access_model MUST reject this.
+    bob.send(&format!(
+        r#"<iq type="get" id="bob-snoop" to="alice@{DOMAIN}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <items node="{READS_NODE}"/>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("bob fetch");
+    let bob_result = bob
+        .recv_matching(|frame| frame.contains(r#"id="bob-snoop""#))
+        .await
+        .expect("bob fetch result");
+    assert!(
+        bob_result.contains(r#"type="error""#),
+        "non-owner fetch must error on a whitelist PEP node: {bob_result}"
+    );
+    // Either `forbidden` or `item-not-found` is acceptable depending on
+    // the server's leak-avoidance posture — both prevent disclosure.
+    assert!(
+        bob_result.contains("forbidden") || bob_result.contains("item-not-found"),
+        "expected forbidden or item-not-found, got: {bob_result}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn private_pep_does_not_fan_out_to_roster() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    // Initial presence so the server routes per-resource events to
+    // both connected clients. PEP fan-out keys off presence state.
+    alice
+        .send("<presence/>")
+        .await
+        .expect("alice initial presence");
+    bob.send("<presence/>").await.expect("bob initial presence");
+
+    // Bob attempts to subscribe to alice's private read-state node.
+    // Whitelist access_model should refuse this directly, but even if
+    // the server accepted it, the `pubsub_fanout.rs` carve-out for
+    // `urn:waddle:story:reads:0` ensures bob still won't receive
+    // headline events. We exercise both paths together: try to
+    // subscribe (best-effort, response ignored) then publish and prove
+    // bob's stream stays silent for the read-state node.
+    bob.send(&format!(
+        r#"<iq type="set" id="bob-sub" to="alice@{DOMAIN}">
+          <pubsub xmlns="http://jabber.org/protocol/pubsub">
+            <subscribe node="{READS_NODE}" jid="bob@{DOMAIN}"/>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("bob subscribe");
+    let _ = bob
+        .recv_matching(|f| f.contains(r#"id="bob-sub""#))
+        .await
+        .expect("bob subscribe response");
+
+    // Alice publishes. Bob MUST NOT receive any headline event for
+    // the story-reads node.
+    let body = reads_body(&[("story-x", "2026-05-19T11:00:00Z")]);
+    alice
+        .send(&publish_reads_iq("alice-pub", &body))
+        .await
+        .expect("alice publish");
+    let _ = alice
+        .recv_matching(|f| f.contains(r#"id="alice-pub""#))
+        .await
+        .expect("alice publish result");
+
+    // Drain bob's inbound stream briefly. Any frame referencing the
+    // story-reads node or its payload would indicate a fan-out leak.
+    let mut leaked: Option<String> = None;
+    for _ in 0..3 {
+        match bob.recv_timeout(Duration::from_millis(250)).await {
+            Ok(frame) => {
+                if frame.contains(READS_NODE) || frame.contains("story-x") {
+                    leaked = Some(frame);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        leaked.is_none(),
+        "private PEP node leaked to roster contact: {leaked:?}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/client_story_reads.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_story_reads.rs
@@ -1,0 +1,309 @@
+//! Per-user story read state — wasm bridge surface.
+//!
+//! Stored as a single PEP item on the user's own JID per XEP-0223.
+//! Node options are committed via `<publish-options>` precondition on
+//! every publish; see `waddle-xmpp-core::waddle_story_reads` and the
+//! design spec at
+//! `docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md`.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use waddle_xmpp_core::waddle_story_reads::{
+    StoryId, StoryReads, NS_WADDLE_STORY_READS, PEP_ITEM_WADDLE_STORY_READS,
+    PEP_NODE_WADDLE_STORY_READS,
+};
+use wasm_bindgen::prelude::*;
+
+use super::{js_error, send_iq_command, to_js_value, WaddleClient};
+use crate::NS_CLIENT;
+
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_PUBSUB_PUBLISH_OPTIONS: &str = "http://jabber.org/protocol/pubsub#publish-options";
+const NS_XDATA: &str = "jabber:x:data";
+
+/// JS-facing entry (id, RFC 3339 timestamp). `StoryId` is unwrapped at
+/// this boundary — the wasm/JS layer carries it as a plain string.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsStoryRead {
+    pub id: String,
+    pub at: String,
+}
+
+/// JS-facing read-state payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct JsStoryReads {
+    pub entries: Vec<JsStoryRead>,
+}
+
+impl From<&StoryReads> for JsStoryReads {
+    fn from(reads: &StoryReads) -> Self {
+        Self {
+            entries: reads
+                .iter()
+                .map(|(id, at)| JsStoryRead {
+                    id: id.as_str().to_owned(),
+                    at: at.to_rfc3339(),
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Build the `<publish-options>` precondition form. ALL FOUR fields are
+/// mandatory — omitting any of them lets a server auto-create the node
+/// with different defaults and silently leak read-state notifications.
+pub(crate) fn build_publish_options_form() -> Element {
+    let form = Element::builder("x", NS_XDATA)
+        .attr("type", "submit")
+        .append(hidden_field("FORM_TYPE", NS_PUBSUB_PUBLISH_OPTIONS))
+        .append(text_single_field("pubsub#persist_items", "true"))
+        .append(text_single_field("pubsub#access_model", "whitelist"))
+        .append(text_single_field(
+            "pubsub#send_last_published_item",
+            "never",
+        ))
+        .append(text_single_field("pubsub#max_items", "1"))
+        .build();
+    Element::builder("publish-options", NS_PUBSUB)
+        .append(form)
+        .build()
+}
+
+fn hidden_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_XDATA)
+        .attr("var", var)
+        .attr("type", "hidden")
+        .append(Element::builder("value", NS_XDATA).append(value).build())
+        .build()
+}
+
+fn text_single_field(var: &str, value: &str) -> Element {
+    Element::builder("field", NS_XDATA)
+        .attr("var", var)
+        .append(Element::builder("value", NS_XDATA).append(value).build())
+        .build()
+}
+
+pub(crate) fn build_story_reads_publish_iq(reads: &StoryReads) -> Element {
+    let id = format!("story-reads-publish-{}", Uuid::new_v4());
+    let item = Element::builder("item", NS_PUBSUB)
+        .attr("id", PEP_ITEM_WADDLE_STORY_READS)
+        .append(reads.build_element())
+        .build();
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr("node", PEP_NODE_WADDLE_STORY_READS)
+        .append(item)
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .append(build_publish_options_form())
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "set")
+        .attr("id", id)
+        .append(pubsub)
+        .build()
+}
+
+pub(crate) fn build_story_reads_fetch_iq() -> Element {
+    let id = format!("story-reads-fetch-{}", Uuid::new_v4());
+    let items = Element::builder("items", NS_PUBSUB)
+        .attr("node", PEP_NODE_WADDLE_STORY_READS)
+        .attr("max_items", "1")
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB).append(items).build();
+    Element::builder("iq", NS_CLIENT)
+        .attr("type", "get")
+        .attr("id", id)
+        .append(pubsub)
+        .build()
+}
+
+/// Parse the items result returned by `build_story_reads_fetch_iq()`.
+///
+/// Returns an empty `StoryReads` if the node has no items or the result
+/// shape doesn't match expectations — read state is non-critical, so
+/// silently degrading to "nothing read" is better than surfacing an
+/// error the user can't act on.
+pub(crate) fn parse_story_reads_fetch_result(iq: &Element) -> StoryReads {
+    let Some(pubsub) = iq.get_child("pubsub", NS_PUBSUB) else {
+        return StoryReads::default();
+    };
+    let Some(items) = pubsub.get_child("items", NS_PUBSUB) else {
+        return StoryReads::default();
+    };
+    items
+        .children()
+        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+        .find_map(|item| {
+            item.children()
+                .find(|c| c.name() == "reads" && c.ns() == NS_WADDLE_STORY_READS)
+                .and_then(|reads_el| StoryReads::parse(reads_el).ok())
+        })
+        .unwrap_or_default()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JsStoryReadsInput {
+    pub entries: Vec<JsStoryReadInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JsStoryReadInput {
+    pub id: String,
+    pub at: String,
+}
+
+fn story_reads_from_js(input: JsStoryReadsInput) -> Result<StoryReads, JsValue> {
+    let mut reads = StoryReads::default();
+    for entry in input.entries {
+        let id =
+            StoryId::new(entry.id).map_err(|err| js_error(format!("invalid story id: {err}")))?;
+        let at = entry
+            .at
+            .parse::<DateTime<Utc>>()
+            .map_err(|_| js_error(format!("invalid timestamp: {}", entry.at)))?;
+        reads.mark_read(id, at);
+    }
+    Ok(reads)
+}
+
+#[wasm_bindgen]
+impl WaddleClient {
+    /// Fetch the latest read-state from the user's own PEP node.
+    ///
+    /// Per XEP-0223 §Security Considerations (CVE-2023-28686), the
+    /// result IQ's `from` attribute MUST be either absent or equal to
+    /// the account's bare JID. Anything else is treated as spoofed
+    /// and produces an empty result.
+    pub fn story_reads_fetch(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let own_bare = {
+                let jid_str = inner.borrow().config.jid.clone();
+                let parsed: jid::Jid = jid_str
+                    .parse()
+                    .map_err(|err| js_error(format!("invalid own JID: {err}")))?;
+                parsed.to_bare().to_string()
+            };
+            let iq = build_story_reads_fetch_iq();
+            let result = match send_iq_command(inner, iq).await {
+                Ok(r) => r,
+                Err(_) => return to_js_value(&JsStoryReads::default()),
+            };
+            if let Some(from) = result.attr("from") {
+                if from != own_bare {
+                    return to_js_value(&JsStoryReads::default());
+                }
+            }
+            let reads = parse_story_reads_fetch_result(&result);
+            to_js_value(&JsStoryReads::from(&reads))
+        })
+    }
+
+    /// Publish the user's read-state. Overwrites the single `current`
+    /// item on every call.
+    pub fn story_reads_publish(&self, input: JsValue) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let input: JsStoryReadsInput = serde_wasm_bindgen::from_value(input)
+                .map_err(|err| js_error(format!("invalid story_reads input: {err}")))?;
+            let reads = story_reads_from_js(input)?;
+            let iq = build_story_reads_publish_iq(&reads);
+            send_iq_command(inner, iq).await?;
+            to_js_value(&JsStoryReads::from(&reads))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn publish_iq_carries_required_publish_options() {
+        let reads = StoryReads::default();
+        let iq = build_story_reads_publish_iq(&reads);
+        let pubsub = iq.get_child("pubsub", NS_PUBSUB).expect("pubsub element");
+        let options = pubsub
+            .get_child("publish-options", NS_PUBSUB)
+            .expect("publish-options element");
+        let form = options.get_child("x", NS_XDATA).expect("data form");
+
+        let field_value = |var: &str| -> Option<String> {
+            form.children()
+                .filter(|c| c.name() == "field" && c.ns() == NS_XDATA)
+                .find(|c| c.attr("var") == Some(var))
+                .and_then(|f| f.get_child("value", NS_XDATA))
+                .map(|v| v.text())
+        };
+
+        assert_eq!(
+            field_value("FORM_TYPE").as_deref(),
+            Some(NS_PUBSUB_PUBLISH_OPTIONS)
+        );
+        assert_eq!(field_value("pubsub#persist_items").as_deref(), Some("true"));
+        assert_eq!(
+            field_value("pubsub#access_model").as_deref(),
+            Some("whitelist")
+        );
+        assert_eq!(
+            field_value("pubsub#send_last_published_item").as_deref(),
+            Some("never")
+        );
+        assert_eq!(field_value("pubsub#max_items").as_deref(), Some("1"));
+    }
+
+    #[test]
+    fn publish_iq_targets_correct_node_and_item() {
+        let reads = StoryReads::default();
+        let iq = build_story_reads_publish_iq(&reads);
+        let publish = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("publish", NS_PUBSUB))
+            .expect("publish element");
+        assert_eq!(publish.attr("node"), Some(PEP_NODE_WADDLE_STORY_READS));
+        let item = publish.get_child("item", NS_PUBSUB).expect("item");
+        assert_eq!(item.attr("id"), Some(PEP_ITEM_WADDLE_STORY_READS));
+    }
+
+    #[test]
+    fn fetch_iq_targets_correct_node() {
+        let iq = build_story_reads_fetch_iq();
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PEP_NODE_WADDLE_STORY_READS));
+        assert_eq!(items.attr("max_items"), Some("1"));
+    }
+
+    #[test]
+    fn parse_fetch_handles_missing_pubsub() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
+            .parse()
+            .expect("valid");
+        let reads = parse_story_reads_fetch_result(&iq);
+        assert!(reads.is_empty());
+    }
+
+    #[test]
+    fn parse_fetch_returns_entries() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+            <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+              <items node='urn:waddle:story:reads:0'>\
+                <item id='current'>\
+                  <reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='story-a' at='2026-05-19T10:11:12Z'/>\
+                  </reads>\
+                </item>\
+              </items>\
+            </pubsub>\
+          </iq>";
+        let iq: Element = xml.parse().expect("valid");
+        let reads = parse_story_reads_fetch_result(&iq);
+        assert_eq!(reads.len(), 1);
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -66,6 +66,7 @@ mod client_messaging;
 mod client_rooms;
 mod client_social_feed;
 mod client_stories;
+mod client_story_reads;
 mod client_xcal;
 mod commands;
 mod conversions;

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod pubsub;
 pub mod roster;
 pub mod stanza;
 pub mod types;
+pub mod waddle_story_reads;
 pub mod xcal;
 pub mod xep0201;
 pub mod xep0359;

--- a/server/crates/waddle-xmpp-core/src/waddle_story_reads.rs
+++ b/server/crates/waddle-xmpp-core/src/waddle_story_reads.rs
@@ -1,0 +1,411 @@
+//! Waddle Story Reads: private per-user read state for XEP-0501 stories.
+//!
+//! A custom payload (no XEP defines a story-read shape) stored as a single
+//! pubsub item on the user's own JID per XEP-0223 "Persistent Storage of
+//! Private Data via PubSub". See the design spec at
+//! `docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md`.
+//!
+//! ## XML Format
+//!
+//! ```xml
+//! <reads xmlns='urn:waddle:story:reads:0'>
+//!   <read id='story-aaa' at='2026-05-19T10:11:12Z'/>
+//!   <read id='story-bbb' at='2026-05-19T10:13:44Z'/>
+//! </reads>
+//! ```
+//!
+//! ## Node options (committed via `<publish-options>` precondition)
+//!
+//! - `pubsub#persist_items = true`
+//! - `pubsub#access_model = whitelist` (private — only owner can fetch)
+//! - `pubsub#send_last_published_item = never`
+//! - `pubsub#max_items = 1`
+//!
+//! Omitting any of these in the precondition form lets a server
+//! auto-create the node with different defaults (notably an
+//! `on_sub_and_presence` send mode) and silently leak read state.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use std::collections::BTreeMap;
+
+/// XML namespace + PEP node id for the story-reads payload. They
+/// coincide deliberately, matching XEP-0163's one-node-per-namespace
+/// convention; the two constants exist for call-site readability.
+pub const NS_WADDLE_STORY_READS: &str = "urn:waddle:story:reads:0";
+
+/// PEP node id for the story-reads payload. Equal to
+/// [`NS_WADDLE_STORY_READS`] by design.
+pub const PEP_NODE_WADDLE_STORY_READS: &str = NS_WADDLE_STORY_READS;
+
+/// Single fixed item id, overwritten in place on every publish.
+pub const PEP_ITEM_WADDLE_STORY_READS: &str = "current";
+
+/// Defence-in-depth cap on stored entries. Stories expire at 24h and
+/// pruning runs at 48h; a user opening 5000 distinct stories inside
+/// 48h is implausible, so any blow-past indicates a bug or abuse and
+/// the oldest entries are dropped.
+pub const READ_ENTRY_MAX: usize = 5000;
+
+/// Validated wrapper around an XEP-0501 pubsub item id.
+///
+/// Empty strings are rejected at construction so consumers can rely on
+/// the type system to enforce non-emptiness without re-checking at
+/// every call site.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StoryId(String);
+
+impl StoryId {
+    /// Construct a [`StoryId`], rejecting empty strings.
+    pub fn new(id: impl Into<String>) -> Result<Self, StoryReadsParseError> {
+        let value = id.into();
+        if value.is_empty() {
+            return Err(StoryReadsParseError::EmptyId);
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the underlying id as a `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume and return the inner `String`. Used at the wasm boundary
+    /// where JS-side payloads carry the id as a plain string.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for StoryId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Errors produced when parsing a `<reads>` element.
+#[derive(Debug, thiserror::Error)]
+pub enum StoryReadsParseError {
+    /// The root element name was not `reads`.
+    #[error("wrong element name: expected `reads`, got `{0}`")]
+    WrongElementName(String),
+    /// The root element namespace was not [`NS_WADDLE_STORY_READS`].
+    #[error("wrong namespace: expected `{NS_WADDLE_STORY_READS}`, got `{0}`")]
+    WrongNamespace(String),
+    /// A `<read>` child had no `id` attribute.
+    #[error("<read> missing `id` attribute")]
+    MissingId,
+    /// A `<read>` child had an empty `id` attribute.
+    #[error("<read> has empty `id` attribute")]
+    EmptyId,
+    /// A `<read>` child had no `at` attribute.
+    #[error("<read> missing `at` attribute")]
+    MissingAt,
+    /// A `<read>` child's `at` attribute was not parseable as RFC 3339.
+    #[error("<read> `at` is not RFC 3339: {0}")]
+    BadTimestamp(String),
+}
+
+/// Per-user story read state.
+///
+/// Backed by a `BTreeMap<StoryId, DateTime<Utc>>` so uniqueness on
+/// `story_id` is enforced structurally — re-marking the same story
+/// simply updates the timestamp.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoryReads {
+    entries: BTreeMap<StoryId, DateTime<Utc>>,
+}
+
+impl StoryReads {
+    /// Construct an empty read-state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of stored entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// `true` when no entries are stored.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// `true` when `id` is marked read.
+    pub fn contains(&self, id: &StoryId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    /// Mark `id` as read at `at`, replacing any prior timestamp.
+    pub fn mark_read(&mut self, id: StoryId, at: DateTime<Utc>) {
+        self.entries.insert(id, at);
+    }
+
+    /// Drop entries with `at < cutoff`.
+    pub fn prune_before(&mut self, cutoff: DateTime<Utc>) {
+        self.entries.retain(|_, at| *at >= cutoff);
+    }
+
+    /// Drop oldest entries (by `at`) until the count is `<= max`.
+    pub fn cap_to(&mut self, max: usize) {
+        if self.entries.len() <= max {
+            return;
+        }
+        let mut by_age: Vec<(StoryId, DateTime<Utc>)> = self
+            .entries
+            .iter()
+            .map(|(id, at)| (id.clone(), *at))
+            .collect();
+        by_age.sort_by_key(|(_, at)| *at);
+        let drop_count = self.entries.len() - max;
+        for (id, _) in by_age.into_iter().take(drop_count) {
+            self.entries.remove(&id);
+        }
+    }
+
+    /// Iterate entries in `StoryId` order.
+    pub fn iter(&self) -> impl Iterator<Item = (&StoryId, &DateTime<Utc>)> {
+        self.entries.iter()
+    }
+
+    /// Build the `<reads/>` element. Entries are emitted in `StoryId`
+    /// order so the wire shape is deterministic and tests are stable.
+    pub fn build_element(&self) -> Element {
+        let mut root = Element::builder("reads", NS_WADDLE_STORY_READS).build();
+        for (id, at) in &self.entries {
+            let read = Element::builder("read", NS_WADDLE_STORY_READS)
+                .attr("id", id.as_str())
+                .attr("at", at.to_rfc3339())
+                .build();
+            root.append_child(read);
+        }
+        root
+    }
+
+    /// Parse a `<reads/>` element. Unknown child elements and unknown
+    /// attributes on `<read>` are ignored for forward-compat.
+    pub fn parse(el: &Element) -> Result<Self, StoryReadsParseError> {
+        if el.name() != "reads" {
+            return Err(StoryReadsParseError::WrongElementName(el.name().to_owned()));
+        }
+        if el.ns() != NS_WADDLE_STORY_READS {
+            return Err(StoryReadsParseError::WrongNamespace(el.ns()));
+        }
+        let mut out = Self::new();
+        for child in el.children() {
+            if child.name() != "read" || child.ns() != NS_WADDLE_STORY_READS {
+                continue;
+            }
+            let id_attr = child
+                .attr("id")
+                .ok_or(StoryReadsParseError::MissingId)?
+                .to_owned();
+            let id = StoryId::new(id_attr)?;
+            let at_attr = child.attr("at").ok_or(StoryReadsParseError::MissingAt)?;
+            let at = at_attr
+                .parse::<DateTime<Utc>>()
+                .map_err(|_| StoryReadsParseError::BadTimestamp(at_attr.to_owned()))?;
+            out.entries.insert(id, at);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(year, month, day, hour, 0, 0)
+            .single()
+            .expect("valid timestamp")
+    }
+
+    #[test]
+    fn story_id_rejects_empty() {
+        assert!(matches!(
+            StoryId::new(""),
+            Err(StoryReadsParseError::EmptyId)
+        ));
+    }
+
+    #[test]
+    fn story_id_accepts_non_empty() {
+        let id = StoryId::new("story-aaa").expect("non-empty");
+        assert_eq!(id.as_str(), "story-aaa");
+    }
+
+    #[test]
+    fn mark_read_inserts_entry() {
+        let mut reads = StoryReads::new();
+        let id = StoryId::new("story-a").expect("ok");
+        reads.mark_read(id.clone(), ts(2026, 5, 19, 10));
+        assert!(reads.contains(&id));
+        assert_eq!(reads.len(), 1);
+    }
+
+    #[test]
+    fn mark_read_updates_existing() {
+        let mut reads = StoryReads::new();
+        let id = StoryId::new("story-a").expect("ok");
+        reads.mark_read(id.clone(), ts(2026, 5, 19, 9));
+        reads.mark_read(id.clone(), ts(2026, 5, 19, 11));
+        assert_eq!(reads.len(), 1);
+        let (_, at) = reads.iter().next().expect("entry");
+        assert_eq!(*at, ts(2026, 5, 19, 11));
+    }
+
+    #[test]
+    fn prune_before_drops_old_entries() {
+        let mut reads = StoryReads::new();
+        reads.mark_read(StoryId::new("a").expect("ok"), ts(2026, 5, 17, 10));
+        reads.mark_read(StoryId::new("b").expect("ok"), ts(2026, 5, 18, 10));
+        reads.mark_read(StoryId::new("c").expect("ok"), ts(2026, 5, 19, 10));
+        reads.prune_before(ts(2026, 5, 18, 0));
+        let kept: Vec<&str> = reads.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(kept, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn cap_to_drops_oldest_first() {
+        let mut reads = StoryReads::new();
+        reads.mark_read(StoryId::new("a").expect("ok"), ts(2026, 5, 17, 10));
+        reads.mark_read(StoryId::new("b").expect("ok"), ts(2026, 5, 18, 10));
+        reads.mark_read(StoryId::new("c").expect("ok"), ts(2026, 5, 19, 10));
+        reads.cap_to(2);
+        let kept: Vec<&str> = reads.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(kept, vec!["b", "c"]);
+    }
+
+    #[test]
+    fn cap_to_is_noop_when_under_cap() {
+        let mut reads = StoryReads::new();
+        reads.mark_read(StoryId::new("a").expect("ok"), ts(2026, 5, 17, 10));
+        reads.cap_to(10);
+        assert_eq!(reads.len(), 1);
+    }
+
+    #[test]
+    fn parse_round_trip() {
+        let mut reads = StoryReads::new();
+        reads.mark_read(StoryId::new("story-a").expect("ok"), ts(2026, 5, 19, 10));
+        reads.mark_read(StoryId::new("story-b").expect("ok"), ts(2026, 5, 19, 11));
+        let elem = reads.build_element();
+        let parsed = StoryReads::parse(&elem).expect("parseable");
+        assert_eq!(parsed, reads);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_element() {
+        let xml = "<readz xmlns='urn:waddle:story:reads:0'/>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::WrongElementName(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_wrong_namespace() {
+        let xml = "<reads xmlns='urn:waddle:wrong'/>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::WrongNamespace(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_missing_id() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <read at='2026-05-19T10:11:12Z'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::MissingId)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_empty_id() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='' at='2026-05-19T10:11:12Z'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::EmptyId)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_missing_at() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='story-a'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::MissingAt)
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_bad_timestamp() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='story-a' at='not-a-date'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        assert!(matches!(
+            StoryReads::parse(&elem),
+            Err(StoryReadsParseError::BadTimestamp(_))
+        ));
+    }
+
+    #[test]
+    fn parse_ignores_unknown_children() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <future xmlns='urn:waddle:story:reads:0'/>\
+                    <read id='story-a' at='2026-05-19T10:11:12Z'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let parsed = StoryReads::parse(&elem).expect("ok");
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn parse_ignores_unknown_attrs_on_read() {
+        let xml = "<reads xmlns='urn:waddle:story:reads:0'>\
+                    <read id='story-a' at='2026-05-19T10:11:12Z' device='phone-1' version='2'/>\
+                    </reads>";
+        let elem: Element = xml.parse().expect("valid xml");
+        let parsed = StoryReads::parse(&elem).expect("ok");
+        assert_eq!(parsed.len(), 1);
+    }
+
+    #[test]
+    fn build_element_is_deterministic_by_id() {
+        let mut reads = StoryReads::new();
+        reads.mark_read(StoryId::new("story-c").expect("ok"), ts(2026, 5, 19, 9));
+        reads.mark_read(StoryId::new("story-a").expect("ok"), ts(2026, 5, 19, 10));
+        reads.mark_read(StoryId::new("story-b").expect("ok"), ts(2026, 5, 19, 11));
+        let elem = reads.build_element();
+        let ids: Vec<&str> = elem
+            .children()
+            .filter(|c| c.name() == "read")
+            .filter_map(|c| c.attr("id"))
+            .collect();
+        assert_eq!(ids, vec!["story-a", "story-b", "story-c"]);
+    }
+
+    #[test]
+    fn empty_reads_round_trip() {
+        let reads = StoryReads::new();
+        let elem = reads.build_element();
+        let parsed = StoryReads::parse(&elem).expect("ok");
+        assert!(parsed.is_empty());
+    }
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -241,6 +241,20 @@ export class WaddleClient {
      */
     stories_publish(community_jid: string, input: any): Promise<any>;
     /**
+     * Fetch the latest read-state from the user's own PEP node.
+     *
+     * Per XEP-0223 §Security Considerations (CVE-2023-28686), the
+     * result IQ's `from` attribute MUST be either absent or equal to
+     * the account's bare JID. Anything else is treated as spoofed
+     * and produces an empty result.
+     */
+    story_reads_fetch(): Promise<any>;
+    /**
+     * Publish the user's read-state. Overwrites the single `current`
+     * item on every call.
+     */
+    story_reads_publish(input: any): Promise<any>;
+    /**
      * XEP-0060 explicit subscribe to the MDS node, used as a
      * fallback path for receiving `+notify` events when the chat
      * client's presence does not yet carry XEP-0115 caps. The

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpbvvpxa";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpceyevq";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpbvvpxa";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";


### PR DESCRIPTION
## Summary

Replace the URL-only Stories composer with an Instagram-like flow
(file attach, in-app photo, in-app video) and add per-user read state
synced across devices via a private PEP node. Read stories show a
dimmed avatar ring; your own posts auto-mark.

Design spec: `docs/superpowers/specs/2026-05-19-stories-media-and-reads-design.md`.
Spec went through four adversarial SME reviews (XEP/XMPP protocol,
browser media APIs, security/privacy, Rust typed-payloads) and an
implementation review before merge.

## Commits

1. **docs(stories)** — design spec (rev 2 post-SME review)
2. **feat(server)** — typed `StoryId` + `StoryReads` in `waddle-xmpp-core`,
   `<publish-options>` builder + IQ wiring in `waddle-xmpp-client-wasm`,
   private-PEP carve-out extension in `pubsub_fanout.rs`,
   regenerated wasm-pkg, 23 unit tests + 4 integration tests
3. **feat(chat)** — `StoryComposer.vue` (Attach / Photo / Record),
   read-state store with debounced publish, ring dimming, sanitised
   `uploadStoryMedia` (PII-free filenames)

## Safety / XEP conformance highlights

- **CVE-2023-28686 mitigation**: `story_reads_fetch` validates the IQ
  result's `from` equals the account's bare JID; spoofed read-state
  injection drops to empty.
- **All four publish-options committed**: precondition form pins
  `persist_items=true`, `access_model=whitelist`,
  `send_last_published_item=never`, `max_items=1`. Without this,
  server auto-creation could silently leak (`on_sub_and_presence`
  default).
- **Roster fan-out carve-out**: whitelist `access_model` alone only
  gates fetch; PEP fan-out runs separately. `pubsub_fanout.rs`
  `is_private_bookmarks_node` (XEP-0402-only) generalised to
  `is_private_pep_node` and proven by the
  `private_pep_does_not_fan_out_to_roster` integration test.
- **Typed payloads**: `StoryId` newtype with validated constructor;
  `StoryReads` backed by `BTreeMap` for structural uniqueness;
  `StoryReadsParseError` enum with six explicit variants; XML built
  with typed `minidom` builders, never `format!`.
- **Camera lifecycle**: `MediaStreamTrack.stop()` called at every
  teardown site (unmount, cancel, tab switch, camera flip). Recorder
  event handlers detached before `stop()` to avoid late `onstop`
  producing a zero-byte blob.
- **iOS Safari safe**: `playsinline` + `muted` + `autoplay` on the
  live preview; `MediaRecorder` MIME feature-detection falls through
  to no-`mimeType` (the only path Safari accepts); `getUserMedia`
  called only on Photo/Record tab activation (lazy permission).
- **Pre-upload size check**: 20s/2 Mbps recording cap; `blob.size`
  checked before slot request so the user sees the error inline
  with the clip still in memory.
- **Sanitised filenames**: `story-<uuid>.<ext>` replaces user-facing
  names before upload so PII doesn't leak into XEP-0363 GET URLs or
  Faro OTel spans.

## Tests

- **Rust unit** (waddle-xmpp-core): 18 tests covering parse/build
  round-trip, all six error variants, prune, cap, deterministic
  ordering.
- **Rust unit** (waddle-xmpp-client-wasm): 5 tests covering the
  `<publish-options>` wire shape (all four fields), fetch IQ targeting,
  and parse fallbacks.
- **Rust integration** (waddle-server): 4 WebSocket E2E tests —
  `publish_then_fetch_returns_entries`, `republish_overwrites_item`,
  `node_is_private_to_owner` (whitelist fetch rejection),
  `private_pep_does_not_fan_out_to_roster` (carve-out proof).
- **TypeScript**: `bun run lint` (knip) clean; `astro check` 0
  errors / 0 warnings across 160 files.

## Test plan

- [ ] CI: `cargo fmt --check`, `cargo clippy -D warnings`, all tests
- [ ] CI: chat lint + astro check
- [ ] Manual: iOS Safari camera permission on Photo tab activation,
      inline preview (no fullscreen), record + upload flow
- [ ] Manual: Chrome desktop — photo, record, attach in one session;
      camera light goes off on Cancel
- [ ] Manual: cross-device — open story on device A, dimmed ring on
      device B's next mount

This PR was created with the assistance of a LLM.