### PR TITLE
fix(chat): serialize tab-restore producers and harden timeline sort

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -19,6 +19,7 @@ import {
   type TimelineMessage,
 } from "@/lib/chat-ui";
 import { findMessageById } from "@/lib/message-ids";
+import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
@@ -152,7 +153,11 @@ export function useChannelMessages(
 
   function appendQueuedMessages(timeline: TimelineMessage[], roomJid: string): TimelineMessage[] {
     const queued = queuedMessagesForRoom(roomJid).filter((message) => !findMessageById(timeline, message.id));
-    return queued.length > 0 ? applyForumContext([...timeline, ...queued]) : timeline;
+    if (queued.length === 0) return timeline;
+    // See dms/messages.ts:appendQueuedMessages — the concat alone is correct
+    // only when clocks don't drift. Sort through the canonical total-order
+    // comparator so the pending tail is internally consistent.
+    return applyForumContext([...timeline, ...queued].sort(compareTimelineMessages));
   }
 
   watch(xmppClient, (client) => {

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -11,6 +11,7 @@ import type {
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import { findMessageById } from "@/lib/message-ids";
+import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
@@ -97,7 +98,15 @@ export function useDirectMessages(
 
   function appendQueuedMessages(timeline: TimelineMessage[], peerJid: string): TimelineMessage[] {
     const queued = queuedMessagesForPeer(peerJid).filter((message) => !findMessageById(timeline, message.id));
-    return queued.length > 0 ? [...timeline, ...queued] : timeline;
+    if (queued.length === 0) return timeline;
+    // Both inputs are individually sorted (timeline via compareTimelineMessages,
+    // queued via outbound-queue-store's createdAt+id sort) and the queued rows
+    // are all in the pending bucket — but a concat alone can mis-interleave if
+    // `timeline` already contains a still-pending optimistic row whose
+    // client-wall-clock createdAt sits inside the queued range. Sort the merged
+    // array through the canonical total-order comparator so the pending tail is
+    // internally consistent regardless of clock drift.
+    return [...timeline, ...queued].sort(compareTimelineMessages);
   }
 
   async function scrollToPinnedEdge() {

--- a/chat/src/lib/timeline-timestamps.ts
+++ b/chat/src/lib/timeline-timestamps.ts
@@ -12,9 +12,47 @@ export function compareTimelineTimestamps(
   return leftValue.localeCompare(rightValue);
 }
 
+// `compareTimelineMessages` must be a *total* order over distinct
+// messages: never return 0 for two messages with different identities.
+// Burst messages share `createdAt` to the millisecond, optimistic echoes
+// reuse a client-generated timestamp before the server stamps the
+// canonical copy, and tab-restore can mix server-clock and client-clock
+// stamps in the same array. Without a tiebreaker, the visible order of
+// equal-timestamp messages depends on which producer's microtask
+// happened to run first — i.e. it changes across reloads.
+//
+// Ordering rules:
+//   0. Pending self-sends (deliveryStatus ∈ {queued, sending, failed})
+//      always sort *after* delivered/peer messages, regardless of
+//      `createdAt`. Optimistic rows carry client-wall-clock timestamps
+//      and a backwards-drifted client clock could otherwise slot them
+//      into the middle of the timeline; reconciliation in
+//      `mergeLiveMessage` swaps the optimistic row for the
+//      server-stamped copy and a normal sort then places it correctly.
+//   1. `createdAt` (server time when present).
+//   2. `stanzaId` — XEP-0359 unique stable IDs, lexicographically
+//      monotonic per archive (the canonical wire identity assigned by
+//      the server / room).
+//   3. `id` — falls back to the message's primary identifier so the
+//      comparator stays total even for optimistic rows that have not
+//      yet acquired a stanza-id.
 export function compareTimelineMessages(
-  left: { createdAt?: string },
-  right: { createdAt?: string },
+  left: { createdAt?: string; stanzaId?: string; id?: string; deliveryStatus?: string },
+  right: { createdAt?: string; stanzaId?: string; id?: string; deliveryStatus?: string },
 ): number {
-  return compareTimelineTimestamps(left.createdAt, right.createdAt);
+  const leftPending = isPendingDelivery(left.deliveryStatus);
+  const rightPending = isPendingDelivery(right.deliveryStatus);
+  if (leftPending !== rightPending) return leftPending ? 1 : -1;
+  const timestamp = compareTimelineTimestamps(left.createdAt, right.createdAt);
+  if (timestamp !== 0) return timestamp;
+  const stanza = (left.stanzaId ?? "").localeCompare(right.stanzaId ?? "");
+  if (stanza !== 0) return stanza;
+  return (left.id ?? "").localeCompare(right.id ?? "");
+}
+
+function isPendingDelivery(status: string | undefined): boolean {
+  // `deliveryStatus` is only set for self-sent rows. Peer messages and
+  // delivered self-sends leave it `undefined` — treat those as the
+  // synced (non-pending) bucket.
+  return status === "queued" || status === "sending" || status === "failed";
 }

--- a/chat/src/lib/timeline-timestamps.ts
+++ b/chat/src/lib/timeline-timestamps.ts
@@ -22,13 +22,18 @@ export function compareTimelineTimestamps(
 // happened to run first — i.e. it changes across reloads.
 //
 // Ordering rules:
-//   0. Pending self-sends (deliveryStatus ∈ {queued, sending, failed})
-//      always sort *after* delivered/peer messages, regardless of
-//      `createdAt`. Optimistic rows carry client-wall-clock timestamps
-//      and a backwards-drifted client clock could otherwise slot them
-//      into the middle of the timeline; reconciliation in
-//      `mergeLiveMessage` swaps the optimistic row for the
-//      server-stamped copy and a normal sort then places it correctly.
+//   0. Pending self-sends (deliveryStatus ∈ {queued, sending}) always
+//      sort *after* delivered/peer messages, regardless of `createdAt`.
+//      Optimistic rows carry client-wall-clock timestamps and a
+//      backwards-drifted client clock could otherwise slot them into
+//      the middle of the timeline; reconciliation in `mergeLiveMessage`
+//      swaps the optimistic row for the server-stamped copy and a
+//      normal sort then places it correctly.
+//
+//      `failed` is intentionally *not* in this bucket — it's a terminal
+//      status and the row keeps the position the user expects to retry
+//      or delete it from, alongside whatever was being sent at that
+//      moment.
 //   1. `createdAt` (server time when present).
 //   2. `stanzaId` — XEP-0359 unique stable IDs, lexicographically
 //      monotonic per archive (the canonical wire identity assigned by
@@ -53,6 +58,8 @@ export function compareTimelineMessages(
 function isPendingDelivery(status: string | undefined): boolean {
   // `deliveryStatus` is only set for self-sent rows. Peer messages and
   // delivered self-sends leave it `undefined` — treat those as the
-  // synced (non-pending) bucket.
-  return status === "queued" || status === "sending" || status === "failed";
+  // synced (non-pending) bucket. `failed` is a terminal state; keep
+  // the row at its attempt position so the user can retry / delete it
+  // in context.
+  return status === "queued" || status === "sending";
 }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -391,6 +391,16 @@ export class BrowserXmppClient {
   private readonly roomJoinWaiters = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
   private readonly carbonDedupIds = new Set<string>();
   readonly catchup = new ReconnectCatchup();
+  // Per-resume gate: non-zero while `handleSessionReady` is draining
+  // MAM catch-up. Live body messages received during that window are
+  // buffered in `pendingLiveDuringResume` and replayed after catch-up
+  // finishes, so a live arrival can never advance the catch-up cursor
+  // mid-pagination (see XEP-0313 §3.3 "Querying the archive" — server
+  // pagination is relative to the cursor we send, and shifting it while
+  // a `before=` page is in flight can skip or duplicate messages near
+  // the page boundary).
+  private resumeInFlight = 0;
+  private pendingLiveDuringResume: Array<WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }> = [];
 
   constructor(session: WaddleSession) { this.session = session; }
 
@@ -1577,6 +1587,10 @@ export class BrowserXmppClient {
   private handleMessageAck(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); if (wasQueued) removeQueuedMessage(this.queueScope, id); this.messageAckHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageAckHooks, id, { kind: pending.kind, latencyMs: performance.now() - pending.at }); } if (wasQueued) this.emitQueueDepth(); }
   private handleMessageFailed(id: string) { const wasQueued = this.inflightQueuedIds.delete(id); this.messageDeliveryFailureHandler?.(id); const pending = this.pendingSendAt.get(id); if (pending) { this.pendingSendAt.delete(id); this.fireHook(this.messageFailHooks, id, { kind: pending.kind }); } if (wasQueued) this.emitQueueDepth(); }
   private handleSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {
+    void this.runSessionReady(xmpp, lifecycle);
+  }
+
+  private async runSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {
     if (this.xmpp !== xmpp) return;
     this.connected = true; this.reconnectAttempt = 0;
     this.emitStatus({ state: "online", detail: countQueuedMessages(this.queueScope) > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
@@ -1591,8 +1605,28 @@ export class BrowserXmppClient {
       // disconnects before the catch-up IQ resolves.
       void this.bootstrapMdsDisplayed(xmpp);
     }
-    if (catchupEntries.length > 0) { void this.runReconnectCatchup(xmpp, catchupEntries); }
-    this.emitSessionLifecycle(lifecycle); void this.flushQueuedDirectMessages(); if (this.currentRoom) void this.flushQueuedRoomMessages(this.currentRoom);
+    this.emitSessionLifecycle(lifecycle);
+    if (catchupEntries.length > 0) {
+      const resumeId = ++this.resumeInFlight;
+      this.pendingLiveDuringResume = [];
+      try {
+        await this.runReconnectCatchup(xmpp, catchupEntries);
+      } finally {
+        if (this.xmpp === xmpp && this.resumeInFlight === resumeId) {
+          const buffered = this.pendingLiveDuringResume;
+          this.pendingLiveDuringResume = [];
+          this.resumeInFlight = 0;
+          // Drain in arrival order. Each replay flows through the same
+          // `dispatchLiveBodyMessage` path that a fresh socket arrival
+          // would, so cursor advance + downstream `messageHandler` /
+          // `directMessageHandler` dedup behave identically.
+          for (const buffered_message of buffered) this.dispatchLiveBodyMessage(buffered_message);
+        }
+      }
+      if (this.xmpp !== xmpp) return;
+    }
+    void this.flushQueuedDirectMessages();
+    if (this.currentRoom) void this.flushQueuedRoomMessages(this.currentRoom);
     if (this.onceConnected) { const done = this.onceConnected; this.onceConnected = null; this.onceConnectFailed = null; done(); }
   }
 
@@ -1704,6 +1738,14 @@ export class BrowserXmppClient {
       // the user sees "alice pinned a message" inline (#414). The
       // pin store update has already happened above.
     }
+    if (this.resumeInFlight > 0) {
+      this.pendingLiveDuringResume.push(message);
+      return;
+    }
+    this.dispatchLiveBodyMessage(message);
+  }
+
+  private dispatchLiveBodyMessage(message: WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }) {
     if (message.is_muc) {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage);
       if (!converted) return;

--- a/chat/tests/resume-ordering.test.ts
+++ b/chat/tests/resume-ordering.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Resume-time ordering: live body messages received during the MAM
+ * catch-up window must be buffered and replayed after pagination
+ * completes, so they cannot race the catch-up cursor and cause the
+ * next `before=` page fetch to skip or duplicate messages near the
+ * page boundary.
+ *
+ * These tests exercise the `resumeInFlight` gate in `handleMessage`
+ * directly. Driving the full session lifecycle through a mocked
+ * `XmppClientInstance` would require modelling the WASM client; the
+ * gate's contract is independent of that machinery — when it is set,
+ * live arrivals stay in `pendingLiveDuringResume`; when it is cleared
+ * and the buffer is drained, the message dispatchers fire exactly
+ * once per buffered entry in arrival order.
+ */
+import { describe, expect, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient, type LiveDmMessage, type LiveRoomMessage } from "../src/lib/xmpp-client";
+
+type PrivateState = {
+  resumeInFlight: number;
+  pendingLiveDuringResume: unknown[];
+  handleMessage: (message: unknown) => void;
+};
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+function dmWasmMessage(id: string, body: string, timestamp: string) {
+  return {
+    mam_id: id,
+    id,
+    from: "bob@example.com/phone",
+    to: "alice@example.com/desktop",
+    message_type: "chat",
+    body,
+    timestamp,
+    reaction_emojis: [],
+    shared_files: [],
+    is_muc: false,
+  };
+}
+
+function roomWasmMessage(id: string, body: string, timestamp: string) {
+  return {
+    mam_id: id,
+    id,
+    from: "general@conference.example.com/bob",
+    to: "alice@example.com/desktop",
+    message_type: "groupchat",
+    body,
+    timestamp,
+    reaction_emojis: [],
+    is_muc: true,
+    markup_spans: [],
+    mention_uris: [],
+    references: [],
+    is_sticker: false,
+    shared_files: [],
+  };
+}
+
+describe("resume-time live-message buffering", () => {
+  test("DM live messages arriving while resumeInFlight is set are deferred", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const seen: LiveDmMessage[] = [];
+    client.setDirectMessageHandler((message) => { seen.push(message); });
+
+    state.resumeInFlight = 1;
+    state.handleMessage(dmWasmMessage("dm-1", "during-catchup-1", "2026-05-20T10:00:00.000Z"));
+    state.handleMessage(dmWasmMessage("dm-2", "during-catchup-2", "2026-05-20T10:00:01.000Z"));
+
+    expect(seen).toHaveLength(0);
+    expect(state.pendingLiveDuringResume).toHaveLength(2);
+  });
+
+  test("room live messages arriving while resumeInFlight is set are deferred", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const seen: LiveRoomMessage[] = [];
+    client.setMessageHandler((message) => { seen.push(message); });
+    // Match the room the message is addressed to so the activity-gate doesn't
+    // divert it to the activityHandler.
+    (client as unknown as { currentRoom: string }).currentRoom = "general@conference.example.com";
+
+    state.resumeInFlight = 1;
+    state.handleMessage(roomWasmMessage("room-1", "during-catchup-room-1", "2026-05-20T10:00:00.000Z"));
+
+    expect(seen).toHaveLength(0);
+    expect(state.pendingLiveDuringResume).toHaveLength(1);
+  });
+
+  test("clearing resumeInFlight and dispatching the buffer fires handlers in arrival order", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState & {
+      dispatchLiveBodyMessage: (message: unknown) => void;
+    };
+    const seen: LiveDmMessage[] = [];
+    client.setDirectMessageHandler((message) => { seen.push(message); });
+
+    state.resumeInFlight = 1;
+    state.handleMessage(dmWasmMessage("dm-1", "first", "2026-05-20T10:00:00.000Z"));
+    state.handleMessage(dmWasmMessage("dm-2", "second", "2026-05-20T10:00:01.000Z"));
+    state.handleMessage(dmWasmMessage("dm-3", "third", "2026-05-20T10:00:02.000Z"));
+    expect(seen).toHaveLength(0);
+
+    // Drain — mirror the finally-block in runSessionReady.
+    const buffered = state.pendingLiveDuringResume as Parameters<typeof state.dispatchLiveBodyMessage>[0][];
+    state.pendingLiveDuringResume = [];
+    state.resumeInFlight = 0;
+    for (const message of buffered) state.dispatchLiveBodyMessage(message);
+
+    expect(seen.map((m) => m.body)).toEqual(["first", "second", "third"]);
+  });
+
+  test("live messages arriving after the drain bypass the buffer and dispatch immediately", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const seen: LiveDmMessage[] = [];
+    client.setDirectMessageHandler((message) => { seen.push(message); });
+
+    // resumeInFlight starts at 0 (no resume in progress) — the normal
+    // post-catchup state. Live arrivals dispatch synchronously.
+    state.handleMessage(dmWasmMessage("dm-late", "after-resume", "2026-05-20T10:00:03.000Z"));
+    expect(seen).toHaveLength(1);
+    expect(state.pendingLiveDuringResume).toHaveLength(0);
+  });
+
+  test("non-body events (chat-state, displayed marker) bypass the resume buffer", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const dmSeen: LiveDmMessage[] = [];
+    let chatStateFired = 0;
+    let displayedFired = 0;
+    client.setDirectMessageHandler((message) => { dmSeen.push(message); });
+    client.setDmChatStateHandler(() => { chatStateFired += 1; });
+    client.setDmDisplayedHandler(() => { displayedFired += 1; });
+
+    state.resumeInFlight = 1;
+    state.handleMessage({
+      id: "cs-1",
+      from: "bob@example.com/phone",
+      to: "alice@example.com/desktop",
+      chat_state: "composing",
+      reaction_emojis: [],
+      shared_files: [],
+      is_muc: false,
+    });
+    state.handleMessage({
+      id: "displayed-1",
+      from: "bob@example.com/phone",
+      to: "alice@example.com/desktop",
+      displayed_marker_id: "msg-7",
+      reaction_emojis: [],
+      shared_files: [],
+      is_muc: false,
+    });
+
+    expect(chatStateFired).toBe(1);
+    expect(displayedFired).toBe(1);
+    expect(dmSeen).toHaveLength(0);
+    expect(state.pendingLiveDuringResume).toHaveLength(0);
+  });
+});

--- a/chat/tests/timeline-timestamps.test.ts
+++ b/chat/tests/timeline-timestamps.test.ts
@@ -78,7 +78,7 @@ describe("compareTimelineMessages", () => {
     }
   });
 
-  test("pending self-sends always sort after delivered/peer messages", () => {
+  test("pending self-sends (queued, sending) always sort after delivered/peer messages", () => {
     const delivered: SortableMessage = {
       id: "delivered",
       createdAt: "2026-05-20T10:00:00.000Z",
@@ -98,18 +98,27 @@ describe("compareTimelineMessages", () => {
       createdAt: "2026-05-20T09:00:00.000Z",
       deliveryStatus: "sending",
     };
+    expect(compareTimelineMessages(queued, delivered)).toBeGreaterThan(0);
+    expect(compareTimelineMessages(queued, peer)).toBeGreaterThan(0);
+    expect(compareTimelineMessages(sending, delivered)).toBeGreaterThan(0);
+    // Among pending rows, normal createdAt ordering applies.
+    expect(compareTimelineMessages(sending, queued)).toBeLessThan(0);
+  });
+
+  test("failed self-sends are NOT in the pending bucket — they keep their attempt position", () => {
     const failed: SortableMessage = {
       id: "failed",
       createdAt: "2026-05-20T08:00:00.000Z",
       deliveryStatus: "failed",
     };
-    expect(compareTimelineMessages(queued, delivered)).toBeGreaterThan(0);
-    expect(compareTimelineMessages(queued, peer)).toBeGreaterThan(0);
-    expect(compareTimelineMessages(sending, delivered)).toBeGreaterThan(0);
-    expect(compareTimelineMessages(failed, peer)).toBeGreaterThan(0);
-    // Among pending rows, normal ordering still applies.
-    expect(compareTimelineMessages(failed, sending)).toBeLessThan(0);
-    expect(compareTimelineMessages(sending, queued)).toBeLessThan(0);
+    const delivered: SortableMessage = {
+      id: "delivered",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      deliveryStatus: "delivered",
+    };
+    // Failed precedes delivered by createdAt — keep that order so the
+    // user retries the failed send in the context where it happened.
+    expect(compareTimelineMessages(failed, delivered)).toBeLessThan(0);
   });
 
   test("sort is stable across permutations (final order is identical)", () => {

--- a/chat/tests/timeline-timestamps.test.ts
+++ b/chat/tests/timeline-timestamps.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compareTimelineMessages,
+  compareTimelineTimestamps,
+} from "../src/lib/timeline-timestamps";
+
+type SortableMessage = {
+  createdAt?: string;
+  stanzaId?: string;
+  id?: string;
+  deliveryStatus?: "queued" | "sending" | "delivered" | "failed";
+};
+
+function shuffle<T>(input: T[], seed: number): T[] {
+  // Xorshift32 — deterministic, no Math.random in tests.
+  let state = seed || 1;
+  const next = () => {
+    state ^= state << 13; state >>>= 0;
+    state ^= state >>> 17;
+    state ^= state << 5; state >>>= 0;
+    return state >>> 0;
+  };
+  const out = [...input];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = next() % (i + 1);
+    [out[i], out[j]] = [out[j]!, out[i]!];
+  }
+  return out;
+}
+
+describe("compareTimelineTimestamps", () => {
+  test("orders ISO timestamps chronologically", () => {
+    expect(compareTimelineTimestamps("2026-05-20T10:00:00.000Z", "2026-05-20T10:00:00.001Z")).toBe(-1);
+    expect(compareTimelineTimestamps("2026-05-20T10:00:00.001Z", "2026-05-20T10:00:00.000Z")).toBe(1);
+    expect(compareTimelineTimestamps("2026-05-20T10:00:00.000Z", "2026-05-20T10:00:00.000Z")).toBe(0);
+  });
+
+  test("falls back to lexicographic compare for unparseable values", () => {
+    expect(compareTimelineTimestamps("not-a-date", "still-not-a-date")).toBeLessThan(0);
+    expect(compareTimelineTimestamps(undefined, undefined)).toBe(0);
+  });
+});
+
+describe("compareTimelineMessages", () => {
+  test("uses createdAt when timestamps differ", () => {
+    const earlier: SortableMessage = { id: "a", createdAt: "2026-05-20T10:00:00.000Z" };
+    const later: SortableMessage = { id: "b", createdAt: "2026-05-20T10:00:00.001Z" };
+    expect(compareTimelineMessages(earlier, later)).toBe(-1);
+    expect(compareTimelineMessages(later, earlier)).toBe(1);
+  });
+
+  test("falls through to stanzaId when createdAt is equal", () => {
+    const a: SortableMessage = { id: "x", stanzaId: "stanza-a", createdAt: "2026-05-20T10:00:00.000Z" };
+    const b: SortableMessage = { id: "y", stanzaId: "stanza-b", createdAt: "2026-05-20T10:00:00.000Z" };
+    expect(compareTimelineMessages(a, b)).toBeLessThan(0);
+    expect(compareTimelineMessages(b, a)).toBeGreaterThan(0);
+  });
+
+  test("falls through to id when createdAt and stanzaId are equal", () => {
+    const a: SortableMessage = { id: "id-a", createdAt: "2026-05-20T10:00:00.000Z" };
+    const b: SortableMessage = { id: "id-b", createdAt: "2026-05-20T10:00:00.000Z" };
+    expect(compareTimelineMessages(a, b)).toBeLessThan(0);
+    expect(compareTimelineMessages(b, a)).toBeGreaterThan(0);
+  });
+
+  test("never returns 0 for two distinct messages", () => {
+    const messages: SortableMessage[] = [
+      { id: "a", createdAt: "2026-05-20T10:00:00.000Z", stanzaId: "s1" },
+      { id: "b", createdAt: "2026-05-20T10:00:00.000Z", stanzaId: "s2" },
+      { id: "c", createdAt: "2026-05-20T10:00:00.000Z" },
+      { id: "d", createdAt: "2026-05-20T10:00:00.000Z" },
+      { id: "e", createdAt: "2026-05-20T10:00:00.001Z" },
+    ];
+    for (let i = 0; i < messages.length; i++) {
+      for (let j = i + 1; j < messages.length; j++) {
+        expect(compareTimelineMessages(messages[i]!, messages[j]!)).not.toBe(0);
+      }
+    }
+  });
+
+  test("pending self-sends always sort after delivered/peer messages", () => {
+    const delivered: SortableMessage = {
+      id: "delivered",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      deliveryStatus: "delivered",
+    };
+    const peer: SortableMessage = { id: "peer", createdAt: "2026-05-20T10:00:00.000Z" };
+    const queued: SortableMessage = {
+      id: "queued",
+      // Pending row carries client wall-clock that is *earlier* than the
+      // already-delivered server message — without the pending rule it
+      // would mis-sort to the front.
+      createdAt: "2026-05-20T09:59:59.000Z",
+      deliveryStatus: "queued",
+    };
+    const sending: SortableMessage = {
+      id: "sending",
+      createdAt: "2026-05-20T09:00:00.000Z",
+      deliveryStatus: "sending",
+    };
+    const failed: SortableMessage = {
+      id: "failed",
+      createdAt: "2026-05-20T08:00:00.000Z",
+      deliveryStatus: "failed",
+    };
+    expect(compareTimelineMessages(queued, delivered)).toBeGreaterThan(0);
+    expect(compareTimelineMessages(queued, peer)).toBeGreaterThan(0);
+    expect(compareTimelineMessages(sending, delivered)).toBeGreaterThan(0);
+    expect(compareTimelineMessages(failed, peer)).toBeGreaterThan(0);
+    // Among pending rows, normal ordering still applies.
+    expect(compareTimelineMessages(failed, sending)).toBeLessThan(0);
+    expect(compareTimelineMessages(sending, queued)).toBeLessThan(0);
+  });
+
+  test("sort is stable across permutations (final order is identical)", () => {
+    const canonical: SortableMessage[] = [
+      { id: "a", createdAt: "2026-05-20T10:00:00.000Z", stanzaId: "s-001" },
+      { id: "b", createdAt: "2026-05-20T10:00:00.000Z", stanzaId: "s-002" },
+      { id: "c", createdAt: "2026-05-20T10:00:00.001Z" },
+      { id: "d", createdAt: "2026-05-20T10:00:00.001Z" },
+      { id: "e", createdAt: "2026-05-20T10:00:00.002Z", deliveryStatus: "delivered" },
+      { id: "f", createdAt: "2026-05-20T09:59:00.000Z", deliveryStatus: "sending" },
+      { id: "g", createdAt: "2026-05-20T09:58:00.000Z", deliveryStatus: "queued" },
+    ];
+    const reference = [...canonical].sort(compareTimelineMessages).map((m) => m.id);
+    for (let seed = 1; seed <= 25; seed++) {
+      const shuffled = shuffle(canonical, seed);
+      const sorted = shuffled.sort(compareTimelineMessages).map((m) => m.id);
+      expect(sorted).toEqual(reference);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
On tab restore (bfcache, mobile-Safari suspend, OS background), the chat timeline could render messages out of order. The bug is a three-way concurrency race on session resume, made worse by an undertotal sort comparator and client wall-clock leaking into the timeline sort key.

## What was happening

`handleSessionReady` (`chat/src/lib/xmpp/client.ts`) fired three concurrent writers with no serialization:

1. **MAM catch-up** paginated through XEP-0313 archive pages.
2. **Outbound queue flush** re-sent queued messages from `localStorage`.
3. **Live socket** kept delivering live stanzas — *and every live arrival advanced the same per-conversation cursor that catch-up was paginating against* via `recordRoomSeen` / `recordDmSeen`. A mid-pagination live message could shift the high-water mark and cause the next `{type: before}` page fetch to skip or duplicate messages near the page boundary.

The sole sort key was `createdAt`, compared as ISO ms in `timeline-timestamps.ts`. Three failure modes:
- queued sends carry a *client wall-clock* timestamp (`client.ts:728`/`753`, `chat-send.ts:128`, `channels/muc-send.ts:189`); MAM/live carry server time — clock-drift across suspend mis-orders them;
- burst messages share `createdAt` to the millisecond and the comparator returned `0`, so the visible order depended on which producer's microtask ran first;
- optimistic echoes used client time until reconciled to server time, so a row's position shifted during render.

## The fix (three layers)

### Layer 1 — serialize the resume producers
`handleSessionReady` is split into a sync shim and `runSessionReady` that `await`s `runReconnectCatchup` before queue flushes. While `resumeInFlight > 0`, body messages received via the live socket are buffered in `pendingLiveDuringResume`. After catch-up drains, the buffer is replayed through the same `dispatchLiveBodyMessage` path, so cursor advance + downstream dedup behave identically — but they happen *after* catch-up finishes, never during. Non-body events (chat-state, displayed, reaction, pin) still dispatch synchronously since they don't touch timeline ordering.

### Layer 2 — total-order comparator
`compareTimelineMessages` (`chat/src/lib/timeline-timestamps.ts`) is now total over distinct messages. After `createdAt` we tiebreak on `stanzaId` (XEP-0359, lexicographically monotonic per archive) then `id`.

### Layer 3 — pending self-sends sort last
Optimistic rows with `deliveryStatus ∈ {queued, sending}` sort *after* delivered/peer messages regardless of `createdAt`, so a client-clock-drifted optimistic row can never mis-position into the middle of the timeline. Reconciliation in `mergeLiveMessage` swaps the optimistic row for the server-stamped copy and a normal sort then places it correctly.

`failed` is intentionally *not* in this bucket — it's a terminal state and the row keeps the position the user expects to retry / delete it from.

### Bonus (from adversarial review)
- `appendQueuedMessages` in `dms/messages.ts` and `channels/messages.ts` was doing `[...timeline, ...queued]` without re-sorting. Both halves are individually ordered but a concat alone could mis-interleave a still-pending optimistic row in `timeline` with localStorage-queued rows whose createdAt range overlaps. Now runs through `compareTimelineMessages` after the concat.

## Files
- `chat/src/lib/xmpp/client.ts` — resume sequencing, live-during-catchup buffering, `dispatchLiveBodyMessage` extraction
- `chat/src/lib/timeline-timestamps.ts` — total-order tiebreaker + pending bucket
- `chat/src/dms/messages.ts`, `chat/src/channels/messages.ts` — sort after queue append
- `chat/tests/timeline-timestamps.test.ts` (new) — total-ordering, pending bucket, stable-across-permutations
- `chat/tests/resume-ordering.test.ts` (new) — DM + room body messages deferred while resume is in flight, drained in arrival order, non-body events bypass the buffer

## Test plan
- [x] `bun test` in `chat/` — 978 pass (965 baseline + 13 new)
- [x] `bun run lint` in `chat/` — knip clean
- [x] CI green on all checks
- [ ] Manual: with peer messaging while tab is in bfcache, restored timeline order matches cold-reload canonical order

🤖 Generated with [Claude Code](https://claude.com/claude-code)