### PR TITLE
fix(chat): outbound queue TTL + consolidate appendQueuedMessages

### DIFF
--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -19,7 +19,7 @@ import {
   type TimelineMessage,
 } from "@/lib/chat-ui";
 import { findMessageById } from "@/lib/message-ids";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { mergeQueuedIntoTimeline } from "@/lib/timeline-queue-merge";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
@@ -152,12 +152,7 @@ export function useChannelMessages(
   }
 
   function appendQueuedMessages(timeline: TimelineMessage[], roomJid: string): TimelineMessage[] {
-    const queued = queuedMessagesForRoom(roomJid).filter((message) => !findMessageById(timeline, message.id));
-    if (queued.length === 0) return timeline;
-    // See dms/messages.ts:appendQueuedMessages — the concat alone is correct
-    // only when clocks don't drift. Sort through the canonical total-order
-    // comparator so the pending tail is internally consistent.
-    return applyForumContext([...timeline, ...queued].sort(compareTimelineMessages));
+    return mergeQueuedIntoTimeline(timeline, queuedMessagesForRoom(roomJid), applyForumContext);
   }
 
   watch(xmppClient, (client) => {

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -11,7 +11,7 @@ import type {
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import { findMessageById } from "@/lib/message-ids";
-import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+import { mergeQueuedIntoTimeline } from "@/lib/timeline-queue-merge";
 import { findMessageElementById } from "@/lib/message-targeting";
 import { isTopPinnedScrollDirection, type ScrollDirectionMode } from "@/lib/scroll-direction";
 import { createPinnedEdgeScroller } from "@/lib/pinned-edge-scroll";
@@ -97,16 +97,7 @@ export function useDirectMessages(
   }
 
   function appendQueuedMessages(timeline: TimelineMessage[], peerJid: string): TimelineMessage[] {
-    const queued = queuedMessagesForPeer(peerJid).filter((message) => !findMessageById(timeline, message.id));
-    if (queued.length === 0) return timeline;
-    // Both inputs are individually sorted (timeline via compareTimelineMessages,
-    // queued via outbound-queue-store's createdAt+id sort) and the queued rows
-    // are all in the pending bucket — but a concat alone can mis-interleave if
-    // `timeline` already contains a still-pending optimistic row whose
-    // client-wall-clock createdAt sits inside the queued range. Sort the merged
-    // array through the canonical total-order comparator so the pending tail is
-    // internally consistent regardless of clock drift.
-    return [...timeline, ...queued].sort(compareTimelineMessages);
+    return mergeQueuedIntoTimeline(timeline, queuedMessagesForPeer(peerJid));
   }
 
   async function scrollToPinnedEdge() {

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -4,6 +4,18 @@ import { reportError } from "@/lib/telemetry";
 
 const PREFIX = "waddle.chat.outbound-queue";
 
+/**
+ * Drop persisted queued messages older than this window. A user
+ * who types a message, closes the tab before it sends, and then
+ * comes back days later does not want yesterday's draft replayed
+ * with its stale `createdAt` — it would insert ahead of every
+ * message received since, mis-positioning the row in the timeline
+ * and surprising the user with a send they don't remember
+ * intending. 7 days bounds the per-account storage footprint
+ * without losing same-session retries.
+ */
+const QUEUE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 interface PersistedQueuedMessageBase {
   id: string;
   createdAt: string;
@@ -83,7 +95,8 @@ function readQueue(accountKey: string): PersistedQueuedMessage[] {
     if (!raw) return [];
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    return sortQueue(parsed.filter(isPersistedQueuedMessage));
+    const all = sortQueue(parsed.filter(isPersistedQueuedMessage));
+    return pruneStaleEntries(s, accountKey, all);
   } catch (err) {
     // Storage read failure usually means corrupt JSON or privacy-mode
     // localStorage. Surface to Faro but keep the app working — we just
@@ -95,6 +108,69 @@ function readQueue(accountKey: string): PersistedQueuedMessage[] {
     });
     return [];
   }
+}
+
+/**
+ * Filter out queue entries past the TTL and rewrite the snapshot if
+ * any were dropped. This keeps the persisted footprint bounded over
+ * the lifetime of the account without needing a separate cleanup
+ * pass — the next read naturally trims stale rows.
+ *
+ * Pruning is silent to the UI: the row never enters `messages.value`
+ * (the prune fires inside the read that builds the timeline), so
+ * there is no "stuck queued" row left dangling. The trade-off is
+ * that a user who reloads a long-suspended tab will not see a
+ * failure notification for the drop — by design, because 7-day-old
+ * drafts are almost always abandoned. Pruning IS logged via
+ * `reportError` so a sudden spike in pruned-counts surfaces in
+ * telemetry.
+ */
+function pruneStaleEntries(
+  s: Storage,
+  accountKey: string,
+  all: PersistedQueuedMessage[],
+): PersistedQueuedMessage[] {
+  const cutoff = Date.now() - QUEUE_TTL_MS;
+  const fresh = all.filter((entry) => parseCreatedAt(entry.createdAt) >= cutoff);
+  if (fresh.length === all.length) return all;
+  const dropped = all.length - fresh.length;
+  try {
+    if (fresh.length === 0) {
+      s.removeItem(queueKey(accountKey));
+    } else {
+      s.setItem(queueKey(accountKey), JSON.stringify(fresh));
+    }
+  } catch (err) {
+    // Best-effort prune; surface to Faro but still hand back the
+    // pruned list to the caller so the stale entries are not used
+    // in this session even if persistence couldn't be updated.
+    reportError("storage.write", err, {
+      recoverable: true,
+      detail: "outbound-queue prune failed",
+      accountKey,
+      dropped,
+    });
+    return fresh;
+  }
+  // Successful prune — surface to telemetry so a spike in pruned
+  // counts is visible to operators. `storage.write` is the closest
+  // existing `ErrorKind` (we wrote the pruned snapshot back), and
+  // `recoverable: true` keeps this in the informational tier rather
+  // than alerting on it.
+  reportError("storage.write", new Error("queue ttl prune"), {
+    recoverable: true,
+    detail: `pruned ${dropped} stale queued message(s)`,
+    accountKey,
+    dropped,
+  });
+  return fresh;
+}
+
+function parseCreatedAt(value: string): number {
+  const ms = Date.parse(value);
+  // If the timestamp is unparseable, treat the entry as fresh —
+  // refusing to prune is safer than dropping a legitimate send.
+  return Number.isFinite(ms) ? ms : Date.now();
 }
 
 function writeQueue(accountKey: string, messages: PersistedQueuedMessage[]): void {

--- a/chat/src/lib/timeline-queue-merge.ts
+++ b/chat/src/lib/timeline-queue-merge.ts
@@ -1,0 +1,36 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { findMessageById } from "@/lib/message-ids";
+import { compareTimelineMessages } from "@/lib/timeline-timestamps";
+
+/**
+ * Append locally-queued (still-pending) outbound messages onto a
+ * timeline that just arrived from MAM, then re-sort through the
+ * canonical total-order comparator.
+ *
+ * Shared between DM and channel composables — both call this from
+ * four sites each (initial load, load-older, restore-from-cursor,
+ * stale-cursor recovery). The single source of truth for queue+sort
+ * ordering also makes future invariant changes (e.g. tightening the
+ * pending-bucket rule in `compareTimelineMessages`) effective
+ * everywhere at once instead of needing parallel edits.
+ *
+ * Concat-without-sort is correct only when wall clocks don't drift;
+ * a still-pending optimistic row whose client `createdAt` sits
+ * inside the queued range would otherwise mis-interleave. The
+ * canonical comparator (with its pending-bucket-last rule) handles
+ * this regardless of clock drift.
+ *
+ * `postProcess` lets the channel side re-apply `applyForumContext`
+ * to the merged result — the only kind-specific step. DM passes
+ * `undefined`.
+ */
+export function mergeQueuedIntoTimeline(
+  timeline: TimelineMessage[],
+  queued: TimelineMessage[],
+  postProcess?: (sorted: TimelineMessage[]) => TimelineMessage[],
+): TimelineMessage[] {
+  const fresh = queued.filter((message) => !findMessageById(timeline, message.id));
+  if (fresh.length === 0) return timeline;
+  const sorted = [...timeline, ...fresh].sort(compareTimelineMessages);
+  return postProcess ? postProcess(sorted) : sorted;
+}

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -163,7 +163,9 @@ describe("client send readiness", () => {
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",
       id: "queued-dm-1",
-      createdAt: "2026-05-07T00:00:00Z",
+      // Recent stamp — the queue store now prunes entries older
+      // than 7 days on read (PR4).
+      createdAt: new Date().toISOString(),
       peerJid: "bob@example.com",
       body: "queued while offline",
     });

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -201,7 +201,11 @@ describe("offline outbound queue hydration", () => {
     enqueueQueuedMessage("alice@example.com", {
       kind: "room",
       id: "queued-room-1",
-      createdAt: "2024-01-01T00:00:00Z",
+      // Recent stamp — the queue store now prunes entries older
+      // than 7 days on read (PR4), so a fixed 2024 date would be
+      // dropped by the time these tests run on a wall clock past
+      // that window.
+      createdAt: new Date().toISOString(),
       roomJid,
       body: "hello from storage",
     });
@@ -235,7 +239,9 @@ describe("offline outbound queue hydration", () => {
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",
       id: "queued-dm-1",
-      createdAt: "2024-01-01T00:00:00Z",
+      // See `room timelines restore queued messages from localStorage` —
+      // the queue store now prunes entries older than 7 days.
+      createdAt: new Date().toISOString(),
       peerJid: "bob@example.com",
       body: "hello from storage",
     });

--- a/chat/tests/outbound-queue-ttl.test.ts
+++ b/chat/tests/outbound-queue-ttl.test.ts
@@ -1,0 +1,140 @@
+/**
+ * PR4 — outbound queue TTL.
+ *
+ * A queued message that fails to ack (e.g. user typed it, closed
+ * the tab before sending, then opened a new tab weeks later) used
+ * to replay forever with its frozen `createdAt`, inserting ahead
+ * of every message received since and surprising the user with a
+ * send they don't remember intending. The store now prunes
+ * entries older than 7 days on read so the persisted footprint
+ * stays bounded over the lifetime of the account.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  countQueuedMessages,
+  enqueueQueuedMessage,
+  listQueuedDmMessages,
+} from "../src/lib/outbound-queue-store";
+
+function createStorageMock() {
+  const values = new Map<string, string>();
+  return {
+    getItem(key: string) { return values.has(key) ? values.get(key)! : null; },
+    setItem(key: string, value: string) { values.set(key, value); },
+    removeItem(key: string) { values.delete(key); },
+    clear() { values.clear(); },
+    has(key: string) { return values.has(key); },
+  };
+}
+
+const originalWindow = globalThis.window;
+const originalLocalStorage = globalThis.localStorage;
+let storage: ReturnType<typeof createStorageMock>;
+
+beforeEach(() => {
+  storage = createStorageMock();
+  (globalThis as typeof globalThis & { localStorage: typeof storage }).localStorage = storage;
+  (globalThis as typeof globalThis & { window: Window & { localStorage: typeof storage } }).window = {
+    ...(originalWindow ?? {}),
+    localStorage: storage,
+  } as Window & { localStorage: typeof storage };
+});
+
+afterEach(() => {
+  storage.clear();
+  if (originalLocalStorage === undefined) {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  } else {
+    (globalThis as typeof globalThis & { localStorage: Storage }).localStorage = originalLocalStorage;
+  }
+  if (originalWindow === undefined) {
+    Reflect.deleteProperty(globalThis, "window");
+  } else {
+    (globalThis as typeof globalThis & { window: Window & typeof globalThis }).window = originalWindow;
+  }
+});
+
+function isoDaysAgo(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe("outbound queue TTL", () => {
+  test("entries within the 7-day window are preserved", () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-fresh",
+      createdAt: isoDaysAgo(3),
+      peerJid: "bob@example.com",
+      body: "still in window",
+    });
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toHaveLength(1);
+  });
+
+  test("entries older than 7 days are pruned on read", () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-stale",
+      createdAt: isoDaysAgo(30),
+      peerJid: "bob@example.com",
+      body: "ancient draft",
+    });
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+  });
+
+  test("pruning rewrites the persisted snapshot (the entry is gone, not just hidden)", () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-stale",
+      createdAt: isoDaysAgo(30),
+      peerJid: "bob@example.com",
+      body: "ancient draft",
+    });
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-fresh",
+      createdAt: isoDaysAgo(1),
+      peerJid: "bob@example.com",
+      body: "recent draft",
+    });
+
+    // Reading triggers prune.
+    expect(countQueuedMessages("alice@example.com")).toBe(1);
+    // The persisted blob should reflect just the fresh entry now.
+    const raw = storage.getItem("waddle.chat.outbound-queue.alice@example.com");
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe("dm-fresh");
+  });
+
+  test("when every entry is stale the storage key is removed entirely", () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-stale-1",
+      createdAt: isoDaysAgo(30),
+      peerJid: "bob@example.com",
+      body: "ancient 1",
+    });
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-stale-2",
+      createdAt: isoDaysAgo(60),
+      peerJid: "bob@example.com",
+      body: "ancient 2",
+    });
+
+    expect(countQueuedMessages("alice@example.com")).toBe(0);
+    expect(storage.has("waddle.chat.outbound-queue.alice@example.com")).toBe(false);
+  });
+
+  test("unparseable createdAt is treated as fresh (refuse-to-prune is safer than dropping)", () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "dm-mystery",
+      createdAt: "not-a-date",
+      peerJid: "bob@example.com",
+      body: "weird stamp",
+    });
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

PR4 of the 4-stack closing the tab-restore ordering bug from issue (no #). Two small wins; the larger TimelineStore unification (Refactor A) is deferred to a follow-up — see *Scope note* below.

### Outbound queue TTL (Bug 7)

A queued message that fails to ack permanently used to replay forever with its frozen `createdAt`, inserting ahead of every message received since. The store now prunes entries older than **7 days** on read; pruned counts are surfaced to telemetry via `reportError("storage.write", ...)` so a spike is operator-visible.

Pruning is silent to the UI (the row never enters `messages.value` because the prune fires inside the read that builds the timeline). The trade-off: a user who reloads a long-suspended tab will not see a failure notification for the drop — by design, 7-day-old drafts are almost always abandoned.

### `appendQueuedMessages` consolidation (Bug 9)

DM and channel had nearly-identical inline implementations differing only in the channel's `applyForumContext` post-processing. Extracted to a shared `lib/timeline-queue-merge.ts` helper taking an optional post-processor callback. Behaviour-equivalent; ends the drift between the two sides for this one routine.

## Scope note — full TimelineStore unification deferred

Refactor A from the master plan (single `TimelineStore` class replacing the duplicated DM and channel merge logic) was assessed during PR4 and **deferred to a follow-up**. The reasoning:

- DM and channel have genuine protocol-level differences (forum context, moderation, reactionSenders, retraction-sender gating) that would require parametrizing every site of the unified store
- The cost/risk for a behaviour-preserving extraction was judged too high against the practical benefit, given PR1–PR3 already close the user-visible symptom and the major silent-bug classes
- The shared `mergeQueuedIntoTimeline` helper added here is the first concrete step toward the unification; a follow-up PR can extract more shared slices (merge spread, dedup index) as appetite allows

If you'd prefer the full extraction in this PR, let me know and I'll expand the scope.

## Tests

- `tests/outbound-queue-ttl.test.ts` (new) — 5 tests:
  - entries within 7 days preserved
  - entries past 7 days pruned on read
  - prune rewrites the persisted snapshot (not just hides)
  - all-stale removes the storage key entirely
  - unparseable `createdAt` is refused-to-prune (safer than dropping)
- 3 existing tests updated to use `new Date().toISOString()` for queued message fixtures (they previously hard-coded 2024/2026-05-07 timestamps the new TTL would prune)

## Verification

- [x] `bun test` — 1019/1019 pass
- [x] `bun run lint` — knip clean
- [x] `bun run astro check` — 0 errors / warnings / hints
- [ ] Manual repro: enqueue a draft in a chat, wait 8+ days (or fiddle the system clock), reload, confirm the row doesn't replay
- [ ] Watch telemetry for `storage.write` "queue ttl prune" events after rollout — a sudden spike means something is keeping the queue full longer than it should

## Stack

- [#725](https://github.com/waddle-social/waddle/pull/725) — PR1 (merged) — preserve authoritative createdAt
- [#726](https://github.com/waddle-social/waddle/pull/726) — PR2 (merged) — resume coalescing + drain order
- [#727](https://github.com/waddle-social/waddle/pull/727) — PR3 (merged) — persistence across reloads
- **this PR** — PR4 — queue TTL + queue-merge consolidation
- (deferred) — PR5 — full DM/channel timeline merge unification

🤖 Generated with [Claude Code](https://claude.com/claude-code)