### PR TITLE
fix(chat): use correct XEP-0199 namespace for MUC self-ping

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1573,7 +1573,7 @@ export class BrowserXmppClient {
 
   private startSelfPing() { this.stopSelfPing(); this.selfPingTimer = setInterval(() => { void this.doSelfPing(); }, 60000); }
   private stopSelfPing() { if (this.selfPingTimer) { clearInterval(this.selfPingTimer); this.selfPingTimer = null; } }
-  private async doSelfPing() { if (!this.xmpp?.send_raw_iq || !this.currentRoom) return; try { await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${this.currentRoom}/${this.session.username}"><ping xmlns="urn:ietf:params:xml:ns:xmpp-ping"/></iq>`); } catch { this.roomDisconnectHandler?.(); } }
+  private async doSelfPing() { if (!this.xmpp?.send_raw_iq || !this.currentRoom) return; try { await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${this.currentRoom}/${this.session.username}"><ping xmlns="urn:xmpp:ping"/></iq>`); } catch { this.roomDisconnectHandler?.(); } }
   private handleMessageAck(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); if (wasQueued) removeQueuedMessage(this.queueScope, id); this.messageAckHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageAckHooks, id, { kind: pending.kind, latencyMs: performance.now() - pending.at }); } if (wasQueued) this.emitQueueDepth(); }
   private handleMessageFailed(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); this.messageDeliveryFailureHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageFailHooks, id, { kind: pending.kind }); } if (wasQueued) this.emitQueueDepth(); }
   private handleSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {


### PR DESCRIPTION
## Summary
- MUC self-ping IQ in `chat/src/lib/xmpp/client.ts` was using `urn:ietf:params:xml:ns:xmpp-ping` — not a real XMPP namespace.
- XEP-0199 / XEP-0410 self-ping requires `urn:xmpp:ping`. Server's handler matched on the correct namespace, so every ping was logged as "Unhandled IQ stanza" and replied with `feature-not-implemented`.
- The client's catch then ran `roomDisconnectHandler`, so users were getting spurious room-disconnect signals on every 60s ping tick.

## Plan
1. Fix the namespace string in `doSelfPing` to `urn:xmpp:ping`.
2. Verify chat unit tests still pass.
3. Monitor CI until green.

## Test plan
- [x] `bun test` in `chat/` passes (964 tests).
- [ ] CI green on the PR (lint, knip, server tests).
- [ ] Manual: with this client running against a server, the "Unhandled IQ stanza" warn no longer fires for `urn:ietf:params:xml:ns:xmpp-ping` and the room stays connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)