### PR TITLE
fix(server): discover_topology — also list standalone MUC rooms

### DIFF
--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -331,28 +331,20 @@ impl WaddleClient {
     }
 
     pub async fn discover_topology(&self) -> WaddleTopology {
-        let guard = self.handle.lock().await;
-        let Some(h) = guard.as_ref() else {
-            drop(guard);
-            self.listener.on_error("Not connected".to_string());
+        let Some(handle) = self.clone_handle().await else {
             return empty_topology();
         };
-
-        let spaces_domain = format!("spaces.{}", jid_domain(&self.config.jid));
-        let spaces_jid: BareJid = match spaces_domain.parse() {
-            Ok(jid) => jid,
-            Err(e) => {
-                drop(guard);
-                self.listener
-                    .on_error(format!("discover_topology: invalid spaces JID: {e}"));
-                return empty_topology();
-            }
-        };
-
-        match h.discover_topology(&spaces_jid).await {
+        // `discover_topology` now resolves the MUC and Spaces service
+        // JIDs from the server domain itself (with conventional
+        // subdomain fallbacks), enumerates rooms via *both* the
+        // Spaces bookmarks and the MUC component directly, and
+        // attaches non-bookmarked rooms to a synthetic "standalone"
+        // space. So a fresh waddle deployment with no XEP-0503 space
+        // bookmarks still produces a usable channel list.
+        let server_domain = jid_domain(&self.config.jid);
+        match handle.discover_topology(server_domain).await {
             Ok(topology) => topology_to_ffi(topology),
             Err(e) => {
-                drop(guard);
                 self.listener
                     .on_error(format!("discover_topology failed: {e}"));
                 empty_topology()

--- a/server/crates/waddle-xmpp-client/src/discovery.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery.rs
@@ -22,9 +22,9 @@ pub use parsing::{
 };
 pub use types::{
     DiscoDataField, DiscoDataForm, DiscoFeature, DiscoIdentity, DiscoInfoResult, DiscoItem,
-    DiscoveredChannel, DiscoveredChannelType, DiscoveredSpace, DiscoveredTopology,
-    MucAdminAffiliationItem, RosterResult, SpaceNode, UploadSlot, UserSearchForm, UserSearchItem,
-    UserSearchQuery, UserSearchResult, WaddleInboxMarkRead,
+    DiscoveredChannel, DiscoveredChannelType, DiscoveredComponentServices, DiscoveredSpace,
+    DiscoveredTopology, MucAdminAffiliationItem, RosterResult, SpaceNode, UploadSlot,
+    UserSearchForm, UserSearchItem, UserSearchQuery, UserSearchResult, WaddleInboxMarkRead,
 };
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
@@ -49,6 +49,16 @@ pub const PUBSUB_METADATA_FORM_TYPE: &str = "http://jabber.org/protocol/pubsub#m
 pub const BOOKMARKS_NS: &str = "urn:xmpp:bookmarks:1";
 pub const SPACES_NS: &str = "urn:xmpp:spaces:0";
 pub const WADDLE_ROOM_METADATA_FORM_TYPE: &str = "urn:waddle:room:0";
+/// `http://jabber.org/protocol/muc` — the XEP-0045 feature
+/// advertised by Multi-User Chat services. Used at service
+/// discovery time to identify which component hosts MUC rooms.
+pub const MUC_NS: &str = "http://jabber.org/protocol/muc";
+/// Synthetic space id assigned to MUC rooms that are *not* bookmarked
+/// into any XEP-0503 space. Lets the UI place every joinable room
+/// under some space without requiring server-side bookmark
+/// administration first. Keep stable: clients may store the id as
+/// part of their last-selected-space state.
+pub const STANDALONE_SPACE_ID: &str = "standalone";
 pub const USER_SEARCH_NS: &str = "jabber:iq:search";
 pub const MUC_ADMIN_NS: &str = "http://jabber.org/protocol/muc#admin";
 pub use waddle_xmpp_core::roster::ROSTER_NS;

--- a/server/crates/waddle-xmpp-client/src/discovery/ext.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/ext.rs
@@ -9,13 +9,13 @@ use super::iq::{
 };
 use super::parsing::{
     parse_disco_info_result, parse_disco_items_result, parse_space_channels_result,
-    parse_upload_slot, space_from_disco_item,
+    parse_upload_slot, resolve_component_services, space_from_disco_item,
 };
 use super::types::{
-    DiscoInfoResult, DiscoItem, DiscoveredChannel, DiscoveredChannelType, DiscoveredSpace,
-    DiscoveredTopology, SpaceNode, UploadSlot,
+    DiscoInfoResult, DiscoItem, DiscoveredChannel, DiscoveredChannelType,
+    DiscoveredComponentServices, DiscoveredSpace, DiscoveredTopology, SpaceNode, UploadSlot,
 };
-use super::{UPLOAD_NS, WADDLE_ROOM_METADATA_FORM_TYPE};
+use super::{STANDALONE_SPACE_ID, UPLOAD_NS, WADDLE_ROOM_METADATA_FORM_TYPE};
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
@@ -80,8 +80,27 @@ pub trait DiscoveryExt {
         space_id: &SpaceNode,
     ) -> ClientResult<Vec<DiscoveredChannel>>;
 
-    /// Discover the native spaces + channels topology.
-    async fn discover_topology(&self, spaces_jid: &BareJid) -> ClientResult<DiscoveredTopology>;
+    /// Resolve the MUC and Spaces service JIDs against `server_domain`
+    /// via `disco#items` + `disco#info`. Falls back to the conventional
+    /// `muc.<domain>` and `spaces.<domain>` subdomains when the
+    /// server does not explicitly advertise the relevant features
+    /// (XEP-0045 `http://jabber.org/protocol/muc` for MUC, the
+    /// `urn:xmpp:spaces:0` feature for Spaces).
+    async fn discover_component_services(
+        &self,
+        server_domain: &str,
+    ) -> ClientResult<DiscoveredComponentServices>;
+
+    /// Discover the native spaces + channels topology against the
+    /// server domain. Resolves both the MUC and Spaces service JIDs
+    /// (via [`discover_component_services`](Self::discover_component_services)),
+    /// reads XEP-0503 space bookmarks, **and** enumerates the MUC
+    /// component directly so rooms without a space bookmark still
+    /// surface to the UI. Rooms not bookmarked into any space are
+    /// attached to a synthetic space with id [`STANDALONE_SPACE_ID`]
+    /// so a single channel list can be rendered without
+    /// special-casing.
+    async fn discover_topology(&self, server_domain: &str) -> ClientResult<DiscoveredTopology>;
 }
 
 // ── Implementation ────────────────────────────────────────────────────────────
@@ -195,12 +214,154 @@ impl DiscoveryExt for ClientHandle {
         Ok(channels)
     }
 
-    async fn discover_topology(&self, spaces_jid: &BareJid) -> ClientResult<DiscoveredTopology> {
-        let spaces = self.discover_spaces(spaces_jid).await?;
-        let mut channels = Vec::new();
-        for space in &spaces {
-            channels.extend(self.discover_space_channels(spaces_jid, &space.id).await?);
+    async fn discover_component_services(
+        &self,
+        server_domain: &str,
+    ) -> ClientResult<DiscoveredComponentServices> {
+        // Conventional defaults: many waddle deployments don't advertise
+        // their components via server disco (or the fallback is plenty).
+        // Parse failures here would be a misconfigured server domain
+        // and would have already failed connect; bubble up the error.
+        let fallback_muc: BareJid =
+            format!("muc.{server_domain}")
+                .parse()
+                .map_err(|e: jid::Error| {
+                    ClientError::StanzaError(StanzaError {
+                        error_type: StanzaErrorType::Cancel,
+                        condition: "bad-request".to_string(),
+                        text: Some(format!("invalid MUC fallback JID: {e}")),
+                    })
+                })?;
+        let fallback_spaces: BareJid =
+            format!("spaces.{server_domain}")
+                .parse()
+                .map_err(|e: jid::Error| {
+                    ClientError::StanzaError(StanzaError {
+                        error_type: StanzaErrorType::Cancel,
+                        condition: "bad-request".to_string(),
+                        text: Some(format!("invalid Spaces fallback JID: {e}")),
+                    })
+                })?;
+
+        // Best-effort: if disco#items fails on the server domain (some
+        // small servers reject it), fall back to the conventional
+        // subdomains rather than refusing to load the topology entirely.
+        let Ok(items) = self.discover_items(server_domain, None).await else {
+            return Ok(DiscoveredComponentServices {
+                muc: fallback_muc,
+                spaces: fallback_spaces,
+            });
+        };
+
+        // Hydrate each disco#items entry with its disco#info so the
+        // service-selection logic can dispatch on advertised features.
+        // Disco#info failures are tolerated: they downgrade the entry
+        // to "feature unknown", which never wins against the fallback.
+        let mut hydrated: Vec<(BareJid, Option<DiscoInfoResult>)> = Vec::new();
+        for item in items {
+            let Ok(jid) = item.jid.parse::<BareJid>() else {
+                continue;
+            };
+            let info = self.discover_info(&item.jid, None).await.ok();
+            hydrated.push((jid, info));
         }
+        Ok(resolve_component_services(
+            &hydrated,
+            fallback_muc,
+            fallback_spaces,
+        ))
+    }
+
+    async fn discover_topology(&self, server_domain: &str) -> ClientResult<DiscoveredTopology> {
+        let services = self.discover_component_services(server_domain).await?;
+
+        // (1) XEP-0503 space bookmarks via the Spaces component.
+        // discover_spaces returns an empty list when the user has no
+        // spaces; that's fine — we still want to surface raw MUC rooms.
+        let spaces = self
+            .discover_spaces(&services.spaces)
+            .await
+            .unwrap_or_default();
+        let mut channels: Vec<DiscoveredChannel> = Vec::new();
+        for space in &spaces {
+            if let Ok(space_channels) = self
+                .discover_space_channels(&services.spaces, &space.id)
+                .await
+            {
+                channels.extend(space_channels);
+            }
+        }
+
+        // (2) Direct MUC component enumeration. Any room not already
+        // surfaced as a space bookmark is attached to a synthetic
+        // "standalone" space so the UI's space-keyed channel list can
+        // render every room a user might want to join without
+        // requiring server-side bookmark administration first.
+        let bookmarked: std::collections::HashSet<BareJid> = channels
+            .iter()
+            .map(|channel| channel.room_jid.clone())
+            .collect();
+
+        let mut spaces = spaces;
+        let standalone_space_id = SpaceNode::new(STANDALONE_SPACE_ID).ok_or_else(parse_error)?;
+        let mut standalone_count = 0usize;
+        if let Ok(rooms) = self.discover_items(&services.muc.to_string(), None).await {
+            for (offset, room) in rooms.into_iter().enumerate() {
+                let Ok(room_jid) = room.jid.parse::<BareJid>() else {
+                    continue;
+                };
+                if bookmarked.contains(&room_jid) {
+                    continue;
+                }
+                let mut channel_type = DiscoveredChannelType::Text;
+                let mut description = None;
+                if let Ok(info) = self.discover_info(&room.jid, None).await {
+                    if let Some(parsed_type) = info
+                        .form_value(WADDLE_ROOM_METADATA_FORM_TYPE, "waddle#channel_type")
+                        .and_then(DiscoveredChannelType::from_metadata)
+                    {
+                        channel_type = parsed_type;
+                    }
+                    description = info
+                        .form_value(
+                            "http://jabber.org/protocol/muc#roominfo",
+                            "muc#roominfo_description",
+                        )
+                        .filter(|description| !description.trim().is_empty())
+                        .map(str::to_string);
+                }
+                let name = room
+                    .name
+                    .filter(|name| !name.trim().is_empty())
+                    .unwrap_or_else(|| {
+                        room_jid
+                            .node()
+                            .map(|node| node.as_str().to_string())
+                            .unwrap_or_else(|| room_jid.to_string())
+                    });
+                let id = format!("{}::{}", STANDALONE_SPACE_ID, room_jid);
+                channels.push(DiscoveredChannel {
+                    id,
+                    room_jid,
+                    name,
+                    description,
+                    channel_type,
+                    position: offset as i32,
+                    space_id: standalone_space_id.clone(),
+                });
+                standalone_count += 1;
+            }
+        }
+
+        if standalone_count > 0 {
+            spaces.push(DiscoveredSpace {
+                id: standalone_space_id,
+                service_jid: services.muc.clone(),
+                name: "Rooms".to_string(),
+                description: None,
+            });
+        }
+
         Ok(DiscoveredTopology { spaces, channels })
     }
 }

--- a/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/parsing.rs
@@ -111,6 +111,54 @@ pub fn parse_spaces_from_disco_items(
         .collect()
 }
 
+/// Resolve the MUC and Spaces service JIDs from a server's
+/// `disco#items` items list, hydrated with each item's `disco#info`
+/// where available. The result preserves the supplied fallbacks for
+/// any component that the server does not explicitly advertise
+/// (most small deployments only advertise the MUC component).
+///
+/// MUC services are identified by the XEP-0045 feature
+/// `http://jabber.org/protocol/muc` (or the `conference` disco
+/// category as a legacy fallback). Spaces services are identified
+/// strictly by the `urn:xmpp:spaces:0` feature — a generic pubsub
+/// identity is not enough because Waddle's extensions component is
+/// also pubsub but unrelated to spaces (this is the same shape the
+/// chat web client uses; see `chat/src/lib/xmpp/discovery.ts`).
+///
+/// The first matching service wins for each component; subsequent
+/// matches are ignored.
+pub fn resolve_component_services(
+    items: &[(jid::BareJid, Option<DiscoInfoResult>)],
+    fallback_muc: jid::BareJid,
+    fallback_spaces: jid::BareJid,
+) -> super::types::DiscoveredComponentServices {
+    use super::{MUC_NS, SPACES_NS};
+
+    let mut muc: Option<jid::BareJid> = None;
+    let mut spaces: Option<jid::BareJid> = None;
+    for (jid, info_opt) in items {
+        let Some(info) = info_opt else {
+            continue;
+        };
+        if muc.is_none()
+            && (info.has_feature(MUC_NS)
+                || info
+                    .identities
+                    .iter()
+                    .any(|identity| identity.category == "conference"))
+        {
+            muc = Some(jid.clone());
+        }
+        if spaces.is_none() && info.has_feature(SPACES_NS) {
+            spaces = Some(jid.clone());
+        }
+    }
+    super::types::DiscoveredComponentServices {
+        muc: muc.unwrap_or(fallback_muc),
+        spaces: spaces.unwrap_or(fallback_spaces),
+    }
+}
+
 pub fn space_from_disco_item(
     spaces_jid: &BareJid,
     item: DiscoItem,

--- a/server/crates/waddle-xmpp-client/src/discovery/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/tests.rs
@@ -3,6 +3,7 @@ use minidom::Element;
 
 use crate::messaging::MucAffiliation;
 
+use super::parsing::resolve_component_services;
 use super::*;
 
 #[test]
@@ -601,4 +602,149 @@ fn build_and_parse_muc_admin_affiliation_queries() {
     assert_eq!(parsed[0].jid.as_deref(), Some("alice@example.com"));
     assert_eq!(parsed[0].affiliation, Some(MucAffiliation::Admin));
     assert_eq!(parsed[0].reason.as_deref(), Some("promoted"));
+}
+
+// ── Component service resolution ─────────────────────────────────────
+
+fn info(jid: &str, features: &[&str], identities: &[(&str, &str)]) -> DiscoInfoResult {
+    DiscoInfoResult {
+        jid: jid.to_string(),
+        node: None,
+        identities: identities
+            .iter()
+            .map(|(category, identity_type)| DiscoIdentity {
+                category: (*category).to_string(),
+                identity_type: (*identity_type).to_string(),
+                name: None,
+            })
+            .collect(),
+        features: features.iter().map(|f| (*f).to_string()).collect(),
+        forms: Vec::new(),
+    }
+}
+
+fn bare(jid: &str) -> BareJid {
+    jid.parse().expect("test JID parses")
+}
+
+#[test]
+fn resolve_component_services_picks_explicitly_advertised_jids() {
+    // Standard waddle deployment: the bare server domain advertises
+    // both component children via disco#items + disco#info; resolver
+    // returns those, ignoring the fallback values.
+    let items = vec![
+        (
+            bare("muc.waddle.test"),
+            Some(info("muc.waddle.test", &[MUC_NS], &[])),
+        ),
+        (
+            bare("spaces.waddle.test"),
+            Some(info("spaces.waddle.test", &[SPACES_NS], &[])),
+        ),
+    ];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.waddle.test"),
+        bare("spaces-fallback.waddle.test"),
+    );
+    assert_eq!(resolved.muc, bare("muc.waddle.test"));
+    assert_eq!(resolved.spaces, bare("spaces.waddle.test"));
+}
+
+#[test]
+fn resolve_component_services_falls_back_for_unadvertised_components() {
+    // Minimally configured server that only advertises MUC. The
+    // resolver must still produce a Spaces fallback so
+    // discover_topology can attempt the pubsub query (and
+    // gracefully return zero spaces if the fallback JID doesn't
+    // exist either).
+    let items = vec![(
+        bare("muc.waddle.test"),
+        Some(info("muc.waddle.test", &[MUC_NS], &[])),
+    )];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.waddle.test"),
+        bare("spaces.waddle.test"),
+    );
+    assert_eq!(resolved.muc, bare("muc.waddle.test"));
+    assert_eq!(resolved.spaces, bare("spaces.waddle.test"));
+}
+
+#[test]
+fn resolve_component_services_accepts_conference_identity_as_muc_fallback() {
+    // Legacy XEP-0045 deployments often advertise the MUC component
+    // only by identity category, not feature URI. The resolver
+    // honours either.
+    let items = vec![(
+        bare("rooms.legacy.test"),
+        Some(info("rooms.legacy.test", &[], &[("conference", "text")])),
+    )];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.legacy.test"),
+        bare("spaces-fallback.legacy.test"),
+    );
+    assert_eq!(resolved.muc, bare("rooms.legacy.test"));
+}
+
+#[test]
+fn resolve_component_services_does_not_pick_generic_pubsub_as_spaces() {
+    // Waddle's extensions component is also pubsub. Selecting it
+    // for "Spaces" would route every space query at the wrong
+    // service. Only the explicit XEP-0503 feature counts.
+    let items = vec![(
+        bare("pubsub.waddle.test"),
+        Some(info(
+            "pubsub.waddle.test",
+            &["http://jabber.org/protocol/pubsub"],
+            &[],
+        )),
+    )];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.waddle.test"),
+        bare("spaces-fallback.waddle.test"),
+    );
+    // Spaces falls back — extensions component is not eligible.
+    assert_eq!(resolved.spaces, bare("spaces-fallback.waddle.test"));
+}
+
+#[test]
+fn resolve_component_services_skips_entries_without_info() {
+    // disco#info on the component can fail (timeout, error iq).
+    // Entries with `None` info are skipped so the fallback wins
+    // rather than the resolver mis-classifying an unknown
+    // component.
+    let items = vec![(bare("unknown.waddle.test"), None)];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.waddle.test"),
+        bare("spaces-fallback.waddle.test"),
+    );
+    assert_eq!(resolved.muc, bare("muc-fallback.waddle.test"));
+    assert_eq!(resolved.spaces, bare("spaces-fallback.waddle.test"));
+}
+
+#[test]
+fn resolve_component_services_first_match_wins() {
+    // Two MUC components — resolver picks the first encountered
+    // and ignores subsequent matches (server presents components
+    // in a stable order, so this is deterministic on the wire).
+    let items = vec![
+        (
+            bare("muc1.waddle.test"),
+            Some(info("muc1.waddle.test", &[MUC_NS], &[])),
+        ),
+        (
+            bare("muc2.waddle.test"),
+            Some(info("muc2.waddle.test", &[MUC_NS], &[])),
+        ),
+    ];
+    let resolved = resolve_component_services(
+        &items,
+        bare("muc-fallback.waddle.test"),
+        bare("spaces-fallback.waddle.test"),
+    );
+    assert_eq!(resolved.muc, bare("muc1.waddle.test"));
 }

--- a/server/crates/waddle-xmpp-client/src/discovery/types.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/types.rs
@@ -146,6 +146,19 @@ pub struct DiscoveredTopology {
     pub channels: Vec<DiscoveredChannel>,
 }
 
+/// Service JIDs hosting the MUC and Spaces components for a Waddle
+/// deployment, resolved via service discovery against the server
+/// domain. Falls back to the conventional `muc.<domain>` and
+/// `spaces.<domain>` subdomains when the server does not advertise
+/// either feature explicitly — so clients keep working on
+/// minimally-configured servers and on standalone single-Waddle
+/// builds where the components share the bare domain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredComponentServices {
+    pub muc: BareJid,
+    pub spaces: BareJid,
+}
+
 /// Waddle-private `<mark-read/>` IQ-set parameters carried under
 /// `urn:waddle:inbox:0`. The query/response side of inbox lives on the
 /// XEP-0430 surface (`waddle_xmpp_client::inbox`).


### PR DESCRIPTION
## Why

The iOS app installed from PR #715 connects to a real server but renders an empty channel list. Live device test on iPhone 17 Pro: zero spaces, zero rooms.

**Root cause**: the native `discover_topology` in `waddle-xmpp-client` only enumerates XEP-0503 space bookmarks. It hardcoded `spaces.<domain>` as the service JID and never queried the MUC component directly. Rooms that exist on `muc.<domain>` but aren't bookmarked into any space were invisible. The chat web client (`chat/src/lib/xmpp/discovery.ts`) does the right thing — it discovers both services, enumerates the MUC component, and cross-references bookmarks; that's why chat works and Apple doesn't.

The XEP-0503 single-space refactor on the server (commits `e2fb8ec4`, `d84f4ee6`, `7278c094`) made this a hard regression for any deployment where rooms aren't pre-bookmarked.

## What this PR does

**`server/crates/waddle-xmpp-client/`**

- `discovery.rs`: new `MUC_NS` constant + new `STANDALONE_SPACE_ID` constant (`"standalone"`).
- `discovery/types.rs`: new `DiscoveredComponentServices { muc: BareJid, spaces: BareJid }` typed value.
- `discovery/parsing.rs`: new pure `resolve_component_services(items, fallback_muc, fallback_spaces)` function that picks the right service JID per component based on advertised features:
  - MUC = XEP-0045 feature `http://jabber.org/protocol/muc` **or** the legacy `conference` disco-info identity.
  - Spaces = strict `urn:xmpp:spaces:0` feature (a generic pubsub identity is rejected — Waddle's extensions component is also pubsub).
- `discovery/ext.rs`: new trait method `discover_component_services(server_domain)` (best-effort: returns conventional `muc.<domain>` / `spaces.<domain>` fallbacks if disco fails). `discover_topology` is rewritten to:
  1. Resolve both component services.
  2. Read XEP-0503 space bookmarks (existing path).
  3. **Also** enumerate `disco#items` on the MUC component directly.
  4. Cross-reference: bookmarked rooms keep their `space_id`; un-bookmarked rooms get a synthetic space with id `"standalone"` and name `"Rooms"` so the UI's space-keyed channel list can render them without special-casing.
- Trait signature: `discover_topology(spaces_jid: &BareJid)` → `discover_topology(server_domain: &str)`. The only caller outside tests is the FFI.

**`server/crates/waddle-xmpp-client-ffi/`**

- `discover_topology` passes the server domain instead of building a hardcoded spaces JID.
- Migrated to use the `clone_handle()` helper introduced in PR #715 — drops the tokio Mutex before the long-running discovery awaits.

## Tests

`server/crates/waddle-xmpp-client/src/discovery/tests.rs`: six new tests for `resolve_component_services`:

- explicit feature-advertised JIDs win over fallbacks
- unadvertised components fall back to conventional subdomains
- legacy `conference` identity is accepted as a MUC fallback
- generic pubsub identity is **not** picked as Spaces
- entries without disco#info are skipped (don't poison the fallback)
- first match wins on duplicates (deterministic)

Workspace test suite remains green: `cargo test --workspace --all-targets --locked` — every crate's tests pass.

## Stacked on PR #715

This PR is based on `feat/apple-ffi-parity` (PR #715), which was rebased onto current main to resolve the conflict from #714's livekit audit. PR #715 must merge first.

## Verification

Built the rebased FFI, regenerated Swift bindings, rebuilt the iOS app, and installed on a physical iPhone 17 Pro. (User-facing verification: open app, log in, expect spaces + rooms to appear.)

This PR was created with the assistance of a LLM.