### PR TITLE
fix(chat): route GIFs sent from a thread + XEP-0201 conformance

### DIFF
--- a/chat/src/channels/chat-states.ts
+++ b/chat/src/channels/chat-states.ts
@@ -81,8 +81,15 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
    * the first time the user types in a window of activity, then arms a
    * 3-second timer to send "paused" once typing stops. Re-arms on every
    * call.
+   *
+   * XEP-0201 §3: when typing happens inside a thread, the composing /
+   * paused notifications SHOULD carry the same `<thread/>` so peers can
+   * scope the indicator to the active thread instead of treating it as
+   * channel-wide. The debounce machine itself stays channel-shared —
+   * users only type in one place at a time, so a single composing window
+   * is fine; the wire stanza carries whatever thread is active right now.
    */
-  function notifyComposing() {
+  function notifyComposing(thread?: { id: string; parent?: string }) {
     const client = xmppClient.value;
     const spaceId = activeSpaceId.value ?? "";
     const channelId = activeChannelId.value;
@@ -90,7 +97,7 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
 
     if (lastChatState !== "composing") {
       lastChatState = "composing";
-      void client.sendChatState(spaceId, channelId, "composing").catch(() => undefined);
+      void client.sendChatState(spaceId, channelId, "composing", thread).catch(() => undefined);
     }
 
     if (composingTimeout) clearTimeout(composingTimeout);
@@ -102,7 +109,7 @@ export function useChannelChatStates(deps: UseChannelChatStatesDeps) {
       )
         return;
       lastChatState = "paused";
-      void client.sendChatState(spaceId, channelId, "paused").catch(() => undefined);
+      void client.sendChatState(spaceId, channelId, "paused", thread).catch(() => undefined);
     }, COMPOSING_PAUSE_MS);
   }
 

--- a/chat/src/channels/message-actions.ts
+++ b/chat/src/channels/message-actions.ts
@@ -5,6 +5,18 @@ import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { findMessageById } from "@/lib/message-ids";
 
+// Derive an XEP-0201 thread reference from a timeline message, if it belongs
+// to one. Returns undefined for top-level (non-threaded) messages so callers
+// pass plain channel-level stanzas in that case.
+function threadRefFromMessage(
+  message: TimelineMessage | undefined,
+): { id: string; parent?: string } | undefined {
+  const id = message?.threadId;
+  if (!id) return undefined;
+  const parent = message.parentThreadId;
+  return parent ? { id, parent } : { id };
+}
+
 // Outbound message-action handlers for the channel side: reactions
 // (XEP-0444), retractions (XEP-0424), moderator retractions (XEP-0425), and
 // extension-annotation actions. Each action targets an already-rendered
@@ -78,11 +90,16 @@ export function useChannelMessageActions(deps: UseChannelMessageActionsDeps) {
     applyReaction(targetId, myNick, nextEmojis, senderId);
 
     try {
+      // XEP-0201 §3 + XEP-0444: reactions targeting a threaded message echo
+      // that message's <thread/>. Receivers without thread-aware UIs ignore it;
+      // thread-aware peers attribute the reaction to the right conversation.
+      const thread = threadRefFromMessage(msg);
       await xmppClient.value.sendReaction(
         activeSpaceId.value ?? "",
         activeChannelId.value,
         targetId,
         nextEmojis,
+        thread,
       );
     } catch (e) {
       // Roll back the optimistic update so the chip stops claiming a
@@ -111,10 +128,15 @@ export function useChannelMessageActions(deps: UseChannelMessageActionsDeps) {
     }
 
     try {
+      // XEP-0201 §3 + XEP-0424: tombstone targeting a threaded message echoes
+      // that message's <thread/> so the retraction routes into the same
+      // thread on receiving clients instead of the parent channel.
+      const thread = threadRefFromMessage(target);
       await xmppClient.value.sendRetraction(
         activeSpaceId.value ?? "",
         activeChannelId.value,
         targetId,
+        thread,
       );
     } catch (e) {
       actionError.value = normalizeError(e);

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -263,6 +263,15 @@ export function useMucSend(deps: UseMucSendDeps) {
 
     clearActionError();
 
+    // XEP-0201 §3 + XEP-0308: a correction targeting a threaded message
+    // SHOULD repeat the original `<thread/>` so receivers attribute the
+    // edit to the right thread instead of the parent channel.
+    const thread = message?.threadId
+      ? message.parentThreadId
+        ? { id: message.threadId, parent: message.parentThreadId }
+        : { id: message.threadId }
+      : undefined;
+
     try {
       await xmppClient.value.sendCorrection(
         activeSpaceId.value ?? "",
@@ -271,6 +280,7 @@ export function useMucSend(deps: UseMucSendDeps) {
         targetId,
         markup,
         references,
+        thread,
       );
     } catch (e) {
       actionError.value = normalizeError(e);

--- a/chat/src/channels/read-markers.ts
+++ b/chat/src/channels/read-markers.ts
@@ -45,8 +45,16 @@ export function useChannelReadMarkers(deps: UseChannelReadMarkersDeps) {
     const client = xmppClient.value;
     const spaceId = activeSpaceId.value ?? "";
     const channelId = activeChannelId.value;
+    // XEP-0201 §3 + XEP-0333: a displayed marker for a threaded message
+    // SHOULD echo that message's <thread/> so the marker scopes to the
+    // right thread instead of being treated as a channel-wide read.
+    const thread = target?.threadId
+      ? target.parentThreadId
+        ? { id: target.threadId, parent: target.parentThreadId }
+        : { id: target.threadId }
+      : undefined;
     void client
-      .sendDisplayed(spaceId, channelId, targetId)
+      .sendDisplayed(spaceId, channelId, targetId, thread)
       .catch(() => undefined);
     // XEP-0490 §3 publish — MUC stanza-id by= room JID. Only fires
     // when the room actually stamped the message (XEP-0359 §3.4

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -70,8 +70,14 @@ const emit = defineEmits<{
   retractMessage: [messageId: string];
   reactMessage: [messageId: string, emoji: string];
   displayed: [messageId: string];
-  selectGif: [url: string];
-  typing: [];
+  selectGif: [
+    url: string,
+    threadOverride: { threadId: string; parentThreadId?: string },
+  ];
+  // Typing notifications from inside a thread carry the active thread so
+  // the outbound XEP-0085 chat-state can include an XEP-0201 `<thread/>`
+  // and peers can show "typing in thread X" instead of channel-wide.
+  typing: [threadOverride?: { threadId: string; parentThreadId?: string }];
   loadOlder: [threadId: string];
 }>();
 
@@ -517,6 +523,30 @@ function onSend(body: string, markup: MarkupSpan[], references: MessageReference
   draft.value = "";
 }
 
+// GIF picks mirror onSend's thread routing: derive the active thread (and
+// parent, when nested) so the GIF message joins the open thread instead of
+// landing in the parent channel timeline.
+function onSelectGif(url: string) {
+  const threadId = activeThreadId.value;
+  if (!threadId) return;
+  const override: { threadId: string; parentThreadId?: string } = { threadId };
+  if (parentThreadId.value) override.parentThreadId = parentThreadId.value;
+  emit("selectGif", url, override);
+}
+
+// Forward composer typing with the active thread context attached so the
+// outbound XEP-0085 chat-state stanza can include the matching `<thread/>`.
+function onTyping() {
+  const threadId = activeThreadId.value;
+  if (!threadId) {
+    emit("typing");
+    return;
+  }
+  const override: { threadId: string; parentThreadId?: string } = { threadId };
+  if (parentThreadId.value) override.parentThreadId = parentThreadId.value;
+  emit("typing", override);
+}
+
 function onOpenThreadFromCard(threadId: string) {
   // Already-open thread id is a no-op; otherwise push it onto the stack.
   if (threadId === activeThreadId.value) return;
@@ -638,8 +668,8 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :is-top-pinned="true"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"
-        @typing="emit('typing')"
-        @select-gif="(url: string) => emit('selectGif', url)"
+        @typing="onTyping"
+        @select-gif="onSelectGif"
       />
     </div>
 
@@ -820,8 +850,8 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :is-top-pinned="false"
         @send="onSend"
         @cancel-reply="cancelReplyInThread"
-        @typing="emit('typing')"
-        @select-gif="(url: string) => emit('selectGif', url)"
+        @typing="onTyping"
+        @select-gif="onSelectGif"
       />
     </div>
   </div>

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -63,7 +63,11 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
     onScopeDispose(() => clearTypingState());
   }
 
-  function notifyComposing() {
+  // DMs have no thread surface — the optional `thread` arg keeps a uniform
+  // signature with the channel-side notifyComposing so the shell controller
+  // can call `activeTarget.value.notifyComposing(thread)` against either
+  // target without branching on sidebar mode.
+  function notifyComposing(_thread?: { id: string; parent?: string }) {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     if (!client || !peerJid) return;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -791,23 +791,27 @@ export class BrowserXmppClient {
     throw new Error("XMPP session is not ready");
   }
 
-  private async compatSendChatState(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", state: ChatStateType) {
-    if (xmpp.send_chat_state) return xmpp.send_chat_state(to, type, state);
+  // XEP-0201 §3: chat-states, displayed markers, reactions, retractions, and
+  // corrections that relate to a threaded message SHOULD repeat the original
+  // `<thread/>`. The wasm bindings accept thread id + optional parent so the
+  // related stanzas route to the same conversation context on receivers.
+  private async compatSendChatState(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", state: ChatStateType, thread?: { id: string; parent?: string }) {
+    if (xmpp.send_chat_state) return xmpp.send_chat_state(to, type, state, thread?.id, thread?.parent);
     throw new Error("XMPP session is not ready");
   }
 
-  private async compatSendDisplayed(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string) {
-    if (xmpp.send_displayed) return xmpp.send_displayed(to, type, id);
+  private async compatSendDisplayed(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string, thread?: { id: string; parent?: string }) {
+    if (xmpp.send_displayed) return xmpp.send_displayed(to, type, id, thread?.id, thread?.parent);
     throw new Error("XMPP session is not ready");
   }
 
-  private async compatSendReaction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string, emojis: string[]) {
-    if (xmpp.send_reaction) return xmpp.send_reaction(to, type, id, emojis);
+  private async compatSendReaction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string, emojis: string[], thread?: { id: string; parent?: string }) {
+    if (xmpp.send_reaction) return xmpp.send_reaction(to, type, id, emojis, thread?.id, thread?.parent);
     throw new Error("XMPP session is not ready");
   }
 
-  private async compatSendRetraction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string) {
-    if (xmpp.send_retraction) return xmpp.send_retraction(to, type, id);
+  private async compatSendRetraction(xmpp: XmppClientInstance, to: string, type: "chat" | "groupchat", id: string, thread?: { id: string; parent?: string }) {
+    if (xmpp.send_retraction) return xmpp.send_retraction(to, type, id, thread?.id, thread?.parent);
     throw new Error("XMPP session is not ready");
   }
 
@@ -898,9 +902,9 @@ export class BrowserXmppClient {
     return this.queueDirectMessage(normalizedPeerJid, body, opts);
   }
 
-  async sendChatState(spaceId: string, channelId: string, state: ChatStateType) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendChatState(xmpp, roomJid, "groupchat", state); }
-  async sendDisplayed(spaceId: string, channelId: string, messageId: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendDisplayed(xmpp, roomJid, "groupchat", messageId); }
-  async sendReaction(spaceId: string, channelId: string, messageId: string, emojis: string[]) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendReaction(xmpp, roomJid, "groupchat", messageId, emojis); }
+  async sendChatState(spaceId: string, channelId: string, state: ChatStateType, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendChatState(xmpp, roomJid, "groupchat", state, thread); }
+  async sendDisplayed(spaceId: string, channelId: string, messageId: string, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendDisplayed(xmpp, roomJid, "groupchat", messageId, thread); }
+  async sendReaction(spaceId: string, channelId: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendReaction(xmpp, roomJid, "groupchat", messageId, emojis, thread); }
   /** #414: pin a message in the room. Server gates on Owner/Admin
    * affiliation; non-admins receive a `<forbidden/>` error which
    * surfaces as a rejected Promise. */
@@ -936,9 +940,19 @@ export class BrowserXmppClient {
     const page = (await xmpp.fetch_room_messages_by_stanza_ids(roomJid, stanzaIds)) as import("./wasm-types").WasmMamPage | null;
     return Array.isArray(page?.messages) ? page.messages : [];
   }
-  async sendRetraction(spaceId: string, channelId: string, retractsId: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendRetraction(xmpp, roomJid, "groupchat", retractsId); }
+  async sendRetraction(spaceId: string, channelId: string, retractsId: string, thread?: { id: string; parent?: string }) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendRetraction(xmpp, roomJid, "groupchat", retractsId, thread); }
   async sendModeration(spaceId: string, channelId: string, targetId: string, reason?: string) { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); await this.compatSendModeration(xmpp, roomJid, targetId, reason); }
-  async sendCorrection(spaceId: string, channelId: string, body: string, replacesId: string, markup?: SendGroupMessageOptions["markup"], references?: SendGroupMessageOptions["references"]): Promise<string | null> { const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId); return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, { markup, references }); }
+  // Corrections (XEP-0308) flow through compatSendCorrection's options dict,
+  // which already serializes thread/parent into the wasm send options used by
+  // build_outbound_message — so passing { threadId, parentThreadId } here is
+  // all the wire-level conformance needs.
+  async sendCorrection(spaceId: string, channelId: string, body: string, replacesId: string, markup?: SendGroupMessageOptions["markup"], references?: SendGroupMessageOptions["references"], thread?: { id: string; parent?: string }): Promise<string | null> {
+    const { xmpp, roomJid } = await this.requireJoinedRoom(spaceId, channelId);
+    const opts: SendGroupMessageOptions = { markup, references };
+    if (thread?.id) opts.threadId = thread.id;
+    if (thread?.parent) opts.parentThreadId = thread.parent;
+    return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, opts);
+  }
   async sendDmChatState(peerJid: string, state: ChatStateType): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, barePeerJid(peerJid), "chat", state); }
   async sendDmDisplayed(peerJid: string, messageId: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, barePeerJid(peerJid), "chat", messageId); }
   async sendDmRetraction(peerJid: string, messageId: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, barePeerJid(peerJid), "chat", messageId); }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -856,7 +856,14 @@ export function useChatAppController(giphyApiKey: string) {
     await messaging.sendMessage(body, markup, references, files, replyTo, threadOverride);
   }
 
-  function sendGif(url: string) {
+  function sendGif(
+    url: string,
+    threadOverride?: { threadId: string; parentThreadId?: string },
+  ) {
+    if (threadOverride) {
+      void sendThreadMessage(url, [], [], undefined, undefined, threadOverride);
+      return;
+    }
     void sendActiveMessage(url, [], []);
   }
 
@@ -925,8 +932,18 @@ export function useChatAppController(giphyApiKey: string) {
     normalizeActiveRightPanel("thread");
   }
 
-  function notifyActiveComposing() {
-    activeTarget.value.notifyComposing();
+  function notifyActiveComposing(
+    threadOverride?: { threadId: string; parentThreadId?: string },
+  ) {
+    // XEP-0201 §3: when typing originates in a thread composer, the
+    // outbound XEP-0085 stanza echoes the active thread so peers can
+    // scope the indicator instead of treating it as channel-wide.
+    const thread = threadOverride
+      ? threadOverride.parentThreadId
+        ? { id: threadOverride.threadId, parent: threadOverride.parentThreadId }
+        : { id: threadOverride.threadId }
+      : undefined;
+    activeTarget.value.notifyComposing(thread);
   }
 
   function editActiveMessage(messageId: string, newBody: string, markup?: MarkupSpan[], references?: MessageReference[]) {

--- a/chat/tests/edit-targeting.test.ts
+++ b/chat/tests/edit-targeting.test.ts
@@ -66,6 +66,8 @@ describe("edit targeting", () => {
       "original-message-id",
       undefined,
       undefined,
+      // XEP-0201 thread arg — absent for a non-threaded target message.
+      undefined,
     );
   });
 

--- a/chat/tests/muc-send.test.ts
+++ b/chat/tests/muc-send.test.ts
@@ -191,6 +191,52 @@ describe("useMucSend.sendMessage — failure paths", () => {
   });
 });
 
+describe("useMucSend.sendMessage — thread routing (GIF picks)", () => {
+  // Regression: GIFs picked from inside a thread used to land in the parent
+  // channel because sendGif never forwarded a threadOverride. The composer's
+  // text path always built one in ThreadPanel.onSend; the GIF emit chain now
+  // mirrors it, so sendMessage gets threadOverride.threadId in arg 6.
+  test("threadOverride.threadId is forwarded to client.sendGroupMessage as opts.threadId", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "sid-gif", state: "sending" }));
+    const client = makeClient({ sendGroupMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+
+    await h.send.sendMessage(
+      "https://giphy.example/animated.gif",
+      [],
+      [],
+      undefined,
+      undefined,
+      { threadId: "thread-42" },
+    );
+
+    expect(sendGroupMessage).toHaveBeenCalledTimes(1);
+    const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    // sendGroupMessage(spaceId, channelId, body, opts) — threadId on opts (arg 4)
+    expect(call[3].threadId).toBe("thread-42");
+    expect(call[2]).toBe("https://giphy.example/animated.gif");
+  });
+
+  test("threadOverride.parentThreadId is forwarded for nested sub-threads", async () => {
+    const sendGroupMessage = mock(async () => ({ id: "sid-gif", state: "sending" }));
+    const client = makeClient({ sendGroupMessage } as Partial<BrowserXmppClient>);
+    const h = harness({ client });
+
+    await h.send.sendMessage(
+      "https://giphy.example/nested.gif",
+      [],
+      [],
+      undefined,
+      undefined,
+      { threadId: "thread-child", parentThreadId: "thread-parent" },
+    );
+
+    const call = (sendGroupMessage as unknown as ReturnType<typeof mock>).mock.calls[0]!;
+    expect(call[3].threadId).toBe("thread-child");
+    expect(call[3].parentThreadId).toBe("thread-parent");
+  });
+});
+
 describe("useMucSend.editMessage", () => {
   test("delegates to client.sendCorrection with the message's correctionTargetId", async () => {
     const sendCorrection = mock(async () => undefined);

--- a/chat/tests/reply-addressing.test.ts
+++ b/chat/tests/reply-addressing.test.ts
@@ -337,7 +337,8 @@ describe("room stanza-id targeting", () => {
     await messaging.retractMessage("client-id-1");
     await messaging.moderateMessage("client-id-1", "spam");
 
-    expect(sendRetraction).toHaveBeenCalledWith("w1", "c1", "room-stanza-1");
+    // XEP-0201 thread arg — absent for a non-threaded target message.
+    expect(sendRetraction).toHaveBeenCalledWith("w1", "c1", "room-stanza-1", undefined);
     expect(sendModeration).toHaveBeenCalledWith("w1", "c1", "room-stanza-1", "spam");
   });
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -29,22 +29,38 @@ impl WaddleClient {
         })
     }
 
-    pub fn send_chat_state(&self, to: String, msg_type: String, state: String) -> Promise {
+    pub fn send_chat_state(
+        &self,
+        to: String,
+        msg_type: String,
+        state: String,
+        thread_id: Option<String>,
+        thread_parent: Option<String>,
+    ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let _ = NS_CHAT_STATES;
-            let stanza = build_chat_state_message(&to, &state, &msg_type)
+            let thread = thread_ref_from_args(thread_id, thread_parent);
+            let stanza = build_chat_state_message(&to, &state, &msg_type, thread.as_ref())
                 .map_err(|err| js_error(err.to_string()))?;
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
     }
 
-    pub fn send_displayed(&self, to: String, msg_type: String, message_id: String) -> Promise {
+    pub fn send_displayed(
+        &self,
+        to: String,
+        msg_type: String,
+        message_id: String,
+        thread_id: Option<String>,
+        thread_parent: Option<String>,
+    ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let _ = NS_CHAT_MARKERS;
-            let stanza = build_displayed_message(&to, &message_id, &msg_type);
+            let thread = thread_ref_from_args(thread_id, thread_parent);
+            let stanza = build_displayed_message(&to, &message_id, &msg_type, thread.as_ref());
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -119,11 +135,15 @@ impl WaddleClient {
         msg_type: String,
         target_id: String,
         emojis: Vec<String>,
+        thread_id: Option<String>,
+        thread_parent: Option<String>,
     ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let _ = (NS_REACTIONS, NS_HINTS);
-            let stanza = build_reaction_message(&to, &msg_type, &target_id, &emojis);
+            let thread = thread_ref_from_args(thread_id, thread_parent);
+            let stanza =
+                build_reaction_message(&to, &msg_type, &target_id, &emojis, thread.as_ref());
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
@@ -154,11 +174,19 @@ impl WaddleClient {
         })
     }
 
-    pub fn send_retraction(&self, to: String, msg_type: String, retracts_id: String) -> Promise {
+    pub fn send_retraction(
+        &self,
+        to: String,
+        msg_type: String,
+        retracts_id: String,
+        thread_id: Option<String>,
+        thread_parent: Option<String>,
+    ) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let _ = (NS_RETRACT, NS_HINTS);
-            let stanza = build_retraction_message(&to, &msg_type, &retracts_id);
+            let thread = thread_ref_from_args(thread_id, thread_parent);
+            let stanza = build_retraction_message(&to, &msg_type, &retracts_id, thread.as_ref());
             send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })

--- a/server/crates/waddle-xmpp-client-wasm/src/options.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/options.rs
@@ -1,5 +1,21 @@
 use super::*;
 
+/// Build an optional `ThreadRef` from a pair of `Option<String>` wasm
+/// arguments. An empty/missing `thread_id` yields `None` so callers can
+/// thread context through without conditionals at every site. A
+/// `thread_parent` without a `thread_id` is ignored — XEP-0201 only
+/// defines `parent` as a qualifier on a present `<thread/>`.
+pub(crate) fn thread_ref_from_args(
+    thread_id: Option<String>,
+    thread_parent: Option<String>,
+) -> Option<ThreadRef> {
+    let id = thread_id.filter(|s| !s.is_empty())?;
+    Some(ThreadRef {
+        id,
+        parent: thread_parent.filter(|s| !s.is_empty()),
+    })
+}
+
 pub(crate) fn send_options_from_js(options: JsValue) -> Result<SendMessageOptions, JsValue> {
     let options = if options.is_null() || options.is_undefined() {
         WaddleSendOptions::default()

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -14,6 +14,7 @@ pub fn build_chat_state_message(
     to: &str,
     state: &str,
     message_type: &str,
+    thread: Option<&xep_thread::ThreadRef>,
 ) -> ClientResult<Element> {
     let state = validate_chat_state(state)?;
     let stanza_id = Uuid::new_v4().to_string();
@@ -21,6 +22,9 @@ pub fn build_chat_state_message(
         .attr("to", to)
         .attr("type", message_type)
         .append(Element::builder(state, NS_CHAT_STATES).build());
+    if let Some(thread) = thread {
+        builder = builder.append(xep_thread::build_thread_element(thread));
+    }
     if should_stamp_origin_id(message_type) {
         builder = builder
             .attr("id", stanza_id.as_str())
@@ -29,7 +33,12 @@ pub fn build_chat_state_message(
     Ok(builder.build())
 }
 
-pub fn build_displayed_message(to: &str, message_id: &str, message_type: &str) -> Element {
+pub fn build_displayed_message(
+    to: &str,
+    message_id: &str,
+    message_type: &str,
+    thread: Option<&xep_thread::ThreadRef>,
+) -> Element {
     let stanza_id = Uuid::new_v4().to_string();
     let mut builder = Element::builder("message", NS_CLIENT)
         .attr("to", to)
@@ -39,6 +48,9 @@ pub fn build_displayed_message(to: &str, message_id: &str, message_type: &str) -
                 .attr("id", message_id)
                 .build(),
         );
+    if let Some(thread) = thread {
+        builder = builder.append(xep_thread::build_thread_element(thread));
+    }
     if should_stamp_origin_id(message_type) {
         builder = builder
             .attr("id", stanza_id.as_str())
@@ -52,6 +64,7 @@ pub fn build_reaction_message(
     message_type: &str,
     target_id: &str,
     emojis: &[String],
+    thread: Option<&xep_thread::ThreadRef>,
 ) -> Element {
     let stanza_id = Uuid::new_v4().to_string();
     let mut reactions = Element::builder("reactions", NS_REACTIONS)
@@ -65,12 +78,16 @@ pub fn build_reaction_message(
         );
     }
 
-    Element::builder("message", NS_CLIENT)
+    let mut builder = Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
         .attr("id", stanza_id.as_str())
         .append(build_origin_id(&stanza_id))
-        .append(reactions)
+        .append(reactions);
+    if let Some(thread) = thread {
+        builder = builder.append(xep_thread::build_thread_element(thread));
+    }
+    builder
         .append(Element::builder("store", NS_HINTS).build())
         .build()
 }
@@ -109,9 +126,14 @@ pub fn build_unpinned_message(to: &str, target_stanza_id: &str) -> Element {
         .build()
 }
 
-pub fn build_retraction_message(to: &str, message_type: &str, retracts_id: &str) -> Element {
+pub fn build_retraction_message(
+    to: &str,
+    message_type: &str,
+    retracts_id: &str,
+    thread: Option<&xep_thread::ThreadRef>,
+) -> Element {
     let stanza_id = Uuid::new_v4().to_string();
-    Element::builder("message", NS_CLIENT)
+    let mut builder = Element::builder("message", NS_CLIENT)
         .attr("to", to)
         .attr("type", message_type)
         .attr("id", stanza_id.as_str())
@@ -125,7 +147,11 @@ pub fn build_retraction_message(to: &str, message_type: &str, retracts_id: &str)
             Element::builder("body", NS_CLIENT)
                 .append("This person attempted to retract a previous message.")
                 .build(),
-        )
+        );
+    if let Some(thread) = thread {
+        builder = builder.append(xep_thread::build_thread_element(thread));
+    }
+    builder
         .append(Element::builder("store", NS_HINTS).build())
         .build()
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/native.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/native.rs
@@ -10,6 +10,7 @@ use super::builders::{
 };
 use super::namespaces::*;
 use super::types::SendMessageOptions;
+use crate::xep::thread::ThreadRef;
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub trait MessagingExt {
@@ -45,18 +46,21 @@ pub trait MessagingExt {
         jid: &'a str,
         state: &'a str,
         message_type: &'a str,
+        thread: Option<&'a ThreadRef>,
     ) -> impl std::future::Future<Output = ClientResult<()>> + Send + 'a;
     fn send_displayed_marker<'a>(
         &'a self,
         jid: &'a str,
         message_id: &'a str,
         message_type: &'a str,
+        thread: Option<&'a ThreadRef>,
     ) -> impl std::future::Future<Output = ClientResult<()>> + Send + 'a;
     fn retract_message<'a>(
         &'a self,
         jid: &'a str,
         message_id: &'a str,
         message_type: &'a str,
+        thread: Option<&'a ThreadRef>,
     ) -> impl std::future::Future<Output = ClientResult<()>> + Send + 'a;
 }
 
@@ -118,8 +122,9 @@ impl MessagingExt for ClientHandle {
         jid: &str,
         state: &str,
         message_type: &str,
+        thread: Option<&ThreadRef>,
     ) -> ClientResult<()> {
-        let stanza = build_chat_state_message(jid, state, message_type)?;
+        let stanza = build_chat_state_message(jid, state, message_type, thread)?;
         self.send_stanza(stanza).await
     }
 
@@ -128,8 +133,9 @@ impl MessagingExt for ClientHandle {
         jid: &str,
         message_id: &str,
         message_type: &str,
+        thread: Option<&ThreadRef>,
     ) -> ClientResult<()> {
-        let stanza = build_displayed_message(jid, message_id, message_type);
+        let stanza = build_displayed_message(jid, message_id, message_type, thread);
         self.send_stanza(stanza).await
     }
 
@@ -138,8 +144,9 @@ impl MessagingExt for ClientHandle {
         jid: &str,
         message_id: &str,
         message_type: &str,
+        thread: Option<&ThreadRef>,
     ) -> ClientResult<()> {
-        let stanza = build_retraction_message(jid, message_type, message_id);
+        let stanza = build_retraction_message(jid, message_type, message_id, thread);
         self.send_stanza(stanza).await
     }
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -1236,18 +1236,53 @@ fn xep0394_markup_roundtrip_parse_and_build() {
 
 #[test]
 fn build_chat_state_message_validates_state() {
-    let stanza = build_chat_state_message("alice@example.com", "composing", "chat")
+    let stanza = build_chat_state_message("alice@example.com", "composing", "chat", None)
         .expect("valid chat state");
     assert_eq!(stanza.attr("to"), Some("alice@example.com"));
     assert_eq!(stanza.attr("type"), Some("chat"));
     assert_origin_id_matches_message_id(&stanza);
     assert!(stanza.get_child("composing", NS_CHAT_STATES).is_some());
-    assert!(build_chat_state_message("alice@example.com", "typing", "chat").is_err());
+    assert!(build_chat_state_message("alice@example.com", "typing", "chat", None).is_err());
+}
+
+#[test]
+fn build_chat_state_message_includes_thread_when_present() {
+    // XEP-0201 §3 — chat-state notifications related to a threaded
+    // conversation SHOULD echo the same `<thread/>`. Without it, peers
+    // see typing as channel-wide instead of "in thread X".
+    let thread = crate::xep::thread::ThreadRef {
+        id: "thread-42".to_string(),
+        parent: None,
+    };
+    let stanza =
+        build_chat_state_message("room@muc.example", "composing", "groupchat", Some(&thread))
+            .expect("valid chat state");
+    let thread_el = stanza
+        .get_child("thread", "jabber:client")
+        .expect("thread child present");
+    assert_eq!(thread_el.text(), "thread-42");
+    assert!(thread_el.attr("parent").is_none());
+}
+
+#[test]
+fn build_chat_state_message_carries_parent_for_nested_threads() {
+    let thread = crate::xep::thread::ThreadRef {
+        id: "child".to_string(),
+        parent: Some("root".to_string()),
+    };
+    let stanza =
+        build_chat_state_message("room@muc.example", "composing", "groupchat", Some(&thread))
+            .expect("valid chat state");
+    let thread_el = stanza
+        .get_child("thread", "jabber:client")
+        .expect("thread child present");
+    assert_eq!(thread_el.text(), "child");
+    assert_eq!(thread_el.attr("parent"), Some("root"));
 }
 
 #[test]
 fn build_displayed_message_has_expected_shape() {
-    let stanza = build_displayed_message("room@muc.example", "msg-1", "groupchat");
+    let stanza = build_displayed_message("room@muc.example", "msg-1", "groupchat", None);
     assert_eq!(stanza.attr("to"), Some("room@muc.example"));
     assert_origin_id_matches_message_id(&stanza);
     assert!(stanza.get_child("displayed", NS_CHAT_MARKERS).is_some());
@@ -1257,6 +1292,23 @@ fn build_displayed_message_has_expected_shape() {
             .and_then(|child| child.attr("id")),
         Some("msg-1")
     );
+    assert!(stanza.get_child("thread", "jabber:client").is_none());
+}
+
+#[test]
+fn build_displayed_message_includes_thread_when_present() {
+    // XEP-0201 §3 — read markers for a threaded message SHOULD carry the
+    // same `<thread/>` so other clients can scope the marker to the right
+    // thread instead of treating it as a channel-wide displayed.
+    let thread = crate::xep::thread::ThreadRef {
+        id: "thread-99".to_string(),
+        parent: None,
+    };
+    let stanza = build_displayed_message("room@muc.example", "msg-1", "groupchat", Some(&thread));
+    let thread_el = stanza
+        .get_child("thread", "jabber:client")
+        .expect("thread child present");
+    assert_eq!(thread_el.text(), "thread-99");
 }
 
 #[test]
@@ -1295,7 +1347,7 @@ fn build_correction_message_with_markup_spans() {
 #[test]
 fn build_reaction_message_has_expected_shape() {
     let emojis = vec!["👍".to_string(), "❤️".to_string()];
-    let stanza = build_reaction_message("room@muc.example", "groupchat", "msg-1", &emojis);
+    let stanza = build_reaction_message("room@muc.example", "groupchat", "msg-1", &emojis, None);
     assert_origin_id_matches_message_id(&stanza);
     let reactions = stanza
         .get_child("reactions", NS_REACTIONS)
@@ -1308,11 +1360,35 @@ fn build_reaction_message_has_expected_shape() {
         .collect();
     assert_eq!(values, vec!["👍", "❤️"]);
     assert!(stanza.get_child("store", NS_HINTS).is_some());
+    assert!(stanza.get_child("thread", "jabber:client").is_none());
+}
+
+#[test]
+fn build_reaction_message_includes_thread_when_present() {
+    // XEP-0201 §3 + XEP-0444 — reactions targeting a threaded message
+    // SHOULD repeat the message's `<thread/>` so the reaction routes to
+    // the same conversation context on receiving clients.
+    let emojis = vec!["🎉".to_string()];
+    let thread = crate::xep::thread::ThreadRef {
+        id: "thread-react".to_string(),
+        parent: None,
+    };
+    let stanza = build_reaction_message(
+        "room@muc.example",
+        "groupchat",
+        "msg-1",
+        &emojis,
+        Some(&thread),
+    );
+    let thread_el = stanza
+        .get_child("thread", "jabber:client")
+        .expect("thread child present");
+    assert_eq!(thread_el.text(), "thread-react");
 }
 
 #[test]
 fn build_retraction_message_has_expected_shape() {
-    let stanza = build_retraction_message("room@muc.example", "groupchat", "msg-1");
+    let stanza = build_retraction_message("room@muc.example", "groupchat", "msg-1", None);
     assert_origin_id_matches_message_id(&stanza);
     assert_eq!(
         stanza
@@ -1327,6 +1403,23 @@ fn build_retraction_message_has_expected_shape() {
         Some("This person attempted to retract a previous message.".to_string())
     );
     assert!(stanza.get_child("store", NS_HINTS).is_some());
+    assert!(stanza.get_child("thread", "jabber:client").is_none());
+}
+
+#[test]
+fn build_retraction_message_includes_thread_when_present() {
+    // XEP-0201 §3 + XEP-0424 — retracting a threaded message SHOULD
+    // repeat the message's `<thread/>` so the tombstone routes to the
+    // same thread on receiving clients.
+    let thread = crate::xep::thread::ThreadRef {
+        id: "thread-retract".to_string(),
+        parent: None,
+    };
+    let stanza = build_retraction_message("room@muc.example", "groupchat", "msg-1", Some(&thread));
+    let thread_el = stanza
+        .get_child("thread", "jabber:client")
+        .expect("thread child present");
+    assert_eq!(thread_el.text(), "thread-retract");
 }
 
 #[test]

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -171,9 +171,9 @@ export class WaddleClient {
     send_call_session_initiate(peer_full_jid: string, initiator_full_jid: string, sid_str: string, audio: boolean, video: boolean): Promise<any>;
     send_call_session_terminate(peer_full_jid: string, sid_str: string, reason?: string | null): Promise<any>;
     send_chat_message(peer_jid: string, body: string, options: any): Promise<any>;
-    send_chat_state(to: string, msg_type: string, state: string): Promise<any>;
+    send_chat_state(to: string, msg_type: string, state: string, thread_id?: string | null, thread_parent?: string | null): Promise<any>;
     send_correction(to: string, msg_type: string, body: string, replaces_id: string, options: any): Promise<any>;
-    send_displayed(to: string, msg_type: string, message_id: string): Promise<any>;
+    send_displayed(to: string, msg_type: string, message_id: string, thread_id?: string | null, thread_parent?: string | null): Promise<any>;
     send_groupchat_message(room_jid: string, body: string, options: any): Promise<any>;
     send_moderation(to: string, msg_type: string, target_id: string, reason?: string | null): Promise<any>;
     /**
@@ -200,8 +200,8 @@ export class WaddleClient {
     send_muc_call_leave(room_jid: string): Promise<any>;
     send_presence(status?: string | null, show?: string | null): Promise<any>;
     send_raw_iq(xml: string): Promise<any>;
-    send_reaction(to: string, msg_type: string, target_id: string, emojis: string[]): Promise<any>;
-    send_retraction(to: string, msg_type: string, retracts_id: string): Promise<any>;
+    send_reaction(to: string, msg_type: string, target_id: string, emojis: string[], thread_id?: string | null, thread_parent?: string | null): Promise<any>;
+    send_retraction(to: string, msg_type: string, retracts_id: string, thread_id?: string | null, thread_parent?: string | null): Promise<any>;
     /**
      * Register a callback for inbound XMPP-native call events
      * (XEP-0353 JMI envelopes + XEP-0166 Jingle session control

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpceyevq";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=mpd9mlpz";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=mpd9mlpz";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=mpd9mlpz";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=mpceyevq";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=mpd9mlpz";


### PR DESCRIPTION
## Summary

- **GIF-to-thread routing fix** — GIFs picked from inside a thread used to land in the parent channel. The composer's `selectGif` emit chain dropped thread context; only the text-send path built a `threadOverride`. The fix carries the override through `ThreadPanel.vue` to the controller's `sendGif`, which now routes via `sendThreadMessage` when an override is present.
- **XEP-0201 §3 conformance** — chat-states (XEP-0085), displayed markers (XEP-0333), reactions (XEP-0444), retractions (XEP-0424), and corrections (XEP-0308) targeting a threaded message now echo the target's `<thread/>` so they scope to the thread instead of being treated as channel-wide.

## Root cause (GIF bug)

1. `MessageComposer.vue:538` emits `selectGif(url)` — URL only.
2. `ThreadPanel.vue` (lines 642, 824) forwarded that emit verbatim — dropping thread context.
3. `ChatReadyShell.vue:622` wires `@select-gif="sendGif"`.
4. `chat-app-controller.ts:859` `sendGif(url)` calls `sendActiveMessage(url, [], [])` — never passes a `threadOverride`.
5. `muc-send.ts:157` falls back to `undefined` threadId for non-forum rooms → wire stanza has no `<thread/>`, so the message lands in the parent channel.

## Fix

1. **`ThreadPanel.vue`** — widen `selectGif` event signature, add `onSelectGif` handler that derives `{ threadId, parentThreadId? }` from `activeThreadId` / `parentThreadId`, replace inline arrows at both composer mounts.
2. **`chat-app-controller.ts`** — widen `sendGif` to accept an optional `threadOverride`; when present, route through the existing `sendThreadMessage`.
3. **No change** in `ChatReadyShell.vue` — Vue forwards the extra emit arg through to `sendGif` automatically.

## XEP-0201 conformance work

Per CLAUDE.md's XEP conformance hard rule, plumbed a thread reference through the four client-side Rust builders that lacked it, the wasm bindings, the TS compat layer, and each caller:

| Layer | Change |
| --- | --- |
| `waddle-xmpp-client/src/messaging/builders.rs` | `build_chat_state_message`, `build_displayed_message`, `build_reaction_message`, `build_retraction_message` accept `Option<&ThreadRef>` and append `<thread/>` when present. `build_correction_message` already supported via `SendMessageOptions.thread`. |
| `waddle-xmpp-client/src/messaging/native.rs` | `MessagingExt` trait + impl widened. |
| `waddle-xmpp-client-wasm/src/client_messaging.rs` | 5 wasm bindings accept `thread_id`, `thread_parent` flat optional args. Helper `thread_ref_from_args` lives in `options.rs`. |
| `chat/src/lib/xmpp/client.ts` | 5 compat wrappers + 5 public methods (`sendChatState`/`sendDisplayed`/`sendReaction`/`sendRetraction`/`sendCorrection`) accept `thread?: { id; parent? }`. |
| `chat/src/channels/chat-states.ts` | `notifyComposing(thread?)` carries thread through XEP-0085 composing/paused. |
| `chat/src/channels/message-actions.ts` | `toggleReaction` / `retractMessage` look up the target's `threadId` and pass it. |
| `chat/src/channels/muc-send.ts` | `editMessage` (XEP-0308) looks up target's thread and passes it. |
| `chat/src/channels/read-markers.ts` | `markDisplayed` looks up target's thread. |
| `chat/src/dms/chat-states.ts` | Uniform `notifyComposing(_thread?)` signature (DMs ignore thread). |
| `ThreadPanel.vue` | `typing` event widened to carry active thread; `notifyActiveComposing(threadOverride?)` plumbs it through to the channel/DM target. |

## Test plan

- [x] `cd chat && bun run lint` — knip clean
- [x] `cd chat && bun test` — 980 tests pass; new tests assert `threadId` is forwarded for GIF-in-thread sends and that the legacy non-threaded calls still match (trailing `undefined` thread arg)
- [x] `cd chat && bunx --bun vue-tsc --noEmit -p . --ignoreDeprecations 6.0` — clean
- [x] Rust: `cargo test -p waddle-xmpp-client --lib` — 282 pass; new builder tests assert `<thread/>` is appended when present and absent when not
- [x] `cargo fmt --check` clean
- [ ] Manual: open a thread, pick a GIF — appears in thread, not main; verify chat-state/reactions/edits inside thread also carry `<thread/>` on the wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)