### PR TITLE
fix(chat): drop redundant presence ring — keep the dot only

### DIFF
--- a/chat/src/components/ui/AppAvatar.vue
+++ b/chat/src/components/ui/AppAvatar.vue
@@ -113,9 +113,6 @@ watch(
     :class="[
       wrapperSizeClass,
       presence === 'offline' ? 'app-avatar--offline' : '',
-      presence === 'online' ? 'app-avatar--online' : '',
-      presence === 'away' ? 'app-avatar--away' : '',
-      presence === 'dnd' ? 'app-avatar--dnd' : '',
     ]"
     :title="presenceTooltip"
   >

--- a/chat/src/styles/global/type.css
+++ b/chat/src/styles/global/type.css
@@ -221,26 +221,8 @@
   transform: translate(50%, 50%);
 }
 
-/* Active / inactive presence treatment on the avatar itself.
- * Goal: at a glance, an online avatar should pop and an offline one
- * should clearly recede — without making either feel "broken". */
-.app-avatar.app-avatar--online > img,
-.app-avatar.app-avatar--online > .type-avatar-mark {
-  box-shadow:
-    0 0 0 1.5px color-mix(in oklab, var(--success) 55%, transparent),
-    0 0 8px color-mix(in oklab, var(--success) 22%, transparent);
-}
-
-.app-avatar.app-avatar--away > img,
-.app-avatar.app-avatar--away > .type-avatar-mark {
-  box-shadow: 0 0 0 1.5px color-mix(in oklab, var(--warning) 50%, transparent);
-}
-
-.app-avatar.app-avatar--dnd > img,
-.app-avatar.app-avatar--dnd > .type-avatar-mark {
-  box-shadow: 0 0 0 1.5px color-mix(in oklab, var(--destructive) 50%, transparent);
-}
-
+/* Offline avatars recede; active states are signaled by the
+ * presence dot at the bottom-right, not by a ring around the avatar. */
 .app-avatar.app-avatar--offline {
   opacity: 0.55;
 }


### PR DESCRIPTION
## Summary

Active users were getting two presence indicators at once: a colored ring/glow around the avatar **and** a colored dot at the bottom-right. The ring fought the avatar content visually, and the dot already covers the same signal in a more conventional way (Slack/Discord/iMessage).

- Removed the `box-shadow` ring treatment on `--online`, `--away`, and `--dnd` avatar states (`chat/src/styles/global/type.css`).
- Stopped emitting the now-unused modifier classes from `AppAvatar.vue`.
- Kept `--offline` opacity + desaturation: a distinct visual treatment, not a colored border.

Active presence is now signaled solely by the bottom-right dot.

## Test plan

- [ ] Verify online/away/dnd avatars no longer have a colored ring around them
- [ ] Verify the bottom-right presence dot still renders in the correct color per state
- [ ] Verify offline avatars still appear desaturated and dimmed
- [ ] `bun run lint` clean in `chat/`

This PR was created with the assistance of a LLM.