### PR TITLE
fix(chat,server): XEP-0201 <thread/> is scope metadata, not content

### DIFF
--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -313,11 +313,17 @@ export function buildChannelTimelineFromMamResults(params: {
       || msg.isRetracted
       || (msg.sharedFiles && msg.sharedFiles.length > 0)
       || msg.isSticker
-      || msg.threadId
       || msg.replyTo
       || msg.forumPostKind
       || (msg.extensionAnnotations && msg.extensionAnnotations.length > 0)
     ) {
+      // NB: `msg.threadId` is intentionally absent from this gate.
+      // XEP-0201 `<thread/>` is scope metadata, not content — see
+      // `wasm-message-codecs.ts` (`roomMessageFromArchived`) and
+      // `server/.../room/archive.rs` (`is_archivable`). A stanza whose
+      // only "content" is a thread reference is a chat-state /
+      // displayed-marker / etc. echoed per XEP-0201 §3 and must not
+      // materialise as a timeline row.
       regularMessages.push(msg);
     }
   }

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -384,7 +384,15 @@ export function roomMessageFromArchived(
   const markupSpans = message.markup_spans ?? [];
   const references = message.references ?? [];
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
-  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.thread && !message.forum_post_kind && !message.is_retracted) {
+  // XEP-0201 `<thread/>` is scope metadata, not content. A stanza that
+  // carries only a thread reference (no body, no subject, no attachments,
+  // no extension annotations, no forum-post payload, not a retraction)
+  // is a chat-state / displayed-marker / etc. echoed inside a thread per
+  // XEP-0201 §3 — it MUST drop here so it never materialises as an empty
+  // row inside the thread panel. The server-side `is_archivable` already
+  // refuses to persist these; this is the defence-in-depth pass for
+  // foreign servers and legacy archive rows.
+  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.forum_post_kind && !message.is_retracted) {
     return null;
   }
   const base: LiveRoomMessage = {
@@ -485,7 +493,11 @@ export function dmMessageFromArchived(
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
   const dmWireIds = [message.id, message.origin_id]
     .filter((value): value is string => !!value && value !== dmPrimaryId);
-  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.thread && !message.is_retracted) return null;
+  // See `roomMessageFromArchived` for the rationale: `<thread/>` alone is
+  // metadata, not content. DMs don't currently surface threads in the UI
+  // anyway, but the codec stays symmetric with the room path so a stray
+  // foreign-server archive row can't manifest a bodyless DM ghost either.
+  if (!message.body && !message.subject && !sharedFiles.length && !extensionAnnotations.length && !message.is_retracted) return null;
   const base: LiveDmMessage = {
     id: dmPrimaryId,
     archiveId: message.mam_id,

--- a/chat/tests/bodyless-thread-only-not-content.test.ts
+++ b/chat/tests/bodyless-thread-only-not-content.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { roomMessageFromArchived, dmMessageFromArchived } from "../src/lib/xmpp/wasm-message-codecs";
+import { buildChannelTimelineFromMamResults } from "../src/channels/message-timeline-state";
+import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+
+// Regression coverage for the "threads now show empty messages" bug.
+//
+// PR #724 (XEP-0201 §3 conformance) made chat-states / displayed markers /
+// reactions / retractions / corrections targeting a threaded message echo
+// the target's `<thread/>`. Combined with three layers of code that
+// treated `<thread/>` as "real content" (server `is_archivable`, client
+// codec null-check, client MAM merge gate), bodyless metadata stanzas
+// started surfacing as empty rows inside the thread panel.
+//
+// The fix recognises that `<thread/>` is scope metadata, not content. A
+// stanza needs an actual body / subject / file / reaction / retraction /
+// moderation / forum-action / sticker payload to materialise as a
+// timeline row. These tests lock that semantic at every layer the bug
+// touched.
+
+const session: WaddleSession = {
+  session_id: "session-1",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/web",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+const ROOM_JID = "topic@conf.example.com";
+const SENDER_FULL = `${ROOM_JID}/bob`;
+const PEER_BARE = "bob@example.com";
+
+function baseArchivedRoom(overrides: Partial<WasmArchivedMessage> = {}): WasmArchivedMessage {
+  return {
+    mam_id: "mam-1",
+    message_type: "groupchat",
+    from: SENDER_FULL,
+    to: "alice@example.com",
+    reaction_emojis: [],
+    is_muc: true,
+    markup_spans: [],
+    mention_uris: [],
+    references: [],
+    is_sticker: false,
+    shared_files: [],
+    ...overrides,
+  };
+}
+
+function baseArchivedDm(overrides: Partial<WasmArchivedMessage> = {}): WasmArchivedMessage {
+  return {
+    mam_id: "mam-dm-1",
+    message_type: "chat",
+    from: `${PEER_BARE}/desktop`,
+    to: "alice@example.com",
+    reaction_emojis: [],
+    is_muc: false,
+    markup_spans: [],
+    mention_uris: [],
+    references: [],
+    is_sticker: false,
+    shared_files: [],
+    ...overrides,
+  };
+}
+
+describe("XEP-0201 `<thread/>` is scope metadata, not content", () => {
+  test("room codec drops a stanza whose only content is a thread reference", () => {
+    // An XEP-0085 `composing` chat-state echoed inside a thread per
+    // XEP-0201 §3: the wire stanza has no body / no subject / no
+    // attachments / no extension annotations, just `<thread/>` plus
+    // (in practice) a `<composing/>` element the Rust parser surfaces
+    // through `chat_state`. Before the fix, the codec's null-check
+    // included `!message.thread`, so this stanza built a TimelineMessage
+    // with `body: ""` and `threadId: <id>` — which then rendered as an
+    // empty row in the thread panel.
+    const stanza = baseArchivedRoom({ thread: "topic-root", chat_state: "composing" });
+
+    expect(roomMessageFromArchived(stanza)).toBeNull();
+  });
+
+  test("room codec drops a thread-only stanza with no chat-state either", () => {
+    // Pure paranoia: a stanza that carries ONLY a thread reference and
+    // nothing else (no body, no chat-state, no marker) is also rejected.
+    // Such a stanza has no legitimate use in the protocol — there is
+    // nothing to render and nothing to act on — but a misbehaving peer
+    // or stale archive row could produce one.
+    const stanza = baseArchivedRoom({ thread: "topic-root" });
+
+    expect(roomMessageFromArchived(stanza)).toBeNull();
+  });
+
+  test("room codec still keeps a threaded message that carries a body", () => {
+    // Sanity check that the fix doesn't over-correct: a real reply with
+    // body content is still surfaced as a timeline message.
+    const stanza = baseArchivedRoom({ thread: "topic-root", body: "agreed", id: "reply-1" });
+
+    const result = roomMessageFromArchived(stanza);
+    expect(result).not.toBeNull();
+    expect(result?.body).toBe("agreed");
+    expect(result?.threadId).toBe("topic-root");
+  });
+
+  test("dm codec drops a stanza whose only content is a thread reference", () => {
+    // DMs don't surface threads in the Waddle UI, but the codec stays
+    // symmetric with the room path so a stray foreign-server archive
+    // row can't manifest a bodyless DM ghost either.
+    const stanza = baseArchivedDm({ thread: "any-thread", chat_state: "composing" });
+
+    expect(dmMessageFromArchived(stanza, "alice@example.com")).toBeNull();
+  });
+
+  test("channel MAM merge does not surface a thread-only row even if the codec slips", () => {
+    // Defence-in-depth: if a future codec change (or a foreign server's
+    // own decoder) ever hands the merge layer a LiveRoomMessage with an
+    // empty body and a threadId, the merge gate must still refuse to
+    // promote it to a timeline row. The pre-fix gate accepted any
+    // `msg.threadId` as enough; this asserts the corrected semantic.
+    const phantom: LiveRoomMessage = {
+      id: "phantom-1",
+      roomJid: ROOM_JID,
+      nick: "bob",
+      body: "",
+      createdAt: "2026-05-20T09:00:00Z",
+      createdAtSource: "archive",
+      type: "message",
+      threadId: "topic-root",
+    };
+    const real: LiveRoomMessage = {
+      id: "reply-1",
+      roomJid: ROOM_JID,
+      nick: "bob",
+      body: "agreed",
+      createdAt: "2026-05-20T09:01:00Z",
+      createdAtSource: "archive",
+      type: "message",
+      threadId: "topic-root",
+    };
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [phantom, real],
+    });
+
+    expect(timeline.map((m) => m.id)).toEqual(["reply-1"]);
+  });
+});

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -12,9 +12,16 @@
 //! - `<no-store/>` (XEP-0334 §3) suppresses; `<store/>` overrides.
 //! - Body / subject-bearing groupchat messages are archived.
 //! - Body-less *protocol* messages (reactions, retractions, moderation,
-//!   file shares, stickers) are archived so MAM replay reproduces the
-//!   timeline. Mirrors the legacy `should_archive_groupchat_message`
-//!   heuristic from `message.rs`.
+//!   file shares, stickers, forum actions) are archived so MAM replay
+//!   reproduces the timeline.
+//! - XEP-0201 `<thread/>` is **scope metadata, not content**. Stanzas
+//!   that carry only a thread reference — e.g. XEP-0085 chat-states or
+//!   XEP-0333 chat markers echoed inside a thread per XEP-0201 §3 —
+//!   are NOT archive-eligible on their own. Real thread content
+//!   (replies with bodies, file shares, forum thread-create/reply
+//!   payloads) is archived through the body / file / forum-action
+//!   branches above; the `<thread/>` element rides along but does not
+//!   itself promote a stanza to archivable.
 
 use super::super::event::OutboundEvent;
 use super::context::RoomContext;
@@ -24,7 +31,6 @@ use crate::xep::{
     extract_forum_action, has_file_sharing, is_moderation_result_message, is_reaction_message,
     is_sticker_message, should_skip_storage,
 };
-use waddle_xmpp_core::xep0201::{thread_info_from_message_in_stanza_ns, CLIENT_STANZA_NS};
 use xmpp_parsers::message::{Message, MessageType};
 
 /// XEP-0313 archive handler for the room handler chain.
@@ -67,8 +73,12 @@ impl RoomHandler for MucArchiveHandler {
     }
 }
 
-/// XEP-0313 §5.1.3 archive-eligibility for groupchat. Mirrors the
-/// legacy `should_archive_groupchat_message` heuristic.
+/// XEP-0313 §5.1.3 archive-eligibility for groupchat.
+///
+/// Archive iff the stanza carries durable conversational content. Note
+/// that an XEP-0201 `<thread/>` element is scope metadata, not content,
+/// and does NOT on its own promote a stanza to archivable — see the
+/// module docstring.
 pub fn is_archivable(message: &Message) -> bool {
     if matches!(message.type_, MessageType::Error) || should_skip_storage(message) {
         return false;
@@ -82,7 +92,6 @@ pub fn is_archivable(message: &Message) -> bool {
             Some(RetractionKind::Request(_))
         )
         || is_moderation_result_message(message)
-        || thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS).is_some()
         || extract_forum_action(message).is_some()
         || has_file_sharing(message)
         || is_sticker_message(message)
@@ -98,6 +107,7 @@ mod tests {
     use crate::xep::xep0421::OccupantIdSecret;
     use jid::{BareJid, FullJid, Jid};
     use minidom::Element;
+    use waddle_xmpp_core::xep0201::CLIENT_STANZA_NS;
     use xmpp_parsers::message::{Body, Message, MessageType};
 
     fn full(s: &str) -> FullJid {
@@ -237,7 +247,15 @@ mod tests {
     }
 
     #[test]
-    fn xep_0313_archives_bodyless_standard_muc_thread_metadata() {
+    fn xep_0313_skips_bodyless_standard_muc_thread_only_stanza() {
+        // XEP-0201 §3: chat-states / displayed markers / etc. SHOULD echo
+        // a target message's `<thread/>` so receivers can scope them to
+        // the same conversation. That makes `<thread/>` scope metadata,
+        // not content — a stanza that carries only a thread reference
+        // (no body, no subject, no XEP-0444/0424/0425/0508/file/sticker
+        // payload) MUST NOT be archived; otherwise the next MAM replay
+        // would surface the bodyless metadata stanza as an empty row
+        // inside the thread.
         let room = bare("team@conf.example.com");
         let sender = full("alice@example.com/web");
         let mut msg = groupchat(&room, &sender, "");
@@ -246,10 +264,64 @@ mod tests {
         let events = run(&room, &sender, &mut msg);
 
         assert!(
-            events
+            !events
                 .iter()
                 .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
-            "XEP-0201 thread metadata is durable MUC UI state and must be archived"
+            "XEP-0201 `<thread/>` alone is scope metadata, not content — \
+             a thread-only stanza without a body or other archivable \
+             payload must not be archived"
+        );
+    }
+
+    #[test]
+    fn xep_0085_chat_state_with_thread_is_not_archived() {
+        // Regression test for the bug where post-PR #724 in-thread
+        // chat-states echo `<thread/>` (XEP-0201 §3) and slipped past
+        // `is_archivable` via the now-removed lone thread-info clause.
+        // XEP-0085 §5.4 chat-states are by definition transient; the
+        // surrounding `<thread/>` echo MUST NOT change that.
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        msg.payloads
+            .push(Element::builder("composing", "http://jabber.org/protocol/chatstates").build());
+        waddle_xmpp_core::xep0201::set_thread_id(&mut msg, "topic-root");
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "XEP-0085 chat-states must not be archived even when scoped \
+             to a thread per XEP-0201 §3"
+        );
+    }
+
+    #[test]
+    fn xep_0333_displayed_marker_with_thread_is_not_archived() {
+        // Same regression class as the chat-state case above: in-thread
+        // XEP-0333 chat markers echo `<thread/>` after PR #724. Markers
+        // are transient receipts (XEP-0333 §5); the thread echo doesn't
+        // promote them to durable content.
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "");
+        msg.payloads.push(
+            Element::builder("displayed", "urn:xmpp:chat-markers:0")
+                .attr("id", "target-sid")
+                .build(),
+        );
+        waddle_xmpp_core::xep0201::set_thread_id(&mut msg, "topic-root");
+
+        let events = run(&room, &sender, &mut msg);
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::ArchiveGroupchat { .. })),
+            "XEP-0333 chat markers must not be archived even when \
+             scoped to a thread per XEP-0201 §3"
         );
     }
 


### PR DESCRIPTION
## Symptom

After PR #724 (XEP-0201 §3 conformance) merged, threads started rendering empty message rows. Triage confirmed the empty rows were chat-states / displayed markers that had been echoed inside a thread per XEP-0201 §3 and then mis-routed into the timeline.

## Root cause

PR #724 made chat-states (XEP-0085), displayed markers (XEP-0333), reactions (XEP-0444), retractions (XEP-0424), and corrections (XEP-0308) echo the target's `<thread/>` so peers can scope them to the right conversation. That was correct on the *send* side. The bug is that three independent layers, written before XEP-0201 §3 echoes existed, treated `<thread/>` alone as evidence of real content:

1. **Server `is_archivable`** (`server/crates/waddle-xmpp/src/protocol/room/archive.rs:85`)
   ```rust
   || thread_info_from_message_in_stanza_ns(message, CLIENT_STANZA_NS).is_some()
   ```
   Any stanza with `<thread/>` became archive-eligible. Pre-#724 only thread-start stanzas (which also carried bodies) hit this branch. Post-#724, bodyless chat-state / displayed-marker stanzas now carry `<thread/>` too, so MAM started persisting them.

2. **Client codec `roomMessageFromArchived` / `dmMessageFromArchived`** (`chat/src/lib/xmpp/wasm-message-codecs.ts`)
   ```ts
   if (!message.body && ... && !message.thread && ...) return null;
   ```
   The null-return treated `<thread/>` as content. Same bad assumption — bodyless thread-only stanzas built `LiveRoomMessage` shapes with `body: ""` and `threadId` set.

3. **Channel MAM merge gate** (`chat/src/channels/message-timeline-state.ts:316`)
   ```ts
   } else if (msg.body || ... || msg.threadId || ...) regularMessages.push(msg);
   ```
   `msg.threadId` alone passed the gate. The empty-body row became a `TimelineMessage`, was grouped under the thread by `useMessageThreads`, and rendered as an empty `MessageCard`.

## Fix

`<thread/>` is **scope metadata, not content**. A stanza needs body / subject / reaction / retraction / moderation / file / sticker / forum-action / extension to materialise as content. The `<thread/>` element rides along but doesn't promote anything to archivable or surface-able.

Applied at all three layers (defence-in-depth — a foreign server or a stale archive row from before this fix shouldn't be able to surface as an empty row either):

- **Server** `is_archivable`: removed the standalone `thread_info` clause. Module docstring updated to spell out why. Flipped the existing `xep_0313_archives_bodyless_standard_muc_thread_metadata` test → `xep_0313_skips_bodyless_standard_muc_thread_only_stanza`. Added `xep_0085_chat_state_with_thread_is_not_archived` and `xep_0333_displayed_marker_with_thread_is_not_archived` regressions that nail the specific PR #724 vectors.
- **Client codec**: removed `!message.thread` from the null-check in both `roomMessageFromArchived` and `dmMessageFromArchived`. DM symmetry is deliberate — DMs don't surface threads today but the codec stays uniform.
- **Client MAM merge**: removed `msg.threadId` from the channel-side "is this a regular row?" OR-chain, with a comment locking the new semantic.
- **Tests**: new `chat/tests/bodyless-thread-only-not-content.test.ts` covers codec rejection (room + DM, with and without chat-state) and the merge-gate behaviour end-to-end.

Forum thread-create / thread-reply metadata (XEP-0508) is unaffected — that path runs through `extract_forum_action`, which is a separate archivable branch.

## Verification

- [x] `cargo test -p waddle-xmpp` — 1883 + 21 + 12 + 9 + … all green (no regressions in the affected crate)
- [x] `cargo test -p waddle-server` — all green
- [x] `cargo clippy -p waddle-xmpp --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cd chat && bun test` — 1024/1024 pass (5 new in `bodyless-thread-only-not-content.test.ts`)
- [x] `cd chat && bun run lint` — knip clean
- [x] `cd chat && bun astro check` — 0 errors / 0 warnings / 0 hints
- [ ] Manual: open a thread, type / scroll / mark-as-read; reload and confirm no empty rows appear among the replies

## Related

- PR #724 (`ba99350a`) — the XEP-0201 §3 conformance work that triggered the latent bug
- PR #318 (`583088ef`) — added the `is_archivable` thread-info clause for "thread metadata is durable MUC UI state", which is the assumption this PR retracts