### PR TITLE
fix(chat): recover tab-resumed timeline layout

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -21,6 +21,7 @@ import { parseChatLocation, type AdminPanel } from "@/shell/navigation";
 import { buildHomeDashboardProps } from "@/home/dashboard-props";
 import type { ChatAppController } from "@/shell/chat-app-controller";
 import type { DiscoveredExtensionRoute } from "@/lib/xmpp/extension-commands";
+import { installMessageToolbarLifecycleSuppression } from "@/stores/message-toolbar";
 
 const props = defineProps<{
   controller: ChatAppController;
@@ -219,8 +220,18 @@ function onAdminBack() {
     window.dispatchEvent(new PopStateEvent("popstate"));
   }
 }
-onMounted(() => window.addEventListener("popstate", refreshAdminPanelFromUrl));
-onUnmounted(() => window.removeEventListener("popstate", refreshAdminPanelFromUrl));
+let disconnectMessageToolbarLifecycle: (() => void) | null = null;
+
+onMounted(() => {
+  window.addEventListener("popstate", refreshAdminPanelFromUrl);
+  disconnectMessageToolbarLifecycle = installMessageToolbarLifecycleSuppression();
+});
+
+onUnmounted(() => {
+  window.removeEventListener("popstate", refreshAdminPanelFromUrl);
+  disconnectMessageToolbarLifecycle?.();
+  disconnectMessageToolbarLifecycle = null;
+});
 </script>
 
 <template>

--- a/chat/src/components/chat/MessageCard.vue
+++ b/chat/src/components/chat/MessageCard.vue
@@ -41,7 +41,12 @@ import { formatTimelineTimeOfDay } from "@/channels/timeline";
 import { useLongPress } from "@/ui/gestures/long-press";
 import { useHorizontalSwipe } from "@/ui/gestures/horizontal-swipe";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
-import { $desktopToolbarOwnerId } from "@/stores/message-toolbar";
+import {
+  $desktopToolbarOwnerId,
+  $desktopToolbarSuppressed,
+  $desktopToolbarSuspensionEpoch,
+  clearDesktopToolbarOwner,
+} from "@/stores/message-toolbar";
 import { QUICK_REACTION_EMOJIS } from "@/lib/reaction-mode";
 
 // Two separate badge layers:
@@ -456,15 +461,21 @@ type SheetView = "actions" | "emoji";
 const sheetView = ref<SheetView>("actions");
 
 const desktopToolbarOwnerId = useStore($desktopToolbarOwnerId);
+const desktopToolbarSuppressed = useStore($desktopToolbarSuppressed);
+const desktopToolbarSuspensionEpoch = useStore($desktopToolbarSuspensionEpoch);
 const ownsDesktopToolbarLock = computed(() => desktopToolbarOwnerId.value === props.message.id);
 const desktopToolbarLockedByAnother = computed(() =>
   desktopToolbarOwnerId.value !== null && desktopToolbarOwnerId.value !== props.message.id,
 );
-const desktopToolbarVisibilityClass = computed(() => (
-  ownsDesktopToolbarLock.value || props.reactionModeSelected
-    ? "opacity-100 translate-y-0 pointer-events-auto z-floating"
-    : "opacity-0 motion-safe:translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 focus-within:opacity-100 focus-within:translate-y-0 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto z-sticky"
-));
+const desktopToolbarVisibilityClass = computed(() => {
+  if (desktopToolbarSuppressed.value) {
+    return "opacity-0 motion-safe:translate-y-1 pointer-events-none z-sticky";
+  }
+  if (ownsDesktopToolbarLock.value || props.reactionModeSelected) {
+    return "opacity-100 translate-y-0 pointer-events-auto z-floating";
+  }
+  return "opacity-0 motion-safe:translate-y-1 group-hover:opacity-100 group-hover:translate-y-0 focus-within:opacity-100 focus-within:translate-y-0 pointer-events-none group-hover:pointer-events-auto focus-within:pointer-events-auto z-sticky";
+});
 const anyOverlayOpen = computed(() => pickerOpen.value || sheetOpen.value);
 
 function blurToolbarFocus() {
@@ -484,6 +495,14 @@ function closePicker(blur = false) {
 function closeSheet() {
   sheetOpen.value = false;
   sheetView.value = "actions";
+}
+
+function closeTransientMessageSurfaces() {
+  pickerOpen.value = false;
+  closeSheet();
+  hoveredReaction.value = null;
+  if (ownsDesktopToolbarLock.value) clearDesktopToolbarOwner();
+  blurToolbarFocus();
 }
 
 function openSheet() {
@@ -690,6 +709,13 @@ watch(
     if (typeof window === "undefined") return;
     if (open) window.addEventListener("keydown", onWindowKeydown);
     else window.removeEventListener("keydown", onWindowKeydown);
+  },
+);
+
+watch(
+  () => desktopToolbarSuspensionEpoch.value,
+  () => {
+    closeTransientMessageSurfaces();
   },
 );
 

--- a/chat/src/components/chat/VirtualTimeline.vue
+++ b/chat/src/components/chat/VirtualTimeline.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch, watchEffect } from "vue";
+import { computed, nextTick, onBeforeUnmount, ref, watch, watchEffect } from "vue";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import type { TimelineMessage } from "@/lib/chat-ui";
 import {
   isTopPinnedScrollDirection,
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
+import { installVirtualTimelineMeasurementRecovery } from "@/ui/virtual-timeline-measurement";
 
 const props = withDefaults(defineProps<{
   items: TimelineMessage[];
@@ -64,6 +65,28 @@ const virtualizer = useVirtualizer(computed(() => ({
   overscan: 8,
   getItemKey: (index: number) => itemForVirtualIndex(index)?.id ?? "older-history-sentinel",
 })));
+
+let disconnectMeasurementRecovery: (() => void) | null = null;
+
+watch(
+  scrollElement,
+  (el) => {
+    disconnectMeasurementRecovery?.();
+    disconnectMeasurementRecovery = null;
+    if (!el) return;
+    disconnectMeasurementRecovery = installVirtualTimelineMeasurementRecovery({
+      scrollElement: el,
+      measure: () => virtualizer.value.measure(),
+      measureElement: (row) => virtualizer.value.measureElement(row),
+    });
+  },
+  { flush: "post", immediate: true },
+);
+
+onBeforeUnmount(() => {
+  disconnectMeasurementRecovery?.();
+  disconnectMeasurementRecovery = null;
+});
 
 const virtualItems = computed(() => virtualizer.value.getVirtualItems());
 const totalSize = computed(() => virtualizer.value.getTotalSize());

--- a/chat/src/stores/message-toolbar.ts
+++ b/chat/src/stores/message-toolbar.ts
@@ -2,3 +2,88 @@ import { atom } from "nanostores";
 
 // Desktop reaction toolbars are mutually exclusive while an emoji picker is open.
 export const $desktopToolbarOwnerId = atom<string | null>(null);
+export const $desktopToolbarSuppressed = atom(false);
+export const $desktopToolbarSuspensionEpoch = atom(0);
+
+type ToolbarLifecycleTarget = {
+  addEventListener: (
+    type: string,
+    listener: EventListener,
+    options?: boolean | AddEventListenerOptions,
+  ) => void;
+  removeEventListener: (
+    type: string,
+    listener: EventListener,
+    options?: boolean | EventListenerOptions,
+  ) => void;
+};
+
+type ToolbarLifecycleDocument = ToolbarLifecycleTarget & {
+  visibilityState?: DocumentVisibilityState;
+};
+
+export function clearDesktopToolbarOwner() {
+  $desktopToolbarOwnerId.set(null);
+}
+
+function suppressDesktopToolbar() {
+  clearDesktopToolbarOwner();
+  $desktopToolbarSuppressed.set(true);
+  $desktopToolbarSuspensionEpoch.set($desktopToolbarSuspensionEpoch.get() + 1);
+}
+
+function resumeDesktopToolbar() {
+  $desktopToolbarSuppressed.set(false);
+}
+
+export function installMessageToolbarLifecycleSuppression(options: {
+  windowTarget?: ToolbarLifecycleTarget | null;
+  documentTarget?: ToolbarLifecycleDocument | null;
+} = {}): () => void {
+  const windowTarget = options.windowTarget ?? (typeof window === "undefined" ? null : window);
+  const documentTarget = options.documentTarget ?? (typeof document === "undefined" ? null : document);
+  let resumeListenersActive = false;
+
+  const resumeFromInteraction: EventListener = () => {
+    resumeDesktopToolbar();
+    stopResumeListeners();
+  };
+
+  function startResumeListeners() {
+    if (resumeListenersActive || !windowTarget) return;
+    resumeListenersActive = true;
+    windowTarget.addEventListener("pointerdown", resumeFromInteraction);
+    windowTarget.addEventListener("pointermove", resumeFromInteraction);
+    windowTarget.addEventListener("keydown", resumeFromInteraction, true);
+  }
+
+  function stopResumeListeners() {
+    if (!resumeListenersActive || !windowTarget) return;
+    resumeListenersActive = false;
+    windowTarget.removeEventListener("pointerdown", resumeFromInteraction);
+    windowTarget.removeEventListener("pointermove", resumeFromInteraction);
+    windowTarget.removeEventListener("keydown", resumeFromInteraction, true);
+  }
+
+  const suspendForInactivePage: EventListener = () => {
+    suppressDesktopToolbar();
+    startResumeListeners();
+  };
+
+  const suspendWhenHidden: EventListener = () => {
+    if (documentTarget?.visibilityState === "visible") return;
+    suspendForInactivePage(new Event("visibilitychange"));
+  };
+
+  windowTarget?.addEventListener("blur", suspendForInactivePage);
+  windowTarget?.addEventListener("pagehide", suspendForInactivePage);
+  documentTarget?.addEventListener("visibilitychange", suspendWhenHidden);
+
+  return () => {
+    windowTarget?.removeEventListener("blur", suspendForInactivePage);
+    windowTarget?.removeEventListener("pagehide", suspendForInactivePage);
+    documentTarget?.removeEventListener("visibilitychange", suspendWhenHidden);
+    stopResumeListeners();
+    resumeDesktopToolbar();
+  };
+}

--- a/chat/src/ui/virtual-timeline-measurement.ts
+++ b/chat/src/ui/virtual-timeline-measurement.ts
@@ -1,0 +1,185 @@
+type ListenerTarget = {
+  addEventListener: (
+    type: string,
+    listener: EventListener,
+    options?: boolean | AddEventListenerOptions,
+  ) => void;
+  removeEventListener: (
+    type: string,
+    listener: EventListener,
+    options?: boolean | EventListenerOptions,
+  ) => void;
+};
+
+type VisibilityDocument = ListenerTarget & {
+  visibilityState?: DocumentVisibilityState;
+};
+
+type AnimationFrameRequest = (callback: FrameRequestCallback) => number;
+type AnimationFrameCancel = (handle: number) => void;
+
+const MEDIA_SETTLE_EVENTS = ["load", "loadedmetadata", "error"] as const;
+
+function requestFrame(callback: FrameRequestCallback): number {
+  if (typeof requestAnimationFrame === "function") {
+    return requestAnimationFrame(callback);
+  }
+  return setTimeout(() => callback(Date.now()), 16) as unknown as number;
+}
+
+function cancelFrame(handle: number): void {
+  if (typeof cancelAnimationFrame === "function") {
+    cancelAnimationFrame(handle);
+    return;
+  }
+  clearTimeout(handle as unknown as ReturnType<typeof setTimeout>);
+}
+
+export function createVirtualTimelineMeasureScheduler(
+  measure: () => void,
+  options: {
+    requestAnimationFrame?: AnimationFrameRequest;
+    cancelAnimationFrame?: AnimationFrameCancel;
+  } = {},
+) {
+  const request = options.requestAnimationFrame ?? requestFrame;
+  const cancel = options.cancelAnimationFrame ?? cancelFrame;
+  let frame: number | null = null;
+  let disposed = false;
+
+  function clearPendingFrame() {
+    if (frame === null) return;
+    cancel(frame);
+    frame = null;
+  }
+
+  function scheduleMeasure() {
+    if (disposed || frame !== null) return;
+    frame = request(() => {
+      frame = request(() => {
+        frame = null;
+        if (!disposed) measure();
+      });
+    });
+  }
+
+  function disconnect() {
+    disposed = true;
+    clearPendingFrame();
+  }
+
+  return { scheduleMeasure, disconnect };
+}
+
+export function createVirtualTimelineElementMeasureScheduler(
+  measureElement: (element: HTMLElement) => void,
+  options: {
+    requestAnimationFrame?: AnimationFrameRequest;
+    cancelAnimationFrame?: AnimationFrameCancel;
+  } = {},
+) {
+  const request = options.requestAnimationFrame ?? requestFrame;
+  const cancel = options.cancelAnimationFrame ?? cancelFrame;
+  const elements = new Set<HTMLElement>();
+  let frame: number | null = null;
+  let disposed = false;
+
+  function clearPendingFrame() {
+    if (frame === null) return;
+    cancel(frame);
+    frame = null;
+  }
+
+  function scheduleMeasure(element: HTMLElement) {
+    if (disposed) return;
+    elements.add(element);
+    if (frame !== null) return;
+    frame = request(() => {
+      frame = request(() => {
+        frame = null;
+        if (disposed) return;
+        const pending = [...elements];
+        elements.clear();
+        for (const measuredElement of pending) measureElement(measuredElement);
+      });
+    });
+  }
+
+  function disconnect() {
+    disposed = true;
+    elements.clear();
+    clearPendingFrame();
+  }
+
+  return { scheduleMeasure, disconnect };
+}
+
+function closestMeasuredRow(scrollElement: HTMLElement, event: Event): HTMLElement | null {
+  const target = event.target;
+  if (!target || typeof target !== "object" || !("closest" in target)) return null;
+  const closest = (target as { closest?: (selector: string) => Element | null }).closest;
+  if (typeof closest !== "function") return null;
+  const row = closest.call(target, "[data-index]");
+  if (!row) return null;
+  if (typeof scrollElement.contains === "function" && !scrollElement.contains(row)) return null;
+  return row as HTMLElement;
+}
+
+export function installVirtualTimelineMeasurementRecovery(options: {
+  scrollElement: HTMLElement;
+  measure: () => void;
+  measureElement?: (element: HTMLElement) => void;
+  windowTarget?: ListenerTarget | null;
+  documentTarget?: VisibilityDocument | null;
+  requestAnimationFrame?: AnimationFrameRequest;
+  cancelAnimationFrame?: AnimationFrameCancel;
+}): () => void {
+  const scheduler = createVirtualTimelineMeasureScheduler(options.measure, {
+    requestAnimationFrame: options.requestAnimationFrame,
+    cancelAnimationFrame: options.cancelAnimationFrame,
+  });
+  const elementScheduler = options.measureElement
+    ? createVirtualTimelineElementMeasureScheduler(options.measureElement, {
+      requestAnimationFrame: options.requestAnimationFrame,
+      cancelAnimationFrame: options.cancelAnimationFrame,
+    })
+    : null;
+  const windowTarget = options.windowTarget ?? (typeof window === "undefined" ? null : window);
+  const documentTarget = options.documentTarget ?? (typeof document === "undefined" ? null : document);
+
+  const scheduleFullMeasure: EventListener = () => {
+    scheduler.scheduleMeasure();
+  };
+  const scheduleElementMeasure: EventListener = (event) => {
+    const row = elementScheduler ? closestMeasuredRow(options.scrollElement, event) : null;
+    if (row && elementScheduler) {
+      elementScheduler.scheduleMeasure(row);
+      return;
+    }
+    if (!elementScheduler) scheduler.scheduleMeasure();
+  };
+  const scheduleWhenVisible: EventListener = () => {
+    if (documentTarget?.visibilityState && documentTarget.visibilityState !== "visible") return;
+    scheduler.scheduleMeasure();
+  };
+
+  for (const eventName of MEDIA_SETTLE_EVENTS) {
+    options.scrollElement.addEventListener(eventName, scheduleElementMeasure, true);
+  }
+  documentTarget?.addEventListener("visibilitychange", scheduleWhenVisible);
+  windowTarget?.addEventListener("focus", scheduleFullMeasure);
+  windowTarget?.addEventListener("pageshow", scheduleFullMeasure);
+
+  scheduler.scheduleMeasure();
+
+  return () => {
+    for (const eventName of MEDIA_SETTLE_EVENTS) {
+      options.scrollElement.removeEventListener(eventName, scheduleElementMeasure, true);
+    }
+    documentTarget?.removeEventListener("visibilitychange", scheduleWhenVisible);
+    windowTarget?.removeEventListener("focus", scheduleFullMeasure);
+    windowTarget?.removeEventListener("pageshow", scheduleFullMeasure);
+    elementScheduler?.disconnect();
+    scheduler.disconnect();
+  };
+}

--- a/chat/tests/message-toolbar.test.ts
+++ b/chat/tests/message-toolbar.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  $desktopToolbarOwnerId,
+  $desktopToolbarSuppressed,
+  $desktopToolbarSuspensionEpoch,
+  clearDesktopToolbarOwner,
+  installMessageToolbarLifecycleSuppression,
+} from "../src/stores/message-toolbar";
+
+class ListenerHarness {
+  private listeners = new Map<string, Array<{ listener: EventListener; capture: boolean }>>();
+  visibilityState: DocumentVisibilityState = "visible";
+
+  addEventListener(type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push({ listener, capture: options === true || (typeof options === "object" && options.capture === true) });
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener, options?: boolean | EventListenerOptions) {
+    const capture = options === true || (typeof options === "object" && options.capture === true);
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((entry) =>
+      entry.listener !== listener || entry.capture !== capture,
+    ));
+  }
+
+  dispatch(type: string) {
+    const event = new Event(type);
+    for (const { listener } of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.length ?? 0;
+  }
+
+  captureListenerCount(type: string): number {
+    return (this.listeners.get(type) ?? []).filter((entry) => entry.capture).length;
+  }
+}
+
+afterEach(() => {
+  $desktopToolbarOwnerId.set(null);
+  $desktopToolbarSuppressed.set(false);
+  $desktopToolbarSuspensionEpoch.set(0);
+});
+
+describe("message toolbar store", () => {
+  test("clears the desktop toolbar owner on page lifecycle cleanup", () => {
+    $desktopToolbarOwnerId.set("message-1");
+
+    clearDesktopToolbarOwner();
+
+    expect($desktopToolbarOwnerId.get()).toBeNull();
+  });
+
+  test("suppresses hover/focus toolbars while a restored tab waits for fresh input", () => {
+    const windowTarget = new ListenerHarness();
+    const documentTarget = new ListenerHarness();
+    const disconnect = installMessageToolbarLifecycleSuppression({
+      windowTarget,
+      documentTarget,
+    });
+    $desktopToolbarOwnerId.set("message-1");
+
+    windowTarget.dispatch("blur");
+
+    expect($desktopToolbarOwnerId.get()).toBeNull();
+    expect($desktopToolbarSuppressed.get()).toBe(true);
+    expect($desktopToolbarSuspensionEpoch.get()).toBe(1);
+    expect(windowTarget.listenerCount("pointerdown")).toBe(1);
+    expect(windowTarget.listenerCount("pointermove")).toBe(1);
+    expect(windowTarget.listenerCount("keydown")).toBe(1);
+    expect(windowTarget.captureListenerCount("keydown")).toBe(1);
+
+    windowTarget.dispatch("pointermove");
+
+    expect($desktopToolbarSuppressed.get()).toBe(false);
+    expect(windowTarget.listenerCount("pointerdown")).toBe(0);
+    expect(windowTarget.listenerCount("pointermove")).toBe(0);
+    expect(windowTarget.listenerCount("keydown")).toBe(0);
+
+    disconnect();
+  });
+
+  test("suppresses on hidden visibility changes but not visible ones", () => {
+    const windowTarget = new ListenerHarness();
+    const documentTarget = new ListenerHarness();
+    const disconnect = installMessageToolbarLifecycleSuppression({
+      windowTarget,
+      documentTarget,
+    });
+
+    documentTarget.visibilityState = "visible";
+    documentTarget.dispatch("visibilitychange");
+    expect($desktopToolbarSuppressed.get()).toBe(false);
+    expect($desktopToolbarSuspensionEpoch.get()).toBe(0);
+
+    documentTarget.visibilityState = "hidden";
+    documentTarget.dispatch("visibilitychange");
+    expect($desktopToolbarSuppressed.get()).toBe(true);
+    expect($desktopToolbarSuspensionEpoch.get()).toBe(1);
+
+    disconnect();
+  });
+
+  test("removes lifecycle listeners and clears suppression on disconnect", () => {
+    const windowTarget = new ListenerHarness();
+    const documentTarget = new ListenerHarness();
+    const disconnect = installMessageToolbarLifecycleSuppression({
+      windowTarget,
+      documentTarget,
+    });
+
+    windowTarget.dispatch("pagehide");
+    expect($desktopToolbarSuppressed.get()).toBe(true);
+    expect(windowTarget.listenerCount("blur")).toBe(1);
+    expect(documentTarget.listenerCount("visibilitychange")).toBe(1);
+
+    disconnect();
+
+    expect($desktopToolbarSuppressed.get()).toBe(false);
+    expect(windowTarget.listenerCount("blur")).toBe(0);
+    expect(windowTarget.listenerCount("pagehide")).toBe(0);
+    expect(documentTarget.listenerCount("visibilitychange")).toBe(0);
+    expect(windowTarget.listenerCount("pointerdown")).toBe(0);
+  });
+});

--- a/chat/tests/virtual-timeline-measurement.test.ts
+++ b/chat/tests/virtual-timeline-measurement.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createVirtualTimelineElementMeasureScheduler,
+  createVirtualTimelineMeasureScheduler,
+  installVirtualTimelineMeasurementRecovery,
+} from "../src/ui/virtual-timeline-measurement";
+
+class ListenerHarness {
+  private listeners = new Map<string, Array<{ listener: EventListener; capture: boolean }>>();
+
+  addEventListener(type: string, listener: EventListener, options?: boolean | AddEventListenerOptions) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push({ listener, capture: options === true || (typeof options === "object" && options.capture === true) });
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener, options?: boolean | EventListenerOptions) {
+    const capture = options === true || (typeof options === "object" && options.capture === true);
+    this.listeners.set(type, (this.listeners.get(type) ?? []).filter((entry) =>
+      entry.listener !== listener || entry.capture !== capture,
+    ));
+  }
+
+  dispatch(type: string) {
+    const event = new Event(type);
+    for (const { listener } of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  dispatchFromDescendant(type: string, target: object) {
+    const event = { target } as Event;
+    for (const { listener, capture } of this.listeners.get(type) ?? []) {
+      if (capture) listener(event);
+    }
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.length ?? 0;
+  }
+}
+
+class MeasuredRow {
+  closest(selector: string) {
+    return selector === "[data-index]" ? this : null;
+  }
+}
+
+class MediaChild {
+  constructor(private readonly row: MeasuredRow) {}
+
+  closest(selector: string) {
+    return this.row.closest(selector);
+  }
+}
+
+class ScrollElementHarness extends ListenerHarness {
+  private readonly rows = new Set<object>();
+
+  addMeasuredRow(row: object) {
+    this.rows.add(row);
+  }
+
+  contains(node: object) {
+    return this.rows.has(node);
+  }
+}
+
+function createFrameHarness() {
+  let nextId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  return {
+    request(callback: FrameRequestCallback) {
+      const id = nextId++;
+      callbacks.set(id, callback);
+      return id;
+    },
+    cancel(id: number) {
+      callbacks.delete(id);
+    },
+    flushFrame() {
+      const pending = Array.from(callbacks.entries());
+      callbacks.clear();
+      for (const [, callback] of pending) {
+        callback(0);
+      }
+    },
+    pendingCount() {
+      return callbacks.size;
+    },
+  };
+}
+
+describe("virtual timeline measurement recovery", () => {
+  test("coalesces repeated measure requests until the next layout frame", () => {
+    const frames = createFrameHarness();
+    const measure = mock(() => {});
+    const scheduler = createVirtualTimelineMeasureScheduler(measure, {
+      requestAnimationFrame: frames.request,
+      cancelAnimationFrame: frames.cancel,
+    });
+
+    scheduler.scheduleMeasure();
+    scheduler.scheduleMeasure();
+
+    expect(frames.pendingCount()).toBe(1);
+    expect(measure).toHaveBeenCalledTimes(0);
+
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(0);
+
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(1);
+  });
+
+  test("coalesces targeted row measurements until the next layout frame", () => {
+    const frames = createFrameHarness();
+    const measureElement = mock(() => {});
+    const row = new MeasuredRow() as unknown as HTMLElement;
+    const scheduler = createVirtualTimelineElementMeasureScheduler(measureElement, {
+      requestAnimationFrame: frames.request,
+      cancelAnimationFrame: frames.cancel,
+    });
+
+    scheduler.scheduleMeasure(row);
+    scheduler.scheduleMeasure(row);
+
+    expect(frames.pendingCount()).toBe(1);
+    expect(measureElement).toHaveBeenCalledTimes(0);
+
+    frames.flushFrame();
+    expect(measureElement).toHaveBeenCalledTimes(0);
+
+    frames.flushFrame();
+    expect(measureElement).toHaveBeenCalledTimes(1);
+    expect(measureElement).toHaveBeenCalledWith(row);
+  });
+
+  test("remeasures descendant media rows by capture while full measuring on restore events", () => {
+    const frames = createFrameHarness();
+    const scrollElement = new ScrollElementHarness();
+    const windowTarget = new ListenerHarness();
+    const documentTarget = Object.assign(new ListenerHarness(), {
+      visibilityState: "visible" as DocumentVisibilityState,
+    });
+    const measure = mock(() => {});
+    const measureElement = mock(() => {});
+    const row = new MeasuredRow();
+    const media = new MediaChild(row);
+    scrollElement.addMeasuredRow(row);
+    const disconnect = installVirtualTimelineMeasurementRecovery({
+      scrollElement: scrollElement as unknown as HTMLElement,
+      windowTarget,
+      documentTarget,
+      measure,
+      measureElement,
+      requestAnimationFrame: frames.request,
+      cancelAnimationFrame: frames.cancel,
+    });
+
+    frames.flushFrame();
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(1);
+    expect(measureElement).toHaveBeenCalledTimes(0);
+
+    scrollElement.dispatchFromDescendant("load", media);
+    scrollElement.dispatchFromDescendant("loadedmetadata", media);
+    frames.flushFrame();
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(1);
+    expect(measureElement).toHaveBeenCalledTimes(1);
+    expect(measureElement).toHaveBeenCalledWith(row);
+
+    windowTarget.dispatch("focus");
+    frames.flushFrame();
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(2);
+
+    documentTarget.visibilityState = "hidden";
+    documentTarget.dispatch("visibilitychange");
+    frames.flushFrame();
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(2);
+
+    documentTarget.visibilityState = "visible";
+    documentTarget.dispatch("visibilitychange");
+    windowTarget.dispatch("pageshow");
+    frames.flushFrame();
+    frames.flushFrame();
+    expect(measure).toHaveBeenCalledTimes(3);
+
+    disconnect();
+  });
+
+  test("removes listeners and cancels pending measurements", () => {
+    const frames = createFrameHarness();
+    const scrollElement = new ListenerHarness();
+    const windowTarget = new ListenerHarness();
+    const documentTarget = Object.assign(new ListenerHarness(), {
+      visibilityState: "visible" as DocumentVisibilityState,
+    });
+    const measure = mock(() => {});
+    const disconnect = installVirtualTimelineMeasurementRecovery({
+      scrollElement: scrollElement as unknown as HTMLElement,
+      windowTarget,
+      documentTarget,
+      measure,
+      requestAnimationFrame: frames.request,
+      cancelAnimationFrame: frames.cancel,
+    });
+
+    expect(scrollElement.listenerCount("load")).toBe(1);
+    expect(windowTarget.listenerCount("focus")).toBe(1);
+    expect(documentTarget.listenerCount("visibilitychange")).toBe(1);
+
+    disconnect();
+    frames.flushFrame();
+    frames.flushFrame();
+
+    expect(measure).toHaveBeenCalledTimes(0);
+    expect(scrollElement.listenerCount("load")).toBe(0);
+    expect(windowTarget.listenerCount("focus")).toBe(0);
+    expect(documentTarget.listenerCount("visibilitychange")).toBe(0);
+  });
+});


### PR DESCRIPTION
## Plan

- [x] Reproduce the failure shape from the screenshot as stale virtualized row measurements plus stale hover/focus overlays after a backgrounded tab resumes.
- [x] Add lifecycle recovery for the virtual timeline without changing XMPP protocol behavior.
- [x] Clear stale message toolbar, picker, sheet, and reaction tooltip state across tab blur/hide/resume.
- [x] Cover the new lifecycle and measurement behavior with focused Bun tests.
- [x] Run adversarial review passes and address real findings before marking ready.
- [x] Verify with full chat tests, lint, and production build.
- [x] Monitor CI until all checks are green.

## What Changed

- Added virtual timeline measurement recovery for browser resume/media-settle cases.
- Media load/error/metadata events now remeasure only the affected mounted row via `measureElement`; full virtualizer cache resets are reserved for explicit restore events like `focus`, `pageshow`, and visible `visibilitychange`.
- Added global message-toolbar lifecycle suppression from `ChatReadyShell` so tab blur/pagehide/hidden visibility clears stale toolbar ownership and suppresses hover/focus toolbars until fresh pointer or keyboard input.
- Added a suspension epoch consumed by `MessageCard` so mounted cards clear stale emoji pickers, action sheets, focused toolbar controls, and reaction tooltips even when no overlay was open.
- Registered the keyboard resume listener in capture phase so consumed shortcuts such as reaction mode still clear suppression.
- Added focused tests for toolbar lifecycle suppression, capture-phase keyboard resume, descendant media capture, targeted row measurement coalescing, restore remeasure behavior, and cleanup.

## XEP Review

This is a chat UI lifecycle/layout fix only. It does not change stanza construction, namespaces, XMPP transport behavior, discovery, or any send/receive protocol path.

## Review Notes

Adversarial review found and I fixed:

- stale CSS hover/focus toolbar visibility after tab restore
- stale focused toolbar controls and reaction tooltips without an open picker/sheet
- keyboard-only resume through capture-phase shortcuts
- whole-list virtualizer remeasure on media load
- insufficient tests for non-bubbling descendant media events

No broad Knip ignores or dependency ignores were added.

## Verification

- `bun test` from `chat/` — 947 pass, 0 fail
- `nix develop .. -c bun run lint` from `chat/` — pass
- `nix develop .. -c bun run build` from `chat/` — pass; Astro check reports 0 errors, 0 warnings, 0 hints. Vite still emits the existing chunk-size warning.
- `git diff --check` — pass
- Local HTTP smoke via `curl -fsS http://127.0.0.1:4321/` returned the Waddle shell HTML while the dev server was running.

## CI

All PR checks are green:

- `waddle-chat-pullRequest` — pass
- CodeQL `Analyze (actions)` — pass
- CodeQL `Analyze (go)` — pass
- CodeQL `Analyze (javascript-typescript)` — pass
- CodeQL `Analyze (rust)` — pass
- CodeQL summary — pass