### PR TITLE
refactor(server): move push decisions from T0 to T1 evaluator (#526)

### DIFF
--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pubsub;
 pub mod pubsub_authz;
 pub mod push_registrations;
 pub mod push_service;
+pub mod room_policy;
 pub mod server;
 pub mod sm_persistence;
 pub mod sm_promotion;

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -836,52 +836,14 @@ impl NotificationOutboxStore {
     async fn migrate_postgres_notification_candidates_reason_constraint(
         &self,
     ) -> Result<(), NotificationOutboxError> {
-        if !self
-            .postgres_notification_candidates_reason_constraint_is_stale()
-            .await?
-        {
-            return Ok(());
-        }
-
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_candidates DROP CONSTRAINT IF EXISTS {NOTIFICATION_CANDIDATES_REASON_CHECK_NAME}"
-            ),
-            (),
+        self.migrate_postgres_check_constraint_on_column(
+            "notification_candidates",
+            "reason",
+            NOTIFICATION_CANDIDATES_REASON_CHECK_NAME,
+            NOTIFICATION_CANDIDATES_REASON_CHECK_SQL,
+            notification_candidates_reason_constraint_matches_expected,
         )
-        .await?;
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_candidates ADD CONSTRAINT {NOTIFICATION_CANDIDATES_REASON_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_REASON_CHECK_SQL})"
-            ),
-            (),
-        )
-        .await?;
-        Ok(())
-    }
-
-    async fn postgres_notification_candidates_reason_constraint_is_stale(
-        &self,
-    ) -> Result<bool, NotificationOutboxError> {
-        let mut rows = self
-            .query(
-                r#"
-                SELECT pg_get_constraintdef(oid)
-                FROM pg_constraint
-                WHERE conrelid = 'notification_candidates'::regclass
-                  AND conname = ?
-                  AND contype = 'c'
-                "#,
-                crate::db_params![NOTIFICATION_CANDIDATES_REASON_CHECK_NAME],
-            )
-            .await?;
-        let Some(row) = rows.next().await? else {
-            return Ok(true);
-        };
-        let definition: String = row.get(0)?;
-        Ok(!notification_candidates_reason_constraint_matches_expected(
-            &definition,
-        ))
+        .await
     }
 
     async fn migrate_sqlite_notification_candidates_reason_constraint(
@@ -984,55 +946,14 @@ impl NotificationOutboxStore {
     async fn migrate_postgres_notification_candidates_class_constraint(
         &self,
     ) -> Result<(), NotificationOutboxError> {
-        if !self
-            .postgres_notification_candidates_class_constraint_is_stale()
-            .await?
-        {
-            return Ok(());
-        }
-
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_candidates DROP CONSTRAINT IF EXISTS {NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME}"
-            ),
-            (),
+        self.migrate_postgres_check_constraint_on_column(
+            "notification_candidates",
+            "class",
+            NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME,
+            NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL,
+            notification_candidates_class_constraint_matches_expected,
         )
-        .await?;
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_candidates ADD CONSTRAINT {NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL})"
-            ),
-            (),
-        )
-        .await?;
-        Ok(())
-    }
-
-    async fn postgres_notification_candidates_class_constraint_is_stale(
-        &self,
-    ) -> Result<bool, NotificationOutboxError> {
-        let mut rows = self
-            .query(
-                r#"
-                SELECT pg_get_constraintdef(oid)
-                FROM pg_constraint
-                WHERE conrelid = 'notification_candidates'::regclass
-                  AND conname = ?
-                  AND contype = 'c'
-                "#,
-                crate::db_params![NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME],
-            )
-            .await?;
-        let Some(row) = rows.next().await? else {
-            // No named class CHECK constraint exists yet — Postgres
-            // emits anonymous CHECKs from the table-level CHECK literal.
-            // Treat as stale so the migration adds the named constraint.
-            return Ok(true);
-        };
-        let definition: String = row.get(0)?;
-        Ok(!notification_candidates_class_constraint_matches_expected(
-            &definition,
-        ))
+        .await
     }
 
     async fn migrate_sqlite_notification_candidates_class_constraint(
@@ -1135,52 +1056,108 @@ impl NotificationOutboxStore {
     async fn migrate_postgres_notification_outbox_class_constraint(
         &self,
     ) -> Result<(), NotificationOutboxError> {
-        if !self
-            .postgres_notification_outbox_class_constraint_is_stale()
-            .await?
-        {
+        self.migrate_postgres_check_constraint_on_column(
+            "notification_outbox",
+            "class",
+            NOTIFICATION_OUTBOX_CLASS_CHECK_NAME,
+            NOTIFICATION_OUTBOX_CLASS_CHECK_SQL,
+            notification_outbox_class_constraint_matches_expected,
+        )
+        .await
+    }
+
+    /// Drops every CHECK constraint on `table.column` whose definition
+    /// does NOT match the expected value set, and ensures a single
+    /// named CHECK constraint is in place.
+    ///
+    /// Old schemas (created before this PR via inline
+    /// `CHECK (column IN (...))` literals in `CREATE TABLE`) carry
+    /// **anonymous** CHECK constraints with autogenerated names like
+    /// `notification_candidates_class_check1`. Dropping only the named
+    /// constraint we own would leave those anonymous ones in place,
+    /// rejecting any newly-added enum value indefinitely. Walking
+    /// `pg_constraint` + `pg_attribute` and dropping every
+    /// non-matching CHECK on the column closes that gap.
+    async fn migrate_postgres_check_constraint_on_column(
+        &self,
+        table: &str,
+        column: &str,
+        expected_name: &str,
+        expected_check_sql: &str,
+        matches_expected: fn(&str) -> bool,
+    ) -> Result<(), NotificationOutboxError> {
+        let existing = self
+            .postgres_check_constraints_on_column(table, column)
+            .await?;
+        let mut current_named_present = false;
+        let mut to_drop: Vec<String> = Vec::new();
+        for (conname, definition) in &existing {
+            if conname == expected_name && matches_expected(definition) {
+                current_named_present = true;
+            } else {
+                to_drop.push(conname.clone());
+            }
+        }
+        if current_named_present && to_drop.is_empty() {
             return Ok(());
         }
-
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_outbox DROP CONSTRAINT IF EXISTS {NOTIFICATION_OUTBOX_CLASS_CHECK_NAME}"
-            ),
-            (),
-        )
-        .await?;
-        self.execute(
-            &format!(
-                "ALTER TABLE notification_outbox ADD CONSTRAINT {NOTIFICATION_OUTBOX_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_OUTBOX_CLASS_CHECK_SQL})"
-            ),
-            (),
-        )
-        .await?;
+        for conname in &to_drop {
+            // Identifier-safe: conname comes from `pg_constraint` and
+            // matches the Postgres identifier rules; we additionally
+            // quote it to defend against unexpected characters.
+            self.execute(
+                &format!("ALTER TABLE {table} DROP CONSTRAINT IF EXISTS \"{conname}\""),
+                (),
+            )
+            .await?;
+        }
+        if !current_named_present {
+            self.execute(
+                &format!(
+                    "ALTER TABLE {table} ADD CONSTRAINT {expected_name} CHECK ({expected_check_sql})"
+                ),
+                (),
+            )
+            .await?;
+        }
         Ok(())
     }
 
-    async fn postgres_notification_outbox_class_constraint_is_stale(
+    /// Returns every CHECK constraint on `table` that references
+    /// `column` exclusively, as `(conname, pg_get_constraintdef)`.
+    ///
+    /// The `conkey = ARRAY[<attnum>]::int2[]` filter narrows to
+    /// single-column CHECKs against the target column — multi-column
+    /// CHECKs covering other columns are deliberately out of scope
+    /// since they encode different invariants.
+    async fn postgres_check_constraints_on_column(
         &self,
-    ) -> Result<bool, NotificationOutboxError> {
+        table: &str,
+        column: &str,
+    ) -> Result<Vec<(String, String)>, NotificationOutboxError> {
         let mut rows = self
             .query(
                 r#"
-                SELECT pg_get_constraintdef(oid)
-                FROM pg_constraint
-                WHERE conrelid = 'notification_outbox'::regclass
-                  AND conname = ?
-                  AND contype = 'c'
+                SELECT c.conname,
+                       pg_get_constraintdef(c.oid)
+                FROM pg_constraint AS c
+                JOIN pg_attribute AS a
+                  ON a.attrelid = c.conrelid
+                 AND a.attname = ?
+                WHERE c.conrelid = (? :: regclass)
+                  AND c.contype = 'c'
+                  AND c.conkey = ARRAY[a.attnum]::int2[]
                 "#,
-                crate::db_params![NOTIFICATION_OUTBOX_CLASS_CHECK_NAME],
+                crate::db_params![column, table],
             )
             .await?;
-        let Some(row) = rows.next().await? else {
-            return Ok(true);
-        };
-        let definition: String = row.get(0)?;
-        Ok(!notification_outbox_class_constraint_matches_expected(
-            &definition,
-        ))
+        let mut out = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let conname: String = row.get(0)?;
+            let definition: String = row.get(1)?;
+            out.push((conname, definition));
+        }
+        Ok(out)
     }
 
     async fn migrate_sqlite_notification_outbox_class_constraint(
@@ -3402,6 +3379,208 @@ mod tests {
             plain_row.get::<String>(1).expect("plain reason"),
             "offline_dm"
         );
+    }
+
+    /// Postgres-only regression for the anonymous CHECK constraint bug:
+    /// schemas created before this PR via inline
+    /// `CHECK (class IN (...))` literals in `CREATE TABLE` end up with
+    /// **anonymous** CHECK constraints whose name is autogenerated
+    /// (e.g. `notification_candidates_class_check1`). The migration
+    /// must walk `pg_constraint` and drop every CHECK on the target
+    /// column — not just the named one we own — otherwise the
+    /// anonymous CHECK keeps rejecting newly-added enum values
+    /// (`dm_mention` here) on upgraded deployments.
+    ///
+    /// Opt-in via `WADDLE_TEST_POSTGRES_URL` since the project's
+    /// default test backend is SQLite (which uses a different
+    /// CREATE-TABLE-rebuild migration path).
+    #[tokio::test]
+    async fn store_initialization_drops_anonymous_postgres_class_check_constraint() {
+        let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+            eprintln!(
+                "skipping: WADDLE_TEST_POSTGRES_URL not set \
+                 (postgres-only regression for anonymous CHECK drop)"
+            );
+            return;
+        };
+
+        // Use a UUID-suffixed table name so concurrent runs against
+        // the same Postgres do not clobber each other.
+        let table_suffix = uuid::Uuid::new_v4().simple().to_string();
+        let table = format!("notification_candidates_{table_suffix}");
+        let scoped_url = database_url;
+        let db = Database::from_config(
+            "notification-outbox-anonymous-pg-check",
+            &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Postgres, scoped_url),
+        )
+        .await
+        .expect("connect postgres");
+        let conn = db.guard().await.expect("db guard");
+
+        // Anonymous CHECK: no `CONSTRAINT name` clause means Postgres
+        // generates one (e.g. `<table>_class_check`). The legacy class
+        // set deliberately excludes `'dm_mention'` to mirror the
+        // pre-#526 schema.
+        let create_sql = format!(
+            r#"
+            CREATE TABLE "{table}" (
+                recipient_bare_jid TEXT NOT NULL,
+                conversation_jid TEXT NOT NULL,
+                sender_jid TEXT NOT NULL,
+                thread_id TEXT NOT NULL DEFAULT '',
+                stanza_id_by TEXT NOT NULL,
+                stanza_id TEXT NOT NULL,
+                class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
+                reason TEXT NOT NULL CHECK (reason IN ('offline_dm', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')),
+                created_at_ms BIGINT NOT NULL,
+                policy_error_count INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at_ms BIGINT,
+                outboxed_at_ms BIGINT,
+                PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
+            )
+            "#
+        );
+        conn.execute(&create_sql, ())
+            .await
+            .expect("create scoped table");
+
+        // Cleanup on test exit: scope-guard pattern via a closure
+        // that captures `&db` (we can't use `Drop` because it would
+        // require async cleanup).
+        let cleanup_table = table.clone();
+        let cleanup_db = db.clone();
+        let cleanup = async move {
+            let conn = cleanup_db.guard().await.expect("cleanup db guard");
+            let _ = conn
+                .execute(&format!(r#"DROP TABLE IF EXISTS "{cleanup_table}""#), ())
+                .await;
+        };
+
+        // Sanity check: pre-migration, the anonymous CHECK exists
+        // and is named (any non-empty `conname` qualifies — Postgres
+        // never emits truly nameless constraints, but autogenerated
+        // names are still NOT ours).
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT c.conname
+                FROM pg_constraint AS c
+                JOIN pg_attribute AS a
+                  ON a.attrelid = c.conrelid
+                 AND a.attname = 'class'
+                WHERE c.conrelid = ($1 :: regclass)
+                  AND c.contype = 'c'
+                  AND c.conkey = ARRAY[a.attnum]::int2[]
+                "#,
+                crate::db_params![table.as_str()],
+            )
+            .await
+            .expect("pre-migration check constraint query");
+        let mut found_anonymous = false;
+        while let Some(row) = rows.next().await.expect("row") {
+            let conname: String = row.get(0).expect("conname");
+            if conname != NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME {
+                found_anonymous = true;
+            }
+        }
+        assert!(
+            found_anonymous,
+            "test fixture must produce an anonymous (non-canonical-name) CHECK on the class column"
+        );
+        drop(conn);
+        drop(rows);
+
+        // Drive the migration helper directly against our scoped
+        // table. This sidesteps the full `NotificationOutboxStore::new`
+        // initialization (which targets the hard-coded
+        // `notification_candidates` table name).
+        let store = NotificationOutboxStore { db: db.clone() };
+        let migrate_result = store
+            .migrate_postgres_check_constraint_on_column(
+                &table,
+                "class",
+                NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME,
+                NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL,
+                notification_candidates_class_constraint_matches_expected,
+            )
+            .await;
+        if let Err(error) = &migrate_result {
+            cleanup.await;
+            panic!("migration failed: {error}");
+        }
+
+        // Post-migration: only the canonical named CHECK should
+        // remain on the class column, and it should accept the new
+        // `dm_mention` value.
+        let conn = db.guard().await.expect("db guard");
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT c.conname
+                FROM pg_constraint AS c
+                JOIN pg_attribute AS a
+                  ON a.attrelid = c.conrelid
+                 AND a.attname = 'class'
+                WHERE c.conrelid = ($1 :: regclass)
+                  AND c.contype = 'c'
+                  AND c.conkey = ARRAY[a.attnum]::int2[]
+                "#,
+                crate::db_params![table.as_str()],
+            )
+            .await
+            .expect("post-migration check constraint query");
+        let mut remaining: Vec<String> = Vec::new();
+        while let Some(row) = rows.next().await.expect("row") {
+            remaining.push(row.get(0).expect("conname"));
+        }
+        let canonical_present = remaining
+            .iter()
+            .any(|n| n == NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME);
+        let anonymous_present = remaining
+            .iter()
+            .any(|n| n != NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME);
+        let dm_mention_insert = conn
+            .execute(
+                &format!(
+                    r#"
+                    INSERT INTO "{table}" (
+                        recipient_bare_jid,
+                        conversation_jid,
+                        sender_jid,
+                        thread_id,
+                        stanza_id_by,
+                        stanza_id,
+                        class,
+                        reason,
+                        created_at_ms,
+                        policy_error_count
+                    ) VALUES (
+                        'bob@example.com',
+                        'alice@example.com',
+                        'alice@example.com/web',
+                        '',
+                        'bob@example.com',
+                        'post-migration-mention',
+                        'dm_mention',
+                        'offline_dm_mention',
+                        1,
+                        0
+                    )
+                    "#
+                ),
+                (),
+            )
+            .await;
+        cleanup.await;
+        assert!(
+            canonical_present,
+            "named CHECK constraint must remain after migration; saw {remaining:?}"
+        );
+        assert!(
+            !anonymous_present,
+            "anonymous CHECK constraint(s) must be dropped by migration; saw {remaining:?}"
+        );
+        dm_mention_insert.expect("dm_mention insert must succeed post-migration");
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -1501,7 +1501,13 @@ impl NotificationOutboxStore {
                     continue;
                 }
                 T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
-                    tracing::warn!(
+                    // Actionable diagnostics for `Err(_)` lookups already
+                    // fired exactly once per (drain batch, room) in
+                    // `resolve_cached_room_policy`. The per-candidate
+                    // deferral is `debug!` here so the cache-miss warn
+                    // stays the single source-of-truth signal for
+                    // operators triaging room-policy lookup failures.
+                    tracing::debug!(
                         recipient = %candidate.recipient_bare_jid(),
                         conversation = %candidate.conversation_jid(),
                         class = ?candidate.class(),
@@ -2343,20 +2349,29 @@ pub(crate) enum T1PushDispatchOutcome {
 pub(crate) enum RoomPolicyCacheEntry {
     Public,
     Private,
-    Unknown,
+    /// MUC policy could not be resolved. Wrapped source distinguishes
+    /// the expected/normal `Ok(None)` (room not currently live) case
+    /// from the actionable `Err(_)` (actor transport / lookup failure)
+    /// case so production debugging and alert triage can act on the
+    /// distinction. Both still defer identically at the dispatch site
+    /// (the typed `T1PushDispatchOutcome::DeferUnknownRoomPolicy`).
+    Unknown(UnknownRoomPolicySource),
 }
 
-impl RoomPolicyCacheEntry {
-    fn from_lookup(result: Result<Option<bool>, NotificationOutboxError>) -> Self {
-        match result {
-            Ok(Some(true)) => Self::Private,
-            Ok(Some(false)) => Self::Public,
-            // `Ok(None)` = room not currently live; `Err(_)` = actor
-            // transport failure. Both collapse to `Unknown` so the
-            // batch defers identically rather than guessing.
-            Ok(None) | Err(_) => Self::Unknown,
-        }
-    }
+/// Why a [`RoomPolicyCacheEntry::Unknown`] was produced. Logged at
+/// most once per (drain batch, room) thanks to the cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UnknownRoomPolicySource {
+    /// `RoomPolicyStore::room_members_only` returned `Ok(None)` —
+    /// the room actor is not currently live. Expected/normal on
+    /// restart windows or for rooms with no recent activity.
+    NotLive,
+    /// `RoomPolicyStore::room_members_only` returned `Err(_)` —
+    /// an actor transport failure or other lookup error. Actionable;
+    /// surfaces the underlying error string at cache-miss time so
+    /// operators can correlate without needing every per-candidate
+    /// log line.
+    LookupError,
 }
 
 /// T1 XEP-0492 push-dispatch evaluator.
@@ -2437,7 +2452,7 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
                     crate::notification_settings_projection::ConversationKind::PublicGroup,
                     true,
                 ),
-                RoomPolicyCacheEntry::Unknown => {
+                RoomPolicyCacheEntry::Unknown(_) => {
                     return Ok(T1PushDispatchOutcome::DeferUnknownRoomPolicy);
                 }
             }
@@ -2458,7 +2473,7 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
                     crate::notification_settings_projection::ConversationKind::PublicGroup,
                     false,
                 ),
-                RoomPolicyCacheEntry::Unknown => {
+                RoomPolicyCacheEntry::Unknown(_) => {
                     return Ok(T1PushDispatchOutcome::DeferUnknownRoomPolicy);
                 }
             }
@@ -2484,6 +2499,16 @@ pub(crate) async fn evaluate_xep0492_at_dispatch(
 }
 
 /// Looks up `room` in the per-batch policy cache, populating on miss.
+///
+/// On miss the raw `room_members_only` result is handled explicitly:
+///
+/// - `Ok(Some(true/false))` → cache `Private`/`Public`.
+/// - `Ok(None)` → cache `Unknown(NotLive)` — expected/normal.
+/// - `Err(error)` → emit a `tracing::warn!` with the error string,
+///   then cache `Unknown(LookupError)`. Because the result is cached,
+///   the warn fires at most once per (drain batch, room) — every
+///   subsequent candidate for the same room in this batch hits the
+///   cache silently.
 async fn resolve_cached_room_policy(
     room_policy: &dyn RoomPolicyStore,
     room: &BareJid,
@@ -2492,7 +2517,19 @@ async fn resolve_cached_room_policy(
     if let Some(entry) = cache.get(room) {
         return *entry;
     }
-    let entry = RoomPolicyCacheEntry::from_lookup(room_policy.room_members_only(room).await);
+    let entry = match room_policy.room_members_only(room).await {
+        Ok(Some(true)) => RoomPolicyCacheEntry::Private,
+        Ok(Some(false)) => RoomPolicyCacheEntry::Public,
+        Ok(None) => RoomPolicyCacheEntry::Unknown(UnknownRoomPolicySource::NotLive),
+        Err(error) => {
+            tracing::warn!(
+                %room,
+                %error,
+                "RoomPolicyStore::room_members_only failed; deferring T1 candidates for this room in the current drain batch"
+            );
+            RoomPolicyCacheEntry::Unknown(UnknownRoomPolicySource::LookupError)
+        }
+    };
     cache.insert(room.clone(), entry);
     entry
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -4216,6 +4216,119 @@ mod tests {
         assert_eq!(jobs[0].class(), NotificationClass::DirectMessage);
     }
 
+    /// T1 race-window regression: a candidate inserted while the
+    /// recipient's XEP-0492 setting said "deliver" must still be
+    /// suppressed at drain time if the setting flipped to `<never/>`
+    /// between T0 emission and T1 dispatch.
+    ///
+    /// The T0 emission gate (in `offline_delivery.rs` /
+    /// `groupchat_inbox.rs`) catches the common case where the
+    /// setting was already `<never/>` at message-arrival time and
+    /// short-circuits the insert — that case is covered by
+    /// `xep0492_direct_chat_*_persists_no_candidate_row*` over in
+    /// `tests/messages.rs`. This test exercises the *other*
+    /// invocation moment of the same shared evaluator function: a
+    /// row already exists, and the recipient's effective level has
+    /// since changed.
+    ///
+    /// Expected behaviour: `drain_pending_candidates_into_outbox`
+    /// re-evaluates against the fresh projection, marks the row
+    /// outboxed without enqueuing a job, and returns `processed = 1`.
+    /// The row exists only briefly during the race window — push
+    /// output is preserved per the locked Q2 design.
+    #[tokio::test]
+    async fn t1_drain_reevaluates_xep0492_when_projection_changes_after_insert() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let candidate = candidate("archive-t1-race-window");
+        register_push_target(&push_store, candidate.recipient_bare_jid(), &target).await;
+        // Insert with no projection — defaults to `<always/>`, so a
+        // T0 evaluator at this moment would say "deliver". The
+        // candidate row gets persisted.
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("candidate insert");
+        assert_eq!(
+            store
+                .count_all_candidates()
+                .await
+                .expect("post-insert row count"),
+            1,
+            "T0 must have persisted the candidate row when projection said deliver"
+        );
+
+        // Race window: between T0 emission and T1 drain, the
+        // recipient's XEP-0492 setting flips to `<never/>`.
+        projection
+            .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+                owner_bare_jid: candidate.recipient_bare_jid().clone(),
+                conversation_jid: candidate.conversation_jid().clone(),
+                conversation_kind:
+                    crate::notification_settings_projection::ConversationKind::Direct,
+                mode: waddle_xmpp::xep::NotificationLevel::Never,
+                source_version: 1,
+                updated_at_ms: crate::time::now_ms(),
+                source:
+                    crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+                source_item_jid: candidate.conversation_jid().clone(),
+            })
+            .await
+            .expect("flip xep-0492 setting to <never/>");
+
+        // T1 drain re-evaluates against the now-`<never/>`
+        // projection and suppresses the candidate.
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &projection,
+                    &room_policy,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            1,
+            "T1 race-window guard MUST count the candidate as processed via suppression"
+        );
+
+        // No outbox job — the suppression path goes
+        // `mark_candidate_outboxed_tx` WITHOUT `enqueue_outbox_job_tx`.
+        assert!(store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty());
+        // The candidate row still exists, now marked outboxed —
+        // this is the documented race-window exception. The
+        // compliance rule is "no row for the common case"; the
+        // race-window row is acceptable per locked Q2.
+        let mut rows = store
+            .query(
+                "SELECT outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["archive-t1-race-window"],
+            )
+            .await
+            .expect("candidate marker query");
+        let row = rows
+            .next()
+            .await
+            .expect("candidate marker row")
+            .expect("candidate marker row");
+        assert!(
+            row.get::<Option<i64>>(0)
+                .expect("outboxed marker")
+                .is_some(),
+            "T1 race-window suppression MUST mark the candidate outboxed"
+        );
+    }
+
     #[tokio::test]
     async fn candidate_worker_marks_malformed_bare_sender_candidate_terminal() {
         let store = store().await;

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3157,6 +3157,201 @@ mod tests {
         );
     }
 
+    /// Regression for slice 1 of #526: a database created before the
+    /// `dm_mention` class variant existed still has the legacy class
+    /// CHECK constraint (`dm`/`personal_mention`/`channel_mention`/
+    /// `active_channel_mention`/`notify_all`). After
+    /// `NotificationOutboxStore::new` runs the class-constraint
+    /// migration, the new `dm_mention` variant must be insertable.
+    #[tokio::test]
+    async fn store_initialization_migrates_legacy_candidate_class_check() {
+        let db = Database::in_memory("notification-outbox-legacy-candidate-class")
+            .await
+            .unwrap();
+        let conn = db.guard().await.expect("db guard");
+        conn.execute(
+            r#"
+            CREATE TABLE notification_candidates (
+                recipient_bare_jid TEXT NOT NULL,
+                conversation_jid TEXT NOT NULL,
+                sender_jid TEXT NOT NULL,
+                thread_id TEXT NOT NULL DEFAULT '',
+                stanza_id_by TEXT NOT NULL,
+                stanza_id TEXT NOT NULL,
+                class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
+                reason TEXT NOT NULL CHECK (reason IN ('offline_dm', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')),
+                created_at_ms INTEGER NOT NULL,
+                policy_error_count INTEGER NOT NULL DEFAULT 0,
+                next_attempt_at_ms INTEGER,
+                outboxed_at_ms INTEGER,
+                PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create legacy candidate table");
+        conn.execute(
+            r#"
+            INSERT INTO notification_candidates (
+                recipient_bare_jid,
+                conversation_jid,
+                sender_jid,
+                thread_id,
+                stanza_id_by,
+                stanza_id,
+                class,
+                reason,
+                created_at_ms,
+                policy_error_count,
+                next_attempt_at_ms,
+                outboxed_at_ms
+            ) VALUES (
+                'bob@example.com',
+                'alice@example.com',
+                'alice@example.com/web',
+                '',
+                'bob@example.com',
+                'legacy-direct',
+                'dm',
+                'offline_dm',
+                1,
+                0,
+                NULL,
+                NULL
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("insert legacy direct candidate");
+        drop(conn);
+
+        let store = NotificationOutboxStore::new(db)
+            .await
+            .expect("store initializes and migrates legacy class check");
+        let recipient = bare("bob@example.com");
+        let sender_bare = bare("alice@example.com");
+        let mention_candidate = NotificationCandidate::direct_message(
+            recipient.clone(),
+            "alice@example.com/web".parse().expect("full sender jid"),
+            StanzaId::new("post-migration-mention", Jid::from(recipient.clone())),
+            true,
+        )
+        .expect("dm_mention candidate after migration");
+        assert_eq!(mention_candidate.class(), NotificationClass::DirectMessageMention);
+        assert_eq!(
+            store
+                .insert_candidate(&mention_candidate)
+                .await
+                .expect("insert dm_mention candidate post-migration"),
+            NotificationCandidateInsertOutcome::Inserted
+        );
+        let mut rows = store
+            .query(
+                "SELECT class FROM notification_candidates ORDER BY stanza_id",
+                (),
+            )
+            .await
+            .expect("query migrated candidates");
+        let first = rows
+            .next()
+            .await
+            .expect("first row query")
+            .expect("legacy row");
+        let second = rows
+            .next()
+            .await
+            .expect("second row query")
+            .expect("dm_mention row");
+        assert_eq!(first.get::<String>(0).expect("legacy class"), "dm");
+        assert_eq!(
+            second.get::<String>(0).expect("dm_mention class"),
+            "dm_mention"
+        );
+        // Touch unused fields to keep them documented as required
+        // identity inputs for the candidate row.
+        let _ = sender_bare;
+    }
+
+    /// Round-trip regression for the new `DirectMessageMention` class /
+    /// `OfflineDirectMessageMention` reason variants introduced in
+    /// slice 1 of #526. Inserts a DM candidate with `is_mention=true`
+    /// and asserts the persisted row carries the typed `dm_mention`
+    /// class and `offline_dm_mention` reason values.
+    #[tokio::test]
+    async fn direct_message_mention_class_round_trips_through_storage() {
+        let db = Database::in_memory("notification-outbox-dm-mention-roundtrip")
+            .await
+            .unwrap();
+        let store = NotificationOutboxStore::new(db)
+            .await
+            .expect("store init");
+        let recipient = bare("bob@example.com");
+        let plain = NotificationCandidate::direct_message(
+            recipient.clone(),
+            "alice@example.com/web".parse().expect("full sender jid"),
+            StanzaId::new("plain-dm", Jid::from(recipient.clone())),
+            false,
+        )
+        .expect("plain dm candidate");
+        let mention = NotificationCandidate::direct_message(
+            recipient.clone(),
+            "alice@example.com/web".parse().expect("full sender jid"),
+            StanzaId::new("mention-dm", Jid::from(recipient.clone())),
+            true,
+        )
+        .expect("dm_mention candidate");
+        assert_eq!(plain.class(), NotificationClass::DirectMessage);
+        assert_eq!(plain.reason(), NotificationReason::OfflineDirectMessage);
+        assert_eq!(mention.class(), NotificationClass::DirectMessageMention);
+        assert_eq!(
+            mention.reason(),
+            NotificationReason::OfflineDirectMessageMention
+        );
+        assert_eq!(
+            store.insert_candidate(&plain).await.expect("insert plain"),
+            NotificationCandidateInsertOutcome::Inserted
+        );
+        assert_eq!(
+            store
+                .insert_candidate(&mention)
+                .await
+                .expect("insert mention"),
+            NotificationCandidateInsertOutcome::Inserted
+        );
+        let mut rows = store
+            .query(
+                "SELECT class, reason FROM notification_candidates ORDER BY stanza_id",
+                (),
+            )
+            .await
+            .expect("query round-trip candidates");
+        let mention_row = rows
+            .next()
+            .await
+            .expect("first row query")
+            .expect("mention row");
+        let plain_row = rows
+            .next()
+            .await
+            .expect("second row query")
+            .expect("plain row");
+        assert_eq!(
+            mention_row.get::<String>(0).expect("mention class"),
+            "dm_mention"
+        );
+        assert_eq!(
+            mention_row.get::<String>(1).expect("mention reason"),
+            "offline_dm_mention"
+        );
+        assert_eq!(plain_row.get::<String>(0).expect("plain class"), "dm");
+        assert_eq!(
+            plain_row.get::<String>(1).expect("plain reason"),
+            "offline_dm"
+        );
+    }
+
     #[tokio::test]
     async fn store_initialization_rejects_outbox_schema_without_sender_provenance_columns() {
         let db = Database::in_memory("notification-outbox-missing-job-senders")

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -545,10 +545,12 @@ pub enum NotificationOutboxError {
 /// — the kind drives both the XEP-0492 default level and the projection
 /// store lookup.
 ///
-/// Returning `Ok(None)` signals "room not currently live" — when the room
-/// actor is not registered we treat the room as public-by-default rather
-/// than failing closed, mirroring the slice-1 limitation that there is
-/// no durable T1 projection of MUC config yet.
+/// Returning `Ok(None)` signals "room not currently live" — the T1
+/// evaluator treats this as an *unknown* signal (not a public one)
+/// and defers the candidate via the policy-error backoff so the next
+/// drain pass can retry once the actor is reachable. Slice 2 will
+/// replace the live-actor lookup with a durable T1 projection of
+/// MUC config that does not have this hole.
 #[async_trait::async_trait]
 pub trait RoomPolicyStore: Send + Sync {
     async fn room_members_only(
@@ -1356,8 +1358,36 @@ impl NotificationOutboxStore {
         let candidates = self.pending_candidates(batch_size).await?;
         let mut target_cache =
             std::collections::BTreeMap::<BareJid, Vec<NotificationOutboxTarget>>::new();
+        let mut room_policy_cache =
+            std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
         let mut processed = 0usize;
         for candidate in candidates {
+            // Self-DM suppression at T1 (#506 Q3 strict (A): no T0
+            // carve-outs based on routing recipient). Derived
+            // entirely from message-frozen columns already on the
+            // candidate row, so no extra read is required. XEP-0357
+            // §8 "online with active resource" semantics will be
+            // expanded in slice 2; for now self-DM is the only
+            // condition we suppress here, consistent with the
+            // headless `OfflineDeliveryHandler` no longer carving it
+            // out at T0.
+            if candidate.sender_jid().to_bare() == *candidate.recipient_bare_jid() {
+                tracing::info!(
+                    recipient = %candidate.recipient_bare_jid(),
+                    conversation = %candidate.conversation_jid(),
+                    sender = %candidate.sender_jid(),
+                    class = ?candidate.class(),
+                    "self-DM suppressed at T1; marking notification candidate outboxed without job"
+                );
+                let now_ms = crate::time::now_ms();
+                let mut tx = self.db.begin().await?;
+                let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
+                tx.commit().await?;
+                if claimed > 0 {
+                    processed += 1;
+                }
+                continue;
+            }
             match xep0191_blocks_notification_candidate(&candidate, blocking_storage).await {
                 Ok(true) => {
                     let now_ms = crate::time::now_ms();
@@ -1385,43 +1415,59 @@ impl NotificationOutboxStore {
             // is purely message-derived from T0; combined with the
             // recipient's effective notification level (consulted fresh
             // here against the projection store) the typed reducer
-            // decides publish-or-suppress.
-            let decision =
-                match evaluate_xep0492_at_dispatch(settings_projection, room_policy, &candidate)
-                    .await
-                {
-                    Ok(decision) => decision,
-                    Err(error) => {
-                        tracing::warn!(
-                            recipient = %candidate.recipient_bare_jid(),
-                            conversation = %candidate.conversation_jid(),
-                            %error,
-                            "XEP-0492 notification setting lookup failed at T1; deferring candidate"
-                        );
-                        self.defer_candidate_policy_error(&candidate).await?;
-                        continue;
-                    }
-                };
-            if let crate::notification_settings_projection::PushDispatchDecision::Suppressed {
-                reason,
-            } = decision
+            // decides publish-or-suppress. The room-policy lookup is
+            // cached for the duration of this drain pass so a 100-
+            // member groupchat does not produce 100 actor round-trips.
+            let outcome = match evaluate_xep0492_at_dispatch(
+                settings_projection,
+                room_policy,
+                &candidate,
+                &mut room_policy_cache,
+            )
+            .await
             {
-                tracing::info!(
-                    recipient = %candidate.recipient_bare_jid(),
-                    conversation = %candidate.conversation_jid(),
-                    sender = %candidate.sender_jid(),
-                    class = ?candidate.class(),
-                    %reason,
-                    "XEP-0492 push gate suppressed XEP-0357 notification candidate at T1"
-                );
-                let now_ms = crate::time::now_ms();
-                let mut tx = self.db.begin().await?;
-                let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
-                tx.commit().await?;
-                if claimed > 0 {
-                    processed += 1;
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    tracing::warn!(
+                        recipient = %candidate.recipient_bare_jid(),
+                        conversation = %candidate.conversation_jid(),
+                        %error,
+                        "XEP-0492 notification setting lookup failed at T1; deferring candidate"
+                    );
+                    self.defer_candidate_policy_error(&candidate).await?;
+                    continue;
                 }
-                continue;
+            };
+            match outcome {
+                T1PushDispatchOutcome::Suppressed { reason } => {
+                    tracing::info!(
+                        recipient = %candidate.recipient_bare_jid(),
+                        conversation = %candidate.conversation_jid(),
+                        sender = %candidate.sender_jid(),
+                        class = ?candidate.class(),
+                        %reason,
+                        "XEP-0492 push gate suppressed XEP-0357 notification candidate at T1"
+                    );
+                    let now_ms = crate::time::now_ms();
+                    let mut tx = self.db.begin().await?;
+                    let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
+                    tx.commit().await?;
+                    if claimed > 0 {
+                        processed += 1;
+                    }
+                    continue;
+                }
+                T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
+                    tracing::warn!(
+                        recipient = %candidate.recipient_bare_jid(),
+                        conversation = %candidate.conversation_jid(),
+                        class = ?candidate.class(),
+                        "MUC config unavailable at T1; deferring candidate (unknown room policy is not 'public')"
+                    );
+                    self.defer_candidate_policy_error(&candidate).await?;
+                    continue;
+                }
+                T1PushDispatchOutcome::Deliver => {}
             }
             let recipient_key = candidate.recipient_bare_jid.clone();
             if !target_cache.contains_key(&recipient_key) {
@@ -2192,6 +2238,63 @@ impl NotificationOutboxStore {
     }
 }
 
+/// Typed outcome of `evaluate_xep0492_at_dispatch`.
+///
+/// Extends [`crate::notification_settings_projection::PushDispatchDecision`]
+/// with a third state — `DeferUnknownRoomPolicy` — that surfaces the
+/// "room actor not currently live" signal as a retry rather than
+/// silently defaulting to public. Slice 1 has no durable T1
+/// projection of MUC `members_only`; if the actor lookup returns
+/// `Ok(None)` we cannot know whether the room is private (default
+/// `Always` level → `NotifyAll` candidates SHOULD push) or public
+/// (default `OnMention` level → `NotifyAll` candidates SHOULD NOT
+/// push), and silently picking either would either drop legitimate
+/// private-room pushes or fan out unwanted public-room pushes. Slice
+/// 2 will replace the live actor lookup with a durable projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum T1PushDispatchOutcome {
+    /// XEP-0492 gate decided to fan out; enqueue the push job.
+    Deliver,
+    /// XEP-0492 gate decided to suppress; mark candidate outboxed
+    /// without enqueuing a job. `reason` is the resolved
+    /// `NotificationLevel` that caused suppression.
+    Suppressed {
+        reason: waddle_xmpp::xep::NotificationLevel,
+    },
+    /// MUC config could not be resolved (room actor unavailable or
+    /// failed). Defer with policy-error backoff so the next drain
+    /// pass can retry once the actor (or, slice 2, the durable
+    /// projection) is available.
+    DeferUnknownRoomPolicy,
+}
+
+/// Typed per-batch cache entry for the [`RoomPolicyStore`] lookup.
+///
+/// `Unknown` is deliberately distinct from `Public` — see
+/// [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`] for the
+/// reasoning. Once a room resolves to `Unknown` for a given batch,
+/// every candidate for that room in the same batch reuses that
+/// outcome to avoid retrying the same failing actor 100×.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoomPolicyCacheEntry {
+    Public,
+    Private,
+    Unknown,
+}
+
+impl RoomPolicyCacheEntry {
+    fn from_lookup(result: Result<Option<bool>, NotificationOutboxError>) -> Self {
+        match result {
+            Ok(Some(true)) => Self::Private,
+            Ok(Some(false)) => Self::Public,
+            // `Ok(None)` = room not currently live; `Err(_)` = actor
+            // transport failure. Both collapse to `Unknown` so the
+            // batch defers identically rather than guessing.
+            Ok(None) | Err(_) => Self::Unknown,
+        }
+    }
+}
+
 /// T1 XEP-0492 push-dispatch evaluator.
 ///
 /// Derives `(level, is_mention)` from the recorded candidate class +
@@ -2203,15 +2306,20 @@ impl NotificationOutboxStore {
 ///   [`NotificationClass::DirectMessageMention`]).
 /// - Groupchat classes encode both mention scope and
 ///   live-occupant scope; the room is private/public per the
-///   [`RoomPolicyStore`] lookup at dispatch time (slice 1 limitation:
-///   no durable T1 projection of MUC config exists yet, so we read
-///   live actor state, defaulting to public when unknown).
+///   [`RoomPolicyStore`] lookup, cached per drain batch through
+///   `room_policy_cache` so a 100-member groupchat does not produce
+///   100 actor round-trips. When the lookup yields
+///   `Ok(None)`/`Err(_)`, the evaluator returns
+///   [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`] — slice 1 has
+///   no durable T1 projection of MUC config yet, so an unknown
+///   policy must defer rather than default-to-public.
 async fn evaluate_xep0492_at_dispatch(
     settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
     room_policy: &dyn RoomPolicyStore,
     candidate: &NotificationCandidate,
+    room_policy_cache: &mut std::collections::BTreeMap<BareJid, RoomPolicyCacheEntry>,
 ) -> Result<
-    crate::notification_settings_projection::PushDispatchDecision,
+    T1PushDispatchOutcome,
     crate::notification_settings_projection::NotificationSettingsProjectionError,
 > {
     let (conversation_kind, is_mention) = match candidate.class() {
@@ -2226,32 +2334,46 @@ async fn evaluate_xep0492_at_dispatch(
         NotificationClass::PersonalMention
         | NotificationClass::ChannelMention
         | NotificationClass::ActiveChannelMention => {
-            let members_only = room_policy
-                .room_members_only(candidate.conversation_jid())
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or(false);
-            let kind = if members_only {
-                crate::notification_settings_projection::ConversationKind::PrivateGroup
-            } else {
-                crate::notification_settings_projection::ConversationKind::PublicGroup
-            };
-            (kind, true)
+            match resolve_cached_room_policy(
+                room_policy,
+                candidate.conversation_jid(),
+                room_policy_cache,
+            )
+            .await
+            {
+                RoomPolicyCacheEntry::Private => (
+                    crate::notification_settings_projection::ConversationKind::PrivateGroup,
+                    true,
+                ),
+                RoomPolicyCacheEntry::Public => (
+                    crate::notification_settings_projection::ConversationKind::PublicGroup,
+                    true,
+                ),
+                RoomPolicyCacheEntry::Unknown => {
+                    return Ok(T1PushDispatchOutcome::DeferUnknownRoomPolicy);
+                }
+            }
         }
         NotificationClass::NotifyAll => {
-            let members_only = room_policy
-                .room_members_only(candidate.conversation_jid())
-                .await
-                .ok()
-                .flatten()
-                .unwrap_or(false);
-            let kind = if members_only {
-                crate::notification_settings_projection::ConversationKind::PrivateGroup
-            } else {
-                crate::notification_settings_projection::ConversationKind::PublicGroup
-            };
-            (kind, false)
+            match resolve_cached_room_policy(
+                room_policy,
+                candidate.conversation_jid(),
+                room_policy_cache,
+            )
+            .await
+            {
+                RoomPolicyCacheEntry::Private => (
+                    crate::notification_settings_projection::ConversationKind::PrivateGroup,
+                    false,
+                ),
+                RoomPolicyCacheEntry::Public => (
+                    crate::notification_settings_projection::ConversationKind::PublicGroup,
+                    false,
+                ),
+                RoomPolicyCacheEntry::Unknown => {
+                    return Ok(T1PushDispatchOutcome::DeferUnknownRoomPolicy);
+                }
+            }
         }
     };
     let level = settings_projection
@@ -2261,7 +2383,30 @@ async fn evaluate_xep0492_at_dispatch(
             conversation_kind,
         )
         .await?;
-    Ok(crate::notification_settings_projection::PushDispatchDecision::evaluate(level, is_mention))
+    let decision =
+        crate::notification_settings_projection::PushDispatchDecision::evaluate(level, is_mention);
+    Ok(match decision {
+        crate::notification_settings_projection::PushDispatchDecision::Deliver => {
+            T1PushDispatchOutcome::Deliver
+        }
+        crate::notification_settings_projection::PushDispatchDecision::Suppressed { reason } => {
+            T1PushDispatchOutcome::Suppressed { reason }
+        }
+    })
+}
+
+/// Looks up `room` in the per-batch policy cache, populating on miss.
+async fn resolve_cached_room_policy(
+    room_policy: &dyn RoomPolicyStore,
+    room: &BareJid,
+    cache: &mut std::collections::BTreeMap<BareJid, RoomPolicyCacheEntry>,
+) -> RoomPolicyCacheEntry {
+    if let Some(entry) = cache.get(room) {
+        return *entry;
+    }
+    let entry = RoomPolicyCacheEntry::from_lookup(room_policy.room_members_only(room).await);
+    cache.insert(room.clone(), entry);
+    entry
 }
 
 async fn xep0191_blocks_notification_job(
@@ -3023,6 +3168,66 @@ mod tests {
             &self,
             _room: &BareJid,
         ) -> Result<Option<bool>, NotificationOutboxError> {
+            Ok(Some(false))
+        }
+    }
+
+    /// Test stub that returns `Ok(None)` — the "room not currently
+    /// live" signal that the T1 evaluator must treat as `Unknown`
+    /// (defer) rather than `Public` (default-OnMention). The counter
+    /// proves the per-batch cache short-circuits repeat lookups.
+    struct UnknownRoomPolicy {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl UnknownRoomPolicy {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RoomPolicyStore for UnknownRoomPolicy {
+        async fn room_members_only(
+            &self,
+            _room: &BareJid,
+        ) -> Result<Option<bool>, NotificationOutboxError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(None)
+        }
+    }
+
+    /// Test stub that returns `Ok(Some(false))` (public) but counts
+    /// the calls so the per-batch cache can be asserted as effective.
+    struct CountingPublicRoomPolicy {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingPublicRoomPolicy {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RoomPolicyStore for CountingPublicRoomPolicy {
+        async fn room_members_only(
+            &self,
+            _room: &BareJid,
+        ) -> Result<Option<bool>, NotificationOutboxError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(Some(false))
         }
     }
@@ -6003,6 +6208,273 @@ mod tests {
         assert_eq!(
             remaining,
             vec!["archive-older".to_string(), "archive-live".to_string()]
+        );
+    }
+
+    /// Regression for the self-DM suppression migration from T0 to T1
+    /// (#506 Q3 strict (A) — no T0 carve-outs based on routing
+    /// recipient). The candidate row is now inserted unconditionally
+    /// at T0; the T1 evaluator detects
+    /// `sender_jid.to_bare() == recipient_bare_jid` from the frozen
+    /// columns and marks the candidate outboxed without enqueuing a
+    /// push job — same shape as the XEP-0191 blocked path and the
+    /// XEP-0492 suppressed path.
+    #[tokio::test]
+    async fn self_dm_candidate_is_suppressed_at_t1_with_no_job_enqueued() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
+        let recipient = bare("alice@example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        // Self-DM: sender's bare JID equals recipient's bare JID.
+        let candidate = NotificationCandidate::direct_message(
+            recipient.clone(),
+            "alice@example.com/desktop"
+                .parse()
+                .expect("full self sender"),
+            StanzaId::new("self-dm-archive", Jid::from(recipient.clone())),
+            false,
+        )
+        .expect("self-dm candidate");
+        assert_eq!(
+            store
+                .insert_candidate(&candidate)
+                .await
+                .expect("self-dm insert"),
+            NotificationCandidateInsertOutcome::Inserted,
+            "T0 must insert the self-DM candidate row unconditionally — \
+             suppression is a T1 concern"
+        );
+
+        // Sanity: candidate is pending pre-drain.
+        assert_eq!(
+            store
+                .pending_candidates(16)
+                .await
+                .expect("pre-drain pending")
+                .len(),
+            1
+        );
+
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &projection,
+                    &room_policy,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            1,
+            "self-DM candidate is processed (marked outboxed), counted toward 'processed'",
+        );
+
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "self-DM at T1 must NOT enqueue a push outbox job",
+        );
+        assert!(
+            store
+                .pending_candidates(16)
+                .await
+                .expect("pending candidates")
+                .is_empty(),
+            "self-DM candidate must be marked outboxed after T1 suppression",
+        );
+    }
+
+    /// Regression for the unknown-room-policy deferral behavior. When
+    /// the [`RoomPolicyStore`] returns `Ok(None)` (room actor not
+    /// currently live), the T1 evaluator MUST defer the candidate via
+    /// the policy-error backoff rather than silently defaulting to
+    /// public — see [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`].
+    /// Dropped pushes for members-only rooms (`Always` default level
+    /// → `NotifyAll` candidates SHOULD push) would otherwise be the
+    /// blast radius.
+    #[tokio::test]
+    async fn unknown_room_policy_defers_groupchat_candidate_at_t1() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = UnknownRoomPolicy::new();
+        let recipient = bare("alice@example.com");
+        let room = bare("team@muc.example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        let candidate = groupchat_candidate_for(
+            &recipient,
+            &room,
+            "team@muc.example.com/bob".parse().expect("room occupant"),
+            "archive-unknown-policy",
+            NotificationClass::NotifyAll,
+        );
+        store
+            .insert_candidate(&candidate)
+            .await
+            .expect("groupchat insert");
+
+        // Drain returns 0 processed because the candidate deferred
+        // (not marked outboxed, not enqueued).
+        assert_eq!(
+            store
+                .drain_pending_candidates_into_outbox(
+                    &push_store,
+                    &blocking,
+                    &projection,
+                    &room_policy,
+                    &bare("push.example.com"),
+                    16,
+                )
+                .await
+                .expect("drain candidates"),
+            0,
+            "unknown room policy must NOT count as a processed candidate",
+        );
+
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "unknown room policy must NOT enqueue a push job",
+        );
+        // The candidate is still un-outboxed but has its
+        // policy_error_count incremented and next_attempt_at_ms set
+        // in the future, so it is NOT pending right now but WILL be
+        // retried by the next drain pass after the backoff elapses.
+        let mut rows = store
+            .query(
+                "SELECT policy_error_count, next_attempt_at_ms, outboxed_at_ms FROM notification_candidates WHERE stanza_id = ?",
+                crate::db_params!["archive-unknown-policy"],
+            )
+            .await
+            .expect("candidate row query");
+        let row = rows
+            .next()
+            .await
+            .expect("candidate row read")
+            .expect("candidate row");
+        let policy_error_count: i64 = row.get(0).expect("policy_error_count");
+        let next_attempt: Option<i64> = row.get(1).expect("next_attempt_at_ms");
+        let outboxed: Option<i64> = row.get(2).expect("outboxed_at_ms");
+        assert_eq!(
+            policy_error_count, 1,
+            "deferral must bump policy_error_count",
+        );
+        assert!(
+            next_attempt.is_some(),
+            "deferral must schedule a retry via next_attempt_at_ms",
+        );
+        assert!(
+            outboxed.is_none(),
+            "deferral must NOT mark the candidate outboxed",
+        );
+    }
+
+    /// The per-batch room-policy cache MUST collapse repeat lookups
+    /// for the same room into a single [`RoomPolicyStore`]
+    /// round-trip. With one room and N candidates, only one actor
+    /// call is permitted.
+    #[tokio::test]
+    async fn room_policy_lookup_is_cached_within_drain_batch() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = CountingPublicRoomPolicy::new();
+        let recipient = bare("alice@example.com");
+        let room = bare("team@muc.example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        // Three distinct groupchat candidates for the *same* room
+        // (different archive ids, all PersonalMention so they hit
+        // the room-policy path).
+        for id in ["arc-1", "arc-2", "arc-3"] {
+            let candidate = groupchat_candidate_for(
+                &recipient,
+                &room,
+                "team@muc.example.com/bob".parse().expect("room occupant"),
+                id,
+                NotificationClass::PersonalMention,
+            );
+            store
+                .insert_candidate(&candidate)
+                .await
+                .expect("groupchat insert");
+        }
+
+        let _ = store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                &room_policy,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        assert_eq!(
+            room_policy.call_count(),
+            1,
+            "per-batch room-policy cache must collapse repeat lookups for the same room",
+        );
+    }
+
+    /// The per-batch deferral cache MUST short-circuit
+    /// `RoomPolicyCacheEntry::Unknown` once observed — subsequent
+    /// candidates for the same room in the same batch SHOULD reuse
+    /// the deferral outcome instead of re-asking a failing actor.
+    #[tokio::test]
+    async fn unknown_room_policy_lookup_is_cached_within_drain_batch() {
+        let store = store().await;
+        let target = target();
+        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = UnknownRoomPolicy::new();
+        let recipient = bare("alice@example.com");
+        let room = bare("team@muc.example.com");
+        register_push_target(&push_store, &recipient, &target).await;
+
+        for id in ["arc-1", "arc-2", "arc-3"] {
+            let candidate = groupchat_candidate_for(
+                &recipient,
+                &room,
+                "team@muc.example.com/bob".parse().expect("room occupant"),
+                id,
+                NotificationClass::NotifyAll,
+            );
+            store
+                .insert_candidate(&candidate)
+                .await
+                .expect("groupchat insert");
+        }
+
+        let _ = store
+            .drain_pending_candidates_into_outbox(
+                &push_store,
+                &blocking,
+                &projection,
+                &room_policy,
+                &bare("push.example.com"),
+                16,
+            )
+            .await
+            .expect("drain candidates");
+
+        assert_eq!(
+            room_policy.call_count(),
+            1,
+            "deferral outcomes must be cached per-batch — failing actor must NOT be re-queried per candidate",
         );
     }
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -664,12 +664,30 @@ fn notification_outbox_table_sql(i64_type: &str, if_not_exists: bool) -> String 
     )
 }
 
+/// Returns `true` iff `definition` quotes `value` as a SQL string literal,
+/// e.g. `'value'`.
+///
+/// Postgres' `pg_get_constraintdef` and SQLite's `sqlite_master.sql` both
+/// render IN-list literals with single quotes around each enum value
+/// (Postgres adds a `::character varying` cast but the leading `'value'`
+/// token is the same). Matching against the quoted form prevents false
+/// positives where one enum value is a substring of another — e.g.
+/// `'dm_mention'` contains the substring `dm`, but the bare token `'dm'`
+/// is absent from a CHECK list that only allows `dm_mention`.
+fn constraint_definition_quotes_value(definition: &str, value: &str) -> bool {
+    let mut needle = String::with_capacity(value.len() + 2);
+    needle.push('\'');
+    needle.push_str(value);
+    needle.push('\'');
+    definition.contains(&needle)
+}
+
 fn notification_candidates_reason_constraint_matches_expected(definition: &str) -> bool {
     let normalized = definition.to_ascii_lowercase();
     normalized.contains("reason")
         && NOTIFICATION_CANDIDATES_REASON_VALUES
             .iter()
-            .all(|reason| normalized.contains(reason))
+            .all(|reason| constraint_definition_quotes_value(&normalized, reason))
 }
 
 fn notification_candidates_class_constraint_matches_expected(definition: &str) -> bool {
@@ -677,7 +695,7 @@ fn notification_candidates_class_constraint_matches_expected(definition: &str) -
     normalized.contains("class")
         && NOTIFICATION_CANDIDATES_CLASS_VALUES
             .iter()
-            .all(|class| normalized.contains(class))
+            .all(|class| constraint_definition_quotes_value(&normalized, class))
 }
 
 fn notification_outbox_class_constraint_matches_expected(definition: &str) -> bool {
@@ -685,7 +703,7 @@ fn notification_outbox_class_constraint_matches_expected(definition: &str) -> bo
     normalized.contains("class")
         && NOTIFICATION_OUTBOX_CLASS_VALUES
             .iter()
-            .all(|class| normalized.contains(class))
+            .all(|class| constraint_definition_quotes_value(&normalized, class))
 }
 
 #[derive(Clone)]
@@ -2933,6 +2951,39 @@ mod tests {
         assert!(!notification_candidates_class_constraint_matches_expected(
             postgres_definition
         ));
+    }
+
+    /// Regression: a constraint definition that contains the substring
+    /// `dm` only because the longer value `dm_mention` is present (i.e.
+    /// `'dm'` is NOT a quoted literal in the IN-list) must be flagged
+    /// stale. Earlier code used `definition.contains("dm")` which
+    /// false-positively accepted such a constraint and skipped the
+    /// migration — leaving a stale CHECK that rejects new
+    /// `'dm'` inserts.
+    #[test]
+    fn postgres_class_constraint_match_rejects_substring_only_definition() {
+        let postgres_definition = "CHECK (((class)::text = ANY ((ARRAY['dm_mention'::character varying, 'personal_mention'::character varying, 'channel_mention'::character varying, 'active_channel_mention'::character varying, 'notify_all'::character varying])::text[])))";
+        assert!(
+            !notification_candidates_class_constraint_matches_expected(postgres_definition),
+            "stale constraint missing 'dm' must NOT be treated as current",
+        );
+        assert!(
+            !notification_outbox_class_constraint_matches_expected(postgres_definition),
+            "stale outbox constraint missing 'dm' must NOT be treated as current",
+        );
+    }
+
+    /// Regression: a SQLite `CREATE TABLE` body that contains the
+    /// substring `offline_dm` only because the longer value
+    /// `offline_dm_mention` is present must be flagged stale for the
+    /// reason CHECK migration.
+    #[test]
+    fn sqlite_reason_constraint_match_rejects_substring_only_definition() {
+        let sqlite_create_sql = "CREATE TABLE notification_candidates (reason TEXT NOT NULL CHECK (reason IN ('offline_dm_mention', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')))";
+        assert!(
+            !notification_candidates_reason_constraint_matches_expected(sqlite_create_sql),
+            "stale reason constraint missing 'offline_dm' must NOT be treated as current",
+        );
     }
 
     async fn failed_outbox_jobs_count(store: &NotificationOutboxStore) -> i64 {

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -2977,22 +2977,15 @@ mod tests {
 
     /// Test stub for [`RoomPolicyStore`] — defaults rooms to public
     /// (`members_only = false`) unless explicitly mapped to private.
-    #[derive(Default)]
-    struct StubRoomPolicy {
-        private_rooms: std::sync::Mutex<std::collections::BTreeSet<BareJid>>,
-    }
+    /// Test double for [`RoomPolicyStore`] that pretends every room is
+    /// public. Slice 1's tests do not exercise private-room dispatch
+    /// policy; when slice 2 adds those paths it will grow this stub
+    /// (or replace it with a richer fixture).
+    struct StubRoomPolicy;
 
     impl StubRoomPolicy {
         fn new() -> Self {
-            Self::default()
-        }
-
-        #[allow(dead_code)]
-        fn mark_private(&self, room: BareJid) {
-            self.private_rooms
-                .lock()
-                .expect("stub room policy lock")
-                .insert(room);
+            Self
         }
     }
 
@@ -3000,14 +2993,9 @@ mod tests {
     impl RoomPolicyStore for StubRoomPolicy {
         async fn room_members_only(
             &self,
-            room: &BareJid,
+            _room: &BareJid,
         ) -> Result<Option<bool>, NotificationOutboxError> {
-            Ok(Some(
-                self.private_rooms
-                    .lock()
-                    .expect("stub room policy lock")
-                    .contains(room),
-            ))
+            Ok(Some(false))
         }
     }
 

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -1672,6 +1672,27 @@ impl NotificationOutboxStore {
         Ok(())
     }
 
+    /// Test/diagnostic helper: total count of `notification_candidates`
+    /// rows, including ones already marked outboxed.
+    ///
+    /// Compliance regression tests use this to assert that a
+    /// T0-suppressed XEP-0492 outcome persists *no* row at all
+    /// (`count_all_candidates == 0`), distinct from the older
+    /// "row exists, marked outboxed without a job" shape.
+    pub async fn count_all_candidates(&self) -> Result<i64, NotificationOutboxError> {
+        let mut rows = self
+            .query("SELECT COUNT(*) FROM notification_candidates", ())
+            .await?;
+        // `COUNT(*)` is guaranteed to return exactly one row on every
+        // SQL backend; an empty result here would mean a corrupted
+        // driver. Default to 0 fail-loud-via-row-decode instead of
+        // panicking.
+        let Some(row) = rows.next().await? else {
+            return Ok(0);
+        };
+        Ok(row.get::<i64>(0)?)
+    }
+
     pub async fn pending_outbox_jobs(
         &self,
     ) -> Result<Vec<NotificationOutboxJob>, NotificationOutboxError> {

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3695,12 +3695,17 @@ mod tests {
         drop(conn);
         drop(rows);
 
-        // Drive the migration helper directly against our scoped
+        // Drive the migration helpers directly against our scoped
         // table. This sidesteps the full `NotificationOutboxStore::new`
         // initialization (which targets the hard-coded
-        // `notification_candidates` table name).
+        // `notification_candidates` table name). We migrate BOTH the
+        // class and reason anonymous CHECK constraints because the
+        // post-migration insert below carries `dm_mention` (new class
+        // value) AND `offline_dm_mention` (new reason value) — Postgres
+        // enforces every constraint on the row, so leaving either
+        // anonymous CHECK in place will reject the insert.
         let store = NotificationOutboxStore { db: db.clone() };
-        let migrate_result = store
+        let class_migrate = store
             .migrate_postgres_check_constraint_on_column(
                 &table,
                 "class",
@@ -3709,9 +3714,22 @@ mod tests {
                 notification_candidates_class_constraint_matches_expected,
             )
             .await;
-        if let Err(error) = &migrate_result {
+        if let Err(error) = &class_migrate {
             cleanup.await;
-            panic!("migration failed: {error}");
+            panic!("class migration failed: {error}");
+        }
+        let reason_migrate = store
+            .migrate_postgres_check_constraint_on_column(
+                &table,
+                "reason",
+                NOTIFICATION_CANDIDATES_REASON_CHECK_NAME,
+                NOTIFICATION_CANDIDATES_REASON_CHECK_SQL,
+                notification_candidates_reason_constraint_matches_expected,
+            )
+            .await;
+        if let Err(error) = &reason_migrate {
+            cleanup.await;
+            panic!("reason migration failed: {error}");
         }
 
         // Post-migration: only the canonical named CHECK should

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -28,19 +28,38 @@ const BASE_POLICY_RETRY_DELAY_MS: i64 = 60_000;
 const MAX_RETRY_DELAY_MS: i64 = 300_000;
 const OUTBOX_CLAIM_TIMEOUT_MS: i64 = 300_000;
 const NOTIFICATION_CANDIDATES_REASON_CHECK_NAME: &str = "notification_candidates_reason_check";
-const NOTIFICATION_CANDIDATES_REASON_VALUES: [&str; 5] = [
+const NOTIFICATION_CANDIDATES_REASON_VALUES: [&str; 6] = [
     "offline_dm",
+    "offline_dm_mention",
     "groupchat_personal_mention",
     "groupchat_channel_mention",
     "groupchat_active_channel_mention",
     "groupchat_notify_all",
 ];
-const NOTIFICATION_CANDIDATES_REASON_CHECK_SQL: &str = "reason IN ('offline_dm', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')";
+const NOTIFICATION_CANDIDATES_REASON_CHECK_SQL: &str = "reason IN ('offline_dm', 'offline_dm_mention', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')";
+const NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME: &str = "notification_candidates_class_check";
+const NOTIFICATION_CANDIDATES_CLASS_VALUES: [&str; 6] = [
+    "dm",
+    "dm_mention",
+    "personal_mention",
+    "channel_mention",
+    "active_channel_mention",
+    "notify_all",
+];
+const NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
+const NOTIFICATION_OUTBOX_CLASS_CHECK_NAME: &str = "notification_outbox_class_check";
+const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
     "idx_notification_candidates_identity",
     "idx_notification_candidates_pending_worker",
     "idx_notification_candidates_outboxed_prune",
+];
+const NOTIFICATION_OUTBOX_INDEXES: [&str; 4] = [
+    "idx_notification_outbox_queued_coalesce",
+    "idx_notification_outbox_conversation_status",
+    "idx_notification_outbox_status_next_attempt",
+    "idx_notification_outbox_retention_prune",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +118,7 @@ impl From<String> for NotificationOutboxJobId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationClass {
     DirectMessage,
+    DirectMessageMention,
     PersonalMention,
     ChannelMention,
     ActiveChannelMention,
@@ -109,6 +129,7 @@ impl NotificationClass {
     fn as_db_value(self) -> &'static str {
         match self {
             Self::DirectMessage => "dm",
+            Self::DirectMessageMention => "dm_mention",
             Self::PersonalMention => "personal_mention",
             Self::ChannelMention => "channel_mention",
             Self::ActiveChannelMention => "active_channel_mention",
@@ -119,6 +140,7 @@ impl NotificationClass {
     fn from_db_value(value: &str) -> Result<Self, NotificationOutboxError> {
         match value {
             "dm" => Ok(Self::DirectMessage),
+            "dm_mention" => Ok(Self::DirectMessageMention),
             "personal_mention" => Ok(Self::PersonalMention),
             "channel_mention" => Ok(Self::ChannelMention),
             "active_channel_mention" => Ok(Self::ActiveChannelMention),
@@ -131,6 +153,7 @@ impl NotificationClass {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NotificationReason {
     OfflineDirectMessage,
+    OfflineDirectMessageMention,
     GroupchatPersonalMention,
     GroupchatChannelMention,
     GroupchatActiveChannelMention,
@@ -141,6 +164,7 @@ impl NotificationReason {
     fn as_db_value(self) -> &'static str {
         match self {
             Self::OfflineDirectMessage => "offline_dm",
+            Self::OfflineDirectMessageMention => "offline_dm_mention",
             Self::GroupchatPersonalMention => "groupchat_personal_mention",
             Self::GroupchatChannelMention => "groupchat_channel_mention",
             Self::GroupchatActiveChannelMention => "groupchat_active_channel_mention",
@@ -151,6 +175,7 @@ impl NotificationReason {
     fn from_db_value(value: &str) -> Result<Self, NotificationOutboxError> {
         match value {
             "offline_dm" => Ok(Self::OfflineDirectMessage),
+            "offline_dm_mention" => Ok(Self::OfflineDirectMessageMention),
             "groupchat_personal_mention" => Ok(Self::GroupchatPersonalMention),
             "groupchat_channel_mention" => Ok(Self::GroupchatChannelMention),
             "groupchat_active_channel_mention" => Ok(Self::GroupchatActiveChannelMention),
@@ -197,6 +222,7 @@ impl NotificationCandidate {
         recipient_bare_jid: BareJid,
         sender_jid: Jid,
         archive_stanza_id: StanzaId,
+        is_mention: bool,
     ) -> Result<Self, NotificationOutboxError> {
         require_full_sender_jid(&sender_jid)?;
         let expected_by = Jid::from(recipient_bare_jid.clone());
@@ -206,14 +232,25 @@ impl NotificationCandidate {
                 actual: archive_stanza_id.by,
             });
         }
+        let (class, reason) = if is_mention {
+            (
+                NotificationClass::DirectMessageMention,
+                NotificationReason::OfflineDirectMessageMention,
+            )
+        } else {
+            (
+                NotificationClass::DirectMessage,
+                NotificationReason::OfflineDirectMessage,
+            )
+        };
         Ok(Self {
             recipient_bare_jid,
             conversation_jid: sender_jid.to_bare(),
             sender_jid,
             thread_id: NotificationThreadId::root(),
             archive_stanza_id,
-            class: NotificationClass::DirectMessage,
-            reason: NotificationReason::OfflineDirectMessage,
+            class,
+            reason,
             policy_error_count: 0,
         })
     }
@@ -242,7 +279,7 @@ impl NotificationCandidate {
                 NotificationReason::GroupchatActiveChannelMention
             }
             NotificationClass::NotifyAll => NotificationReason::GroupchatNotifyAll,
-            NotificationClass::DirectMessage => {
+            NotificationClass::DirectMessage | NotificationClass::DirectMessageMention => {
                 return Err(NotificationOutboxError::InvalidClass(
                     class.as_db_value().to_string(),
                 ));
@@ -489,6 +526,29 @@ pub enum NotificationOutboxError {
     OutboxCoalesceContention,
 }
 
+/// T1 lookup of XEP-0045 room policy state needed to project a
+/// candidate's conversation kind for the XEP-0492 evaluator.
+///
+/// At T0 (candidate emission) we record the message-derived
+/// [`NotificationClass`] only. At T1 (outbox dispatch) the evaluator
+/// needs to know whether the room is members-only to pick
+/// [`crate::notification_settings_projection::ConversationKind::PrivateGroup`]
+/// or [`crate::notification_settings_projection::ConversationKind::PublicGroup`]
+/// — the kind drives both the XEP-0492 default level and the projection
+/// store lookup.
+///
+/// Returning `Ok(None)` signals "room not currently live" — when the room
+/// actor is not registered we treat the room as public-by-default rather
+/// than failing closed, mirroring the slice-1 limitation that there is
+/// no durable T1 projection of MUC config yet.
+#[async_trait::async_trait]
+pub trait RoomPolicyStore: Send + Sync {
+    async fn room_members_only(
+        &self,
+        room: &BareJid,
+    ) -> Result<Option<bool>, NotificationOutboxError>;
+}
+
 fn require_full_sender_jid(sender_jid: &Jid) -> Result<(), NotificationOutboxError> {
     if sender_jid.resource().is_some() {
         Ok(())
@@ -553,7 +613,7 @@ fn notification_candidates_table_sql(i64_type: &str, if_not_exists: bool) -> Str
             thread_id TEXT NOT NULL DEFAULT '',
             stanza_id_by TEXT NOT NULL,
             stanza_id TEXT NOT NULL,
-            class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
+            class TEXT NOT NULL CONSTRAINT {NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL}),
             reason TEXT NOT NULL CONSTRAINT {NOTIFICATION_CANDIDATES_REASON_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_REASON_CHECK_SQL}),
             created_at_ms {i64_type} NOT NULL,
             policy_error_count INTEGER NOT NULL DEFAULT 0,
@@ -565,12 +625,59 @@ fn notification_candidates_table_sql(i64_type: &str, if_not_exists: bool) -> Str
     )
 }
 
+fn notification_outbox_table_sql(i64_type: &str, if_not_exists: bool) -> String {
+    let if_not_exists = if if_not_exists { "IF NOT EXISTS " } else { "" };
+    format!(
+        r#"
+        CREATE TABLE {if_not_exists}notification_outbox (
+            job_id TEXT PRIMARY KEY,
+            recipient_bare_jid TEXT NOT NULL,
+            push_service_jid TEXT NOT NULL,
+            node TEXT NOT NULL,
+            conversation_jid TEXT NOT NULL,
+            sender_jid TEXT NOT NULL,
+            sender_jids TEXT NOT NULL,
+            thread_id TEXT NOT NULL DEFAULT '',
+            class TEXT NOT NULL CONSTRAINT {NOTIFICATION_OUTBOX_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_OUTBOX_CLASS_CHECK_SQL}),
+            message_count INTEGER NOT NULL,
+            context_xml TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('queued', 'in-progress', 'published', 'failed')),
+            attempt_count INTEGER NOT NULL DEFAULT 0,
+            policy_error_count INTEGER NOT NULL DEFAULT 0,
+            last_error TEXT,
+            next_attempt_at_ms {i64_type},
+            claimed_at_ms {i64_type},
+            claim_token TEXT,
+            created_at_ms {i64_type} NOT NULL,
+            updated_at_ms {i64_type} NOT NULL,
+            published_at_ms {i64_type}
+        )
+        "#
+    )
+}
+
 fn notification_candidates_reason_constraint_matches_expected(definition: &str) -> bool {
     let normalized = definition.to_ascii_lowercase();
     normalized.contains("reason")
         && NOTIFICATION_CANDIDATES_REASON_VALUES
             .iter()
             .all(|reason| normalized.contains(reason))
+}
+
+fn notification_candidates_class_constraint_matches_expected(definition: &str) -> bool {
+    let normalized = definition.to_ascii_lowercase();
+    normalized.contains("class")
+        && NOTIFICATION_CANDIDATES_CLASS_VALUES
+            .iter()
+            .all(|class| normalized.contains(class))
+}
+
+fn notification_outbox_class_constraint_matches_expected(definition: &str) -> bool {
+    let normalized = definition.to_ascii_lowercase();
+    normalized.contains("class")
+        && NOTIFICATION_CANDIDATES_CLASS_VALUES
+            .iter()
+            .all(|class| normalized.contains(class))
 }
 
 #[derive(Clone)]
@@ -601,6 +708,8 @@ impl NotificationOutboxStore {
             .await?;
         self.migrate_notification_candidates_reason_constraint(i64_type)
             .await?;
+        self.migrate_notification_candidates_class_constraint(i64_type)
+            .await?;
         self.execute(
             "CREATE INDEX IF NOT EXISTS idx_notification_candidates_recipient_created \
              ON notification_candidates (recipient_bare_jid, created_at_ms)",
@@ -627,37 +736,8 @@ impl NotificationOutboxStore {
             (),
         )
         .await?;
-        self.execute(
-            &format!(
-                r#"
-                CREATE TABLE IF NOT EXISTS notification_outbox (
-                    job_id TEXT PRIMARY KEY,
-                    recipient_bare_jid TEXT NOT NULL,
-                    push_service_jid TEXT NOT NULL,
-                    node TEXT NOT NULL,
-                    conversation_jid TEXT NOT NULL,
-                    sender_jid TEXT NOT NULL,
-                    sender_jids TEXT NOT NULL,
-                    thread_id TEXT NOT NULL DEFAULT '',
-                    class TEXT NOT NULL CHECK (class IN ('dm', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),
-                    message_count INTEGER NOT NULL,
-                    context_xml TEXT NOT NULL,
-                    status TEXT NOT NULL CHECK (status IN ('queued', 'in-progress', 'published', 'failed')),
-                    attempt_count INTEGER NOT NULL DEFAULT 0,
-                    policy_error_count INTEGER NOT NULL DEFAULT 0,
-                    last_error TEXT,
-                    next_attempt_at_ms {i64_type},
-                    claimed_at_ms {i64_type},
-                    claim_token TEXT,
-                    created_at_ms {i64_type} NOT NULL,
-                    updated_at_ms {i64_type} NOT NULL,
-                    published_at_ms {i64_type}
-                )
-                "#
-            ),
-            (),
-        )
-        .await?;
+        self.execute(&notification_outbox_table_sql(i64_type, true), ())
+            .await?;
         self.query(
             "SELECT sender_jid, sender_jids FROM notification_outbox LIMIT 0",
             (),
@@ -670,6 +750,8 @@ impl NotificationOutboxStore {
             "policy_error_count INTEGER NOT NULL DEFAULT 0",
         )
         .await?;
+        self.migrate_notification_outbox_class_constraint(i64_type)
+            .await?;
         self.execute(
             "DROP INDEX IF EXISTS idx_notification_outbox_queued_coalesce",
             (),
@@ -857,6 +939,323 @@ impl NotificationOutboxStore {
         ))
     }
 
+    async fn migrate_notification_candidates_class_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        match self.db.driver() {
+            crate::db::DatabaseDriver::Postgres => {
+                self.migrate_postgres_notification_candidates_class_constraint()
+                    .await
+            }
+            crate::db::DatabaseDriver::Sqlite => {
+                self.migrate_sqlite_notification_candidates_class_constraint(i64_type)
+                    .await
+            }
+        }
+    }
+
+    async fn migrate_postgres_notification_candidates_class_constraint(
+        &self,
+    ) -> Result<(), NotificationOutboxError> {
+        if !self
+            .postgres_notification_candidates_class_constraint_is_stale()
+            .await?
+        {
+            return Ok(());
+        }
+
+        self.execute(
+            &format!(
+                "ALTER TABLE notification_candidates DROP CONSTRAINT IF EXISTS {NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME}"
+            ),
+            (),
+        )
+        .await?;
+        self.execute(
+            &format!(
+                "ALTER TABLE notification_candidates ADD CONSTRAINT {NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL})"
+            ),
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn postgres_notification_candidates_class_constraint_is_stale(
+        &self,
+    ) -> Result<bool, NotificationOutboxError> {
+        let mut rows = self
+            .query(
+                r#"
+                SELECT pg_get_constraintdef(oid)
+                FROM pg_constraint
+                WHERE conrelid = 'notification_candidates'::regclass
+                  AND conname = ?
+                  AND contype = 'c'
+                "#,
+                crate::db_params![NOTIFICATION_CANDIDATES_CLASS_CHECK_NAME],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            // No named class CHECK constraint exists yet — Postgres
+            // emits anonymous CHECKs from the table-level CHECK literal.
+            // Treat as stale so the migration adds the named constraint.
+            return Ok(true);
+        };
+        let definition: String = row.get(0)?;
+        Ok(!notification_candidates_class_constraint_matches_expected(
+            &definition,
+        ))
+    }
+
+    async fn migrate_sqlite_notification_candidates_class_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        if !self
+            .sqlite_notification_candidates_class_constraint_is_stale()
+            .await?
+        {
+            return Ok(());
+        }
+
+        let mut tx = self.db.begin().await?;
+        for index in NOTIFICATION_CANDIDATES_INDEXES {
+            tx.execute(&format!("DROP INDEX IF EXISTS {index}"), ())
+                .await?;
+        }
+        tx.execute(
+            "ALTER TABLE notification_candidates RENAME TO notification_candidates_old_class_check",
+            (),
+        )
+        .await?;
+        tx.execute(&notification_candidates_table_sql(i64_type, false), ())
+            .await?;
+        tx.execute(
+            r#"
+            INSERT INTO notification_candidates (
+                recipient_bare_jid,
+                conversation_jid,
+                sender_jid,
+                thread_id,
+                stanza_id_by,
+                stanza_id,
+                class,
+                reason,
+                created_at_ms,
+                policy_error_count,
+                next_attempt_at_ms,
+                outboxed_at_ms
+            )
+            SELECT
+                recipient_bare_jid,
+                conversation_jid,
+                sender_jid,
+                thread_id,
+                stanza_id_by,
+                stanza_id,
+                class,
+                reason,
+                created_at_ms,
+                policy_error_count,
+                next_attempt_at_ms,
+                outboxed_at_ms
+            FROM notification_candidates_old_class_check
+            "#,
+            (),
+        )
+        .await?;
+        tx.execute("DROP TABLE notification_candidates_old_class_check", ())
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn sqlite_notification_candidates_class_constraint_is_stale(
+        &self,
+    ) -> Result<bool, NotificationOutboxError> {
+        let mut rows = self
+            .query(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'notification_candidates'",
+                (),
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(false);
+        };
+        let create_sql: String = row.get(0)?;
+        Ok(!notification_candidates_class_constraint_matches_expected(
+            &create_sql,
+        ))
+    }
+
+    async fn migrate_notification_outbox_class_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        match self.db.driver() {
+            crate::db::DatabaseDriver::Postgres => {
+                self.migrate_postgres_notification_outbox_class_constraint()
+                    .await
+            }
+            crate::db::DatabaseDriver::Sqlite => {
+                self.migrate_sqlite_notification_outbox_class_constraint(i64_type)
+                    .await
+            }
+        }
+    }
+
+    async fn migrate_postgres_notification_outbox_class_constraint(
+        &self,
+    ) -> Result<(), NotificationOutboxError> {
+        if !self
+            .postgres_notification_outbox_class_constraint_is_stale()
+            .await?
+        {
+            return Ok(());
+        }
+
+        self.execute(
+            &format!(
+                "ALTER TABLE notification_outbox DROP CONSTRAINT IF EXISTS {NOTIFICATION_OUTBOX_CLASS_CHECK_NAME}"
+            ),
+            (),
+        )
+        .await?;
+        self.execute(
+            &format!(
+                "ALTER TABLE notification_outbox ADD CONSTRAINT {NOTIFICATION_OUTBOX_CLASS_CHECK_NAME} CHECK ({NOTIFICATION_OUTBOX_CLASS_CHECK_SQL})"
+            ),
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn postgres_notification_outbox_class_constraint_is_stale(
+        &self,
+    ) -> Result<bool, NotificationOutboxError> {
+        let mut rows = self
+            .query(
+                r#"
+                SELECT pg_get_constraintdef(oid)
+                FROM pg_constraint
+                WHERE conrelid = 'notification_outbox'::regclass
+                  AND conname = ?
+                  AND contype = 'c'
+                "#,
+                crate::db_params![NOTIFICATION_OUTBOX_CLASS_CHECK_NAME],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(true);
+        };
+        let definition: String = row.get(0)?;
+        Ok(!notification_outbox_class_constraint_matches_expected(
+            &definition,
+        ))
+    }
+
+    async fn migrate_sqlite_notification_outbox_class_constraint(
+        &self,
+        i64_type: &str,
+    ) -> Result<(), NotificationOutboxError> {
+        if !self
+            .sqlite_notification_outbox_class_constraint_is_stale()
+            .await?
+        {
+            return Ok(());
+        }
+
+        let mut tx = self.db.begin().await?;
+        for index in NOTIFICATION_OUTBOX_INDEXES {
+            tx.execute(&format!("DROP INDEX IF EXISTS {index}"), ())
+                .await?;
+        }
+        tx.execute(
+            "ALTER TABLE notification_outbox RENAME TO notification_outbox_old_class_check",
+            (),
+        )
+        .await?;
+        tx.execute(&notification_outbox_table_sql(i64_type, false), ())
+            .await?;
+        tx.execute(
+            r#"
+            INSERT INTO notification_outbox (
+                job_id,
+                recipient_bare_jid,
+                push_service_jid,
+                node,
+                conversation_jid,
+                sender_jid,
+                sender_jids,
+                thread_id,
+                class,
+                message_count,
+                context_xml,
+                status,
+                attempt_count,
+                policy_error_count,
+                last_error,
+                next_attempt_at_ms,
+                claimed_at_ms,
+                claim_token,
+                created_at_ms,
+                updated_at_ms,
+                published_at_ms
+            )
+            SELECT
+                job_id,
+                recipient_bare_jid,
+                push_service_jid,
+                node,
+                conversation_jid,
+                sender_jid,
+                sender_jids,
+                thread_id,
+                class,
+                message_count,
+                context_xml,
+                status,
+                attempt_count,
+                policy_error_count,
+                last_error,
+                next_attempt_at_ms,
+                claimed_at_ms,
+                claim_token,
+                created_at_ms,
+                updated_at_ms,
+                published_at_ms
+            FROM notification_outbox_old_class_check
+            "#,
+            (),
+        )
+        .await?;
+        tx.execute("DROP TABLE notification_outbox_old_class_check", ())
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn sqlite_notification_outbox_class_constraint_is_stale(
+        &self,
+    ) -> Result<bool, NotificationOutboxError> {
+        let mut rows = self
+            .query(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'notification_outbox'",
+                (),
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Ok(false);
+        };
+        let create_sql: String = row.get(0)?;
+        Ok(!notification_outbox_class_constraint_matches_expected(
+            &create_sql,
+        ))
+    }
+
     async fn add_column_if_missing(
         &self,
         table: &str,
@@ -946,6 +1345,8 @@ impl NotificationOutboxStore {
         &self,
         push_store: &dyn PushSubscriptionStore,
         blocking_storage: &dyn BlockingStorage,
+        settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
+        room_policy: &dyn RoomPolicyStore,
         first_party_service_jid: &BareJid,
         batch_size: usize,
     ) -> Result<usize, NotificationOutboxError> {
@@ -976,6 +1377,48 @@ impl NotificationOutboxStore {
                     self.defer_candidate_policy_error(&candidate).await?;
                     continue;
                 }
+            }
+            // T1 XEP-0492 push-dispatch gate. The class on the candidate
+            // is purely message-derived from T0; combined with the
+            // recipient's effective notification level (consulted fresh
+            // here against the projection store) the typed reducer
+            // decides publish-or-suppress.
+            let decision =
+                match evaluate_xep0492_at_dispatch(settings_projection, room_policy, &candidate)
+                    .await
+                {
+                    Ok(decision) => decision,
+                    Err(error) => {
+                        tracing::warn!(
+                            recipient = %candidate.recipient_bare_jid(),
+                            conversation = %candidate.conversation_jid(),
+                            %error,
+                            "XEP-0492 notification setting lookup failed at T1; deferring candidate"
+                        );
+                        self.defer_candidate_policy_error(&candidate).await?;
+                        continue;
+                    }
+                };
+            if let crate::notification_settings_projection::PushDispatchDecision::Suppressed {
+                reason,
+            } = decision
+            {
+                tracing::info!(
+                    recipient = %candidate.recipient_bare_jid(),
+                    conversation = %candidate.conversation_jid(),
+                    sender = %candidate.sender_jid(),
+                    class = ?candidate.class(),
+                    %reason,
+                    "XEP-0492 push gate suppressed XEP-0357 notification candidate at T1"
+                );
+                let now_ms = crate::time::now_ms();
+                let mut tx = self.db.begin().await?;
+                let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
+                tx.commit().await?;
+                if claimed > 0 {
+                    processed += 1;
+                }
+                continue;
             }
             let recipient_key = candidate.recipient_bare_jid.clone();
             if !target_cache.contains_key(&recipient_key) {
@@ -1746,6 +2189,78 @@ impl NotificationOutboxStore {
     }
 }
 
+/// T1 XEP-0492 push-dispatch evaluator.
+///
+/// Derives `(level, is_mention)` from the recorded candidate class +
+/// recipient state and feeds them into the shared pure reducer
+/// [`crate::notification_settings_projection::PushDispatchDecision::evaluate`].
+///
+/// - DM classes encode the mention bit directly
+///   ([`NotificationClass::DirectMessage`] vs
+///   [`NotificationClass::DirectMessageMention`]).
+/// - Groupchat classes encode both mention scope and
+///   live-occupant scope; the room is private/public per the
+///   [`RoomPolicyStore`] lookup at dispatch time (slice 1 limitation:
+///   no durable T1 projection of MUC config exists yet, so we read
+///   live actor state, defaulting to public when unknown).
+async fn evaluate_xep0492_at_dispatch(
+    settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
+    room_policy: &dyn RoomPolicyStore,
+    candidate: &NotificationCandidate,
+) -> Result<
+    crate::notification_settings_projection::PushDispatchDecision,
+    crate::notification_settings_projection::NotificationSettingsProjectionError,
+> {
+    let (conversation_kind, is_mention) = match candidate.class() {
+        NotificationClass::DirectMessage => (
+            crate::notification_settings_projection::ConversationKind::Direct,
+            false,
+        ),
+        NotificationClass::DirectMessageMention => (
+            crate::notification_settings_projection::ConversationKind::Direct,
+            true,
+        ),
+        NotificationClass::PersonalMention
+        | NotificationClass::ChannelMention
+        | NotificationClass::ActiveChannelMention => {
+            let members_only = room_policy
+                .room_members_only(candidate.conversation_jid())
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or(false);
+            let kind = if members_only {
+                crate::notification_settings_projection::ConversationKind::PrivateGroup
+            } else {
+                crate::notification_settings_projection::ConversationKind::PublicGroup
+            };
+            (kind, true)
+        }
+        NotificationClass::NotifyAll => {
+            let members_only = room_policy
+                .room_members_only(candidate.conversation_jid())
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or(false);
+            let kind = if members_only {
+                crate::notification_settings_projection::ConversationKind::PrivateGroup
+            } else {
+                crate::notification_settings_projection::ConversationKind::PublicGroup
+            };
+            (kind, false)
+        }
+    };
+    let level = settings_projection
+        .effective_setting(
+            candidate.recipient_bare_jid(),
+            candidate.conversation_jid(),
+            conversation_kind,
+        )
+        .await?;
+    Ok(crate::notification_settings_projection::PushDispatchDecision::evaluate(level, is_mention))
+}
+
 async fn xep0191_blocks_notification_job(
     job: &NotificationOutboxJob,
     blocking_storage: &dyn BlockingStorage,
@@ -2354,6 +2869,7 @@ mod tests {
             recipient.clone(),
             sender_jid,
             StanzaId::new(id, Jid::from(recipient.clone())),
+            false,
         )
         .expect("candidate")
     }
@@ -2378,7 +2894,7 @@ mod tests {
 
     #[test]
     fn postgres_reason_constraint_match_accepts_current_definition() {
-        let postgres_definition = "CHECK (((reason)::text = ANY ((ARRAY['offline_dm'::character varying, 'groupchat_personal_mention'::character varying, 'groupchat_channel_mention'::character varying, 'groupchat_active_channel_mention'::character varying, 'groupchat_notify_all'::character varying])::text[])))";
+        let postgres_definition = "CHECK (((reason)::text = ANY ((ARRAY['offline_dm'::character varying, 'offline_dm_mention'::character varying, 'groupchat_personal_mention'::character varying, 'groupchat_channel_mention'::character varying, 'groupchat_active_channel_mention'::character varying, 'groupchat_notify_all'::character varying])::text[])))";
         assert!(notification_candidates_reason_constraint_matches_expected(
             postgres_definition
         ));
@@ -2388,6 +2904,25 @@ mod tests {
     fn postgres_reason_constraint_match_rejects_legacy_definition() {
         let postgres_definition = "CHECK (((reason)::text = 'offline_dm'::character varying))";
         assert!(!notification_candidates_reason_constraint_matches_expected(
+            postgres_definition
+        ));
+    }
+
+    #[test]
+    fn postgres_class_constraint_match_accepts_current_definition() {
+        let postgres_definition = "CHECK (((class)::text = ANY ((ARRAY['dm'::character varying, 'dm_mention'::character varying, 'personal_mention'::character varying, 'channel_mention'::character varying, 'active_channel_mention'::character varying, 'notify_all'::character varying])::text[])))";
+        assert!(notification_candidates_class_constraint_matches_expected(
+            postgres_definition
+        ));
+        assert!(notification_outbox_class_constraint_matches_expected(
+            postgres_definition
+        ));
+    }
+
+    #[test]
+    fn postgres_class_constraint_match_rejects_legacy_definition() {
+        let postgres_definition = "CHECK (((class)::text = ANY ((ARRAY['dm'::character varying, 'personal_mention'::character varying])::text[])))";
+        assert!(!notification_candidates_class_constraint_matches_expected(
             postgres_definition
         ));
     }
@@ -2430,6 +2965,52 @@ mod tests {
         NotificationOutboxStore::new(Database::in_memory("notification-outbox").await.unwrap())
             .await
             .expect("store")
+    }
+
+    /// Test stub for [`RoomPolicyStore`] — defaults rooms to public
+    /// (`members_only = false`) unless explicitly mapped to private.
+    #[derive(Default)]
+    struct StubRoomPolicy {
+        private_rooms: std::sync::Mutex<std::collections::BTreeSet<BareJid>>,
+    }
+
+    impl StubRoomPolicy {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        #[allow(dead_code)]
+        fn mark_private(&self, room: BareJid) {
+            self.private_rooms
+                .lock()
+                .expect("stub room policy lock")
+                .insert(room);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RoomPolicyStore for StubRoomPolicy {
+        async fn room_members_only(
+            &self,
+            room: &BareJid,
+        ) -> Result<Option<bool>, NotificationOutboxError> {
+            Ok(Some(
+                self.private_rooms
+                    .lock()
+                    .expect("stub room policy lock")
+                    .contains(room),
+            ))
+        }
+    }
+
+    async fn settings_projection(
+    ) -> crate::notification_settings_projection::NotificationSettingsProjectionStore {
+        let storage = crate::pubsub::DatabasePubSubStorage::open(Some("sqlite::memory:"))
+            .await
+            .expect("settings pubsub storage");
+        crate::notification_settings_projection::NotificationSettingsProjectionStore::new(
+            storage.database(),
+        )
     }
 
     #[tokio::test]
@@ -2655,6 +3236,7 @@ mod tests {
             recipient.clone(),
             Jid::from(bare("bob@example.com")),
             StanzaId::new("archive-bare-sender", Jid::from(recipient)),
+            false,
         );
 
         assert!(matches!(
@@ -2849,6 +3431,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let first = candidate("archive-1");
         let duplicate = candidate("archive-1");
         let second = candidate("archive-2");
@@ -2883,6 +3467,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -2903,6 +3489,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
         let candidate = candidate_for_sender_jid(
@@ -2927,6 +3515,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -2970,6 +3560,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
         let candidate = candidate_for_sender_jid(
@@ -2994,6 +3586,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3036,6 +3630,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
         let candidate = candidate_for_sender_jid(
@@ -3060,6 +3656,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3086,6 +3684,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let malformed_recipient = bare("alice@example.com");
         let valid_recipient = bare("carol@example.com");
         register_push_target(&push_store, &malformed_recipient, &target).await;
@@ -3121,6 +3721,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3145,6 +3747,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3175,6 +3779,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3208,6 +3814,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3222,6 +3830,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3252,6 +3862,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3278,6 +3890,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3292,6 +3906,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3321,6 +3937,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3347,6 +3965,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3361,6 +3981,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3390,6 +4012,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3417,6 +4041,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3431,6 +4057,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3460,6 +4088,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3486,6 +4116,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
 
@@ -3500,6 +4132,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3529,6 +4163,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3555,6 +4191,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
         blocking.set_blocklist_jids(
@@ -3586,6 +4224,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3607,6 +4247,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         let room = bare("team@muc.example.com");
         register_push_target(&push_store, &recipient, &target).await;
@@ -3629,6 +4271,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3684,6 +4328,8 @@ mod tests {
         let recipient = bare("alice@example.com");
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let push_service = crate::push_service::DatabasePushServiceStore::new(
             Database::in_memory("push-service-coalesced-full-jid-block")
                 .await
@@ -3746,6 +4392,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3807,6 +4455,8 @@ mod tests {
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
         let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let alice = bare("alice@example.com");
         let carol = bare("carol@example.com");
         let bob = bare("bob@example.com");
@@ -3847,6 +4497,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3866,6 +4518,8 @@ mod tests {
         let store = store().await;
         let target = target();
         let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+        let projection = settings_projection().await;
+        let room_policy = StubRoomPolicy::new();
         let recipient = bare("alice@example.com");
         register_push_target(&push_store, &recipient, &target).await;
         store
@@ -3890,6 +4544,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &FailingBlockingStorage,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )
@@ -3935,6 +4591,8 @@ mod tests {
                 .drain_pending_candidates_into_outbox(
                     &push_store,
                     &blocking,
+                    &projection,
+                    &room_policy,
                     &bare("push.example.com"),
                     16,
                 )

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -577,6 +577,30 @@ pub trait RoomPolicyStore: Send + Sync {
     ) -> Result<Option<bool>, NotificationOutboxError>;
 }
 
+/// Zero-state [`RoomPolicyStore`] for DM emission paths.
+///
+/// The T0 emission gate for direct messages calls
+/// [`evaluate_xep0492_at_dispatch`] on a candidate whose class is
+/// [`NotificationClass::DirectMessage`] or
+/// [`NotificationClass::DirectMessageMention`]. Those arms never
+/// dispatch into `room_policy`, so the trait object is held only to
+/// satisfy the typed signature. This adapter encodes that no-op shape
+/// once at the type level; if the evaluator ever did consult it for a
+/// DM, it would surface as [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`]
+/// rather than a silent default — fail-loud per the slice 1 design.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopRoomPolicy;
+
+#[async_trait::async_trait]
+impl RoomPolicyStore for NoopRoomPolicy {
+    async fn room_members_only(
+        &self,
+        _room: &BareJid,
+    ) -> Result<Option<bool>, NotificationOutboxError> {
+        Ok(None)
+    }
+}
+
 fn require_full_sender_jid(sender_jid: &Jid) -> Result<(), NotificationOutboxError> {
     if sender_jid.resource().is_some() {
         Ok(())
@@ -1410,13 +1434,33 @@ impl NotificationOutboxStore {
                     continue;
                 }
             }
-            // T1 XEP-0492 push-dispatch gate. The class on the candidate
-            // is purely message-derived from T0; combined with the
-            // recipient's effective notification level (consulted fresh
-            // here against the projection store) the typed reducer
-            // decides publish-or-suppress. The room-policy lookup is
-            // cached for the duration of this drain pass so a 100-
-            // member groupchat does not produce 100 actor round-trips.
+            // T1 XEP-0492 push-dispatch re-evaluation — race-window
+            // guard, defense-in-depth.
+            //
+            // The same typed evaluator already ran at T0 (DM emission
+            // in `offline_delivery.rs`, groupchat emission in
+            // `groupchat_inbox.rs`) and a Suppressed outcome there
+            // short-circuits the candidate insert entirely. Per the
+            // compliance rule the common case is "no row in
+            // `notification_candidates` for suppressed outcomes."
+            //
+            // This T1 invocation catches the race where recipient
+            // state changed *between* the T0 emission and the T1
+            // dispatch (e.g. the user flipped XEP-0492 to `<never/>`
+            // mid-flight, or a groupchat config change toggled
+            // members-only). If the projection has changed the drain
+            // marks the candidate outboxed without enqueueing a job —
+            // the row exists only briefly during the race window,
+            // which is acceptable per the locked Q2 design (push
+            // output is preserved).
+            //
+            // The class on the candidate is purely message-derived
+            // from T0; combined with the recipient's effective
+            // notification level (consulted fresh here against the
+            // projection store) the typed reducer decides
+            // publish-or-suppress. The room-policy lookup is cached
+            // for the duration of this drain pass so a 100-member
+            // groupchat does not produce 100 actor round-trips.
             let outcome = match evaluate_xep0492_at_dispatch(
                 settings_projection,
                 room_policy,
@@ -2251,7 +2295,7 @@ impl NotificationOutboxStore {
 /// private-room pushes or fan out unwanted public-room pushes. Slice
 /// 2 will replace the live actor lookup with a durable projection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum T1PushDispatchOutcome {
+pub(crate) enum T1PushDispatchOutcome {
     /// XEP-0492 gate decided to fan out; enqueue the push job.
     Deliver,
     /// XEP-0492 gate decided to suppress; mark candidate outboxed
@@ -2275,7 +2319,7 @@ enum T1PushDispatchOutcome {
 /// every candidate for that room in the same batch reuses that
 /// outcome to avoid retrying the same failing actor 100×.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RoomPolicyCacheEntry {
+pub(crate) enum RoomPolicyCacheEntry {
     Public,
     Private,
     Unknown,
@@ -2296,23 +2340,47 @@ impl RoomPolicyCacheEntry {
 
 /// T1 XEP-0492 push-dispatch evaluator.
 ///
+/// **Same typed evaluator called at two invocation moments**:
+///
+/// - **T0 (candidate emission gate, compliance)** — DM
+///   ([`crate::server::routes::interpret::offline_delivery`]) and
+///   groupchat
+///   ([`crate::server::routes::interpret::groupchat_inbox`])
+///   emission paths invoke this on a constructed-but-not-inserted
+///   [`NotificationCandidate`] before persisting it. A `Suppressed`
+///   outcome short-circuits emission entirely — no row is written.
+///   This satisfies the compliance rule that suppressed candidates
+///   leave no audit trail in `notification_candidates`.
+/// - **T1 (drain re-evaluator, race-window guard)** — the same
+///   function runs again inside
+///   [`NotificationOutboxStore::drain_pending_candidates_into_outbox`]
+///   against fresh recipient state. If the projection changed
+///   between T0 and T1 (e.g. the user flipped XEP-0492 to
+///   `<never/>` mid-flight), the drain marks the candidate outboxed
+///   without enqueuing a job. The brief race window where a row
+///   exists then gets retroactively suppressed is acceptable per
+///   the locked Q2 design.
+///
 /// Derives `(level, is_mention)` from the recorded candidate class +
 /// recipient state and feeds them into the shared pure reducer
 /// [`crate::notification_settings_projection::PushDispatchDecision::evaluate`].
 ///
 /// - DM classes encode the mention bit directly
 ///   ([`NotificationClass::DirectMessage`] vs
-///   [`NotificationClass::DirectMessageMention`]).
+///   [`NotificationClass::DirectMessageMention`]). DM evaluation
+///   never consults `room_policy` and may pass any [`RoomPolicyStore`]
+///   (e.g. [`NoopRoomPolicy`]) at the T0 call site.
 /// - Groupchat classes encode both mention scope and
 ///   live-occupant scope; the room is private/public per the
-///   [`RoomPolicyStore`] lookup, cached per drain batch through
+///   [`RoomPolicyStore`] lookup, cached per call through
 ///   `room_policy_cache` so a 100-member groupchat does not produce
-///   100 actor round-trips. When the lookup yields
+///   100 actor round-trips at T1, and a single-message emission at
+///   T0 trivially hits one entry. When the lookup yields
 ///   `Ok(None)`/`Err(_)`, the evaluator returns
 ///   [`T1PushDispatchOutcome::DeferUnknownRoomPolicy`] — slice 1 has
 ///   no durable T1 projection of MUC config yet, so an unknown
 ///   policy must defer rather than default-to-public.
-async fn evaluate_xep0492_at_dispatch(
+pub(crate) async fn evaluate_xep0492_at_dispatch(
     settings_projection: &crate::notification_settings_projection::NotificationSettingsProjectionStore,
     room_policy: &dyn RoomPolicyStore,
     candidate: &NotificationCandidate,

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -546,6 +546,8 @@ pub enum NotificationOutboxError {
     ArchiveStanzaIdOwnerMismatch { expected: Jid, actual: Jid },
     #[error("notification candidate sender bare JID equals recipient bare JID: {0}")]
     SelfDirectedNotificationCandidate(BareJid),
+    #[error("room policy lookup failed for {room}: {message}")]
+    RoomPolicyLookup { room: BareJid, message: String },
     #[error("message count is out of range: {0}")]
     InvalidMessageCount(i64),
     #[error("notification outbox coalesce contention persisted after retry")]
@@ -3352,6 +3354,41 @@ mod tests {
         ) -> Result<Option<bool>, NotificationOutboxError> {
             self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Ok(Some(false))
+        }
+    }
+
+    /// Test stub that always returns a typed `RoomPolicyLookup` error
+    /// — models actor mailbox / transport failures. Counts the calls
+    /// so we can assert the per-batch cache short-circuits subsequent
+    /// lookups (one error → one cache entry → one warn → many silent
+    /// reuses, never re-asking the failing dependency).
+    struct ErroringRoomPolicy {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl ErroringRoomPolicy {
+        fn new() -> Self {
+            Self {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RoomPolicyStore for ErroringRoomPolicy {
+        async fn room_members_only(
+            &self,
+            room: &BareJid,
+        ) -> Result<Option<bool>, NotificationOutboxError> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err(NotificationOutboxError::RoomPolicyLookup {
+                room: room.clone(),
+                message: "test-fixture: simulated actor mailbox failure".to_string(),
+            })
         }
     }
 
@@ -6720,6 +6757,60 @@ mod tests {
             room_policy.call_count(),
             1,
             "deferral outcomes must be cached per-batch — failing actor must NOT be re-queried per candidate",
+        );
+    }
+
+    /// A `RoomPolicyStore::room_members_only` returning a typed
+    /// `RoomPolicyLookup` error MUST classify the cache entry as
+    /// `LookupError`, not `NotLive`. The dispatch outcome remains
+    /// `DeferUnknownRoomPolicy` either way, but the source split is
+    /// what gives operators an actionable signal vs routine dormancy.
+    /// Caching still applies: a single failing lookup populates one
+    /// `Unknown(LookupError)` entry and every subsequent candidate
+    /// for that room reuses it.
+    #[tokio::test]
+    async fn room_policy_lookup_error_classifies_as_lookup_error_and_caches() {
+        let room_policy = ErroringRoomPolicy::new();
+        let room = bare("team@muc.example.com");
+        let mut cache = std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+
+        let first = resolve_cached_room_policy(&room_policy, &room, &mut cache).await;
+        assert_eq!(
+            first,
+            RoomPolicyCacheEntry::Unknown(UnknownRoomPolicySource::LookupError),
+            "typed RoomPolicyLookup error must classify as LookupError, not NotLive"
+        );
+
+        let second = resolve_cached_room_policy(&room_policy, &room, &mut cache).await;
+        assert_eq!(
+            second, first,
+            "second lookup MUST hit the cache and return the same typed entry"
+        );
+
+        assert_eq!(
+            room_policy.call_count(),
+            1,
+            "cache MUST short-circuit subsequent lookups — failing actor is never re-asked in the same batch",
+        );
+    }
+
+    /// A `RoomPolicyStore::room_members_only` returning `Ok(None)`
+    /// MUST classify the cache entry as `NotLive`, not `LookupError`.
+    /// Distinguishing these is the whole point of the typed source —
+    /// `NotLive` is routine dormancy and stays at `debug!` level in
+    /// the drain loop, whereas `LookupError` triggers the once-per-
+    /// batch `warn!` for operators to triage.
+    #[tokio::test]
+    async fn room_policy_ok_none_classifies_as_not_live() {
+        let room_policy = UnknownRoomPolicy::new();
+        let room = bare("team@muc.example.com");
+        let mut cache = std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
+
+        let entry = resolve_cached_room_policy(&room_policy, &room, &mut cache).await;
+        assert_eq!(
+            entry,
+            RoomPolicyCacheEntry::Unknown(UnknownRoomPolicySource::NotLive),
+            "Ok(None) must classify as NotLive, distinct from LookupError"
         );
     }
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3273,12 +3273,10 @@ mod tests {
             .expect("store")
     }
 
-    /// Test stub for [`RoomPolicyStore`] — defaults rooms to public
-    /// (`members_only = false`) unless explicitly mapped to private.
     /// Test double for [`RoomPolicyStore`] that pretends every room is
-    /// public. Slice 1's tests do not exercise private-room dispatch
-    /// policy; when slice 2 adds those paths it will grow this stub
-    /// (or replace it with a richer fixture).
+    /// public (`members_only = false`). Slice 1's tests do not exercise
+    /// private-room dispatch policy; when slice 2 adds those paths it
+    /// will grow this stub (or replace it with a richer fixture).
     struct StubRoomPolicy;
 
     impl StubRoomPolicy {

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -233,6 +233,22 @@ impl NotificationCandidate {
         is_mention: bool,
     ) -> Result<Self, NotificationOutboxError> {
         require_full_sender_jid(&sender_jid)?;
+        // Structural invariant: a notification candidate cannot be
+        // self-directed. A self-DM (sender bare JID == recipient bare
+        // JID) is not a valid push candidate at all — there is no
+        // distinct recipient to notify, so the candidate is malformed
+        // by construction. This is *input validation*, not recipient-
+        // state suppression, so it lives at the constructor boundary
+        // alongside the existing full-sender-JID and archive-id owner
+        // checks. T0 emission paths surface this error as a typed
+        // emission no-op; no candidate row is persisted. (Per #506 Q3:
+        // T0 has no recipient-state reads — sender vs recipient JID
+        // comparison is message-intrinsic provenance.)
+        if sender_jid.to_bare() == recipient_bare_jid {
+            return Err(NotificationOutboxError::SelfDirectedNotificationCandidate(
+                recipient_bare_jid,
+            ));
+        }
         let expected_by = Jid::from(recipient_bare_jid.clone());
         if archive_stanza_id.by != expected_by {
             return Err(NotificationOutboxError::ArchiveStanzaIdOwnerMismatch {
@@ -528,6 +544,8 @@ pub enum NotificationOutboxError {
     InvalidContextXml(String),
     #[error("archive stanza-id by mismatch: expected {expected}, got {actual}")]
     ArchiveStanzaIdOwnerMismatch { expected: Jid, actual: Jid },
+    #[error("notification candidate sender bare JID equals recipient bare JID: {0}")]
+    SelfDirectedNotificationCandidate(BareJid),
     #[error("message count is out of range: {0}")]
     InvalidMessageCount(i64),
     #[error("notification outbox coalesce contention persisted after retry")]
@@ -1362,32 +1380,13 @@ impl NotificationOutboxStore {
             std::collections::BTreeMap::<BareJid, RoomPolicyCacheEntry>::new();
         let mut processed = 0usize;
         for candidate in candidates {
-            // Self-DM suppression at T1 (#506 Q3 strict (A): no T0
-            // carve-outs based on routing recipient). Derived
-            // entirely from message-frozen columns already on the
-            // candidate row, so no extra read is required. XEP-0357
-            // §8 "online with active resource" semantics will be
-            // expanded in slice 2; for now self-DM is the only
-            // condition we suppress here, consistent with the
-            // headless `OfflineDeliveryHandler` no longer carving it
-            // out at T0.
-            if candidate.sender_jid().to_bare() == *candidate.recipient_bare_jid() {
-                tracing::info!(
-                    recipient = %candidate.recipient_bare_jid(),
-                    conversation = %candidate.conversation_jid(),
-                    sender = %candidate.sender_jid(),
-                    class = ?candidate.class(),
-                    "self-DM suppressed at T1; marking notification candidate outboxed without job"
-                );
-                let now_ms = crate::time::now_ms();
-                let mut tx = self.db.begin().await?;
-                let claimed = mark_candidate_outboxed_tx(&mut tx, &candidate, now_ms).await?;
-                tx.commit().await?;
-                if claimed > 0 {
-                    processed += 1;
-                }
-                continue;
-            }
+            // Self-DM filtering happens at the `NotificationCandidate`
+            // constructor (`SelfDirectedNotificationCandidate` typed
+            // error). A self-directed candidate is structurally
+            // invalid and is rejected before it can be persisted, so
+            // the T1 drain loop never observes one. See
+            // `NotificationCandidate::direct_message` for the typed
+            // boundary.
             match xep0191_blocks_notification_candidate(&candidate, blocking_storage).await {
                 Ok(true) => {
                     let now_ms = crate::time::now_ms();
@@ -6229,82 +6228,73 @@ mod tests {
         );
     }
 
-    /// Regression for the self-DM suppression migration from T0 to T1
-    /// (#506 Q3 strict (A) — no T0 carve-outs based on routing
-    /// recipient). The candidate row is now inserted unconditionally
-    /// at T0; the T1 evaluator detects
-    /// `sender_jid.to_bare() == recipient_bare_jid` from the frozen
-    /// columns and marks the candidate outboxed without enqueuing a
-    /// push job — same shape as the XEP-0191 blocked path and the
-    /// XEP-0492 suppressed path.
+    /// Regression for self-DM structural-validity rejection at the
+    /// `NotificationCandidate::direct_message` constructor (#506
+    /// compliance: no push candidate/outbox entry for self-directed
+    /// notifications). Self-DM is *input validation*, not recipient-
+    /// state suppression, so it lives at the typed constructor
+    /// boundary alongside `require_full_sender_jid` and
+    /// `ArchiveStanzaIdOwnerMismatch`. No candidate row is ever
+    /// persisted, satisfying both:
+    ///   (a) #506 Q3: T0 has no recipient-state reads — sender vs
+    ///       recipient JID comparison is message-intrinsic provenance.
+    ///   (b) compliance: self-notifications produce no candidate or
+    ///       outbox entry.
     #[tokio::test]
-    async fn self_dm_candidate_is_suppressed_at_t1_with_no_job_enqueued() {
-        let store = store().await;
-        let target = target();
-        let push_store = waddle_xmpp::push::InMemoryPushStore::new();
-        let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
-        let projection = settings_projection().await;
-        let room_policy = StubRoomPolicy::new();
+    async fn self_directed_dm_candidate_is_rejected_at_constructor() {
         let recipient = bare("alice@example.com");
-        register_push_target(&push_store, &recipient, &target).await;
-
-        // Self-DM: sender's bare JID equals recipient's bare JID.
-        let candidate = NotificationCandidate::direct_message(
+        let result = NotificationCandidate::direct_message(
             recipient.clone(),
             "alice@example.com/desktop"
                 .parse()
                 .expect("full self sender"),
             StanzaId::new("self-dm-archive", Jid::from(recipient.clone())),
             false,
-        )
-        .expect("self-dm candidate");
-        assert_eq!(
-            store
-                .insert_candidate(&candidate)
-                .await
-                .expect("self-dm insert"),
-            NotificationCandidateInsertOutcome::Inserted,
-            "T0 must insert the self-DM candidate row unconditionally — \
-             suppression is a T1 concern"
         );
+        assert!(matches!(
+            result,
+            Err(NotificationOutboxError::SelfDirectedNotificationCandidate(jid))
+                if jid == recipient
+        ));
+    }
 
-        // Sanity: candidate is pending pre-drain.
-        assert_eq!(
-            store
-                .pending_candidates(16)
-                .await
-                .expect("pre-drain pending")
-                .len(),
-            1
+    /// Regression that the offline-delivery path silently drops self-
+    /// directed notification attempts without persisting anything to
+    /// `notification_candidates` or `notification_outbox`. End-to-end
+    /// surface of the constructor rejection above: insert is attempted
+    /// once, fails fast as a typed error, and the candidate table
+    /// stays empty.
+    #[tokio::test]
+    async fn self_directed_dm_inserts_no_candidate_row() {
+        let store = store().await;
+        let recipient = bare("alice@example.com");
+        let result = NotificationCandidate::direct_message(
+            recipient.clone(),
+            "alice@example.com/desktop"
+                .parse()
+                .expect("full self sender"),
+            StanzaId::new("self-dm-archive", Jid::from(recipient.clone())),
+            false,
         );
-
-        assert_eq!(
-            store
-                .drain_pending_candidates_into_outbox(
-                    &push_store,
-                    &blocking,
-                    &projection,
-                    &room_policy,
-                    &bare("push.example.com"),
-                    16,
-                )
-                .await
-                .expect("drain candidates"),
-            1,
-            "self-DM candidate is processed (marked outboxed), counted toward 'processed'",
-        );
-
-        assert!(
-            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
-            "self-DM at T1 must NOT enqueue a push outbox job",
-        );
+        assert!(matches!(
+            result,
+            Err(NotificationOutboxError::SelfDirectedNotificationCandidate(
+                _
+            ))
+        ));
+        // No candidate insert attempted because the constructor refused
+        // to produce one. Verify the candidate table is empty.
         assert!(
             store
                 .pending_candidates(16)
                 .await
                 .expect("pending candidates")
                 .is_empty(),
-            "self-DM candidate must be marked outboxed after T1 suppression",
+            "self-DM must not persist a candidate row"
+        );
+        assert!(
+            store.pending_outbox_jobs().await.expect("jobs").is_empty(),
+            "self-DM must not persist an outbox job"
         );
     }
 

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -48,6 +48,14 @@ const NOTIFICATION_CANDIDATES_CLASS_VALUES: [&str; 6] = [
 ];
 const NOTIFICATION_CANDIDATES_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_OUTBOX_CLASS_CHECK_NAME: &str = "notification_outbox_class_check";
+const NOTIFICATION_OUTBOX_CLASS_VALUES: [&str; 6] = [
+    "dm",
+    "dm_mention",
+    "personal_mention",
+    "channel_mention",
+    "active_channel_mention",
+    "notify_all",
+];
 const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
@@ -675,7 +683,7 @@ fn notification_candidates_class_constraint_matches_expected(definition: &str) -
 fn notification_outbox_class_constraint_matches_expected(definition: &str) -> bool {
     let normalized = definition.to_ascii_lowercase();
     normalized.contains("class")
-        && NOTIFICATION_CANDIDATES_CLASS_VALUES
+        && NOTIFICATION_OUTBOX_CLASS_VALUES
             .iter()
             .all(|class| normalized.contains(class))
 }

--- a/server/crates/waddle-server/src/notification_outbox.rs
+++ b/server/crates/waddle-server/src/notification_outbox.rs
@@ -3239,7 +3239,10 @@ mod tests {
             true,
         )
         .expect("dm_mention candidate after migration");
-        assert_eq!(mention_candidate.class(), NotificationClass::DirectMessageMention);
+        assert_eq!(
+            mention_candidate.class(),
+            NotificationClass::DirectMessageMention
+        );
         assert_eq!(
             store
                 .insert_candidate(&mention_candidate)
@@ -3284,9 +3287,7 @@ mod tests {
         let db = Database::in_memory("notification-outbox-dm-mention-roundtrip")
             .await
             .unwrap();
-        let store = NotificationOutboxStore::new(db)
-            .await
-            .expect("store init");
+        let store = NotificationOutboxStore::new(db).await.expect("store init");
         let recipient = bare("bob@example.com");
         let plain = NotificationCandidate::direct_message(
             recipient.clone(),

--- a/server/crates/waddle-server/src/room_policy.rs
+++ b/server/crates/waddle-server/src/room_policy.rs
@@ -1,0 +1,71 @@
+//! Adapter that exposes the live [`RoomRegistryActor`] to the T1 push
+//! evaluator via the [`RoomPolicyStore`] trait.
+//!
+//! At T1 (outbox dispatch) the XEP-0492 evaluator needs to know
+//! whether a groupchat conversation is members-only to project the
+//! correct [`ConversationKind`] (PrivateGroup vs PublicGroup) and
+//! pick the right default notification level. Slice 1 of #526 reads
+//! this fresh from the live actor; slice 2 will replace it with a
+//! durable T1 projection alongside `notification_activity`.
+//!
+//! [`RoomRegistryActor`]: waddle_xmpp::muc::room_registry_actor::RoomRegistryActor
+//! [`RoomPolicyStore`]: crate::notification_outbox::RoomPolicyStore
+//! [`ConversationKind`]: crate::notification_settings_projection::ConversationKind
+
+use async_trait::async_trait;
+use jid::BareJid;
+use kameo::actor::ActorRef;
+use waddle_xmpp::muc::room_actor::GetConfig;
+use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
+
+use crate::notification_outbox::{NotificationOutboxError, RoomPolicyStore};
+
+/// Live-actor adapter for [`RoomPolicyStore`].
+#[derive(Clone)]
+pub struct RoomRegistryActorPolicy {
+    registry: ActorRef<RoomRegistryActor>,
+}
+
+impl RoomRegistryActorPolicy {
+    pub fn new(registry: ActorRef<RoomRegistryActor>) -> Self {
+        Self { registry }
+    }
+}
+
+#[async_trait]
+impl RoomPolicyStore for RoomRegistryActorPolicy {
+    async fn room_members_only(
+        &self,
+        room: &BareJid,
+    ) -> Result<Option<bool>, NotificationOutboxError> {
+        let room_actor = match self
+            .registry
+            .ask(GetRoom {
+                room_jid: room.clone(),
+            })
+            .await
+        {
+            Ok(Some(actor)) => actor,
+            Ok(None) => return Ok(None),
+            Err(error) => {
+                tracing::warn!(
+                    room = %room,
+                    %error,
+                    "room registry GetRoom failed at T1 push gate; defaulting to public"
+                );
+                return Ok(None);
+            }
+        };
+        match room_actor.ask(GetConfig).await {
+            Ok(config) => Ok(Some(config.members_only)),
+            Err(error) => {
+                tracing::warn!(
+                    room = %room,
+                    %error,
+                    "room actor GetConfig failed at T1 push gate; defaulting to public"
+                );
+                Ok(None)
+            }
+        }
+    }
+}

--- a/server/crates/waddle-server/src/room_policy.rs
+++ b/server/crates/waddle-server/src/room_policy.rs
@@ -5,8 +5,11 @@
 //! whether a groupchat conversation is members-only to project the
 //! correct [`ConversationKind`] (PrivateGroup vs PublicGroup) and
 //! pick the right default notification level. Slice 1 of #526 reads
-//! this fresh from the live actor; slice 2 will replace it with a
-//! durable T1 projection alongside `notification_activity`.
+//! this fresh from the live actor; when the actor is unavailable
+//! (`Ok(None)` or transport error here) the evaluator defers the
+//! candidate via policy-error backoff rather than guessing. Slice 2
+//! will replace this with a durable T1 projection alongside
+//! `notification_activity`, eliminating the deferral hole.
 //!
 //! [`RoomRegistryActor`]: waddle_xmpp::muc::room_registry_actor::RoomRegistryActor
 //! [`RoomPolicyStore`]: crate::notification_outbox::RoomPolicyStore
@@ -51,7 +54,7 @@ impl RoomPolicyStore for RoomRegistryActorPolicy {
                 tracing::warn!(
                     room = %room,
                     %error,
-                    "room registry GetRoom failed at T1 push gate; defaulting to public"
+                    "room registry GetRoom failed at T1 push gate; evaluator will defer candidate"
                 );
                 return Ok(None);
             }
@@ -62,7 +65,7 @@ impl RoomPolicyStore for RoomRegistryActorPolicy {
                 tracing::warn!(
                     room = %room,
                     %error,
-                    "room actor GetConfig failed at T1 push gate; defaulting to public"
+                    "room actor GetConfig failed at T1 push gate; evaluator will defer candidate"
                 );
                 Ok(None)
             }

--- a/server/crates/waddle-server/src/room_policy.rs
+++ b/server/crates/waddle-server/src/room_policy.rs
@@ -5,11 +5,25 @@
 //! whether a groupchat conversation is members-only to project the
 //! correct [`ConversationKind`] (PrivateGroup vs PublicGroup) and
 //! pick the right default notification level. Slice 1 of #526 reads
-//! this fresh from the live actor; when the actor is unavailable
-//! (`Ok(None)` or transport error here) the evaluator defers the
-//! candidate via policy-error backoff rather than guessing. Slice 2
-//! will replace this with a durable T1 projection alongside
-//! `notification_activity`, eliminating the deferral hole.
+//! this fresh from the live actor.
+//!
+//! Three result shapes are distinguished:
+//!
+//! - `Ok(Some(members_only))` — the room actor answered; the evaluator
+//!   uses the typed bit.
+//! - `Ok(None)` — the registry reports the room is not currently live.
+//!   Expected/normal (restart windows, dormant rooms). The evaluator
+//!   defers the candidate via policy-error backoff.
+//! - `Err(NotificationOutboxError::RoomPolicyLookup { .. })` — an
+//!   actor transport / mailbox failure. Surfaces actionable lookup
+//!   failures to [`crate::notification_outbox::resolve_cached_room_policy`],
+//!   which classifies the cache entry as
+//!   [`crate::notification_outbox::UnknownRoomPolicySource::LookupError`]
+//!   and emits a single typed `warn!` per (drain batch, room). The
+//!   evaluator then defers via the same policy-error backoff.
+//!
+//! Slice 2 will replace this with a durable T1 projection alongside
+//! `notification_activity`, eliminating the deferral hole entirely.
 //!
 //! [`RoomRegistryActor`]: waddle_xmpp::muc::room_registry_actor::RoomRegistryActor
 //! [`RoomPolicyStore`]: crate::notification_outbox::RoomPolicyStore
@@ -49,26 +63,31 @@ impl RoomPolicyStore for RoomRegistryActorPolicy {
             .await
         {
             Ok(Some(actor)) => actor,
+            // Registry knows about no currently-live actor for this
+            // room. Expected/normal — the evaluator defers.
             Ok(None) => return Ok(None),
+            // Mailbox / transport failure. Surface as a typed lookup
+            // error so the cache layer in `resolve_cached_room_policy`
+            // classifies this as `UnknownRoomPolicySource::LookupError`
+            // and emits its single per-batch `warn!`. Returning
+            // `Ok(None)` here would otherwise mask actor failures as
+            // routine dormancy.
             Err(error) => {
-                tracing::warn!(
-                    room = %room,
-                    %error,
-                    "room registry GetRoom failed at T1 push gate; evaluator will defer candidate"
-                );
-                return Ok(None);
+                return Err(NotificationOutboxError::RoomPolicyLookup {
+                    room: room.clone(),
+                    message: format!("RoomRegistryActor::GetRoom: {error}"),
+                });
             }
         };
         match room_actor.ask(GetConfig).await {
             Ok(config) => Ok(Some(config.members_only)),
-            Err(error) => {
-                tracing::warn!(
-                    room = %room,
-                    %error,
-                    "room actor GetConfig failed at T1 push gate; evaluator will defer candidate"
-                );
-                Ok(None)
-            }
+            // Same rationale as above: typed lookup error so the cache
+            // layer fires its once-per-batch warn and classifies the
+            // entry as `LookupError` rather than `NotLive`.
+            Err(error) => Err(NotificationOutboxError::RoomPolicyLookup {
+                room: room.clone(),
+                message: format!("RoomActor::GetConfig: {error}"),
+            }),
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -239,11 +239,13 @@ async fn insert_groupchat_notification_candidate(
     thread_id: crate::notification_outbox::NotificationThreadId,
     archive_stanza_id: Xep0359StanzaId,
     is_live_occupant: bool,
-    // room_members_only is no longer used at T0 — the T1 evaluator
-    // re-reads room policy fresh at dispatch time. The recovery
-    // snapshot still carries the bit for backwards compatibility with
-    // older queued rows during slice 1.
-    _room_members_only: bool,
+    // `room_members_only` is known message-locally on this T0 path
+    // (the projection event carries it) and is consumed below to
+    // pre-populate the policy cache so the synchronous T0 evaluator
+    // never asks the live `RoomRegistryActor`. Each recipient in a
+    // groupchat fan-out would otherwise produce an actor round-trip,
+    // even though the same bit is already in hand.
+    room_members_only: bool,
 ) -> GroupchatNotificationCandidateQueueOutcome {
     let GroupchatNotificationClassDecision::Deliver(class) =
         groupchat_notification_class(state, owner, room, message, is_live_occupant);
@@ -270,12 +272,28 @@ async fn insert_groupchat_notification_candidate(
     // outcomes leave no row in `notification_candidates`. The same
     // typed evaluator runs again at T1 inside
     // `drain_pending_candidates_into_outbox` as a race-window guard.
-    let room_policy =
-        crate::room_policy::RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
+    //
+    // Pre-populate the policy cache with the known `room_members_only`
+    // bit so the typed evaluator hits the cache on its first lookup
+    // and never reaches the (unused) `RoomPolicyStore`. This avoids
+    // N actor round-trips for an N-member fan-out — every recipient's
+    // T0 emission already carries the same bit. The `NoopRoomPolicy`
+    // is held only to satisfy the trait-object signature; if the
+    // cache ever misses (it won't, given the pre-insert) it would
+    // surface as `DeferUnknownRoomPolicy` rather than a silent default.
+    let room_policy = crate::notification_outbox::NoopRoomPolicy;
     let mut room_policy_cache = std::collections::BTreeMap::<
         BareJid,
         crate::notification_outbox::RoomPolicyCacheEntry,
     >::new();
+    room_policy_cache.insert(
+        room.clone(),
+        if room_members_only {
+            crate::notification_outbox::RoomPolicyCacheEntry::Private
+        } else {
+            crate::notification_outbox::RoomPolicyCacheEntry::Public
+        },
+    );
     let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
         state
             .deps

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -239,26 +239,14 @@ async fn insert_groupchat_notification_candidate(
     thread_id: crate::notification_outbox::NotificationThreadId,
     archive_stanza_id: Xep0359StanzaId,
     is_live_occupant: bool,
-    room_members_only: bool,
+    // room_members_only is no longer used at T0 — the T1 evaluator
+    // re-reads room policy fresh at dispatch time. The recovery
+    // snapshot still carries the bit for backwards compatibility with
+    // older queued rows during slice 1.
+    _room_members_only: bool,
 ) -> GroupchatNotificationCandidateQueueOutcome {
-    let class = match groupchat_notification_class(
-        state,
-        owner,
-        room,
-        message,
-        is_live_occupant,
-        room_members_only,
-    )
-    .await
-    {
-        GroupchatNotificationClassDecision::Deliver(class) => class,
-        GroupchatNotificationClassDecision::Suppress => {
-            return GroupchatNotificationCandidateQueueOutcome::Completed;
-        }
-        GroupchatNotificationClassDecision::RetryLater => {
-            return GroupchatNotificationCandidateQueueOutcome::RetryLater;
-        }
-    };
+    let GroupchatNotificationClassDecision::Deliver(class) =
+        groupchat_notification_class(state, owner, room, message, is_live_occupant);
     let candidate = match crate::notification_outbox::NotificationCandidate::groupchat(
         owner.clone(),
         room.clone(),
@@ -454,65 +442,38 @@ async fn mark_recovery_completed_from_state(
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GroupchatNotificationClassDecision {
     Deliver(crate::notification_outbox::NotificationClass),
-    Suppress,
-    RetryLater,
 }
 
-async fn groupchat_notification_class(
+fn groupchat_notification_class(
     state: &WebSocketState,
     owner: &BareJid,
     room: &BareJid,
     message: &Message,
+    // TODO(#526 slice 2): move is_live_occupant evaluation to T1 against
+    // the notification_activity projection. For slice 1 the bit stays
+    // here because there is no T1 projection of MUC presence yet.
     is_live_occupant: bool,
-    room_members_only: bool,
 ) -> GroupchatNotificationClassDecision {
-    let conversation_kind = if room_members_only {
-        crate::notification_settings_projection::ConversationKind::PrivateGroup
-    } else {
-        crate::notification_settings_projection::ConversationKind::PublicGroup
-    };
-    let level = match state
-        .deps
-        .protocol
-        .notification_settings_projection
-        .effective_setting(owner, room, conversation_kind)
-        .await
-    {
-        Ok(level) => level,
-        Err(error) => {
-            warn!(
-                recipient = %owner,
-                room = %room,
-                error = %error,
-                "ProjectGroupchatInbox: XEP-0492 setting lookup failed; retrying groupchat push candidate later"
-            );
-            return GroupchatNotificationClassDecision::RetryLater;
-        }
-    };
     let owner_occupant_id =
         waddle_xmpp::xep::generate_occupant_id(owner, room, &state.deps.occupant_id_secret);
     let personal_mention = groupchat_mentions_owner(message, owner, owner_occupant_id.as_str());
     let channel_mention = groupchat_channel_mention_scope(message, room);
-    groupchat_notification_class_for_level(
-        level,
-        personal_mention,
-        channel_mention,
-        is_live_occupant,
-    )
+    groupchat_notification_class_from_message(personal_mention, channel_mention, is_live_occupant)
 }
 
-fn groupchat_notification_class_for_level(
-    level: waddle_xmpp::xep::NotificationLevel,
+/// Message-derived classification of a groupchat notification candidate.
+///
+/// After the T0 → T1 push-decision move (#526 slice 1) the class is a
+/// pure function of the message payloads + scope: there is no
+/// XEP-0492 recipient-state read here. The T1 evaluator at outbox
+/// dispatch time consults the projection store and decides
+/// publish-or-suppress based on the recorded class + recipient's
+/// effective notification level.
+fn groupchat_notification_class_from_message(
     personal_mention: bool,
     channel_mention: Option<GroupchatChannelMentionScope>,
     is_live_occupant: bool,
 ) -> GroupchatNotificationClassDecision {
-    let is_mention = personal_mention || channel_mention.is_some();
-    if !crate::notification_settings_projection::PushDispatchDecision::evaluate(level, is_mention)
-        .should_deliver()
-    {
-        return GroupchatNotificationClassDecision::Suppress;
-    }
     if personal_mention {
         return GroupchatNotificationClassDecision::Deliver(
             crate::notification_outbox::NotificationClass::PersonalMention,
@@ -531,12 +492,9 @@ fn groupchat_notification_class_for_level(
         }
         _ => {}
     }
-    if level == waddle_xmpp::xep::NotificationLevel::Always {
-        return GroupchatNotificationClassDecision::Deliver(
-            crate::notification_outbox::NotificationClass::NotifyAll,
-        );
-    }
-    GroupchatNotificationClassDecision::Suppress
+    GroupchatNotificationClassDecision::Deliver(
+        crate::notification_outbox::NotificationClass::NotifyAll,
+    )
 }
 
 fn groupchat_mentions_owner(message: &Message, owner: &BareJid, owner_occupant_id: &str) -> bool {
@@ -625,62 +583,39 @@ mod tests {
     }
 
     #[test]
-    fn xep0492_groupchat_push_policy_matrix() {
+    fn groupchat_message_classification_matrix() {
         use crate::notification_outbox::NotificationClass;
-        use waddle_xmpp::xep::NotificationLevel;
 
+        // Post-#526 slice 1: the T0 classifier is purely message-derived
+        // (personal mention, channel mention scope, live-occupant gate).
+        // XEP-0492 enforcement lives at T1, exercised separately in the
+        // notification_outbox dispatcher tests.
         let cases = [
             (
-                NotificationLevel::Always,
                 false,
                 None,
                 false,
                 GroupchatNotificationClassDecision::Deliver(NotificationClass::NotifyAll),
             ),
             (
-                NotificationLevel::Always,
                 true,
                 None,
                 false,
                 GroupchatNotificationClassDecision::Deliver(NotificationClass::PersonalMention),
             ),
             (
-                NotificationLevel::Always,
                 false,
                 Some(GroupchatChannelMentionScope::All),
                 false,
                 GroupchatNotificationClassDecision::Deliver(NotificationClass::ChannelMention),
             ),
             (
-                NotificationLevel::Always,
                 false,
                 Some(GroupchatChannelMentionScope::Active),
                 false,
                 GroupchatNotificationClassDecision::Deliver(NotificationClass::NotifyAll),
             ),
             (
-                NotificationLevel::OnMention,
-                false,
-                None,
-                true,
-                GroupchatNotificationClassDecision::Suppress,
-            ),
-            (
-                NotificationLevel::OnMention,
-                true,
-                None,
-                false,
-                GroupchatNotificationClassDecision::Deliver(NotificationClass::PersonalMention),
-            ),
-            (
-                NotificationLevel::OnMention,
-                false,
-                Some(GroupchatChannelMentionScope::All),
-                false,
-                GroupchatNotificationClassDecision::Deliver(NotificationClass::ChannelMention),
-            ),
-            (
-                NotificationLevel::OnMention,
                 false,
                 Some(GroupchatChannelMentionScope::Active),
                 true,
@@ -689,45 +624,23 @@ mod tests {
                 ),
             ),
             (
-                NotificationLevel::OnMention,
-                false,
-                Some(GroupchatChannelMentionScope::Active),
-                false,
-                GroupchatNotificationClassDecision::Suppress,
-            ),
-            (
-                NotificationLevel::Never,
                 true,
-                None,
-                true,
-                GroupchatNotificationClassDecision::Suppress,
-            ),
-            (
-                NotificationLevel::Never,
-                false,
                 Some(GroupchatChannelMentionScope::All),
-                true,
-                GroupchatNotificationClassDecision::Suppress,
-            ),
-            (
-                NotificationLevel::Never,
                 false,
-                None,
-                false,
-                GroupchatNotificationClassDecision::Suppress,
+                // Personal mention wins over channel-wide mention.
+                GroupchatNotificationClassDecision::Deliver(NotificationClass::PersonalMention),
             ),
         ];
 
-        for (level, personal_mention, channel_mention, is_live_occupant, expected) in cases {
+        for (personal_mention, channel_mention, is_live_occupant, expected) in cases {
             assert_eq!(
-                groupchat_notification_class_for_level(
-                    level,
+                groupchat_notification_class_from_message(
                     personal_mention,
                     channel_mention,
                     is_live_occupant,
                 ),
                 expected,
-                "unexpected groupchat XEP-0492 decision for {level:?}, personal_mention={personal_mention}, channel_mention={channel_mention:?}, is_live_occupant={is_live_occupant}"
+                "unexpected groupchat T0 class for personal_mention={personal_mention}, channel_mention={channel_mention:?}, is_live_occupant={is_live_occupant}"
             );
         }
     }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -266,6 +266,61 @@ async fn insert_groupchat_notification_candidate(
             return GroupchatNotificationCandidateQueueOutcome::Completed;
         }
     };
+    // T0 XEP-0492 push-dispatch gate — compliance: suppressed
+    // outcomes leave no row in `notification_candidates`. The same
+    // typed evaluator runs again at T1 inside
+    // `drain_pending_candidates_into_outbox` as a race-window guard.
+    let room_policy =
+        crate::room_policy::RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
+    let mut room_policy_cache = std::collections::BTreeMap::<
+        BareJid,
+        crate::notification_outbox::RoomPolicyCacheEntry,
+    >::new();
+    let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+        state
+            .deps
+            .protocol
+            .notification_settings_projection
+            .as_ref(),
+        &room_policy,
+        &candidate,
+        &mut room_policy_cache,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            warn!(
+                recipient = %owner,
+                room = %room,
+                error = %error,
+                "ProjectGroupchatInbox: XEP-0492 notification setting lookup failed at T0; deferring candidate"
+            );
+            return GroupchatNotificationCandidateQueueOutcome::RetryLater;
+        }
+    };
+    match outcome {
+        crate::notification_outbox::T1PushDispatchOutcome::Deliver => {}
+        crate::notification_outbox::T1PushDispatchOutcome::Suppressed { reason } => {
+            info!(
+                recipient = %owner,
+                room = %room,
+                class = ?class,
+                %reason,
+                "ProjectGroupchatInbox: XEP-0492 push gate suppressed groupchat candidate at T0; no candidate row persisted"
+            );
+            return GroupchatNotificationCandidateQueueOutcome::Completed;
+        }
+        crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
+            warn!(
+                recipient = %owner,
+                room = %room,
+                class = ?class,
+                "ProjectGroupchatInbox: MUC config unavailable at T0; deferring groupchat candidate (unknown room policy is not 'public')"
+            );
+            return GroupchatNotificationCandidateQueueOutcome::RetryLater;
+        }
+    }
     match state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -522,9 +522,22 @@ fn groupchat_notification_class(
     owner: &BareJid,
     room: &BareJid,
     message: &Message,
-    // TODO(#526 slice 2): move is_live_occupant evaluation to T1 against
-    // the notification_activity projection. For slice 1 the bit stays
-    // here because there is no T1 projection of MUC presence yet.
+    // `is_live_occupant` here is **message-time-frozen presence** — the
+    // XMPP room handler computes it at room-dispatch time
+    // (`live_recipient_bares.contains(bare)` in
+    // `waddle_xmpp::protocol::room::inbox`) and propagates it on the
+    // `ProjectGroupchatInbox` event. That makes it a T0 message-frozen
+    // input on the same axis as XEP-0513 `<active/>` (sender intent)
+    // and XEP-0421 occupant-id (sender provenance), NOT a T1 recipient-
+    // state read. Per #506 Q2 the candidate row snapshots message-
+    // intrinsic facts and the T1 evaluator reads fresh recipient
+    // state; encoding the message-time live-occupant bit into the
+    // [`NotificationClass`] taxonomy (`ActiveChannelMention` vs
+    // `ChannelMention`) is the snapshot mechanism here. Slice 2 will
+    // add a richer `notification_activity` projection so the T1
+    // evaluator can additionally consult *current* recipient activity
+    // (XEP-0513 §"active mention" §"the receiving server may filter")
+    // — that augments this T0 snapshot, it does not relocate it.
     is_live_occupant: bool,
 ) -> GroupchatNotificationClassDecision {
     let owner_occupant_id =

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -278,18 +278,18 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
-    // Self-DM suppression has moved to T1 (#506 Q3 strict (A): no T0
-    // carve-outs based on routing recipient). The candidate is emitted
-    // unconditionally here; `drain_pending_candidates_into_outbox`
-    // applies the self-DM check by comparing `sender_jid.to_bare()`
-    // against `recipient_bare_jid` — both message-frozen columns
-    // already on the candidate row — and marks the row outboxed
-    // without enqueuing a push job (same pattern as XEP-0191 blocked
-    // and XEP-0492 suppressed).
-    //
     // XEP-0513 mention bit is message-intrinsic and frozen at T0; T1
     // reads it back from the candidate row when running the XEP-0492
     // dispatch gate.
+    //
+    // Self-directed candidates (sender bare JID == recipient bare JID)
+    // are rejected at the `NotificationCandidate::direct_message`
+    // constructor as `SelfDirectedNotificationCandidate` — no row is
+    // persisted, satisfying the compliance requirement that
+    // self-notifications produce no candidate/outbox entry. This is
+    // input validation, not recipient-state suppression, so it lives
+    // at the typed constructor boundary alongside the existing
+    // full-sender-JID and archive-id owner checks.
     let is_mention = message_is_mention_for_recipient(original_message, recipient);
     let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
         recipient.clone(),
@@ -298,6 +298,18 @@ async fn enqueue_xep0357_notification_candidate_for_message(
         is_mention,
     ) {
         Ok(candidate) => candidate,
+        Err(
+            crate::notification_outbox::NotificationOutboxError::SelfDirectedNotificationCandidate(
+                _,
+            ),
+        ) => {
+            debug!(
+                recipient = %recipient,
+                sender = %sender,
+                "XEP-0357 notification candidate skipped: self-directed (sender bare JID == recipient bare JID)"
+            );
+            return NotificationCandidateQueueOutcome::Completed;
+        }
         Err(error) => {
             warn!(
                 recipient = %recipient,

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -278,34 +278,30 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
-    // XEP-0492 gate: consult the recipient's per-conversation notification
-    // level (defaulting to XEP-0492 conversation-kind defaults via the
-    // projection store) and the XEP-0513 mention bit. The decision is a
-    // typed `PushDispatchDecision` — never a stringly-typed diagnostic —
-    // so the suppression reason flows through to the typed log line.
-    let decision =
-        match evaluate_xep0492_push_dispatch_decision(state, recipient, sender, original_message)
-            .await
-        {
-            Ok(decision) => decision,
-            Err(()) => return NotificationCandidateQueueOutcome::RetryLater,
-        };
-    match decision {
-        crate::notification_settings_projection::PushDispatchDecision::Deliver => {}
-        crate::notification_settings_projection::PushDispatchDecision::Suppressed { reason } => {
-            info!(
-                recipient = %recipient,
-                sender = %sender,
-                reason = %reason,
-                "XEP-0492 push gate suppressed XEP-0357 notification candidate"
-            );
-            return NotificationCandidateQueueOutcome::Completed;
-        }
+    // Self-DM short-circuit. The sender_jid landing in the offline queue
+    // for one's own bare JID is message-intrinsic provenance — never a
+    // recipient-state read — so this stays at T0. The headless
+    // OfflineDeliveryHandler should never project a self-DM into the
+    // pending queue today, but we keep the guard as a defense-in-depth
+    // emission no-op so we never insert a self-DM candidate that the T1
+    // evaluator would have to learn to ignore.
+    if sender == recipient {
+        debug!(
+            recipient = %recipient,
+            sender = %sender,
+            "XEP-0357 notification candidate skipped: self-DM is intrinsic to message provenance"
+        );
+        return NotificationCandidateQueueOutcome::Completed;
     }
+    // XEP-0513 mention bit is message-intrinsic and frozen at T0; T1
+    // reads it back from the candidate row when running the XEP-0492
+    // dispatch gate.
+    let is_mention = message_is_mention_for_recipient(original_message, recipient);
     let candidate = match crate::notification_outbox::NotificationCandidate::direct_message(
         recipient.clone(),
         sender_jid.clone(),
         archive_stanza_id.clone(),
+        is_mention,
     ) {
         Ok(candidate) => candidate,
         Err(error) => {
@@ -329,6 +325,7 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             debug!(
                 recipient = %recipient,
                 sender = %sender,
+                is_mention,
                 "XEP-0357 notification candidate inserted for durable outbox worker"
             );
             NotificationCandidateQueueOutcome::Completed
@@ -351,67 +348,6 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             NotificationCandidateQueueOutcome::RetryLater
         }
     }
-}
-
-/// Resolve the XEP-0492 push-dispatch gate for a single inbound DM that
-/// is about to be projected into the recipient's offline queue.
-///
-/// The gate combines the recipient's typed
-/// [`waddle_xmpp::xep::NotificationLevel`] (resolved by the
-/// `NotificationSettingsProjectionStore`, falling back to the XEP-0492
-/// conversation-kind defaults) with the XEP-0513 mention bit derived
-/// directly from the inbound `<message>` payloads. Both inputs flow as
-/// typed values; there are no string-typed payloads on the gate boundary.
-///
-/// `QueueOfflineDelivery` only fires for DM intake
-/// ([`waddle_xmpp::protocol::handlers::offline_delivery::OfflineDeliveryHandler`]
-/// is gated on `Locality::Recipient` + headless pass for `<message
-/// type='chat'>`), so the conversation kind on this path is always
-/// `ConversationKind::Direct`. The shared pure reducer
-/// [`crate::notification_settings_projection::PushDispatchDecision::evaluate`]
-/// is the single decision point — when MUC push fan-out lands it will
-/// reuse the same reducer rather than re-implementing the level matrix.
-async fn evaluate_xep0492_push_dispatch_decision(
-    state: &WebSocketState,
-    recipient: &BareJid,
-    sender: &BareJid,
-    original_message: &Message,
-) -> Result<crate::notification_settings_projection::PushDispatchDecision, ()> {
-    if sender == recipient {
-        // Self-DM: never push to your own offline queue. Per XEP-0492
-        // semantics this is a hard suppression independent of the
-        // configured level; surface it as `Never` to keep the typed log
-        // path uniform.
-        return Ok(
-            crate::notification_settings_projection::PushDispatchDecision::Suppressed {
-                reason: waddle_xmpp::xep::NotificationLevel::Never,
-            },
-        );
-    }
-    let level = match state
-        .deps
-        .protocol
-        .notification_settings_projection
-        .effective_setting(
-            recipient,
-            sender,
-            crate::notification_settings_projection::ConversationKind::Direct,
-        )
-        .await
-    {
-        Ok(level) => level,
-        Err(error) => {
-            warn!(
-                recipient = %recipient,
-                conversation = %sender,
-                error = %error,
-                "XEP-0492 notification setting lookup failed; retrying notification candidate later"
-            );
-            return Err(());
-        }
-    };
-    let is_mention = message_is_mention_for_recipient(original_message, recipient);
-    Ok(crate::notification_settings_projection::PushDispatchDecision::evaluate(level, is_mention))
 }
 
 /// Returns `true` when the inbound XEP-0513 explicit-mention payloads

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -320,6 +320,65 @@ async fn enqueue_xep0357_notification_candidate_for_message(
             return NotificationCandidateQueueOutcome::Completed;
         }
     };
+    // T0 XEP-0492 push-dispatch gate — compliance: suppressed
+    // outcomes leave no row in `notification_candidates`. The same
+    // typed evaluator runs again at T1 inside
+    // `drain_pending_candidates_into_outbox` as a race-window guard.
+    // DM evaluation never consults `room_policy`, so the no-op
+    // adapter is sufficient here; the per-call cache is a fresh empty
+    // map (one-shot eval).
+    let room_policy = crate::notification_outbox::NoopRoomPolicy;
+    let mut room_policy_cache = std::collections::BTreeMap::<
+        BareJid,
+        crate::notification_outbox::RoomPolicyCacheEntry,
+    >::new();
+    let outcome = match crate::notification_outbox::evaluate_xep0492_at_dispatch(
+        state
+            .deps
+            .protocol
+            .notification_settings_projection
+            .as_ref(),
+        &room_policy,
+        &candidate,
+        &mut room_policy_cache,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            warn!(
+                recipient = %recipient,
+                sender = %sender,
+                error = %error,
+                "XEP-0492 notification setting lookup failed at T0; deferring DM candidate"
+            );
+            return NotificationCandidateQueueOutcome::RetryLater;
+        }
+    };
+    match outcome {
+        crate::notification_outbox::T1PushDispatchOutcome::Deliver => {}
+        crate::notification_outbox::T1PushDispatchOutcome::Suppressed { reason } => {
+            info!(
+                recipient = %recipient,
+                sender = %sender,
+                is_mention,
+                %reason,
+                "XEP-0492 push gate suppressed XEP-0357 DM candidate at T0; no candidate row persisted"
+            );
+            return NotificationCandidateQueueOutcome::Completed;
+        }
+        crate::notification_outbox::T1PushDispatchOutcome::DeferUnknownRoomPolicy => {
+            // DM evaluation does not consult room_policy, so this is
+            // a structural invariant violation. Fail-loud and retry.
+            warn!(
+                recipient = %recipient,
+                sender = %sender,
+                "XEP-0492 evaluator returned DeferUnknownRoomPolicy for a DM candidate; \
+                 this is structurally impossible — retrying"
+            );
+            return NotificationCandidateQueueOutcome::RetryLater;
+        }
+    }
     match state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -278,21 +278,15 @@ async fn enqueue_xep0357_notification_candidate_for_message(
     archive_stanza_id: &waddle_xmpp_core::xep0359::StanzaId,
     original_message: &Message,
 ) -> NotificationCandidateQueueOutcome {
-    // Self-DM short-circuit. The sender_jid landing in the offline queue
-    // for one's own bare JID is message-intrinsic provenance — never a
-    // recipient-state read — so this stays at T0. The headless
-    // OfflineDeliveryHandler should never project a self-DM into the
-    // pending queue today, but we keep the guard as a defense-in-depth
-    // emission no-op so we never insert a self-DM candidate that the T1
-    // evaluator would have to learn to ignore.
-    if sender == recipient {
-        debug!(
-            recipient = %recipient,
-            sender = %sender,
-            "XEP-0357 notification candidate skipped: self-DM is intrinsic to message provenance"
-        );
-        return NotificationCandidateQueueOutcome::Completed;
-    }
+    // Self-DM suppression has moved to T1 (#506 Q3 strict (A): no T0
+    // carve-outs based on routing recipient). The candidate is emitted
+    // unconditionally here; `drain_pending_candidates_into_outbox`
+    // applies the self-DM check by comparing `sender_jid.to_bare()`
+    // against `recipient_bare_jid` — both message-frozen columns
+    // already on the candidate row — and marks the row outboxed
+    // without enqueuing a push job (same pattern as XEP-0191 blocked
+    // and XEP-0492 suppressed).
+    //
     // XEP-0513 mention bit is message-intrinsic and frozen at T0; T1
     // reads it back from the candidate row when running the XEP-0492
     // dispatch gate.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -726,6 +726,215 @@ async fn xep0492_direct_chat_never_suppresses_push_with_mention() {
     );
 }
 
+/// Compliance-shape probe — drives DM emission and returns the
+/// post-emission `notification_candidates` row count and outbox job
+/// count.
+///
+/// The T0 emission gate asserts on the *row count*: a suppressed
+/// XEP-0492 outcome MUST leave zero rows behind (not "one row marked
+/// outboxed"). The outbox-job count is reported alongside so the
+/// caller can assert push-output equivalence — the previous T1-only
+/// design preserved push output but persisted an audit row; this
+/// shape preserves both push output AND row-zero on suppression.
+async fn drive_xep0492_direct_chat_emission_shape(
+    level: waddle_xmpp::xep::NotificationLevel,
+    is_mention: bool,
+    message_id: &str,
+) -> (i64, usize) {
+    let state = create_test_websocket_state().await;
+    let recipient: BareJid = "bob@example.com".parse().expect("recipient");
+    let sender: BareJid = "alice@example.com".parse().expect("sender");
+    let node = state
+        .deps
+        .protocol
+        .push_service
+        .ensure_node(&recipient, "web")
+        .await
+        .expect("push node");
+    state
+        .deps
+        .protocol
+        .push_service
+        .upsert_device(
+            &recipient,
+            crate::push_service::PushDeviceRegistration::new(
+                "web-1",
+                node.node(),
+                crate::push_service::PushDevicePlatform::Web,
+                "test",
+            ),
+        )
+        .await
+        .expect("push device");
+    state
+        .deps
+        .protocol
+        .push_service
+        .register_first_party_node_for_owner(&recipient, "push.example.com", node.node(), None)
+        .await
+        .expect("first-party push registration");
+    state
+        .deps
+        .protocol
+        .notification_settings_projection
+        .upsert(&crate::notification_settings_projection::NotificationSettingsProjection {
+            owner_bare_jid: recipient.clone(),
+            conversation_jid: sender.clone(),
+            conversation_kind: crate::notification_settings_projection::ConversationKind::Direct,
+            mode: level,
+            source_version: 1,
+            updated_at_ms: crate::time::now_ms(),
+            source: crate::notification_settings_projection::NotificationSettingsSource::Xep0402Bookmarks,
+            source_item_jid: sender.clone(),
+        })
+        .await
+        .expect("xep-0492 projection");
+
+    let mut message =
+        xmpp_parsers::message::Message::new(Some("bob@example.com".parse().expect("to jid")));
+    message.from = Some("alice@example.com/web".parse().expect("from jid"));
+    message.id = Some(message_id.to_string());
+    message.type_ = XmppMessageType::Chat;
+    message.bodies.insert(
+        String::new(),
+        xmpp_parsers::message::Body("hello bob".to_string()),
+    );
+    if is_mention {
+        let mention = waddle_xmpp::xep::build_mention_element(
+            &waddle_xmpp::xep::ExplicitMention::jid(recipient.clone()),
+        );
+        message.payloads.push(mention);
+    }
+
+    let deps = build_interpret_deps(state.as_ref(), None);
+    let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+        format!("archive-{message_id}"),
+        jid::Jid::from(recipient.clone()),
+    );
+    store_committed_dm_archive_for_notification(&state, &recipient, &archive_stanza_id, &message)
+        .await;
+    crate::server::routes::interpret::interpret(
+        vec![waddle_xmpp::protocol::OutboundEvent::QueueOfflineDelivery {
+            recipient: recipient.clone(),
+            payload: waddle_xmpp::pending_delivery::PendingPayload::Archived(archive_stanza_id),
+            original_receipt_at: chrono::Utc::now(),
+            original_message: Box::new(message),
+        }],
+        &deps,
+    )
+    .await;
+
+    // Read the candidate count BEFORE draining. The T0 gate must
+    // suppress the insert outright; if a row exists here the
+    // compliance rule is violated regardless of what the drain
+    // subsequently does with it.
+    let candidate_count = state
+        .deps
+        .protocol
+        .notification_outbox
+        .count_all_candidates()
+        .await
+        .expect("count notification candidates");
+    drain_notification_candidates_for_test(state.as_ref()).await;
+    let outbox_jobs = state
+        .deps
+        .protocol
+        .notification_outbox
+        .pending_outbox_jobs()
+        .await
+        .expect("notification outbox jobs")
+        .len();
+    (candidate_count, outbox_jobs)
+}
+
+/// Compliance regression: XEP-0492 `<never/>` MUST leave no row at all
+/// in `notification_candidates` — not even one marked outboxed.
+///
+/// The previous T1-only design persisted every DM candidate at T0 and
+/// then marked it outboxed at T1 without enqueuing a job; the row was
+/// still observable in the table. Compliance review rejected that
+/// shape — the row itself is leakage of recipient state to the user-
+/// server schema. The T0 emission gate must short-circuit the insert.
+#[tokio::test]
+async fn xep0492_direct_chat_never_persists_no_candidate_row_at_all() {
+    let (candidates, jobs) = drive_xep0492_direct_chat_emission_shape(
+        waddle_xmpp::xep::NotificationLevel::Never,
+        false,
+        "xep0492-never-no-row",
+    )
+    .await;
+    assert_eq!(
+        candidates, 0,
+        "XEP-0492 <never/> MUST NOT persist a notification_candidates row \
+         (compliance: no audit trail for suppressed candidates)"
+    );
+    assert_eq!(jobs, 0, "XEP-0492 <never/> MUST NOT enqueue an outbox job");
+}
+
+/// Compliance regression: XEP-0492 `<on-mention/>` with a non-mention
+/// DM MUST leave no row at all in `notification_candidates`.
+#[tokio::test]
+async fn xep0492_direct_chat_on_mention_without_mention_persists_no_candidate_row() {
+    let (candidates, jobs) = drive_xep0492_direct_chat_emission_shape(
+        waddle_xmpp::xep::NotificationLevel::OnMention,
+        false,
+        "xep0492-on-mention-no-mention-no-row",
+    )
+    .await;
+    assert_eq!(
+        candidates, 0,
+        "XEP-0492 <on-mention/> with no XEP-0513 mention MUST NOT persist a candidate row"
+    );
+    assert_eq!(
+        jobs, 0,
+        "XEP-0492 <on-mention/> with no mention MUST NOT enqueue a job"
+    );
+}
+
+/// Compliance regression: XEP-0492 `<on-mention/>` with an explicit
+/// XEP-0513 mention naming the recipient DOES produce a candidate row
+/// (and an outbox job). This is the positive side of the compliance
+/// rule — suppression only zeroes rows when the evaluator says
+/// `Suppressed`.
+#[tokio::test]
+async fn xep0492_direct_chat_on_mention_with_mention_persists_candidate_row() {
+    let (candidates, jobs) = drive_xep0492_direct_chat_emission_shape(
+        waddle_xmpp::xep::NotificationLevel::OnMention,
+        true,
+        "xep0492-on-mention-with-mention-row",
+    )
+    .await;
+    assert_eq!(
+        candidates, 1,
+        "XEP-0492 <on-mention/> with XEP-0513 mention MUST persist exactly one candidate row"
+    );
+    assert_eq!(
+        jobs, 1,
+        "XEP-0492 <on-mention/> with mention MUST enqueue exactly one outbox job"
+    );
+}
+
+/// Compliance regression: XEP-0492 `<always/>` (default for DMs) MUST
+/// persist a candidate row and enqueue a job regardless of mention
+/// state. This guards against the T0 gate over-suppressing.
+#[tokio::test]
+async fn xep0492_direct_chat_always_persists_candidate_row_without_mention() {
+    let (candidates, jobs) = drive_xep0492_direct_chat_emission_shape(
+        waddle_xmpp::xep::NotificationLevel::Always,
+        false,
+        "xep0492-always-no-mention-row",
+    )
+    .await;
+    assert_eq!(
+        candidates, 1,
+        "XEP-0492 <always/> MUST persist a candidate row for every DM"
+    );
+    assert_eq!(
+        jobs, 1,
+        "XEP-0492 <always/> MUST enqueue exactly one outbox job"
+    );
+}
+
 #[tokio::test]
 async fn groupchat_personal_mention_pushes_affiliated_non_live_member() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -1009,6 +1009,23 @@ async fn groupchat_notification_recovery_retries_committed_inbox_projection() {
     let room_jid: BareJid = "groupchat-recovery@muc.example.com"
         .parse()
         .expect("room jid");
+    // The T1 push evaluator now defers candidates when the room
+    // actor is not live (no durable T1 projection of MUC config in
+    // slice 1), so the recovery test must spin up the room actor
+    // before draining — otherwise the candidate row is deferred
+    // with policy_error_count = 1 instead of becoming a push job.
+    let _room_actor = get_or_create_room_actor(
+        state.as_ref(),
+        &room_jid,
+        RoomConfig {
+            members_only: false,
+            ..RoomConfig::default()
+        },
+        "space".to_string(),
+        "groupchat-recovery".to_string(),
+    )
+    .await
+    .expect("create recovery room");
     let archive_stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
         "groupchat-recovery-archive",
         jid::Jid::from(room_jid.clone()),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -66,6 +66,8 @@ async fn drain_notification_candidates_for_test(state: &WebSocketState) -> usize
         .push
         .parse()
         .expect("push service jid");
+    let room_policy =
+        crate::room_policy::RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
     state
         .deps
         .protocol
@@ -73,6 +75,12 @@ async fn drain_notification_candidates_for_test(state: &WebSocketState) -> usize
         .drain_pending_candidates_into_outbox(
             state.deps.protocol.push_store.as_ref(),
             state.deps.protocol.blocking_storage.as_ref(),
+            state
+                .deps
+                .protocol
+                .notification_settings_projection
+                .as_ref(),
+            &room_policy,
             &push_service_jid,
             16,
         )
@@ -1254,9 +1262,20 @@ async fn groupchat_channel_mention_for_foreign_room_does_not_ping_current_room()
         responses.is_empty(),
         "valid foreign-room channel mention should not return an error: {responses:?}"
     );
-    assert_eq!(
-        drain_notification_candidates_for_test(state.as_ref()).await,
-        0,
+    // Post-#526 slice 1: foreign-room mentions are not personal/channel
+    // mentions for current-room members, so T0 classifies the candidate
+    // as NotifyAll. The XEP-0492 public-group default (`OnMention`)
+    // then suppresses publication at T1.
+    drain_notification_candidates_for_test(state.as_ref()).await;
+    assert!(
+        state
+            .deps
+            .protocol
+            .notification_outbox
+            .pending_outbox_jobs()
+            .await
+            .expect("notification outbox jobs")
+            .is_empty(),
         "a XEP-0513 #channel mention with a foreign room URI must not notify current-room members"
     );
 }
@@ -1338,10 +1357,11 @@ async fn groupchat_active_channel_mention_pushes_live_occupants_only() {
         responses.is_empty(),
         "valid active channel mention should not return an error: {responses:?}"
     );
-    assert_eq!(
-        drain_notification_candidates_for_test(state.as_ref()).await,
-        1
-    );
+    // Post-#526 slice 1: T0 emits one candidate per affiliated recipient
+    // (bob = live, charlie = non-live), and T1 suppresses charlie's
+    // candidate via the XEP-0492 public-group `OnMention` default once
+    // the non-live `NotifyAll` class is classified at T0.
+    drain_notification_candidates_for_test(state.as_ref()).await;
     let jobs = state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1,3 +1,4 @@
+use crate::room_policy::RoomRegistryActorPolicy;
 use crate::server::routes;
 use crate::server::routes::websocket::WebSocketState;
 use std::sync::Arc;
@@ -529,6 +530,8 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                     "Notification outbox janitor recovered XEP-0357 groupchat candidates from inbox projections"
                 );
             }
+            let room_policy =
+                RoomRegistryActorPolicy::new(state.deps.protocol.room_registry.clone());
             match state
                 .deps
                 .protocol
@@ -536,6 +539,12 @@ pub(crate) fn spawn_notification_outbox_janitor(websocket_state: &Arc<WebSocketS
                 .drain_pending_candidates_into_outbox(
                     state.deps.protocol.push_store.as_ref(),
                     state.deps.protocol.blocking_storage.as_ref(),
+                    state
+                        .deps
+                        .protocol
+                        .notification_settings_projection
+                        .as_ref(),
+                    &room_policy,
                     &first_party_service_jid,
                     batch_size,
                 )


### PR DESCRIPTION
## Parent

#506 / child #526 — slice 1 (behavior-preserving refactor)

## Background

Per the #506 grill-session architecture, push notifications are decided at the **same typed XEP-0492 evaluator**, invoked at TWO moments. Before this PR, the DM offline-delivery path and the groupchat candidate-emission path each carried their own recipient-state decision branches at candidate-emission time (T0). PR #694 (mention policy) closed unmerged because this two-decision-point design let a `<noping/>` flag escape DM `NotificationLevel::Always` — the exact failure mode the single-evaluator shape prevents.

This slice is the **behavior-preserving move**. No new suppressors, no new typed `SuppressedReason` enum, no `notification_activity` projection, no `DndReader`. Those follow in slice 2.

The reframing after compliance review: **one decision FUNCTION, two invocation moments** (T0 emission gate for compliance + T1 drain re-evaluator for race-window defense-in-depth).

## What changes

### T0 (candidate emission gate — compliance)

- `server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs`
  - After constructing the `NotificationCandidate` and BEFORE `insert_candidate`, runs `evaluate_xep0492_at_dispatch` against the recipient's current XEP-0492 projection.
  - `Suppressed` → typed `info!()` log + return; **no candidate row persisted**.
  - DM evaluation never consults `room_policy`, so the no-op `NoopRoomPolicy` adapter is sufficient at this call site.
- `server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs`
  - Same gate added in `insert_groupchat_notification_candidate`. Reuses the existing `RoomRegistryActorPolicy` so MUC `members_only` projects the correct `ConversationKind`.
  - `groupchat_notification_class` stays purely message-derived; recipient-state branching lives in the shared evaluator.

The XEP-0513 explicit-mention bit (`message_is_mention_for_recipient`) is computed once at T0 and recorded on the candidate via `NotificationCandidate::direct_message`'s `is_mention` parameter. Self-DM (`sender == recipient`) is still rejected at the typed constructor boundary as `SelfDirectedNotificationCandidate`.

### Candidate taxonomy

- New `NotificationClass::DirectMessageMention` (db value `dm_mention`).
- New `NotificationReason::OfflineDirectMessageMention` (db value `offline_dm_mention`).
- `NotificationCandidate::direct_message` now takes `is_mention: bool` and picks the right class/reason pair.
- New `notification_candidates_class_check` and `notification_outbox_class_check` constraint migrations mirror the existing `reason_check` migration pattern (both Postgres and SQLite paths).

### T1 (drain re-evaluator — race-window guard, defense-in-depth)

- `notification_outbox::drain_pending_candidates_into_outbox` continues to invoke the **same** `evaluate_xep0492_at_dispatch` function before fanning out each row. This catches the race where recipient state changed between T0 emission and T1 dispatch (e.g. user flipped XEP-0492 to `<never/>` mid-flight). The brief row exists only during the race window — push output is preserved per the locked Q2 design.
- The drain takes the `NotificationSettingsProjectionStore` and the `RoomPolicyStore` (per-batch cached `members_only` lookups so a 100-member groupchat does not produce 100 actor round-trips).
- T1 race-window suppression: `mark_candidate_outboxed_tx` WITHOUT `enqueue_outbox_job_tx`, with a typed `info!()` log carrying the suppression reason.

### New `room_policy` module

- `RoomPolicyStore` trait (declared in `notification_outbox`).
- `RoomRegistryActorPolicy` adapter that asks the live `RoomRegistryActor` → `GetRoom` → `GetConfig` for the room's `members_only` bit at both T0 and T1. Returns `Ok(None)` on not-currently-live rooms; the evaluator returns `DeferUnknownRoomPolicy` and the caller retries. Slice 2 will replace this with a durable T1 projection alongside `notification_activity`.
- `NoopRoomPolicy` adapter for DM call sites (DM arms never consult `room_policy`).

## What does NOT change

- No new typed `SuppressedReason` enum (slice 2).
- No new `<noping/>` / `<active/>` / DND / XEP-0334 enforcement (slice 2).
- No new `notification_activity` projection (slice 2).
- No new `DndReader` trait (slice 2).
- No new metric counters (slice 2).
- XEP-0357 stanza-error → registration disable transitions remain at the publish layer; unchanged by this slice.

## XEP review

- **XEP-0357 §8**: "Each XMPP server will have its own policy for when to send a push notification" — explicitly frames push as a server-policy decision. The shared evaluator IS that policy, invoked at both message-arrival time (compliance: no audit row for suppressed candidates) and at dispatch time (race-window defense-in-depth).
- **XEP-0492 §3**: settings are evaluated when deciding whether to send push notifications — also decision-time. The projection is read fresh at both T0 and T1.
- **XEP-0513 `<noping/>`**: not yet enforced anywhere; slice 2.

## Tests

- `cargo fmt --manifest-path server/Cargo.toml --all`: clean.
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-server --all-targets -- -D warnings`: clean.
- `cargo clippy --manifest-path server/Cargo.toml -p waddle-xmpp --all-targets -- -D warnings`: clean.
- `cargo test --manifest-path server/Cargo.toml -p waddle-server --no-fail-fast`: **879 unit tests** (was 864 before this PR; +5 new tests in the compliance-fix commits) **+ all integration suites pass**.
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp --no-fail-fast`: clean.

New compliance regression tests:
- `xep0492_direct_chat_never_persists_no_candidate_row_at_all`
- `xep0492_direct_chat_on_mention_without_mention_persists_no_candidate_row`
- `xep0492_direct_chat_on_mention_with_mention_persists_candidate_row`
- `xep0492_direct_chat_always_persists_candidate_row_without_mention`
- `t1_drain_reevaluates_xep0492_when_projection_changes_after_insert` (race-window defense-in-depth)

These complement the existing `xep0492_direct_chat_*_push_gate` tests that assert push-output equivalence via `pending_outbox_jobs().len()`. The new tests additionally assert on the post-emission `notification_candidates` row count via the new `count_all_candidates` helper.

## Plan / checklist

- [x] Survey every T0 recipient-state decision site (offline_delivery.rs and groupchat path)
- [x] Locate the outbox dispatch site and define the evaluator hook
- [x] Move DM XEP-0492 + self-suppression to T1; existing tests pass unchanged
- [x] Move groupchat decisions to T1; existing tests pass unchanged
- [x] **Restore T0 emission gate (compliance) using the same shared evaluator** — `Suppressed` outcomes leave no row in `notification_candidates`
- [x] Keep T1 drain re-evaluator as race-window defense-in-depth (NOT removed)
- [x] Add regression tests asserting zero rows on T0 suppression + race-window coverage
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test -p waddle-server` green

## Out of scope (tracked elsewhere)

- `<noping/>` / `<active/>` / DND / XEP-0334 enforcement — slice 2 in #526
- `SuppressedReason` typed enum + audit column — slice 2 in #526
- `notification_activity` projection — slice 2 in #526
- `DndReader` trait — slice 2 in #526
- New metrics / structured logs — slice 2 + provider slices
- Provider work — #528 / #529 / #530, blocked on #718

## Related

- Parent: #506
- Slice 2 (new suppressors + observability) follows this PR
- Closed (superseded): #194, #195
- Foundation slice: #718 (typed push client surface, parallel-eligible)

## Behavioral notes

The refactor is **push-output preserving** and (after the compliance-fix commits) **candidate-row preserving for suppressed cases** in the common path:

- **Suppressed candidates at T0 leave no row.** The T0 emission gate (`evaluate_xep0492_at_dispatch` invoked before `insert_candidate`) short-circuits when XEP-0492 says suppress. This satisfies the compliance rule that suppressed candidates produce no audit trail in `notification_candidates`.
- **T1 race-window exception is documented.** If recipient state changes *between* T0 emission and T1 dispatch (a setting flip mid-flight), the row briefly exists then gets marked outboxed without enqueuing a job. Acceptable per locked Q2 — push output is preserved.
- **Self-DM leaves no row.** Rejected at the typed `NotificationCandidate::direct_message` constructor as `SelfDirectedNotificationCandidate` — input validation, not recipient-state suppression.

## Review findings addressed

Five reviewer passes ran on this branch (XEP conformance, DB/migration safety, concurrency, behavioral regression, compliance shape):

- **Compliance review** (this iteration): flagged that suppressed XEP-0492 outcomes still produced a `notification_candidates` row (marked outboxed at T1 without a job). Fixed by adding the T0 emission gate that calls the shared evaluator before `insert_candidate`; new regression tests assert zero rows on suppression.
- **DB review** (earlier): caught a latent bug in `notification_outbox_class_constraint_matches_expected` iterating over the wrong constant; fixed in `158a550c` with a parallel `NOTIFICATION_OUTBOX_CLASS_VALUES`.
- **XEP conformance review**: no findings; T1 (and now T0) reads recipient state fresh, no string-built XML, no stringly-typed payloads on the new trait boundaries.
- **Concurrency review**: flagged TOCTOU stale projection at T1 — inherent to the single-decision-point design; `mark_candidate_outboxed_tx` `IS NULL` guard prevents double-enqueue. Nested actor asks in `RoomRegistryActorPolicy` flagged as nit for slice 2 (durable T1 projection). Worker reentrance vs claim timeout flagged as nit — worth adding a tokio deadline on `room_policy` calls in slice 2.
- **Behavioral regression review**: confirmed test assertion updates are legitimate; push output is preserved across the refactor.