### PR TITLE
fix(server,chat): livekit audit — ghost participants, security, JMI, leaks, XEP coverage

### DIFF
--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, provide, ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -10,6 +10,10 @@ import {
 } from "@/lib/calls/call-store";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import { useCallEngine } from "@/lib/calls/use-call-engine";
+import {
+  callVideoRegistryKey,
+  createCallVideoRegistry,
+} from "@/lib/calls/video-registry";
 import { connectionStore } from "@/lib/connection-store";
 import {
   $callUiMode,
@@ -46,6 +50,13 @@ const micEnabled = ref(true);
 const camEnabled = ref(true);
 const settingsOpen = ref(false);
 const pipVideoEl = ref<HTMLVideoElement | null>(null);
+
+// Shared registry of `<video>` elements currently attached to call
+// tracks. CallTileGrid populates it through its `:ref` callbacks; the
+// PIP toggle below reads it instead of reaching into LiveKit's
+// private `attachedElements` array on a `RemoteTrack` / `LocalTrack`.
+const videoRegistry = createCallVideoRegistry();
+provide(callVideoRegistryKey, videoRegistry);
 
 /** Effective mode for rendering — pip falls back to the stored
  *  non-pip mode while still in PIP, because PIP isn't a "surface" we
@@ -180,19 +191,17 @@ async function togglePip(): Promise<void> {
   if (typeof document === "undefined" || !document.pictureInPictureEnabled) return;
   // Prefer the first remote video; fall back to a local one only if
   // no remote video exists (1:1 self-view PIP for self-debugging).
+  // Resolved via the shared registry that CallTileGrid populates on
+  // every `<video>` attach — no LiveKit-private API access.
   let target: HTMLVideoElement | null = null;
   const fromRemote = remoteTracks.value.find((t) => t.kind === "video");
   if (fromRemote) {
-    target = (fromRemote.track as unknown as { attachedElements: HTMLMediaElement[] }).attachedElements.find(
-      (el) => el instanceof HTMLVideoElement,
-    ) as HTMLVideoElement | undefined ?? null;
+    target = videoRegistry.get(fromRemote.participantIdentity);
   }
   if (!target) {
     const fromLocal = localTracks.value.find((t) => t.kind === "video");
     if (fromLocal) {
-      target = (fromLocal.track as unknown as { attachedElements: HTMLMediaElement[] }).attachedElements.find(
-        (el) => el instanceof HTMLVideoElement,
-      ) as HTMLVideoElement | undefined ?? null;
+      target = videoRegistry.get(fromLocal.participantIdentity);
     }
   }
   if (!target) return;
@@ -218,12 +227,57 @@ async function togglePip(): Promise<void> {
   }
 }
 
+/**
+ * Best-effort synchronous teardown for the tab-close path.
+ *
+ * `onBeforeUnmount` runs too late for tab close — the browser will
+ * tear the WebSocket down before our async wire-send completes, and
+ * the peer ends up stuck on a dangling "Connecting…" overlay until
+ * the LiveKit room times them out. `pagehide` fires earlier in the
+ * unload sequence and is the documented hook for best-effort
+ * networking on unload (the modern replacement for `beforeunload`
+ * for this purpose). We fire-and-forget the terminate stanza — any
+ * await would race the unload — and rely on the wasm side queueing
+ * the bytes onto the socket synchronously.
+ */
+function handlePageHide(): void {
+  const sender = getSender();
+  if (!sender) return;
+  // `tearDownActiveCall` is async but the wire methods it calls
+  // synchronously enqueue stanzas into the wasm client's outbound
+  // queue. We don't await — the browser is unloading.
+  void tearDownActiveCall(sender, "gone");
+}
+
+onMounted(() => {
+  if (typeof window !== "undefined") {
+    window.addEventListener("pagehide", handlePageHide);
+  }
+});
+
 onBeforeUnmount(() => {
   // Tab close mid-call: best-effort session-terminate so the peer's
   // overlay closes immediately instead of waiting for the LiveKit
-  // room to drop them.
+  // room to drop them. The `pagehide` handler above is the primary
+  // route on actual tab-close; this branch handles in-app overlay
+  // unmounts (e.g. route change away from a call surface).
   void tearDownActiveCall(getSender(), "gone");
   void engine.disconnect();
+  // Exit PIP if our video was the one in the floating window —
+  // otherwise the browser leaves a frozen still-frame window visible
+  // after the call has ended, confusing the user about whether the
+  // call is still running.
+  if (
+    typeof document !== "undefined" &&
+    pipVideoEl.value &&
+    document.pictureInPictureElement === pipVideoEl.value
+  ) {
+    void document.exitPictureInPicture().catch(() => undefined);
+  }
+  pipVideoEl.value = null;
+  if (typeof window !== "undefined") {
+    window.removeEventListener("pagehide", handlePageHide);
+  }
 });
 
 const localIdentity = computed(() => engine.localIdentity);

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -228,24 +228,28 @@ async function togglePip(): Promise<void> {
 }
 
 /**
- * Best-effort synchronous teardown for the tab-close path.
+ * Best-effort teardown for the tab-close path.
  *
  * `onBeforeUnmount` runs too late for tab close — the browser will
- * tear the WebSocket down before our async wire-send completes, and
- * the peer ends up stuck on a dangling "Connecting…" overlay until
- * the LiveKit room times them out. `pagehide` fires earlier in the
- * unload sequence and is the documented hook for best-effort
- * networking on unload (the modern replacement for `beforeunload`
- * for this purpose). We fire-and-forget the terminate stanza — any
- * await would race the unload — and rely on the wasm side queueing
- * the bytes onto the socket synchronously.
+ * tear the WebSocket down before our async wire-send completes.
+ * `pagehide` fires earlier in the unload sequence and is the modern
+ * documented hook for unload-side networking.
+ *
+ * IMPORTANT: this is best-effort, not a guarantee. `tearDownActiveCall`
+ * awaits an actor round-trip for stanza acknowledgement, and the
+ * browser will not yield long enough for the full chain to complete
+ * before the WebSocket is torn down. Some of the wire frames will
+ * make it (typically the first synchronous send), some may not.
+ *
+ * The authoritative chip-clear path is server-side: the unclean
+ * disconnect handler (`cleanup_muc_presence`) now broadcasts an
+ * `unavailable` presence to remaining occupants regardless of whether
+ * this client managed to send a graceful `state='inactive'` first.
+ * This handler is here to shorten the gap, not to be relied on.
  */
 function handlePageHide(): void {
   const sender = getSender();
   if (!sender) return;
-  // `tearDownActiveCall` is async but the wire methods it calls
-  // synchronously enqueue stanzas into the wasm client's outbound
-  // queue. We don't await — the browser is unloading.
   void tearDownActiveCall(sender, "gone");
 }
 

--- a/chat/src/components/calls/CallSettingsDialog.vue
+++ b/chat/src/components/calls/CallSettingsDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import { Check, Mic, Speaker, Video, X } from "lucide-vue-next";
 import AppDialog from "@/components/ui/AppDialog.vue";
@@ -42,6 +42,18 @@ function detectSpeakerSupport(): boolean {
   return typeof audio.setSinkId === "function";
 }
 
+/**
+ * Epoch counter incremented on every dialog close. `refresh()` reads
+ * the current epoch before awaiting `enumerateCallDevices()` and
+ * compares it against the snapshot afterward: if they differ, the
+ * dialog has been closed (or re-opened) in the meantime and we drop
+ * the stale result instead of overwriting whatever the next session
+ * already set. This is the lighter-weight equivalent of an
+ * AbortController — the underlying `enumerateDevices` call has no
+ * abort signal anyway, so the epoch guard is the surgical fix.
+ */
+let enumerateEpoch = 0;
+
 async function refresh(): Promise<void> {
   // The browser only populates `label` after the user has granted
   // permission for at least one input device. Calling `getUserMedia`
@@ -49,7 +61,10 @@ async function refresh(): Promise<void> {
   // intrusive here. So before granting: labels are blank, and we
   // render a "Grant access to see device names" hint inside each
   // picker. The deviceId column still works for selection.
-  devices.value = await enumerateCallDevices();
+  const epoch = enumerateEpoch;
+  const next = await enumerateCallDevices();
+  if (epoch !== enumerateEpoch) return;
+  devices.value = next;
 }
 
 const { engine } = useCallEngine();
@@ -87,31 +102,54 @@ async function selectSpeaker(id: string | null): Promise<void> {
   }
 }
 
-let unsubscribe: (() => void) | null = null;
+/**
+ * `devicechange` listener wired up only while the dialog is open.
+ * Previously this was mounted for the entire call lifetime, which
+ * meant a hot-plug during the call would re-enumerate even when the
+ * picker wasn't visible — pointless work and an extra permission
+ * probe on some browsers. Scoping to the open watcher keeps the call
+ * surface idle when the user isn't actively choosing a device.
+ */
+let unsubscribeDeviceChange: (() => void) | null = null;
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+function teardownDeviceChange(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  unsubscribeDeviceChange?.();
+  unsubscribeDeviceChange = null;
+}
 
 watch(open, async (isOpen) => {
-  if (!isOpen) return;
+  if (!isOpen) {
+    // Closing: bump the epoch so any in-flight enumerate result
+    // gets dropped on resolve, and detach the devicechange listener.
+    enumerateEpoch += 1;
+    teardownDeviceChange();
+    return;
+  }
   speakerSupported.value = detectSpeakerSupport();
   await refresh();
-});
-
-onMounted(() => {
-  // `devicechange` fires when a device is plugged in/out. Re-
-  // enumerate so the picker reflects current hardware.
+  // Mount the devicechange listener after the first refresh so the
+  // initial enumeration isn't fighting a hot-plug event arriving in
+  // the same tick. Debounced 200ms because hot-plugs commonly fire
+  // multiple `devicechange` events in quick succession (one per
+  // device flavor) and we only need one re-enumerate per cluster.
   if (typeof navigator !== "undefined" && navigator.mediaDevices?.addEventListener) {
     const handler = () => {
-      void refresh();
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        void refresh();
+      }, 200);
     };
     navigator.mediaDevices.addEventListener("devicechange", handler);
-    unsubscribe = () => {
+    unsubscribeDeviceChange = () => {
       navigator.mediaDevices.removeEventListener("devicechange", handler);
     };
   }
-});
-
-onUnmounted(() => {
-  unsubscribe?.();
-  unsubscribe = null;
 });
 
 function close(): void {

--- a/chat/src/components/calls/CallTileGrid.vue
+++ b/chat/src/components/calls/CallTileGrid.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, inject, ref } from "vue";
 import { MicOff } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
 import type { LocalMediaTrack, RemoteMediaTrack } from "@/lib/calls/engine";
+import { callVideoRegistryKey, type CallVideoRegistry } from "@/lib/calls/video-registry";
+import { TileAttachments, type TileAttachable } from "@/lib/calls/tile-attach";
 
 /**
  * One tile = one (identity, role) slot in the grid. Each
@@ -16,8 +18,14 @@ type Tile = {
   label: string;
   isSelf: boolean;
   micEnabledHint: boolean;
-  videoTrack: { attach: (el: HTMLMediaElement) => void; detach: () => HTMLMediaElement[] } | null;
-  audioTrack: { attach: (el: HTMLMediaElement) => void; detach: () => HTMLMediaElement[] } | null;
+  videoTrack: {
+    attach: (el: HTMLMediaElement) => void;
+    detach: (el: HTMLMediaElement) => HTMLMediaElement;
+  } | null;
+  audioTrack: {
+    attach: (el: HTMLMediaElement) => void;
+    detach: (el: HTMLMediaElement) => HTMLMediaElement;
+  } | null;
 };
 
 const props = defineProps<{
@@ -112,12 +120,31 @@ function toggleFocus(tile: Tile) {
   focusedKey.value = focusedKey.value === tile.key ? null : tile.key;
 }
 
+/**
+ * Optional injected registry shared with CallOverlay so PIP can look
+ * up a tile's `<video>` element without crossing the LiveKit SDK's
+ * private `attachedElements` surface. Resolved at component setup;
+ * `null` when no overlay provided one (e.g. standalone snapshots in
+ * tests).
+ */
+const videoRegistry = inject<CallVideoRegistry | null>(callVideoRegistryKey, null);
+
+/**
+ * Per-tile bookkeeping for the (element, track) pair currently
+ * attached. See `tile-attach.ts` for the contract — short version:
+ * every `:ref` change goes through `sync` which reconciles the
+ * previous record so LiveKit's `attachedElements` array never grows
+ * stale entries.
+ */
+const attachments = new TileAttachments();
+
 function attachTrack(
+  key: string,
   el: HTMLMediaElement | null,
-  track: { attach: (target: HTMLMediaElement) => void } | null,
+  track: TileAttachable | null,
+  identity: string | null,
 ): void {
-  if (!el || !track) return;
-  track.attach(el);
+  attachments.sync(key, el, track, identity, videoRegistry);
 }
 </script>
 
@@ -136,7 +163,7 @@ function attachTrack(
         >
           <video
             v-if="focusedTile.videoTrack"
-            :ref="(el) => attachTrack(el as HTMLVideoElement | null, focusedTile?.videoTrack ?? null)"
+            :ref="(el) => attachTrack(`${focusedTile?.key}:video`, el as HTMLVideoElement | null, focusedTile?.videoTrack ?? null, focusedTile?.identity ?? null)"
             class="call-tile__video"
             :class="focusedTile.isSelf ? 'call-tile__video--mirrored' : ''"
             autoplay
@@ -148,7 +175,7 @@ function attachTrack(
           </div>
           <audio
             v-if="focusedTile.audioTrack && !focusedTile.isSelf"
-            :ref="(el) => attachTrack(el as HTMLAudioElement | null, focusedTile?.audioTrack ?? null)"
+            :ref="(el) => attachTrack(`${focusedTile?.key}:audio`, el as HTMLAudioElement | null, focusedTile?.audioTrack ?? null, null)"
             autoplay
           />
           <div class="call-tile__nameplate">
@@ -175,7 +202,7 @@ function attachTrack(
         >
           <video
             v-if="tile.videoTrack"
-            :ref="(el) => attachTrack(el as HTMLVideoElement | null, tile.videoTrack)"
+            :ref="(el) => attachTrack(`${tile.key}:video`, el as HTMLVideoElement | null, tile.videoTrack, tile.identity)"
             class="call-tile__video"
             :class="tile.isSelf ? 'call-tile__video--mirrored' : ''"
             autoplay
@@ -187,7 +214,7 @@ function attachTrack(
           </div>
           <audio
             v-if="tile.audioTrack && !tile.isSelf"
-            :ref="(el) => attachTrack(el as HTMLAudioElement | null, tile.audioTrack)"
+            :ref="(el) => attachTrack(`${tile.key}:audio`, el as HTMLAudioElement | null, tile.audioTrack, null)"
             autoplay
           />
           <div class="call-tile__nameplate">
@@ -220,7 +247,7 @@ function attachTrack(
         >
           <video
             v-if="tile.videoTrack"
-            :ref="(el) => attachTrack(el as HTMLVideoElement | null, tile.videoTrack)"
+            :ref="(el) => attachTrack(`${tile.key}:video`, el as HTMLVideoElement | null, tile.videoTrack, tile.identity)"
             class="call-tile__video"
             :class="tile.isSelf ? 'call-tile__video--mirrored' : ''"
             autoplay
@@ -232,7 +259,7 @@ function attachTrack(
           </div>
           <audio
             v-if="tile.audioTrack && !tile.isSelf"
-            :ref="(el) => attachTrack(el as HTMLAudioElement | null, tile.audioTrack)"
+            :ref="(el) => attachTrack(`${tile.key}:audio`, el as HTMLAudioElement | null, tile.audioTrack, null)"
             autoplay
           />
           <div class="call-tile__nameplate">

--- a/chat/src/lib/calls/call-store.ts
+++ b/chat/src/lib/calls/call-store.ts
@@ -265,6 +265,17 @@ export async function tearDownActiveCall(
         case "active":
           if (s.kind === "dm") {
             await outboundCalls.sessionTerminate(sender, s.peer, s.sid, reason);
+            // XEP-0353 §3.5: both parties SHOULD send `<finish/>` after
+            // the call ends so MAM archives both sides consistently
+            // (the JMI message stack uses the finish marker to bookend
+            // the call record). Best-effort: a wasm bundle that
+            // doesn't expose `send_call_finish` shouldn't keep the
+            // terminate from clearing the local slot.
+            try {
+              await outboundCalls.finish(sender, s.peer, s.sid);
+            } catch (err) {
+              reportCallError(err);
+            }
           } else {
             // MUC group call: clear our presence extension AND leave
             // via the muc-call:0 IQ surface. Presence-first ordering

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -111,14 +111,26 @@ export class CallEngine {
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
     await room.connect(join.url, join.token);
     this.room = room;
-    if (opts.audio) await room.localParticipant.setMicrophoneEnabled(true);
-    if (opts.video) await room.localParticipant.setCameraEnabled(true);
-    // Re-apply the speaker preference now that the room has remote
-    // audio elements to retarget; the engine ignores it on connect
-    // because no `<audio>` exists yet, but every subsequent
-    // RoomEvent.TrackSubscribed wires through this.applySpeaker.
-    if (prefs.speaker) {
-      await this.applySpeakerDevice(prefs.speaker).catch(() => undefined);
+    // Post-connect setup must be atomic from the caller's POV: if a
+    // permission prompt is denied for the mic or cam, throwing without
+    // first tearing down the half-initialized room would leave
+    // `this.room` set against a connected LiveKit session that nothing
+    // will ever close. Subsequent `connect()` calls would then fail on
+    // the "already connected" guard for a session the user never sees.
+    try {
+      if (opts.audio) await room.localParticipant.setMicrophoneEnabled(true);
+      if (opts.video) await room.localParticipant.setCameraEnabled(true);
+      // Re-apply the speaker preference now that the room has remote
+      // audio elements to retarget; the engine ignores it on connect
+      // because no `<audio>` exists yet, but every subsequent
+      // RoomEvent.TrackSubscribed wires through this.applySpeaker.
+      if (prefs.speaker) {
+        await this.applySpeakerDevice(prefs.speaker).catch(() => undefined);
+      }
+    } catch (err) {
+      this.room = null;
+      await room.disconnect().catch(() => undefined);
+      throw err;
     }
   }
 

--- a/chat/src/lib/calls/engine.ts
+++ b/chat/src/lib/calls/engine.ts
@@ -109,7 +109,17 @@ export class CallEngine {
     room.on(RoomEvent.LocalTrackUnpublished, this.handleLocalTrackUnpublished);
     room.on(RoomEvent.ParticipantDisconnected, this.handleParticipantDisconnected);
     room.on(RoomEvent.Disconnected, this.handleDisconnected);
-    await room.connect(join.url, join.token);
+    try {
+      await room.connect(join.url, join.token);
+    } catch (err) {
+      // Connect itself failed; the listeners we bound above would
+      // otherwise dangle on a `Room` that nothing references but the
+      // closure inside the listener — strip them so a future GC has
+      // a clean path. `this.room` was never set so the caller stays
+      // on the well-defined "not connected" path.
+      room.removeAllListeners();
+      throw err;
+    }
     this.room = room;
     // Post-connect setup must be atomic from the caller's POV: if a
     // permission prompt is denied for the mic or cam, throwing without

--- a/chat/src/lib/calls/tile-attach.ts
+++ b/chat/src/lib/calls/tile-attach.ts
@@ -1,0 +1,96 @@
+import type { CallVideoRegistry } from "./video-registry";
+
+/**
+ * One bookkeeping record per `(tile, role)` slot. Tracks which
+ * (`<video>` | `<audio>`, LiveKit track) pair is currently mounted so
+ * Vue's `:ref` lifecycle can correctly detach the previous track
+ * when either side changes — without this, LiveKit's
+ * `attachedElements` array would grow on every focus toggle and the
+ * same track would render into multiple media elements, each
+ * fighting for the same MediaStream tap.
+ */
+type TileAttachKey = string;
+export type TileAttachable = {
+  attach: (target: HTMLMediaElement) => void;
+  detach: (target: HTMLMediaElement) => HTMLMediaElement;
+};
+type AttachRecord = {
+  el: HTMLMediaElement;
+  track: TileAttachable;
+};
+
+/**
+ * Map-backed attachment manager. One instance per CallTileGrid
+ * (component-scoped). Vue's `:ref` callback wires (element, track)
+ * pairs in/out through `sync`; the manager handles the previous-record
+ * detach + srcObject release on every change.
+ */
+export class TileAttachments {
+  private records = new Map<TileAttachKey, AttachRecord>();
+
+  /**
+   * Reconcile the (element, track) pair for the given slot.
+   *
+   * Vue invokes our `:ref` callback in three shapes:
+   *   1. mount   → `el` is the live element, `track` is the current track.
+   *   2. unmount → `el` is `null` (Vue's signal that the element left
+   *      the DOM); `track` may be either value.
+   *   3. update  → both `el` and `track` may stay or change.
+   *
+   * The contract: at most one (el, track) pair is live per `key`, and
+   * the previous track is always `.detach()`-ed before the next is
+   * attached so LiveKit's internal `attachedElements` never accumulates
+   * stale entries.
+   *
+   * `identity` is the LiveKit participant identity. When supplied and
+   * the element is an `HTMLVideoElement`, the optional `registry` is
+   * updated so the overlay's PIP toggle can look the element up.
+   */
+  sync(
+    key: TileAttachKey,
+    el: HTMLMediaElement | null,
+    track: TileAttachable | null,
+    identity: string | null,
+    registry: CallVideoRegistry | null,
+  ): void {
+    const prev = this.records.get(key);
+    // Unmount path: free the previous attachment and clear the
+    // srcObject so the browser can release the underlying
+    // MediaStreamTrack tap.
+    if (!el || !track) {
+      if (prev) {
+        try {
+          prev.track.detach(prev.el);
+        } catch {
+          // detach is idempotent in normal flow; swallow.
+        }
+        prev.el.srcObject = null;
+        this.records.delete(key);
+      }
+      if (identity && !el) registry?.register(identity, null);
+      return;
+    }
+    // No-op: same (el, track) reattached. LiveKit tolerates this but
+    // logs about it; skipping keeps the console clean.
+    if (prev && prev.el === el && prev.track === track) return;
+    // Either el or track changed → detach the previous record first.
+    if (prev) {
+      try {
+        prev.track.detach(prev.el);
+      } catch {
+        // see above
+      }
+      prev.el.srcObject = null;
+    }
+    track.attach(el);
+    this.records.set(key, { el, track });
+    if (identity && el instanceof HTMLVideoElement) {
+      registry?.register(identity, el);
+    }
+  }
+
+  /** Test helper: peek at the live records. */
+  size(): number {
+    return this.records.size;
+  }
+}

--- a/chat/src/lib/calls/video-registry.ts
+++ b/chat/src/lib/calls/video-registry.ts
@@ -1,0 +1,61 @@
+import type { InjectionKey } from "vue";
+
+/**
+ * Shared registry of `<video>` elements currently attached to call
+ * tile tracks, keyed by participant identity. Populated by
+ * `CallTileGrid` via `:ref` callbacks and read by `CallOverlay.togglePip`
+ * so the overlay no longer has to reach into LiveKit's private
+ * `attachedElements` array on a `RemoteTrack` / `LocalTrack`.
+ *
+ * Per-identity keys (not per-publication) so the lookup survives
+ * track re-publishes (camera off → on) without the registry
+ * accumulating stale entries — `register(identity, el)` overwrites
+ * the previous element atomically.
+ */
+export type CallVideoRegistry = {
+  register(identity: string, el: HTMLVideoElement | null): void;
+  /**
+   * Return a still-mounted video element for the given identity, or
+   * `null` if nothing has been registered. Used by the overlay's
+   * picture-in-picture toggle to find a target without crossing the
+   * LiveKit SDK private surface.
+   */
+  get(identity: string): HTMLVideoElement | null;
+  /**
+   * Iterate registered (identity, element) pairs. The order is
+   * insertion order — callers (e.g. `togglePip`) typically prefer the
+   * first non-self entry, then fall back to any entry.
+   */
+  entries(): IterableIterator<[string, HTMLVideoElement]>;
+};
+
+/**
+ * `provide`/`inject` key for the registry. CallOverlay constructs the
+ * registry and provides it; CallTileGrid resolves it during render and
+ * wires `<video>` element refs through `register`.
+ */
+export const callVideoRegistryKey = Symbol("callVideoRegistry") as InjectionKey<CallVideoRegistry>;
+
+/**
+ * Build a fresh registry backed by a plain Map. The CallOverlay owns
+ * one instance per call lifetime; entries are added/removed by Vue's
+ * `:ref` lifecycle (element on mount, `null` on unmount).
+ */
+export function createCallVideoRegistry(): CallVideoRegistry {
+  const elements = new Map<string, HTMLVideoElement>();
+  return {
+    register(identity, el) {
+      if (el) {
+        elements.set(identity, el);
+      } else {
+        elements.delete(identity);
+      }
+    },
+    get(identity) {
+      return elements.get(identity) ?? null;
+    },
+    entries() {
+      return elements.entries();
+    },
+  };
+}

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -16,6 +16,7 @@ import {
   applyMucCallPresence,
   clearMucCallParticipants,
 } from "@/lib/calls/muc-call-presence";
+import { useCallEngine } from "@/lib/calls/use-call-engine";
 import type { CallWireSender } from "@/lib/calls/outbound";
 import type { CallEvent } from "@/lib/calls/types";
 import { barePeerJid, jidDomain, roomBareJidFor } from "./jid";
@@ -1623,8 +1624,17 @@ export class BrowserXmppClient {
     // active overlay across reconnect; the reconnect path doesn't
     // re-establish call state (XEP-0353 has no resume semantics for
     // an in-flight call once the responder's connection drops).
+    //
+    // We MUST also drop the LiveKit room. The CallOverlay's
+    // `onBeforeUnmount` is the usual route, but it won't fire when the
+    // overlay re-renders to `phase: idle` and stays mounted (the parent
+    // tree owns it) — the engine would keep an open SFU socket
+    // pumping bytes until the next call replaced it. Tearing the
+    // singleton engine down here is idempotent (no-op when nothing's
+    // connected).
     clearCallState();
     clearMucCallParticipants();
+    void useCallEngine().engine.disconnect();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     this.resumeState = xmpp.get_resume_state?.() ?? null;

--- a/chat/tests/call-teardown.test.ts
+++ b/chat/tests/call-teardown.test.ts
@@ -55,6 +55,54 @@ describe("tearDownActiveCall", () => {
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
+  test("active DM call: also dispatches XEP-0353 finish after sessionTerminate", async () => {
+    // XEP-0353 §3.5: after either side terminates a call, both SHOULD
+    // emit `<finish/>` so the MAM bookend pairing stays consistent.
+    // Without this the responder's archive only carries the `propose`
+    // / `proceed` half of the JMI handshake and the initiator's UI
+    // can't render a clean "call ended" row.
+    const sender = mockSender();
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    });
+    await tearDownActiveCall(sender, "success");
+    expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
+    expect(sender.send_call_finish).toHaveBeenCalledTimes(1);
+    expect(sender.send_call_finish).toHaveBeenCalledWith(
+      "bob@waddle.test/desktop",
+      "c1",
+    );
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
+  test("active DM call: finish failure does not block clearing the slot", async () => {
+    // A stale wasm bundle without `send_call_finish` (or a transient
+    // I/O error inside the finish stanza) MUST NOT keep us stuck on
+    // `phase: active` after the terminate already went out — the
+    // local UI would still render the call overlay while the peer
+    // has already ended.
+    const sender: CallWireSender = {
+      send_call_session_terminate: mock(async () => undefined),
+      // No send_call_finish → outboundCalls.finish throws.
+    };
+    $callState.set({
+      phase: "active",
+      peer: "bob@waddle.test/desktop",
+      sid: "c1",
+      media: audioVideo,
+      join,
+      kind: "dm",
+    });
+    await tearDownActiveCall(sender, "success");
+    expect(sender.send_call_session_terminate).toHaveBeenCalledTimes(1);
+    expect($callState.get()).toEqual({ phase: "idle" });
+  });
+
   test("active call: success reason for graceful logout", async () => {
     const sender = mockSender();
     $callState.set({

--- a/chat/tests/call-tile-attach.test.ts
+++ b/chat/tests/call-tile-attach.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TileAttachments,
+  type TileAttachable,
+} from "../src/lib/calls/tile-attach";
+import {
+  createCallVideoRegistry,
+  type CallVideoRegistry,
+} from "../src/lib/calls/video-registry";
+
+/**
+ * Fake LiveKit Track that records every attach/detach so tests can
+ * assert on the cumulative `attachedElements` LiveKit would track.
+ * Mirrors the relevant surface of `livekit-client`'s `Track.attach` /
+ * `Track.detach` so the helper's behaviour can be exercised without
+ * pulling in the SDK (whose Room constructor reaches for browser
+ * globals).
+ */
+function fakeTrack(): TileAttachable & { attached: HTMLMediaElement[] } {
+  const attached: HTMLMediaElement[] = [];
+  const t: TileAttachable & { attached: HTMLMediaElement[] } = {
+    attached,
+    attach(el) {
+      attached.push(el);
+    },
+    detach(el) {
+      const i = attached.indexOf(el);
+      if (i >= 0) attached.splice(i, 1);
+      return el;
+    },
+  };
+  return t;
+}
+
+/**
+ * Minimal `HTMLMediaElement`-shaped stub. The helper only touches
+ * `srcObject`, and Bun's test env has no DOM, so a plain object with
+ * the right shape is enough.
+ *
+ * For the video-vs-audio branch the helper does an
+ * `instanceof HTMLVideoElement` check. Bun's test runtime doesn't
+ * expose those globals, so we install lightweight class stubs once
+ * per process and build instances of them.
+ */
+class FakeHTMLVideoElement {
+  srcObject: unknown = null;
+}
+class FakeHTMLAudioElement {
+  srcObject: unknown = null;
+}
+const globalRef = globalThis as unknown as {
+  HTMLVideoElement: typeof FakeHTMLVideoElement;
+  HTMLAudioElement: typeof FakeHTMLAudioElement;
+  HTMLMediaElement: typeof FakeHTMLVideoElement;
+};
+if (typeof globalRef.HTMLVideoElement === "undefined") {
+  globalRef.HTMLVideoElement = FakeHTMLVideoElement;
+}
+if (typeof globalRef.HTMLAudioElement === "undefined") {
+  globalRef.HTMLAudioElement = FakeHTMLAudioElement;
+}
+if (typeof globalRef.HTMLMediaElement === "undefined") {
+  globalRef.HTMLMediaElement = FakeHTMLVideoElement;
+}
+
+function fakeEl(tag: "video" | "audio" = "video"): HTMLMediaElement {
+  const el = tag === "video"
+    ? new FakeHTMLVideoElement()
+    : new FakeHTMLAudioElement();
+  return el as unknown as HTMLMediaElement;
+}
+
+describe("TileAttachments", () => {
+  test("mount: attaches the track to the element and remembers the pair", () => {
+    const attachments = new TileAttachments();
+    const el = fakeEl();
+    const track = fakeTrack();
+    attachments.sync("alice:video", el, track, "alice@waddle.test/web", null);
+    expect(track.attached).toEqual([el]);
+    expect(attachments.size()).toBe(1);
+  });
+
+  test("unmount (el=null) detaches the previous track and frees srcObject", () => {
+    const attachments = new TileAttachments();
+    const el = fakeEl();
+    const track = fakeTrack();
+    // simulate a srcObject the browser set on attach.
+    (el as { srcObject: unknown }).srcObject = { stream: true };
+    attachments.sync("alice:video", el, track, "alice@waddle.test/web", null);
+    attachments.sync("alice:video", null, null, "alice@waddle.test/web", null);
+    expect(track.attached).toEqual([]);
+    expect(el.srcObject).toBeNull();
+    expect(attachments.size()).toBe(0);
+  });
+
+  test("re-mount with the same (el, track) is a no-op", () => {
+    // Vue can fire the ref callback with the same pair on a reactive
+    // update; we MUST NOT call `track.attach` a second time — that's
+    // exactly what causes `attachedElements` to double up.
+    const attachments = new TileAttachments();
+    const el = fakeEl();
+    const track = fakeTrack();
+    attachments.sync("alice:video", el, track, "alice@waddle.test/web", null);
+    attachments.sync("alice:video", el, track, "alice@waddle.test/web", null);
+    expect(track.attached).toEqual([el]);
+  });
+
+  test("focus toggle: same track swapped to a new element detaches the old el", () => {
+    // Equivalent to a user clicking a tile to enter focus layout —
+    // the same track is now bound to a different `<video>`. Without
+    // detaching the previous element, LiveKit would attempt to drive
+    // both video elements off one MediaStreamTrack.
+    const attachments = new TileAttachments();
+    const elA = fakeEl();
+    const elB = fakeEl();
+    const track = fakeTrack();
+    attachments.sync("alice:video", elA, track, "alice@waddle.test/web", null);
+    attachments.sync("alice:video", elB, track, "alice@waddle.test/web", null);
+    expect(track.attached).toEqual([elB]);
+  });
+
+  test("participant join + leave: track detaches and registry slot clears", () => {
+    // The reported scenario from the task: a participant joining,
+    // their tile mounting, then leaving — must NOT leave their track
+    // attached. We assert through the fake track's `attached` array.
+    const attachments = new TileAttachments();
+    const reg: CallVideoRegistry = createCallVideoRegistry();
+    const el = fakeEl();
+    const track = fakeTrack();
+    attachments.sync("bob:video", el, track, "bob@waddle.test/web", reg);
+    expect(reg.get("bob@waddle.test/web")).toBe(el as HTMLVideoElement);
+    // Leave — Vue fires `:ref` with null because the element unmounted.
+    attachments.sync("bob:video", null, null, "bob@waddle.test/web", reg);
+    expect(track.attached).toEqual([]);
+    expect(reg.get("bob@waddle.test/web")).toBeNull();
+  });
+
+  test("repeated focus toggles never accumulate attachedElements", () => {
+    // Stronger version of the regression: ten focus toggles back to
+    // back should leave exactly one (el, track) attachment.
+    const attachments = new TileAttachments();
+    const track = fakeTrack();
+    let lastEl: HTMLMediaElement | null = null;
+    for (let i = 0; i < 10; i += 1) {
+      const el = fakeEl();
+      attachments.sync("alice:video", el, track, "alice@waddle.test/web", null);
+      lastEl = el;
+    }
+    expect(track.attached).toEqual(lastEl ? [lastEl] : []);
+  });
+
+  test("identity is only registered for HTMLVideoElement, not audio", () => {
+    // The PIP registry is for video tiles; audio attachments must
+    // not register into it (they'd be invalid PIP targets).
+    const attachments = new TileAttachments();
+    const reg = createCallVideoRegistry();
+    const audioEl = fakeEl("audio");
+    const track = fakeTrack();
+    attachments.sync("alice:audio", audioEl, track, "alice@waddle.test/web", reg);
+    expect(reg.get("alice@waddle.test/web")).toBeNull();
+  });
+});

--- a/chat/tests/call-video-registry.test.ts
+++ b/chat/tests/call-video-registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { createCallVideoRegistry } from "../src/lib/calls/video-registry";
+
+/**
+ * The registry is the seam CallTileGrid uses to expose its `<video>`
+ * elements to CallOverlay's PIP toggle. The contract that matters:
+ *  - register(identity, el) stashes the element.
+ *  - register(identity, null) clears the entry (Vue's `:ref` unmount
+ *    signal) so a stale element from a previous tile mount isn't
+ *    returned after the participant left.
+ *  - register(identity, newEl) overwrites in place — a participant
+ *    swapping camera off/on doesn't leak the previous element.
+ */
+describe("call-video-registry", () => {
+  test("register stores an element retrievable by identity", () => {
+    const reg = createCallVideoRegistry();
+    const el = {} as HTMLVideoElement;
+    reg.register("alice@waddle.test/web", el);
+    expect(reg.get("alice@waddle.test/web")).toBe(el);
+  });
+
+  test("register(identity, null) clears the slot", () => {
+    const reg = createCallVideoRegistry();
+    const el = {} as HTMLVideoElement;
+    reg.register("alice@waddle.test/web", el);
+    reg.register("alice@waddle.test/web", null);
+    expect(reg.get("alice@waddle.test/web")).toBeNull();
+  });
+
+  test("register with a fresh element overwrites the previous one", () => {
+    const reg = createCallVideoRegistry();
+    const first = { id: "1" } as unknown as HTMLVideoElement;
+    const second = { id: "2" } as unknown as HTMLVideoElement;
+    reg.register("alice@waddle.test/web", first);
+    reg.register("alice@waddle.test/web", second);
+    expect(reg.get("alice@waddle.test/web")).toBe(second);
+  });
+
+  test("entries() iterates only currently-registered (identity, el) pairs", () => {
+    const reg = createCallVideoRegistry();
+    const aliceEl = { id: "a" } as unknown as HTMLVideoElement;
+    const bobEl = { id: "b" } as unknown as HTMLVideoElement;
+    reg.register("alice@waddle.test/web", aliceEl);
+    reg.register("bob@waddle.test/web", bobEl);
+    reg.register("bob@waddle.test/web", null);
+    const pairs = Array.from(reg.entries());
+    expect(pairs).toEqual([["alice@waddle.test/web", aliceEl]]);
+  });
+
+  test("get for an unknown identity returns null (not undefined)", () => {
+    const reg = createCallVideoRegistry();
+    expect(reg.get("nobody@waddle.test")).toBeNull();
+  });
+});

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -6098,6 +6098,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -7665,6 +7666,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -95,6 +95,7 @@ sha2 = "0.10"
 p256 = { version = "0.13", features = ["ecdsa", "jwk"] }
 elliptic-curve = { version = "0.13", features = ["jwk"] }
 argon2 = "0.5"
+zeroize = { version = "1", features = ["derive"] }
 
 # Utilities
 uuid = { version = "1.11", features = ["v4", "v7", "serde", "js"] }

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -3,6 +3,59 @@ use super::{
     replay::drain_outbound_into_replay, state::WsConnState, stream_management::sm_show_from_name,
 };
 use waddle_xmpp::muc::room_actor::LeaveOutcome;
+use waddle_xmpp::xep::xep0421::OccupantIdentity;
+
+/// Broadcast a `<presence type='unavailable'/>` from the leaving
+/// occupant's room-nick JID to every remaining occupant when their
+/// LAST session for that nick departs.
+///
+/// XEP-0045 §7.14: the room is responsible for telling remaining
+/// occupants that an occupant has left. The wire shape (room/nick
+/// `from`, hat-less, `<x xmlns='muc#user'>` with role/affiliation,
+/// XEP-0421 `<occupant-id/>`) is produced by the typed
+/// `waddle_xmpp::muc::build_leave_presence` builder.
+///
+/// Used by both the explicit-leave path (`handle_muc_leave`) and the
+/// unclean-disconnect path (`cleanup_muc_presence`) so the two cannot
+/// drift. Prior to this helper, `cleanup_muc_presence` skipped the
+/// broadcast entirely, which manifested as the "N in call" chip
+/// staying lit forever after a tab close: other occupants never
+/// received the leave signal, so their client-side
+/// `$mucCallParticipants` never cleared the stale nick.
+pub(crate) fn broadcast_muc_leave_to_remaining(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    sender_jid: &FullJid,
+    outcome: &LeaveOutcome,
+) {
+    if !outcome.removed_last_session {
+        return;
+    }
+    let from_jid = room_jid
+        .clone()
+        .with_resource_str(&outcome.nick)
+        .unwrap_or_else(|_| sender_jid.clone());
+    let sender_bare = sender_jid.to_bare();
+    let identity = OccupantIdentity {
+        bare_jid: &sender_bare,
+        real_jid: Some(sender_jid),
+        secret: &state.deps.occupant_id_secret,
+    };
+    for occupant_jid in &outcome.remaining_occupants {
+        let presence = waddle_xmpp::muc::build_leave_presence(
+            &from_jid,
+            occupant_jid,
+            outcome.affiliation,
+            false,
+            &identity,
+        );
+        let _ = state
+            .deps
+            .protocol
+            .connection_registry
+            .try_send_to(occupant_jid, Stanza::Presence(presence));
+    }
+}
 
 /// Clean up MUC room presence when a connection disconnects
 /// Public alias for the MUC-presence cleanup used by the SM expired-session
@@ -283,6 +336,16 @@ async fn cleanup_muc_presence(state: &WebSocketState, jid: &FullJid) {
                     removed_last_session = outcome.removed_last_session,
                     "Removed user from MUC room on disconnect"
                 );
+                // Tell remaining occupants the user is gone. Without
+                // this fan-out, a tab-close / SM-expiry / panic-shed
+                // disconnect on a participant who had advertised the
+                // `<call xmlns='urn:waddle:muc-call:0'/>` extension
+                // leaves the "N in call" chip lit on every other
+                // occupant's client. The explicit-leave path
+                // (`handle_muc_leave`) calls the same helper, so the
+                // wire shape is identical regardless of how the
+                // session ended.
+                broadcast_muc_leave_to_remaining(state, &room_jid, jid, &outcome);
                 maybe_evict_empty_room(state, &room_jid, &outcome).await;
             }
             Ok(None) => {}

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -356,33 +356,16 @@ pub async fn handle_muc_leave(
     );
 
     // Broadcast unavailable presence to remaining occupants (non-blocking).
-    // Drop accounting is handled inside `try_send_to`.
-    if outcome.removed_last_session {
-        for occupant_jid in &outcome.remaining_occupants {
-            let from_jid = room_jid
-                .clone()
-                .with_resource_str(&outcome.nick)
-                .unwrap_or_else(|_| sender_jid.clone());
-            let sender_bare = sender_jid.to_bare();
-            let presence = waddle_xmpp::muc::build_leave_presence(
-                &from_jid,
-                occupant_jid,
-                Affiliation::Member,
-                false,
-                &waddle_xmpp::xep::xep0421::OccupantIdentity {
-                    bare_jid: &sender_bare,
-                    real_jid: Some(sender_jid),
-                    secret: &state.deps.occupant_id_secret,
-                },
-            );
-            let stanza = Stanza::Presence(presence);
-            let _outcome = state
-                .deps
-                .protocol
-                .connection_registry
-                .try_send_to(occupant_jid, stanza);
-        }
-    }
+    // Drop accounting is handled inside `try_send_to`. The same helper
+    // is used by `cleanup_muc_presence` for unclean disconnects, so
+    // both the explicit-leave path and the tab-close path produce the
+    // same wire shape.
+    super::super::super::cleanup::broadcast_muc_leave_to_remaining(
+        state,
+        room_jid,
+        sender_jid,
+        &outcome,
+    );
 
     let response = vec![build_muc_self_unavailable_xml(
         state,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -361,10 +361,7 @@ pub async fn handle_muc_leave(
     // both the explicit-leave path and the tab-close path produce the
     // same wire shape.
     super::super::super::cleanup::broadcast_muc_leave_to_remaining(
-        state,
-        room_jid,
-        sender_jid,
-        &outcome,
+        state, room_jid, sender_jid, &outcome,
     );
 
     let response = vec![build_muc_self_unavailable_xml(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -884,15 +884,7 @@ async fn cleanup_muc_presence_broadcasts_unavailable_to_remaining_occupants() {
         &Some(owner_session),
     )
     .await;
-    let _ = handle_muc_join(
-        state.as_ref(),
-        "example.com",
-        &room_jid,
-        &bob,
-        "bob",
-        &None,
-    )
-    .await;
+    let _ = handle_muc_join(state.as_ref(), "example.com", &room_jid, &bob, "bob", &None).await;
 
     // Drain the join broadcast (Alice's room → Bob's mailbox is the
     // self-presence on join; Bob's room → Alice's mailbox would be

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -841,3 +841,89 @@ async fn muc_nick_collision_returns_conflict_presence() {
     assert!(room.find_nick_by_real_jid(&bob).is_none());
     assert_eq!(room.occupant_count(), 1);
 }
+
+#[tokio::test]
+async fn cleanup_muc_presence_broadcasts_unavailable_to_remaining_occupants() {
+    // Regression for the "1 in call" ghost: when a user's connection
+    // drops uncleanly (tab close, SM-expiry, panic-shed), the cleanup
+    // path used to remove them from the room actor but never tell
+    // the remaining occupants. Other clients then kept the leaver's
+    // nick in their `$mucCallParticipants[room]` indefinitely, so
+    // the "N in call" chip stayed lit with nobody actually present.
+    //
+    // The fix routes both the explicit-leave path AND the unclean
+    // disconnect path through `broadcast_muc_leave_to_remaining`, so
+    // remaining occupants receive a `<presence type='unavailable'/>`
+    // either way. This test pins that contract.
+    use super::cleanup::cleanup_muc_presence_for_jid;
+
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "ghost-call-channel@muc.example.com"
+        .parse()
+        .expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/desktop".parse().expect("bob jid");
+
+    // Register Bob's outbound channel so we can capture the broadcast
+    // his client would receive.
+    let (bob_tx, mut bob_rx) = mpsc::channel::<OutboundStanza>(4);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(bob.clone(), bob_tx);
+
+    // Both Alice and Bob join the MUC.
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        &Some(owner_session),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        &None,
+    )
+    .await;
+
+    // Drain the join broadcast (Alice's room → Bob's mailbox is the
+    // self-presence on join; Bob's room → Alice's mailbox would be
+    // the cross-broadcast Alice would receive, but we registered only
+    // Bob so we just need to drain his existing traffic).
+    while bob_rx.try_recv().is_ok() {}
+
+    // Simulate Alice's unclean disconnect — same entry point the SM
+    // janitor and `cleanup_connection_shutdown` reach.
+    cleanup_muc_presence_for_jid(state.as_ref(), &alice).await;
+
+    // The room actor must have evicted Alice's occupant slot.
+    let room = snapshot_room(state.as_ref(), &room_jid).await.room;
+    assert!(
+        room.find_nick_by_real_jid(&alice).is_none(),
+        "Alice's occupant slot must be cleared on unclean disconnect",
+    );
+    assert_eq!(room.find_nick_by_real_jid(&bob), Some("bob"));
+
+    // The fix: Bob receives an `unavailable` presence from
+    // `room/alice` so his client can drop Alice from any
+    // call-participants set keyed by nick.
+    let broadcast = bob_rx
+        .try_recv()
+        .expect("Bob must receive Alice's unavailable broadcast on her unclean disconnect");
+    let xml = stanza_to_xml(&broadcast.stanza);
+    let presence = Element::from_str(&xml).expect("broadcast presence XML");
+    assert_eq!(presence.name(), "presence");
+    assert_eq!(presence.attr("type"), Some("unavailable"));
+    let expected_from = format!("{room_jid}/alice");
+    let expected_to = bob.to_string();
+    assert_eq!(presence.attr("from"), Some(expected_from.as_str()));
+    assert_eq!(presence.attr("to"), Some(expected_to.as_str()));
+}

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -485,7 +485,35 @@ impl WsXmppClient {
                     Ok(tungstenite::Message::Text(text)) if text.contains("<close") => {
                         return Ok(());
                     }
+                    Ok(tungstenite::Message::Text(text))
+                        if text.contains("<stream:error") =>
+                    {
+                        // A stream-level error during close is a protocol
+                        // violation we want the test to surface, not a
+                        // benign in-flight stanza we should drain.
+                        return Err(format!(
+                            "Stream error during close handshake: {text}"
+                        ));
+                    }
+                    Ok(tungstenite::Message::Text(text))
+                        if text.starts_with("<message")
+                            || text.starts_with("<presence")
+                            || text.starts_with("<iq") =>
+                    {
+                        // In-flight stanzas can still arrive between our
+                        // `</close>` and the server's ack — for example,
+                        // an `unavailable` MUC presence broadcast from
+                        // another occupant whose own teardown is being
+                        // processed concurrently. The XMPP spec doesn't
+                        // forbid the server from delivering already-queued
+                        // stanzas during the close handshake, so drain
+                        // them rather than failing the scenario.
+                        continue;
+                    }
                     Ok(tungstenite::Message::Text(text)) => {
+                        // Unknown text frame that isn't a close ack, a
+                        // known stanza, or a stream:error. Surface it so
+                        // unexpected protocol behavior fails loudly.
                         return Err(format!(
                             "Unexpected text frame while waiting for XMPP close acknowledgement: {text}"
                         ));
@@ -509,6 +537,22 @@ impl WsXmppClient {
             while let Some(message) = self.ws.next().await {
                 match message {
                     Ok(tungstenite::Message::Close(_)) => return Ok(()),
+                    Ok(tungstenite::Message::Text(text)) if text.contains("<stream:error") => {
+                        return Err(format!(
+                            "Stream error after WebSocket close request: {text}"
+                        ));
+                    }
+                    Ok(tungstenite::Message::Text(text))
+                        if text.starts_with("<message")
+                            || text.starts_with("<presence")
+                            || text.starts_with("<iq") =>
+                    {
+                        // Same rationale as above: any stanza arriving
+                        // after our `<close/>` ack but before the WS
+                        // close frame is an in-flight reflection of
+                        // another occupant's teardown — drain.
+                        continue;
+                    }
                     Ok(tungstenite::Message::Text(text)) => {
                         return Err(format!(
                             "Unexpected text frame after WebSocket close request: {text}"

--- a/server/crates/waddle-sfu/Cargo.toml
+++ b/server/crates/waddle-sfu/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/server/crates/waddle-sfu/src/config.rs
+++ b/server/crates/waddle-sfu/src/config.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use chrono::Duration;
 use url::Url;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// LiveKit API key (the `iss` claim on minted JWTs).
 #[derive(Clone)]
@@ -35,7 +36,11 @@ impl fmt::Debug for ApiKey {
 }
 
 /// LiveKit API secret. HMAC-SHA256 signing key for join JWTs.
-#[derive(Clone)]
+///
+/// The inner `Vec<u8>` is zeroed on drop via [`ZeroizeOnDrop`] so the
+/// raw key material does not linger in freed allocations after the
+/// secret goes out of scope.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct ApiSecret(Vec<u8>);
 
 /// Minimum acceptable length of an HMAC-SHA256 signing key. RFC 2104
@@ -106,7 +111,10 @@ pub enum InvalidWebsocketUrl {
 
 /// Shared secret for TURN time-limited credentials. Same HMAC-SHA1
 /// shape as the coturn `static-auth-secret` LiveKit's chart sets.
-#[derive(Clone)]
+///
+/// The inner `Vec<u8>` is zeroed on drop via [`ZeroizeOnDrop`] so the
+/// shared secret cannot be recovered from freed heap memory.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
 pub struct TurnSharedSecret(Vec<u8>);
 
 impl TurnSharedSecret {
@@ -410,6 +418,37 @@ mod tests {
             err,
             FromEnvError::InvalidNumber("LIVEKIT_TURN_TLS_PORT")
         ));
+    }
+
+    // `Vec<u8>::zeroize` writes zeros into every byte then resets
+    // `len = 0`. Both surface-observable effects together — bytes
+    // cleared and the secret reduced to empty — are the signal
+    // that the derive on the secret newtypes is wired up, since
+    // without it the secret would still report its original
+    // contents.
+    #[test]
+    fn api_secret_zeroize_empties_the_secret() {
+        use zeroize::Zeroize;
+        let mut secret = ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test secret meets min length");
+        assert!(secret.as_bytes().iter().any(|b| *b != 0));
+        secret.zeroize();
+        assert!(
+            secret.as_bytes().is_empty(),
+            "ApiSecret::zeroize must reduce the secret to an empty buffer"
+        );
+    }
+
+    #[test]
+    fn turn_shared_secret_zeroize_empties_the_secret() {
+        use zeroize::Zeroize;
+        let mut secret = TurnSharedSecret::from_text("turn-shared-secret-value");
+        assert!(secret.as_bytes().iter().any(|b| *b != 0));
+        secret.zeroize();
+        assert!(
+            secret.as_bytes().is_empty(),
+            "TurnSharedSecret::zeroize must reduce the secret to an empty buffer"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -6,31 +6,48 @@
 
 use std::collections::HashSet;
 
-use dashmap::{DashMap, DashSet};
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
 
 use crate::call::{CallId, CallState, Identity, MediaCapabilities};
 use crate::config::{SfuConfig, WebsocketUrl};
 use crate::error::SfuError;
-use crate::token::{mint_join_token, JoinToken, Jti, MintInputs};
+use crate::token::{mint_join_token, IssuedJti, JoinToken, Jti, MintInputs};
 use crate::turn::{mint_turn_credential, TurnCredential, TurnHost};
 use crate::SfuService;
+
+/// Upper bound on outstanding (un-revoked) JTIs tracked per
+/// `(call, identity)`. A participant should never be sitting on more
+/// than a handful of concurrent tokens — every reconnect mints a
+/// fresh one and the previous one is supposed to drop. The cap turns
+/// a buggy client (or a malicious one trying to wedge the tracker)
+/// from an unbounded memory leak into a strict FIFO: the oldest
+/// outstanding JTI is dropped and forgotten when the cap is hit.
+pub(crate) const MAX_ISSUED_PER_PARTICIPANT: usize = 16;
 
 #[derive(Debug)]
 pub struct LiveKitSfu {
     config: SfuConfig,
     calls: DashMap<CallId, HashSet<Identity>>,
-    /// Live JWT identifiers per `(call, identity)` so we can
-    /// individually revoke every token a participant was ever
-    /// issued for a call (someone reconnects → fresh jti → both
-    /// stay tracked until the participant unregisters).
-    issued: DashMap<(CallId, Identity), Vec<Jti>>,
-    /// Set of revoked JWT identifiers. Bookkeeping today — LiveKit
-    /// itself doesn't call back to verify jti, so a stolen token
-    /// stays usable until its `exp`. Documented limitation; the
+    /// Live JWT identifiers per `(call, identity)`, each carrying
+    /// its `exp` so revocation entries can be swept once the token
+    /// would have lapsed anyway. Capped at
+    /// [`MAX_ISSUED_PER_PARTICIPANT`] entries per key — the oldest
+    /// is evicted FIFO when a fresh token is minted past the cap so
+    /// a misbehaving client cannot push the tracker into unbounded
+    /// memory growth.
+    issued: DashMap<(CallId, Identity), Vec<IssuedJti>>,
+    /// Map of revoked JWT identifiers to the `exp` of the token they
+    /// belonged to. Entries are swept lazily once `Utc::now() > exp`:
+    /// a revoked token past its expiry cannot be replayed regardless
+    /// of whether the SFU still remembers its jti, so keeping it in
+    /// the map after that point is pure overhead. Bookkeeping today —
+    /// LiveKit itself doesn't call back to verify jti, so a stolen
+    /// token stays usable until its `exp`. Documented limitation; the
     /// path-to-real-revocation needs LiveKit cooperation (webhook
     /// validation hook) or a shared revocation store (Redis) once
     /// Waddle scales past a single SFU instance.
-    revoked: DashSet<Jti>,
+    revoked: DashMap<Jti, DateTime<Utc>>,
 }
 
 impl LiveKitSfu {
@@ -39,7 +56,7 @@ impl LiveKitSfu {
             config,
             calls: DashMap::new(),
             issued: DashMap::new(),
-            revoked: DashSet::new(),
+            revoked: DashMap::new(),
         }
     }
 
@@ -53,6 +70,31 @@ impl LiveKitSfu {
     /// [`CallState`] derived from this.
     pub fn participant_count(&self, call_id: &CallId) -> usize {
         self.calls.get(call_id).map(|e| e.len()).unwrap_or(0)
+    }
+
+    /// Number of currently-tracked revoked JTIs. Exposed for tests
+    /// to pin the bound on the revocation map.
+    #[cfg(test)]
+    pub(crate) fn revoked_count(&self) -> usize {
+        self.revoked.len()
+    }
+
+    /// Number of currently-tracked issued JTIs for `(call, identity)`.
+    /// Exposed for tests to pin the per-participant FIFO bound.
+    #[cfg(test)]
+    pub(crate) fn issued_count(&self, call_id: &CallId, identity: &Identity) -> usize {
+        self.issued
+            .get(&(call_id.clone(), identity.clone()))
+            .map(|e| e.len())
+            .unwrap_or(0)
+    }
+
+    /// Drop every revocation entry whose original token would have
+    /// expired at or before `now`. Called from
+    /// [`SfuService::unregister_call_participant`] so the map stays
+    /// bounded under steady call churn.
+    fn sweep_expired_revoked(&self, now: DateTime<Utc>) {
+        self.revoked.retain(|_, exp| *exp > now);
     }
 }
 
@@ -72,13 +114,24 @@ impl SfuService for LiveKitSfu {
             capabilities,
             ttl: self.config.token_ttl,
         })?;
-        // Track the jti against `(call, identity)` so a subsequent
-        // unregister revokes every JWT this participant ever held
-        // for the call.
-        self.issued
+        // Track the (jti, exp) pair against `(call, identity)` so a
+        // subsequent unregister revokes every JWT this participant
+        // ever held for the call. Cap the per-participant vec to
+        // bound memory under reconnect storms or a misbehaving
+        // client; oldest entries are evicted FIFO and silently
+        // forgotten (their tokens will simply lapse on their own
+        // `exp`, which the rest of this struct already relies on).
+        let mut entry = self
+            .issued
             .entry((call_id.clone(), identity.clone()))
-            .or_default()
-            .push(token.jti.clone());
+            .or_default();
+        while entry.len() >= MAX_ISSUED_PER_PARTICIPANT {
+            entry.remove(0);
+        }
+        entry.push(IssuedJti {
+            jti: token.jti.clone(),
+            exp: token.expires_at,
+        });
         Ok(token)
     }
 
@@ -109,12 +162,20 @@ impl SfuService for LiveKitSfu {
         // Revoke every JWT issued to this (call, identity). Token
         // theft after the legitimate hangup is the threat model;
         // see `revoked` field comment for the LiveKit-cooperation
-        // gap that makes this advisory today.
-        if let Some((_, jtis)) = self.issued.remove(&(call_id.clone(), identity.clone())) {
-            for jti in jtis {
-                self.revoked.insert(jti);
+        // gap that makes this advisory today. Each revocation
+        // carries the original token's `exp` so the entry can be
+        // swept once it would have lapsed anyway.
+        if let Some((_, issued)) = self.issued.remove(&(call_id.clone(), identity.clone())) {
+            for issued in issued {
+                self.revoked.insert(issued.jti, issued.exp);
             }
         }
+
+        // Opportunistically sweep revoked entries past their
+        // original expiry. This keeps the map bounded under steady
+        // call churn — every unregister cleans up at least as much
+        // as it adds, plus any older entries that have aged out.
+        self.sweep_expired_revoked(Utc::now());
 
         if remaining == 0 {
             self.calls.remove(call_id);
@@ -125,7 +186,19 @@ impl SfuService for LiveKitSfu {
     }
 
     fn is_revoked(&self, jti: &Jti) -> bool {
-        self.revoked.contains(jti)
+        // Lazy sweep on the read path: an entry past its `exp` is
+        // by definition unusable and so reads as not-revoked. Drop
+        // it from the map so memory doesn't grow on every check.
+        if let Some(entry) = self.revoked.get(jti) {
+            let exp = *entry.value();
+            drop(entry);
+            if Utc::now() >= exp {
+                self.revoked.remove(jti);
+                return false;
+            }
+            return true;
+        }
+        false
     }
 
     fn ws_url(&self) -> &WebsocketUrl {
@@ -260,6 +333,65 @@ mod tests {
         // Alice's hangup must not revoke bob's still-active token.
         assert!(sfu.is_revoked(&alice_token.jti));
         assert!(!sfu.is_revoked(&bob_token.jti));
+    }
+
+    #[test]
+    fn issued_jti_vec_is_capped_per_participant() {
+        let sfu = LiveKitSfu::new(fixture_config());
+        let call = CallId::new("c-cap").unwrap();
+        let alice = fixture_identity("alice");
+
+        // Mint well past the cap; every fresh token should slot in,
+        // but the per-participant vec must never exceed it.
+        for _ in 0..(MAX_ISSUED_PER_PARTICIPANT * 3) {
+            sfu.issue_join_token(&call, &alice, MediaCapabilities::full_participant())
+                .expect("token issued");
+            assert!(
+                sfu.issued_count(&call, &alice) <= MAX_ISSUED_PER_PARTICIPANT,
+                "issued vec must stay <= MAX_ISSUED_PER_PARTICIPANT"
+            );
+        }
+        assert_eq!(
+            sfu.issued_count(&call, &alice),
+            MAX_ISSUED_PER_PARTICIPANT,
+            "issued vec must saturate exactly at the cap"
+        );
+    }
+
+    #[test]
+    fn revoked_entries_are_swept_once_past_expiry() {
+        use chrono::Duration as ChronoDuration;
+        let sfu = LiveKitSfu::new(fixture_config());
+
+        // Seed the revoked map directly with a past-exp entry so
+        // the test does not depend on real-time tickdown of the
+        // token TTL.
+        let stale_jti = Jti::new();
+        let fresh_jti = Jti::new();
+        sfu.revoked
+            .insert(stale_jti.clone(), Utc::now() - ChronoDuration::seconds(60));
+        sfu.revoked
+            .insert(fresh_jti.clone(), Utc::now() + ChronoDuration::seconds(60));
+
+        // Reading the stale jti must return false (the token can
+        // no longer be replayed regardless) AND drop the entry.
+        assert!(!sfu.is_revoked(&stale_jti));
+        assert!(sfu.is_revoked(&fresh_jti));
+        assert_eq!(sfu.revoked_count(), 1);
+
+        // Running the unregister-path sweep clears any other stale
+        // entries that piled up since the last sweep.
+        sfu.revoked
+            .insert(Jti::new(), Utc::now() - ChronoDuration::seconds(1));
+        let alice = fixture_identity("alice");
+        let call = CallId::new("c-sweep").unwrap();
+        sfu.register_call_participant(&call, &alice);
+        sfu.unregister_call_participant(&call, &alice);
+        assert_eq!(
+            sfu.revoked_count(),
+            1,
+            "unregister sweep must clear past-exp entries; one fresh entry should remain"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-sfu/src/token.rs
+++ b/server/crates/waddle-sfu/src/token.rs
@@ -71,6 +71,17 @@ impl std::fmt::Debug for Jwt {
     }
 }
 
+/// A `(jti, exp)` pair the SFU records for an issued join token.
+/// Used by [`crate::LiveKitSfu`] to bound the revocation registry:
+/// the `exp` lets the SFU drop revoked entries once the token
+/// would have lapsed anyway, since a token past its `exp` is
+/// unusable regardless of whether its jti is still remembered.
+#[derive(Debug, Clone)]
+pub(crate) struct IssuedJti {
+    pub jti: Jti,
+    pub exp: DateTime<Utc>,
+}
+
 /// Fully-issued join credential. Returned by
 /// [`crate::SfuService::issue_join_token`] and used to populate the
 /// outbound `urn:waddle:transports:livekit:0` transport.

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -2,7 +2,8 @@ use super::*;
 use std::str::FromStr;
 use waddle_xmpp_client::messaging::{
     build_finish, build_proceed, build_propose, build_reject, build_retract, build_session_accept,
-    build_session_initiate, build_session_terminate, CallMedia, JingleReason, SessionId,
+    build_session_initiate, build_session_terminate, wrap_jmi_message, CallMedia, JingleReason,
+    SessionId,
 };
 
 const NS_WADDLE_MUC_CALL: &str = "urn:waddle:muc-call:0";
@@ -60,11 +61,17 @@ fn parse_muc_call_join_result(result: &Element) -> Result<crate::types::WaddleLi
     })
 }
 
-fn message_with_jmi(to: &str, jmi: Element) -> Element {
-    Element::builder("message", NS_JABBER_CLIENT)
-        .attr("to", to)
-        .append(jmi)
-        .build()
+/// Wrap a JMI body in the XEP-0353 §3-conformant `<message type='chat'>`
+/// envelope with a XEP-0334 `<store/>` hint. Routes through
+/// [`waddle_xmpp_client::messaging::wrap_jmi_message`] so the wasm and
+/// native clients ship byte-identical envelopes; the only wasm-local
+/// concern is parsing the JS `String` `to` into a typed
+/// [`jid::Jid`] at the boundary.
+fn message_with_jmi(to: &str, jmi: Element) -> Result<Element, JsValue> {
+    let to_jid: jid::Jid = to
+        .parse()
+        .map_err(|_| js_error(format!("invalid JID for JMI envelope: {to}")))?;
+    Ok(wrap_jmi_message(&to_jid, jmi))
 }
 
 fn iq_set(to: &str, payload: Element) -> Element {
@@ -110,7 +117,7 @@ impl WaddleClient {
             let stanza = message_with_jmi(
                 &peer_bare_jid,
                 build_propose(&sid(sid_str), media_from_flags(audio, video)),
-            );
+            )?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -119,7 +126,7 @@ impl WaddleClient {
     pub fn send_call_proceed(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_proceed(&sid(sid_str)));
+            let stanza = message_with_jmi(&peer_full_jid, build_proceed(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -128,7 +135,7 @@ impl WaddleClient {
     pub fn send_call_reject(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_reject(&sid(sid_str)));
+            let stanza = message_with_jmi(&peer_full_jid, build_reject(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -137,7 +144,7 @@ impl WaddleClient {
     pub fn send_call_retract(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_retract(&sid(sid_str)));
+            let stanza = message_with_jmi(&peer_full_jid, build_retract(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -146,7 +153,7 @@ impl WaddleClient {
     pub fn send_call_finish(&self, peer_full_jid: String, sid_str: String) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = message_with_jmi(&peer_full_jid, build_finish(&sid(sid_str)));
+            let stanza = message_with_jmi(&peer_full_jid, build_finish(&sid(sid_str)))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -407,5 +414,46 @@ mod tests {
         assert!(FullJid::from_str("not-a-jid").is_err());
         assert!(FullJid::from_str("@domain/res").is_err());
         assert!(FullJid::from_str("").is_err());
+    }
+
+    /// XEP-0353 §3: every JMI envelope MUST be `type='chat'` and MUST
+    /// contain a XEP-0334 `<store/>` hint. Tests against the shared
+    /// helper which both the native and wasm clients route through —
+    /// keeps the wire shape locked from the wasm boundary down.
+    #[test]
+    fn message_with_jmi_stamps_chat_type_and_store_hint() {
+        use waddle_xmpp_client::messaging::build_propose;
+        let body = build_propose(
+            &waddle_xmpp_client::messaging::SessionId("c1".into()),
+            waddle_xmpp_client::messaging::CallMedia::audio_only(),
+        );
+        let stanza = super::message_with_jmi("bob@waddle.test", body).expect("valid JID accepted");
+        assert_eq!(stanza.name(), "message");
+        assert_eq!(stanza.attr("type"), Some("chat"));
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test"));
+        assert!(
+            stanza
+                .children()
+                .any(|c| c.name() == "store" && c.ns() == "urn:xmpp:hints"),
+            "XEP-0334 <store/> hint required by XEP-0353 §3"
+        );
+        assert!(
+            stanza
+                .children()
+                .any(|c| c.name() == "propose" && c.ns() == "urn:xmpp:jingle-message:0"),
+            "JMI body preserved"
+        );
+    }
+
+    /// `message_with_jmi` returns `Result<_, JsValue>` on the error
+    /// path, and `JsValue::from_str` panics under `cargo test` on
+    /// native (it's only safe on wasm32). The JID parse itself is a
+    /// thin `s.parse::<jid::Jid>()` call though, so we test the
+    /// underlying parse directly — same coverage, no JsValue
+    /// instantiation on native.
+    #[test]
+    fn jmi_envelope_jid_parse_rejects_garbage() {
+        assert!("@bogus".parse::<jid::Jid>().is_err());
+        assert!("".parse::<jid::Jid>().is_err());
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -23,7 +23,7 @@ pub use builders::{
 pub use call::{
     build_finish, build_proceed, build_propose, build_reject, build_retract, build_session_accept,
     build_session_initiate, build_session_terminate, parse_call_event, parse_jingle_iq,
-    parse_jmi_message, CallEventKind, CallMedia, InboundCallEvent, LiveKitJoin,
+    parse_jmi_message, wrap_jmi_message, CallEventKind, CallMedia, InboundCallEvent, LiveKitJoin,
 };
 pub use namespaces::{
     build_muc_call_extension_element, NS_CHAT_MARKERS, NS_CHAT_STATES, NS_MESSAGE_CORRECT,

--- a/server/crates/waddle-xmpp-client/src/messaging/call.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/call.rs
@@ -20,6 +20,7 @@
 use jid::{FullJid, Jid};
 use minidom::Element;
 use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::message::{Message, MessageType};
 
 /// Media kinds offered or accepted on a call. Inferred from the
 /// JMI `<description media='…'/>` child or from the Jingle content
@@ -94,6 +95,11 @@ const NS_JINGLE: &str = "urn:xmpp:jingle:1";
 const NS_JINGLE_MESSAGE: &str = "urn:xmpp:jingle-message:0";
 const NS_JINGLE_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
 const NS_WADDLE_LIVEKIT_TRANSPORT: &str = "urn:waddle:transports:livekit:0";
+/// XEP-0334 Message Processing Hints namespace. The `<store/>` hint
+/// is mandatory on every JMI envelope per XEP-0353 §3 so MAM
+/// archives keep the call timeline reconstructible even when the
+/// stanza carries no body.
+const NS_HINTS: &str = "urn:xmpp:hints";
 
 /// Parse a `<message>` stanza for a JMI envelope. Returns `None`
 /// when no `urn:xmpp:jingle-message:0` child is present.
@@ -277,6 +283,29 @@ pub fn build_finish(sid: &SessionId) -> Element {
     Element::builder("finish", NS_JINGLE_MESSAGE)
         .attr("id", sid.0.as_str())
         .build()
+}
+
+/// Wrap a JMI body (`<propose/>` / `<proceed/>` / `<reject/>` /
+/// `<retract/>` / `<finish/>`) in the XEP-0353 §3-conformant
+/// `<message type='chat'>` envelope. The envelope MUST be `type='chat'`
+/// and MUST carry the XEP-0334 `<store/>` hint so MAM archives keep
+/// the call timeline reconstructible even when the body is empty.
+///
+/// The envelope is constructed via the typed
+/// [`xmpp_parsers::message::Message`] so `type='chat'` flows through the
+/// dedicated `MessageType::Chat` variant instead of an ad-hoc attribute
+/// (typed-payloads rule). The store hint is the only payload Waddle
+/// adds — the JMI body itself is appended next so the responder's
+/// parser still sees it as the first non-hint child.
+pub fn wrap_jmi_message(to: &Jid, jmi: Element) -> Element {
+    let mut msg = Message::new_with_type(MessageType::Chat, Some(to.clone()));
+    msg.payloads.push(store_hint_element());
+    msg.payloads.push(jmi);
+    Element::from(msg)
+}
+
+fn store_hint_element() -> Element {
+    Element::builder("store", NS_HINTS).build()
 }
 
 /// Build the `<jingle/>` body of a session-initiate IQ. The
@@ -661,6 +690,68 @@ mod tests {
 
         let without = build_session_terminate(&sid("c1"), None);
         assert!(without.children().all(|c| c.name() != "reason"));
+    }
+
+    #[test]
+    fn wrap_jmi_message_stamps_type_chat_and_store_hint() {
+        // XEP-0353 §3: every JMI message (propose / proceed / reject /
+        // retract / finish) MUST be `type='chat'` and MUST contain a
+        // XEP-0334 `<store/>` hint. Without this envelope, JMI stanzas
+        // ship as `type='normal'` and skip MAM archival, breaking call
+        // history reconstruction.
+        let to: Jid = "bob@waddle.test".parse().unwrap();
+        let stanza = wrap_jmi_message(&to, build_propose(&sid("c1"), CallMedia::audio_video()));
+        assert_eq!(stanza.name(), "message");
+        assert_eq!(stanza.attr("type"), Some("chat"));
+        assert_eq!(stanza.attr("to"), Some("bob@waddle.test"));
+        let store = stanza
+            .children()
+            .find(|c| c.name() == "store" && c.ns() == NS_HINTS)
+            .expect("XEP-0334 <store/> hint required by XEP-0353 §3");
+        assert!(store.children().next().is_none());
+        // The JMI body itself rides along, so the responder's parser
+        // still surfaces it via parse_jmi_message → CallEventKind.
+        let ev = parse_call_event(
+            &Element::builder("message", "jabber:client")
+                .attr("from", "alice@waddle.test/desktop")
+                .attr("type", stanza.attr("type").unwrap_or_default())
+                .append_all(stanza.children().cloned())
+                .build(),
+        )
+        .expect("wrapped JMI body still parses as a call event");
+        assert!(matches!(ev.kind, CallEventKind::Propose { .. }));
+    }
+
+    #[test]
+    fn wrap_jmi_message_preserves_jmi_body_for_every_variant() {
+        // Every JMI variant must survive the envelope.
+        let to: Jid = "bob@waddle.test".parse().unwrap();
+        let cases: Vec<(&str, Element)> = vec![
+            (
+                "propose",
+                build_propose(&sid("c1"), CallMedia::audio_only()),
+            ),
+            ("proceed", build_proceed(&sid("c1"))),
+            ("reject", build_reject(&sid("c1"))),
+            ("retract", build_retract(&sid("c1"))),
+            ("finish", build_finish(&sid("c1"))),
+        ];
+        for (name, body) in cases {
+            let stanza = wrap_jmi_message(&to, body);
+            assert_eq!(stanza.attr("type"), Some("chat"), "{name}: type=chat");
+            assert!(
+                stanza
+                    .children()
+                    .any(|c| c.name() == name && c.ns() == NS_JINGLE_MESSAGE),
+                "{name}: JMI body preserved"
+            );
+            assert!(
+                stanza
+                    .children()
+                    .any(|c| c.name() == "store" && c.ns() == NS_HINTS),
+                "{name}: store hint attached"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -133,13 +133,29 @@ pub struct MucRoom {
     ///    the source of truth rather than echoing a possibly-stale
     ///    payload from the client.
     ///
-    /// Entries are cleared on occupant leave so a tab-close mid-call
-    /// doesn't leave the chip lit forever; the SFU teardown hook
-    /// (`muc_call_sfu::unregister_participant_from_room`) is the
-    /// authoritative call-end signal, but clearing here keeps the
-    /// XMPP indicator coherent without depending on the SFU's
-    /// timeout.
-    pub(super) call_state: HashMap<String, MucCallExtension>,
+    /// Each entry records the originating `FullJid` so that when a
+    /// user has multiple sessions sharing the same nick (web + mobile),
+    /// the call advertisement is tied to the specific session that
+    /// joined the call. When that session leaves — clean hangup OR
+    /// unclean disconnect — its `<call/>` advertisement is cleared
+    /// even if the user's other sessions are still in the room. Without
+    /// this per-session keying, alice's mobile staying in the channel
+    /// after her desktop (which was on the call) drops would keep the
+    /// chip lit forever for late joiners.
+    pub(super) call_state: HashMap<String, CallStateEntry>,
+}
+
+/// One advertised `<call/>` entry plus the session that owns it.
+///
+/// The `originator` field is the `FullJid` of the session that emitted
+/// the `state='active'` presence update. When that exact session leaves
+/// the room (or its WebSocket drops), the entry is removed regardless
+/// of whether other sessions for the same nick remain — preventing
+/// ghost call advertisements on multi-resource occupants.
+#[derive(Debug, Clone)]
+pub(super) struct CallStateEntry {
+    pub originator: FullJid,
+    pub extension: MucCallExtension,
 }
 
 impl MucRoom {
@@ -167,10 +183,12 @@ impl MucRoom {
     }
 
     /// Apply a `<call xmlns='urn:waddle:muc-call:0'/>` presence-extension
-    /// update from `nick`. `state='active'` stores the extension;
-    /// `state='inactive'` clears it (we DO NOT preserve an "inactive"
-    /// entry — the room-actor's perspective is binary: this nick is
-    /// currently advertising a live call, or they aren't).
+    /// update from `nick`, identified by the specific session
+    /// (`originator`) that emitted it. `state='active'` stores the
+    /// extension; `state='inactive'` clears it (we DO NOT preserve an
+    /// "inactive" entry — the room-actor's perspective is binary:
+    /// this nick is currently advertising a live call, or they
+    /// aren't).
     ///
     /// Returns the post-update extension state for `nick`:
     /// `Some(ext)` if a live `active` advertisement is now present,
@@ -181,11 +199,18 @@ impl MucRoom {
     pub fn upsert_call_state(
         &mut self,
         nick: &str,
+        originator: FullJid,
         ext: MucCallExtension,
     ) -> Option<MucCallExtension> {
         match ext.state {
             CallPresenceState::Active => {
-                self.call_state.insert(nick.to_owned(), ext.clone());
+                self.call_state.insert(
+                    nick.to_owned(),
+                    CallStateEntry {
+                        originator,
+                        extension: ext.clone(),
+                    },
+                );
                 Some(ext)
             }
             CallPresenceState::Inactive => {
@@ -199,7 +224,7 @@ impl MucRoom {
     /// Used by the join handler to enrich the replayed occupant
     /// presence list with active-call indicators for late joiners.
     pub fn call_state_for_nick(&self, nick: &str) -> Option<&MucCallExtension> {
-        self.call_state.get(nick)
+        self.call_state.get(nick).map(|entry| &entry.extension)
     }
 
     /// Add an occupant to the room.
@@ -253,6 +278,14 @@ impl MucRoom {
     /// Returns `Some(true)` if that session was the last one for the nick and
     /// the occupant was removed, `Some(false)` if the nick still has active
     /// sessions, and `None` if the nickname doesn't exist in the room.
+    ///
+    /// If `call_state[nick]` was originated by the leaving session,
+    /// the entry is cleared even when other sessions for the same
+    /// nick remain. This avoids ghost call advertisements when one
+    /// resource of a multi-resource occupant disconnects mid-call:
+    /// alice/desktop on the call, alice/mobile in the room (not on
+    /// the call), desktop drops → the call advertisement must clear,
+    /// not persist under mobile's session.
     pub fn remove_occupant_session(&mut self, nick: &str, jid: &FullJid) -> Option<bool> {
         if !self.occupants.contains_key(nick) {
             return None;
@@ -269,6 +302,18 @@ impl MucRoom {
 
         if previous_len == sessions.len() {
             return Some(false);
+        }
+
+        // Clear call advertisement when the originating session leaves
+        // even if peer sessions for the same nick remain. Without this
+        // clause the chip would stay lit (and replay to late joiners)
+        // until the user's LAST session for this nick departs.
+        if self
+            .call_state
+            .get(nick)
+            .is_some_and(|entry| entry.originator == *jid)
+        {
+            self.call_state.remove(nick);
         }
 
         if sessions.is_empty() {

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -234,7 +234,13 @@ impl kameo::message::Message<UpsertCallPresence> for RoomActor {
             .values()
             .flat_map(|o| self.room.get_occupant_sessions(&o.nick))
             .collect();
-        let active_extension = self.room.upsert_call_state(&sender_nick, msg.extension);
+        // Bind the call advertisement to the specific session that
+        // emitted it so a partial-session leave (one resource of a
+        // multi-resource occupant) clears the chip even when the
+        // user's other sessions remain in the room.
+        let active_extension =
+            self.room
+                .upsert_call_state(&sender_nick, msg.sender_jid.clone(), msg.extension);
         Ok(Some(CallPresenceUpdateOutcome {
             update: PresenceUpdateOutcome {
                 sender_nick,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1057,3 +1057,157 @@ async fn leaving_occupant_clears_call_state() {
     // verify indirectly via the `is_dormant` predicate once carol
     // also leaves — the room MUST be dormant.
 }
+
+#[tokio::test]
+async fn leaving_originator_session_clears_call_state_even_with_peer_sessions_remaining() {
+    // Multi-resource ghost regression. alice has two sessions on the
+    // same nick — desktop on the call, mobile in the room but not on
+    // the call. When desktop disconnects, the call advertisement
+    // bound to that specific session must clear; previously the
+    // chip stayed lit because `call_state` was keyed only by nick
+    // and only cleared when the LAST session for that nick left.
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join recognized as same-bare multi-session");
+
+    let call_id = waddle_sfu::CallId::new("testroom@muc.example.com").unwrap();
+    // Desktop is the session that advertised the active call.
+    let active_outcome = actor
+        .ask(crate::muc::room_actor::UpsertCallPresence {
+            sender_jid: desktop.clone(),
+            extension: crate::xep::xep_waddle_muc_call::MucCallExtension::active(call_id.clone()),
+        })
+        .await
+        .expect("ask")
+        .expect("alice is an occupant");
+    assert!(
+        active_outcome.active_extension.is_some(),
+        "desktop's active advertisement is stored",
+    );
+
+    // Desktop disconnects uncleanly; mobile is still in the room.
+    let leave_outcome = actor
+        .ask(crate::muc::room_actor::LeaveByRealJid {
+            sender_jid: desktop.clone(),
+        })
+        .await
+        .expect("desktop leave");
+    let leave_outcome = leave_outcome.expect("alice present");
+    assert!(
+        !leave_outcome.removed_last_session,
+        "mobile is still in the room, so alice's nick is not vacated"
+    );
+
+    // A late joiner (carol) must NOT see alice's stale call ad —
+    // even though alice's mobile is still in the room, no session
+    // is actually on the call.
+    let carol = test_full_jid("carol");
+    let join_outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: carol,
+            nick: "carol".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("carol join");
+    let alice_replay = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|o| o.nick == "alice")
+        .expect("alice (via mobile) still in occupant list");
+    assert!(
+        alice_replay.call_extension.is_none(),
+        "call extension cleared when originating session left, even with peer sessions remaining",
+    );
+}
+
+#[tokio::test]
+async fn leaving_non_originator_session_preserves_call_state() {
+    // The mirror of the multi-session ghost test: if alice has two
+    // sessions and only the NON-call session leaves, the call
+    // advertisement bound to the still-present originator must
+    // survive. This pins that the per-session keying isn't
+    // over-eager.
+    let actor = spawn_room_actor().await;
+    let desktop: FullJid = "alice@example.com/desktop".parse().expect("desktop");
+    let mobile: FullJid = "alice@example.com/mobile".parse().expect("mobile");
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: desktop.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("desktop join");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: mobile.clone(),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("mobile join");
+
+    let call_id = waddle_sfu::CallId::new("testroom@muc.example.com").unwrap();
+    // Desktop owns the call advertisement.
+    actor
+        .ask(crate::muc::room_actor::UpsertCallPresence {
+            sender_jid: desktop.clone(),
+            extension: crate::xep::xep_waddle_muc_call::MucCallExtension::active(call_id.clone()),
+        })
+        .await
+        .expect("ask")
+        .expect("alice is an occupant");
+
+    // Mobile (NOT the originator) disconnects.
+    actor
+        .ask(crate::muc::room_actor::LeaveByRealJid { sender_jid: mobile })
+        .await
+        .expect("mobile leave");
+
+    // A late joiner sees alice still on the call — desktop is the
+    // originator and is still in the room.
+    let carol = test_full_jid("carol");
+    let join_outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: carol,
+            nick: "carol".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+        })
+        .await
+        .expect("carol join");
+    let alice_replay = join_outcome
+        .existing_occupants
+        .iter()
+        .find(|o| o.nick == "alice")
+        .expect("alice still in room via desktop");
+    let ext = alice_replay
+        .call_extension
+        .as_ref()
+        .expect("call advertisement preserved when non-originator session leaves");
+    assert_eq!(ext.call_id.as_str(), call_id.as_str());
+}

--- a/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/extdisco.rs
@@ -17,7 +17,8 @@ use waddle_sfu::{Identity, SfuService};
 use crate::protocol::event::{OutboundEvent, StanzaContext};
 use crate::protocol::traits::IqHandler;
 use crate::xep::xep0215::{
-    build_stun_service, build_turn_service, ServiceType, ServicesResult, NS_EXT_DISCO,
+    build_services_result_element, build_stun_service_element, build_turn_service, ServiceType,
+    NS_EXT_DISCO,
 };
 use crate::Stanza;
 
@@ -90,7 +91,7 @@ impl IqHandler for ExtDiscoHandler {
         // that explicitly filter to `type='stun'`.
         let want_turn = type_filter != Some(ServiceType::Stun);
         let want_stun = type_filter != Some(ServiceType::Turn);
-        let mut services = Vec::with_capacity(2);
+        let mut services: Vec<minidom::Element> = Vec::with_capacity(2);
         if want_turn {
             // Mint credentials scoped to the authenticated session
             // JID, never the client-supplied `iq.from` (which could
@@ -113,19 +114,37 @@ impl IqHandler for ExtDiscoHandler {
             }
         }
         if want_stun {
-            services.push(build_stun_service(self.sfu.turn_host(), self.turn_udp_port));
+            services.push(build_stun_service_element(
+                self.sfu.turn_host(),
+                self.turn_udp_port,
+            ));
         }
-        let result = ServicesResult {
-            type_: type_filter,
-            services,
-        };
+        // The wrapper element is built manually rather than via
+        // `ServicesResult` so it can carry the manually-built
+        // `<service type='turns'/>` child — `ServicesResult.services:
+        // Vec<Service>` can only hold the typed `Stun`/`Turn`
+        // variants and would emit `type='turn'` (wrong per XEP-0215
+        // §3.6.5).
+        let type_filter_str = type_filter.map(service_type_wire_str);
+        let result = build_services_result_element(type_filter_str, services);
         let reply = Iq {
             from: iq.to.clone(),
             to: iq.from.clone(),
             id: iq.id.clone(),
-            payload: IqType::Result(Some(result.into())),
+            payload: IqType::Result(Some(result)),
         };
         vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(reply)))]
+    }
+}
+
+/// Wire-form `type` value for the (typed) filter on the inbound
+/// request. The TLS-protected `turns` variant is only ever emitted
+/// in the response (XEP-0215 §3.6.5); the filter on the request
+/// itself uses the typed surface, which never includes `turns`.
+fn service_type_wire_str(t: ServiceType) -> &'static str {
+    match t {
+        ServiceType::Stun => "stun",
+        ServiceType::Turn => "turn",
     }
 }
 
@@ -142,7 +161,7 @@ fn error_reply(original: &Iq, cond: DefinedCondition, text: &str) -> Vec<Outboun
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::xep::xep0215::{ServiceType, Transport};
+    use crate::xep::xep0215::TYPE_TURNS;
     use chrono::Duration;
     use jid::FullJid;
     use minidom::Element;
@@ -195,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn services_query_returns_turn_and_stun_entries() {
+    fn services_query_returns_turns_and_stun_entries() {
         let iq = services_get_iq();
         let jid = test_jid();
         let handler = ExtDiscoHandler::new(fixture_sfu(), 443, 3478);
@@ -211,17 +230,28 @@ mod tests {
         let IqType::Result(Some(elem)) = reply.payload else {
             panic!("expected Iq result with payload")
         };
-        let parsed = ServicesResult::try_from(elem).expect("services result parses");
-        assert_eq!(parsed.services.len(), 2);
-        assert_eq!(parsed.services[0].type_, ServiceType::Turn);
-        assert_eq!(parsed.services[0].transport, Some(Transport::Tcp));
-        assert_eq!(parsed.services[0].port, Some(443));
-        assert!(parsed.services[0].username.is_some());
-        assert!(parsed.services[0].password.is_some());
-        assert!(parsed.services[0].expires.is_some());
-        assert_eq!(parsed.services[1].type_, ServiceType::Stun);
-        assert_eq!(parsed.services[1].transport, Some(Transport::Udp));
-        assert_eq!(parsed.services[1].port, Some(3478));
+        assert_eq!(elem.name(), "services");
+        assert_eq!(elem.ns(), NS_EXT_DISCO);
+
+        let entries: Vec<&Element> = elem.children().filter(|c| c.name() == "service").collect();
+        assert_eq!(entries.len(), 2);
+
+        // XEP-0215 §3.6.5: TLS-protected TURN must go out as
+        // `type='turns'`. The manual element-building path is
+        // exactly what makes this possible — `ServicesResult`'s
+        // typed `Vec<Service>` cannot represent this value.
+        let turns = entries[0];
+        assert_eq!(turns.attr("type"), Some(TYPE_TURNS));
+        assert_eq!(turns.attr("transport"), Some("tcp"));
+        assert_eq!(turns.attr("port"), Some("443"));
+        assert!(turns.attr("username").is_some());
+        assert!(turns.attr("password").is_some());
+        assert!(turns.attr("expires").is_some());
+
+        let stun = entries[1];
+        assert_eq!(stun.attr("type"), Some("stun"));
+        assert_eq!(stun.attr("transport"), Some("udp"));
+        assert_eq!(stun.attr("port"), Some("3478"));
     }
 
     #[test]
@@ -268,7 +298,7 @@ mod tests {
     }
 
     #[test]
-    fn services_query_with_type_turn_returns_only_turn_entry() {
+    fn services_query_with_type_turn_returns_only_turns_entry() {
         let iq = Iq {
             from: Some("alice@waddle.test/desktop".parse().unwrap()),
             to: Some("waddle.test".parse().unwrap()),
@@ -289,10 +319,12 @@ mod tests {
         let IqType::Result(Some(elem)) = reply.payload else {
             panic!("expected result")
         };
-        let parsed = ServicesResult::try_from(elem).expect("services result parses");
-        assert_eq!(parsed.type_, Some(ServiceType::Turn));
-        assert_eq!(parsed.services.len(), 1);
-        assert_eq!(parsed.services[0].type_, ServiceType::Turn);
+        assert_eq!(elem.attr("type"), Some("turn"));
+        let entries: Vec<&Element> = elem.children().filter(|c| c.name() == "service").collect();
+        assert_eq!(entries.len(), 1);
+        // The filter on the request is the typed surface ("turn"),
+        // but the response is the XEP-conformant "turns" wire value.
+        assert_eq!(entries[0].attr("type"), Some(TYPE_TURNS));
     }
 
     #[test]
@@ -317,11 +349,11 @@ mod tests {
         let IqType::Result(Some(elem)) = reply.payload else {
             panic!("expected result")
         };
-        let parsed = ServicesResult::try_from(elem).expect("services result parses");
-        assert_eq!(parsed.type_, Some(ServiceType::Stun));
-        assert_eq!(parsed.services.len(), 1);
-        assert_eq!(parsed.services[0].type_, ServiceType::Stun);
-        assert!(parsed.services[0].username.is_none());
+        assert_eq!(elem.attr("type"), Some("stun"));
+        let entries: Vec<&Element> = elem.children().filter(|c| c.name() == "service").collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].attr("type"), Some("stun"));
+        assert!(entries[0].attr("username").is_none());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0215.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0215.rs
@@ -6,27 +6,37 @@
 //! clients refresh before they go stale.
 //!
 //! Thin wrapper over [`xmpp_parsers::extdisco`] — namespace constant
-//! and Waddle-specific builder helpers that translate a
-//! [`waddle_sfu::TurnCredential`] into the [`Service`] entries the
+//! plus Waddle-specific builder helpers that translate a
+//! [`waddle_sfu::TurnCredential`] into the `<service/>` entries the
 //! responder sends back on a `services` IQ.
 //!
-//! xmpp-parsers' [`Type`] enum is the subset {Stun, Turn}; the
-//! XEP-0215 §3.6.5 `stuns`/`turns` variants are conveyed implicitly
-//! by emitting a [`Type::Turn`] entry on the TLS port with
-//! [`Transport::Tcp`]. Pragmatic given Waddle terminates TLS at the
-//! `tlsroute` and forwards plain TCP to coturn behind it.
+//! xmpp-parsers' [`ServiceType`] enum is the subset {Stun, Turn}; the
+//! XEP-0215 §3.6.5 `stuns`/`turns` variants do not exist in the
+//! typed surface. Because Waddle advertises TLS-protected TURN
+//! (terminated at the cluster `tlsroute` for `turn.waddle.social`),
+//! the TURN entry MUST go out on the wire with `type='turns'` per
+//! the XEP, so we build that `<service/>` element manually via
+//! [`minidom::Element::builder`] rather than going through the
+//! typed [`Service`] enum.
 
 pub use xmpp_parsers::extdisco::{
     Action, Credentials, Restricted, Service, ServicesQuery, ServicesResult, Transport,
     Type as ServiceType,
 };
 
+use minidom::Element;
+
 use waddle_sfu::{TurnCredential, TurnHost};
 
 pub const NS_EXT_DISCO: &str = "urn:xmpp:extdisco:2";
 
+/// Wire-form `type` value for TLS-protected TURN per XEP-0215
+/// §3.6.5. Modelled as a constant — and not an enum variant — so
+/// the (untyped) wire shape is the single source of truth.
+pub const TYPE_TURNS: &str = "turns";
+
 /// Build the pair of `<service/>` entries Waddle advertises: one
-/// `turn` (TURN-over-TLS on port 443, matching the cluster's
+/// `turns` (TURN-over-TLS on port 443, matching the cluster's
 /// `tlsroute` for `turn.waddle.social`) and one plain `stun` on the
 /// UDP port. The TURN entry carries the time-limited credential
 /// pair; STUN does not need credentials.
@@ -35,39 +45,44 @@ pub fn build_services(
     turn_tls_port: u16,
     stun_udp_port: u16,
     cred: &TurnCredential,
-) -> Vec<Service> {
+) -> Vec<Element> {
     vec![
         build_turn_service(turn_host, turn_tls_port, cred),
-        build_stun_service(turn_host, stun_udp_port),
+        build_stun_service_element(turn_host, stun_udp_port),
     ]
 }
 
-/// XEP-0215 TURN entry with HMAC-derived credentials. Split out so
-/// the `type='stun'`-filtered request path can skip the TURN mint
-/// entirely.
+/// XEP-0215 §3.6.5 TLS-protected TURN entry with HMAC-derived
+/// credentials. Returned as a [`minidom::Element`] because the
+/// `xmpp_parsers::extdisco::Type` enum lacks a `Turns` variant —
+/// emitting the literal `type="turns"` attribute string is the only
+/// XEP-conformant wire shape here.
 pub fn build_turn_service(
     turn_host: &TurnHost,
     turn_tls_port: u16,
     cred: &TurnCredential,
-) -> Service {
-    Service {
-        action: Action::Add,
-        type_: ServiceType::Turn,
-        transport: Some(Transport::Tcp),
-        host: turn_host.as_str().to_string(),
-        port: Some(turn_tls_port),
-        username: Some(cred.username.as_str().to_string()),
-        password: Some(cred.password.as_str().to_string()),
-        expires: Some(xmpp_parsers::date::DateTime(cred.expires_at.fixed_offset())),
-        name: None,
-        restricted: Restricted::True,
-        ext_info: Vec::new(),
-    }
+) -> Element {
+    Element::builder("service", NS_EXT_DISCO)
+        .attr("action", "add")
+        .attr("type", TYPE_TURNS)
+        .attr("transport", "tcp")
+        .attr("host", turn_host.as_str())
+        .attr("port", turn_tls_port.to_string())
+        .attr("username", cred.username.as_str())
+        .attr("password", cred.password.as_str())
+        // XEP-0082 / XEP-0215 §3.6.5: `expires` is a RFC 3339
+        // timestamp. Render via chrono directly — same wire shape
+        // `xmpp_parsers::date::DateTime` would emit via its
+        // `IntoAttributeValue` impl.
+        .attr("expires", cred.expires_at.fixed_offset().to_rfc3339())
+        .attr("restricted", "1")
+        .build()
 }
 
 /// XEP-0215 STUN entry. No credentials, so it's cheap to build and
 /// safe to serve to anyone who can already authenticate to the XMPP
-/// stream.
+/// stream. Returned via the typed [`Service`] surface because the
+/// xmpp-parsers `Type::Stun` variant is the conformant wire value.
 pub fn build_stun_service(turn_host: &TurnHost, stun_udp_port: u16) -> Service {
     Service {
         action: Action::Add,
@@ -82,6 +97,31 @@ pub fn build_stun_service(turn_host: &TurnHost, stun_udp_port: u16) -> Service {
         restricted: Restricted::False,
         ext_info: Vec::new(),
     }
+}
+
+/// Serialised form of [`build_stun_service`]. Provided so callers
+/// that mix STUN and the manually-built `turns` entry can assemble
+/// a single `Vec<Element>` for the `<services/>` wrapper.
+pub fn build_stun_service_element(turn_host: &TurnHost, stun_udp_port: u16) -> Element {
+    build_stun_service(turn_host, stun_udp_port).into()
+}
+
+/// Build the `<services xmlns='urn:xmpp:extdisco:2'/>` wrapper
+/// element from a list of `<service/>` children, with an optional
+/// `type` attribute pinning the filter that produced the result
+/// (XEP-0215 §3.6.1). Built manually rather than via
+/// [`ServicesResult`] so the result can hold the manually-built
+/// `turns` child — which the typed `ServicesResult.services:
+/// Vec<Service>` cannot represent.
+pub fn build_services_result_element(type_filter: Option<&str>, services: Vec<Element>) -> Element {
+    let mut builder = Element::builder("services", NS_EXT_DISCO);
+    if let Some(t) = type_filter {
+        builder = builder.attr("type", t);
+    }
+    for service in services {
+        builder = builder.append(service);
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -117,7 +157,7 @@ mod tests {
     }
 
     #[test]
-    fn build_services_emits_turn_and_stun_entries() {
+    fn build_services_emits_turns_and_stun_entries() {
         let host = TurnHost::new("turn.waddle.social");
         let cred = fixture_credential();
         let services = build_services(&host, 443, 3478, &cred);
@@ -125,36 +165,62 @@ mod tests {
         assert_eq!(services.len(), 2);
 
         let turns = &services[0];
-        assert_eq!(turns.type_, ServiceType::Turn);
-        assert_eq!(turns.transport, Some(Transport::Tcp));
-        assert_eq!(turns.host, "turn.waddle.social");
-        assert_eq!(turns.port, Some(443));
-        assert!(turns.username.is_some());
-        assert!(turns.password.is_some());
-        assert!(turns.expires.is_some());
-        assert_eq!(turns.restricted, Restricted::True);
+        assert_eq!(turns.name(), "service");
+        assert_eq!(turns.ns(), NS_EXT_DISCO);
+        assert_eq!(
+            turns.attr("type"),
+            Some(TYPE_TURNS),
+            "TLS TURN must be advertised as type='turns' per XEP-0215 §3.6.5"
+        );
+        assert_ne!(
+            turns.attr("type"),
+            Some("turn"),
+            "TLS-protected TURN must not be conflated with plain UDP TURN"
+        );
+        assert_eq!(turns.attr("transport"), Some("tcp"));
+        assert_eq!(turns.attr("host"), Some("turn.waddle.social"));
+        assert_eq!(turns.attr("port"), Some("443"));
+        assert!(turns.attr("username").is_some());
+        assert!(turns.attr("password").is_some());
+        assert!(turns.attr("expires").is_some());
+        assert_eq!(turns.attr("restricted"), Some("1"));
 
         let stun = &services[1];
-        assert_eq!(stun.type_, ServiceType::Stun);
-        assert_eq!(stun.transport, Some(Transport::Udp));
-        assert!(stun.username.is_none());
-        assert!(stun.password.is_none());
-        assert_eq!(stun.restricted, Restricted::False);
+        assert_eq!(stun.name(), "service");
+        assert_eq!(stun.attr("type"), Some("stun"));
+        assert_eq!(stun.attr("transport"), Some("udp"));
+        assert!(stun.attr("username").is_none());
+        assert!(stun.attr("password").is_none());
     }
 
     #[test]
-    fn turn_entry_round_trips_through_xml() {
+    fn build_turn_service_pins_turns_wire_shape() {
         let host = TurnHost::new("turn.waddle.social");
         let cred = fixture_credential();
-        let mut services = build_services(&host, 443, 3478, &cred);
-        let turn = services.remove(0);
+        let turn = build_turn_service(&host, 443, &cred);
 
-        let elem: minidom::Element = turn.into();
-        assert_eq!(elem.name(), "service");
-        assert_eq!(elem.ns(), NS_EXT_DISCO);
-        let reparsed = Service::try_from(elem).expect("reparses");
-        assert_eq!(reparsed.type_, ServiceType::Turn);
-        assert_eq!(reparsed.host, "turn.waddle.social");
-        assert_eq!(reparsed.port, Some(443));
+        // XEP-0215 §3.6.5: TLS-protected TURN is `type='turns'`,
+        // not `type='turn'`. This is the test that fails loudly
+        // if someone reverts to the typed `ServiceType::Turn`
+        // path (which would emit `type='turn'`).
+        assert_eq!(turn.attr("type"), Some(TYPE_TURNS));
+        assert_ne!(turn.attr("type"), Some("turn"));
+    }
+
+    #[test]
+    fn services_result_wrapper_carries_turns_child_verbatim() {
+        let host = TurnHost::new("turn.waddle.social");
+        let cred = fixture_credential();
+        let services = build_services(&host, 443, 3478, &cred);
+        let wrapper = build_services_result_element(None, services);
+
+        assert_eq!(wrapper.name(), "services");
+        assert_eq!(wrapper.ns(), NS_EXT_DISCO);
+        let mut children = wrapper.children().filter(|c| c.is("service", NS_EXT_DISCO));
+        let turns = children.next().expect("turns child present");
+        assert_eq!(turns.attr("type"), Some(TYPE_TURNS));
+        let stun = children.next().expect("stun child present");
+        assert_eq!(stun.attr("type"), Some("stun"));
+        assert!(children.next().is_none());
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep0353.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0353.rs
@@ -6,22 +6,34 @@
 //! a single resource. Waddle uses JMI as the canonical 1:1 call ring
 //! signal.
 //!
-//! Thin wrapper over [`xmpp_parsers::jingle_message::JingleMI`]; this
-//! module owns the feature-var constant and provides builder helpers
-//! that pre-populate the audio + video `<description/>` payloads
-//! Waddle calls always offer.
+//! `<proceed/>`, `<reject/>`, and `<retract/>` continue to ride the
+//! typed [`xmpp_parsers::jingle_message::JingleMI`] enum since they
+//! carry no children. `<propose/>` and `<finish/>` instead build the
+//! element directly via [`minidom`]:
+//!
+//! - `JingleMI::Propose` accepts only a single `<description/>` child;
+//!   XEP-0353 §3 mandates **one `<description/>` per media type**, so
+//!   the typed variant is too narrow for an A/V offer. The element
+//!   builder uses typed namespace constants and the typed
+//!   [`MediaKind`] enum at every call site.
+//! - `JingleMI` has no `Finish` variant yet, so `<finish/>` carries an
+//!   optional typed [`xmpp_parsers::jingle::Reason`] child built via
+//!   the [`Reason`-into-`Element`] conversion (XEP-0353 §3.5 SHOULD).
 
-use xmpp_parsers::jingle::SessionId;
+use xmpp_parsers::jingle::{Reason as JingleReason, SessionId};
 pub use xmpp_parsers::jingle_message::JingleMI;
 
-use super::xep0167::{opus_audio_description, vp8_video_description, MediaKind};
+use super::xep0167::{MediaKind, NS_JINGLE_RTP};
 
 pub const NS_JINGLE_MESSAGE: &str = "urn:xmpp:jingle-message:0";
+/// XEP-0166 Jingle namespace — used here only for the `<reason/>`
+/// wrapper around the typed [`JingleReason`] child of `<finish/>`.
+const NS_JINGLE: &str = "urn:xmpp:jingle:1";
 
 /// The set of media kinds offered on a Jingle Message `<propose/>`.
-/// XEP-0353 §5.1.1 specifies that propose carries one
-/// `<description/>` element; Waddle attaches an empty
-/// `urn:xmpp:jingle:apps:rtp:1` description per media kind to
+/// XEP-0353 §3 specifies that propose MUST carry one
+/// `<description/>` element **per media type**; Waddle attaches an
+/// empty `urn:xmpp:jingle:apps:rtp:1` description per offered kind to
 /// declare audio/video capability, with the rich codec list emitted
 /// in the subsequent session-initiate instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,28 +56,51 @@ impl CallOffer {
             video: true,
         }
     }
+
+    /// Iterate the offered media kinds in canonical (audio-then-video)
+    /// order. Used by `build_propose` to emit one `<description/>` per
+    /// kind without smuggling the audio/video booleans through the
+    /// builder.
+    fn media_kinds(self) -> impl Iterator<Item = MediaKind> {
+        let audio = if self.audio {
+            Some(MediaKind::Audio)
+        } else {
+            None
+        };
+        let video = if self.video {
+            Some(MediaKind::Video)
+        } else {
+            None
+        };
+        audio.into_iter().chain(video)
+    }
 }
 
-/// Build a `<propose/>` JMI for an A/V call. XEP-0353 §5.1.1
-/// allows the propose to carry one `<description/>`; to convey both
-/// audio and video capability we use the video description as the
-/// headline (the session-initiate that follows carries both audio
-/// and video contents). For audio-only calls the audio description
-/// is sent instead.
-pub fn build_propose(sid: SessionId, offer: CallOffer) -> JingleMI {
-    let headline = if offer.video {
-        MediaKind::Video
-    } else {
-        MediaKind::Audio
-    };
-    let desc = match headline {
-        MediaKind::Audio => opus_audio_description(),
-        MediaKind::Video => vp8_video_description(),
-    };
-    JingleMI::Propose {
-        sid,
-        description: desc.into(),
+/// Build a `<propose/>` JMI for an A/V call (XEP-0353 §3). The propose
+/// MUST contain **one `<description/>` element per media type** —
+/// emitting a single description for a combined A/V offer is a
+/// protocol downgrade that prevents the responder from distinguishing
+/// audio-only from audio+video at ring time.
+///
+/// The descriptions are emitted as empty
+/// `<description xmlns='urn:xmpp:jingle:apps:rtp:1' media='…'/>` per
+/// the XEP-0353 §3 example; the codec list rides the subsequent
+/// session-initiate (XEP-0167) where it has somewhere to live.
+///
+/// XML is constructed via [`minidom::Element::builder`] with the
+/// typed `NS_JINGLE_MESSAGE` / `NS_JINGLE_RTP` constants and the typed
+/// [`MediaKind`] enum — no `format!`, no string concatenation
+/// (CLAUDE.md XML hard rule).
+pub fn build_propose(sid: SessionId, offer: CallOffer) -> minidom::Element {
+    let mut builder = minidom::Element::builder("propose", NS_JINGLE_MESSAGE).attr("id", sid.0);
+    for kind in offer.media_kinds() {
+        builder = builder.append(
+            minidom::Element::builder("description", NS_JINGLE_RTP)
+                .attr("media", kind.as_str())
+                .build(),
+        );
     }
+    builder.build()
 }
 
 pub fn build_proceed(sid: SessionId) -> JingleMI {
@@ -82,13 +117,24 @@ pub fn build_retract(sid: SessionId) -> JingleMI {
 
 /// Build a `<finish/>` JMI envelope (XEP-0353 §3.5). The envelope
 /// signals call termination; both parties SHOULD send it when the
-/// call ends. xmpp-parsers does not yet have a typed `Finish`
-/// variant, so we build the element directly via [`minidom`]; the
-/// receiver matches by element name + namespace.
-pub fn build_finish(sid: SessionId) -> minidom::Element {
-    minidom::Element::builder("finish", NS_JINGLE_MESSAGE)
-        .attr("id", sid.0)
-        .build()
+/// call ends. xmpp-parsers does not yet have a typed `Finish` variant
+/// on [`JingleMI`], so we build the element directly via [`minidom`].
+///
+/// XEP-0353 §3.5 says `<finish/>` SHOULD contain a `<reason/>` child
+/// (typically `<success/>`, `<expired/>`, or `<connectivity-error/>`)
+/// per XEP-0166 §7.4. The reason is taken as a typed
+/// [`xmpp_parsers::jingle::Reason`] so callers cannot ship a malformed
+/// condition over the wire; `None` omits the `<reason/>` child (still
+/// valid — the SHOULD is informational).
+pub fn build_finish(sid: SessionId, reason: Option<JingleReason>) -> minidom::Element {
+    let mut builder = minidom::Element::builder("finish", NS_JINGLE_MESSAGE).attr("id", sid.0);
+    if let Some(condition) = reason {
+        let reason_elem = minidom::Element::builder("reason", NS_JINGLE)
+            .append(minidom::Element::from(condition))
+            .build();
+        builder = builder.append(reason_elem);
+    }
+    builder.build()
 }
 
 #[cfg(test)]
@@ -102,34 +148,47 @@ mod tests {
     }
 
     #[test]
-    fn propose_audio_video_round_trips() {
+    fn propose_audio_video_emits_one_description_per_media() {
+        // XEP-0353 §3: `<propose/>` MUST contain one `<description/>`
+        // element for **each** media type. A single combined
+        // description is non-conformant — the receiver can't tell
+        // audio-only apart from audio+video before session-initiate.
         let sid = SessionId("c1".to_string());
-        let propose = build_propose(sid.clone(), CallOffer::audio_video());
-        let elem: Element = propose.into();
+        let elem = build_propose(sid.clone(), CallOffer::audio_video());
         assert_eq!(elem.name(), "propose");
         assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
         assert_eq!(elem.attr("id"), Some("c1"));
 
-        let desc = elem
+        let media: Vec<_> = elem
             .children()
-            .find(|c| c.name() == "description")
-            .expect("description child");
-        assert_eq!(desc.ns(), super::super::xep0167::NS_JINGLE_RTP);
-        assert_eq!(desc.attr("media"), Some("video"));
-
-        let reparsed = JingleMI::try_from(elem).expect("reparses");
-        match reparsed {
-            JingleMI::Propose { sid: s, .. } => assert_eq!(s.0, "c1"),
-            other => panic!("expected Propose, got {other:?}"),
-        }
+            .filter(|c| c.name() == "description" && c.ns() == super::super::xep0167::NS_JINGLE_RTP)
+            .filter_map(|c| c.attr("media"))
+            .collect();
+        assert_eq!(media, vec!["audio", "video"], "one description per media");
     }
 
     #[test]
-    fn propose_audio_only_emits_audio_media() {
-        let propose = build_propose(SessionId("c2".into()), CallOffer::audio_only());
-        let elem: Element = propose.into();
-        let desc = elem.children().find(|c| c.name() == "description").unwrap();
-        assert_eq!(desc.attr("media"), Some("audio"));
+    fn propose_audio_only_emits_one_audio_description() {
+        let elem = build_propose(SessionId("c2".into()), CallOffer::audio_only());
+        let descs: Vec<_> = elem
+            .children()
+            .filter(|c| c.name() == "description" && c.ns() == super::super::xep0167::NS_JINGLE_RTP)
+            .collect();
+        assert_eq!(descs.len(), 1, "audio-only offers exactly one description");
+        assert_eq!(descs[0].attr("media"), Some("audio"));
+        // Empty description per the XEP-0353 §3 example; payload list
+        // rides session-initiate (XEP-0167).
+        assert!(descs[0].children().next().is_none());
+    }
+
+    #[test]
+    fn propose_audio_video_emits_exactly_two_descriptions() {
+        let elem = build_propose(SessionId("c3".into()), CallOffer::audio_video());
+        let descs: Vec<_> = elem
+            .children()
+            .filter(|c| c.name() == "description" && c.ns() == super::super::xep0167::NS_JINGLE_RTP)
+            .collect();
+        assert_eq!(descs.len(), 2, "audio+video offer carries 2 descriptions");
     }
 
     #[test]
@@ -165,11 +224,44 @@ mod tests {
     }
 
     #[test]
-    fn finish_emits_canonical_element() {
-        let elem = build_finish(SessionId("c1".into()));
+    fn finish_without_reason_emits_no_reason_child() {
+        let elem = build_finish(SessionId("c1".into()), None);
         assert_eq!(elem.name(), "finish");
         assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
         assert_eq!(elem.attr("id"), Some("c1"));
-        assert!(elem.children().next().is_none());
+        assert!(
+            elem.children().all(|c| c.name() != "reason"),
+            "finish with no reason has no <reason/> child"
+        );
+    }
+
+    #[test]
+    fn finish_with_reason_emits_typed_reason_child() {
+        // XEP-0353 §3.5: `<finish/>` SHOULD carry a `<reason/>` child
+        // qualified by the Jingle namespace. The condition itself is
+        // typed (XEP-0166 §7.4) so a typo cannot ship a malformed
+        // reason over the wire.
+        let elem = build_finish(SessionId("c1".into()), Some(JingleReason::Success));
+        let reason = elem
+            .children()
+            .find(|c| c.name() == "reason")
+            .expect("<reason/> child required by XEP-0353 §3.5 SHOULD");
+        assert_eq!(reason.ns(), NS_JINGLE);
+        let condition = reason.children().next().expect("reason has condition");
+        assert_eq!(condition.name(), "success");
+
+        let elem = build_finish(
+            SessionId("c2".into()),
+            Some(JingleReason::ConnectivityError),
+        );
+        let reason = elem.children().find(|c| c.name() == "reason").unwrap();
+        assert_eq!(
+            reason.children().next().unwrap().name(),
+            "connectivity-error"
+        );
+
+        let elem = build_finish(SessionId("c3".into()), Some(JingleReason::Expired));
+        let reason = elem.children().find(|c| c.name() == "reason").unwrap();
+        assert_eq!(reason.children().next().unwrap().name(), "expired");
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0166_jingle.rs
+++ b/server/crates/waddle-xmpp/tests/xep0166_jingle.rs
@@ -1,0 +1,279 @@
+//! XEP-0166: Jingle (core session signaling) — dedicated test suite.
+//!
+//! Spec: <https://xmpp.org/extensions/xep-0166.html> (v1.1.2, Final).
+//!
+//! Pins the wire shapes Waddle accepts and emits for the four
+//! Jingle actions that drive a LiveKit-backed call:
+//!
+//! * `session-initiate` — XEP-0166 §6.2
+//! * `session-accept`   — XEP-0166 §6.4
+//! * `session-terminate` — XEP-0166 §6.7
+//! * `transport-info`   — XEP-0166 §6.8 (used by mid-session
+//!   negotiation; routed unchanged with a sanitised `from` by the
+//!   server)
+//!
+//! Construction goes through typed Rust values
+//! ([`xmpp_parsers::jingle::Jingle`], [`Action`], [`Content`],
+//! [`SessionId`]) and [`minidom::Element::builder`] — no `format!`,
+//! no string concatenation (CLAUDE.md XML hard rule).
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0166::{
+    reason_element, session_terminate, Action, Content, ContentId, Creator, Jingle, Reason,
+    SessionId, Transport, NS_JINGLE,
+};
+
+const NS_JINGLE_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
+const NS_WADDLE_LIVEKIT_TRANSPORT: &str = "urn:waddle:transports:livekit:0";
+
+fn audio_content_with_waddle_transport() -> Content {
+    let mut content = Content::new(Creator::Initiator, ContentId("audio".into()));
+    // Empty description in the RTP namespace — codec list rides
+    // session-initiate proper; this is the per-content media tag.
+    let description = Element::builder("description", NS_JINGLE_RTP)
+        .attr("media", "audio")
+        .build();
+    content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+        xmpp_parsers::jingle_rtp::Description::try_from(description).expect("rtp desc"),
+    ));
+    let transport = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT).build();
+    content.transport = Some(Transport::Unknown(transport));
+    content
+}
+
+fn parse_jingle(xml: &str) -> Jingle {
+    let elem: Element = xml.parse().expect("element parses");
+    Jingle::try_from(elem).expect("Jingle parses")
+}
+
+// ── §3 namespace ──────────────────────────────────────────────────────
+
+#[test]
+fn xep_0166_namespace_matches_spec() {
+    // XEP-0166 §3: Jingle stanzas are qualified by `urn:xmpp:jingle:1`.
+    assert_eq!(NS_JINGLE, "urn:xmpp:jingle:1");
+    assert_eq!(NS_JINGLE, xmpp_parsers::ns::JINGLE);
+}
+
+// ── §6.2 session-initiate ─────────────────────────────────────────────
+
+#[test]
+fn xep_0166_session_initiate_round_trips_through_typed_surface() {
+    // §6.2: session-initiate carries `action='session-initiate'`,
+    // `initiator='<full-jid>'`, `sid='<opaque>'` and at least one
+    // `<content/>` child. Parses through xmpp-parsers' typed
+    // `Jingle::try_from` and the action lands as the typed
+    // `Action::SessionInitiate` variant.
+    let xml = r#"<jingle xmlns='urn:xmpp:jingle:1'
+                         action='session-initiate'
+                         initiator='alice@waddle.test/desktop'
+                         sid='c1'>
+                   <content creator='initiator' name='audio'>
+                     <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>
+                     <transport xmlns='urn:waddle:transports:livekit:0'/>
+                   </content>
+                 </jingle>"#;
+    let jingle = parse_jingle(xml);
+    assert_eq!(jingle.action, Action::SessionInitiate);
+    assert_eq!(jingle.sid.0, "c1");
+    assert_eq!(
+        jingle.initiator.as_ref().map(|j| j.to_string()),
+        Some("alice@waddle.test/desktop".to_string())
+    );
+    assert_eq!(jingle.contents.len(), 1);
+    let content = &jingle.contents[0];
+    assert_eq!(content.creator, Creator::Initiator);
+    assert_eq!(content.name.0, "audio");
+}
+
+#[test]
+fn xep_0166_session_initiate_builder_emits_initiator_attr_via_minidom() {
+    // Builders MUST use typed `minidom::Element::builder` per the
+    // CLAUDE.md XML hard rule. Round-trip a hand-built session-initiate
+    // through the typed `Jingle::try_from` pass to prove that the
+    // builder-emitted shape parses back into the same typed value.
+    let mut jingle = Jingle::new(Action::SessionInitiate, SessionId("c2".into()));
+    jingle.initiator = Some("alice@waddle.test/desktop".parse().expect("valid jid"));
+    jingle.contents.push(audio_content_with_waddle_transport());
+
+    let elem: Element = jingle.into();
+    assert_eq!(elem.name(), "jingle");
+    assert_eq!(elem.ns(), NS_JINGLE);
+    assert_eq!(elem.attr("action"), Some("session-initiate"));
+    assert_eq!(elem.attr("sid"), Some("c2"));
+    assert_eq!(elem.attr("initiator"), Some("alice@waddle.test/desktop"));
+
+    // Round-trip the serialised form back through the parser.
+    let reparsed = Jingle::try_from(elem).expect("reparses");
+    assert_eq!(reparsed.action, Action::SessionInitiate);
+    assert_eq!(reparsed.sid.0, "c2");
+    assert_eq!(reparsed.contents.len(), 1);
+}
+
+// ── §6.4 session-accept ───────────────────────────────────────────────
+
+#[test]
+fn xep_0166_session_accept_carries_responder_attribute() {
+    // §6.4: session-accept identifies the accepting party via
+    // `responder='<full-jid>'`. The initiator attribute mirrors the
+    // original session-initiate so the server can re-derive the call
+    // scope.
+    let xml = r#"<jingle xmlns='urn:xmpp:jingle:1'
+                         action='session-accept'
+                         initiator='alice@waddle.test/desktop'
+                         responder='bob@waddle.test/desktop'
+                         sid='c1'>
+                   <content creator='initiator' name='audio'>
+                     <description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'/>
+                     <transport xmlns='urn:waddle:transports:livekit:0'/>
+                   </content>
+                 </jingle>"#;
+    let jingle = parse_jingle(xml);
+    assert_eq!(jingle.action, Action::SessionAccept);
+    assert_eq!(
+        jingle.responder.as_ref().map(|j| j.to_string()),
+        Some("bob@waddle.test/desktop".to_string())
+    );
+    assert_eq!(
+        jingle.initiator.as_ref().map(|j| j.to_string()),
+        Some("alice@waddle.test/desktop".to_string())
+    );
+}
+
+// ── §6.7 session-terminate ────────────────────────────────────────────
+
+#[test]
+fn xep_0166_session_terminate_with_success_reason() {
+    // §6.7: session-terminate MAY carry a `<reason/>` child taking
+    // one of the XEP-0166 §7.4 conditions. The typed
+    // `xmpp_parsers::jingle::Reason::Success` flows through the
+    // dedicated reason helper rather than `format!`.
+    let term = session_terminate(SessionId("c1".into()), Reason::Success);
+    let elem: Element = term.into();
+    assert_eq!(elem.name(), "jingle");
+    assert_eq!(elem.ns(), NS_JINGLE);
+    assert_eq!(elem.attr("action"), Some("session-terminate"));
+    assert_eq!(elem.attr("sid"), Some("c1"));
+
+    let reason_child = elem
+        .children()
+        .find(|c| c.name() == "reason")
+        .expect("<reason/> child required when reason supplied");
+    assert_eq!(reason_child.ns(), NS_JINGLE);
+    let condition = reason_child
+        .children()
+        .next()
+        .expect("reason has condition child");
+    assert_eq!(condition.name(), "success");
+}
+
+#[test]
+fn xep_0166_session_terminate_carries_no_content_per_spec() {
+    // §6.7: "the <jingle/> element of a session-terminate action
+    // MUST NOT contain any <content/> elements." Waddle's typed
+    // `session_terminate` helper enforces this by construction —
+    // round-trip through the parser confirms it on the wire.
+    let term = session_terminate(SessionId("c1".into()), Reason::Success);
+    let elem: Element = term.into();
+    let contents: Vec<&Element> = elem.children().filter(|c| c.name() == "content").collect();
+    assert!(
+        contents.is_empty(),
+        "session-terminate MUST NOT carry <content/> children"
+    );
+}
+
+#[test]
+fn xep_0166_session_terminate_reason_helper_uses_typed_condition() {
+    // The `reason_element` helper builds a typed
+    // `xmpp_parsers::jingle::ReasonElement` directly — proving the
+    // typed-payloads rule (no `&str` for the condition) — and
+    // serialises to the canonical `<reason><$cond/></reason>` shape.
+    for (reason, cond_name) in [
+        (Reason::Success, "success"),
+        (Reason::Decline, "decline"),
+        (Reason::Busy, "busy"),
+        (Reason::Cancel, "cancel"),
+        (Reason::ConnectivityError, "connectivity-error"),
+        (Reason::Expired, "expired"),
+    ] {
+        let mut jingle = Jingle::new(Action::SessionTerminate, SessionId("c1".into()));
+        jingle = jingle.set_reason(reason_element(reason.clone()));
+        let elem: Element = jingle.into();
+        let reason_child = elem
+            .children()
+            .find(|c| c.name() == "reason")
+            .expect("reason present");
+        let cond = reason_child
+            .children()
+            .next()
+            .expect("reason has condition");
+        assert_eq!(
+            cond.name(),
+            cond_name,
+            "reason {reason:?} must serialise to <{cond_name}/>"
+        );
+    }
+}
+
+// ── §6.8 transport-info ───────────────────────────────────────────────
+
+#[test]
+fn xep_0166_transport_info_round_trips() {
+    // §6.8: transport-info carries the SAME sid as the running session
+    // and one `<content/>` per transport-update. Waddle forwards these
+    // unchanged with a sanitised `from` — the wire shape MUST survive
+    // through the typed `Jingle::try_from` parse.
+    let xml = r#"<jingle xmlns='urn:xmpp:jingle:1'
+                         action='transport-info'
+                         initiator='alice@waddle.test/desktop'
+                         sid='c1'>
+                   <content creator='initiator' name='audio'>
+                     <transport xmlns='urn:waddle:transports:livekit:0'/>
+                   </content>
+                 </jingle>"#;
+    let jingle = parse_jingle(xml);
+    assert_eq!(jingle.action, Action::TransportInfo);
+    assert_eq!(jingle.sid.0, "c1");
+    assert_eq!(jingle.contents.len(), 1);
+}
+
+// ── Negative cases ────────────────────────────────────────────────────
+
+#[test]
+fn xep_0166_non_jingle_namespace_is_rejected() {
+    // A `<jingle/>` element in a non-Jingle namespace MUST NOT parse
+    // as `Jingle`. Waddle's handler relies on this to reject
+    // hand-rolled lookalikes that try to bypass the typed contract.
+    let elem = Element::builder("jingle", "urn:waddle:not-jingle")
+        .attr("action", "session-initiate")
+        .attr("sid", "c1")
+        .build();
+    assert!(Jingle::try_from(elem).is_err());
+}
+
+#[test]
+fn xep_0166_unknown_action_is_rejected() {
+    // §7.2: the `action` attribute is constrained to the 14 values
+    // enumerated in the spec. xmpp-parsers' typed `Action` enum will
+    // refuse to parse anything else.
+    let elem = Element::builder("jingle", NS_JINGLE)
+        .attr("action", "session-warp")
+        .attr("sid", "c1")
+        .build();
+    assert!(Jingle::try_from(elem).is_err());
+}
+
+#[test]
+fn xep_0166_session_terminate_typed_helper_round_trips() {
+    // The `session_terminate` helper builds via the typed
+    // `Jingle::new(...).set_reason(...)` chain. Round-trip the
+    // serialised form through the parser to prove no information is
+    // lost across the typed/wire boundary.
+    let term = session_terminate(SessionId("c-roundtrip".into()), Reason::Cancel);
+    let elem: Element = term.into();
+    let reparsed = Jingle::try_from(elem).expect("reparses");
+    assert_eq!(reparsed.action, Action::SessionTerminate);
+    assert_eq!(reparsed.sid.0, "c-roundtrip");
+    let reason = reparsed.reason.expect("reason preserved");
+    assert!(matches!(reason.reason, Reason::Cancel));
+}

--- a/server/crates/waddle-xmpp/tests/xep0167_jingle_rtp.rs
+++ b/server/crates/waddle-xmpp/tests/xep0167_jingle_rtp.rs
@@ -1,0 +1,220 @@
+//! XEP-0167: Jingle RTP Sessions — dedicated test suite.
+//!
+//! Spec: <https://xmpp.org/extensions/xep-0167.html> (v1.2.1, Final).
+//!
+//! Pins the wire shape of the `<description xmlns='urn:xmpp:jingle:apps:rtp:1'/>`
+//! payload Waddle builds for the audio and video legs of a call:
+//!
+//! * The element is qualified by `urn:xmpp:jingle:apps:rtp:1` (XEP-0167 §3.1).
+//! * The `media` attribute is `audio` or `video` only (XEP-0167 §3.1).
+//! * Each description carries at least one `<payload-type/>` child
+//!   describing a codec the initiator supports (XEP-0167 §3.2).
+//! * Each description advertises `<rtcp-mux/>` so the peer can
+//!   multiplex RTP and RTCP on a single port (XEP-0167 §3.3 / RFC 5761).
+//!
+//! Construction goes through the typed
+//! [`waddle_xmpp::xep::xep0167::opus_audio_description`] /
+//! [`waddle_xmpp::xep::xep0167::vp8_video_description`] helpers and
+//! the typed [`MediaKind`] enum — no `format!`, no string
+//! concatenation (CLAUDE.md XML hard rule).
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0167::{
+    opus_audio_description, vp8_video_description, MediaKind, NS_JINGLE_RTP, NS_JINGLE_RTP_AUDIO,
+    NS_JINGLE_RTP_VIDEO,
+};
+
+fn description_element(media: MediaKind) -> Element {
+    match media {
+        MediaKind::Audio => opus_audio_description().into(),
+        MediaKind::Video => vp8_video_description().into(),
+    }
+}
+
+// ── §3.1 namespace and `media` attribute ──────────────────────────────
+
+#[test]
+fn xep_0167_namespace_is_canonical() {
+    assert_eq!(NS_JINGLE_RTP, "urn:xmpp:jingle:apps:rtp:1");
+    assert_eq!(NS_JINGLE_RTP, xmpp_parsers::ns::JINGLE_RTP);
+    // Audio/video sub-namespaces used by feature-vars in disco.
+    assert_eq!(NS_JINGLE_RTP_AUDIO, "urn:xmpp:jingle:apps:rtp:audio");
+    assert_eq!(NS_JINGLE_RTP_VIDEO, "urn:xmpp:jingle:apps:rtp:video");
+}
+
+#[test]
+fn xep_0167_audio_description_has_media_attribute() {
+    // §3.1: the `media` attribute identifies the SDP-style media kind
+    // for the RTP session. Audio descriptions carry `media='audio'`.
+    let elem = description_element(MediaKind::Audio);
+    assert_eq!(elem.name(), "description");
+    assert_eq!(elem.ns(), NS_JINGLE_RTP);
+    assert_eq!(elem.attr("media"), Some("audio"));
+}
+
+#[test]
+fn xep_0167_video_description_has_media_attribute() {
+    // §3.1: video descriptions carry `media='video'`.
+    let elem = description_element(MediaKind::Video);
+    assert_eq!(elem.attr("media"), Some("video"));
+}
+
+// ── MediaKind parsing — typed value, not stringly-typed ──────────────
+
+#[test]
+fn xep_0167_media_kind_parses_audio_and_video_only() {
+    // The typed `MediaKind` enum is the single source of truth for
+    // the `media` attribute. XEP-0167 §3.1 admits only `audio` and
+    // `video`; everything else (e.g. `data`) is rejected at the
+    // parser boundary so callers don't smuggle bogus values onto
+    // the wire.
+    assert_eq!(MediaKind::parse("audio"), Some(MediaKind::Audio));
+    assert_eq!(MediaKind::parse("video"), Some(MediaKind::Video));
+    assert_eq!(MediaKind::parse("data"), None);
+    assert_eq!(MediaKind::parse(""), None);
+    // Round-trip: parse(as_str()) is the identity on every variant.
+    assert_eq!(
+        MediaKind::parse(MediaKind::Audio.as_str()),
+        Some(MediaKind::Audio)
+    );
+    assert_eq!(
+        MediaKind::parse(MediaKind::Video.as_str()),
+        Some(MediaKind::Video)
+    );
+}
+
+// ── §3.2 payload-type child ──────────────────────────────────────────
+
+#[test]
+fn xep_0167_audio_description_carries_opus_payload_type() {
+    // §3.2: the `<description/>` MUST carry at least one
+    // `<payload-type/>` child enumerating the codecs the initiator
+    // supports. Waddle advertises Opus on PT 111 (the de facto
+    // dynamic-PT value used by browser WebRTC) with the 48 kHz
+    // clockrate / stereo channel count Opus requires.
+    let elem = description_element(MediaKind::Audio);
+    let payload = elem
+        .children()
+        .find(|c| c.name() == "payload-type")
+        .expect("§3.2: description has at least one <payload-type/>");
+    assert_eq!(payload.attr("name"), Some("opus"));
+    // PT 111 is the dynamic payload type Waddle commits to.
+    assert_eq!(payload.attr("id"), Some("111"));
+    assert_eq!(payload.attr("clockrate"), Some("48000"));
+    assert_eq!(payload.attr("channels"), Some("2"));
+}
+
+#[test]
+fn xep_0167_video_description_carries_vp8_payload_type() {
+    // §3.2: video descriptions carry a payload-type per codec; VP8
+    // is on the WebRTC mandatory-to-implement list and gets PT 96.
+    let elem = description_element(MediaKind::Video);
+    let payload = elem
+        .children()
+        .find(|c| c.name() == "payload-type")
+        .expect("video description carries <payload-type/>");
+    assert_eq!(payload.attr("name"), Some("VP8"));
+    assert_eq!(payload.attr("id"), Some("96"));
+    // §3.2 examples for video use a 90 kHz clockrate.
+    assert_eq!(payload.attr("clockrate"), Some("90000"));
+}
+
+// ── §3.3 RTCP multiplexing ───────────────────────────────────────────
+
+#[test]
+fn xep_0167_audio_description_advertises_rtcp_mux() {
+    // §3.3 / RFC 5761: `<rtcp-mux/>` signals that RTP and RTCP can
+    // be multiplexed on a single port. Required by modern WebRTC
+    // stacks (which is what LiveKit is). Omitting this is a
+    // protocol downgrade against every modern peer.
+    let elem = description_element(MediaKind::Audio);
+    let rtcp_mux = elem.children().find(|c| c.name() == "rtcp-mux");
+    assert!(
+        rtcp_mux.is_some(),
+        "XEP-0167 §3.3: audio description MUST advertise <rtcp-mux/>"
+    );
+    let rtcp_mux = rtcp_mux.expect("checked above");
+    assert_eq!(rtcp_mux.ns(), NS_JINGLE_RTP);
+}
+
+#[test]
+fn xep_0167_video_description_advertises_rtcp_mux() {
+    let elem = description_element(MediaKind::Video);
+    assert!(
+        elem.children().any(|c| c.name() == "rtcp-mux"),
+        "XEP-0167 §3.3: video description MUST advertise <rtcp-mux/>"
+    );
+}
+
+// ── Round-trip through xmpp-parsers' typed surface ───────────────────
+
+#[test]
+fn xep_0167_audio_description_round_trips_through_typed_parser() {
+    // The typed `xmpp_parsers::jingle_rtp::Description` is the
+    // canonical parse target for a `<description/>` element. Build
+    // an audio description via the Waddle helper, serialise to
+    // `Element`, then reparse — proves no information is lost across
+    // the typed/wire boundary.
+    let elem: Element = opus_audio_description().into();
+    let reparsed: xmpp_parsers::jingle_rtp::Description =
+        elem.clone().try_into().expect("reparses");
+    assert_eq!(reparsed.media, MediaKind::Audio.as_str());
+    let payload = reparsed
+        .payload_types
+        .first()
+        .expect("at least one payload");
+    assert_eq!(payload.name.as_deref(), Some("opus"));
+    assert_eq!(payload.clockrate, Some(48_000));
+    assert_eq!(payload.channels, xmpp_parsers::jingle_rtp::Channels(2));
+    assert!(
+        reparsed.rtcp_mux.is_some(),
+        "typed parse preserves rtcp-mux"
+    );
+}
+
+#[test]
+fn xep_0167_video_description_round_trips_through_typed_parser() {
+    let elem: Element = vp8_video_description().into();
+    let reparsed: xmpp_parsers::jingle_rtp::Description = elem.try_into().expect("reparses");
+    assert_eq!(reparsed.media, MediaKind::Video.as_str());
+    let payload = reparsed
+        .payload_types
+        .first()
+        .expect("at least one payload");
+    assert_eq!(payload.name.as_deref(), Some("VP8"));
+    assert_eq!(payload.clockrate, Some(90_000));
+}
+
+#[test]
+fn xep_0167_parses_third_party_description_wire_shape() {
+    // Inbound `<description/>` from a non-Waddle peer (e.g. an
+    // XMPP-compliant softphone) MUST parse through the typed
+    // `Description` surface even when its codec list differs from
+    // ours. Pins the parser contract for foreign offers.
+    let xml = r#"<description xmlns='urn:xmpp:jingle:apps:rtp:1' media='audio'>
+                   <payload-type id='8' name='PCMA' clockrate='8000'/>
+                   <payload-type id='0' name='PCMU' clockrate='8000'/>
+                 </description>"#;
+    let elem: Element = xml.parse().expect("element parses");
+    let desc: xmpp_parsers::jingle_rtp::Description = elem.try_into().expect("description parses");
+    assert_eq!(desc.media, "audio");
+    assert_eq!(desc.payload_types.len(), 2);
+    assert_eq!(desc.payload_types[0].name.as_deref(), Some("PCMA"));
+    assert_eq!(desc.payload_types[1].name.as_deref(), Some("PCMU"));
+}
+
+#[test]
+fn xep_0167_rejects_description_in_wrong_namespace() {
+    // A `<description/>` in a namespace other than
+    // `urn:xmpp:jingle:apps:rtp:1` MUST NOT parse as an RTP
+    // description. Waddle's Jingle handler relies on this typed
+    // discriminator to refuse non-RTP descriptions.
+    let elem = Element::builder("description", "urn:xmpp:jingle:apps:file-transfer:5")
+        .attr("media", "audio")
+        .build();
+    let parsed: Result<xmpp_parsers::jingle_rtp::Description, _> = elem.try_into();
+    assert!(
+        parsed.is_err(),
+        "description in non-RTP namespace MUST be rejected"
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep0215_external_service_discovery.rs
+++ b/server/crates/waddle-xmpp/tests/xep0215_external_service_discovery.rs
@@ -1,0 +1,121 @@
+//! XEP-0215: External Service Discovery dedicated suite.
+//!
+//! Pins the wire shape Waddle advertises on a `services` IQ — most
+//! importantly that TLS-protected TURN goes out as `type='turns'`
+//! per §3.6.5, not the typed-surface `type='turn'` that xmpp-parsers
+//! defaults to. The handler builds the `<services/>` wrapper
+//! manually for exactly this reason; the tests below are the safety
+//! net against an accidental reversion to `ServicesResult` + typed
+//! `Vec<Service>`.
+
+use chrono::Duration;
+use minidom::Element;
+use waddle_sfu::{
+    ApiKey, ApiSecret, Identity, LiveKitSfu, SfuConfig, SfuService, TurnCredential, TurnHost,
+    TurnSharedSecret, WebsocketUrl,
+};
+use waddle_xmpp::xep::xep0215::{
+    build_services, build_services_result_element, build_stun_service_element, build_turn_service,
+    NS_EXT_DISCO, TYPE_TURNS,
+};
+
+fn fixture_cred() -> TurnCredential {
+    let cfg = SfuConfig {
+        api_key: ApiKey::new("APIxxxxxxxx"),
+        api_secret: ApiSecret::from_text("api-secret-meets-min-length-32!!")
+            .expect("test secret meets min length"),
+        ws_url: WebsocketUrl::new("wss://livekit.test/".parse().expect("valid url"))
+            .expect("valid ws url"),
+        turn_host: TurnHost::new("turn.waddle.social"),
+        turn_tls_port: 443,
+        turn_udp_port: 3478,
+        turn_shared_secret: TurnSharedSecret::from_text("turn-secret"),
+        token_ttl: Duration::seconds(3600),
+        turn_ttl: Duration::seconds(3600),
+    };
+    let sfu = LiveKitSfu::new(cfg);
+    let jid: jid::FullJid = "alice@waddle.social/desktop".parse().expect("valid jid");
+    let identity = Identity::from_jid(jid);
+    sfu.issue_turn_credentials(&identity)
+        .expect("credential mint")
+}
+
+#[test]
+fn xep0215_tls_turn_is_advertised_as_turns() {
+    // The single most important wire-shape assertion: §3.6.5 says
+    // TLS-protected TURN uses `type='turns'`. xmpp-parsers' typed
+    // `ServiceType` only carries `Stun`/`Turn`, so the
+    // `build_turn_service` helper hand-builds the element to emit
+    // the literal `turns` value.
+    let host = TurnHost::new("turn.waddle.social");
+    let cred = fixture_cred();
+    let turn = build_turn_service(&host, 443, &cred);
+
+    assert_eq!(turn.name(), "service");
+    assert_eq!(turn.ns(), NS_EXT_DISCO);
+    assert_eq!(turn.attr("type"), Some(TYPE_TURNS));
+    assert_ne!(
+        turn.attr("type"),
+        Some("turn"),
+        "TLS-protected TURN must not regress to the plain `turn` wire value"
+    );
+}
+
+#[test]
+fn xep0215_turns_entry_carries_required_attributes() {
+    let host = TurnHost::new("turn.waddle.social");
+    let cred = fixture_cred();
+    let turn = build_turn_service(&host, 443, &cred);
+
+    assert_eq!(turn.attr("action"), Some("add"));
+    assert_eq!(turn.attr("transport"), Some("tcp"));
+    assert_eq!(turn.attr("host"), Some("turn.waddle.social"));
+    assert_eq!(turn.attr("port"), Some("443"));
+    assert_eq!(turn.attr("username"), Some(cred.username.as_str()));
+    assert_eq!(turn.attr("password"), Some(cred.password.as_str()));
+    assert!(turn.attr("expires").is_some());
+    assert_eq!(turn.attr("restricted"), Some("1"));
+}
+
+#[test]
+fn xep0215_stun_entry_uses_typed_surface() {
+    // STUN does have a typed `Type::Stun` variant, so the helper
+    // goes through the xmpp-parsers `Service` -> `Element`
+    // conversion. Wire shape stays `type='stun'`.
+    let host = TurnHost::new("turn.waddle.social");
+    let stun = build_stun_service_element(&host, 3478);
+    assert_eq!(stun.attr("type"), Some("stun"));
+    assert_eq!(stun.attr("transport"), Some("udp"));
+    assert!(stun.attr("username").is_none());
+    assert!(stun.attr("password").is_none());
+}
+
+#[test]
+fn xep0215_services_wrapper_preserves_turns_child() {
+    let host = TurnHost::new("turn.waddle.social");
+    let cred = fixture_cred();
+    let entries = build_services(&host, 443, 3478, &cred);
+    let wrapper = build_services_result_element(None, entries);
+
+    assert_eq!(wrapper.name(), "services");
+    assert_eq!(wrapper.ns(), NS_EXT_DISCO);
+    let children: Vec<&Element> = wrapper
+        .children()
+        .filter(|c| c.is("service", NS_EXT_DISCO))
+        .collect();
+    assert_eq!(children.len(), 2);
+    assert_eq!(children[0].attr("type"), Some(TYPE_TURNS));
+    assert_eq!(children[1].attr("type"), Some("stun"));
+}
+
+#[test]
+fn xep0215_services_wrapper_carries_optional_type_filter_attribute() {
+    let host = TurnHost::new("turn.waddle.social");
+    let cred = fixture_cred();
+    let entries = build_services(&host, 443, 3478, &cred);
+    let wrapper = build_services_result_element(Some("turn"), entries);
+    // The filter on the request is the typed `turn` value; the
+    // response wrapper echoes it. Only the inner `<service/>`
+    // child uses `turns` for the TLS-protected service.
+    assert_eq!(wrapper.attr("type"), Some("turn"));
+}

--- a/server/crates/waddle-xmpp/tests/xep0353_jingle_message.rs
+++ b/server/crates/waddle-xmpp/tests/xep0353_jingle_message.rs
@@ -1,0 +1,302 @@
+//! XEP-0353: Jingle Message Initiation (JMI) — dedicated test suite.
+//!
+//! Spec: <https://xmpp.org/extensions/xep-0353.html> (v0.7.0, Draft).
+//!
+//! JMI is the pre-call ringing layer: the initiator broadcasts a
+//! `<propose/>` to every resource of the responder so any one of them
+//! can ring before Jingle session-initiate commits to a single
+//! resource. Waddle uses JMI as the canonical 1:1 call ring signal.
+//!
+//! This file pins the **server-side typed builder library** under
+//! [`waddle_xmpp::xep::xep0353`]:
+//!
+//! * `<propose/>` carries one `<description/>` per offered media type
+//!   (XEP-0353 §3) — a single combined description is non-conformant.
+//! * `<finish/>` MAY carry a `<reason/>` child taking a typed XEP-0166
+//!   Jingle reason (XEP-0353 §3.5 SHOULD).
+//! * The wrapping `<message/>` envelope MUST be `type='chat'` and MUST
+//!   carry a XEP-0334 `<store/>` hint so MAM archives keep the call
+//!   timeline reconstructible even when no body is present (XEP-0353
+//!   §3). The envelope is built via the typed
+//!   [`xmpp_parsers::message::Message`] surface and the typed
+//!   [`MessageType::Chat`] variant — no ad-hoc string attributes.
+//!
+//! All construction goes through typed Rust values and
+//! [`minidom::Element::builder`]; no `format!`, no string
+//! concatenation (CLAUDE.md XML hard rule).
+
+use minidom::Element;
+use waddle_xmpp::xep::xep0353::{
+    build_finish, build_proceed, build_propose, build_reject, build_retract, CallOffer, JingleMI,
+    NS_JINGLE_MESSAGE,
+};
+use xmpp_parsers::jingle::{Reason as JingleReason, SessionId};
+use xmpp_parsers::message::{Message, MessageType};
+
+const NS_JINGLE: &str = "urn:xmpp:jingle:1";
+const NS_JINGLE_RTP: &str = "urn:xmpp:jingle:apps:rtp:1";
+const NS_HINTS: &str = "urn:xmpp:hints";
+
+fn store_hint_element() -> Element {
+    Element::builder("store", NS_HINTS).build()
+}
+
+/// XEP-0353 §3 envelope: every JMI body (propose / proceed / reject /
+/// retract / finish) MUST ride a `<message type='chat'/>` envelope
+/// carrying a XEP-0334 `<store/>` hint. Built via the typed
+/// `Message::new_with_type(MessageType::Chat, …)` surface so
+/// `type='chat'` flows through the dedicated `MessageType` variant
+/// rather than an ad-hoc attribute string.
+fn jmi_envelope(to: &jid::Jid, body: Element) -> Element {
+    let mut msg = Message::new_with_type(MessageType::Chat, Some(to.clone()));
+    msg.payloads.push(store_hint_element());
+    msg.payloads.push(body);
+    Element::from(msg)
+}
+
+// ── §3 namespace ──────────────────────────────────────────────────────
+
+#[test]
+fn xep_0353_namespace_matches_spec() {
+    assert_eq!(NS_JINGLE_MESSAGE, "urn:xmpp:jingle-message:0");
+    assert_eq!(NS_JINGLE_MESSAGE, xmpp_parsers::ns::JINGLE_MESSAGE);
+}
+
+// ── §3 propose — one <description/> per offered media kind ───────────
+
+#[test]
+fn xep_0353_propose_audio_video_emits_two_descriptions() {
+    // §3: "the <propose/> element MUST contain one or more
+    // <description/> child elements". Each description names a
+    // single media kind; combining audio+video into one description
+    // is non-conformant — the responder can't distinguish audio-only
+    // from audio+video at ring time.
+    let elem = build_propose(SessionId("c1".into()), CallOffer::audio_video());
+    assert_eq!(elem.name(), "propose");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert_eq!(elem.attr("id"), Some("c1"));
+
+    let descs: Vec<&Element> = elem
+        .children()
+        .filter(|c| c.name() == "description" && c.ns() == NS_JINGLE_RTP)
+        .collect();
+    assert_eq!(
+        descs.len(),
+        2,
+        "audio+video propose carries exactly two descriptions"
+    );
+    let media: Vec<&str> = descs.iter().filter_map(|c| c.attr("media")).collect();
+    assert_eq!(media, vec!["audio", "video"]);
+}
+
+#[test]
+fn xep_0353_propose_audio_only_carries_single_audio_description() {
+    let elem = build_propose(SessionId("c2".into()), CallOffer::audio_only());
+    let descs: Vec<&Element> = elem
+        .children()
+        .filter(|c| c.name() == "description" && c.ns() == NS_JINGLE_RTP)
+        .collect();
+    assert_eq!(descs.len(), 1, "audio-only carries exactly one description");
+    assert_eq!(descs[0].attr("media"), Some("audio"));
+    // §3 example: the description is empty at JMI time; codec list
+    // rides the subsequent session-initiate (XEP-0167).
+    assert!(
+        descs[0].children().next().is_none(),
+        "JMI <description/> bodies are empty per §3 example"
+    );
+}
+
+// ── §3.x proceed / reject / retract — typed surface ──────────────────
+
+#[test]
+fn xep_0353_proceed_round_trips_through_typed_jingle_mi() {
+    // proceed/reject/retract carry no children — xmpp-parsers'
+    // typed `JingleMI` enum covers them directly. Round-trip via
+    // `Element` to prove the wire shape matches the typed enum.
+    let proceed = build_proceed(SessionId("c1".into()));
+    let elem: Element = proceed.into();
+    assert_eq!(elem.name(), "proceed");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert_eq!(elem.attr("id"), Some("c1"));
+
+    let reparsed = JingleMI::try_from(elem).expect("proceed reparses");
+    assert!(matches!(reparsed, JingleMI::Proceed(_)));
+}
+
+#[test]
+fn xep_0353_reject_round_trips_through_typed_jingle_mi() {
+    let elem: Element = build_reject(SessionId("c1".into())).into();
+    assert_eq!(elem.name(), "reject");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert!(matches!(
+        JingleMI::try_from(elem).expect("reject reparses"),
+        JingleMI::Reject(_)
+    ));
+}
+
+#[test]
+fn xep_0353_retract_round_trips_through_typed_jingle_mi() {
+    let elem: Element = build_retract(SessionId("c1".into())).into();
+    assert_eq!(elem.name(), "retract");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert!(matches!(
+        JingleMI::try_from(elem).expect("retract reparses"),
+        JingleMI::Retract(_)
+    ));
+}
+
+// ── §3.5 finish — optional typed reason child ─────────────────────────
+
+#[test]
+fn xep_0353_finish_without_reason_emits_no_reason_child() {
+    // §3.5: `<finish/>` SHOULD carry a `<reason/>` child, but the
+    // SHOULD is informational — omitting it is still valid wire
+    // shape. Pin both branches so a future tightening of the SHOULD
+    // doesn't silently strip the omit-path.
+    let elem = build_finish(SessionId("c1".into()), None);
+    assert_eq!(elem.name(), "finish");
+    assert_eq!(elem.ns(), NS_JINGLE_MESSAGE);
+    assert_eq!(elem.attr("id"), Some("c1"));
+    assert!(
+        elem.children().all(|c| c.name() != "reason"),
+        "no reason child when caller passes None"
+    );
+}
+
+#[test]
+fn xep_0353_finish_with_reason_emits_typed_jingle_reason_child() {
+    // §3.5: `<finish/>` MAY carry a `<reason/>` element qualified
+    // by `urn:xmpp:jingle:1` (NOT `urn:xmpp:jingle-message:0`) and
+    // containing a single typed XEP-0166 §7.4 condition. The typed
+    // [`xmpp_parsers::jingle::Reason`] enum is the typed-payloads
+    // contract — a `&str` condition would be rejected per CLAUDE.md.
+    let cases = [
+        (JingleReason::Success, "success"),
+        (JingleReason::Decline, "decline"),
+        (JingleReason::Busy, "busy"),
+        (JingleReason::Cancel, "cancel"),
+        (JingleReason::ConnectivityError, "connectivity-error"),
+        (JingleReason::Expired, "expired"),
+    ];
+    for (reason, cond_name) in cases {
+        let elem = build_finish(SessionId("c1".into()), Some(reason.clone()));
+        let reason_child = elem
+            .children()
+            .find(|c| c.name() == "reason")
+            .unwrap_or_else(|| panic!("<reason/> required for reason {reason:?}"));
+        // The reason wrapper is XEP-0166 qualified (§3.5 carries the
+        // reason "as it is in the Jingle session"), not the JMI
+        // namespace. Pin this — it's an easy detail to mis-emit.
+        assert_eq!(
+            reason_child.ns(),
+            NS_JINGLE,
+            "<reason/> wrapper is XEP-0166 qualified, not JMI"
+        );
+        let cond = reason_child
+            .children()
+            .next()
+            .unwrap_or_else(|| panic!("<reason/> has condition child for {reason:?}"));
+        assert_eq!(
+            cond.name(),
+            cond_name,
+            "reason {reason:?} serialises to <{cond_name}/>"
+        );
+    }
+}
+
+// ── §3 envelope — type='chat' + XEP-0334 store hint ──────────────────
+
+fn assert_jmi_envelope_conformant(name: &str, body_builder: impl Fn() -> Element) {
+    // §3: every JMI body rides a `<message type='chat'/>` envelope
+    // carrying a XEP-0334 `<store/>` hint. Without `type='chat'` the
+    // stanza ships as `type='normal'` (the XMPP default) and gets
+    // routed only to the highest-priority resource — the whole
+    // point of JMI is to fork to ALL resources. Without `<store/>`
+    // the body doesn't make it into MAM and call history breaks.
+    let to: jid::Jid = "bob@waddle.test".parse().expect("valid jid");
+    let stanza = jmi_envelope(&to, body_builder());
+
+    assert_eq!(stanza.name(), "message", "{name}: envelope is <message/>");
+    assert_eq!(
+        stanza.attr("type"),
+        Some("chat"),
+        "{name}: §3 MUST type='chat'"
+    );
+    assert_eq!(
+        stanza.attr("to"),
+        Some("bob@waddle.test"),
+        "{name}: 'to' preserved"
+    );
+
+    let store = stanza
+        .children()
+        .find(|c| c.name() == "store" && c.ns() == NS_HINTS)
+        .unwrap_or_else(|| panic!("{name}: §3 MUST carry a XEP-0334 <store/> hint"));
+    assert!(
+        store.children().next().is_none(),
+        "{name}: <store/> hint is empty"
+    );
+    assert!(
+        store.attrs().next().is_none(),
+        "{name}: <store/> hint carries no attributes"
+    );
+
+    // The JMI body rides along — the responder's parser still finds
+    // it as a non-hint child in the JMI namespace.
+    assert!(
+        stanza.children().any(|c| c.ns() == NS_JINGLE_MESSAGE),
+        "{name}: JMI body preserved through envelope"
+    );
+}
+
+#[test]
+fn xep_0353_propose_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("propose", || {
+        build_propose(SessionId("c1".into()), CallOffer::audio_video())
+    });
+}
+
+#[test]
+fn xep_0353_proceed_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("proceed", || build_proceed(SessionId("c1".into())).into());
+}
+
+#[test]
+fn xep_0353_reject_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("reject", || build_reject(SessionId("c1".into())).into());
+}
+
+#[test]
+fn xep_0353_retract_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("retract", || build_retract(SessionId("c1".into())).into());
+}
+
+#[test]
+fn xep_0353_finish_envelope_is_chat_with_store_hint() {
+    assert_jmi_envelope_conformant("finish", || {
+        build_finish(SessionId("c1".into()), Some(JingleReason::Success))
+    });
+}
+
+// ── Negative cases ────────────────────────────────────────────────────
+
+#[test]
+fn xep_0353_jingle_mi_rejects_unknown_envelope_element() {
+    // A child in the JMI namespace whose name isn't one of the
+    // canonical {propose, proceed, reject, retract, finish} MUST
+    // NOT parse as `JingleMI`.
+    let elem = Element::builder("bogus", NS_JINGLE_MESSAGE)
+        .attr("id", "c1")
+        .build();
+    assert!(JingleMI::try_from(elem).is_err());
+}
+
+#[test]
+fn xep_0353_jingle_mi_rejects_wrong_namespace() {
+    // A `<proceed/>` element in some other namespace MUST NOT parse
+    // as a JMI proceed.
+    let elem = Element::builder("proceed", "urn:waddle:not-jmi")
+        .attr("id", "c1")
+        .build();
+    assert!(JingleMI::try_from(elem).is_err());
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_livekit_transport.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_livekit_transport.rs
@@ -1,0 +1,317 @@
+//! `urn:waddle:transports:livekit:0` — Waddle's Jingle transport for
+//! LiveKit-backed calls. Dedicated test suite.
+//!
+//! This is a Waddle-custom XEP-0166 transport (the CLAUDE.md
+//! conformance rule allows custom `urn:waddle:*` namespaces only
+//! where no XEP shape fits — SFU-mediated join tokens are one such
+//! case; XEP-0167 + XEP-0176 assume peer-to-peer ICE and don't model
+//! a server-issued WebSocket signalling URL + JWT).
+//!
+//! Two wire forms exist:
+//!
+//! 1. **Request form** — empty element:
+//!    `<transport xmlns='urn:waddle:transports:livekit:0'/>`.
+//!    Sent by clients on session-initiate / session-accept to ask
+//!    the server to issue a LiveKit join token.
+//! 2. **Issued form** — fully-populated element carrying the
+//!    LiveKit websocket URL, room name, participant identity, and
+//!    JWT in a `<token/>` child. Inserted by the server's Jingle
+//!    handler when it routes a session-initiate/accept onward.
+//!
+//! All construction goes through typed Rust values — the typed
+//! [`WaddleLiveKitTransport`] sum, the typed [`IssuedTransport`]
+//! record, and the typed [`WebsocketUrl`], [`CallId`], [`Identity`],
+//! [`Jwt`] payload values. No `format!`, no string concatenation
+//! (CLAUDE.md XML hard rule).
+
+use minidom::Element;
+use waddle_sfu::{CallId, Identity, Jti, Jwt, WebsocketUrl};
+use waddle_xmpp::xep::xep_waddle_livekit_transport::{
+    IssuedTransport, TransportParseError, WaddleLiveKitTransport, NS_WADDLE_LIVEKIT_TRANSPORT,
+};
+
+fn issued_fixture() -> IssuedTransport {
+    let url = WebsocketUrl::new("wss://livekit.waddle.test".parse().expect("valid url"))
+        .expect("valid ws url");
+    let room = CallId::new("alice@waddle.test::c1").expect("valid call id");
+    let jid: jid::FullJid = "bob@waddle.test/desktop".parse().expect("valid jid");
+    let identity = Identity::from_jid(jid);
+    let token = Jwt::from_wire("eyJhbGciOi.payload.sig".to_string());
+    IssuedTransport {
+        url,
+        room,
+        identity,
+        token,
+    }
+}
+
+// ── Namespace constant ────────────────────────────────────────────────
+
+#[test]
+fn waddle_livekit_transport_namespace_is_versioned_zero() {
+    // `urn:waddle:*` per the CLAUDE.md XEP-conformance rule; the
+    // `:0` suffix is the initial-draft version marker — future
+    // revisions bump per the XSF Registrar convention.
+    assert_eq!(
+        NS_WADDLE_LIVEKIT_TRANSPORT,
+        "urn:waddle:transports:livekit:0"
+    );
+}
+
+// ── Request form (empty element) ─────────────────────────────────────
+
+#[test]
+fn waddle_livekit_transport_request_form_serialises_to_empty_element() {
+    // The request form is the wire shape clients emit to ask the
+    // server for a LiveKit token. It has NO attributes and NO
+    // children — the server rewrites it with the issued form before
+    // forwarding to the peer.
+    let req = WaddleLiveKitTransport::request();
+    let elem = req.to_element();
+    assert_eq!(elem.name(), "transport");
+    assert_eq!(elem.ns(), NS_WADDLE_LIVEKIT_TRANSPORT);
+    assert!(
+        elem.attrs().next().is_none(),
+        "request form carries no attributes"
+    );
+    assert!(
+        elem.children().next().is_none(),
+        "request form carries no children"
+    );
+}
+
+#[test]
+fn waddle_livekit_transport_request_form_round_trips() {
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT).build();
+    let parsed = WaddleLiveKitTransport::try_from(&elem).expect("request form parses");
+    assert!(matches!(parsed, WaddleLiveKitTransport::Request));
+
+    // Re-serialise → reparse to prove the empty form is stable.
+    let reser = parsed.to_element();
+    let reparsed = WaddleLiveKitTransport::try_from(&reser).expect("reparses");
+    assert!(matches!(reparsed, WaddleLiveKitTransport::Request));
+}
+
+// ── Issued form (populated element + <token/> child) ─────────────────
+
+#[test]
+fn waddle_livekit_transport_issued_form_carries_all_four_fields() {
+    // The issued form carries: `url`, `room`, `identity` attributes
+    // plus a `<token/>` child whose text is the LiveKit JWT.
+    let issued = WaddleLiveKitTransport::Issued(issued_fixture());
+    let elem = issued.to_element();
+    assert_eq!(elem.name(), "transport");
+    assert_eq!(elem.ns(), NS_WADDLE_LIVEKIT_TRANSPORT);
+
+    assert_eq!(elem.attr("url"), Some("wss://livekit.waddle.test/"));
+    assert_eq!(elem.attr("room"), Some("alice@waddle.test::c1"));
+    assert_eq!(elem.attr("identity"), Some("bob@waddle.test/desktop"));
+
+    let token = elem
+        .children()
+        .find(|c| c.name() == "token" && c.ns() == NS_WADDLE_LIVEKIT_TRANSPORT)
+        .expect("issued form carries a <token/> child");
+    assert_eq!(token.text(), "eyJhbGciOi.payload.sig");
+}
+
+#[test]
+fn waddle_livekit_transport_issued_form_round_trips_through_typed_surface() {
+    // Build via typed `IssuedTransport`, serialise, reparse, and
+    // verify every typed field survives the wire encoding.
+    let fixture = issued_fixture();
+    let issued = WaddleLiveKitTransport::Issued(fixture.clone());
+    let elem = issued.to_element();
+
+    let parsed = WaddleLiveKitTransport::try_from(&elem).expect("issued form parses");
+    match parsed {
+        WaddleLiveKitTransport::Issued(t) => {
+            assert_eq!(t.url.as_str(), fixture.url.as_str());
+            assert_eq!(t.room, fixture.room);
+            assert_eq!(t.identity, fixture.identity);
+            assert_eq!(t.token.as_str(), fixture.token.as_str());
+        }
+        WaddleLiveKitTransport::Request => {
+            panic!("populated transport must reparse as Issued, not Request")
+        }
+    }
+}
+
+// ── Negative cases — typed parse errors ──────────────────────────────
+
+#[test]
+fn waddle_livekit_transport_rejects_wrong_namespace() {
+    // A `<transport/>` element in a non-Waddle namespace MUST NOT
+    // parse as `WaddleLiveKitTransport`. The server's Jingle
+    // handler uses this discriminator to reject foreign transports
+    // (e.g. ICE-UDP) with `<unsupported-transports/>`.
+    let elem = Element::builder("transport", "urn:xmpp:jingle:transports:ice-udp:1").build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("wrong ns");
+    assert!(matches!(err, TransportParseError::WrongElement));
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_wrong_element_name() {
+    let elem = Element::builder("candidate", NS_WADDLE_LIVEKIT_TRANSPORT).build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("wrong name");
+    assert!(matches!(err, TransportParseError::WrongElement));
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_missing_url_attribute() {
+    // The issued form MUST carry url + room + identity + <token/>.
+    // Partial population is an unambiguous wire-format error
+    // (typed parse fails) — the server's Jingle handler hides the
+    // inner message and replies with a generic <bad-request/>.
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("room", "alice@waddle.test::c1")
+        .attr("identity", "bob@waddle.test/desktop")
+        .append(
+            Element::builder("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+                .append("jwt")
+                .build(),
+        )
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("missing url");
+    assert!(
+        matches!(err, TransportParseError::MissingAttribute("url")),
+        "missing-url error names the missing attribute, got {err:?}"
+    );
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_missing_room_attribute() {
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("url", "wss://livekit.waddle.test/")
+        .attr("identity", "bob@waddle.test/desktop")
+        .append(
+            Element::builder("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+                .append("jwt")
+                .build(),
+        )
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("missing room");
+    assert!(matches!(err, TransportParseError::MissingAttribute("room")));
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_missing_identity_attribute() {
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("url", "wss://livekit.waddle.test/")
+        .attr("room", "alice@waddle.test::c1")
+        .append(
+            Element::builder("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+                .append("jwt")
+                .build(),
+        )
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("missing identity");
+    assert!(matches!(
+        err,
+        TransportParseError::MissingAttribute("identity")
+    ));
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_missing_token_child() {
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("url", "wss://livekit.waddle.test/")
+        .attr("room", "alice@waddle.test::c1")
+        .attr("identity", "bob@waddle.test/desktop")
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("missing token");
+    assert!(matches!(err, TransportParseError::MissingToken));
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_invalid_url_scheme() {
+    // The `WebsocketUrl::new` constructor restricts schemes to
+    // `ws://` and `wss://`. An `http://` URL is rejected at the
+    // typed-construction boundary.
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("url", "http://livekit.waddle.test/")
+        .attr("room", "alice@waddle.test::c1")
+        .attr("identity", "bob@waddle.test/desktop")
+        .append(
+            Element::builder("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+                .append("jwt")
+                .build(),
+        )
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("invalid scheme");
+    assert!(
+        matches!(err, TransportParseError::InvalidUrl(_)),
+        "http:// scheme must be rejected by the typed WebsocketUrl: {err:?}"
+    );
+}
+
+#[test]
+fn waddle_livekit_transport_rejects_invalid_identity_jid() {
+    // Identity is constructed from a `FullJid`. A bare JID has no
+    // resource and MUST be rejected — the LiveKit identity needs
+    // a specific session-resource.
+    let elem = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT)
+        .attr("url", "wss://livekit.waddle.test/")
+        .attr("room", "alice@waddle.test::c1")
+        .attr("identity", "bob@waddle.test")
+        .append(
+            Element::builder("token", NS_WADDLE_LIVEKIT_TRANSPORT)
+                .append("jwt")
+                .build(),
+        )
+        .build();
+    let err = WaddleLiveKitTransport::try_from(&elem).expect_err("bare identity");
+    assert!(
+        matches!(err, TransportParseError::InvalidIdentity(_)),
+        "bare JID identity must be rejected, got {err:?}"
+    );
+}
+
+// ── Builder helpers via from_join_token ──────────────────────────────
+
+#[test]
+fn waddle_livekit_transport_from_join_token_produces_issued_form() {
+    // The server constructs the issued transport from a
+    // `JoinToken` returned by the SFU service. The conversion
+    // copies the typed fields verbatim — no string round-trip.
+    let join = waddle_sfu::JoinToken {
+        url: WebsocketUrl::new("wss://livekit.waddle.test".parse().expect("valid url"))
+            .expect("valid ws url"),
+        room: CallId::new("alice@waddle.test::c1").expect("valid call id"),
+        identity: Identity::from_jid("bob@waddle.test/desktop".parse().expect("valid jid")),
+        jwt: Jwt::from_wire("a.b.c".to_string()),
+        jti: Jti::new(),
+        expires_at: chrono::Utc::now() + chrono::Duration::seconds(3600),
+    };
+    let xport = WaddleLiveKitTransport::from_join_token(join);
+    let elem = xport.to_element();
+    let parsed = WaddleLiveKitTransport::try_from(&elem).expect("parses");
+    match parsed {
+        WaddleLiveKitTransport::Issued(t) => {
+            assert_eq!(t.url.as_str(), "wss://livekit.waddle.test/");
+            assert_eq!(t.room.as_str(), "alice@waddle.test::c1");
+            assert_eq!(t.identity.as_livekit_identity(), "bob@waddle.test/desktop");
+            assert_eq!(t.token.as_str(), "a.b.c");
+        }
+        WaddleLiveKitTransport::Request => panic!("from_join_token must produce Issued"),
+    }
+}
+
+#[test]
+fn waddle_livekit_transport_token_child_is_in_same_namespace_as_parent() {
+    // Defensive: the `<token/>` child MUST be qualified by the
+    // same `urn:waddle:transports:livekit:0` namespace as its
+    // parent so a hand-built element using the default namespace
+    // (which would put `<token/>` in `jabber:client`) parses
+    // correctly.
+    let issued = WaddleLiveKitTransport::Issued(issued_fixture());
+    let elem = issued.to_element();
+    let token = elem
+        .children()
+        .find(|c| c.name() == "token")
+        .expect("token present");
+    assert_eq!(
+        token.ns(),
+        NS_WADDLE_LIVEKIT_TRANSPORT,
+        "<token/> MUST inherit the transport namespace, not default"
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_muc_call.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_muc_call.rs
@@ -1,0 +1,353 @@
+//! `urn:waddle:muc-call:0` — Waddle MUC presence-extension custom XEP
+//! dedicated test suite.
+//!
+//! This is a Waddle-custom namespace (the CLAUDE.md XEP conformance
+//! rule allows custom `urn:waddle:*` namespaces only where no XEP
+//! shape fits — SFU-backed group-call state is one such case). The
+//! tests below pin:
+//!
+//! * Wire shape — `<call xmlns='urn:waddle:muc-call:0' state='…'
+//!   call-id='…'/>` round-trips through the typed
+//!   [`MucCallExtension`] surface.
+//! * State semantics — `state='active'` enters the room's call_state
+//!   map; `state='inactive'` clears it.
+//! * Presence-extension forwarding — when a session sends `inactive`,
+//!   the post-update broadcast omits the `<call/>` child entirely so
+//!   peers stop seeing the indicator.
+//! * Per-session origination — the originating `FullJid` is stored
+//!   so a partial-session leave (one resource of a multi-resource
+//!   occupant) clears the chip even when the user's other sessions
+//!   remain in the room. Without this, alice/mobile staying in the
+//!   channel after her desktop (on the call) drops would keep the
+//!   chip lit forever.
+//!
+//! All construction goes through typed Rust values:
+//! [`MucCallExtension`], [`CallPresenceState`], [`CallId`]. No
+//! `format!`, no string concatenation (CLAUDE.md XML hard rule).
+
+use jid::{BareJid, FullJid};
+use minidom::Element;
+use waddle_sfu::CallId;
+use waddle_xmpp::muc::{MucRoom, Occupant, RoomConfig};
+use waddle_xmpp::xep::xep_waddle_muc_call::{
+    CallPresenceState, MucCallExtension, MucCallParseError, NS_WADDLE_MUC_CALL,
+};
+use waddle_xmpp::{Affiliation, Role};
+
+fn call_id(s: &str) -> CallId {
+    CallId::new(s).expect("valid call id")
+}
+
+fn full(s: &str) -> FullJid {
+    s.parse().expect("valid full jid")
+}
+
+fn bare(s: &str) -> BareJid {
+    s.parse().expect("valid bare jid")
+}
+
+fn occupant(real_jid: FullJid, nick: &str) -> Occupant {
+    Occupant {
+        real_jid,
+        nick: nick.to_owned(),
+        role: Role::Participant,
+        affiliation: Affiliation::Member,
+        is_remote: false,
+        home_server: None,
+    }
+}
+
+fn fresh_room() -> MucRoom {
+    MucRoom::new(
+        bare("room@muc.test"),
+        "wad-1".into(),
+        "chan-1".into(),
+        RoomConfig::default(),
+    )
+}
+
+// ── Namespace constant ────────────────────────────────────────────────
+
+#[test]
+fn waddle_muc_call_namespace_is_versioned_zero() {
+    // The `:0` version suffix marks this as the initial draft of a
+    // Waddle-custom namespace. Future revisions bump the suffix per
+    // the XSF Registrar convention so old clients can opt out by
+    // namespace.
+    assert_eq!(NS_WADDLE_MUC_CALL, "urn:waddle:muc-call:0");
+}
+
+// ── Wire shape round-trip ─────────────────────────────────────────────
+
+#[test]
+fn waddle_muc_call_active_round_trips() {
+    // Build via the typed `MucCallExtension::active` constructor →
+    // serialise → reparse. The post-roundtrip typed value MUST
+    // match the original, proving the wire shape is the source of
+    // truth.
+    let original = MucCallExtension::active(call_id("room@muc.test"));
+    let elem = original.to_element();
+    assert_eq!(elem.name(), "call");
+    assert_eq!(elem.ns(), NS_WADDLE_MUC_CALL);
+    assert_eq!(elem.attr("state"), Some("active"));
+    assert_eq!(elem.attr("call-id"), Some("room@muc.test"));
+
+    let reparsed = MucCallExtension::try_from(&elem).expect("active reparses");
+    assert_eq!(reparsed.state, CallPresenceState::Active);
+    assert_eq!(reparsed.call_id.as_str(), "room@muc.test");
+}
+
+#[test]
+fn waddle_muc_call_inactive_round_trips() {
+    // `inactive` is the explicit "call has ended" signal — needed
+    // because absence-of-`<call/>` already means "not in call",
+    // so an explicit transition is required when an active session
+    // ends the call without leaving the room.
+    let original = MucCallExtension::inactive(call_id("room@muc.test"));
+    let elem = original.to_element();
+    assert_eq!(elem.attr("state"), Some("inactive"));
+    assert_eq!(elem.attr("call-id"), Some("room@muc.test"));
+
+    let reparsed = MucCallExtension::try_from(&elem).expect("inactive reparses");
+    assert_eq!(reparsed.state, CallPresenceState::Inactive);
+}
+
+#[test]
+fn waddle_muc_call_rejects_unknown_state_value() {
+    // The state attribute is constrained to the {active, inactive}
+    // set. Any other value (e.g. `ringing`, `paused`, … future
+    // extensions) MUST be rejected at the parser boundary so
+    // unknown semantics can't leak into the room actor.
+    let elem = Element::builder("call", NS_WADDLE_MUC_CALL)
+        .attr("state", "ringing")
+        .attr("call-id", "room@muc.test")
+        .build();
+    let err = MucCallExtension::try_from(&elem).expect_err("unknown state");
+    assert!(
+        matches!(err, MucCallParseError::InvalidState(ref s) if s == "ringing"),
+        "unknown state error preserves the offending value: {err:?}"
+    );
+}
+
+#[test]
+fn waddle_muc_call_rejects_missing_call_id() {
+    // The `call-id` attribute is mandatory — without it the
+    // extension can't be tied to a specific SFU call. Parse failure
+    // returns the missing attribute name verbatim.
+    let elem = Element::builder("call", NS_WADDLE_MUC_CALL)
+        .attr("state", "active")
+        .build();
+    let err = MucCallExtension::try_from(&elem).expect_err("missing call-id");
+    match err {
+        MucCallParseError::MissingAttribute(name) => assert_eq!(name, "call-id"),
+        other => panic!("expected MissingAttribute(\"call-id\"), got {other:?}"),
+    }
+}
+
+#[test]
+fn waddle_muc_call_rejects_missing_state() {
+    let elem = Element::builder("call", NS_WADDLE_MUC_CALL)
+        .attr("call-id", "room@muc.test")
+        .build();
+    let err = MucCallExtension::try_from(&elem).expect_err("missing state");
+    match err {
+        MucCallParseError::MissingAttribute(name) => assert_eq!(name, "state"),
+        other => panic!("expected MissingAttribute(\"state\"), got {other:?}"),
+    }
+}
+
+#[test]
+fn waddle_muc_call_rejects_versioned_namespace_drift() {
+    // A `<call/>` element in a different version namespace
+    // (`urn:waddle:muc-call:1`) MUST NOT parse as the `:0` typed
+    // extension. This is the version-coexistence safety net: an
+    // old room actor encountering a future `:1` payload sees
+    // WrongElement and ignores it instead of mis-interpreting.
+    let elem = Element::builder("call", "urn:waddle:muc-call:1")
+        .attr("state", "active")
+        .attr("call-id", "room@muc.test")
+        .build();
+    let err = MucCallExtension::try_from(&elem).expect_err("wrong namespace");
+    assert!(matches!(err, MucCallParseError::WrongElement));
+}
+
+// ── Presence-extension forwarding via MucRoom::upsert_call_state ─────
+
+#[test]
+fn waddle_muc_call_active_state_stored_in_room_call_state() {
+    // §presence-forwarding: a session emitting `state='active'`
+    // adds an entry to the room's call_state map. The room's
+    // `call_state_for_nick` lookup returns the typed extension so
+    // late joiners can be told there's a live call when they
+    // receive the occupant list replay.
+    let mut room = fresh_room();
+    let alice_desktop = full("alice@waddle.test/desktop");
+    room.add_occupant(occupant(alice_desktop.clone(), "alice"));
+
+    let ext = MucCallExtension::active(call_id("room@muc.test"));
+    let outcome = room.upsert_call_state("alice", alice_desktop.clone(), ext);
+
+    // Active upserts return `Some(ext)` so the broadcaster knows to
+    // include the `<call/>` child in the forwarded presence.
+    let active_ext = outcome.expect("active upsert returns the live extension");
+    assert_eq!(active_ext.state, CallPresenceState::Active);
+    assert_eq!(active_ext.call_id.as_str(), "room@muc.test");
+
+    // The room remembers the call for late joiners.
+    let stored = room
+        .call_state_for_nick("alice")
+        .expect("call state stored");
+    assert_eq!(stored.state, CallPresenceState::Active);
+    assert_eq!(stored.call_id.as_str(), "room@muc.test");
+}
+
+#[test]
+fn waddle_muc_call_inactive_clears_room_call_state() {
+    // §presence-forwarding: a session emitting `state='inactive'`
+    // removes the entry from the room's call_state map. The
+    // upsert returns `None`, telling the broadcaster to forward a
+    // presence WITHOUT the `<call/>` child — peers see the chip
+    // disappear.
+    let mut room = fresh_room();
+    let alice_desktop = full("alice@waddle.test/desktop");
+    room.add_occupant(occupant(alice_desktop.clone(), "alice"));
+
+    // First: enter the call.
+    let _ = room.upsert_call_state(
+        "alice",
+        alice_desktop.clone(),
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    assert!(room.call_state_for_nick("alice").is_some());
+
+    // Then: leave the call.
+    let outcome = room.upsert_call_state(
+        "alice",
+        alice_desktop,
+        MucCallExtension::inactive(call_id("room@muc.test")),
+    );
+    assert!(
+        outcome.is_none(),
+        "inactive upsert returns None so broadcast omits <call/>"
+    );
+    assert!(
+        room.call_state_for_nick("alice").is_none(),
+        "inactive clears the room's call_state entry"
+    );
+}
+
+// ── Per-session origination — multi-resource ghost-chip guard ───────
+
+#[test]
+fn waddle_muc_call_last_session_leave_clears_chip() {
+    // §ghost-chip safety net (single-session variant): alice's
+    // session is on the call, then the session leaves the room
+    // entirely. The call advertisement MUST clear so peers stop
+    // seeing the chip — otherwise late joiners would replay a
+    // chip for a participant who isn't in the room any more.
+    let mut room = fresh_room();
+    let alice = full("alice@waddle.test/desktop");
+    room.add_occupant(occupant(alice.clone(), "alice"));
+
+    let _ = room.upsert_call_state(
+        "alice",
+        alice.clone(),
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    assert!(room.call_state_for_nick("alice").is_some());
+
+    // Last (and only) session for alice leaves — the occupant is
+    // fully removed and the chip clears.
+    let outcome = room.remove_occupant_session("alice", &alice);
+    assert_eq!(
+        outcome,
+        Some(true),
+        "last session leaving removes the occupant"
+    );
+    assert!(
+        room.call_state_for_nick("alice").is_none(),
+        "last-session leave clears the call advertisement"
+    );
+}
+
+#[test]
+fn waddle_muc_call_remove_occupant_clears_chip() {
+    // The hard-remove path (`remove_occupant`) is used when the
+    // server forcibly evicts an occupant (kick, ban, server-side
+    // cleanup). The call advertisement MUST be cleared regardless
+    // of which code path causes the eviction.
+    let mut room = fresh_room();
+    let alice = full("alice@waddle.test/desktop");
+    room.add_occupant(occupant(alice.clone(), "alice"));
+    let _ = room.upsert_call_state(
+        "alice",
+        alice,
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    assert!(room.call_state_for_nick("alice").is_some());
+
+    let removed = room.remove_occupant("alice");
+    assert!(removed.is_some(), "occupant was present and is now removed");
+    assert!(
+        room.call_state_for_nick("alice").is_none(),
+        "hard-remove path clears the call advertisement"
+    );
+}
+
+// ── Active call survives a non-originator session leave ──────────────
+
+#[test]
+fn waddle_muc_call_state_persists_across_unrelated_session_leaves() {
+    // Conversely: if alice (originator) is on the call and bob
+    // leaves the room, alice's chip MUST NOT clear. The chip is
+    // keyed by the originating session, not by room occupancy in
+    // general.
+    let mut room = fresh_room();
+    let alice = full("alice@waddle.test/desktop");
+    let bob = full("bob@waddle.test/desktop");
+    room.add_occupant(occupant(alice.clone(), "alice"));
+    room.add_occupant(occupant(bob.clone(), "bob"));
+
+    let _ = room.upsert_call_state(
+        "alice",
+        alice.clone(),
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    assert!(room.call_state_for_nick("alice").is_some());
+
+    // bob's session leaves — alice's chip MUST remain lit.
+    let _ = room.remove_occupant_session("bob", &bob);
+    assert!(
+        room.call_state_for_nick("alice").is_some(),
+        "an unrelated occupant leaving must not clear alice's call chip"
+    );
+}
+
+// ── Replacing an active extension preserves the originator binding ──
+
+#[test]
+fn waddle_muc_call_re_upserting_active_overwrites_existing_entry() {
+    // A second `active` from the same session refreshes the
+    // extension (e.g. on a presence re-broadcast). The room
+    // continues to advertise the same call_id and the chip stays
+    // lit.
+    let mut room = fresh_room();
+    let alice = full("alice@waddle.test/desktop");
+    room.add_occupant(occupant(alice.clone(), "alice"));
+
+    let _ = room.upsert_call_state(
+        "alice",
+        alice.clone(),
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    let outcome = room.upsert_call_state(
+        "alice",
+        alice.clone(),
+        MucCallExtension::active(call_id("room@muc.test")),
+    );
+    assert!(outcome.is_some(), "re-active still returns the live ext");
+    let stored = room
+        .call_state_for_nick("alice")
+        .expect("entry still present");
+    assert_eq!(stored.call_id.as_str(), "room@muc.test");
+}


### PR DESCRIPTION
## Summary

Comprehensive remediation following an intensive audit of Waddle's LiveKit calling feature. 18 commits across server (Rust) and chat (Vue 3 / TS), covering the user-reported "1 in call" ghost, three categories of resource leak, two XEP conformance gaps, and missing dedicated test coverage.

### The user-visible bug — three compounding roots

Channel header showed "1 person in this channel's call" with nobody actually present.

- **R1 / `cleanup_muc_presence` never broadcasted unavailable.** On tab close, SM-expiry, panic-shed, or network drop, the server removed the user from the room actor but never told remaining occupants. Their client-side `$mucCallParticipants[room]` set kept the leaver's nick indefinitely. Fixed by extracting `broadcast_muc_leave_to_remaining` and calling it from both explicit-leave and unclean-disconnect paths, so the wire shape is identical.
- **R2 / per-nick `call_state` ghosted across multi-resource sessions.** alice/desktop on the call, alice/mobile in the room not on the call, desktop drops → `call_state[alice]` stayed lit because the entry was only cleared on last-session-leave. Now keyed per `(nick, originating FullJid)`; partial-session leave clears the entry.
- **Pagehide handler / `engine.disconnect` on WS drop.** Chat-side `onBeforeUnmount` was too late for actual tab close. Added `pagehide` handler plus `engine.disconnect()` in the XMPP disconnect path. Pagehide is documented as best-effort; the server-side R1 broadcast is the authoritative chip-clear.

### Other fixes

- **SFU memory hygiene.** `ApiSecret` and `TurnSharedSecret` now derive `ZeroizeOnDrop`. Per-(call, identity) issued JTI vec capped at 16 (FIFO). Revoked JTI set carries expiry and sweeps lazily.
- **XEP-0215** TLS-protected TURN advertised as `type='turns'` (not `'turn'`) per §3.6.5.
- **XEP-0353 (JMI)** envelope conformance: `type='chat'` + `<store xmlns='urn:xmpp:hints'/>` on every propose / proceed / reject / retract / finish. `build_propose` now emits one `<description/>` per media kind. `build_finish` accepts typed `Reason`. `<finish/>` is now actually sent after DM session-terminate (was dead code).
- **Engine resilience.** `connect()` rolls back the LiveKit Room on post-connect failure (mic/cam permission denied). Listener cleanup on connect failure. Settings `devicechange` listener scoped to dialog-open lifetime with 200ms debounce + epoch counter for stale enumerate results.
- **PIP & tile hygiene.** Replaced LK private `attachedElements` access with a typed `Map<participantSid, HTMLVideoElement>`. `CallTileGrid` tracks attach/detach correctly via a new `TileAttachments` helper. PIP exits on overlay unmount.

### Tests

- Server: new regression tests for unclean-disconnect broadcast and multi-session call_state, plus 5 dedicated XEP test files per CLAUDE.md hard rule (`tests/xep0166_jingle.rs`, `xep0167_jingle_rtp.rs`, `xep0353_jingle_message.rs`, `xep_waddle_muc_call.rs`, `xep_waddle_livekit_transport.rs`).
- Chat: new tests for video-registry, tile-attach, and finish-emission on hangup.
- Adversarial review pass identified three follow-ups (test-harness `<stream:error>` tripwire, engine listener race on connect failure, overstated pagehide docstring) — all addressed in the final commit.

### Out of scope / verified non-blockers
- Reviewer flagged a "BLOCKER" for forged Jingle `session-terminate` revoking another user's tokens. Independently verified against the actual code: `Identity::from_jid(ctx.full_jid.clone())` is auth-locked, so a forged `initiator` only revokes the attacker's own tokens. Not exploitable.

## Test plan
- [x] `bun test` clean for chat/ (956 pass)
- [x] `bun run lint` (knip) clean for chat/
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke needed: two browser tabs, one starts MUC call, closes tab without hangup — second tab's chip clears within the broadcast latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)