### PR TITLE
fix(chat): MUC call teardown — hangup clears presence + dedupe self tile

### DIFF
--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -6,10 +6,9 @@ import {
   $lastCallError,
   clearCallState,
   reportCallError,
-  sendMucCallLeave,
   tearDownActiveCall,
 } from "@/lib/calls/call-store";
-import { outboundCalls } from "@/lib/calls/outbound";
+import type { CallWireSender } from "@/lib/calls/outbound";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
 import { connectionStore } from "@/lib/connection-store";
 import {
@@ -102,7 +101,7 @@ watch(
 
 function getSender() {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
-  return (client?.xmpp as Parameters<typeof outboundCalls.sessionTerminate>[0] | undefined) ?? null;
+  return (client?.xmpp as CallWireSender | undefined) ?? null;
 }
 
 async function toggleMic(): Promise<void> {
@@ -126,25 +125,16 @@ async function toggleCam(): Promise<void> {
 }
 
 async function hangup(): Promise<void> {
-  if (state.value.phase !== "active") {
-    clearCallState();
-    return;
-  }
-  const active = state.value;
-  const sender = getSender();
-  if (sender) {
-    try {
-      if (active.kind === "dm") {
-        await outboundCalls.sessionTerminate(sender, active.peer, active.sid, "success");
-      } else {
-        await sendMucCallLeave(sender as unknown as Parameters<typeof sendMucCallLeave>[0], active.peer);
-      }
-    } catch (err) {
-      reportCallError(err);
-    }
-  }
+  // `tearDownActiveCall` emits the appropriate XEP-0166 /
+  // urn:waddle:muc-call:0 stanza for the current phase AND, for MUC
+  // calls, clears the `<call state="active"/>` presence advertisement
+  // so neither the user's own client nor other occupants keep
+  // rendering the room as "in call" after we leave. Previously the
+  // hangup path sent `<request-leave/>` but skipped the presence
+  // cleanup, leaving the "N in call" indicator visible until the XMPP
+  // session disconnected — which read as "the call won't stop".
+  await tearDownActiveCall(getSender(), "success");
   await engine.disconnect();
-  clearCallState();
 }
 
 const peerLabel = computed(() => {

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -49,8 +49,14 @@ const tiles = computed<Tile[]>(() => {
   const byIdentity = new Map<string, Tile>();
   // Local participant always anchors slot 0 so the user sees a
   // self-preview even pre-publish ("yes, the call is alive and
-  // pointed at me").
-  const selfId = props.localIdentity ?? "you";
+  // pointed at me"). Prefer the first local track's identity over
+  // `props.localIdentity` because the parent reads it from a
+  // non-reactive getter (`engine.localIdentity`) and may pass null on
+  // the first render; falling back to "you" then minting a separate
+  // tile under the real identity when tracks land would render the
+  // local participant twice.
+  const selfId =
+    props.localTracks[0]?.participantIdentity ?? props.localIdentity ?? "you";
   byIdentity.set(selfId, {
     key: `self:${selfId}`,
     identity: selfId,

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -266,15 +266,31 @@ export async function tearDownActiveCall(
           if (s.kind === "dm") {
             await outboundCalls.sessionTerminate(sender, s.peer, s.sid, reason);
           } else {
-            // MUC group call: leave via the muc-call:0 IQ surface
-            // AND clear our presence extension so other occupants
-            // stop showing us as in-call. Both errors flow through
-            // the outer try/catch + reportCallError so failures are
-            // surfaced consistently with every other call-wire op.
-            await sendMucCallLeave(sender, s.peer);
+            // MUC group call: clear our presence extension AND leave
+            // via the muc-call:0 IQ surface. Presence-first ordering
+            // is deliberate — other occupants drive the "N in call"
+            // indicator off our `<call/>` extension, so dropping the
+            // advertisement is what makes the call visibly stop. Each
+            // side gets its own try/catch so a single failure (e.g. a
+            // stale wasm bundle without `send_muc_call_leave`) can't
+            // swallow the other and leave us advertising as in-call.
             const raw = sender as RawIqSender;
             if (s.selfNick && raw.update_muc_call_presence) {
-              await raw.update_muc_call_presence(s.peer, s.selfNick, false, s.peer);
+              try {
+                await raw.update_muc_call_presence(
+                  s.peer,
+                  s.selfNick,
+                  false,
+                  s.peer,
+                );
+              } catch (err) {
+                reportCallError(err);
+              }
+            }
+            try {
+              await sendMucCallLeave(raw, s.peer);
+            } catch (err) {
+              reportCallError(err);
             }
           }
           break;
@@ -334,7 +350,7 @@ async function sendMucCallJoin(
  * Send `<request-leave/>` so the SFU unregisters us and revokes
  * any tokens it minted for this `(room, identity)` pair.
  */
-export async function sendMucCallLeave(
+async function sendMucCallLeave(
   sender: RawIqSender | CallWireSender,
   roomJid: string,
 ): Promise<void> {

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -176,6 +176,13 @@ export class CallEngine {
     const room = this.room;
     this.room = null;
     if (!room) return;
+    // Drop subscribers' track caches synchronously. The LiveKit
+    // `Disconnected` event is the natural trigger, but we unregister
+    // `handleDisconnected` immediately below so the event never reaches
+    // us — without this synthetic emit, `useCallEngine` would carry the
+    // last call's tracks into the next session and the overlay would
+    // render duplicate tiles.
+    this.emit("disconnected", "local");
     room.off(RoomEvent.TrackSubscribed, this.handleTrackSubscribed);
     room.off(RoomEvent.TrackUnsubscribed, this.handleTrackUnsubscribed);
     room.off(RoomEvent.LocalTrackPublished, this.handleLocalTrackPublished);

--- a/chat/tests/call-engine.test.ts
+++ b/chat/tests/call-engine.test.ts
@@ -67,6 +67,42 @@ describe("call-engine module", () => {
     expect(classify("video")).toBe("v");
   });
 
+  test("disconnect() emits the synthetic 'disconnected' event so subscribers drain stale caches", async () => {
+    // Regression guard for the "I see myself twice on rejoin" bug:
+    // `engine.disconnect()` unregisters the LiveKit `Disconnected`
+    // listener before awaiting `room.disconnect()`, so the real event
+    // never reaches our handler. We compensate with a synthetic emit
+    // at the top of `disconnect()`. Without it, `useCallEngine` would
+    // never clear its `localTracks` / `remoteTracks` refs and the
+    // next call's tiles would inherit stale entries.
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    let disconnects = 0;
+    engine.on("disconnected", () => {
+      disconnects += 1;
+    });
+    // Inject a minimal Room stub matching the surface `disconnect()`
+    // touches. `livekit-client`'s real `Room` needs browser globals.
+    const stub = {
+      off: () => stub,
+      disconnect: async () => undefined,
+    };
+    (engine as unknown as { room: typeof stub }).room = stub;
+    await engine.disconnect();
+    expect(disconnects).toBe(1);
+  });
+
+  test("disconnect() is a no-op when no room was connected", async () => {
+    const { CallEngine } = await import("../src/lib/calls/engine");
+    const engine = new CallEngine();
+    let disconnects = 0;
+    engine.on("disconnected", () => {
+      disconnects += 1;
+    });
+    await engine.disconnect();
+    expect(disconnects).toBe(0);
+  });
+
   test("LocalMediaTrack mirrors RemoteMediaTrack's shape so one tile component renders both", () => {
     // The overlay's `Tile.videoTrack` accepts either side via a
     // duck-typed `attach`/`detach` callback. This assertion is a

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -173,6 +173,39 @@ describe("MUC group call", () => {
     );
   });
 
+  test("tearDownActiveCall still clears the call presence when sendMucCallLeave throws", async () => {
+    // Regression guard: a stale wasm bundle without
+    // `send_muc_call_leave` makes `sendMucCallLeave` throw. The
+    // presence cleanup MUST still run — otherwise the user's
+    // `<call state='active'/>` advertisement lingers until the XMPP
+    // session disconnects, exactly the bug this teardown path exists
+    // to fix.
+    const update_muc_call_presence = mock(async () => undefined);
+    $callState.set({
+      phase: "active",
+      peer: "chan@muc.test",
+      sid: "chan@muc.test",
+      media: audioVideo,
+      join,
+      kind: "muc",
+      selfNick: "alice",
+    });
+    await tearDownActiveCall(
+      { update_muc_call_presence } as unknown as Parameters<
+        typeof tearDownActiveCall
+      >[0],
+      "success",
+    );
+    expect(update_muc_call_presence).toHaveBeenCalledTimes(1);
+    expect(update_muc_call_presence).toHaveBeenCalledWith(
+      "chan@muc.test",
+      "alice",
+      false,
+      "chan@muc.test",
+    );
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
   test("tearDownActiveCall on a MUC call dispatches request-leave and clears the call presence", async () => {
     const send_muc_call_leave = mock(async () => undefined);
     const update_muc_call_presence = mock(async () => undefined);


### PR DESCRIPTION
## Summary

Four real bugs in the MUC group-call surface (#706 / #707) + the call overhaul (#709).

### Bug 1 — Hangup never clears the MUC call presence

`CallOverlay.vue` `hangup()` sent `<request-leave/>` but never broadcast `<call state="inactive"/>`. The user's own MUC presence kept advertising them as in-call; their client echo re-added them to `$mucCallParticipants`; the "N in call" indicator stayed until the XMPP session disconnected. To the user this read as "the call won't stop when I'm the only one in there".

Fix: route hangup through `tearDownActiveCall("success")` which already handles both DM (`session-terminate`) and MUC (`request-leave` + inactive presence). Removes the duplicate lifecycle.

### Bug 2 — Local participant rendered twice

The `tiles` computed in `CallTileGrid.vue` keyed the placeholder on `props.localIdentity ?? "you"`. `localIdentity` comes from `engine.localIdentity`, a non-reactive getter; on the first render `room` is still `null`, so the placeholder lands under `"you"`. When local tracks arrive the loop creates a second `isSelf: true` tile under the real LiveKit identity. Two "You" tiles in the dock.

Fix: prefer `props.localTracks[0]?.participantIdentity` for the placeholder. `localTracks` IS reactive, so the placeholder lands on the same key the loop merges into.

### Bug 3 — Stale track caches between calls

`engine.disconnect()` unregistered the LiveKit `Disconnected` listener before awaiting `room.disconnect()`. The engine's synthetic `"disconnected"` event therefore never fired, and `useCallEngine` never cleared `localTracks` / `remoteTracks`. Across calls in the same session, dead entries accumulated and multiplied tiles on rejoin.

Fix: emit the synthetic event at the top of `disconnect()` regardless of LiveKit listener state.

### Bug 4 — MUC presence cleanup skipped on a `request-leave` failure

(Caught by adversarial review.) `tearDownActiveCall`'s MUC branch did `await sendMucCallLeave(...)` first, then `await update_muc_call_presence(...)`, both inside a shared `try`. A stale wasm bundle without `send_muc_call_leave` throws — the catch swallows it AND the presence cleanup never runs. The user is then left advertising `<call state="active"/>` until the XMPP session disconnects, exactly the bug Bug 1 exists to fix.

Fix: presence-first ordering with independent `try`/`catch` blocks so neither failure can suppress the other.

## Test plan

- [x] `bun test` (942 pass, 0 fail)
- [x] `bun run lint` (knip clean)
- [x] `bunx astro check` (0 errors / warnings)
- [x] New regression tests: synthetic-disconnect emit on `engine.disconnect()`; presence cleanup runs even when `sendMucCallLeave` throws.
- [ ] Two-tab manual smoke: A and B join a MUC call, B hangs up — A's "N in call" indicator drops B immediately.
- [ ] Self-tile manual smoke: join a MUC call, confirm a single "You" tile is rendered both pre- and post-publish.
- [ ] Re-join manual smoke: join, hang up, join again — no duplicate tiles in the second session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)