### PR TITLE
feat(chat): persist resume cursors and SM handle across page reloads

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -51,6 +51,10 @@ import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 import { ReconnectCatchup } from "./reconnect-catchup";
+import {
+  createLocalStorageResumePersistence,
+  type ResumePersistence,
+} from "./resume-persistence";
 import { compareTimelineTimestamps } from "../timeline-timestamps";
 import {
   discoverExtensionCommands,
@@ -390,7 +394,8 @@ export class BrowserXmppClient {
   private readonly errorHooks: Array<(event: XmppErrorEvent) => void> = [];
   private readonly roomJoinWaiters = new Map<string, { resolve: () => void; reject: (error: Error) => void }>();
   private readonly carbonDedupIds = new Set<string>();
-  readonly catchup = new ReconnectCatchup();
+  readonly catchup: ReconnectCatchup;
+  private readonly resumePersistence: ResumePersistence;
   // Per-resume gate: non-zero while `handleSessionReady` is draining
   // MAM catch-up. Live body messages received during that window are
   // buffered in `pendingDuringResume` and replayed after catch-up
@@ -425,7 +430,21 @@ export class BrowserXmppClient {
   private resumeBarrier: { xmpp: XmppClientInstance; promise: Promise<void> } | null = null;
   private pendingDuringResume: Array<WasmMessage & { carbon?: { sent?: boolean; received?: boolean }; inboxPush?: InboxEntry; _fromCarbon?: boolean }> | null = null;
 
-  constructor(session: WaddleSession) { this.session = session; }
+  constructor(session: WaddleSession, persistence?: ResumePersistence) {
+    this.session = session;
+    // Per-account so a logout/login on the same browser doesn't mix
+    // cursors. `session.jid` is the bare JID — already unique per
+    // identity — and matches the `accountKey` used by the outbound
+    // queue store.
+    this.resumePersistence = persistence ?? createLocalStorageResumePersistence(session.jid);
+    this.catchup = new ReconnectCatchup(this.resumePersistence);
+    // Restore any XEP-0198 resume state persisted by a prior tab
+    // session. If a `resumeStateHandle` is also recovered via the
+    // WASM client (live, same JS context), that takes precedence in
+    // `doConnect`. The POD `resumeState` is the only piece that
+    // survives a full page reload, so hydrate it eagerly.
+    this.resumeState = this.resumePersistence.loadSm();
+  }
 
   /** Full JID (`bare/resource`) for this session. Needed by the
    * call layer when constructing Jingle session-initiate / accept,
@@ -524,6 +543,14 @@ export class BrowserXmppClient {
   private clearResumeState() {
     this.resumeState = null;
     this.setResumeStateHandle(null);
+    this.resumePersistence.clearSm();
+    // Only called from the `destroying` path — i.e. intentional
+    // logout / shutdown. Drop the catch-up cursors too so a future
+    // login on the same account (same browser) doesn't replay
+    // ancient MAM history. (Transient disconnects do NOT go through
+    // this method; they intentionally keep cursors so the next
+    // resume can fill the gap.)
+    this.catchup.reset();
   }
 
   private setResumeStateHandle(handle: XmppResumeStateHandle | null | undefined) {
@@ -1768,6 +1795,12 @@ export class BrowserXmppClient {
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     this.setResumeStateHandle(xmpp.get_resume_state_handle?.() ?? null);
     this.resumeState = xmpp.get_resume_state?.() ?? null;
+    // Persist the POD form so the next page-load can resume the
+    // XEP-0198 stream without re-binding. The live handle is a JS
+    // object that can't be serialized, so `doConnect` always tries
+    // the handle first (this JS context only) and falls back to
+    // the persisted POD across reloads.
+    if (this.resumeState) this.resumePersistence.saveSm(this.resumeState);
     this.emitStatus({ state: "reconnecting", detail: countQueuedMessages(this.queueScope) > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }
     this.scheduleReconnect();

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -1,5 +1,11 @@
 import { compareTimelineTimestamps } from "@/lib/timeline-timestamps";
 
+import {
+  nullResumePersistence,
+  type PersistedReconnectCatchup,
+  type ResumePersistence,
+} from "./resume-persistence";
+
 /**
  * Per-conversation "last-seen" tracker for XEP-0313 MAM catch-up on reconnect.
  *
@@ -18,8 +24,11 @@ import { compareTimelineTimestamps } from "@/lib/timeline-timestamps";
  * DM peers and rooms are tracked in separate namespaces so the two can never
  * collide even if a bare JID were somehow valid in both worlds.
  *
- * Kept as a tiny pure class so the orchestration in `BrowserXmppClient` has
- * zero state of its own and the logic is trivially testable.
+ * State is hydrated from / persisted to a `ResumePersistence` adapter so
+ * cursors survive a full page reload — without persistence, a hard refresh
+ * loses every cursor and the next `onSessionStarted()` returns `[]`, leaving
+ * any messages received while the tab was gone unrecovered until the user
+ * manually scrolls back (PR3 in the tab-restore plan).
  */
 type CatchupEntry =
   | { kind: "dm"; key: string; after?: string; since?: string; seenIds?: string[] }
@@ -35,6 +44,64 @@ export class ReconnectCatchup {
   private readonly dmLastSeen = new Map<string, SeenCursor>();
   private readonly roomLastSeen = new Map<string, SeenCursor>();
   private sessionStartedOnce = false;
+  private readonly persistence: ResumePersistence;
+  /** Microtask-coalesced write to amortize the cost of localStorage writes
+   * across a burst of arrivals. Bursts are common during MAM catch-up. */
+  private persistScheduled = false;
+
+  constructor(persistence: ResumePersistence = nullResumePersistence) {
+    this.persistence = persistence;
+    this.hydrate();
+  }
+
+  private hydrate(): void {
+    const snapshot = this.persistence.loadCatchup();
+    if (!snapshot) return;
+    for (const [key, cursor] of snapshot.dmLastSeen) this.dmLastSeen.set(key, { ...cursor });
+    for (const [key, cursor] of snapshot.roomLastSeen) this.roomLastSeen.set(key, { ...cursor });
+    // A hydrated instance is by definition *not* a first-ever login —
+    // it represents a prior tab session that left cursors behind. The
+    // next `onSessionStarted()` must return those cursors so MAM
+    // catch-up runs immediately after the page reload (otherwise the
+    // persistence is dead weight: cursors are stored on every advance
+    // but never consumed, which was the bug PR3 was supposed to fix).
+    if (this.dmLastSeen.size > 0 || this.roomLastSeen.size > 0) {
+      this.sessionStartedOnce = true;
+    }
+  }
+
+  private schedulePersist(): void {
+    if (this.persistScheduled || this.persistence === nullResumePersistence) return;
+    this.persistScheduled = true;
+    queueMicrotask(() => {
+      this.persistScheduled = false;
+      // Read-merge-write so two tabs of the same account don't
+      // clobber each other's cursor advances. Pre-fix each tab held
+      // its own in-memory map and serialized the whole thing on
+      // every write — the last writer won, and the other tab's
+      // progress was silently lost. Now we merge any remote state
+      // that landed since our last write back into our in-memory
+      // maps before persisting, so both tabs converge to the union
+      // (per-key: higher timestamp wins, equal timestamps merge
+      // `seenIds` — exactly the rule `advance()` already uses).
+      const remote = this.persistence.loadCatchup();
+      if (remote) this.absorbRemoteSnapshot(remote);
+      const snapshot: PersistedReconnectCatchup = {
+        dmLastSeen: Array.from(this.dmLastSeen.entries()),
+        roomLastSeen: Array.from(this.roomLastSeen.entries()),
+      };
+      this.persistence.saveCatchup(snapshot);
+    });
+  }
+
+  private absorbRemoteSnapshot(remote: PersistedReconnectCatchup): void {
+    for (const [key, cursor] of remote.dmLastSeen) {
+      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds);
+    }
+    for (const [key, cursor] of remote.roomLastSeen) {
+      advance(this.roomLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds);
+    }
+  }
 
   /**
    * Record that a DM with `peerBareJid` was seen at `timestamp`. Only
@@ -43,11 +110,13 @@ export class ReconnectCatchup {
    */
   recordDmSeen(peerBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>): void {
     advance(this.dmLastSeen, peerBareJid, timestamp, archiveId, seenIds);
+    this.schedulePersist();
   }
 
   /** As `recordDmSeen`, but for a MUC room JID. */
   recordRoomSeen(roomBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>): void {
     advance(this.roomLastSeen, roomBareJid, timestamp, archiveId, seenIds);
+    this.schedulePersist();
   }
 
   getDmLastSeen(peerBareJid: string): string | undefined {
@@ -84,6 +153,7 @@ export class ReconnectCatchup {
     this.dmLastSeen.clear();
     this.roomLastSeen.clear();
     this.sessionStartedOnce = false;
+    this.persistence.clearCatchup();
   }
 }
 
@@ -140,11 +210,22 @@ function nonEmptySeenIds(seenIds: ReadonlyArray<string> | undefined): Partial<Pi
   return normalized.length > 0 ? { seenIds: normalized } : {};
 }
 
+// `seenIds` accumulates message ids at the boundary timestamp for
+// exact-equal-second dedupe (see `advance` below). In busy MUCs many
+// messages share the same wall-clock second, so without a cap this
+// would grow without bound and eventually blow localStorage's
+// per-origin quota. 64 is well above any realistic same-second
+// burst; older ids fall off — they only matter for messages whose
+// timestamp matches the cursor exactly, and once the cursor advances
+// past them dedupe is no longer needed.
+const SEEN_IDS_CAP = 64;
+
 function mergeSeenIds(
   current: ReadonlyArray<string> | undefined,
   next: ReadonlyArray<string> | undefined,
 ): string[] {
-  return Array.from(new Set([...(current ?? []), ...(next ?? [])].filter(Boolean)));
+  const merged = Array.from(new Set([...(current ?? []), ...(next ?? [])].filter(Boolean)));
+  return merged.length > SEEN_IDS_CAP ? merged.slice(merged.length - SEEN_IDS_CAP) : merged;
 }
 
 function normalizeTimestamp(timestamp: string): string {

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -1,0 +1,220 @@
+/**
+ * Persisted resume state across page reloads.
+ *
+ * Two kinds of state survive a full reload, both keyed per account:
+ *
+ *   * MAM catch-up cursors (`PersistedReconnectCatchup`) — the
+ *     timestamp + optional XEP-0313 archive UID + dedupe seen-ids
+ *     for every DM peer and MUC room the user has seen. Without
+ *     this, a hard reload (cold start, mobile Safari eviction)
+ *     loses every cursor and the next `session:started` returns
+ *     `[]` from `ReconnectCatchup.onSessionStarted()` — so MAM
+ *     catch-up does NOT run and missed messages are only
+ *     re-fetched if the user manually scrolls back.
+ *
+ *   * XEP-0198 Stream Management resume state
+ *     (`PersistedSmResumeState`) — the `previd` plus inbound /
+ *     outbound stanza counts. The richer "handle" form from the
+ *     WASM client is a live JS object that cannot be serialized;
+ *     the POD `{previd, inboundH, outboundH}` triple can be, and
+ *     the fallback path in `doConnect` already knows how to feed
+ *     it back via `with_resume_state`.
+ *
+ * The shape mirrors `outbound-queue-store.ts` (same `waddle.chat.*`
+ * prefix family, same per-account key namespacing, same defensive
+ * read/write error handling around localStorage availability and
+ * quota) so the storage surface stays uniform.
+ */
+
+import { reportError } from "@/lib/telemetry";
+
+const CATCHUP_PREFIX = "waddle.chat.resume-cursors";
+const SM_PREFIX = "waddle.chat.sm-resume";
+
+export type PersistedSeenCursor = {
+  timestamp: string;
+  archiveId?: string;
+  seenIds?: string[];
+};
+
+export type PersistedReconnectCatchup = {
+  dmLastSeen: Array<[string, PersistedSeenCursor]>;
+  roomLastSeen: Array<[string, PersistedSeenCursor]>;
+};
+
+/**
+ * The on-wire shape that `doConnect` feeds to `with_resume_state`.
+ * Stamped with a private `savedAt` internally so a stale POD can be
+ * rejected without forcing every caller to know about TTL — see
+ * `loadSm`.
+ */
+export type PersistedSmResumeState = {
+  previd: string;
+  inboundH: number;
+  outboundH: number;
+};
+
+interface PersistedSmEnvelope extends PersistedSmResumeState {
+  savedAt: number;
+}
+
+/**
+ * Reject a persisted SM POD older than this window. Servers usually
+ * GC the corresponding session much sooner (XEP-0198 §5); 24h is
+ * generous but bounds the cost of a guaranteed `<failed/>` on every
+ * cold start with a weeks-old POD.
+ */
+const SM_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface ResumePersistence {
+  loadCatchup(): PersistedReconnectCatchup | null;
+  saveCatchup(snapshot: PersistedReconnectCatchup): void;
+  clearCatchup(): void;
+  loadSm(): PersistedSmResumeState | null;
+  saveSm(state: PersistedSmResumeState): void;
+  clearSm(): void;
+}
+
+/** No-op persistence — used in tests / non-browser contexts. */
+export const nullResumePersistence: ResumePersistence = {
+  loadCatchup: () => null,
+  saveCatchup: () => undefined,
+  clearCatchup: () => undefined,
+  loadSm: () => null,
+  saveSm: () => undefined,
+  clearSm: () => undefined,
+};
+
+export function createLocalStorageResumePersistence(accountKey: string): ResumePersistence {
+  const catchupKey = `${CATCHUP_PREFIX}.${accountKey}`;
+  const smKey = `${SM_PREFIX}.${accountKey}`;
+
+  return {
+    loadCatchup() {
+      return readJson<PersistedReconnectCatchup>(catchupKey, isPersistedReconnectCatchup, "catchup");
+    },
+    saveCatchup(snapshot) {
+      writeJson(catchupKey, snapshot, "catchup");
+    },
+    clearCatchup() {
+      removeKey(catchupKey, "catchup");
+    },
+    loadSm() {
+      const envelope = readJson<PersistedSmEnvelope>(smKey, isPersistedSmEnvelope, "sm");
+      if (!envelope) return null;
+      // Drop entries past the TTL — the server has GC'd the
+      // corresponding session, so feeding the POD back to
+      // `with_resume_state` is a guaranteed `<failed/>`. Returning
+      // null lets `doConnect` fall through to a fresh bind.
+      if (Date.now() - envelope.savedAt > SM_TTL_MS) {
+        removeKey(smKey, "sm");
+        return null;
+      }
+      const { previd, inboundH, outboundH } = envelope;
+      return { previd, inboundH, outboundH };
+    },
+    saveSm(state) {
+      const envelope: PersistedSmEnvelope = { ...state, savedAt: Date.now() };
+      writeJson(smKey, envelope, "sm");
+    },
+    clearSm() {
+      removeKey(smKey, "sm");
+    },
+  };
+}
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function readJson<T>(key: string, validate: (value: unknown) => value is T, kind: string): T | null {
+  const s = storage();
+  if (!s) return null;
+  try {
+    const raw = s.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    return validate(parsed) ? parsed : null;
+  } catch (err) {
+    reportError("storage.read", err, {
+      recoverable: true,
+      detail: `resume-persistence read failed (${kind})`,
+      key,
+    });
+    return null;
+  }
+}
+
+function writeJson(key: string, value: unknown, kind: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.setItem(key, JSON.stringify(value));
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    const errorKind = name === "QuotaExceededError" ? "storage.quota" : "storage.write";
+    reportError(errorKind, err, {
+      recoverable: true,
+      detail: `resume-persistence write failed (${kind})`,
+      key,
+    });
+  }
+}
+
+function removeKey(key: string, kind: string): void {
+  const s = storage();
+  if (!s) return;
+  try {
+    s.removeItem(key);
+  } catch (err) {
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: `resume-persistence clear failed (${kind})`,
+      key,
+    });
+  }
+}
+
+function isPersistedSeenCursor(value: unknown): value is PersistedSeenCursor {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.timestamp !== "string") return false;
+  if (candidate.archiveId !== undefined && typeof candidate.archiveId !== "string") return false;
+  if (candidate.seenIds !== undefined) {
+    if (!Array.isArray(candidate.seenIds)) return false;
+    if (!candidate.seenIds.every((id) => typeof id === "string")) return false;
+  }
+  return true;
+}
+
+function isCursorMap(value: unknown): value is Array<[string, PersistedSeenCursor]> {
+  if (!Array.isArray(value)) return false;
+  return value.every((entry) =>
+    Array.isArray(entry)
+    && entry.length === 2
+    && typeof entry[0] === "string"
+    && isPersistedSeenCursor(entry[1]),
+  );
+}
+
+function isPersistedReconnectCatchup(value: unknown): value is PersistedReconnectCatchup {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return isCursorMap(candidate.dmLastSeen) && isCursorMap(candidate.roomLastSeen);
+}
+
+function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.previd === "string"
+    && typeof candidate.inboundH === "number"
+    && typeof candidate.outboundH === "number"
+    && typeof candidate.savedAt === "number"
+  );
+}

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -1,0 +1,265 @@
+/**
+ * PR3 — persistence tests for `ReconnectCatchup` hydration and the
+ * `ResumePersistence` localStorage adapter.
+ *
+ * Without persistence, a hard reload (cold start, mobile Safari
+ * aggressive eviction) loses every per-conversation cursor, so the
+ * next `session:started` returns `[]` and MAM catch-up does NOT
+ * run — missed messages are only re-fetched when the user manually
+ * scrolls back. This PR persists the cursor map (and the XEP-0198
+ * `{previd, inboundH, outboundH}` POD) so a reload picks up where
+ * the last tab left off.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+import {
+  createLocalStorageResumePersistence,
+  nullResumePersistence,
+  type PersistedReconnectCatchup,
+  type ResumePersistence,
+} from "../src/lib/xmpp/resume-persistence";
+
+// Bun's default test env is Node-like (no `window` / `localStorage`).
+// Install a minimal Map-backed Storage polyfill so the localStorage
+// adapter is exercised the same way it would be in a real browser —
+// otherwise we'd be skipping the only tests that prove
+// `JSON.stringify` / `JSON.parse` round-trip and TTL handling work.
+//
+// Scoped: installed in `beforeAll` and uninstalled in `afterAll` so
+// the shim does NOT leak into other test files. Other suites
+// (especially anything constructing `BrowserXmppClient`) assume
+// `typeof window === "undefined"` for the no-op persistence fast
+// path; a leaked shim would activate localStorage in those tests
+// and corrupt state across runs.
+const WINDOW_SENTINEL = Symbol("test-installed-window");
+type ShimmedGlobal = typeof globalThis & {
+  window?: { localStorage: Storage } & { [WINDOW_SENTINEL]?: true };
+};
+beforeAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (typeof g.window !== "undefined") return;
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() { return store.size; },
+    clear: () => store.clear(),
+    getItem: (key) => store.get(key) ?? null,
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key) => { store.delete(key); },
+    setItem: (key, value) => { store.set(key, String(value)); },
+  };
+  g.window = Object.assign({ localStorage: storage }, { [WINDOW_SENTINEL]: true as const });
+});
+
+afterAll(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) {
+    delete (g as { window?: unknown }).window;
+  }
+});
+
+afterEach(() => {
+  const g = globalThis as ShimmedGlobal;
+  if (g.window?.[WINDOW_SENTINEL]) g.window.localStorage.clear();
+});
+
+/** In-memory persistence for tests — same shape as the real adapter
+ * but without touching localStorage. */
+function inMemoryPersistence(): ResumePersistence & {
+  catchupSnapshot: () => PersistedReconnectCatchup | null;
+  smSnapshot: () => { previd: string; inboundH: number; outboundH: number } | null;
+} {
+  let catchup: PersistedReconnectCatchup | null = null;
+  let sm: { previd: string; inboundH: number; outboundH: number } | null = null;
+  return {
+    loadCatchup: () => catchup,
+    saveCatchup: (snapshot) => { catchup = snapshot; },
+    clearCatchup: () => { catchup = null; },
+    loadSm: () => sm,
+    saveSm: (state) => { sm = state; },
+    clearSm: () => { sm = null; },
+    catchupSnapshot: () => catchup,
+    smSnapshot: () => sm,
+  };
+}
+
+async function flushMicrotasks() {
+  // `queueMicrotask` callbacks fire after the current sync block but
+  // before the next macrotask. A zero-delay setTimeout drains them.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("ReconnectCatchup persistence — hydrate from snapshot on construct", () => {
+  test("hydrates DM + room cursors from the persistence snapshot", () => {
+    const persistence = inMemoryPersistence();
+    persistence.saveCatchup({
+      dmLastSeen: [
+        ["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "dm-arch-1" }],
+      ],
+      roomLastSeen: [
+        ["general@muc.example.com", { timestamp: "2026-05-20T11:00:00.000Z", seenIds: ["r-1", "r-2"] }],
+      ],
+    });
+
+    const c = new ReconnectCatchup(persistence);
+
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2026-05-20T10:00:00.000Z");
+    expect(c.getRoomLastSeen("general@muc.example.com")).toBe("2026-05-20T11:00:00.000Z");
+  });
+
+  test("hydrated instance returns cursors on the *first* onSessionStarted (PR3 whole point)", () => {
+    // A hydrated `ReconnectCatchup` represents a prior tab session
+    // that left cursors behind in localStorage. The next page load
+    // gets a fresh instance, but the very first `session:started`
+    // after that load must return the hydrated cursors so MAM
+    // catch-up runs immediately — otherwise the persistence is
+    // dead weight (writes on every advance, never consumed).
+    const persistence = inMemoryPersistence();
+    persistence.saveCatchup({
+      dmLastSeen: [["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "dm-arch-1" }]],
+      roomLastSeen: [],
+    });
+
+    const c = new ReconnectCatchup(persistence);
+    const entries = c.onSessionStarted();
+    expect(entries).toEqual([
+      { kind: "dm", key: "bob@example.com", after: "dm-arch-1" },
+    ]);
+  });
+
+  test("a fresh (un-hydrated) instance still treats the first onSessionStarted as initial login", () => {
+    // Unchanged from pre-PR3 behavior: a brand-new account / first-
+    // ever login has nothing to catch up on.
+    const c = new ReconnectCatchup(nullResumePersistence);
+    expect(c.onSessionStarted()).toEqual([]);
+  });
+
+  test("missing snapshot is a no-op (legacy / first-ever load)", () => {
+    const c = new ReconnectCatchup(nullResumePersistence);
+    expect(c.getDmLastSeen("bob@example.com")).toBeUndefined();
+  });
+});
+
+describe("ReconnectCatchup persistence — writes back on advance", () => {
+  test("recordDmSeen persists the snapshot (microtask-coalesced)", async () => {
+    const persistence = inMemoryPersistence();
+    const c = new ReconnectCatchup(persistence);
+
+    c.recordDmSeen("bob@example.com", "2026-05-20T10:00:00Z", "dm-arch-1");
+    expect(persistence.catchupSnapshot()).toBeNull(); // not yet written
+
+    await flushMicrotasks();
+
+    const snapshot = persistence.catchupSnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.dmLastSeen).toContainEqual([
+      "bob@example.com",
+      { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "dm-arch-1" },
+    ]);
+  });
+
+  test("bursts coalesce into a single write per microtask", async () => {
+    const persistence = inMemoryPersistence();
+    let writeCount = 0;
+    const original = persistence.saveCatchup;
+    persistence.saveCatchup = (snapshot) => { writeCount += 1; original(snapshot); };
+
+    const c = new ReconnectCatchup(persistence);
+    for (let i = 0; i < 10; i++) {
+      c.recordDmSeen(`peer-${i}@example.com`, "2026-05-20T10:00:00Z");
+    }
+    await flushMicrotasks();
+
+    expect(writeCount).toBe(1);
+    expect(persistence.catchupSnapshot()!.dmLastSeen).toHaveLength(10);
+  });
+
+  test("reset clears the persisted snapshot", async () => {
+    const persistence = inMemoryPersistence();
+    const c = new ReconnectCatchup(persistence);
+    c.recordDmSeen("bob@example.com", "2026-05-20T10:00:00Z");
+    await flushMicrotasks();
+    expect(persistence.catchupSnapshot()).not.toBeNull();
+
+    c.reset();
+    expect(persistence.catchupSnapshot()).toBeNull();
+  });
+
+  test("nullResumePersistence does not schedule writes (no-op fast path)", async () => {
+    // The default no-op persistence should not even allocate the
+    // microtask. We can't directly observe that, but we can assert
+    // that no error fires and behavior is unchanged after a tick.
+    const c = new ReconnectCatchup(nullResumePersistence);
+    c.recordDmSeen("bob@example.com", "2026-05-20T10:00:00Z");
+    await flushMicrotasks();
+    expect(c.getDmLastSeen("bob@example.com")).toBe("2026-05-20T10:00:00.000Z");
+  });
+});
+
+describe("createLocalStorageResumePersistence — localStorage adapter", () => {
+  test("round-trips a catchup snapshot through localStorage", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const snapshot: PersistedReconnectCatchup = {
+      dmLastSeen: [["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z" }]],
+      roomLastSeen: [],
+    };
+    persistence.saveCatchup(snapshot);
+    expect(persistence.loadCatchup()).toEqual(snapshot);
+  });
+
+  test("round-trips an SM resume state through localStorage (with internal savedAt)", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const state = { previd: "abc-123", inboundH: 42, outboundH: 7 };
+    persistence.saveSm(state);
+    // Round-trip strips the internal `savedAt` so the caller gets
+    // the same shape it passed in.
+    expect(persistence.loadSm()).toEqual(state);
+  });
+
+  test("SM TTL: a stale envelope is rejected and cleared", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    // Inject a 30-day-old envelope directly (bypassing saveSm so we
+    // control the timestamp). 30d > the 24h TTL.
+    const thirtyDaysAgo = Date.now() - (30 * 24 * 60 * 60 * 1000);
+    window.localStorage.setItem(
+      "waddle.chat.sm-resume.alice@example.com",
+      JSON.stringify({ previd: "stale", inboundH: 1, outboundH: 1, savedAt: thirtyDaysAgo }),
+    );
+    expect(persistence.loadSm()).toBeNull();
+    // Stale entries are pruned on read so the next load doesn't
+    // pay the validation cost again.
+    expect(window.localStorage.getItem("waddle.chat.sm-resume.alice@example.com")).toBeNull();
+  });
+
+  test("loadCatchup returns null for malformed JSON", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    window.localStorage.setItem("waddle.chat.resume-cursors.alice@example.com", "{not valid json");
+    expect(persistence.loadCatchup()).toBeNull();
+  });
+
+  test("loadCatchup rejects payloads with the wrong shape", () => {
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    window.localStorage.setItem(
+      "waddle.chat.resume-cursors.alice@example.com",
+      JSON.stringify({ dmLastSeen: "not-an-array", roomLastSeen: [] }),
+    );
+    expect(persistence.loadCatchup()).toBeNull();
+  });
+
+  test("two tabs converge: read-merge-write avoids cursor clobber", async () => {
+    // Simulate two `ReconnectCatchup` instances sharing the same
+    // localStorage (two tabs of the same account). Each advances
+    // its own conversation; after both persist, BOTH conversations
+    // are present in storage — the pre-fix behavior would have
+    // overwritten one with the other.
+    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const tabA = new ReconnectCatchup(persistence);
+    const tabB = new ReconnectCatchup(persistence);
+    tabA.recordDmSeen("bob@example.com", "2026-05-20T10:00:00Z", "dm-arch-A");
+    tabB.recordRoomSeen("general@muc.example.com", "2026-05-20T11:00:00Z", "room-arch-B");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const final = persistence.loadCatchup();
+    expect(final).not.toBeNull();
+    expect(final!.dmLastSeen.map((e) => e[0])).toContain("bob@example.com");
+    expect(final!.roomLastSeen.map((e) => e[0])).toContain("general@muc.example.com");
+  });
+});


### PR DESCRIPTION
## Summary

A hard reload (cold start, mobile Safari aggressive eviction) was losing every per-conversation MAM cursor and the XEP-0198 stream resume state, so the next `session:started` returned `[]` from `onSessionStarted()` and MAM catch-up did not run — missed messages were only re-fetched when the user manually scrolled back.

This is **PR3 of a 4-stack** following [#725](https://github.com/waddle-social/waddle/pull/725) (PR1) and [#726](https://github.com/waddle-social/waddle/pull/726) (PR2).

## Implementation

- **`lib/xmpp/resume-persistence.ts` (new)** — localStorage adapter mirroring `outbound-queue-store.ts` shape (same `waddle.chat.*` prefix family, same defensive read/write error handling around storage availability and quota). Exposes `loadCatchup` / `saveCatchup` / `clearCatchup` and `loadSm` / `saveSm` / `clearSm`. Falls back to a no-op `nullResumePersistence` outside the browser.
- **`ReconnectCatchup`** accepts a `ResumePersistence` (default: no-op). Hydrates on construct. Persists on every `record*Seen` via a microtask-coalesced write so MAM-catch-up bursts don't thrash localStorage.
- **`BrowserXmppClient`** wires up `createLocalStorageResumePersistence(session.jid)` by default; saves SM POD on `handleDisconnected`; clears both on `clearResumeState` (the intentional-logout path).

## Hardening from adversarial review

The first cut had several silent-data-loss bugs the adversarial reviewer caught:

| # | Issue | Fix |
|---|---|---|
| 5 | Hydrate-but-discard | a hydrated instance treats the FIRST `onSessionStarted()` as "resumed from prior tab" instead of "initial login", so the persisted cursors actually drive the next catch-up |
| 1 | Multi-tab clobber | `schedulePersist` does read-merge-write so two tabs of the same account converge rather than overwriting each other's progress |
| 3 | `seenIds` unbounded growth | capped at 64 per cursor — busy MUCs with same-second bursts no longer grow the snapshot without bound |
| 4 | SM POD stale forever | stamped with `savedAt`; loads past the 24h TTL are pruned rather than fed to the server (guaranteed `<failed/>` otherwise) |
| 2 | `clearCatchup` never called on logout | `clearResumeState` now also calls `catchup.reset()` so the persisted cursors clear instead of leaking forever |
| 9 | localStorage adapter untested in CI | tests use a scoped `globalThis.window` polyfill (uninstalled in `afterAll`) so localStorage round-trips are exercised under Bun's Node-like test env without leaking the shim into other files |

## Tests

`tests/resume-persistence.test.ts` (new) — 14 tests:

- hydration restores cursors from snapshot
- hydrated instance returns cursors on the first `onSessionStarted` (the whole-point fix)
- fresh instance still treats first `onSessionStarted` as initial login
- microtask-coalesced single write per burst
- `nullResumePersistence` is the no-op fast path
- localStorage round-trip for catchup + SM
- SM TTL: a 30-day-old envelope is pruned on load
- malformed JSON / wrong shape rejected
- read-merge-write: two-tab cursor convergence

## Verification

- [x] `bun test` — 1014/1014 pass (zero skipped)
- [x] `bun run lint` — knip clean
- [x] `bun run astro check` — 0 errors / warnings / hints
- [ ] Manual repro: tab open with active rooms → hard reload → confirm MAM catch-up fires immediately on `session:started` (cursors persisted, not lost)
- [ ] Two-tab repro: same account open in two browser tabs, both receiving messages, confirm no cursor clobber visible to either tab

## Stack

- [#725](https://github.com/waddle-social/waddle/pull/725) — PR1 (merged) — preserve authoritative createdAt
- [#726](https://github.com/waddle-social/waddle/pull/726) — PR2 (merged) — resume coalescing + drain order
- **this PR** — PR3 — persistence across reloads
- next: PR4 — unify DM/channel timeline merge into TimelineStore

🤖 Generated with [Claude Code](https://claude.com/claude-code)