### PR TITLE
fix(chat): preserve authoritative createdAt across producers

### DIFF
--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -20,7 +20,7 @@ import {
   retractChannelTimelineMessage,
 } from "@/channels/message-timeline-state";
 import { classifyRoomMessage } from "@/lib/xmpp/classify-room-message";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { compareTimelineMessages, pickAuthoritativeTimestamp } from "@/lib/timeline-timestamps";
 import {
   canUseSelfEchoBodyFallback,
 } from "@/lib/self-echo-fallback";
@@ -209,10 +209,20 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
       messages.value = messages.value.map((m) => {
         if (m.id !== existing.id) return m;
         const mergedIds = mergeMessageIds(m, msg.id, msg.wireIds);
+        // Pick the more authoritative `createdAt` so a redelivered
+        // live stanza (`fallback`) can't overwrite a true server
+        // stamp (`archive`/`delay`) that landed via MAM first. See
+        // `dms/live-merge.ts` for the same rule.
+        const authoritativeTimestamp = pickAuthoritativeTimestamp(
+          { createdAt: m.createdAt, createdAtSource: m.createdAtSource },
+          { createdAt: msg.createdAt, createdAtSource: msg.createdAtSource },
+        );
         const updated: TimelineMessage = {
           ...m,
           ...msg,
           id: mergedIds.id,
+          createdAt: authoritativeTimestamp.createdAt,
+          createdAtSource: authoritativeTimestamp.createdAtSource,
         };
         if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
         else delete updated.wireIds;

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -16,7 +16,7 @@ import {
   applyForumContext,
   mapLiveRoomMessageToTimeline,
 } from "@/channels/timeline";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { compareTimelineMessages, pickAuthoritativeTimestamp } from "@/lib/timeline-timestamps";
 
 function mergeReplyToMetadata(
   existing: TimelineMessage["replyTo"],
@@ -93,7 +93,26 @@ function mergeRetractionTombstone(
   existing: TimelineMessage,
   incoming: TimelineMessage,
 ): TimelineMessage {
-  return incoming.isRetracted ? retractChannelTimelineMessage(existing, incoming.retractionId) : existing;
+  let result = incoming.isRetracted
+    ? retractChannelTimelineMessage(existing, incoming.retractionId)
+    : existing;
+  // Upgrade the timestamp if the MAM hit carries a higher-authority
+  // stamp than the row we already had — see `dms/message-timeline-state.ts`.
+  const authoritativeTimestamp = pickAuthoritativeTimestamp(
+    { createdAt: result.createdAt, createdAtSource: result.createdAtSource },
+    { createdAt: incoming.createdAt, createdAtSource: incoming.createdAtSource },
+  );
+  if (
+    authoritativeTimestamp.createdAt !== result.createdAt
+    || authoritativeTimestamp.createdAtSource !== result.createdAtSource
+  ) {
+    result = {
+      ...result,
+      createdAt: authoritativeTimestamp.createdAt,
+      createdAtSource: authoritativeTimestamp.createdAtSource,
+    };
+  }
+  return result;
 }
 
 export interface TimelineBuildOptions {
@@ -112,6 +131,7 @@ export function queuedRoomMessageToTimeline(
     authorJid: `${roomJid}/${session.username}`,
     body: queued.body || (queued.files?.[0]?.url ?? ""),
     createdAt: queued.createdAt,
+    createdAtSource: "queued",
     isSelf: true,
     deliveryStatus: "queued",
   };

--- a/chat/src/channels/muc-send.ts
+++ b/chat/src/channels/muc-send.ts
@@ -187,6 +187,7 @@ export function useMucSend(deps: UseMucSendDeps) {
           authorJid: `${currentRoomJid.value}/${session.value.username}`,
           body: bodyText || (attachments?.[0]?.url ?? ""),
           createdAt: new Date().toISOString(),
+          createdAtSource: "queued",
           isSelf: true,
           deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
           ...(markup && markup.length > 0 ? { markup } : {}),

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -15,6 +15,7 @@ export function mapLiveRoomMessageToTimeline(
     authorOccupantJid,
     body: msg.body,
     createdAt: msg.createdAt,
+    createdAtSource: msg.createdAtSource,
     isSelf: msg.nick === session.username,
   };
   if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -126,6 +126,7 @@ export function useChatSend(deps: UseChatSendDeps) {
             authorJid: session.value.jid,
             body: bodyText || (attachments?.[0]?.url ?? ""),
             createdAt: new Date().toISOString(),
+            createdAtSource: "queued",
             isSelf: true,
             deliveryStatus: (result?.state ?? "sending") as DeliveryStatus,
             ...(markup && markup.length > 0 ? { markup } : {}),

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -11,7 +11,7 @@ import {
   isSameDmCorrectionSender,
   retractDmTimelineMessage,
 } from "@/dms/message-timeline-state";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { compareTimelineMessages, pickAuthoritativeTimestamp } from "@/lib/timeline-timestamps";
 import {
   canUseSelfEchoBodyFallback,
 } from "@/lib/self-echo-fallback";
@@ -174,10 +174,21 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
       messages.value = messages.value.map((m) => {
         if (m.id !== existing.id) return m;
         const mergedIds = mergeMessageIds(m, msg.id, msg.wireIds);
+        // Pick the more authoritative `createdAt` so a redelivered
+        // live stanza (`fallback`) can't overwrite a true server
+        // stamp (`archive`/`delay`) that landed via MAM first. This
+        // is the path that produced the "old message lands at the
+        // bottom on tab restore" symptom (PR1 root cause).
+        const authoritativeTimestamp = pickAuthoritativeTimestamp(
+          { createdAt: m.createdAt, createdAtSource: m.createdAtSource },
+          { createdAt: msg.createdAt, createdAtSource: msg.createdAtSource },
+        );
         const updated: TimelineMessage = {
           ...m,
           ...msg,
           id: mergedIds.id,
+          createdAt: authoritativeTimestamp.createdAt,
+          createdAtSource: authoritativeTimestamp.createdAtSource,
         };
         if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
         else delete updated.wireIds;

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -9,7 +9,7 @@ import {
   findMessageById,
   MessageIdIndex,
 } from "@/lib/message-ids";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { compareTimelineMessages, pickAuthoritativeTimestamp } from "@/lib/timeline-timestamps";
 
 export function fromLiveDmMessage(
   session: WaddleSession,
@@ -22,6 +22,7 @@ export function fromLiveDmMessage(
     authorJid: msg.fromJid,
     body: msg.body,
     createdAt: msg.createdAt,
+    createdAtSource: msg.createdAtSource,
     isSelf: barePeerJid(msg.fromJid) === barePeerJid(session.jid),
   };
   if (msg.correctionTargetId) tm.correctionTargetId = msg.correctionTargetId;
@@ -62,6 +63,7 @@ export function queuedDmMessageToTimeline(
     authorJid: session.jid,
     body: queued.body || (queued.files?.[0]?.url ?? ""),
     createdAt: queued.createdAt,
+    createdAtSource: "queued",
     isSelf: true,
     deliveryStatus: "queued",
   };
@@ -123,7 +125,28 @@ function mergeDmRetractionTombstone(
   existing: TimelineMessage,
   incoming: TimelineMessage,
 ): TimelineMessage {
-  return incoming.isRetracted ? retractDmTimelineMessage(existing, incoming.retractionId) : existing;
+  let result = incoming.isRetracted
+    ? retractDmTimelineMessage(existing, incoming.retractionId)
+    : existing;
+  // Upgrade the timestamp if the MAM hit carries a higher-authority
+  // stamp than the row we already had — this is the path that
+  // corrects a previously-fallback live insert once the archive
+  // result lands.
+  const authoritativeTimestamp = pickAuthoritativeTimestamp(
+    { createdAt: result.createdAt, createdAtSource: result.createdAtSource },
+    { createdAt: incoming.createdAt, createdAtSource: incoming.createdAtSource },
+  );
+  if (
+    authoritativeTimestamp.createdAt !== result.createdAt
+    || authoritativeTimestamp.createdAtSource !== result.createdAtSource
+  ) {
+    result = {
+      ...result,
+      createdAt: authoritativeTimestamp.createdAt,
+      createdAtSource: authoritativeTimestamp.createdAtSource,
+    };
+  }
+  return result;
 }
 
 export function buildDmTimelineFromMamResults(params: {
@@ -174,7 +197,15 @@ export function buildDmTimelineFromMamResults(params: {
   const timeline = [...existing];
   for (const raw of regular) {
     const tm = fromLiveDmMessage(session, raw, (id) => byId.get(id));
-    const existingMessage = findMessageById(timeline, tm.id);
+    // Look up via every wire alias, not just the primary id — when
+    // the live arrival landed first with a client-side id and MAM
+    // later returns the canonical stanza-id, a bare `findMessageById`
+    // (on `tm.id` only) would miss the existing row and insert a
+    // duplicate. Channel side has done this for a while; this is the
+    // matching DM-side fix (Bug 5 in PR1).
+    const existingMessage = [tm.id, ...(tm.wireIds ?? [])]
+      .map((id) => byId.get(id))
+      .find((message): message is TimelineMessage => !!message);
     if (existingMessage) {
       const merged = mergeDmRetractionTombstone(existingMessage, tm);
       if (merged !== existingMessage) {

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -1,4 +1,5 @@
 import type { PinPermission } from "@/lib/chat-types";
+import type { TimestampSource } from "@/lib/timeline-timestamps";
 import type { WaddleEncryptedFile } from "@/lib/xmpp/extensions/encrypted-file";
 import {
   renderRichMessageHtml,
@@ -153,6 +154,13 @@ export interface TimelineMessage {
   stanzaIdBy?: string;
   body: string;
   createdAt: string;
+  /**
+   * Provenance of `createdAt`. Merges across producers prefer the
+   * higher-authority source so a redelivered live stanza without a
+   * `<delay/>` (decoded as `fallback`) cannot overwrite a true
+   * server stamp (`archive`/`delay`) that landed via MAM first.
+   */
+  createdAtSource: TimestampSource;
   isSelf: boolean;
   /** Delivery status — only meaningful for self-sent messages. */
   deliveryStatus?: DeliveryStatus;

--- a/chat/src/lib/timeline-timestamps.ts
+++ b/chat/src/lib/timeline-timestamps.ts
@@ -12,6 +12,66 @@ export function compareTimelineTimestamps(
   return leftValue.localeCompare(rightValue);
 }
 
+// Provenance of a message's `createdAt` value. The same logical message
+// can flow through multiple producers (live socket, MAM catch-up,
+// queued outbound, stream-resume redelivery) and each producer can
+// supply a different timestamp with a different degree of authority.
+// We tag the source so merges can pick the most trustworthy stamp
+// instead of letting "whoever wrote last wins" reorder the timeline
+// on tab restore (see PR1 plan).
+//
+// Authority ranking (highest first):
+//   * archive: XEP-0313 MAM forwarded `<delay/>` — the server's own
+//     copy of the message in its archive. Canonical.
+//   * delay:   XEP-0203 `<delay/>` on a live stanza — added by the
+//     server when the message was buffered/redelivered. Also server-
+//     authoritative for the original send time.
+//   * queued:  client wall-clock captured at the moment the user
+//     pressed send. Only used for self-sent rows awaiting echo.
+//   * fallback: client wall-clock at decode of a live stanza that
+//     arrived without any `<delay/>`. This is correct for genuinely-
+//     new arrivals ("now" really is the right answer) but is wrong
+//     for redelivered stanzas (XEP-0198 resume, carbons that lose
+//     delay, server replays). Lowest authority — any other source
+//     replaces it on merge.
+export type TimestampSource = "archive" | "delay" | "queued" | "fallback";
+
+const TIMESTAMP_SOURCE_RANK: Record<TimestampSource, number> = {
+  archive: 3,
+  delay: 2,
+  queued: 1,
+  fallback: 0,
+};
+
+interface DatedTimelineFields {
+  createdAt: string;
+  createdAtSource: TimestampSource;
+}
+
+// Pick the more authoritative of two stamps for the *same* logical
+// message. On equal authority, prefer the earlier wall-clock value:
+// for `archive`/`delay` the server stamp is deterministic so equal
+// authority implies equal value; for `queued`/`fallback` the earlier
+// stamp is the one closer to when the user actually performed the
+// action.
+//
+// An unknown / undefined source ranks below every named source — test
+// fixtures sometimes build `TimelineMessage` via `as TimelineMessage`
+// casts that omit the field, and we never want such a row to suppress
+// a properly-tagged authoritative stamp on merge.
+export function pickAuthoritativeTimestamp(
+  existing: DatedTimelineFields,
+  incoming: DatedTimelineFields,
+): DatedTimelineFields {
+  const existingRank = TIMESTAMP_SOURCE_RANK[existing.createdAtSource] ?? -1;
+  const incomingRank = TIMESTAMP_SOURCE_RANK[incoming.createdAtSource] ?? -1;
+  if (incomingRank > existingRank) return incoming;
+  if (existingRank > incomingRank) return existing;
+  return compareTimelineTimestamps(existing.createdAt, incoming.createdAt) <= 0
+    ? existing
+    : incoming;
+}
+
 // `compareTimelineMessages` must be a *total* order over distinct
 // messages: never return 0 for two messages with different identities.
 // Burst messages share `createdAt` to the millisecond, optimistic echoes

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1340,7 +1340,7 @@ export class BrowserXmppClient {
   }
 
   private roomMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveRoomMessage> {
-    return { messages: page.messages.map(roomMessageFromArchived).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
+    return { messages: page.messages.map((message) => roomMessageFromArchived(message)).filter((message): message is LiveRoomMessage => !!message), ...(page.first_id ? { firstArchiveId: page.first_id } : {}), ...(page.last_id ? { lastArchiveId: page.last_id } : {}), complete: page.is_complete };
   }
   private dmMamPageToMessages(page: WasmMamPage): MamHistoryPage<LiveDmMessage> {
     const selfBare = barePeerJid(this.session.jid);
@@ -1761,13 +1761,13 @@ export class BrowserXmppClient {
 
   private dispatchLiveBodyMessage(message: WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }) {
     if (message.is_muc) {
-      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage);
+      const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live");
       if (!converted) return;
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.activityHandler?.(roomActivityEventFromMessage(converted)); return; }
       this.messageHandler?.(converted); return;
     }
-    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid));
+    const converted = dmMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, barePeerJid(this.session.jid), "live");
     if (converted) {
       this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       this.directMessageHandler?.(converted);

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -1,6 +1,7 @@
 import type { WaddleChannelType } from "@/lib/channel-types";
 import type { PinPermission } from "@/lib/chat-types";
 import type { ExtensionAnnotation } from "@/lib/chat-ui";
+import type { TimestampSource } from "@/lib/timeline-timestamps";
 import type { WaddleEncryptedFile } from "./extensions/encrypted-file";
 
 /** Shared types for the XMPP client layer. */
@@ -102,6 +103,8 @@ export interface LiveRoomMessage {
   nick: string;
   body: string;
   createdAt: string;
+  /** Provenance of `createdAt` (see `TimestampSource`). */
+  createdAtSource: TimestampSource;
   type: "message" | "subject" | "pin-event";
   /** #414: pin/unpin action carried by a `<pin-event/>` system
    * message. Set when `type === "pin-event"`. */
@@ -174,6 +177,8 @@ export interface LiveDmMessage {
   nick: string;
   body: string;
   createdAt: string;
+  /** Provenance of `createdAt` (see `TimestampSource`). */
+  createdAtSource: TimestampSource;
   type: "message";
   replacesId?: string;
   retractsId?: string;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -13,6 +13,7 @@ import {
   type SendDirectMessageOptions,
   type SendGroupMessageOptions,
 } from "./send-types";
+import type { TimestampSource } from "@/lib/timeline-timestamps";
 import type { LiveDmMessage, LiveRoomMessage, OccupantPresence, PresenceUpdateEvent, SharedFileInfo } from "./types";
 import type {
   WasmArchivedMessage,
@@ -274,6 +275,36 @@ function extensionAnnotationsFromWasm(envelope?: WasmExtensionEnvelope): Extensi
   });
 }
 
+/**
+ * Codec source distinguishes a true MAM archive result from a live
+ * wire stanza that was reshaped into the archived struct via
+ * `{ ...message, mam_id: ... }`. The two cases share a codec but
+ * carry different timestamp authority — see `TimestampSource`.
+ */
+type CodecSource = "archive" | "live";
+
+function deriveCreatedAt(
+  rawTimestamp: string | undefined | null,
+  source: CodecSource,
+): { createdAt: string; createdAtSource: TimestampSource } {
+  if (typeof rawTimestamp === "string" && rawTimestamp.length > 0) {
+    return {
+      createdAt: rawTimestamp,
+      createdAtSource: source === "archive" ? "archive" : "delay",
+    };
+  }
+  // Live wire stanza without a `<delay/>` element — the message is
+  // genuinely arriving "now" in most cases (peer just sent it), so
+  // `Date.now()` is a sensible best-effort. For redelivered stanzas
+  // (XEP-0198 resume tail, carbons that dropped delay, MUC join
+  // history) this is wrong, but a later MAM hit with `archive` /
+  // `delay` authority will replace it via `pickAuthoritativeTimestamp`.
+  return {
+    createdAt: new Date().toISOString(),
+    createdAtSource: "fallback",
+  };
+}
+
 function roomAssignedStanzaId(message: WasmArchivedMessage, roomJid: string): string | undefined {
   const byScoped = message.stanza_ids?.find((stanzaId) => stanzaId.by === roomJid);
   if (byScoped?.id) return byScoped.id;
@@ -282,11 +313,14 @@ function roomAssignedStanzaId(message: WasmArchivedMessage, roomJid: string): st
     : undefined;
 }
 
-export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomMessage | null {
+export function roomMessageFromArchived(
+  message: WasmArchivedMessage,
+  source: CodecSource = "archive",
+): LiveRoomMessage | null {
   const fromJid = message.from ?? "";
   const roomJid = barePeerJid(fromJid || message.to || "");
   const nick = fromJid.split("/")[1] ?? "unknown";
-  const createdAt = message.timestamp ?? new Date().toISOString();
+  const { createdAt, createdAtSource } = deriveCreatedAt(message.timestamp, source);
   const stampedByRoom = roomAssignedStanzaId(message, roomJid);
   const moderationTargetId = message.moderation_target_id && fromJid === roomJid
     ? message.moderation_target_id
@@ -304,6 +338,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
       nick,
       body: "",
       createdAt,
+      createdAtSource,
       type: "message",
       retractsId: activeRetractionTarget,
       ...(message.retraction_id ? { retractionId: message.retraction_id } : {}),
@@ -321,6 +356,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
       nick,
       body: "",
       createdAt,
+      createdAtSource,
       type: "subject",
       _reactionTarget: message.reaction_target_id,
       _reactionEmojis: message.reaction_emojis,
@@ -338,6 +374,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
       nick: "",
       body: message.body ?? "",
       createdAt,
+      createdAtSource,
       type: "pin-event",
       pinEventAction: message.pin_event.action,
     };
@@ -358,6 +395,7 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
     nick,
     body: message.is_retracted ? "" : (message.body ?? message.subject ?? ""),
     createdAt,
+    createdAtSource,
     type: message.subject && !message.body ? "subject" : "message",
     ...(message.replaces_id ? { replacesId: message.replaces_id } : {}),
     ...(roomWireIds.length > 0
@@ -396,7 +434,11 @@ export function roomMessageFromArchived(message: WasmArchivedMessage): LiveRoomM
   return stripReplyFallback(base, message.reply_fallback_start, message.reply_fallback_end);
 }
 
-export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid: string): LiveDmMessage | null {
+export function dmMessageFromArchived(
+  message: WasmArchivedMessage,
+  selfBareJid: string,
+  source: CodecSource = "archive",
+): LiveDmMessage | null {
   const fromBare = barePeerJid(message.from ?? "");
   const toBare = barePeerJid(message.to ?? "");
   const isSelf = fromBare === selfBareJid;
@@ -404,7 +446,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
   if (!peerJid) return null;
   const fromJid = message.from ?? fromBare;
   const nick = barePeerJid(fromJid).split("@")[0] ?? "unknown";
-  const createdAt = message.timestamp ?? new Date().toISOString();
+  const { createdAt, createdAtSource } = deriveCreatedAt(message.timestamp, source);
   const dmPrimaryId = message.id ?? message.origin_id ?? message.mam_id;
   if (message.retracts_id) {
     return {
@@ -415,6 +457,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
       nick,
       body: "",
       createdAt,
+      createdAtSource,
       type: "message",
       retractsId: message.retracts_id,
       ...(message.retraction_id ? { retractionId: message.retraction_id } : {}),
@@ -429,6 +472,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
       nick,
       body: "",
       createdAt,
+      createdAtSource,
       type: "message",
       _reactionTarget: message.reaction_target_id,
       _reactionEmojis: message.reaction_emojis,
@@ -450,6 +494,7 @@ export function dmMessageFromArchived(message: WasmArchivedMessage, selfBareJid:
     nick,
     body: message.is_retracted ? "" : (message.body ?? message.subject ?? ""),
     createdAt,
+    createdAtSource,
     type: "message",
     ...(message.replaces_id ? { replacesId: message.replaces_id } : {}),
     ...(message.reply_to_id

--- a/chat/tests/timeline-timestamps.test.ts
+++ b/chat/tests/timeline-timestamps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   compareTimelineMessages,
   compareTimelineTimestamps,
+  pickAuthoritativeTimestamp,
 } from "../src/lib/timeline-timestamps";
 
 type SortableMessage = {
@@ -137,5 +138,55 @@ describe("compareTimelineMessages", () => {
       const sorted = shuffled.sort(compareTimelineMessages).map((m) => m.id);
       expect(sorted).toEqual(reference);
     }
+  });
+});
+
+describe("pickAuthoritativeTimestamp", () => {
+  test("higher-authority source wins regardless of value", () => {
+    // The exact scenario that produced the user-visible bug: a live
+    // wire stanza without `<delay/>` decoded as `fallback` with a
+    // wall-clock-now timestamp, then the MAM hit lands later with
+    // `archive` authority and an older server stamp. The merge MUST
+    // keep the archive copy.
+    const fallbackNow = {
+      createdAt: "2026-05-20T11:00:00.000Z",
+      createdAtSource: "fallback" as const,
+    };
+    const archiveOlder = {
+      createdAt: "2026-05-20T10:00:00.000Z",
+      createdAtSource: "archive" as const,
+    };
+    expect(pickAuthoritativeTimestamp(fallbackNow, archiveOlder)).toBe(archiveOlder);
+    // Symmetric: same outcome regardless of arrival order.
+    expect(pickAuthoritativeTimestamp(archiveOlder, fallbackNow)).toBe(archiveOlder);
+  });
+
+  test("authority order: archive > delay > queued > fallback", () => {
+    const archive = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "archive" as const };
+    const delay = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "delay" as const };
+    const queued = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "queued" as const };
+    const fallback = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "fallback" as const };
+    expect(pickAuthoritativeTimestamp(delay, archive)).toBe(archive);
+    expect(pickAuthoritativeTimestamp(queued, delay)).toBe(delay);
+    expect(pickAuthoritativeTimestamp(fallback, queued)).toBe(queued);
+  });
+
+  test("on equal authority, the earlier wall-clock value wins", () => {
+    // For queued/fallback, "earlier" is closer to when the event
+    // actually happened. For archive/delay, equal authority implies
+    // equal value (server stamp is deterministic) so this tiebreaker
+    // is a no-op for them; it matters for client-stamped rows.
+    const earlier = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "queued" as const };
+    const later = { createdAt: "2026-05-20T10:00:01.000Z", createdAtSource: "queued" as const };
+    expect(pickAuthoritativeTimestamp(later, earlier)).toBe(earlier);
+    expect(pickAuthoritativeTimestamp(earlier, later)).toBe(earlier);
+  });
+
+  test("symmetric: same result regardless of argument order", () => {
+    const a = { createdAt: "2026-05-20T10:00:00.000Z", createdAtSource: "delay" as const };
+    const b = { createdAt: "2026-05-20T11:00:00.000Z", createdAtSource: "fallback" as const };
+    const r1 = pickAuthoritativeTimestamp(a, b);
+    const r2 = pickAuthoritativeTimestamp(b, a);
+    expect(r1).toEqual(r2);
   });
 });

--- a/chat/tests/timestamp-authority.test.ts
+++ b/chat/tests/timestamp-authority.test.ts
@@ -1,0 +1,354 @@
+// End-to-end tests for the PR1 timestamp-authority fix.
+//
+// These cover:
+//   * the codec stamps `createdAtSource` correctly when `timestamp`
+//     is present vs. absent and when called from a live vs. archive
+//     entry point (XEP-0203 / XEP-0313 distinction)
+//   * `mergeLiveMessage` (DM + channel) keeps the higher-authority
+//     `createdAt` when a redelivered live stanza arrives after a
+//     MAM hit has already populated the row (the user-visible bug)
+//   * `buildDmTimelineFromMamResults` dedupes against `wireIds`
+//     aliases (the Bug 5 channel-vs-DM divergence)
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+
+import { useDmLiveMerge } from "../src/dms/live-merge";
+import { useChannelLiveMerge } from "../src/channels/live-merge";
+import { buildDmTimelineFromMamResults, fromLiveDmMessage } from "../src/dms/message-timeline-state";
+import { mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
+import { dmMessageFromArchived, roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { LiveDmMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
+
+const session: WaddleSession = {
+  session_id: "tok",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/desktop",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+const baseArchivedDm: WasmArchivedMessage = {
+  mam_id: "mam-dm-1",
+  message_type: "chat",
+  from: "bob@example.com",
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: false,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+const baseArchivedRoom: WasmArchivedMessage = {
+  mam_id: "mam-room-1",
+  message_type: "groupchat",
+  from: "room@conf.example.com/bob",
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: true,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+describe("codec createdAtSource tagging", () => {
+  test("dmMessageFromArchived defaults to archive source and trusts wire timestamp", () => {
+    const result = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "m1", timestamp: "2026-05-20T10:00:00.000Z" },
+      "alice@example.com",
+    );
+    expect(result?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(result?.createdAtSource).toBe("archive");
+  });
+
+  test("dmMessageFromArchived('live') tags a server-stamped live arrival as delay", () => {
+    const result = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "m1", timestamp: "2026-05-20T10:00:00.000Z" },
+      "alice@example.com",
+      "live",
+    );
+    expect(result?.createdAtSource).toBe("delay");
+  });
+
+  test("dmMessageFromArchived('live') without `timestamp` falls back and tags as fallback", () => {
+    const result = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "m1", timestamp: undefined },
+      "alice@example.com",
+      "live",
+    );
+    expect(result?.createdAtSource).toBe("fallback");
+    expect(typeof result?.createdAt).toBe("string");
+  });
+
+  test("roomMessageFromArchived defaults to archive source", () => {
+    const result = roomMessageFromArchived(
+      { ...baseArchivedRoom, id: "r1", timestamp: "2026-05-20T10:00:00.000Z" },
+    );
+    expect(result?.createdAtSource).toBe("archive");
+  });
+
+  test("roomMessageFromArchived('live') without `timestamp` is fallback", () => {
+    const result = roomMessageFromArchived(
+      { ...baseArchivedRoom, id: "r1", timestamp: undefined },
+      "live",
+    );
+    expect(result?.createdAtSource).toBe("fallback");
+  });
+});
+
+function dmHarness() {
+  const messages = ref<TimelineMessage[]>([]);
+  const pendingEchoClientIds = new Set<string>();
+  const liveMerge = useDmLiveMerge({
+    session: ref(session),
+    messages,
+    activePeerJid: ref("bob@example.com"),
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin: mock(async () => true),
+    persistLastSeen: mock(() => {}),
+    isFeedVisible: () => true,
+  });
+  return { messages, pendingEchoClientIds, liveMerge };
+}
+
+function channelHarness() {
+  const messages = ref<TimelineMessage[]>([]);
+  const pendingEchoClientIds = new Set<string>();
+  const liveMerge = useChannelLiveMerge({
+    session: ref(session),
+    messages,
+    activeChannelId: ref("channel-1"),
+    pendingEchoClientIds,
+    scrollToPinnedEdgeAndPin: mock(async () => true),
+    persistLastSeen: mock(() => {}),
+  });
+  return { messages, liveMerge };
+}
+
+describe("mergeLiveMessage timestamp authority", () => {
+  test("DM: redelivered fallback stanza does NOT overwrite an archive stamp", () => {
+    // Setup: the MAM catch-up already inserted the row with the
+    // server-authoritative `archive` stamp.
+    const h = dmHarness();
+    h.messages.value = [
+      {
+        id: "m1",
+        body: "hello",
+        author: "bob",
+        authorJid: "bob@example.com",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        createdAtSource: "archive",
+        isSelf: false,
+      },
+    ];
+    // The buffered live drain replays the same message but the WASM
+    // parser didn't see a `<delay/>` so the codec stamped it `fallback`
+    // with `Date.now()`.
+    h.liveMerge.mergeLiveMessage({
+      id: "m1",
+      body: "hello",
+      author: "bob",
+      authorJid: "bob@example.com",
+      createdAt: "2026-05-20T11:00:00.000Z",
+      createdAtSource: "fallback",
+      isSelf: false,
+    });
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(h.messages.value[0]?.createdAtSource).toBe("archive");
+  });
+
+  test("DM: an incoming `delay` stamp still upgrades over `queued`", () => {
+    const h = dmHarness();
+    h.messages.value = [
+      {
+        id: "client-1",
+        body: "hi",
+        author: "alice",
+        authorJid: "alice@example.com",
+        createdAt: "2026-05-20T10:00:01.500Z",
+        createdAtSource: "queued",
+        isSelf: true,
+        deliveryStatus: "sending",
+      },
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "client-1",
+      body: "hi",
+      author: "alice",
+      authorJid: "alice@example.com",
+      createdAt: "2026-05-20T10:00:00.000Z",
+      createdAtSource: "delay",
+      isSelf: true,
+    });
+    expect(h.messages.value[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(h.messages.value[0]?.createdAtSource).toBe("delay");
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+  });
+
+  test("channel: redelivered fallback stanza does NOT overwrite a delay stamp", () => {
+    const h = channelHarness();
+    h.messages.value = [
+      {
+        id: "r1",
+        wireIds: ["origin-r1"],
+        body: "hello",
+        author: "bob",
+        authorJid: "room@conf.example.com/bob",
+        authorOccupantJid: "room@conf.example.com/bob",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        createdAtSource: "delay",
+        isSelf: false,
+      },
+    ];
+    h.liveMerge.mergeLiveMessage({
+      id: "r1",
+      body: "hello",
+      author: "bob",
+      authorJid: "room@conf.example.com/bob",
+      authorOccupantJid: "room@conf.example.com/bob",
+      createdAt: "2026-05-20T12:00:00.000Z",
+      createdAtSource: "fallback",
+      isSelf: false,
+    });
+    expect(h.messages.value[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(h.messages.value[0]?.createdAtSource).toBe("delay");
+  });
+});
+
+describe("buildDmTimelineFromMamResults wireIds dedup (Bug 5)", () => {
+  test("MAM hit using stanza-id as primary id dedupes against existing row's wireIds alias", () => {
+    // Existing live row inserted with the client-side id; the
+    // canonical stanza-id is held in `wireIds`.
+    const existing: TimelineMessage[] = [
+      {
+        id: "client-id",
+        wireIds: ["server-stanza-id"],
+        body: "hello",
+        author: "bob",
+        authorJid: "bob@example.com",
+        createdAt: "2026-05-20T11:00:00.000Z",
+        createdAtSource: "fallback",
+        isSelf: false,
+      },
+    ];
+    // MAM result returns the same logical message but with the
+    // server stanza-id as the primary id.
+    const mam: LiveDmMessage[] = [
+      {
+        id: "server-stanza-id",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com",
+        nick: "bob",
+        body: "hello",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        createdAtSource: "archive",
+        type: "message",
+      },
+    ];
+    const result = buildDmTimelineFromMamResults({ session, mamResults: mam, existing });
+    expect(result).toHaveLength(1);
+    // Existing row is updated in place; its createdAt is upgraded to
+    // the MAM `archive` stamp.
+    expect(result[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(result[0]?.createdAtSource).toBe("archive");
+  });
+
+  test("MAM hit with a totally new id appends rather than duplicating", () => {
+    const existing: TimelineMessage[] = [
+      {
+        id: "existing-1",
+        body: "first",
+        author: "bob",
+        authorJid: "bob@example.com",
+        createdAt: "2026-05-20T10:00:00.000Z",
+        createdAtSource: "archive",
+        isSelf: false,
+      },
+    ];
+    const mam: LiveDmMessage[] = [
+      {
+        id: "different-id",
+        peerJid: "bob@example.com",
+        fromJid: "bob@example.com",
+        nick: "bob",
+        body: "second",
+        createdAt: "2026-05-20T10:00:01.000Z",
+        createdAtSource: "archive",
+        type: "message",
+      } satisfies LiveDmMessage,
+    ];
+    const result = buildDmTimelineFromMamResults({ session, mamResults: mam, existing });
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("end-to-end tab-restore scenario (codec → merge)", () => {
+  test("DM: MAM hit lands first, then redelivered live stanza with no <delay/> does NOT corrupt the row", () => {
+    // Simulate exactly the user-visible scenario:
+    //   1. Tab is resumed; MAM catch-up decodes a `WasmArchivedMessage`
+    //      with the server delay stamp into the timeline.
+    //   2. The buffered live drain replays the SAME message but with
+    //      no `<delay/>` — the WASM parser leaves `timestamp` as None
+    //      (Option<String>), the codec falls back to `Date.now()`,
+    //      and the live merge spread would historically have
+    //      overwritten the row's `createdAt`.
+    const h = dmHarness();
+    const archive = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "msg-1", timestamp: "2026-05-20T10:00:00.000Z" },
+      "alice@example.com",
+    );
+    expect(archive).not.toBeNull();
+    h.messages.value = [fromLiveDmMessage(session, archive!)];
+    expect(h.messages.value[0]?.createdAtSource).toBe("archive");
+
+    const live = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "msg-1", timestamp: undefined },
+      "alice@example.com",
+      "live",
+    );
+    expect(live).not.toBeNull();
+    expect(live?.createdAtSource).toBe("fallback");
+    h.liveMerge.mergeLiveMessage(fromLiveDmMessage(session, live!));
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(h.messages.value[0]?.createdAtSource).toBe("archive");
+  });
+
+  test("channel: same scenario via roomMessageFromArchived → mapLiveRoomMessageToTimeline → mergeLiveMessage", () => {
+    const h = channelHarness();
+    const archive = roomMessageFromArchived(
+      { ...baseArchivedRoom, id: "msg-1", timestamp: "2026-05-20T10:00:00.000Z" },
+    );
+    expect(archive).not.toBeNull();
+    h.messages.value = [mapLiveRoomMessageToTimeline(session, archive!)];
+    expect(h.messages.value[0]?.createdAtSource).toBe("archive");
+
+    const live = roomMessageFromArchived(
+      { ...baseArchivedRoom, id: "msg-1", timestamp: undefined },
+      "live",
+    );
+    expect(live).not.toBeNull();
+    expect(live?.createdAtSource).toBe("fallback");
+    h.liveMerge.mergeLiveMessage(mapLiveRoomMessageToTimeline(session, live!));
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.createdAt).toBe("2026-05-20T10:00:00.000Z");
+    expect(h.messages.value[0]?.createdAtSource).toBe("archive");
+  });
+});


### PR DESCRIPTION
## Summary

A redelivered live stanza without `<delay/>` was decoded with wallclock-now and then unconditionally overwrote the row's `createdAt` on merge, mis-positioning older messages at the bottom of the timeline on tab restore — the symptom users reported as *"older messages sometimes land at the newest spot on browser tab re-activation, then their displayed timestamp changes"*.

This is **PR1 of a 4-stack** that fixes the visible symptom and the supporting bugs identified by the deep audit.

## Root cause

1. **Rust:** `WaddleMessage.timestamp: Option<String>` — only populated when `<delay/>` is present (`server/crates/waddle-xmpp-client/src/messaging/parsing/mod.rs:47`). XEP-0198 stream-resume replays, carbons that don't preserve delay, and MUC join history all hit this `None` case.
2. **TS codec:** `wasm-message-codecs.ts:289/407` substituted `new Date().toISOString()` when `timestamp` was missing — *correct* for a brand-new live arrival, *wrong* for a redelivered older stanza.
3. **TS merge:** `dms/live-merge.ts` and `channels/live-merge.ts` did `{ ...m, ...msg }` which unconditionally overwrote `createdAt`. So when MAM catch-up inserted X with the true server stamp T₁, and the post-resume buffer drain then delivered the same X via the live path with `Date.now()` (T₂), the spread replaced T₁ with T₂. The next `.sort()` moved X to the bottom.

## Fix

Tag every `createdAt` with a `TimestampSource`:

| source | meaning | rank |
|---|---|---|
| `archive` | XEP-0313 MAM forwarded `<delay/>` | 3 (highest) |
| `delay` | XEP-0203 `<delay/>` on a live stanza | 2 |
| `queued` | client wall-clock at user send | 1 |
| `fallback` | client wall-clock at decode of a live stanza without `<delay/>` | 0 (lowest) |

The new `pickAuthoritativeTimestamp` helper keeps the higher-authority stamp on merge (tie → earlier wall-clock wins). All four merge sites (DM live + MAM, channel live + MAM) route through it. Unknown source ranks as -1 so test fixtures using `as TimelineMessage` casts can't suppress a properly-tagged stamp.

Also fixes **Bug 5** from the audit: DM-side `buildDmTimelineFromMamResults` was deduping with `findMessageById(timeline, tm.id)` only, missing wireIds aliases. Channel side already did the right lookup; this lifts the DM side to match.

## Tests

- `tests/timeline-timestamps.test.ts` — 4 new tests for `pickAuthoritativeTimestamp` (authority order, symmetry, tie-breaking, fallback-can't-overwrite-archive).
- `tests/timestamp-authority.test.ts` (new) — 12 tests covering:
  - codec source tagging for archive/delay/fallback on both DM + channel paths,
  - merge preserving the higher-authority stamp on both DM + channel paths,
  - DM MAM dedup against wireIds (the Bug 5 channel-vs-DM divergence),
  - **end-to-end:** a real `WasmArchivedMessage` with no `timestamp` is decoded via the live codec, then merged onto a row inserted via the archive codec — the row's `createdAt` is preserved.

## Stacked PRs (see `/Users/icepuma/.claude/plans/sometimes-older-messages-land-immutable-frost.md`)

- **PR1 — this one** — fix(chat): preserve authoritative createdAt across producers
- PR2 — fix(chat): coalesce resume triggers and serialize producers correctly (Bugs 2, 3, 4)
- PR3 — feat(chat): persist resume cursors + SM handle across page reloads (Bug 6)
- PR4 — refactor(chat): unify DM and channel timeline merge into TimelineStore (Bugs 8, 9, 10)

## Verification

- [x] `bun test` — 1008/1008 pass
- [x] `bun run lint` — knip clean
- [x] `bun run astro check` — 0 errors / warnings / hints
- [ ] Manual repro: suspend tab 30s+ while peers send, reactivate, confirm no message flickers to the bottom
- [ ] Cross-resource test (browser + mobile carbons) to exercise the Bug 5 dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)